### PR TITLE
Sort imports lexicographically by default

### DIFF
--- a/src/python/pants/backend/jvm/tasks/templates/idea/project-12.mustache
+++ b/src/python/pants/backend/jvm/tasks/templates/idea/project-12.mustache
@@ -75,6 +75,11 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       <SOURCES />
     </library>
   </component>
+
+  <component name="ScalaProjectSettings">
+    <option name="sortImports" value="true" />
+  </component>
+
   {{/project.scala?}}
 
   <component name="VcsDirectoryMappings">


### PR DESCRIPTION
I wonder if anyone can advice me on how to test it.

I'm guessing I have to build Pants' binary and drop it into a Scala project and generate IDEA file. I see that we cannot just install Pants for any project.

Can I do: ./pants goal idea src/scala/com/pants/example:jvm-run-example-lib to test if 'sort imports' is checked?