### PR TITLE
Use a temporary file as the source of 'y' on stdin for the publish IT.

### DIFF
--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -23,8 +23,9 @@ python_library(
   name = 'int-test',
   sources = ['pants_run_integration_test.py'],
   dependencies = [
+    pants('3rdparty/python/twitter/commons:twitter.common.contextutil'),
     pants('3rdparty/python/twitter/commons:twitter.common.dirutil'),
-    pants('src/python/pants/commands:goal'),
+    pants('src/python/pants/base:build_environment'),
   ]
 )
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -5,29 +5,31 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 
+from contextlib import contextmanager
 import os
 import subprocess
+from textwrap import dedent
 import unittest
 
-from contextlib import contextmanager
-from textwrap import dedent
-
-from pants.base.build_environment import get_buildroot
 from twitter.common.contextutil import temporary_dir
 from twitter.common.dirutil import safe_open
 
-from mock import patch
+from pants.base.build_environment import get_buildroot
 
 
 class PantsRunIntegrationTest(unittest.TestCase):
   """A baseclass useful for integration tests for targets in the same repo"""
 
   PANTS_SUCCESS_CODE = 0
-  PANTS_GOAL_COMMAND = 'goal'
   PANTS_SCRIPT_NAME = 'pants'
 
   @contextmanager
-  def run_pants(self, goal, targets, command_args=None):
+  def run_pants(self, command, **kwargs):
+    """Runs pants in a subprocess.
+
+    :param list command: A list of command line arguments coming after `./pants`.
+    :param kwargs: Extra keyword args to pass to `subprocess.Popen`.
+    """
     with temporary_dir() as work_dir:
       ini = dedent('''
               [DEFAULT]
@@ -39,7 +41,6 @@ class PantsRunIntegrationTest(unittest.TestCase):
         fp.write(ini)
       env = os.environ.copy()
       env['PANTS_CONFIG_OVERRIDE'] = ini_file_name
-      pants_commands = [os.path.join(get_buildroot(), self.PANTS_SCRIPT_NAME),
-                        self.PANTS_GOAL_COMMAND, goal]  + targets + command_args
-      result = subprocess.call(pants_commands, env=env)
+      pants_command = [os.path.join(get_buildroot(), self.PANTS_SCRIPT_NAME)] + command
+      result = subprocess.call(pants_command, env=env, **kwargs)
       yield result

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -259,7 +259,7 @@ python_tests(
   name = 'jar_publish_integration',
   sources = ['test_jar_publish_integration.py'],
   dependencies = [
-    pants('3rdparty/python:mock'),
+    pants('3rdparty/python/twitter/commons:twitter.common.contextutil'),
     pants('tests/python/pants_test:int-test'),
   ],
 )


### PR DESCRIPTION
The prior method of pumping yes to stdin of `./pants goal publish`
did not work under travis-ci.  This method does and it also works
when un-suppressing pytest output as well.
