### PR TITLE
Add missing python backend plugin dep on the old py commands.

### DIFF
--- a/src/python/pants/backend/core/tasks/filemap.py
+++ b/src/python/pants/backend/core/tasks/filemap.py
@@ -22,7 +22,7 @@ class Filemap(ConsoleTask):
           for sourcefile in target.payload.sources:
             path = os.path.normpath(os.path.join(target.payload.sources_rel_path,
                                                  sourcefile))
-            yield '%s %s' % (path, target.address.build_file_spec)
+            yield '%s %s' % (path, target.address.spec)
 
   def _find_targets(self):
     if len(self.context.target_roots) > 0:

--- a/src/python/pants/backend/core/tasks/listtargets.py
+++ b/src/python/pants/backend/core/tasks/listtargets.py
@@ -56,7 +56,7 @@ class ListTargets(ConsoleTask):
         return '%s%s%s' % (provided_jar.org, '#', provided_jar.name)
 
       extractors = dict(
-          address=lambda target: target.address.build_file_spec,
+          address=lambda target: target.address.spec,
           artifact_id=extract_artifact_id,
           repo_name=lambda target: target.provides.repo.name,
           repo_url=lambda target: target.provides.repo.url,
@@ -81,7 +81,7 @@ class ListTargets(ConsoleTask):
                                '\n  '.join(target.description.strip().split('\n')))
       print_fn = print_documented
     else:
-      print_fn = lambda target: target.address.build_file_spec
+      print_fn = lambda target: target.address.spec
 
     visited = set()
     for target in self._targets():

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -5,6 +5,7 @@ python_library(
   name = 'plugin',
   sources = ['__init__.py', 'register.py'],
   dependencies = [
+    pants('src/python/pants/backend/python/commands:pants_old'),
     pants('src/python/pants/backend/python/targets:python'),
     pants('src/python/pants/backend/python/tasks:python'),
     pants(':all_utils'),

--- a/tests/python/pants_test/tasks/test_filemap.py
+++ b/tests/python/pants_test/tasks/test_filemap.py
@@ -52,22 +52,22 @@ class FilemapTest(ConsoleTaskTest):
 
   def test_all(self):
     self.assert_console_output(
-      'common/a/one.py common/a/BUILD:a',
-      'common/b/two.py common/b/BUILD:b',
-      'common/b/three.py common/b/BUILD:b',
-      'common/c/four.py common/c/BUILD:c',
+      'common/a/one.py common/a:a',
+      'common/b/two.py common/b:b',
+      'common/b/three.py common/b:b',
+      'common/c/four.py common/c:c',
     )
 
   def test_one(self):
     self.assert_console_output(
-      'common/b/two.py common/b/BUILD:b',
-      'common/b/three.py common/b/BUILD:b',
+      'common/b/two.py common/b:b',
+      'common/b/three.py common/b:b',
       targets=[self.target('common/b')]
     )
 
   def test_dup(self):
     self.assert_console_output(
-      'common/a/one.py common/a/BUILD:a',
-      'common/c/four.py common/c/BUILD:c',
+      'common/a/one.py common/a:a',
+      'common/c/four.py common/c:c',
       targets=[self.target('common/a'), self.target('common/c'), self.target('common/a')]
     )

--- a/tests/python/pants_test/tasks/test_listtargets.py
+++ b/tests/python/pants_test/tasks/test_listtargets.py
@@ -84,8 +84,8 @@ class ListTargetsTest(BaseListTargetsTest):
         dependencies(
           name='alias',
           dependencies=[
-            pants('a/b/c/BUILD:c3'),
-            pants('a/b/d/BUILD:d')
+            pants('a/b/c:c3'),
+            pants('a/b/d:d')
           ]
         ).with_description("""
         Exercises alias resolution.
@@ -94,71 +94,71 @@ class ListTargetsTest(BaseListTargetsTest):
         '''))
 
   def test_list_path(self):
-    self.assert_console_output('a/b/BUILD:b', targets=[self.target('a/b')])
+    self.assert_console_output('a/b:b', targets=[self.target('a/b')])
 
   def test_list_siblings(self):
-    self.assert_console_output('a/b/BUILD:b', targets=self.targets('a/b:'))
-    self.assert_console_output('a/b/c/BUILD:c', 'a/b/c/BUILD:c2', 'a/b/c/BUILD:c3',
+    self.assert_console_output('a/b:b', targets=self.targets('a/b:'))
+    self.assert_console_output('a/b/c:c', 'a/b/c:c2', 'a/b/c:c3',
                                targets=self.targets('a/b/c/:'))
 
   def test_list_descendants(self):
-    self.assert_console_output('a/b/c/BUILD:c', 'a/b/c/BUILD:c2', 'a/b/c/BUILD:c3',
+    self.assert_console_output('a/b/c:c', 'a/b/c:c2', 'a/b/c:c3',
                                targets=self.targets('a/b/c/::'))
 
     self.assert_console_output(
-        'a/b/BUILD:b',
-        'a/b/c/BUILD:c',
-        'a/b/c/BUILD:c2',
-        'a/b/c/BUILD:c3',
-        'a/b/d/BUILD:d',
-        'a/b/e/BUILD:e1',
+        'a/b:b',
+        'a/b/c:c',
+        'a/b/c:c2',
+        'a/b/c:c3',
+        'a/b/d:d',
+        'a/b/e:e1',
         targets=self.targets('a/b::'))
 
   def test_list_all(self):
     self.assert_entries('\n',
-        'repos/BUILD:public',
-        'a/BUILD:a',
-        'a/b/BUILD:b',
-        'a/b/c/BUILD:c',
-        'a/b/c/BUILD:c2',
-        'a/b/c/BUILD:c3',
-        'a/b/d/BUILD:d',
-        'a/b/e/BUILD:e1',
-        'f/BUILD:alias')
+        'repos:public',
+        'a:a',
+        'a/b:b',
+        'a/b/c:c',
+        'a/b/c:c2',
+        'a/b/c:c3',
+        'a/b/d:d',
+        'a/b/e:e1',
+        'f:alias')
 
     self.assert_entries(', ',
-        'repos/BUILD:public',
-        'a/BUILD:a',
-        'a/b/BUILD:b',
-        'a/b/c/BUILD:c',
-        'a/b/c/BUILD:c2',
-        'a/b/c/BUILD:c3',
-        'a/b/d/BUILD:d',
-        'a/b/e/BUILD:e1',
-        'f/BUILD:alias',
+        'repos:public',
+        'a:a',
+        'a/b:b',
+        'a/b/c:c',
+        'a/b/c:c2',
+        'a/b/c:c3',
+        'a/b/d:d',
+        'a/b/e:e1',
+        'f:alias',
         args=['--test-sep=, '])
 
     self.assert_console_output(
-        'repos/BUILD:public',
-        'a/BUILD:a',
-        'a/b/BUILD:b',
-        'a/b/c/BUILD:c',
-        'a/b/c/BUILD:c2',
-        'a/b/c/BUILD:c3',
-        'a/b/d/BUILD:d',
-        'a/b/e/BUILD:e1',
-        'f/BUILD:alias')
+        'repos:public',
+        'a:a',
+        'a/b:b',
+        'a/b/c:c',
+        'a/b/c:c2',
+        'a/b/c:c3',
+        'a/b/d:d',
+        'a/b/e:e1',
+        'f:alias')
 
   def test_list_provides(self):
     self.assert_console_output(
-        'a/b/BUILD:b com.twitter#b',
-        'a/b/c/BUILD:c2 com.twitter#c2',
+        'a/b:b com.twitter#b',
+        'a/b/c:c2 com.twitter#c2',
         args=['--test-provides'])
 
   def test_list_provides_customcols(self):
     self.assert_console_output(
-        '/tmp/publish.properties a/b/BUILD:b http://maven.twttr.com public com.twitter#b',
-        '/tmp/publish.properties a/b/c/BUILD:c2 http://maven.twttr.com public com.twitter#c2',
+        '/tmp/publish.properties a/b:b http://maven.twttr.com public com.twitter#b',
+        '/tmp/publish.properties a/b/c:c2 http://maven.twttr.com public com.twitter#c2',
         args=[
             '--test-provides',
             '--test-provides-columns=repo_db,address,repo_url,repo_name,artifact_id'
@@ -168,10 +168,10 @@ class ListTargetsTest(BaseListTargetsTest):
     targets = []
     targets.extend(self.targets('a/b/d/::'))
     targets.extend(self.target('f:alias').dependencies)
-    self.assertEquals(3, len(targets), "Expected a duplicate of a/b/d/BUILD:d")
+    self.assertEquals(3, len(targets), "Expected a duplicate of a/b/d:d")
     self.assert_console_output(
-      'a/b/c/BUILD:c3',
-      'a/b/d/BUILD:d',
+      'a/b/c:c3',
+      'a/b/d:d',
       targets=targets
     )
 
@@ -184,7 +184,7 @@ class ListTargetsTest(BaseListTargetsTest):
 
     self.assert_console_output(
       dedent('''
-      f/BUILD:alias
+      f:alias
         Exercises alias resolution.
         Further description.
       ''').strip(),


### PR DESCRIPTION
Fixup listtargets test - use uniform address.spec.

Also do the same for filemap as a cleanup sweep on
https://rbcommons.com/s/twitter/r/537/

https://rbcommons.com/s/twitter/r/540/
