### PR TITLE
Adding a package-info.java file breaks pants

### DIFF
--- a/src/java/com/pants/examples/hello/greet/package-info.java
+++ b/src/java/com/pants/examples/hello/greet/package-info.java
@@ -1,0 +1,1 @@
+package com.pants.examples.hello.greet;


### PR DESCRIPTION
Something has broken recently such that a 'package-info.java' file (a Java file with just a package declaration).

```
./pants goal compile src/java/com/pants/examples/hello/greet
...
21:54:30 00:01           [jmake]
                         warning: bootstrap class path not set in conjunction with -source 1.6
                         jmake: Could not find class file for /Users/zundel/Src/pants/src/java/com/pants/examples/hello/greet/package-info.java
                         Jmake version 1.3.8-1
                         Warning: unable to find .class file corresponding to source /Users/zundel/Src/pants/src/java/com/pants/examples/hello/greet/package-info.java

FAILURE: deduced and actual class name mismatch


               Waiting for background workers to finish.
               FAILURE
```
