### PR TITLE
Explicitly initialize the logger

### DIFF
--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -183,4 +183,4 @@ class BuildFile(object):
     return not self.__eq__(other)
 
   def __repr__(self):
-    return self.relpath
+    return self.full_path

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -5,6 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
+import logging
 import optparse
 import os
 import sys
@@ -91,6 +92,8 @@ def _run():
   [main]
   roots: ['src/python/pants_internal/test/',]
   """
+
+  logging.basicConfig()
   version = get_version()
   if len(sys.argv) == 2 and sys.argv[1] == _VERSION_OPTION:
     _do_exit(version)


### PR DESCRIPTION
I was working and got the following error message:

```
*** Running pants in dev mode from /Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py ***
No handlers could be found for logger "pants.base.build_file_parser"
Traceback (most recent call last):
  File "/Users/zundel/Src/Pants/src/python/pants/base/build_file_parser.py", line 477, in parse_build_file
    build_file_code = build_file.code()
  File "/Users/zundel/Src/Pants/src/python/pants/base/build_file.py", line 168, in code
    code = compile(source.read(), '<string>', 'exec', flags=0, dont_inherit=True)
  File "<string>", line 5
SyntaxError: non-keyword arg after keyword arg
Traceback (most recent call last):
  File "/Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py", line 181, in <module>
    main()
  File "/Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py", line 175, in main
    _run()
  File "/Users/zundel/Src/Pants/src/python/pants/bin/pants_exe.py", line 143, in _run
    build_graph)
  File "/Users/zundel/Src/Pants/src/python/pants/commands/goal.py", line 112, in __init__
    super(Goal, self).__init__(*args, **kwargs)
  File "/Users/zundel/Src/Pants/src/python/pants/commands/command.py", line 74, in __init__
    self.build_file_parser.parse_build_file_family(build_file)
  File "/Users/zundel/Src/Pants/src/python/pants/base/build_file_parser.py", line 432, in parse_build_file_family
    self.parse_build_file(bf)
  File "/Users/zundel/Src/Pants/src/python/pants/base/build_file_parser.py", line 477, in parse_build_file
    build_file_code = build_file.code()
  File "/Users/zundel/Src/Pants/src/python/pants/base/build_file.py", line 168, in code
    code = compile(source.read(), '<string>', 'exec', flags=0, dont_inherit=True)
  File "<string>", line 5
SyntaxError: non-keyword arg after keyword arg

```

The problem was that I was editing the root BUILD file and there was a syntax error in it.   I wondered why it didn't show the BUILD file, so I tried putting a syntax error in another file and got a useful log message:

```
ERROR:pants.base.build_file_parser:Error parsing src/java/com/pants/examples/hello/main/BUILD.
```

I looked around for the root problem and I think the issue is that we are not configuring the logger.  I could not find where we configured this with a logger.addHandler() call or a call to logging.basicConfig(), logging.fileConfig() or logging.dictConfig().    Probably some library is configuring it for us somewhere down the line, but that must be after pants tries to parse the root BUILD file.
