### PR TITLE
Instead of always bootstrapping to eggs, only do this in dev mode.

### DIFF
--- a/pants
+++ b/pants
@@ -52,9 +52,6 @@ function activate_pants_bare() {
     fingerprint="${fingerprint}$(cat ${req} | fingerprint_data)"
   done
   fingerprint=$(echo "${fingerprint}" | fingerprint_data)
-  if [ ! -z "${PANTS_DEV}" ]; then
-    fingerprint="PANTS_DEV.${fingerprint}"
-  fi
 
   BOOTSTRAPPED_FILE="$(venv_dir)/BOOTSTRAPPED.${fingerprint}"
 


### PR DESCRIPTION
Since egg bootstrapping is just there to support IDEs - implying
PANTS_DEV mode makes sense to be using, and, more importantly,
since travis-ci runs choke on the generated eggs almost 100% of the
time [1], just use eggs in dev mode.

[1] pip fails like so:
  Running setup.py install for twitter.common.dirutil

```
installing library code to build/bdist.linux-x86_64/egg
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing twitter.common.dirutil-0.1.3-py2.7.egg
Removing /home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/lib/python2.7/site-packages/twitter.common.dirutil-0.1.3-py2.7.egg
twitter.common.dirutil 0.1.3 is already the active version in easy-install.pth

Installed /home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/lib/python2.7/site-packages/twitter.common.dirutil-0.1.3-py2.7.egg
Processing dependencies for twitter.common.dirutil==0.1.3
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/build/twitter.common.dirutil/setup.py", line 22, in <module>
    'zip_safe': True}
  File "/usr/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/setuptools/command/install.py", line 74, in run
    self.do_egg_install()
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/setuptools/command/install.py", line 97, in do_egg_install
    cmd.run()
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 358, in run
    self.easy_install(spec, not self.no_deps)
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 574, in easy_install
    return self.install_item(None, spec, tmpdir, deps, True)
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 625, in install_item
    self.process_distribution(spec, dist, deps)
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 671, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 593, in resolve
    requirements.extend(dist.requires(req.extras)[::-1])
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 2251, in requires
    dm = self._dep_map
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 2237, in _dep_map
    for extra,reqs in split_sections(self._get_metadata(name)):
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 2673, in split_sections
    for line in yield_lines(s):
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 1949, in yield_lines
    for ss in strs:
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 2265, in _get_metadata
    for line in self.get_metadata_lines(name):
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 1329, in get_metadata_lines
    return yield_lines(self.get_metadata(name))
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 1321, in get_metadata
    return self._get(self._fn(self.egg_info,name))
  File "/home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/local/lib/python2.7/site-packages/pkg_resources.py", line 1385, in _get
    return self.loader.get_data(path)
zipimport.ZipImportError: bad local file header in /home/travis/build/pantsbuild/pants/build-support/pants_deps.venv/lib/python2.7/site-packages/twitter.common.dirutil-0.1.3-py2.7.egg
```

https://rbcommons.com/s/twitter/r/272/
