### PR TITLE
Adding ability to exclude a spec from a list of specs 

### DIFF
--- a/src/python/pants/base/build_manual.py
+++ b/src/python/pants/base/build_manual.py
@@ -19,8 +19,7 @@ class manual(object):
     ignores methods. You want to decorate methods that are kosher for
     BUILD files.)
 
-    tags: E.g., tags=["python"] means This thingy should appear in the
-          Python section"
+    :param tags: E.g., tags=["python"] means "This thingy should appear in the Python section"
     """
     tags = tags or []
     def builddictdecorator(funcorclass):

--- a/src/python/pants/commands/goal.py
+++ b/src/python/pants/commands/goal.py
@@ -177,11 +177,10 @@ class Goal(Command):
       # Bootstrap user goals by loading any BUILD files implied by targets.
       spec_parser = CmdLineSpecParser(self.root_dir, self.build_file_parser)
       with self.run_tracker.new_workunit(name='parse', labels=[WorkUnit.SETUP]):
-        for spec in specs:
-          for address in spec_parser.parse_addresses(spec):
-            self.build_file_parser.inject_spec_closure_into_build_graph(address.spec,
-                                                                        self.build_graph)
-            self.targets.append(self.build_graph.get_target(address))
+        for address in spec_parser.parse_addresses(specs):
+          self.build_file_parser.inject_spec_closure_into_build_graph(address.spec,
+                                                                      self.build_graph)
+          self.targets.append(self.build_graph.get_target(address))
     self.phases = [Phase(goal) for goal in goals]
 
     rcfiles = self.config.getdefault('rcfiles', type=list,

--- a/src/python/pants/docs/target_addresses.rst
+++ b/src/python/pants/docs/target_addresses.rst
@@ -95,3 +95,21 @@ location::
     tests/python/pants_test/tasks:targets_help
     tests/python/pants_test/tasks:what_changed
     tests/python/pants_test/testutils:testutils
+
+A leading caret specifies that this target or set of targets should be excluded from the
+list of targets::
+
+    $ ./pants goal list tests/python/pants_test/:: ^tests/python/pants_test/base::
+    tests/python/pants_test:base-test
+    tests/python/pants_test:test_maven_layout
+    tests/python/pants_test/BUILD:test_thrift_util
+    tests/python/pants_test:all
+    tests/python/pants_test/cache:cache
+    tests/python/pants_test/commands:commands
+    tests/python/pants_test/commands:test_goal
+    ...
+    tests/python/pants_test/tasks:sorttargets
+    tests/python/pants_test/tasks:targets_help
+    tests/python/pants_test/tasks:what_changed
+    tests/python/pants_test/testutils:testutils
+

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -112,6 +112,7 @@ python_tests(
   name = 'cmd_line_spec_parser',
   sources = ['test_cmd_line_spec_parser.py'],
   dependencies = [
+    pants('3rdparty/python/twitter/commons:twitter.common.collections'),
     pants('src/python/pants/base:cmd_line_spec_parser'),
     pants('tests/python/pants_test:base_test'),
   ]

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -77,6 +77,14 @@ class CmdLineSpecParserTest(BaseTest):
     self.assert_parsed(cmdline_spec='a/b/:b', expected=['a/b'])
     self.assert_parsed(cmdline_spec='./a/b/:b', expected=['a/b'])
 
+  def test_cmd_line_spec_list(self):
+    self.assert_parsed_list(cmdline_spec_list=['a', 'a/b'], expected=['a', 'a/b'])
+    self.assert_parsed_list(cmdline_spec_list=['a', 'a/b', '^a/b'], expected=['a'])
+    self.assert_parsed_list(cmdline_spec_list=['^a/b', 'a', 'a/b'], expected=['a'])
+    self.assert_parsed_list(cmdline_spec_list=['::'], expected=[':root', 'a', 'a:b', 'a/b', 'a/b:c'])
+    self.assert_parsed_list(cmdline_spec_list=['::', '^a/b::'], expected=[':root', 'a', 'a:b'])
+    self.assert_parsed_list(cmdline_spec_list=['^a/b::', '::'], expected=[':root', 'a', 'a:b'])
+
   def test_does_not_exist(self):
     with self.assertRaises(IOError):
       self.spec_parser.parse_addresses('c').next()
@@ -92,3 +100,10 @@ class CmdLineSpecParserTest(BaseTest):
 
     self.assertEqual(sort(SyntheticAddress.parse(addr) for addr in expected),
                      sort(self.spec_parser.parse_addresses(cmdline_spec)))
+
+  def assert_parsed_list(self, cmdline_spec_list, expected):
+    def sort(addresses):
+      return sorted(addresses, key=lambda address: address.spec)
+
+    self.assertEqual(sort(SyntheticAddress.parse(addr) for addr in expected),
+                     sort(self.spec_parser.parse_addresses(cmdline_spec_list)))


### PR DESCRIPTION
I have a user that wants to perform tasks on large swaths of the repo, but some of the targets are currently broken.  This adds the ability to exclude some targets using the '^' prefix.  For example

pants goal idea :: ^src/java/broken/project::

Would launch the IDE on everything except for one broken project.
