### PR TITLE
Added a maven style example with a single top level directory

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,3 +13,5 @@ source_root('tests/java', java_library, junit_tests, page)
 source_root('tests/python', page, python_library, python_tests, python_test_suite, resources)
 source_root('tests/resources', page, resources)
 source_root('tests/scala', page, junit_tests, scala_library, scala_specs)
+
+source_root('src/maven-example', jvm_binary)

--- a/maven-example/BUILD
+++ b/maven-example/BUILD
@@ -1,0 +1,4 @@
+jvm_binary(name='maven-example',
+  source='src/main/java/example/Main.java',
+  main='example.Main'
+) 

--- a/maven-example/src/main/java/example/Main.java
+++ b/maven-example/src/main/java/example/Main.java
@@ -1,0 +1,7 @@
+package example;
+
+public class Main {
+  public void main(String[] args) {
+    System.out.println("Hello world!");
+  }
+}


### PR DESCRIPTION
This example shows a problem when you try to build with a BUILD file one level deep

```
$ cat at maven-example/BUILD
jvm_binary(name='maven-example',
  source='src/main/java/example/Main.java',
  main='example.Main'
) 
```

 and try to invoke pants on the default target in that file:

```
PANTS_DEV=1 ./pants goal binary maven-example
*** Running pants in dev mode from /Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py ***

14:59:46 00:00 [main]
               See a report at: http://localhost:57641/run/pants_run_2014_05_27_14_59_46_615
14:59:46 00:00   [bootstrap]
14:59:46 00:00   [setup]
14:59:46 00:00     [parse]
               Unknown goal(s): maven-example

               FAILURE
```

It works correctly if you add a slash on to the end of the name:

```
PANTS_DEV=1 ./pants goal binary maven-example/
*** Running pants in dev mode from /Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py ***

14:58:56 00:00 [main]
               See a report at: http://localhost:57641/run/pants_run_2014_05_27_14_58_56_486
14:58:56 00:00   [bootstrap]
14:58:56 00:00   [setup]
14:58:56 00:00     [parse]
...
               SUCCESS
```

or if you fully specify the target as "./pants goal binary maven-example:maven-example
