### PR TITLE
Kill support for legacy scrooge.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -97,11 +97,6 @@ jar_library(name = 'scrooge-gen',
               jar(org='com.twitter', name='scrooge-generator_2.9.2', rev='3.12.1')
             ])
 
-jar_library(name = 'scrooge-legacy-gen',
-            jars = [
-              jar(org = 'com.twitter', name = 'scrooge', rev = '2.6.0-SNAPSHOT', type_='jar')
-            ])
-
 jar_library(name = 'jar-tool',
             jars = [
               jar(org = 'com.twitter.common', name = 'jar-tool', rev = '0.1.7')

--- a/pants.ini
+++ b/pants.ini
@@ -91,27 +91,6 @@ scala: {
   }
 
 
-[scrooge-legacy-gen]
-bootstrap-tools: ['//:scrooge-legacy-gen']
-supportdir: %(pants_supportdir)s/bin/scrooge-legacy
-strict: False
-verbose: True
-java: {
-    'gen': 'java',
-    'deps': {
-      'service': [],
-      'structs': []
-    }
-  }
-scala: {
-    'gen': 'scala',
-    'deps': {
-      'service': [],
-      'structs': []
-    }
-  }
-
-
 [thrift-gen]
 supportdir: bin/thrift
 strict: False

--- a/src/python/pants/backend/codegen/targets/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/java_thrift_library.py
@@ -5,16 +5,10 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from collections import Iterable
-from functools import partial
-
-from twitter.common.collections import maybe_list
-
+from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.build_manual import manual
 from pants.base.config import Config
 from pants.base.exceptions import TargetDefinitionException
-from pants.backend.jvm.targets.jar_dependency import JarDependency
-from pants.backend.jvm.targets.jvm_target import JvmTarget
 
 
 @manual.builddict(tags=['java'])
@@ -50,7 +44,7 @@ class JavaThriftLibrary(JvmTarget):
   # In general a plugin will contribute a target and a task, but in this case we have a shared
   # target that can be used by at least 2 tasks - ThriftGen and ScroogeGen.  This is likely not
   # uncommon (gcc & clang) so the arrangement needs to be cleaned up and supported well.
-  _COMPILERS = frozenset(['thrift', 'scrooge', 'scrooge-legacy'])
+  _COMPILERS = frozenset(['thrift', 'scrooge'])
   _LANGUAGES = frozenset(['java', 'scala'])
   _RPC_STYLES = frozenset(['sync', 'finagle', 'ostrich'])
 
@@ -62,7 +56,7 @@ class JavaThriftLibrary(JvmTarget):
                **kwargs):
     """
     :param string name: The name of this target, which combined with this
-      build file defines the target :class:`pants.base.address.Address`.
+      build file defines the target:class:`pants.base.address.Address`.
     :param sources: A list of filenames representing the source code
       this library is compiled from.
     :type sources: list of strings

--- a/src/python/pants/backend/codegen/tasks/scrooge_gen.py
+++ b/src/python/pants/backend/codegen/tasks/scrooge_gen.py
@@ -22,9 +22,7 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
-from pants.thrift_util import (
-    calculate_compile_sources,
-    calculate_compile_sources_HACK_FOR_SCROOGE_LEGACY)
+from pants.thrift_util import calculate_compile_sources
 
 
 CompilerConfig = namedtuple('CompilerConfig', ['name', 'config_section', 'profile',
@@ -54,6 +52,9 @@ class Compiler(namedtuple('CompilerConfigWithContext', ('context',) + CompilerCo
     return self.context.config.getbool(self.config_section, 'strict', default=False)
 
 
+# TODO(John Sirois): We used to support multiple incompatible scrooge compilers but no longer do.
+# As a result code in this file can be substantially simplified and made more direct.  Do so.
+# See: https://github.com/pantsbuild/pants/issues/288
 _COMPILERS = [
     CompilerConfig(name='scrooge',
                    config_section='scrooge-gen',
@@ -61,12 +62,6 @@ _COMPILERS = [
                    main='com.twitter.scrooge.Main',
                    calc_srcs=calculate_compile_sources,
                    langs=frozenset(['scala', 'java'])),
-    CompilerConfig(name='scrooge-legacy',
-                   config_section='scrooge-legacy-gen',
-                   profile='scrooge-legacy-gen',
-                   main='com.twitter.scrooge.Main',
-                   calc_srcs=calculate_compile_sources_HACK_FOR_SCROOGE_LEGACY,
-                   langs=frozenset(['scala']))
 ]
 
 _CONFIG_FOR_COMPILER = dict((compiler.name, compiler) for compiler in _COMPILERS)

--- a/src/python/pants/thrift_util.py
+++ b/src/python/pants/thrift_util.py
@@ -59,30 +59,6 @@ def find_root_thrifts(basedirs, sources, log=None):
   return root_sources
 
 
-def calculate_compile_sources_HACK_FOR_SCROOGE_LEGACY(targets, is_thrift_target):
-  """Calculates the set of thrift source files that need to be compiled
-  as well as their associated import/include directories.
-  It does not exclude sources that are included in other sources.
-
-  A tuple of (include dirs, thrift sources) is returned.
-
-  :targets: The targets to examine.
-  :is_thrift_target: A predicate to pick out thrift targets for consideration in the analysis.
-  """
-
-  dirs = set()
-  sources = set()
-
-  def collect_sources(target):
-    for source in target.sources:
-      dirs.add(os.path.normpath(os.path.join(target.target_base, os.path.dirname(source))))
-      sources.add(os.path.join(target.target_base, source))
-  for target in targets:
-    target.walk(collect_sources, predicate=is_thrift_target)
-
-  return dirs, sources
-
-
 def calculate_compile_sources(targets, is_thrift_target):
   """Calculates the set of thrift source files that need to be compiled.
   It does not exclude sources that are included in other sources.

--- a/tests/python/pants_test/targets/test_java_thrift_library.py
+++ b/tests/python/pants_test/targets/test_java_thrift_library.py
@@ -35,12 +35,6 @@ class JavaThriftLibraryDefaultsTest(BaseTest):
         )
 
         java_thrift_library(
-          name='compiler',
-          sources=[],
-          compiler='scrooge-legacy',
-        )
-
-        java_thrift_library(
           name='language',
           sources=[],
           language='scala',
@@ -59,7 +53,6 @@ class JavaThriftLibraryDefaultsTest(BaseTest):
         '''))
 
     self.target_default = self.target('thrift:default')
-    self.target_compiler = self.target('thrift:compiler')
     self.target_language = self.target('thrift:language')
     self.target_rpc_style = self.target('thrift:rpc_style')
     self.target_invalid = self.target('thrift:invalid')
@@ -94,6 +87,5 @@ class JavaThriftLibraryDefaultsTest(BaseTest):
 
   def test_explicit_values(self):
     defaults = self.create_defaults()
-    self.assertEqual('scrooge-legacy', defaults.get_compiler(self.target_compiler))
     self.assertEqual('scala', defaults.get_language(self.target_language))
     self.assertEqual('ostrich', defaults.get_rpc_style(self.target_rpc_style))


### PR DESCRIPTION
This change punts on cleaning up the ScroogeGen task
which now can be simplified a good deal.  The intent is
just to remove the possibility of folks binding to this capability
going forward.

https://rbcommons.com/s/twitter/r/603/
