### PR TITLE
Add a hook to allow pants customizations to inject backends.

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -102,6 +102,9 @@ python_library(
 python_library(
   name = 'dev_backend_loader',
   sources = ['dev_backend_loader.py'],
+  dependencies = [
+    pants('3rdparty/python/twitter/commons:twitter.common.collections'),
+  ]
 )
 
 python_library(

--- a/src/python/pants/base/dev_backend_loader.py
+++ b/src/python/pants/base/dev_backend_loader.py
@@ -1,6 +1,20 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from twitter.common.collections import OrderedSet
 
 
-def load_backends_from_source(build_file_parser):
+def load_backends_from_source(build_file_parser, additional_backends=None):
+  """Installs pants backend packages to provide targets and helper functions to BUILD files and
+  goals to the cli.
+
+  :param build_file_parser: The parser to populate with target aliases and helper functions from
+    the backends.
+  :param additional_backends: An optional list of additional packages to load backends from.
+  """
   print("Loading pants backends from source")
   backend_packages = [
     'pants.backend.core',
@@ -9,7 +23,7 @@ def load_backends_from_source(build_file_parser):
     'pants.backend.codegen',
     'pants.backend.maven_layout',
   ]
-  for backend_package in backend_packages:
+  for backend_package in OrderedSet(backend_packages + (additional_backends or [])):
     module = __import__(backend_package + '.register',
                         {}, # globals
                         {}, # locals

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -131,7 +131,8 @@ def _run():
   build_file_parser = BuildFileParser(root_dir=root_dir, run_tracker=run_tracker)
   build_graph = BuildGraph(run_tracker=run_tracker)
 
-  load_backends_from_source(build_file_parser)
+  additional_backends = config.getlist('backends', 'packages')
+  load_backends_from_source(build_file_parser, additional_backends=additional_backends)
 
   command_class, command_args = _parse_command(root_dir, argv)
   command = command_class(run_tracker,


### PR DESCRIPTION
This may be provisional until the backend reorg finalizes, but
for now it assumes the additional backend packages injected
have been arranged to be on the PYTHONPATH by other means.

https://rbcommons.com/s/twitter/r/447/
