### PR TITLE
reproduces redirecting java_protobuf_library through target()

### DIFF
--- a/testprojects/src/java/com/pants/testproject/indirectprotodep/BUILD
+++ b/testprojects/src/java/com/pants/testproject/indirectprotodep/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='indirectprotodep',
+           basename='indirectprotodep-example',
+           dependencies=[
+             'testprojects/src/protobuf/com/pants/testproject/indirectprotodep',
+             '3rdparty:protobuf-java',
+             ],
+           source='ExampleMain.java',
+           main='com.pants.testproject.indirectprotodep.ExampleMain',
+           )

--- a/testprojects/src/java/com/pants/testproject/indirectprotodep/ExampleMain.java
+++ b/testprojects/src/java/com/pants/testproject/indirectprotodep/ExampleMain.java
@@ -1,0 +1,13 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.pants.testproject.indirectprotodep;
+
+import com.pants.testproject.indirectprotodep.Redirect;
+
+class ExampleMain {
+
+  public static void main(String[] args) {
+    System.out.println(Redirect.Foo.newBuilder().setValue("Hello World!").build());
+  }
+}

--- a/testprojects/src/protobuf/com/pants/testproject/indirectprotodep/BUILD
+++ b/testprojects/src/protobuf/com/pants/testproject/indirectprotodep/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+ # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Redirect the protobuf dependency through a target() declaration
+target(name='indirectprotodep',
+  dependencies = [
+    ':redirect',
+  ],
+)
+
+java_protobuf_library(name='redirect',
+  sources = globs('*.proto'),
+)

--- a/testprojects/src/protobuf/com/pants/testproject/indirectprotodep/redirect.proto
+++ b/testprojects/src/protobuf/com/pants/testproject/indirectprotodep/redirect.proto
@@ -1,0 +1,5 @@
+package com.pants.testproject.indirectprotodep;
+
+message Foo {
+  optional string value = 1;
+}


### PR DESCRIPTION
I had a case where I wanted to redirect to a java_protobuf_library() through a dependencies() target.
Should this work?  This is a repro case I made in the protobuf code sample in pants.

```
./pants goal binary src/java/com/pants/examples/protobuf

14:27:07 00:00 [main]
               See a report at: http://localhost:57641/run/pants_run_2014_05_13_14_27_07_254
14:27:07 00:00   [setup]
14:27:07 00:00     [bootstrap]
14:27:07 00:00     [parse]
14:27:07 00:00   [jvm-locate]
14:27:07 00:00   [jvm-locate]
14:27:07 00:00   [jvm-locate]
14:27:07 00:00   [jvm-locate]
14:27:07 00:00   [jvm-locate]
14:27:07 00:00   [jvm-locate]
14:27:07 00:00   [bootstrap]
14:27:07 00:00     [bootstrap-jvm-tools]
14:27:07 00:00   [gen]
14:27:07 00:00     [thrift]
14:27:07 00:00     [scrooge]
14:27:07 00:00     [protoc]
                   Left with unexpected unconsumed gen targets:
                   	JarLibrary(src/protobuf/com/pants/examples/distance/BUILD:distance) -> set([Pants(src/protobuf/com/pants/examples/distance/BUILD:redirect)])
                   Invalidated 1 target containing 1 source file.
               FAILURE
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/Users/zundel/Src/Pants/pants.pex/__main__.py", line 24, in <module>
  File "/Users/zundel/Src/Pants/pants.pex/.bootstrap/_twitter_common_python/pex_bootstrapper.py", line 65, in bootstrap_pex
  File "/Users/zundel/Src/Pants/pants.pex/.bootstrap/_twitter_common_python/pex.py", line 215, in execute
  File "/Users/zundel/Src/Pants/pants.pex/.bootstrap/_twitter_common_python/pex.py", line 258, in execute_entry
  File "/Users/zundel/Src/Pants/pants.pex/.bootstrap/_twitter_common_python/pex.py", line 281, in execute_pkg_resources
  File "/Users/zundel/Src/Pants/pants.pex/pants/bin/pants_exe.py", line 169, in main
  File "/Users/zundel/Src/Pants/pants.pex/pants/bin/pants_exe.py", line 150, in _run
  File "/Users/zundel/Src/Pants/pants.pex/pants/commands/goal.py", line 301, in run
  File "/Users/zundel/Src/Pants/pants.pex/pants/engine/engine.py", line 49, in execute
  File "/Users/zundel/Src/Pants/pants.pex/pants/engine/group_engine.py", line 283, in attempt
  File "/Users/zundel/Src/Pants/pants.pex/pants/engine/group_engine.py", line 172, in attempt
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/contextlib.py", line 34, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/zundel/Src/Pants/pants.pex/pants/goal/context.py", line 181, in new_workunit
  File "/Users/zundel/Src/Pants/pants.pex/pants/engine/group_engine.py", line 172, in attempt
  File "/Users/zundel/Src/Pants/pants.pex/pants/engine/group_engine.py", line 143, in execute_task
  File "/Users/zundel/Src/Pants/pants.pex/pants/tasks/code_gen.py", line 122, in execute
  File "/Users/zundel/Src/Pants/pants.pex/pants/tasks/protobuf_gen.py", line 125, in createtarget
  File "/Users/zundel/Src/Pants/pants.pex/pants/tasks/protobuf_gen.py", line 145, in _create_java_target
AttributeError: 'JarLibrary' object has no attribute 'update_dependencies'
```