### PR TITLE
Adding os.path.realpath to help macos build pass tests.

### DIFF
--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -84,7 +84,7 @@ class BaseTest(unittest2.TestCase):
 
   def setUp(self):
     self.real_build_root = BuildRoot().path
-    self.build_root = mkdtemp(suffix='_BUILD_ROOT')
+    self.build_root = os.path.realpath(mkdtemp(suffix='_BUILD_ROOT'))
     BuildRoot().path = self.build_root
     self.create_file('pants.ini')
     self.build_file_parser = BuildFileParser(self.build_root)


### PR DESCRIPTION
Tests are failing on mac due to tempdir naming issues.  Solution is to pepper in os.path.realname() in places...
