### PR TITLE
Regression in handling an external dep containing a unicode character classname

### DIFF
--- a/src/java/com/pants/examples/unicode/cucumber/BUILD
+++ b/src/java/com/pants/examples/unicode/cucumber/BUILD
@@ -1,0 +1,17 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='cucumber',
+  sources=globs('*.java'),
+  dependencies = [
+    ':info.cukes.cucumber-java',
+  ],
+)
+
+jar_library(name='info.cukes.cucumber-java',
+    jars=[
+      jar(org='info.cukes',
+          name='cucumber-java',
+          rev='1.1.7'),
+    ],
+)

--- a/src/java/com/pants/examples/unicode/cucumber/CucumberAnnotatedExample.java
+++ b/src/java/com/pants/examples/unicode/cucumber/CucumberAnnotatedExample.java
@@ -1,0 +1,20 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.pants.examples.unicode.cucumber;
+
+import cucumber.api.java.zh_cn.假如;
+
+/**
+ * References a class in an external dependency with a non-ascii encodable unicode name.
+ */
+public class CucumberAnnotatedExample {
+
+  public CucumberAnnotatedExample() {
+  }
+
+  @假如("祝你今天愉快!")
+  public String pleasantry() {
+    return "Have a nice day!";
+  }
+}

--- a/src/java/com/pants/examples/unicode/main/BUILD
+++ b/src/java/com/pants/examples/unicode/main/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Demonstrates compiling code with a unicode classes
+
+jvm_binary(name = 'main',
+  dependencies = [
+    'src/java/com/pants/examples/unicode/cucumber'
+  ],
+  source = 'CucumberMain.java',
+  main = 'com.pants.examples.unicode.main.CucumberMain',
+)

--- a/src/java/com/pants/examples/unicode/main/CucumberMain.java
+++ b/src/java/com/pants/examples/unicode/main/CucumberMain.java
@@ -1,0 +1,18 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.pants.examples.unicode.main;
+
+import com.pants.examples.unicode.cucumber.CucumberAnnotatedExample;
+
+/**
+ * This does not do anything usefule with the Cucumber library, but uses it as an external
+ * dep to demonstrate that pants works with non-ascii unicode classes.
+ */
+public class CucumberMain {
+
+  public static void main(String[] args) {
+    CucumberAnnotatedExample example = new CucumberAnnotatedExample();
+    System.out.println(example.pleasantry());
+  }
+}

--- a/src/python/pants/backend/jvm/tasks/detect_duplicates.py
+++ b/src/python/pants/backend/jvm/tasks/detect_duplicates.py
@@ -102,7 +102,7 @@ class DuplicateDetector(JvmBinaryTask):
       with closing(ZipFile(external_dep)) as dep_zip:
         for qualified_file_name in dep_zip.namelist():
           file_name = os.path.basename(qualified_file_name)
-          if file_name.lower() in self._excludes:
+          if file_name.decode('utf-8').lower() in self._excludes:
             continue
           jar_name = os.path.basename(external_dep)
           if (not self._isdir(qualified_file_name)) and Manifest.PATH != qualified_file_name:

--- a/tests/java/com/pants/examples/unicode/cucumber/BUILD
+++ b/tests/java/com/pants/examples/unicode/cucumber/BUILD
@@ -1,0 +1,15 @@
+junit_tests(name='cucumber',
+  sources=globs('*.java'),
+  dependencies=[
+    pants('3rdparty:junit'),
+    pants('src/java/com/pants/examples/unicode/cucumber'),
+  ],
+)
+
+jar_library(name='info.cukes.cucumber-core',
+    jars=[
+      jar(org='info.cukes',
+          name='cucumber-core',
+          rev='1.1.7'),
+    ],
+)

--- a/tests/java/com/pants/examples/unicode/cucumber/CucumberTest.java
+++ b/tests/java/com/pants/examples/unicode/cucumber/CucumberTest.java
@@ -1,0 +1,20 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+// Test the cucumber library which contains unicode classnames
+
+package com.pants.examples.unicode.cucumber;
+
+import org.junit.Test;
+
+import com.pants.examples.unicode.cucumber.CucumberAnnotatedExample;
+
+import static org.junit.Assert.assertEquals;
+
+/** Ensure our greetings are polite */
+public class CucumberTest {
+  @Test
+  public void testUnicodeClass() {
+    assertEquals("Have a nice day!", new CucumberAnnotatedExample().pleasantry());
+  }
+}

--- a/tests/python/pants_test/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/tasks/test_detect_duplicates.py
@@ -1,4 +1,5 @@
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# coding=utf-8
+#  Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
@@ -30,10 +31,12 @@ class DuplicateDetectorTest(TaskTest):
     test_class_path = generate_path('com/twitter/Test.class')
     duplicate_class_path = generate_path('com/twitter/commons/Duplicate.class')
     unique_class_path = generate_path('org/apache/Unique.class')
+    unicode_class_path = generate_path('cucumber/api/java/zh_cn/假如.class')
 
     touch(test_class_path)
     touch(duplicate_class_path)
     touch(unique_class_path)
+    touch(unicode_class_path)
 
     def generate_jar(path, *class_name):
       with closing(ZipFile(generate_path(path), 'w')) as zipfile:
@@ -46,20 +49,23 @@ class DuplicateDetectorTest(TaskTest):
       test_jar = generate_jar('test.jar', test_class_path, duplicate_class_path)
       jar_with_duplicates = generate_jar('dups.jar', duplicate_class_path, unique_class_path)
       jar_without_duplicates = generate_jar('no_dups.jar', unique_class_path)
+      jar_with_unicode = generate_jar('unicode_class.jar', unicode_class_path)
 
-      yield test_jar, jar_with_duplicates, jar_without_duplicates
+      yield test_jar, jar_with_duplicates, jar_without_duplicates, jar_with_unicode
 
     with jars() as jars:
-      test_jar, jar_with_duplicates, jar_without_duplicates = jars
+      test_jar, jar_with_duplicates, jar_without_duplicates, jar_with_unicode = jars
       self.path_with_duplicates = {
           'com/twitter/Test.class': set([test_jar]),
           'com/twitter/commons/Duplicate.class': set([test_jar, jar_with_duplicates]),
-          'org/apache/Unique.class': set([jar_with_duplicates])
+          'org/apache/Unique.class': set([jar_with_duplicates]),
+          'cucumber/api/java/zh_cn/假如.class' : set([jar_with_unicode]),
       }
       self.path_without_duplicates = {
           'com/twitter/Test.class': set([test_jar]),
           'com/twitter/commons/Duplicate.class': set([test_jar]),
-          'org/apache/Unique.class': set([jar_without_duplicates])
+          'org/apache/Unique.class': set([jar_without_duplicates]),
+          'cucumber/api/java/zh_cn/假如.class' : set([jar_with_unicode]),
       }
 
   def tearDown(self):


### PR DESCRIPTION
A recent change to dup detection broke compiling in our repo.  This one line change contains another 100 lines of tests to try and make sure we don't regress again.
