### PR TITLE
Restore the explicit identity conf mappings.

### DIFF
--- a/src/python/pants/tasks/templates/ivy_resolve/ivy.mustache
+++ b/src/python/pants/tasks/templates/ivy_resolve/ivy.mustache
@@ -52,7 +52,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
                 {{#mutable}}changing="true"{{/mutable}}
     >
       {{#configurations}}
-      <conf name="{{.}}"/>
+      <conf name="{{.}}" mapped="{{.}}"/>
       {{/configurations}}
       {{#artifacts}}
       <artifact


### PR DESCRIPTION
It looks like the absence of an explicit mapping
behaves like a '*' mapping.

https://rbcommons.com/s/twitter/r/229/
