### PR TITLE
Fixes the bug where pants doesn't recognize build targets on top-level d...

### DIFF
--- a/tests/python/pants_test/commands/BUILD
+++ b/tests/python/pants_test/commands/BUILD
@@ -20,7 +20,9 @@ python_tests(
   name = 'test_goal',
   sources = [ 'test_goal.py' ],
   dependencies = [
+    pants('src/python/pants/backend/jvm:plugin'),
     pants('src/python/pants/commands:goal'),
+    pants('src/python/pants/goal:phase'),
     pants('tests/python/pants_test:base_test'),
   ]
 )

--- a/tests/python/pants_test/commands/test_goal.py
+++ b/tests/python/pants_test/commands/test_goal.py
@@ -7,41 +7,82 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import unittest
 
+from pants.backend.jvm.register import register_goals
 from pants.commands.goal import Goal, GoalError
+from pants.goal import GoalError
+from pants.goal.phase import Phase
+from pants_test.base_test import BaseTest
 
 
-class GoalTest(unittest.TestCase):
+class GoalTest(BaseTest):
+
+  def setUp(self):
+    super(GoalTest, self).setUp()
+    # Have to load in goals, because parse_args requires Phase.all() now.
+    # Fortunately, we only have to load in the goals we're actually using below, so the goals in the
+    # core register are sufficient.
+    register_goals()
+
+  def tearDown(self):
+    super(GoalTest, self).tearDown()
+    Phase.clear()
+
+  def assert_result(self, goals, specs, args):
+    g, s = Goal.parse_args(args)
+    self.assertEquals((goals, specs), (list(g), list(s)))
+
+  def test_top_level_dir(self):
+    self.create_dir('topleveldir')
+    self.create_file('topleveldir/BUILD', contents='')
+    self.assert_result(goals=[], specs=['topleveldir'], args=['topleveldir'])
+
+  def test_arg_ambiguity(self):
+    self.create_dir('compile')
+    self.create_file('compile/BUILD', contents='')
+    self.assert_result(goals=['compile'], specs=[], args=['compile'])
+    # Only end up with one 'compile' here, because goals and specs are sets.
+    self.assert_result(goals=['compile'], specs=[], args=['compile', 'compile'])
+    self.assert_result(goals=['compile'], specs=['compile'], args=['compile', '--', 'compile'])
+
+    try:
+      self.assert_result(goals=['compile'], specs=[], args=['compile', 'spec:', '--', 'compile'])
+      self.fail('Expected mixed specs and goals to the left of an explicit multi-goal sep (--) to '
+                'be rejected.')
+    except Goal.IntermixedArgumentsError:
+      pass # expected
+
+    self.assert_result(goals=['bundle', 'compile'], specs=['run'],
+                       args=['bundle', 'compile', '--', 'run'])
+
   def test_parse_args(self):
-    def assert_result(goals, specs, args):
-      g, s = Goal.parse_args(args)
-      self.assertEquals((goals, specs), (list(g), list(s)))
+    self.assert_result(goals=[], specs=[], args=[])
+    self.assert_result(goals=[], specs=[], args=['--'])
+    self.assert_result(goals=[], specs=[], args=['-v', '--help'])
 
-    assert_result(goals=[], specs=[], args=[])
-    assert_result(goals=[], specs=[], args=['--'])
-    assert_result(goals=[], specs=[], args=['-v', '--help'])
+    self.assert_result(goals=['compile'], specs=[], args=['compile', '--log'])
+    self.assert_result(goals=['compile', 'test'], specs=[], args=['compile', 'test'])
+    self.assert_result(goals=['compile', 'test'], specs=[], args=['compile', '-v', 'test'])
 
-    assert_result(goals=['compile'], specs=[], args=['compile', '--log'])
-    assert_result(goals=['compile', 'test'], specs=[], args=['compile', 'test'])
-    assert_result(goals=['compile', 'test'], specs=[], args=['compile', '-v', 'test'])
-
-    assert_result(goals=[], specs=['resolve'], args=['--', 'resolve', '--ivy-open'])
-    assert_result(goals=['test'], specs=['resolve'], args=['test', '--', 'resolve', '--ivy-open'])
+    self.assert_result(goals=[], specs=['resolve'], args=['--', 'resolve', '--ivy-open'])
+    self.assert_result(goals=['test'], specs=['resolve'], args=['test', '--', 'resolve',
+                                                                '--ivy-open'])
 
     try:
       Goal.parse_args(['test', 'lib:all', '--', 'resolve'])
       self.fail('Expected mixed specs and goals to the left of an explicit '
                 'multi-goal sep (--) to be rejected.')
-    except GoalError:
+    except Goal.IntermixedArgumentsError:
       pass # expected
 
     try:
       Goal.parse_args(['resolve', 'lib/all', 'test', '--'])
       self.fail('Expected mixed specs and goals to the left of an explicit '
                 'multi-goal sep (--) to be rejected.')
-    except GoalError:
+    except Goal.IntermixedArgumentsError:
       pass # expected
 
-    assert_result(goals=['test'], specs=['lib:all'], args=['lib:all', '-v', 'test'])
-    assert_result(goals=['test'], specs=['lib/'], args=['-v', 'test', 'lib/'])
-    assert_result(goals=['test'], specs=['lib/io:sound'], args=['test', '-v', 'lib/io:sound'])
-    assert_result(goals=['test'], specs=['lib:all'], args=['-h', 'test', '-v', 'lib:all', '-x'])
+    self.assert_result(goals=['test'], specs=['lib:all'], args=['lib:all', '-v', 'test'])
+    self.assert_result(goals=['test'], specs=['lib/'], args=['-v', 'test', 'lib/'])
+    self.assert_result(goals=['test'], specs=['lib/io:sound'], args=['test', '-v', 'lib/io:sound'])
+    self.assert_result(goals=['test'], specs=['lib:all'], args=['-h', 'test', '-v', 'lib:all',
+                                                                '-x'])


### PR DESCRIPTION
...irectories.

The previous argument parser naively simply checked whether a command-line argument contained a slash (/) or a colon (:). This is a reasonable assumption most of the time, but in the case where a BUILD file is located only one directory deep, (eg, buildroot/folder/BUILD), this makes it impossible to run pants on the target simply by calling (eg) ./pants goal bundle folder.

See github issue for example: https://github.com/pantsbuild/pants/pull/159

This fixes it by actually checking to see if a phase with goals is defined by the command-line argument, and whether a BUILD file associated with the spec actually exists. It still checks before that whether the argument contains a slash or a colon, because that if an argument has those characters it can't mean a goal. But an argument not having those characters doesn't mean it is a goal.
