### PR TITLE
Use the pantsbuild cheeseshop and binaries repos instead of maven.twttr.com & twitter/commons

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -9,7 +9,7 @@
 
 [DEFAULT]
 # TODO(John Sirois): Come up with a better public solution.
-pants_support_baseurl: http://maven.twttr.com/twitter-commons/pants/build-support
+pants_support_baseurl: https://pantsbuild.github.io/binaries/build-support
 pants_support_fetch_timeout_secs: 30
 
 max_subprocess_args: 100
@@ -326,8 +326,8 @@ java_maximum_heap_size_mb: 1024
 
 [python-repos]
 repos: [
-  'https://raw.github.com/twitter/commons/binaries/pants/third_party/python/dist/index.html',
-  'https://raw.github.com/twitter/commons/binaries/pants/third_party/python/index.html']
+  'https://pantsbuild.github.io/cheeseshop/third_party/python/dist/index.html',
+  'https://pantsbuild.github.io/cheeseshop/third_party/python/index.html']
 
 indices: ['pypi.python.org']
 


### PR DESCRIPTION
Use the pantsbuild cheeseshop for platform specific eggs and the pantsbuild binaries repo for thrift & protoc.

https://rbcommons.com/s/twitter/r/209/
