### PR TITLE
Added a second top level class in Greeting.java

### DIFF
--- a/src/java/com/pants/examples/hello/greet/Greeting.java
+++ b/src/java/com/pants/examples/hello/greet/Greeting.java
@@ -5,9 +5,15 @@ package com.pants.examples.hello.greet;
 
 public final class Greeting {
   public static String greet(String s) {
-    return "Hello, " + s + "!";
+    return EnglishGreeting.salutation() + ", " + s + "!";
   }
   private Greeting() {
       // not called. placates checkstyle
   }
+}
+
+class EnglishGreeting {
+ public static String salutation() {
+   return "Hello";
+ }
 }


### PR DESCRIPTION
This reproduces an issue we're seeing in some code with a package protected class at the top level in the same file with another top level class.   I don't know why they did it this way, but apparently it is valid and Maven handles it.   In Pants, it compiles with a warning:

```
17:21:56 00:00           [scan_deps]
                       Missing BUILD dependency src/java/com/pants/examples/hello/greet -> .pants.d/compile/java/classes/com/pants/examples/hello/greet/EnglishGreeting.class
```

But it fails to bundle the .class file into a .jar file.

```
java -jar dist/main-bundle/main-bin.jar 
log4j:ERROR Could not read configuration file [log4j.properties].
java.io.FileNotFoundException: log4j.properties (No such file or directory)
    at java.io.FileInputStream.open(Native Method)
    at java.io.FileInputStream.<init>(FileInputStream.java:131)
    at java.io.FileInputStream.<init>(FileInputStream.java:87)
    at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:316)
    at org.apache.log4j.PropertyConfigurator.configure(PropertyConfigurator.java:342)
    at com.pants.examples.hello.main.HelloMain.main(HelloMain.java:15)
log4j:ERROR Ignoring configuration file [log4j.properties].
Exception in thread "main" java.lang.NoClassDefFoundError: com/pants/examples/hello/greet/EnglishGreeting
    at com.pants.examples.hello.greet.Greeting.greet(Greeting.java:8)
    at com.pants.examples.hello.main.HelloMain.main(HelloMain.java:16)
Caused by: java.lang.ClassNotFoundException: com.pants.examples.hello.greet.EnglishGreeting
    at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    ... 2 more
```

We are working around the issue by just putting each class into its own file.
