### PR TITLE
Removing .pants.d during clean.sh makes it easier for me to get past the Untranslatable .. exception

### DIFF
--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -5,4 +5,5 @@ rm -rf ${HOME}/.pex
 rm -rf ${PANTS_BASE}/build-support/pants_deps.venv
 rm -rf ${PANTS_BASE}/build-support/pants_dev_deps.venv
 rm -f  ${PANTS_BASE}/pants.pex
+rm -rf ${PANTS_BASE}/.pants.d
 find ${PANTS_BASE} -name '*.pyc' | xargs rm -f


### PR DESCRIPTION
This may be heavy handed, but it seems to be key to getting past the Untranslatable exceptions that crop up.
If there is a reason not to delete the entire .pants.d during a clean, then I'll look into cleaning up just the portion that is caching the failed package download.
