### PR TITLE
Fixup the contributor's guide to point everyone to use `rbt patch`.

### DIFF
--- a/src/python/pants/docs/howto_contribute.rst
+++ b/src/python/pants/docs/howto_contribute.rst
@@ -119,7 +119,7 @@ Throughout the review process, there is one workflow rule to keep in mind to
 play nice with rbt's expectations.  Once you post a diff, don't alter the
 commits that form that diff.  Put another way, its fine to rebase commits
 not yet exposed to ReviewBoard, but once they are via `./rbt post` you should
-refrain from forther rebasing those commits.  In practice this makes sense;
+refrain from further rebasing those commits.  In practice this makes sense;
 in general, you want to rebase local commits into the logical commits you send
 as diffs in the ReviewBoard workflow.
 

--- a/src/python/pants/docs/howto_contribute.rst
+++ b/src/python/pants/docs/howto_contribute.rst
@@ -100,7 +100,7 @@ Now that your change is complete, we'll post it for review.
 We use https://rbcommons.com to host code reviews and
 `rbt <http://www.reviewboard.org/docs/rbtools/dev/>`_ (RBTools)
 
-Posting the First Draft
+Setting up ReviewBoard
 -----------------------
 
 **Before posting your first review,** you must create an
@@ -111,6 +111,20 @@ To set up local tools, run `./rbt status`.
 (``./rbt`` is a wrapper around the usual RBTools ``rbt`` script.)
 The first time this runs it will bootstrap and you will be asked to log in.
 Subsequent runs use your cached login credentials.
+
+Playing by ReviewBoard Rules
+----------------------------
+
+Throughout the review process, there is one workflow rule to keep in mind to
+play nice with rbt's expectations.  Once you post a diff, don't alter the
+commits that form that diff.  Put another way, its fine to rebase commits
+not yet exposed to ReviewBoard, but once they are via `./rbt post` you should
+refrain from forther rebasing those commits.  In practice this makes sense;
+in general, you want to rebase local commits into the logical commits you send
+as diffs in the ReviewBoard workflow.
+
+Posting the First Draft
+-----------------------
 
 Post your change for review::
 
@@ -153,23 +167,8 @@ At this point you've made a change, had it reviewed and are ready to
 complete things by getting your change in master. (If you're not a committer,
 please ask one do do this section for you.) ::
 
-   cd /path/to/pants/repo
-   ./build-support/bin/ci.sh
-   git checkout master
-   git pull
-   git merge --squash $FEATURE_BRANCH
-   git commit -a
-
-Here, fix up the commit message: replace ``git``'s default message
-("Squashed commit of the following... <long list>") with a summary.
-Finally, ::
-
+   ./rbt patch -c <RB_ID>
    git push origin master
 
 The very last step is closing the review. The change is now complete. Huzzah!
 
-**If you're a committer committing someone else's review,** a handy way to
-patch a local branch with a diff from rbcommons where
-<RB_ID> is a review number like 123::
-
-   ./rbt patch -c <RB_ID>


### PR DESCRIPTION
There are still holes in my knowledge of what is needed from the
reviewee using a pantsbuild/pants fork to post RB's that can be
applied later with `rbt patch -c`, but this at least points
committers and contributors alike at the same process to start.

https://rbcommons.com/s/twitter/r/306/