### PR TITLE
Use an absolute path for sourcing set_archflags.sh.

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -2,9 +2,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-source build-support/set_archflags.sh
-
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+
+source ${REPO_ROOT}/build-support/set_archflags.sh
 
 REQUIREMENTS=(
   ${REPO_ROOT}/3rdparty/python/requirements.txt


### PR DESCRIPTION
This was breaking wrapping usages from foreign repos.

https://rbcommons.com/s/twitter/r/604/
