### PR TITLE
Instead of defaulting task-related knobs for JavaThriftLibrary, pull the...

### DIFF
--- a/src/python/pants/commands/BUILD
+++ b/src/python/pants/commands/BUILD
@@ -116,6 +116,7 @@ python_library(
     pants('src/python/pants/tasks/jvm_compile:scala'),
     pants('src/python/pants/tasks/python'),
     pants('src/python/pants/tasks:antlr_gen'),
+    pants('src/python/pants/tasks:apache_thrift_gen'),
     pants('src/python/pants/tasks:benchmark_run'),
     pants('src/python/pants/tasks:binary_create'),
     pants('src/python/pants/tasks:bootstrap_jvm_tools'),
@@ -158,7 +159,6 @@ python_library(
     pants('src/python/pants/tasks:sorttargets'),
     pants('src/python/pants/tasks:specs_run'),
     pants('src/python/pants/tasks:targets_help'),
-    pants('src/python/pants/tasks:thrift_gen'),
     pants('src/python/pants:binary_util'),
   ],
 )

--- a/src/python/pants/commands/goal.py
+++ b/src/python/pants/commands/goal.py
@@ -480,7 +480,7 @@ from pants.tasks.scala_repl import ScalaRepl
 from pants.tasks.scaladoc_gen import ScaladocGen
 from pants.tasks.scrooge_gen import ScroogeGen
 from pants.tasks.specs_run import SpecsRun
-from pants.tasks.thrift_gen import ThriftGen
+from pants.tasks.apache_thrift_gen import ApacheThriftGen
 
 
 def _cautious_rmtree(root):
@@ -673,7 +673,7 @@ goal(name='check-exclusives',
 
 # TODO(John Sirois): gen attempted as the sole Goal should gen for all known gen types but
 # recognize flags to narrow the gen set
-goal(name='thrift', action=ThriftGen).install('gen').with_description('Generate code.')
+goal(name='thrift', action=ApacheThriftGen).install('gen').with_description('Generate code.')
 goal(name='scrooge',
      dependencies=['bootstrap'],
      action=ScroogeGen).install('gen')

--- a/src/python/pants/targets/BUILD
+++ b/src/python/pants/targets/BUILD
@@ -81,6 +81,7 @@ python_library(
     pants('3rdparty/python/twitter/commons:twitter.common.collections'),
     pants('3rdparty/python/twitter/commons:twitter.common.lang'),
     pants('src/python/pants/base:build_manual'),
+    pants('src/python/pants/base:config'),
     pants('src/python/pants/base:target'),
   ],
 )

--- a/src/python/pants/tasks/BUILD
+++ b/src/python/pants/tasks/BUILD
@@ -714,8 +714,8 @@ python_library(
 """
 
 python_library(
-  name = 'thrift_gen',
-  sources = ['thrift_gen.py'],
+  name = 'apache_thrift_gen',
+  sources = ['apache_thrift_gen.py'],
   dependencies = [
     pants(':common'),
     pants(':code_gen'),

--- a/src/python/pants/tasks/apache_thrift_gen.py
+++ b/src/python/pants/tasks/apache_thrift_gen.py
@@ -45,7 +45,7 @@ def _copytree(from_base, to_base):
       safe_link(os.path.join(dirpath, filename), os.path.join(to_path, filename))
 
 
-class ThriftGen(CodeGen):
+class ApacheThriftGen(CodeGen):
   GenInfo = namedtuple('GenInfo', ['gen', 'deps'])
   ThriftSession = namedtuple('ThriftSession', ['outdir', 'cmd', 'process'])
 
@@ -97,6 +97,8 @@ class ThriftGen(CodeGen):
     self.thrift_binary = select_thrift_binary(context.config,
                                               version=context.options.thrift_version)
 
+    self.defaults = JavaThriftLibrary.Defaults(context.config)
+
   def invalidate_for(self):
     return self.gen_langs
 
@@ -106,7 +108,8 @@ class ThriftGen(CodeGen):
     return [self.thrift_binary]
 
   def is_gentarget(self, target):
-    return ((isinstance(target, JavaThriftLibrary) and target.compiler == 'thrift')
+    return ((isinstance(target, JavaThriftLibrary)
+             and self.defaults.get_compiler(target) == 'thrift')
             or isinstance(target, PythonThriftLibrary))
 
   def is_forced(self, lang):

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -9,6 +9,7 @@ python_test_suite(
     pants(':exclusive'),
     pants(':internal'),
     pants(':jar_library'),
+    pants(':java_thrift_library'),
     pants(':pants_target'),
     pants(':python_binary'),
     pants(':python_target'),
@@ -66,6 +67,16 @@ python_tests(
     pants('src/python/pants/base:parse_context'),
     pants('src/python/pants/base:target'),
     pants('src/python/pants/targets:jvm'),
+  ]
+)
+
+python_tests(
+  name = 'java_thrift_library',
+  sources = ['test_java_thrift_library.py'],
+  dependencies = [
+    pants('src/python/pants/targets:java'),
+    pants('tests/python/pants_test:base-test'),
+    pants('tests/python/pants_test/base:base-test'),
   ]
 )
 

--- a/tests/python/pants_test/targets/test_java_thrift_library.py
+++ b/tests/python/pants_test/targets/test_java_thrift_library.py
@@ -1,0 +1,90 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from textwrap import dedent
+
+import pytest
+
+from pants.targets.java_thrift_library import JavaThriftLibrary
+from pants_test.base.context_utils import create_config
+from pants_test.base_build_root_test import BaseBuildRootTest
+
+
+class JavaThriftLibraryDefaultsTest(BaseBuildRootTest):
+
+  @classmethod
+  def setUpClass(cls):
+    super(JavaThriftLibraryDefaultsTest, cls).setUpClass()
+
+    cls.create_target('thrift', dedent('''
+        java_thrift_library(
+          name='default',
+          sources=[],
+        )
+
+        java_thrift_library(
+          name='compiler',
+          sources=[],
+          compiler='scrooge-legacy',
+        )
+
+        java_thrift_library(
+          name='language',
+          sources=[],
+          language='scala',
+        )
+
+        java_thrift_library(
+          name='rpc_style',
+          sources=[],
+          rpc_style='ostrich',
+        )
+
+        java_library(
+          name='invalid',
+          sources=[]
+        )
+        '''))
+
+    cls.target_default = cls.target('thrift:default')
+    cls.target_compiler = cls.target('thrift:compiler')
+    cls.target_language = cls.target('thrift:language')
+    cls.target_rpc_style = cls.target('thrift:rpc_style')
+    cls.target_invalid = cls.target('thrift:invalid')
+
+  @staticmethod
+  def create_defaults(ini=''):
+    config = create_config(ini)
+    return JavaThriftLibrary.Defaults(config)
+
+  def test_invalid(self):
+    defaults = self.create_defaults()
+    with pytest.raises(ValueError):
+      defaults.get_compiler(self.target_invalid)
+
+  def test_hardwired_defaults(self):
+    defaults = self.create_defaults()
+    self.assertEqual('thrift', defaults.get_compiler(self.target_default))
+    self.assertEqual('java', defaults.get_language(self.target_default))
+    self.assertEqual('sync', defaults.get_rpc_style(self.target_default))
+
+  def test_configured_defaults(self):
+    defaults = self.create_defaults(dedent('''
+        [java-thrift-library]
+        compiler: scrooge
+        language: scala
+        rpc_style: finagle
+        '''))
+
+    self.assertEqual('scrooge', defaults.get_compiler(self.target_default))
+    self.assertEqual('scala', defaults.get_language(self.target_default))
+    self.assertEqual('finagle', defaults.get_rpc_style(self.target_default))
+
+  def test_explicit_values(self):
+    defaults = self.create_defaults()
+    self.assertEqual('scrooge-legacy', defaults.get_compiler(self.target_compiler))
+    self.assertEqual('scala', defaults.get_language(self.target_language))
+    self.assertEqual('ostrich', defaults.get_rpc_style(self.target_rpc_style))

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -286,6 +286,7 @@ python_tests(
   sources = ['test_scrooge_gen.py'],
   dependencies = [
     pants('tests/python/pants_test:base-test'),
+    pants('src/python/pants/targets:java'),
     pants('src/python/pants/tasks:task_error'),
     pants('src/python/pants/tasks:scrooge_gen'),
   ],

--- a/tests/python/pants_test/tasks/test_scrooge_gen.py
+++ b/tests/python/pants_test/tasks/test_scrooge_gen.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 
 import pytest
 
+from pants.targets.java_thrift_library import JavaThriftLibrary
 from pants.tasks import TaskError
 from pants.tasks.scrooge_gen import ScroogeGen
 from pants_test.base_build_root_test import BaseBuildRootTest
@@ -16,6 +17,8 @@ from pants_test.base_build_root_test import BaseBuildRootTest
 class ScroogeGenTest(BaseBuildRootTest):
 
   def test_validate(self):
+    defaults = JavaThriftLibrary.Defaults()
+
     self.create_target('test_validate', dedent('''
       java_thrift_library(name='one',
         sources=None,
@@ -38,8 +41,8 @@ class ScroogeGenTest(BaseBuildRootTest):
       )
     '''))
 
-    ScroogeGen._validate([self.target('test_validate:one')])
-    ScroogeGen._validate([self.target('test_validate:two')])
+    ScroogeGen._validate(defaults, [self.target('test_validate:one')])
+    ScroogeGen._validate(defaults, [self.target('test_validate:two')])
 
     with pytest.raises(TaskError):
-      ScroogeGen._validate([self.target('test_validate:three')])
+      ScroogeGen._validate(defaults, [self.target('test_validate:three')])


### PR DESCRIPTION
... defaulting into a Task helper.

This solves half the problem of the JavaThriftLibrary target knowing about the Tasks that use it.
In particular it solves acute pain on the default value side and allows a whole repo to configure
a non-standard default compiler, target language or target rpc_style.

Also re-name ThriftGen to the more accurate ApacheThriftGen.
Finally - restore ScroogeGen's use of the _validate helper - this
was lost in the final Twitter -> OSS merge.

https://rbcommons.com/s/twitter/r/244/
