### PR TITLE
Zundel/diagnose missing protobuf gen

### DIFF
--- a/src/python/pants/tasks/cache_manager.py
+++ b/src/python/pants/tasks/cache_manager.py
@@ -325,5 +325,5 @@ class CacheManager(object):
         fingerprint_extra=fingerprint_extra
       )
     except IOError as e:
-      raise self.CacheValidationErrorError("Problem validating file %s for target %s: %s"
-                                           % (e.filename, target.id, e))
+      raise self.CacheValidationError("Problem validating file %s for target %s: %s"
+          % (e.filename, target.id, e))

--- a/src/python/pants/tasks/protobuf_gen.py
+++ b/src/python/pants/tasks/protobuf_gen.py
@@ -217,7 +217,6 @@ def calculate_genfiles(path, source):
             match = END_TYPE_PARSER.match(line)
             if match:
               type_depth -= 1
-              pass
 
     # TODO(Eric Ayers) replace with a real lex/parse understanding of protos
     # This is a big hack.  The parsing for finding type definitions is not reliable.

--- a/tests/python/pants_test/tasks/test_protobuf_gen.py
+++ b/tests/python/pants_test/tasks/test_protobuf_gen.py
@@ -136,9 +136,8 @@ def test_whitespace_insensitivity(self):
 
     self.assert_java_files(
       'no_newline_at_all1.proto',
-      '''
-        package com.pants.protos; option java_multiple_files = true; message Foo { enum Bar { BAZ = 0; } } message FooBar { }
-      ''',
+      'package com.pants.protos; option java_multiple_files = true; message Foo {'
+      + ' enum Bar { BAZ = 0; } } message FooBar { }',
       'com/pants/protos/InnerClassNoNewlineAtAll1.java',
       'com/pants/protos/Foo.java',
       'com/pants/protos/FooOrBuilder.java'


### PR DESCRIPTION
I'm having an issue with protoc that looks like:

There is no 'type.proto' anywhere and shouldn't be.  I am assuming that this is referencing an object defined in another proto that looks like the change I made to the example.

```
                 While validating targets, got IOError: 2 ENOENT
                    accessing file: /Users/zundel/Development/java/.pants.d/gen/protoc/gen-java/com/squareup/protos/multipass/service/Type.java
                    target: multipass.multipass-protos.src.main.proto.proto.protobuf_gen
           FAILURE
```

Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "./pants.pex/__main__.py", line 24, in <module>
  File "/Users/zundel/Development/java/pants.pex/.bootstrap/_twitter_common_python/pex_bootstrapper.py", line 65, in bootstrap_pex
  File "/Users/zundel/Development/java/pants.pex/.bootstrap/_twitter_common_python/pex.py", line 215, in execute
  File "/Users/zundel/Development/java/pants.pex/.bootstrap/_twitter_common_python/pex.py", line 258, in execute_entry
  File "/Users/zundel/Development/java/pants.pex/.bootstrap/_twitter_common_python/pex.py", line 281, in execute_pkg_resources
  File "/Users/zundel/Development/java/pants.pex/pants/bin/pants_exe.py", line 184, in main
  File "/Users/zundel/Development/java/pants.pex/pants/bin/pants_exe.py", line 167, in _run
  File "/Users/zundel/Development/java/pants.pex/pants/commands/goal.py", line 395, in run
  File "/Users/zundel/Development/java/pants.pex/pants/commands/goal.py", line 186, in _execute
  File "/Users/zundel/Development/java/pants.pex/pants/engine/engine.py", line 182, in execute
  File "/Users/zundel/Development/java/pants.pex/pants/engine/group_engine.py", line 284, in attempt
  File "/Users/zundel/Development/java/pants.pex/pants/engine/group_engine.py", line 212, in attempt
  File "/Users/zundel/Development/java/pants.pex/pants/engine/group_engine.py", line 144, in execute_task
  File "/Users/zundel/Development/java/pants.pex/pants/tasks/jvm_compile/jvm_compile.py", line 288, in execute
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/contextlib.py", line 16, in __enter__
    return self.gen.next()
  File "/Users/zundel/Development/java/pants.pex/pants/tasks/task.py", line 202, in invalidated
  File "/Users/zundel/Development/java/pants.pex/pants/tasks/cache_manager.py", line 200, in check
  File "/Users/zundel/Development/java/pants.pex/pants/tasks/cache_manager.py", line 256, in _sort_and_validate_targets
  File "/Users/zundel/Development/java/pants.pex/pants/tasks/cache_manager.py", line 329, in _key_for
IOError: [Errno 2] No such file or directory: u'/Users/zundel/Development/java/.pants.d/gen/protoc/gen-java/com/squareup/protos/multipass/service/Type.java'
