### PR TITLE
Revert "Minimize the classpath pants passes to java for running tests."

### DIFF
--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -1,10 +1,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
-                        unicode_literals, with_statement)
-
-from contextlib import contextmanager
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
 
 from twitter.common.collections import maybe_list
 from twitter.common.lang import Compatibility
@@ -57,16 +55,15 @@ class Ivy(object):
 
     Raises Ivy.Error if the command fails for any reason.
     """
-    with self.runner(jvm_options=jvm_options, args=args, executor=executor) as runner:
-      try:
-        result = util.execute_runner(runner, workunit_factory, workunit_name, workunit_labels)
-        if result != 0:
-          raise self.Error('Ivy command failed with exit code %d%s'
-                          % (result, ': ' + ' '.join(args) if args else ''))
-      except self._java.Error as e:
-        raise self.Error('Problem executing ivy: %s' % e)
+    runner = self.runner(jvm_options=jvm_options, args=args, executor=executor)
+    try:
+      result = util.execute_runner(runner, workunit_factory, workunit_name, workunit_labels)
+      if result != 0:
+        raise self.Error('Ivy command failed with exit code %d%s'
+                         % (result, ': ' + ' '.join(args) if args else ''))
+    except self._java.Error as e:
+      raise self.Error('Problem executing ivy: %s' % e)
 
-  @contextmanager
   def runner(self, jvm_options=None, args=None, executor=None):
     """Creates an ivy commandline client runner for the given args."""
     args = args or []
@@ -85,6 +82,5 @@ class Ivy(object):
     if self._ivy_settings and '-settings' not in args:
       args = ['-settings', self._ivy_settings] + args
 
-    with executor.runner(classpath=self._classpath, main='org.apache.ivy.Main',
-                         jvm_options=jvm_options, args=args) as runner:
-      yield runner
+    return executor.runner(classpath=self._classpath, main='org.apache.ivy.Main',
+                           jvm_options=jvm_options, args=args)

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -18,7 +18,6 @@ python_library(
   sources = ['executor.py'],
   dependencies = [
     pants(':distribution'),
-    pants(':jar'),
     pants('3rdparty/python/twitter/commons:twitter.common.collections'),
     pants('3rdparty/python/twitter/commons:twitter.common.contextutil'),
     pants('3rdparty/python/twitter/commons:twitter.common.lang'),

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -33,12 +33,12 @@ def execute_java(classpath, main, jvm_options=None, args=None, executor=None,
     raise ValueError('The executor argument must be a java Executor instance, give %s of type %s'
                      % (executor, type(executor)))
 
-  with executor.runner(classpath, main, args=args, jvm_options=jvm_options) as runner:
-    workunit_name = workunit_name or main
-    return execute_runner(runner,
-                          workunit_factory=workunit_factory,
-                          workunit_name=workunit_name,
-                          workunit_labels=workunit_labels)
+  runner = executor.runner(classpath, main, args=args, jvm_options=jvm_options)
+  workunit_name = workunit_name or main
+  return execute_runner(runner,
+                        workunit_factory=workunit_factory,
+                        workunit_name=workunit_name,
+                        workunit_labels=workunit_labels)
 
 
 def execute_runner(runner, workunit_factory=None, workunit_name=None, workunit_labels=None):

--- a/src/python/pants/tasks/ivy_utils.py
+++ b/src/python/pants/tasks/ivy_utils.py
@@ -411,18 +411,18 @@ class IvyUtils(object):
 
     with IvyUtils.ivy_lock:
       self._generate_ivy(targets, jars, excludes, ivyxml, confs_to_resolve)
-      with ivy.runner(jvm_options=self._jvm_options, args=ivy_args) as runner:
-        try:
-          result = util.execute_runner(runner,
-                                      workunit_factory=workunit_factory,
-                                      workunit_name=workunit_name)
+      runner = ivy.runner(jvm_options=self._jvm_options, args=ivy_args)
+      try:
+        result = util.execute_runner(runner,
+                                     workunit_factory=workunit_factory,
+                                     workunit_name=workunit_name)
 
-          # Symlink to the current ivy.xml file (useful for IDEs that read it).
-          if symlink_ivyxml:
-            ivyxml_symlink = os.path.join(self._work_dir, 'ivy.xml')
-            safe_link(ivyxml, ivyxml_symlink)
+        # Symlink to the current ivy.xml file (useful for IDEs that read it).
+        if symlink_ivyxml:
+          ivyxml_symlink = os.path.join(self._work_dir, 'ivy.xml')
+          safe_link(ivyxml, ivyxml_symlink)
 
-          if result != 0:
-            raise TaskError('Ivy returned %d' % result)
-        except runner.executor.Error as e:
-          raise TaskError(e)
+        if result != 0:
+          raise TaskError('Ivy returned %d' % result)
+      except runner.executor.Error as e:
+        raise TaskError(e)


### PR DESCRIPTION
This reverts commit aa4a419785e1d45e778292ddc67df90420f60185.

This change breaks code that tries to re-formulate classpaths.
A notable example is here:
  https://github.com/twitter/util/blob/master/util-eval/src/main/scala/com/twitter/util/Eval.scala#L317

We'll attack this from a different angle.

https://rbcommons.com/s/twitter/r/269/
