### PR TITLE
Refactored binary_util methods to be wrapped inside BinaryUtil object.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -21,7 +21,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
-from pants.binary_util import select_binary
+from pants.binary_util import BinaryUtil
 
 
 class ProtobufGen(CodeGen):
@@ -46,11 +46,10 @@ class ProtobufGen(CodeGen):
       if self.context.products.isrequired(lang):
         self.gen_langs.add(lang)
 
-    self.protobuf_binary = select_binary(
+    self.protobuf_binary = BinaryUtil(config=context.config).select_binary(
       self.protoc_supportdir,
       self.protoc_version,
-      'protoc',
-      context.config
+      'protoc'
     )
 
   def resolve_deps(self, key):

--- a/src/python/pants/binary_util.py
+++ b/src/python/pants/binary_util.py
@@ -28,28 +28,10 @@ from pants.base.config import Config
 from pants.base.exceptions import TaskError
 
 
-# TODO(Garrett Malmquist): Refactor the methods inside this class into BinaryUtil with a convenience
-# factory classmethod which takes a Config. (see John's comment on rb 556).
-class BinaryUtil(object):
-  """Created to wrap custom exceptions."""
-
-  class MissingMachineInfo(TaskError):
-    """Indicates that pants was unable to map this machine's OS to a binary path prefix."""
-
-  class BinaryNotFound(TaskError):
-    def __init__(self, binary, accumulated_errors):
-      super(BinaryNotFound, self).__init__(
-          'Failed to fetch binary {binary} from any source: ({sources})'
-          .format(binary=binary, sources=', '.join(accumulated_errors)))
-
-  class NoBaseUrlsError(TaskError):
-    """Indicates that no urls were specified in pants.ini."""
-
 _ID_BY_OS = {
   'linux': lambda release, machine: ('linux', machine),
   'darwin': lambda release, machine: ('darwin', release.split('.')[0]),
 }
-
 
 _PATH_BY_ID = {
   ('linux', 'x86_64'):  ['linux', 'x86_64'],
@@ -63,82 +45,131 @@ _PATH_BY_ID = {
 }
 
 
-def select_binary_base_path(base_path, version, name):
-  """Base path used to select the binary file, exposed for associated unit tests."""
-  sysname, _, release, _, machine = os.uname()
-  os_id = _ID_BY_OS[sysname.lower()]
-  if os_id:
-    middle_path = _PATH_BY_ID[os_id(release, machine)]
-    if middle_path:
-      return os.path.join(base_path, *(middle_path + [version, name]))
-  raise BinaryUtil.MissingMachineInfo('No {binary} binary found for: {machine_info}'
-      .format(binary=name, machine_info=(sysname, release, machine)))
+class BinaryUtil(object):
+  """Wraps utility methods for finding binary executables."""
 
+  class MissingMachineInfo(TaskError):
+    """Indicates that pants was unable to map this machine's OS to a binary path prefix."""
 
-@contextmanager
-def select_binary_stream(base_path, version, name, config=None, url_opener=None):
-  """Select a binary matching the current os and architecture.
+  class BinaryNotFound(TaskError):
+    def __init__(self, binary, accumulated_errors):
+      super(BinaryNotFound, self).__init__(
+          'Failed to fetch binary {binary} from any source: ({sources})'
+          .format(binary=binary, sources=', '.join(accumulated_errors)))
 
-  :param url_opener: Optional argument used only for testing, to 'pretend' to open urls.
-  :returns: a 'stream' to download it from a support directory. The returned 'stream' is actually a
-    lambda function which returns the files binary contents.
-  :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no binary of the given version
-    and name could not be found.
-  """
-  config = config or Config.load()
-  baseurls = config.getdefault('pants_support_baseurls', type=list, default=[])
-  if not baseurls:
-    raise BinaryUtil.NoBaseUrlsError(
-        'No urls are defined under pants_support_baseurls in the DEFAULT section of pants.ini.')
-  timeout_secs = config.getdefault('pants_support_fetch_timeout_secs', type=int, default=30)
-  binary_path = select_binary_base_path(base_path, version, name)
-  if url_opener is None:
-    url_opener = lambda u: closing(urllib_request.urlopen(u, timeout=timeout_secs))
+  class NoBaseUrlsError(TaskError):
+    """Indicates that no urls were specified in pants.ini."""
 
-  downloaded_successfully = False
-  accumulated_errors = []
-  for baseurl in OrderedSet(baseurls): # Wrap in OrderedSet because duplicates are wasteful.
-    url = posixpath.join(baseurl, binary_path)
-    log.info('Attempting to fetch {name} binary from: {url} ...'.format(name=name, url=url))
-    try:
-      with url_opener(url) as binary:
-        log.info('Fetched {name} binary from: {url} .'.format(name=name, url=url))
-        downloaded_successfully = True
-        yield lambda: binary.read()
-        break
-    except (IOError, urllib_error.HTTPError, urllib_error.URLError, ValueError) as e:
-      accumulated_errors.append('Failed to fetch binary from {url}: {error}'
-                                .format(url=url, error=e))
-  if not downloaded_successfully:
-    raise BinaryUtil.BinaryNotFound((base_path, version, name), accumulated_errors)
+  def __init__(self, bootstrap_dir=None, baseurls=None, timeout=None, config=None,
+               binary_base_path_strategy=None):
+    """Creates a BinaryUtil with the given settings to define binary lookup behavior.
 
+    Relevant settings may either be specified in the arguments, or will be loaded from the given
+    config file.
+    :param bootstrap_dir: Directory search for binaries in, or download binaries to if needed.
+      Defaults to the value of 'pants_bootstrapdir' in config if unspecified.
+    :param baseurls: List of url prefixes which represent repositories of binaries. Defaults to the
+      value of 'pants_support_baseurls' in config if unspecified.
+    :param timeout: Timeout in seconds for url reads. Defaults to the value of
+      'pants_support_fetch_timeout_secs' in config if unspecified, or 30 seconds if that value isn't
+      found in config.
+    :param config: Config object to lookup parameters which are left unspecified as None. If config
+      is left unspecified, it defaults to pants.ini via Config.load().
+    :param binary_base_path_strategy: Optional function to override default select_binary_base_path
+      behavior. Takes in parameters (base_path, version, name) and returns a relative path to a
+      binary. This relative path is used both for appending to the baseurl to determine the full url
+      to the binary, and as the path to the subfolder the binary is stored in under the bootstrap_dir.
+    """
+    if bootstrap_dir is None or baseurls is None or timeout is None:
+      config = config or Config.load()
+    if bootstrap_dir is None:
+      bootstrap_dir = config.getdefault('pants_bootstrapdir')
+    if baseurls is None:
+      baseurls = config.getdefault('pants_support_baseurls', type=list, default=[])
+    if timeout is None:
+      timeout = config.getdefault('pants_support_fetch_timeout_secs', type=int, default=30)
+    bootstrap_dir = os.path.realpath(os.path.expanduser(bootstrap_dir))
 
-def select_binary(base_path, version, name, config=None):
-  """Selects a binary matching the current os and architecture.
+    self._boostrap_dir = bootstrap_dir
+    self._timeout = timeout
+    self._baseurls = baseurls
+    self._binary_base_path_strategy = binary_base_path_strategy
 
-  :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no binary of the given version
-    and name could be found.
-  """
-  # TODO(John Sirois): finish doc of the path structure expexcted under base_path
-  config = config or Config.load()
-  bootstrap_dir = config.getdefault('pants_bootstrapdir')
+  def select_binary_base_path(self, base_path, version, name):
+    """Base path used to select the binary file, exposed for associated unit tests."""
+    # If user-defined strategy function exists, use it instead of default behavior.
+    if self._binary_base_path_strategy:
+      return self.binary_base_path_strategy(base_path, version, name)
 
-  binary_path = select_binary_base_path(base_path, version, name)
-  bootstrapped_binary_path = os.path.join(bootstrap_dir, binary_path)
-  if not os.path.exists(bootstrapped_binary_path):
-    downloadpath = bootstrapped_binary_path + '~'
-    try:
-      with select_binary_stream(base_path, version, name, config) as stream:
-        with safe_open(downloadpath, 'wb') as bootstrapped_binary:
-          bootstrapped_binary.write(stream())
-        os.rename(downloadpath, bootstrapped_binary_path)
-        chmod_plus_x(bootstrapped_binary_path)
-    finally:
-      safe_delete(downloadpath)
+    sysname, _, release, _, machine = os.uname()
+    os_id = _ID_BY_OS[sysname.lower()]
+    if os_id:
+      middle_path = _PATH_BY_ID[os_id(release, machine)]
+      if middle_path:
+        return os.path.join(base_path, *(middle_path + [version, name]))
+    raise BinaryUtil.MissingMachineInfo('No {binary} binary found for: {machine_info}'
+        .format(binary=name, machine_info=(sysname, release, machine)))
 
-  log.debug('Selected {binary} binary bootstrapped to: {path}'
-            .format(binary=name, path=bootstrapped_binary_path))
-  return bootstrapped_binary_path
+  @contextmanager
+  def select_binary_stream(self, base_path, version, name, url_opener=None):
+    """Select a binary matching the current os and architecture.
+
+    :param url_opener: Optional argument used only for testing, to 'pretend' to open urls.
+    :returns: a 'stream' to download it from a support directory. The returned 'stream' is actually
+      a lambda function which returns the files binary contents.
+    :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no binary of the given version
+      and name could not be found.
+    """
+    baseurls = self._baseurls
+    if not baseurls:
+      raise BinaryUtil.NoBaseUrlsError(
+          'No urls are defined under pants_support_baseurls in the DEFAULT section of pants.ini.')
+    timeout_secs = self._timeout
+    binary_path = self.select_binary_base_path(base_path, version, name)
+    if url_opener is None:
+      url_opener = lambda u: closing(urllib_request.urlopen(u, timeout=timeout_secs))
+
+    downloaded_successfully = False
+    accumulated_errors = []
+    for baseurl in OrderedSet(baseurls): # Wrap in OrderedSet because duplicates are wasteful.
+      url = posixpath.join(baseurl, binary_path)
+      log.info('Attempting to fetch {name} binary from: {url} ...'.format(name=name, url=url))
+      try:
+        with url_opener(url) as binary:
+          log.info('Fetched {name} binary from: {url} .'.format(name=name, url=url))
+          downloaded_successfully = True
+          yield lambda: binary.read()
+          break
+      except (IOError, urllib_error.HTTPError, urllib_error.URLError, ValueError) as e:
+        accumulated_errors.append('Failed to fetch binary from {url}: {error}'
+                                  .format(url=url, error=e))
+    if not downloaded_successfully:
+      raise BinaryUtil.BinaryNotFound((base_path, version, name), accumulated_errors)
+
+  def select_binary(self, base_path, version, name):
+    """Selects a binary matching the current os and architecture.
+
+    :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no binary of the given version
+      and name could be found.
+    """
+    # TODO(John Sirois): finish doc of the path structure expected under base_path
+    bootstrap_dir = self._boostrap_dir
+    binary_path = self.select_binary_base_path(base_path, version, name)
+    bootstrapped_binary_path = os.path.join(bootstrap_dir, binary_path)
+    if not os.path.exists(bootstrapped_binary_path):
+      downloadpath = bootstrapped_binary_path + '~'
+      try:
+        with self.select_binary_stream(base_path, version, name) as stream:
+          with safe_open(downloadpath, 'wb') as bootstrapped_binary:
+            bootstrapped_binary.write(stream())
+          os.rename(downloadpath, bootstrapped_binary_path)
+          chmod_plus_x(bootstrapped_binary_path)
+      finally:
+        safe_delete(downloadpath)
+
+    log.debug('Selected {binary} binary bootstrapped to: {path}'
+              .format(binary=name, path=bootstrapped_binary_path))
+    return bootstrapped_binary_path
 
 
 @contextmanager
@@ -149,21 +180,21 @@ def safe_args(args,
               delimiter='\n',
               quoter=None,
               delete=True):
-  """
-    Yields args if there are less than a limit otherwise writes args to an argfile and yields an
-    argument list with one argument formed from the path of the argfile.
+  """Yields args if there are less than a limit otherwise writes args to an argfile and yields an
+  argument list with one argument formed from the path of the argfile.
 
-    :args The args to work with.
-    :max_args The maximum number of args to let though without writing an argfile.  If not specified
-              then the maximum will be loaded from config.
-    :config Used to lookup the configured maximum number of args that can be passed to a subprocess;
-            defaults to the default config and looks for key 'max_subprocess_args' in the DEFAULTS.
-    :argfile The file to write args to when there are too many; defaults to a temporary file.
-    :delimiter The delimiter to insert between args written to the argfile, defaults to '\n'
-    :quoter A function that can take the argfile path and return a single argument value;
-            defaults to:
-            <code>lambda f: '@' + f<code>
-    :delete If True deletes any arg files created upon exit from this context; defaults to True.
+  :param args: The args to work with.
+  :param max_args: The maximum number of args to let though without writing an argfile.  If not
+    specified then the maximum will be loaded from config.
+  :param config: Used to lookup the configured maximum number of args that can be passed to a
+    subprocess; defaults to the default config and looks for key 'max_subprocess_args' in the
+    DEFAULTS.
+  :param argfile: The file to write args to when there are too many; defaults to a temporary file.
+  :param delimiter: The delimiter to insert between args written to the argfile, defaults to '\n'
+  :param quoter: A function that can take the argfile path and return a single argument value;
+    defaults to: <code>lambda f: '@' + f<code>
+  :param delete: If True deletes any arg files created upon exit from this context; defaults to
+    True.
   """
   max_args = max_args or (config or Config.load()).getdefault('max_subprocess_args', int, 10)
   if len(args) > max_args:

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -133,6 +133,7 @@ class Bootstrapper(object):
     # https://jira.twitter.biz/browse/DPB-283
     ivy_bootstrap_dir = \
       os.path.join(self._config.getdefault('pants_bootstrapdir'), 'tools', 'jvm', 'ivy')
+    ivy_bootstrap_dir = os.path.expanduser(ivy_bootstrap_dir) # Support ~ in pants_bootstrapdir.
 
     digest = hashlib.sha1()
     if os.path.isfile(self._version_or_ivyxml):

--- a/src/python/pants/thrift_util.py
+++ b/src/python/pants/thrift_util.py
@@ -8,7 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 import re
 
-from pants.binary_util import select_binary
+from pants.binary_util import BinaryUtil
 
 
 INCLUDE_PARSER = re.compile(r'^\s*include\s+"([^"]+)"\s*([\/\/|\#].*)*$')
@@ -128,4 +128,4 @@ def select_thrift_binary(config, version=None):
   """
   thrift_supportdir = config.get('thrift-gen', 'supportdir')
   thrift_version = version or config.get('thrift-gen', 'version')
-  return select_binary(thrift_supportdir, thrift_version, 'thrift', config)
+  return BinaryUtil(config=config).select_binary(thrift_supportdir, thrift_version, 'thrift')


### PR DESCRIPTION
BinaryUtil can be initialized with bootstrap_dir, baseurls, and timeout; missing parameters are loaded from config.
See John's comment on https://rbcommons.com/s/twitter/r/556: "It might be nice to just clean this up wholesale and construct one with urls and a timeout and make this a full self-contained utility class.  There could be a convenience factory classmethod that takes a Config.  This would have some small ripple to current useages so if you agree but wish to defer, TODO and circle back in a new RB."
