### PR TITLE
Remove obsolete JarCreate constructor argument based tests.

### DIFF
--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -240,9 +240,3 @@ class JarCreateExecuteTest(JarCreateTestBase):
 
   def test_javadoc_jar_flagged(self):
     self.assert_javadoc_jar_contents(self.context(jar_create_javadoc=True))
-
-  def test_javadoc_jar_constructor_required(self):
-    self.assert_javadoc_jar_contents(self.context(), jar_javadoc=True)
-
-  def test_javadoc_jar_not_required(self):
-    self.assert_javadoc_jar_contents(self.context(), empty=True, jar_javadoc=False)


### PR DESCRIPTION
The constructor argument exercised was removed.

https://rbcommons.com/s/twitter/r/234/
