### PR TITLE
Unbreak test_detect_duplicates.py and link into :all.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/detect_duplicates.py
+++ b/src/python/pants/backend/jvm/tasks/detect_duplicates.py
@@ -14,12 +14,12 @@ from pants.base.exceptions import TaskError
 from pants.java.jar.manifest import Manifest
 
 
-EXCLUDED_FILES = "dependencies,license,notice,.DS_Store,notice.txt,cmdline.arg.info.txt.1," \
-                 "license.txt"
+EXCLUDED_FILES = ("dependencies,license,notice,.DS_Store,notice.txt,cmdline.arg.info.txt.1,"
+                  "license.txt")
+
 
 class DuplicateDetector(JvmBinaryTask):
   """ Detect classes and resources with the same qualified name on the classpath. """
-
 
   @staticmethod
   def _isdir(name):
@@ -27,7 +27,7 @@ class DuplicateDetector(JvmBinaryTask):
 
   @classmethod
   def setup_parser(cls, option_group, args, mkflag):
-    JvmBinaryTask.setup_parser(option_group, args, mkflag)
+    super(DuplicateDetector, cls).setup_parser(option_group, args, mkflag)
     option_group.add_option(mkflag("fail-fast"), mkflag("fail-fast", negate=True),
                             dest="fail_fast", default=False,
                             action="callback", callback=mkflag.set_bool,
@@ -37,7 +37,6 @@ class DuplicateDetector(JvmBinaryTask):
                             help="A comma separated list of files to exclude from duplicate check, "
                                  "defaults to: [%default]")
 
-
   def __init__(self, context, workdir):
     super(DuplicateDetector, self).__init__(context, workdir)
     self._fail_fast = context.options.fail_fast
@@ -46,7 +45,6 @@ class DuplicateDetector(JvmBinaryTask):
       self._excludes = EXCLUDED_FILES
     context.products.require_data('classes_by_target')
     context.products.require_data('resources_by_target')
-
 
   def execute(self):
     for binary_target in filter(self.is_binary, self.context.targets()):

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -31,6 +31,7 @@ python_test_suite(
     pants(':dependees'),
     pants(':dependencies'),
     pants(':depmap'),
+    pants(':detect_duplicates'),
     pants(':filemap'),
     pants(':filter'),
     pants(':group_task'),
@@ -186,14 +187,15 @@ python_tests(
   ]
 )
 
-# XXX(pl): This test isn't rolled into :all and is broken
 python_tests(
   name = 'detect_duplicates',
   sources = ['test_detect_duplicates.py'],
   dependencies = [
     pants(':base'),
     pants('3rdparty/python/twitter/commons:twitter.common.dirutil'),
+    pants('src/python/pants/base:exceptions'),
     pants('src/python/pants/backend/jvm/tasks:detect_duplicates'),
+    pants('tests/python/pants_test/base:context_utils'),
   ],
 )
 


### PR DESCRIPTION
I think the test could be improved to be more black box and not dip
in to test a private method directly, but this fixes the basic break
due to a signature change in the tested private method.

https://rbcommons.com/s/twitter/r/484/
