### PR TITLE
Upgrade to com.twitter.common#jar-tool;0.1.6

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -95,6 +95,6 @@ jar_library(name = 'scrooge-legacy-gen',
 
 jar_library(name = 'jar-tool',
             jars = [
-              jar(org = 'com.twitter.common', name = 'jar-tool', rev = '0.1.5')
+              jar(org = 'com.twitter.common', name = 'jar-tool', rev = '0.1.6')
             ])
 


### PR DESCRIPTION
This picks up a fix for moving the temporary jar file created
to it final target location when the two reside on different
filesystems.

https://rbcommons.com/s/twitter/r/465/
