### PR TITLE
Fixup jar, binary and bundle.

### DIFF
--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -47,7 +47,7 @@ class TarArchiver(Archiver):
   def create(self, basedir, outdir, name, prefix=None):
     tarpath = os.path.join(outdir, '%s.%s' % (name, self.extension))
     with open_tar(tarpath, self.mode, dereference=True, errorlevel=1) as tar:
-      tar.add(basedir, arcname=prefix or '')
+      tar.add(basedir, arcname=prefix or '.')
     return tarpath
 
 
@@ -94,6 +94,7 @@ ZIP = ZipArchiver(ZIP_DEFLATED)
 _ARCHIVER_BY_TYPE = OrderedDict(tar=TGZ, tgz=TGZ, tbz2=TBZ2, zip=ZIP)
 
 TYPE_NAMES = frozenset(_ARCHIVER_BY_TYPE.keys())
+
 
 def archiver(typename):
   """Returns Archivers in common configurations.

--- a/src/python/pants/goal/register.py
+++ b/src/python/pants/goal/register.py
@@ -196,12 +196,12 @@ goal(name='scaladoc_publish', action=ScaladocJarShim
 # Bundling and publishing.
 
 goal(name='jar', action=JarCreate, dependencies=['compile', 'resources', 'bootstrap']
-).install('jar').with_description('Create one or more jars.')
+).install('jar')
 
 goal(name='binary', action=BinaryCreate, dependencies=['jar', 'bootstrap']
 ).install().with_description('Create a jvm binary jar.')
 
-goal(name='bundle', action=BundleCreate, dependencies=['binary', 'bootstrap']
+goal(name='bundle', action=BundleCreate, dependencies=['jar', 'bootstrap']
 ).install().with_description('Create an application bundle from binary targets.')
 
 goal(name='check_published_deps', action=CheckPublishedDeps

--- a/src/python/pants/tasks/binary_create.py
+++ b/src/python/pants/tasks/binary_create.py
@@ -5,117 +5,36 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import zipfile
-from zipfile import ZIP_DEFLATED, ZIP_STORED
 
-from twitter.common.contextutil import temporary_dir
 from twitter.common.dirutil import safe_mkdir
 
-from pants.base.build_environment import get_buildroot, get_version
-from pants.fs.archive import ZIP
-from pants.java.jar import Manifest, open_jar
-from pants.tasks import TaskError
+from pants.base.build_environment import get_buildroot
+from pants.java.jar import Manifest
 from pants.tasks.jvm_binary_task import JvmBinaryTask
 
 
 class BinaryCreate(JvmBinaryTask):
   """Creates a runnable monolithic binary deploy jar."""
 
-  @classmethod
-  def setup_parser(cls, option_group, args, mkflag):
-    JvmBinaryTask.setup_parser(option_group, args, mkflag)
-    option_group.add_option(mkflag("compressed"), mkflag("compressed", negate=True),
-                            dest="binary_create_compressed", default=True,
-                            action="callback", callback=mkflag.set_bool,
-                            help="[%default] Create a compressed binary jar.")
-
-    option_group.add_option(mkflag("zip64"), mkflag("zip64", negate=True),
-                            dest="binary_create_zip64", default=False,
-                            action="callback", callback=mkflag.set_bool,
-                            help="[%default] Create the binary jar with zip64 extensions.")
-
   def __init__(self, context, workdir):
     super(BinaryCreate, self).__init__(context, workdir)
 
-    self.outdir = os.path.abspath(
-      context.options.jvm_binary_create_outdir or
-      context.config.get('binary-create', 'outdir',
-                         default=context.config.getdefault('pants_distdir'))
-    )
-    self.compression = ZIP_DEFLATED if context.options.binary_create_compressed else ZIP_STORED
-    self.zip64 = (
-      context.options.binary_create_zip64
-      or context.config.getbool('binary-create', 'zip64', default=False)
-    )
-    self.deployjar = context.options.jvm_binary_create_deployjar
+    self._outdir = context.config.getdefault('pants_distdir')
 
-    context.products.require('jars', predicate=self.is_binary)
-    context.products.require_data('classes_by_target')
-    context.products.require_data('resources_by_target')
-    if self.deployjar:
-      self.require_jar_dependencies()
+    context.products.require('jars')
+    self.require_jar_dependencies()
 
   def execute(self, targets):
     for binary in filter(self.is_binary, targets):
       self.create_binary(binary)
 
   def create_binary(self, binary):
-    import platform
-    safe_mkdir(self.outdir)
-
-    jarmap = self.context.products.get('jars')
+    safe_mkdir(self._outdir)
 
     binary_jarname = '%s.jar' % binary.basename
-    binaryjarpath = os.path.join(self.outdir, binary_jarname)
-    self.context.log.info('creating %s' % os.path.relpath(binaryjarpath, get_buildroot()))
+    binary_jarpath = os.path.join(self._outdir, binary_jarname)
+    self.context.log.info('creating %s' % os.path.relpath(binary_jarpath, get_buildroot()))
 
-    with open_jar(binaryjarpath, 'w', compression=self.compression, allowZip64=self.zip64) as jar:
-      def add_jars(target):
-        generated = jarmap.get(target)
-        if generated:
-          for basedir, jars in generated.items():
-            for internaljar in jars:
-              self.dump(os.path.join(basedir, internaljar), jar)
-
-      binary.walk(add_jars, lambda t: t.is_internal)
-
-      if self.deployjar:
-        for basedir, externaljar in self.list_jar_dependencies(binary):
-          self.dump(os.path.join(basedir, externaljar), jar)
-
-      def write_binary_data(product_type):
-        data = self.context.products.get_data(product_type).get(binary)
-        if data:
-          for root, rel_paths in data.rel_paths():
-            for rel_path in rel_paths:
-              jar.write(os.path.join(root, rel_path), arcname=rel_path)
-
-      write_binary_data('classes_by_target')
-      write_binary_data('resources_by_target')
-
-      manifest = Manifest()
-      manifest.addentry(Manifest.MANIFEST_VERSION, '1.0')
-      manifest.addentry(
-        Manifest.CREATED_BY,
-        'python %s pants %s' % (platform.python_version(), get_version())
-      )
-      main = binary.main or '*** java -jar not supported, please use -cp and pick a main ***'
-      manifest.addentry(Manifest.MAIN_CLASS,  main)
+    with self.deployjar(binary, binary_jarpath) as jar:
+      manifest = self.create_main_manifest(binary)
       jar.writestr(Manifest.PATH, manifest.contents())
-
-      jarmap.add(binary, self.outdir, [binary_jarname])
-
-  def dump(self, jarpath, jarfile):
-    self.context.log.debug('  dumping %s' % jarpath)
-
-    with temporary_dir() as tmpdir:
-      try:
-        ZIP.extract(jarpath, tmpdir)
-      except zipfile.BadZipfile:
-        raise TaskError('Bad JAR file, maybe empty: %s' % jarpath)
-      for root, dirs, files in os.walk(tmpdir):
-        for f in files:
-          path = os.path.join(root, f)
-          relpath = os.path.relpath(path, tmpdir)
-          if Manifest.PATH != relpath:
-            jarfile.write(path, relpath)

--- a/src/python/pants/tasks/jar_create.py
+++ b/src/python/pants/tasks/jar_create.py
@@ -14,27 +14,18 @@ from twitter.common.dirutil import safe_mkdir
 from pants.base.build_environment import get_buildroot
 from pants.fs.fs import safe_filename
 from pants.java.jar import Manifest, open_jar
-from pants.targets.jvm_binary import JvmBinary
 from pants.targets.scala_library import ScalaLibrary
 from pants.tasks import Task, TaskError
 from pants.tasks.javadoc_gen import javadoc
 from pants.tasks.scaladoc_gen import scaladoc
 
 
-
-DEFAULT_CONFS = ['default']
-
-
-def is_binary(target):
-  return isinstance(target, JvmBinary)
-
-
 def is_java_library(target):
-  return target.has_sources('.java') and not is_binary(target)
+  return target.has_sources('.java')
 
 
 def is_scala_library(target):
-  return target.has_sources('.scala') and not is_binary(target)
+  return target.has_sources('.scala')
 
 
 def is_jvm_library(target):
@@ -89,7 +80,6 @@ class JarCreate(Task):
     products = context.products
 
     self.transitive = options.jar_create_transitive
-    self.confs = context.config.getlist('jar-create', 'confs', default=DEFAULT_CONFS)
     self.compression = ZIP_DEFLATED if options.jar_create_compressed else ZIP_STORED
 
     self.jar_classes = options.jar_create_classes or products.isrequired('jars')

--- a/src/python/pants/tasks/jvm_binary_task.py
+++ b/src/python/pants/tasks/jvm_binary_task.py
@@ -3,29 +3,24 @@
 
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
+from contextlib import contextmanager
 
 import os
+import platform
+import zipfile
 
 from twitter.common.collections.ordereddict import OrderedDict
 from twitter.common.collections.orderedset import OrderedSet
+from twitter.common.contextutil import temporary_dir
 
+from pants.base.build_environment import get_version
+from pants.fs.archive import ZIP
+from pants.java.jar import Manifest, open_jar
 from pants.targets.jvm_binary import JvmBinary
-from pants.tasks import Task
+from pants.tasks import Task, TaskError
 
 
 class JvmBinaryTask(Task):
-
-  @classmethod
-  def setup_parser(cls, option_group, args, mkflag):
-    option_group.add_option(mkflag("outdir"), dest="jvm_binary_create_outdir",
-                            help="Create bundles and archives in this directory.")
-
-    option_group.add_option(mkflag("deployjar"), mkflag("deployjar", negate=True),
-                            dest="jvm_binary_create_deployjar", default=False,
-                            action="callback", callback=mkflag.set_bool,
-                            help="[%default] Create a monolithic deploy jar containing this "
-                                 "binaries classfiles as well as all classfiles it depends on "
-                                 "transitively.")
 
   def __init__(self, context, workdir):
     super(JvmBinaryTask, self).__init__(context, workdir)
@@ -43,6 +38,49 @@ class JvmBinaryTask(Task):
       return self._mapped_dependencies(jardepmap, binary, confs)
     else:
       return self._unexcluded_dependencies(jardepmap, binary)
+
+  def create_main_manifest(self, binary):
+    manifest = Manifest()
+    manifest.addentry(Manifest.MANIFEST_VERSION, '1.0')
+    manifest.addentry(Manifest.CREATED_BY,
+                      'python %s pants %s' % (platform.python_version(), get_version()))
+    main = binary.main or '*** java -jar not supported, please use -cp and pick a main ***'
+    manifest.addentry(Manifest.MAIN_CLASS, main)
+    return manifest
+
+  @contextmanager
+  def deployjar(self, binary, path):
+    jarmap = self.context.products.get('jars')
+
+    with open_jar(path, 'w', compression=zipfile.ZIP_DEFLATED) as jar:
+      def add_jars(target):
+        generated = jarmap.get(target)
+        if generated:
+          for base_dir, jars in generated.items():
+            for internal_jar in jars:
+              self._dump(os.path.join(base_dir, internal_jar), jar)
+
+      binary.walk(add_jars, lambda t: t.is_internal)
+
+      for basedir, external_jar in self.list_jar_dependencies(binary):
+        self._dump(os.path.join(basedir, external_jar), jar)
+
+      yield jar
+
+  def _dump(self, jar_path, jar_file):
+    self.context.log.debug('  dumping %s' % jar_path)
+
+    with temporary_dir() as tmpdir:
+      try:
+        ZIP.extract(jar_path, tmpdir)
+      except zipfile.BadZipfile:
+        raise TaskError('Bad JAR file, maybe empty: %s' % jar_path)
+      for root, dirs, files in os.walk(tmpdir):
+        for f in files:
+          path = os.path.join(root, f)
+          relpath = os.path.relpath(path, tmpdir)
+          if Manifest.PATH != relpath:
+            jar_file.write(path, relpath)
 
   def _mapped_dependencies(self, jardepmap, binary, confs):
     # TODO(John Sirois): rework product mapping towards well known types
@@ -77,7 +115,8 @@ class JvmBinaryTask(Task):
         for basedir, jars in exclude.items():
           for jar in jars:
             excludes.add((basedir, jar))
-    self.context.log.debug('Calculated excludes:\n\t%s' % '\n\t'.join(str(e) for e in excludes))
+    if excludes:
+      self.context.log.debug('Calculated excludes:\n\t%s' % '\n\t'.join(str(e) for e in excludes))
 
     externaljars = OrderedSet()
 

--- a/tests/python/pants_test/tasks/test_binary_create.py
+++ b/tests/python/pants_test/tasks/test_binary_create.py
@@ -25,4 +25,4 @@ class BinaryCreateTest(unittest.TestCase):
                'jvm_binary_create_deployjar': None}
     binary_create = BinaryCreate(create_context(config=sample_ini_test_1, options=options),
                                  '/tmp/workdir')
-    self.assertEquals(binary_create.outdir, '/tmp/dist')
+    self.assertEquals(binary_create._outdir, '/tmp/dist')

--- a/tests/python/pants_test/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/tasks/test_bundle_create.py
@@ -20,13 +20,10 @@ class BundleCreateTest(unittest.TestCase):
 
   def test_bundle_create_init(self):
     options = {
-               'jvm_binary_create_outdir': None,
-               'binary_create_compressed': None,
-               'binary_create_zip64': None,
-               'jvm_binary_create_deployjar': None,
+               'bundle_create_deployjar': None,
                'bundle_create_prefix': None,
                'bundle_create_archive': None
                }
     bundle_create = BundleCreate(create_context(config=sample_ini_test_1, options=options),
                                  '/tmp/workdir')
-    self.assertEquals(bundle_create.outdir, '/tmp/dist')
+    self.assertEquals(bundle_create._outdir, '/tmp/dist')

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -44,9 +44,7 @@ class JarCreateMiscTest(JarCreateTestBase):
           pants_supportdir: /tmp/build-support
           """).strip()
 
-    jar_create = JarCreate(create_context(config=ini, options=self.create_options()),
-                           '/tmp/workdir')
-    self.assertEquals(jar_create.confs, ['default'])
+    JarCreate(create_context(config=ini, options=self.create_options()), '/tmp/workdir')
 
   def test_resources_with_scala_java_files(self):
     for ftype in ('java', 'scala'):


### PR DESCRIPTION
First and foremost this fixes binary (and bundle) to work with jvm_binary targets
that declare resources.

In general this divides binary and bundle into unrelated Tasks that share code
instead of products.  This allows for sane defaults for the binary Task, un-confusing
dist/ jar products - only binary now deposits binary jars at the root of dist now, and
generally simpler code.

Smaller fallout:
- hide the JarCreate goal - this only outputs to the .pants.d/ dir now and so is an
  implementation detail of dependee Tasks
- fix the tar archivers to use '.' for the empty prefix - previously tar's were created
  with absolute paths when no prefix was supplied

https://rbcommons.com/s/twitter/r/315/
https://github.com/pantsbuild/pants/issues/103
