### PR TITLE
Divorce 'binary' and 'bundle' goals from the 'jar' goal.

### DIFF
--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -167,10 +167,10 @@ def register_goals():
   goal(name='jar', action=JarCreate, dependencies=['compile', 'resources', 'bootstrap']
   ).install('jar')
 
-  goal(name='binary', action=BinaryCreate, dependencies=['jar', 'bootstrap']
+  goal(name='binary', action=BinaryCreate, dependencies=['compile', 'resources', 'bootstrap']
   ).install().with_description('Create a jvm binary jar.')
 
-  goal(name='bundle', action=BundleCreate, dependencies=['jar', 'bootstrap']
+  goal(name='bundle', action=BundleCreate, dependencies=['compile', 'resources', 'bootstrap']
   ).install().with_description('Create an application bundle from binary targets.')
 
   goal(name='check_published_deps', action=CheckPublishedDeps


### PR DESCRIPTION
Save effort and time by extracting classfile jar creation
logic to JarTask and using this in JarCreate and JvmBinaryTask
to create classfile jars directly.  Previously BinaryCreate and
BundleCreate re-packed jars containing internal classes created
by the JarCreate Task.  Now time is saved by not creating these
middle-man jars at all.

https://rbcommons.com/s/twitter/r/514/
