### PR TITLE
Fix missing java & scala product types for ScroogeGen.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/scrooge_gen.py
+++ b/src/python/pants/backend/codegen/tasks/scrooge_gen.py
@@ -93,6 +93,10 @@ class ScroogeGen(NailgunTask, JvmToolTaskMixin):
                             action='callback', callback=mkflag.set_bool, default=None,
                             help='[%default] Suppress output, overrides verbose flag in pants.ini.')
 
+  @classmethod
+  def product_type(cls):
+    return ['java', 'scala']
+
   def __init__(self, context, workdir):
     super(ScroogeGen, self).__init__(context, workdir)
     self.compiler_for_name = dict((name, Compiler.from_config(context, config))


### PR DESCRIPTION
CodeGen handles this, but ScroogeGen is not a subclass.

https://rbcommons.com/s/twitter/r/639/
