### PR TITLE
Added support for including .proto files in remote .jars on the --proto_...

### DIFF
--- a/src/java/com/pants/examples/protobuf/BUILD
+++ b/src/java/com/pants/examples/protobuf/BUILD
@@ -1,10 +1,25 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+jvm_binary(name='protobuf-all',
+  dependencies=[
+    ':protobuf',
+    ':protobuf-imports',
+  ],
+)
+
 jvm_binary(name='protobuf',
   dependencies=[
     'src/protobuf/com/pants/examples/distance',
   ],
   source='ExampleProtobuf.java',
   main='com.pants.examples.protobuf.ExampleProtobuf',
+)
+
+jvm_binary(name='protobuf-imports',
+  dependencies=[
+    'src/protobuf/com/pants/examples/imports',
+  ],
+  source='imports/ExampleProtobufImports.java',
+  main='com.pants.examples.protobuf.ExampleProtobufImports',
 )

--- a/src/java/com/pants/examples/protobuf/imports/ExampleProtobufImports.java
+++ b/src/java/com/pants/examples/protobuf/imports/ExampleProtobufImports.java
@@ -1,0 +1,17 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.pants.examples.protobuf.imports;
+
+import com.pants.examples.imports.TestImports;
+
+class ExampleProtobufImports {
+
+  private ExampleProtobufImports() {
+  }
+
+  public static void main(String[] args) {
+      System.out.println(TestImports.TestImport.newBuilder().setTestNum(12).setTestStr("very test")
+          .build());
+  }
+}

--- a/src/protobuf/com/pants/examples/distance/BUILD
+++ b/src/protobuf/com/pants/examples/distance/BUILD
@@ -2,5 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_protobuf_library(name='distance',
-  sources=globs('*.proto'),
+  sources=['distances.proto',],
 )

--- a/src/protobuf/com/pants/examples/imports/BUILD
+++ b/src/protobuf/com/pants/examples/imports/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_protobuf_library(name='imports',
+  sources=['test_imports.proto',],
+  imports=jar_sources(':protobuf-test-import'),
+)
+
+# Normally, this would live in 3rdparty. This is here because we didn't want to clutter Pants' own
+# 3rdparty with its sample code's deps.
+jar_library(name='protobuf-test-import',
+  jars = [
+    jar(org='com.squareup.testing.protolib', name='protolib-test', rev='1.0'),
+  ],
+)

--- a/src/protobuf/com/pants/examples/imports/test_imports.proto
+++ b/src/protobuf/com/pants/examples/imports/test_imports.proto
@@ -1,0 +1,15 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.pants.examples.imports;
+
+import "com/squareup/testing/protolib/a.proto";
+
+/**
+ * Completely useless proto designed to test import remote functionality.
+ */
+message TestImport {
+  optional string testStr = 1;
+  required int64 testNum = 2;
+  optional com.squareup.testing.protolib.AMessage letter = 3;
+}

--- a/src/python/pants/backend/codegen/register.py
+++ b/src/python/pants/backend/codegen/register.py
@@ -58,7 +58,7 @@ def register_goals():
   goal(name='scrooge', dependencies=['bootstrap'], action=ScroogeGen
   ).install('gen')
 
-  goal(name='protoc', action=ProtobufGen
+  goal(name='protoc', dependencies=['imports'], action=ProtobufGen
   ).install('gen')
 
   goal(name='antlr', dependencies=['bootstrap'], action=AntlrGen

--- a/src/python/pants/backend/codegen/targets/java_protobuf_library.py
+++ b/src/python/pants/backend/codegen/targets/java_protobuf_library.py
@@ -5,33 +5,52 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from pants.base.build_manual import manual
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
+from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.base.build_manual import manual
 
 
 @manual.builddict(tags=["java"])
 class JavaProtobufLibrary(ExportableJvmLibrary):
   """Generates a stub Java library from protobuf IDL files."""
 
-  def __init__(self, buildflags=None, **kwargs):
-
+  def __init__(self, buildflags=None, imports=None, **kwargs):
     """
-    :param string name: The name of this target, which combined with this
-      build file defines the target :class:`pants.base.address.Address`.
-    :param sources: A list of filenames representing the source code
-      this library is compiled from.
+    :param string name: The name of this target, which combined with this build file defines the
+      target :class:`pants.base.address.Address`.
+    :param sources: A list of filenames representing the source code this library is compiled from.
     :type sources: list of strings
-    :param Artifact provides:
-      The :class:`pants.targets.artifact.Artifact`
-      to publish that represents this target outside the repo.
-    :param dependencies: List of :class:`pants.base.target.Target` instances
-      this target depends on.
+    :param Artifact provides: The :class:`pants.targets.artifact.Artifact` to publish that
+      represents this target outside the repo.
+    :param dependencies: List of :class:`pants.base.target.Target` instances this target depends on.
     :type dependencies: list of targets
-    :param excludes: List of :class:`pants.targets.exclude.Exclude` instances
-      to filter this target's transitive dependencies against.
+    :param excludes: List of :class:`pants.targets.exclude.Exclude` instances to filter this
+      target's transitive dependencies against.
     :param buildflags: Unused, and will be removed in a future release.
+    :param imports: External jar(s) which contain .proto definitions, inputted with jar_sources in
+      the format: imports=jar_sources(jar(...), jar(...), jar(...)).
     :param exclusives: An optional map of exclusives tags. See CheckExclusives for details.
     """
-
     super(JavaProtobufLibrary, self).__init__(**kwargs)
-    self.add_labels('codegen')
+    self.add_labels('codegen', 'has_imports')
+    self._imports = imports
+
+  _import_jars = None
+  _proto_dirs = None
+  def _init_jars(self, context):
+    if self._import_jars is not None:
+      return
+    self._import_jars = set()
+    self._proto_dirs = set()
+    if self._imports:
+      for fileset, jar in self._imports(context, self.address.build_file):
+        self._proto_dirs.add(fileset)
+        self._import_jars.add(jar)
+
+  def import_jars(self, context):
+    self._init_jars(context)
+    return self._import_jars
+
+  def proto_dirs(self, context):
+    self._init_jars(context)
+    return self._proto_dirs

--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -34,6 +34,7 @@ from pants.backend.core.wrapped_globs import Globs, RGlobs, ZGlobs
 from pants.base.build_environment import get_buildroot, get_version, get_scm, set_scm
 from pants.base.config import Config
 from pants.base.source_root import SourceRoot
+from pants.fs.source_util import jar_sources
 from pants.goal import Goal, Goal as goal, Phase
 
 
@@ -86,6 +87,7 @@ def object_aliases():
     'set_scm': set_scm,
     'Time': Time,
     'wiki_artifact': WikiArtifact,
+    'jar_sources': jar_sources,
   }
 
 

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -30,10 +30,11 @@ from pants.backend.jvm.tasks.bundle_create import BundleCreate
 from pants.backend.jvm.tasks.check_published_deps import CheckPublishedDeps
 from pants.backend.jvm.tasks.dependencies import Dependencies
 from pants.backend.jvm.tasks.depmap import Depmap
-from pants.backend.jvm.tasks.filedeps import FileDeps
 from pants.backend.jvm.tasks.detect_duplicates import DuplicateDetector
 from pants.backend.jvm.tasks.eclipse_gen import EclipseGen
+from pants.backend.jvm.tasks.filedeps import FileDeps
 from pants.backend.jvm.tasks.idea_gen import IdeaGen
+from pants.backend.jvm.tasks.ivy_imports import IvyImports
 from pants.backend.jvm.tasks.ivy_resolve import IvyResolve
 from pants.backend.jvm.tasks.jar_create import JarCreate
 from pants.backend.jvm.tasks.jar_publish import JarPublish
@@ -106,6 +107,9 @@ def register_goals():
   goal(name='ivy', action=IvyResolve, dependencies=['gen', 'check-exclusives', 'bootstrap']
   ).install('resolve').with_description('Resolve dependencies and produce dependency reports.')
 
+  goal(name='ivy-imports', action=IvyImports, dependencies=['bootstrap']
+  ).install('imports').with_description('Resolve dependencies for (currently just .proto) imports.')
+
   # Compilation.
 
   # AnnotationProcessors are java targets, but we need to force them into their own compilation
@@ -124,11 +128,11 @@ def register_goals():
 
   jvm_compile = GroupTask.named('jvm-compilers', product_type='classes', flag_namespace=['compile'])
 
-  # At some point ScalaLibrary targets will be able to won mixed scala and java source sets.
-  # At that point, the ScalaCompile group member will still only select targets via
-  # has_sources('*.scala'); however if the JavaCompile group member were registered earlier, it
-  # would claim the ScalaLibrary targets with mixed source sets leaving those targets un-compiled
-  # by scalac and resulting in systemic compile errors.
+  # At some point ScalaLibrary targets will be able to won mixed scala and java source sets. At that
+  # point, the ScalaCompile group member will still only select targets via has_sources('*.scala');
+  # however if the JavaCompile group member were registered earlier, it would claim the ScalaLibrary
+  # targets with mixed source sets leaving those targets un-compiled by scalac and resulting in
+  # systemic compile errors.
   jvm_compile.add_member(ScalaCompile)
 
   # Its important we add AptCompile before JavaCompile since it 1st selector wins and apt code is a

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -26,6 +26,7 @@ python_library(
     ':filedeps',
     ':ide_gen',
     ':idea_gen',
+    ':ivy_imports',
     ':ivy_resolve',
     ':ivy_task_mixin',
     ':jar_create',
@@ -210,6 +211,22 @@ python_library(
     pants('src/python/pants/backend/core/targets:common'),
     pants('src/python/pants/backend/jvm/targets:java'),
     pants('src/python/pants/backend/jvm/targets:scala'),
+  ],
+)
+
+python_library(
+  name = 'ivy_imports',
+  sources = ['ivy_imports.py'],
+  dependencies = [
+    pants('src/python/pants/backend/jvm:ivy_utils'),
+    pants(':nailgun_task'),
+    pants('3rdparty/python/twitter/commons:twitter.common.dirutil'),
+    pants('src/python/pants:binary_util'),
+    pants('src/python/pants/base:cache_manager'),
+    pants('src/python/pants/ivy'),
+    pants('src/python/pants/backend/jvm/tasks:ivy_task_mixin'),
+    pants('src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin'),
+    pants('src/python/pants/fs'),
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -1,0 +1,163 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from collections import defaultdict
+import os
+import shutil
+import time
+
+from twitter.common.dirutil import safe_mkdir
+
+from pants import binary_util
+from pants.backend.jvm.ivy_utils import IvyUtils
+from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
+from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.cache_manager import VersionedTargetSet
+from pants.base.exceptions import TaskError
+from pants.fs.source_util import get_archive_root
+from pants.ivy.bootstrapper import Bootstrapper
+from pants.ivy.ivy import Ivy
+from pants.java import util
+
+
+class IvyImports(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
+  """Resolves jar source imports (currently only used by java_protobuf_library)."""
+  @classmethod
+  def setup_parser(cls, option_group, args, mkflag):
+    super(IvyImports, cls).setup_parser(option_group, args, mkflag)
+    option_group.add_option(mkflag("args"), dest="ivy_args", action="append", default=[],
+                            help="Pass these extra args to ivy.")
+
+
+  def __init__(self, context, workdir, confs=None):
+    super(IvyImports, self).__init__(context, workdir)
+    # Mostly copy-pastad from ivy_resolve.py; perhaps some of this is obsolete?
+    self._ivy_bootstrapper = Bootstrapper.instance()
+    self._cachedir = self._ivy_bootstrapper.ivy_cache_dir
+    self._confs = confs or context.config.getlist('ivy-resolve', 'confs', default=['default'])
+    self._classpath_dir = os.path.join(self.workdir, 'mapped')
+
+    self._outdir = context.options.ivy_resolve_outdir or os.path.join(self.workdir, 'reports')
+    self._open = context.options.ivy_resolve_open
+
+    self._ivy_bootstrap_key = 'ivy'
+    ivy_bootstrap_tools = context.config.getlist('ivy-resolve', 'bootstrap-tools', ':xalan')
+    self.register_jvm_tool(self._ivy_bootstrap_key, ivy_bootstrap_tools)
+
+    self._ivy_utils = IvyUtils(config=context.config,
+                               options=context.options,
+                               log=context.log)
+
+    # Typically this should be a local cache only, since classpaths aren't portable.
+    self.setup_artifact_cache_from_config(config_section='ivy-resolve')
+
+  def invalidate_for(self):
+    return self.context.options.ivy_resolve_overrides
+
+  def execute(self):
+    """Resolves the import_jars for any protobuf libraries in the context's targets."""
+    executor = self.create_java_executor()
+    targets = self.context.targets()
+
+    # Vastly simplified from ivy_resolve, due to very restricted use (protobuf headers, basically)
+    group_targets = set(filter(lambda t: t.has_label('has_imports'), targets))
+
+    # NOTE(pl): The symlinked ivy.xml (for IDEs, particularly IntelliJ) in the presence of multiple
+    # exclusives groups will end up as the last exclusives group run.  I'd like to deprecate this
+    # eventually, but some people rely on it, and it's not clear to me right now whether telling
+    # them to use IdeaGen instead is feasible.
+    classpath = self.ivy_resolve(group_targets,
+                                 executor=executor,
+                                 symlink_ivyxml=True,
+                                 workunit_name='ivy-resolve')
+
+    for conf in self._confs:
+      # It's important we add the full classpath as an (ordered) unit for code that is classpath
+      # order sensitive
+      classpath_entries = map(lambda entry: (conf, entry), classpath)
+
+    genmap = {}
+    for target in group_targets:
+      self._ivy_proto(target, executor=executor,
+                              workunit_factory=self.context.new_workunit)
+
+  def _ivy_proto(self, target, executor, workunit_factory):
+    """Resolves the import_jars in target."""
+    mapdir = get_archive_root()
+    safe_mkdir(mapdir, clean=False)
+    ivyargs = [
+      '-retrieve', '%s/[organisation]/[artifact]/jars/'
+                   '[artifact]-[revision].[ext]' % mapdir,
+      '-symlink',
+    ]
+
+    def exec_ivy(target_workdir,
+                 targets,
+                 args,
+                 confs=None,
+                 ivy=None,
+                 workunit_name='ivy',
+                 workunit_factory=None,
+                 symlink_ivyxml=False):
+      ivy = ivy or Bootstrapper.default_ivy()
+      if not isinstance(ivy, Ivy):
+        raise ValueError('The ivy argument supplied must be an Ivy instance, given %s of type %s'
+                         % (ivy, type(ivy)))
+
+      ivyxml = os.path.join(target_workdir, 'ivy.xml')
+      # Combine all targets' import_jars into one set
+      jars = reduce(lambda a,b: a^b, (t.import_jars(self.context) for t in targets), set())
+      excludes = set()
+
+      ivy_args = ['-ivy', ivyxml]
+
+      confs_to_resolve = confs or ['default']
+      ivy_args.append('-confs')
+      ivy_args.extend(confs_to_resolve)
+
+      ivy_args.extend(args)
+      ivy_args.append('-notransitive') # always intransitive
+      ivy_args.extend(self._ivy_utils._args)
+
+      def safe_link(src, dest):
+        if os.path.exists(dest):
+          os.unlink(dest)
+        os.symlink(src, dest)
+
+      with IvyUtils.ivy_lock:
+        self._ivy_utils._generate_ivy(targets, jars, excludes, ivyxml, confs_to_resolve)
+        runner = ivy.runner(jvm_options=self._ivy_utils._jvm_options, args=ivy_args)
+        try:
+          result = util.execute_runner(runner,
+                                       workunit_factory=workunit_factory,
+                                       workunit_name=workunit_name)
+
+          # Symlink to the current ivy.xml file (useful for IDEs that read it).
+          if symlink_ivyxml:
+            ivyxml_symlink = os.path.join(self._ivy_utils._workdir, 'ivy.xml')
+            safe_link(ivyxml, ivyxml_symlink)
+
+          if result != 0:
+            raise TaskError('Ivy returned %d' % result)
+        except runner.executor.Error as e:
+          raise TaskError(e)
+
+    exec_ivy(mapdir,
+             [target],
+             ivyargs,
+             confs=target.payload.configurations,
+             ivy=Bootstrapper.default_ivy(executor),
+             workunit_factory=workunit_factory,
+             workunit_name='map-import-jars')
+
+
+  def check_artifact_cache_for(self, invalidation_check):
+    # Ivy resolution is an output dependent on the entire target set, and is not divisible by
+    # target. So we can only cache it keyed by the entire target set.
+    global_vts = VersionedTargetSet.from_versioned_targets(invalidation_check.all_vts)
+    return [global_vts]

--- a/src/python/pants/fs/source_util.py
+++ b/src/python/pants/fs/source_util.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from collections import defaultdict
+import os
+import re
+import shutil
+
+from twitter.common import log
+from twitter.common.collections import OrderedSet
+from twitter.common.contextutil import open_tar
+from twitter.common.contextutil import open_zip
+from twitter.common.contextutil import temporary_dir
+from twitter.common.contextutil import temporary_file_path
+from twitter.common.dirutil import safe_rmtree
+from twitter.common.dirutil.fileset import Fileset
+from twitter.common.lang import Compatibility
+
+from pants.base.address import parse_spec
+from pants.base.build_environment import get_buildroot
+from pants.base.build_manual import manual
+from pants.fs.archive import archiver
+
+
+def get_archive_root():
+  """Gets the directory which JarFileset expects ivy to stick imports jars in."""
+  return os.path.join(get_buildroot(), '.pants.d', 'archives', 'jars')
+
+
+@manual.builddict(tags=["java"])
+def jar_sources(*jar_deps):
+  """Creates JarFilesets for use in protobuf imports.
+
+  :param jar_deps: varargs list of jar() objects and/or strings storing spec-paths to jar_library
+    targets containing jar() objects (for use with the 3rdparty pattern).
+  :returns: a callable which takes in a Context and a BuildFile and returns a list of (JarFileset,
+    JarDependency) tuples for each JarDependency input argument.
+  """
+  def expand_jar_dep(context, build_file, jar_dep):
+    # isinstance is ugly in general, but this is the way build_file_parser.py does it so it seems
+    # reasonable to do the same.
+    if isinstance(jar_dep, Compatibility.string):
+      # Need to grab JarLibrary
+      try:
+        for library in context.resolve(':'.join(parse_spec(jar_dep, relative_to=build_file.spec_path))):
+          for jar in library.jar_dependencies:
+            yield jar
+      except Exception as e:
+        raise JarSourcesError('Failed to expand jar_library spec "{spec}": {error}'
+                              .format(spec=jar_dep, error=str(e)))
+      return
+    yield jar_dep
+
+  def resolve_jar_pairs(context, build_file):
+    real_deps = []
+    for jar_dep in jar_deps:
+      real_deps.extend(expand_jar_dep(context, build_file, jar_dep))
+    return [(JarFileset(jar_dep), jar_dep) for jar_dep in real_deps]
+
+  return resolve_jar_pairs
+
+
+class JarSourcesError(Exception):
+  """Error which is raised if there is a problem fetching the jarred protos."""
+
+
+class JarFileset(Fileset):
+  """Takes in a JarDependency and returns a fileset which iterates over its contents."""
+
+  def __init__(self, jar_dep):
+    super(JarFileset, self).__init__(self._expand_directory)
+    self._jar = jar_dep
+    self._dir = os.path.join('.pants.d', 'extracted', jar_dep.org, jar_dep.name, jar_dep.rev)
+    # Probably not the best way to do this. See also ivy_imports.py.
+    self._jar_path = os.path.join(get_archive_root(), jar_dep.org, jar_dep.name, 'jars',
+                                  jar_dep.name + '-' + jar_dep.rev + '.jar')
+    self._jar_path = os.path.relpath(self._jar_path, get_buildroot())
+    if not os.path.exists(self._jar_path):
+      # If the jar doesn't exist, ivy hasn't gotten it yet, so we shouldn't have a folder for
+      # extracted files yet. Which means this is leftover from a past run, so nuke it.
+      safe_rmtree(self._dir)
+
+  def _expand_directory(self):
+    if not os.path.exists(self._dir):
+      if not os.path.exists(self._jar_path):
+        raise JarSourcesError('Never got the jar file from ivy! ({jar})'.format(jar=self._jar_path))
+      archiver('zip').extract(self._jar_path, self._dir)
+    return [self._dir]

--- a/tests/java/com/pants/examples/useproto/BUILD
+++ b/tests/java/com/pants/examples/useproto/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Tests functionality of protoc generating java code.
+
+junit_tests(name='useproto',
+  sources=['UseProtoTest.java',],
+  dependencies=[
+    pants('3rdparty:junit'),
+    pants('src/java/com/pants/examples/protobuf'),
+  ],
+)

--- a/tests/java/com/pants/examples/useproto/UseProtoTest.java
+++ b/tests/java/com/pants/examples/useproto/UseProtoTest.java
@@ -1,0 +1,21 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+// Illustrate using Proto-generated code from Java.
+
+package com.pants.examples.useproto;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.pants.examples.distance.Distances;
+
+public class UseProtoTest {
+  @Test
+  public void checkDistanceExistence() {
+    String value = Distances.Distance.newBuilder().setNumber(12).setUnit("parsecs").build()
+        .toString();
+    Assert.assertTrue("Distances string value (" + value + ")", value.contains("12"));
+  }
+}
+

--- a/tests/java/com/pants/examples/useprotoimports/BUILD
+++ b/tests/java/com/pants/examples/useprotoimports/BUILD
@@ -1,0 +1,14 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Tests functionality of protoc generating java code, using 'imports' parameter.
+
+junit_tests(name='useprotoimports',
+  sources=['UseImportsTest.java',],
+  dependencies=[
+    pants('3rdparty:junit'),
+    pants('src/java/com/pants/examples/protobuf:protobuf-imports'),
+  ],
+)
+
+

--- a/tests/java/com/pants/examples/useprotoimports/UseImportsTest.java
+++ b/tests/java/com/pants/examples/useprotoimports/UseImportsTest.java
@@ -1,0 +1,21 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+// Illustrate using Proto-generated code from Java.
+
+package com.pants.examples.useprotoimports;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.pants.examples.imports.TestImports;
+
+public class UseImportsTest {
+  @Test
+  public void checkDistanceExistence() {
+    String value = TestImports.TestImport.newBuilder().setTestNum(19).setTestStr("legions").build()
+        .toString();
+    Assert.assertTrue("TestImports string value (" + value + ")", value.contains("legions"));
+  }
+}
+


### PR DESCRIPTION
...path when compiling with protoc.

This is done by way of a new 'imports' parameter added to the java_protobuf_library target, which accepts jar dependencies as inputs. The syntax for this is:

java_protobuf_library(name='foo',
  imports=jar_sources(jar(org='foo.com', name='bar', rev='1.2.3'), jar(org='bar.com', name='foo', rev='3.2.1')),
  ...,
)

An extra ivy step called 'ivy-imports' (rather than ivy-resolve) has been added to accomodate this. It occurs after bootstrap and before codegen.

Note: Not ready for full rbcommons review yet. Still need to test properly (with actual jars of .protos on the nexus somewhere), and there's probably ways (I hope) that ivy_imports can be cleaned up.
