### PR TITLE
Upgrade jar-tool to 0.1.7

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -95,6 +95,6 @@ jar_library(name = 'scrooge-legacy-gen',
 
 jar_library(name = 'jar-tool',
             jars = [
-              jar(org = 'com.twitter.common', name = 'jar-tool', rev = '0.1.6')
+              jar(org = 'com.twitter.common', name = 'jar-tool', rev = '0.1.7')
             ])
 


### PR DESCRIPTION
This picks up a fix that prevented clean cross-fs
jar copies due to unclosed temprorary files.

https://rbcommons.com/s/twitter/r/475/
