### PR TITLE
hole in pants: Non-ascii class names

### DIFF
--- a/src/java/com/pants/examples/pingpong/main/BUILD
+++ b/src/java/com/pants/examples/pingpong/main/BUILD
@@ -22,5 +22,11 @@ jvm_binary(name='main',
     pants('3rdparty/jvm/com/twitter/common:args'),
     pants('3rdparty/jvm/com/twitter/common:base'),
     pants('src/java/com/pants/examples/pingpong/handler'),
+      jar(org='info.cukes', name='cucumber-core', rev='1.1.6',
+      url='https://nexus.corp.squareup.com/',).with_sources(),
+      jar(org='info.cukes', name='cucumber-guice', rev='1.1.6',
+      url='https://nexus.corp.squareup.com/',).with_sources(),
+      jar(org='info.cukes', name='cucumber-java', rev='1.1.6',
+      url='https://nexus.corp.squareup.com/',).with_sources(),
   ]
 )

--- a/src/python/pants/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/tasks/jvm_compile/jvm_compile.py
@@ -639,7 +639,8 @@ class JvmCompile(NailgunTask):
         if os.path.isfile(jarpath) and ((jarpath.endswith('.jar') or jarpath.endswith('.zip'))):
           with open_zip(jarpath, 'r') as jar:
             for cls in jar.namelist():
-              # First jar with a given class wins, just like when classloading.
+              # First jar with a given class wi)ns, just like when classloading.
+              self.context.log.info("Class is: %s" % (repr(cls)))
               if cls.endswith('.class') and not cls in self._class_to_jarfile:
                 self._class_to_jarfile[cls] = jarpath
         elif os.path.isdir(jarpath):


### PR DESCRIPTION
This change to pingpong reproduces a problem with unicode class names by adding a BUILD file dependency on cucumber-java.

Once we can get past this issue, we should try actually referencing part of the API, that might uncover more issues.
