### PR TITLE
Fixup ExampleProcessor to output its resource to the current compile cla...

### DIFF
--- a/src/java/com/pants/examples/annotation/processor/ExampleProcessor.java
+++ b/src/java/com/pants/examples/annotation/processor/ExampleProcessor.java
@@ -3,6 +3,7 @@
 
 package com.pants.examples.annotation.processor;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closer;
 import com.pants.examples.annotation.example.Example;
 import java.io.File;
@@ -22,23 +23,29 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
 
 /**
  * A sample implementation of an annotation processor which looks for the @Example annotation on
  * class and prints out a list of all such classes to a file named <code>examples.txt</code>.
  */
 public class ExampleProcessor extends AbstractProcessor {
-  private final static String EXAMPLES_FILE_NAME = "examples.txt";
+  private static final String EXAMPLES_FILE_NAME = "examples.txt";
+
   private ProcessingEnvironment processingEnvironment = null;
 
+  @Override public void init(ProcessingEnvironment processingEnvironment) {
+    this.processingEnvironment = processingEnvironment;
+  }
+
   @Override public Set<String> getSupportedAnnotationTypes() {
-    Set<String> result = new LinkedHashSet<String>();
-    result.add(Example.class.getCanonicalName());
-    return result;
+    return ImmutableSet.of(Example.class.getCanonicalName());
   }
 
   @Override public SourceVersion getSupportedSourceVersion() {
-    return SourceVersion.RELEASE_6;
+    return SourceVersion.latest();
   }
 
   @Override public boolean process(Set<? extends TypeElement> annotations,
@@ -47,42 +54,65 @@ public class ExampleProcessor extends AbstractProcessor {
       return false;
     }
 
-    File outputFile = new File(EXAMPLES_FILE_NAME);
-    Closer closer = Closer.create();
-
-    try {
-      PrintWriter writer = closer.register(new PrintWriter(new FileWriter(outputFile)));
-      writer.println("{");
-      for (TypeElement appAnnotation : annotations) {
-        Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(appAnnotation);
-        Set<TypeElement> exampleElements = ElementFilter.typesIn(annotatedElements);
-        for (Element elem : exampleElements) {
-          String typeName = elem.getSimpleName().toString();
-          for (AnnotationMirror mirror : elem.getAnnotationMirrors()) {
-            String n =
-                ((TypeElement) mirror.getAnnotationType().asElement()).getQualifiedName()
-                    .toString();
-            if (Example.class.getCanonicalName().equals(n)) {
-              Map<? extends ExecutableElement, ? extends AnnotationValue> values =
-                  mirror.getElementValues();
-              for (ExecutableElement key : values.keySet()) {
-                if ("value".equals(key.getSimpleName().toString())) {
-                  String exampleValue = (String) values.get(key).getValue();
-                  if (exampleValue != null) {
-                    writer.println(
-                        "  {'type' : '" + typeName + "', 'value': '" + exampleValue + "'},");
+    FileObject outputFile = createResource("" /* no package */, EXAMPLES_FILE_NAME);
+    if (outputFile != null) {
+      Closer closer = Closer.create();
+      try {
+        PrintWriter writer = closer.register(new PrintWriter(outputFile.openWriter()));
+        writer.println("{");
+        for (TypeElement appAnnotation : annotations) {
+          Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(appAnnotation);
+          Set<TypeElement> exampleElements = ElementFilter.typesIn(annotatedElements);
+          for (Element elem : exampleElements) {
+            String typeName = elem.getSimpleName().toString();
+            for (AnnotationMirror mirror : elem.getAnnotationMirrors()) {
+              String n =
+                  ((TypeElement) mirror.getAnnotationType().asElement()).getQualifiedName()
+                      .toString();
+              if (Example.class.getCanonicalName().equals(n)) {
+                Map<? extends ExecutableElement, ? extends AnnotationValue> values =
+                    mirror.getElementValues();
+                for (ExecutableElement key : values.keySet()) {
+                  if ("value".equals(key.getSimpleName().toString())) {
+                    String exampleValue = (String) values.get(key).getValue();
+                    if (exampleValue != null) {
+                      writer.println(
+                          "  {'type' : '" + typeName + "', 'value': '" + exampleValue + "'},");
+                    }
                   }
                 }
               }
             }
           }
+          writer.println("}\n");
         }
-        writer.println("}\n");
+        closer.close();
+        log(Diagnostic.Kind.NOTE, "Generated resource '%s'", outputFile.toUri());
+      } catch (IOException e) {
+        error("Couldn't write to '%s': %s", outputFile.toUri(), e);
       }
-      closer.close();
-    } catch (IOException e) {
-      System.err.println("*** Couldn't write to " + outputFile.getAbsolutePath() + " " + e);
     }
     return true;
+  }
+
+  private FileObject createResource(String packageName, String fileName) {
+    try {
+      return processingEnvironment.getFiler().createResource(
+          StandardLocation.CLASS_OUTPUT,
+          packageName,
+          fileName);
+    } catch (IOException e) {
+      error("Failed to create resource for package: '%s' with name: '%s': %s", packageName,
+          fileName, e);
+      return null;
+    }
+  }
+
+  private void error(String message, Object... args) {
+    log(Diagnostic.Kind.ERROR, message, args);
+  }
+
+  private void log(Diagnostic.Kind category, String message, Object... args) {
+    processingEnvironment.getMessager().printMessage(category, String.format(message, args));
   }
 }


### PR DESCRIPTION
...ss output dir.

This alleviates the untracked examples.txt left loose in the repo root after compiling
the example and its also more in line with how a typical resource generating apt
processor would locate its output.

https://rbcommons.com/s/twitter/r/535/
