### PR TITLE
Fixup clean-all, clean-all-async and invalidate dependencies.

### DIFF
--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -106,16 +106,16 @@ def register_goals():
 
 
   # Cleaning.
+  invalidate = goal(name='invalidate', action=Invalidator, dependencies=['ng-killall'])
+  invalidate.install().with_description('Invalidate all targets.')
 
-  goal(name='invalidate', action=Invalidator, dependencies=['ng-killall']
-  ).install().with_description('Invalidate all targets.')
+  clean_all = goal(name='clean-all', action=Cleaner, dependencies=['invalidate']).install()
+  clean_all.with_description('Clean all build output.')
+  clean_all.install(invalidate, first=True)
 
-  goal(name='clean-all', action=Cleaner, dependencies=['invalidate']
-  ).install().with_description('Clean all build output.')
-
-  goal(name='clean-all-async', action=AsyncCleaner, dependencies=['invalidate']
+  clean_all_async = goal(name='clean-all-async', action=AsyncCleaner, dependencies=['invalidate']
   ).install().with_description('Clean all build output in a background process.')
-
+  clean_all_async.install(invalidate, first=True)
 
   # Reporting.
 

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -5,8 +5,6 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from pants.goal import Goal as goal
-
 from pants.backend.core.tasks.group_task import GroupTask
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.artifact import Artifact
@@ -47,6 +45,7 @@ from pants.backend.jvm.tasks.provides import Provides
 from pants.backend.jvm.tasks.scala_repl import ScalaRepl
 from pants.backend.jvm.tasks.scaladoc_gen import ScaladocGen
 from pants.backend.jvm.tasks.specs_run import SpecsRun
+from pants.goal import Goal as goal, Phase
 
 
 def target_aliases():
@@ -95,9 +94,12 @@ def register_commands():
 
 
 def register_goals():
-  goal(name='ng-killall', action=NailgunKillall
-  ).install().with_description('Kill running nailgun servers.')
+  ng_killall = goal(name='ng-killall', action=NailgunKillall)
+  ng_killall.install().with_description('Kill running nailgun servers.')
 
+  Phase('invalidate').install(ng_killall, first=True)
+  Phase('clean-all').install(ng_killall, first=True)
+  Phase('clean-all-async').install(ng_killall, first=True)
 
   goal(name='bootstrap-jvm-tools', action=BootstrapJvmTools
   ).install('bootstrap').with_description('Bootstrap tools needed for building.')


### PR DESCRIPTION
In the wake of Goal.dependencies no longer being used for scheduling,
clean-all and invalidate no longer properly depend on ng-killall.

https://rbcommons.com/s/twitter/r/638/
