### PR TITLE
Fix depmap to be able to see past a Dependencies target

### DIFF
--- a/src/python/pants/backend/core/targets/dependencies.py
+++ b/src/python/pants/backend/core/targets/dependencies.py
@@ -26,3 +26,4 @@ class Dependencies(Target):
       for details.
     """
     super(Dependencies, self).__init__(payload=EmptyPayload(), *args, **kwargs)
+    self.add_labels('delegate')

--- a/src/python/pants/backend/jvm/tasks/depmap.py
+++ b/src/python/pants/backend/jvm/tasks/depmap.py
@@ -118,7 +118,7 @@ class Depmap(ConsoleTask):
         yield line
       return
     for target in self.context.target_roots:
-      if self._is_jvm(target):
+      if self._is_jvm(target) or target.is_delegate:
         if self.is_graph:
           for line in self._output_digraph(target):
             yield line
@@ -159,7 +159,7 @@ class Depmap(ConsoleTask):
           outputted.add(dep_id)
           indent += 1
 
-        if self._is_jvm(dep):
+        if self._is_jvm(dep) or dep.is_delegate:
           for internal_dep in dep.dependencies:
             output += output_deps(internal_dep, indent, outputted)
 

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -99,6 +99,11 @@ class AbstractTarget(object):
     """Returns True if the target is an android target."""
     return self.has_label('android')
 
+  @property
+  def is_delegate(self):
+    """Returns True if this target only delegates to other targets"""
+    return self.has_label('delegate')
+
 @manual.builddict()
 class Target(AbstractTarget):
   """The baseclass for all pants targets.

--- a/tests/python/pants_test/tasks/test_depmap.py
+++ b/tests/python/pants_test/tasks/test_depmap.py
@@ -131,10 +131,31 @@ class DepmapTest(BaseDepmapTest):
         resources=[pants('resources/a:a_resources')]
       )
     '''))
+    self.add_to_build_file('src/java/a', dedent('''
+      dependencies(
+        name='a_dep',
+        dependencies=[pants(':a_java')]
+      )
+    '''))
+
+    self.add_to_build_file('src/java/b', dedent('''
+      java_library(
+        name='b_java',
+        dependencies=[':b_dep']
+      )
+      dependencies(
+        name='b_dep',
+        dependencies=[':b_lib']
+      )
+      java_library(
+        name='b_lib',
+        sources=[],
+      )
+    '''))
 
   def test_empty(self):
-    self.assert_console_raises(
-      TaskError,
+    self.assert_console_output(
+      'internal-common.a.a',
       targets=[self.target('common/a')]
     )
 
@@ -244,7 +265,21 @@ class DepmapTest(BaseDepmapTest):
       targets=[self.target('src/java/a:a_java')]
     )
 
+  def test_resources_dep(self):
+    self.assert_console_output(
+      'internal-src.java.a.a_dep',
+      '  internal-src.java.a.a_java',
+      '    internal-resources.a.a_resources',
+      targets=[self.target('src/java/a:a_dep')]
+    )
 
+  def test_intermediate_dep(self):
+    self.assert_console_output(
+      'internal-src.java.b.b_java',
+      '  internal-src.java.b.b_dep',
+      '    internal-src.java.b.b_lib',
+      targets=[self.target('src/java/b:b_java')]
+    )
 class ProjectInfoTest(ConsoleTaskTest):
   @classmethod
   def task_type(cls):
@@ -296,6 +331,12 @@ class ProjectInfoTest(ConsoleTaskTest):
       dependencies=[second],
     )
 
+    top_dependency = self.make_target(
+      'project_info:top_dependency',
+      target_type=Dependencies,
+      dependencies=[jvm_binary]
+    )
+
   def test_without_dependencies(self):
     result = get_json(self.execute_console_task(
       args=['--test-project-info'],
@@ -340,6 +381,16 @@ class ProjectInfoTest(ConsoleTaskTest):
       targets=[self.target('project_info:jvm_binary')]
     ))
     self.assertEqual(['org.apache:apache-jar:12.12.2012'], result['targets']['project_info:jvm_binary']['libraries'])
+
+  def test_top_dependency(self):
+    result = get_json(self.execute_console_task(
+      args=['--test-project-info'],
+      targets=[self.target('project_info:top_dependency')]
+    ))
+    print ("RESULT is {result}".format(result=result))
+
+    self.assertEqual([], result['targets']['project_info:top_dependency']['libraries'])
+    self.assertEqual(['project_info:jvm_binary'], result['targets']['project_info:top_dependency']['targets'])
 
   def test_format_flag(self):
     result = self.execute_console_task(


### PR DESCRIPTION
Fixes issue 242: https://github.com/pantsbuild/pants/issues/242

Looks like there was a specific test to make sure that using Dependencies failed, which is a behavior I changed.  There is a note in the code to get it reviewed by  fkorotkov or ajohnson for impact on the IntelliJ plugin
