### PR TITLE
Error running tests: AttributeError: 'unicode' object has no attribute 'id'

### DIFF
--- a/src/python/pants/tasks/prepare_resources.py
+++ b/src/python/pants/tasks/prepare_resources.py
@@ -12,9 +12,13 @@ from twitter.common.dirutil import safe_mkdir
 
 from pants.goal.products import MultipleRootedProducts
 from pants.tasks import Task
+from pants.base.target import Target
 
 
 class PrepareResources(Task):
+
+  class NotATargetError(Exception):
+    """Indicates a Target instance was expected."""
 
   def __init__(self, context, workdir):
     super(PrepareResources, self).__init__(context, workdir)
@@ -59,6 +63,8 @@ class PrepareResources(Task):
       group_key = egroups.get_group_key_for_target(targets[0])
 
       for resources_tgt in all_resources_tgts:
+        if resources_tgt and not isinstance(resources_tgt, Target):
+          raise self.NotATargetError("Expected a target, got instance of type %s (%s)" % (resources_tgt.__class__.__name__, resources_tgt))
         resources_dir = target_dir(resources_tgt)
         for conf in self.confs:
           egroups.update_compatible_classpaths(group_key, [(conf, resources_dir)])


### PR DESCRIPTION
I am able to run ./build-support/bin/ci.sh, but if I try to run a test target directly, we get the following error:

```
$ PANTS_DEV=1 ./pants goal test tests/python/pants_test/java/distribution
*** Running pants in dev mode from /Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py ***

12:03:14 00:00 [main]
               (To run a reporting server: ./pants goal server)
12:03:14 00:00   [setup]
12:03:14 00:00     [bootstrap]
12:03:14 00:00     [parse]
12:03:14 00:00   [bootstrap]
12:03:14 00:00     [bootstrap-jvm-tools]
12:03:14 00:00   [gen]
12:03:14 00:00     [thrift]
12:03:14 00:00     [scrooge]
12:03:14 00:00     [protoc]
12:03:14 00:00     [antlr]
12:03:14 00:00   [check-exclusives]
12:03:14 00:00     [check-exclusives]
12:03:14 00:00   [resolve]
12:03:14 00:00     [ivy]
                   Invalidated 8 targets.
12:03:14 00:00       [ivy-resolve]
12:03:14 00:00         [ivy]
12:03:14 00:00   [compile]
12:03:14 00:00     [jvm]
12:03:14 00:00   [resources]
12:03:14 00:00     [prepare]
               FAILURE
Traceback (most recent call last):
  File "/Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py", line 175, in <module>
    main()
  File "/Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py", line 169, in main
    _run()
  File "/Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py", line 150, in _run
    result = command.run(lock)
  File "/Users/zundel/Src/Pants/src/python/pants/commands/goal.py", line 319, in run
    return engine.execute(context, self.phases)
  File "/Users/zundel/Src/Pants/src/python/pants/engine/engine.py", line 182, in execute
    self.attempt(timer, context, phases)
  File "/Users/zundel/Src/Pants/src/python/pants/engine/group_engine.py", line 284, in attempt
    phase_executor.attempt(timer, explain)
  File "/Users/zundel/Src/Pants/src/python/pants/engine/group_engine.py", line 173, in attempt
    execute_task(goal, self._tasks_by_goal[goal], self._context.targets())
  File "/Users/zundel/Src/Pants/src/python/pants/engine/group_engine.py", line 144, in execute_task
    task.execute(targets)
  File "/Users/zundel/Src/Pants/src/python/pants/tasks/prepare_resources.py", line 62, in execute
    resources_dir = target_dir(resources_tgt)
  File "/Users/zundel/Src/Pants/src/python/pants/tasks/prepare_resources.py", line 39, in target_dir
    return os.path.join(self.workdir, resources_tgt.id)
AttributeError: 'unicode' object has no attribute 'id'
```

I added some diagnostics to help track this down.  Here's what actually is being passed to target_dir():

  File "/Users/zundel/Src/Pants/src/python/pants/tasks/prepare_resources.py", line 67, in execute
    raise self.NotATargetError("Expected a target, got instance of type %s (%s)" % (resources_tgt.**class**.**name**, resources_tgt))
pants.tasks.prepare_resources.NotATargetError: Expected a target, got instance of type unicode (pants/java/distribution/SystemProperties.class)
