### PR TITLE
Added support for multiple pants_support_baseurls.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -9,7 +9,9 @@
 
 [DEFAULT]
 # TODO(John Sirois): Come up with a better public solution.
-pants_support_baseurl: https://pantsbuild.github.io/binaries/build-support
+pants_support_baseurls = [
+    'https://pantsbuild.github.io/binaries/build-support',
+  ]
 pants_support_fetch_timeout_secs: 30
 
 max_subprocess_args: 100

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -42,6 +42,7 @@ python_library(
   name = 'binary_util',
   sources = ['binary_util.py'],
   dependencies = [
+    pants('3rdparty/python/twitter/commons:twitter.common.collections'),
     pants('3rdparty/python/twitter/commons:twitter.common.contextutil'),
     pants('3rdparty/python/twitter/commons:twitter.common.dirutil'),
     pants('3rdparty/python/twitter/commons:twitter.common.lang'),

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -30,6 +30,16 @@ python_library(
 )
 
 python_tests(
+  name = 'test_binary_util',
+  sources = ['test_binary_util.py',],
+  dependencies = [
+    pants(':base_test'),
+    pants('src/python/pants:binary_util'),
+    pants('src/python/pants/base:exceptions')
+  ]
+)
+
+python_tests(
   name = 'test_maven_layout',
   sources = ['test_maven_layout.py'],
   dependencies = [
@@ -73,6 +83,7 @@ dependencies(
 python_test_suite(
   name = 'all',
   dependencies = [
+    pants(':test_binary_util'),
     pants(':test_maven_layout'),
     pants(':test_thrift_util'),
     pants(':test_utf8_header'),

--- a/tests/python/pants_test/test_binary_util.py
+++ b/tests/python/pants_test/test_binary_util.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+import os
+
+from pants.base.config import Config
+from pants.binary_util import BinaryUtil, select_binary_stream, select_binary_base_path
+from pants_test.base_test import BaseTest
+
+
+class BinaryUtilTest(BaseTest):
+  """Tests binary_util's pants_support_baseurls handling."""
+
+  class LambdaReader(object):
+    """Class which pretends to be an input stream, but is actually a lambda function."""
+    def __init__(self, func):
+      self._func = func
+
+    def __call__(self):
+      return self._func()
+
+    def read(self):
+      return self()
+
+    def __enter__(self, a=None, b=None, c=None, d=None):
+      return self
+
+    def __exit__(self, a=None, b=None, c=None, d=None):
+      pass
+
+  class MapReader(object):
+    """Class which pretends to be a url stream opener, but is actually a dictionary."""
+    def __init__(self, read_map):
+      self._map = read_map
+
+    def __call__(self, key):
+      if not key in self._map:
+        raise IOError("404: Virtual URL '{key}' does not exist.".format(key=key))
+      value = self._map[key]
+      return BinaryUtilTest.LambdaReader(lambda: value)
+
+    def keys(self):
+      return self._map.keys()
+
+    def values(self):
+      return self._map.values()
+
+    def __getitem__(self, key):
+      return self._map[key] # Vanilla internal map access (without lambda shenanigans).
+
+  def setUp(self):
+    super(BinaryUtilTest, self).setUp()
+
+  def config_urls(self, urls=None, legacy=None):
+    """Generates the contents of a configuration file."""
+    def clean_config(txt):
+      return '\n'.join((line.strip() for line in txt.split('\n')))
+
+    if legacy:
+      legacy = '\npants_support_baseurl: {url}'.format(url=legacy)
+    else:
+      legacy = ''
+
+    if urls:
+      urls = '\npants_support_baseurls = {urls}'.format(urls=urls)
+    else:
+      urls = ''
+
+    return self.config(overrides=clean_config('[DEFAULT]{urls}{legacy}'.format(urls=urls,
+                                                                                legacy=legacy)))
+
+  @classmethod
+  def _fake_base(cls, name):
+    return 'fake-url-{name}'.format(name=name)
+
+  @classmethod
+  def _fake_url(cls, binaries, base, binary_key):
+    base_path, version, name = binaries[binary_key]
+    return '{base}/{binary}'.format(base=base,
+                                    binary=select_binary_base_path(base_path, version, name))
+
+  def _seens_test(self, binaries, bases, reader, config=None):
+    unseen = [item for item in reader.values() if item.startswith('SEEN ')]
+    if not config:
+      config = self.config_urls(bases)
+    for key in binaries:
+      base_path, version, name = binaries[key]
+      with select_binary_stream(base_path,
+                                version,
+                                name,
+                                config=config,
+                                url_opener=reader) as stream:
+        self.assertEqual(stream(), 'SEEN ' + key.upper())
+        unseen.remove(stream())
+    self.assertEqual(0, len(unseen)) # Make sure we've seen all the SEENs.
+
+  def test_nobases(self):
+    """Tests exception handling if build support urls are improperly specified."""
+    try:
+      with select_binary_stream('bin/foo', '4.4.3', 'foo', self.config_urls()) as stream:
+        self.fail('We should have gotten a "NoBaseUrlsError".')
+    except BinaryUtil.NoBaseUrlsError as e:
+      pass # expected
+
+  def test_support_url_multi(self):
+    """Tests to make sure existing base urls function as expected."""
+    config = self.config_urls([
+      'BLATANTLY INVALID URL',
+      'https://pantsbuild.github.io/binaries/reasonably-invalid-url',
+      'https://pantsbuild.github.io/binaries/build-support',
+      'https://pantsbuild.github.io/binaries/build-support', # Test duplicate entry handling.
+      'https://pantsbuild.github.io/binaries/another-invalid-url',
+    ])
+    binaries = [
+      ('bin/protobuf', '2.4.1', 'protoc',),
+    ]
+    for base_path, version, name in binaries:
+      one = 0
+      with select_binary_stream(base_path, version, name, config=config) as stream:
+        stream()
+        one += 1
+      self.assertEqual(one, 1)
+
+  def test_support_url_fallback(self):
+    """Tests fallback behavior with multiple support baseurls."""
+    fake_base, fake_url = self._fake_base, self._fake_url
+    binaries = {
+      'protoc': ('bin/protobuf', '2.4.1', 'protoc',),
+      'ivy': ('bin/ivy', '4.3.7', 'ivy',),
+      'bash': ('bin/bash', '4.4.3', 'bash',),
+    }
+    bases = [fake_base('apple'), fake_base('orange'), fake_base('banana'),]
+    reader = self.MapReader({
+      fake_url(binaries, bases[0], 'protoc'): 'SEEN PROTOC',
+      fake_url(binaries, bases[0], 'ivy'): 'SEEN IVY',
+      fake_url(binaries, bases[1], 'bash'): 'SEEN BASH',
+      fake_url(binaries, bases[1], 'protoc'): 'UNSEEN PROTOC 1',
+      fake_url(binaries, bases[2], 'protoc'): 'UNSEEN PROTOC 2',
+      fake_url(binaries, bases[2], 'ivy'): 'UNSEEN IVY 2',
+    })
+    self._seens_test(binaries, bases, reader)


### PR DESCRIPTION
Changed pants_support_baseurl to a list. Pants now goes through each url in the list from first to last, downloading the first binary with a valid url (and then breaking). This way, pants users can set their own support repo online and add it to the beginning of the list, so that their repo will be queried before the default repo on pantsbuild.github.io.
