### PR TITLE
Simplify the JvmTarget resources property.

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -106,6 +106,8 @@ class JvmTarget(Target, Jarable):
 
   @property
   def resources(self):
+    # TODO(John Sirois): Consider removing this convenience:
+    #   https://github.com/pantsbuild/pants/issues/346
     # TODO(John Sirois): Introduce a label and replace the type test?
     return [dependency for dependency in self.dependencies if isinstance(dependency, Resources)]
 


### PR DESCRIPTION
Resources are just another form of dependency as demonstrated
by the traversable_dependency_specs implementation.  They all
get resolved as dependencies during BUILD parsing so we just need
to look at our direct dependencies that are Resources target to
implement the resources property.  This has the side-benefit that the
standard dependency injection primitives for stitching synthetic targets
into a BUILD graph can be used to stitch in new Resources dependencies.

https://rbcommons.com/s/twitter/r/673/
