### PR TITLE
Resurrected pants goal idea.

### DIFF
--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -221,8 +221,7 @@ def register_goals():
 
   # IDE support.
 
-  goal(name='idea', action=IdeaGen,
-       dependencies=['jar', 'bootstrap']
+  goal(name='idea', action=IdeaGen, dependencies=['bootstrap', 'resolve']
   ).install().with_description('Create an IntelliJ IDEA project from the given targets.')
 
   goal(name='eclipse', action=EclipseGen,

--- a/src/python/pants/backend/jvm/tasks/ide_gen.py
+++ b/src/python/pants/backend/jvm/tasks/ide_gen.py
@@ -72,8 +72,8 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
                             help="[%default] Includes java sources in the project; otherwise "
                                  "compiles them and adds them to the project classpath.")
     java_language_level = mkflag("java-language-level")
-    # TODO(John Sirois): Advance the default to 7 when 8 is released.
-    option_group.add_option(java_language_level, default=6,
+
+    option_group.add_option(java_language_level, default=7,
                             dest="ide_gen_java_language_level", type="int",
                             help="[%default] Sets the java language and jdk used to compile the "
                                  "project's java sources.")
@@ -87,6 +87,28 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
                             action="callback", callback=mkflag.set_bool, dest='ide_gen_scala',
                             help="[%default] Includes scala sources in the project; otherwise "
                                  "compiles them and adds them to the project classpath.")
+
+
+  class Error(TaskError):
+    """IdeGen Error."""
+
+  class TargetUtil(Target):
+    def __init__(self, context):
+      self.context = context
+
+    @property
+    def build_file_parser(self):
+      return self.context.build_file_parser
+
+    @property
+    def build_graph(self):
+      return self.context.build_graph
+
+    def get_all_addresses(self, buildfile):
+      return self.build_file_parser.addresses_by_build_file[buildfile]
+
+    def get(self, address):
+      return self.build_file_parser._target_proxy_by_address[address].to_target(self.build_graph)
 
   def __init__(self, context, workdir):
     super(IdeGen, self).__init__(context, workdir)
@@ -130,13 +152,6 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
                                       default=[':scala-compile-2.9.3'])
       self.register_jvm_tool(self.scalac_bootstrap_key, scalac)
 
-    targets, self._project = self.configure_project(
-        context.targets(),
-        self.checkstyle_suppression_files,
-        self.debug_port)
-
-    self.configure_compile_context(targets)
-
   def prepare(self, round_manager):
     if self.python:
       round_manager.require('python')
@@ -144,11 +159,19 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
       round_manager.require('java')
     if not self.skip_scala:
       round_manager.require('scala')
-    round_manager.require('jars')
-    round_manager.require('source_jars')
+    round_manager.require_data('ivy_jar_products')
+    round_manager.require('jar_dependencies')
+
+  def _prepare_project(self):
+    targets, self._project = self.configure_project(
+        self.context.targets(),
+        self.checkstyle_suppression_files,
+        self.debug_port)
+
+    self.configure_compile_context(targets)
 
   def configure_project(self, targets, checkstyle_suppression_files, debug_port):
-    jvm_targets = Target.extract_jvm_targets(targets)
+    jvm_targets = [t for t in targets if t.has_label('jvm') or t.has_label('java')]
     if self.intransitive:
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
     project = Project(self.project_name,
@@ -160,7 +183,8 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
                       debug_port,
                       jvm_targets,
                       not self.intransitive,
-                      self.context.new_workunit)
+                      self.context.new_workunit,
+                      self.TargetUtil(self.context))
 
     if self.python:
       python_source_paths = self.context.config.getlist('ide', 'python_source_paths', default=[])
@@ -182,11 +206,9 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
     def is_cp(target):
       return (
         target.is_codegen or
-
         # Some IDEs need annotation processors pre-compiled, others are smart enough to detect and
         # proceed in 2 compile rounds
         target.is_apt or
-
         (self.skip_java and is_java(target)) or
         (self.skip_scala and is_scala(target)) or
         (self.intransitive and target not in self.context.target_roots)
@@ -207,13 +229,8 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
       target.walk(prune)
 
     self.context.replace_targets(compiles)
+    self.jar_dependencies = jars
 
-    self.binary = self.context.add_new_target(self.gen_project_workdir,
-                                              JvmBinary,
-                                              name='%s-external-jars' % self.project_name,
-                                              dependencies=jars,
-                                              excludes=excludes,
-                                              configurations=('default', 'sources', 'javadoc'))
     self.context.log.debug('pruned to cp:\n\t%s' % '\n\t'.join(
       str(t) for t in self.context.targets())
     )
@@ -232,7 +249,7 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
       if mappings:
         for base, jars in mappings.items():
           if len(jars) != 1:
-            raise TaskError('Unexpected mapping, multiple jars for %s: %s' % (target, jars))
+            raise IdeGen.Error('Unexpected mapping, multiple jars for %s: %s' % (target, jars))
 
           jar = jars[0]
           cp_jar = os.path.join(internal_jar_dir, jar)
@@ -243,7 +260,7 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
           if mappings:
             for base, jars in mappings.items():
               if len(jars) != 1:
-                raise TaskError(
+                raise IdeGen.Error(
                   'Unexpected mapping, multiple source jars for %s: %s' % (target, jars)
                 )
               jar = jars[0]
@@ -251,6 +268,27 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
               shutil.copy(os.path.join(base, jar), cp_source_jar)
 
           self._project.internal_jars.add(ClasspathEntry(cp_jar, source_jar=cp_source_jar))
+
+  def _get_jar_paths(self, jars=None, confs=None):
+    """Returns a list of dicts containing the paths of various jar file resources.
+
+    Keys include 'default' (normal jar path), 'sources' (path to source jar), and 'javadoc'
+    (path to doc jar). None of them are guaranteed to be present, but 'sources' and 'javadoc'
+    will never be present if 'default' isn't.
+
+    :param jardeps: JarDependency objects to resolve paths for
+    :param confs: List of key types to return (eg ['default', 'sources']). Just returns 'default' if
+      left unspecified.
+    """
+    # TODO(Garrett Malmquist): Get mapping working for source and javadoc jars.
+    ivy_products = self.context.products.get_data('ivy_jar_products')
+    classpath_maps = []
+    for info_group in ivy_products.values():
+      for info in info_group:
+        for module in info.modules_by_ref.values():
+          for artifact in module.artifacts:
+            classpath_maps.append({'default': artifact.path})
+    return classpath_maps
 
   def map_external_jars(self):
     external_jar_dir = os.path.join(self.gen_project_workdir, 'external-libs')
@@ -263,7 +301,7 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
     safe_mkdir(external_javadoc_jar_dir, clean=True)
 
     confs = ['default', 'sources', 'javadoc']
-    for entry in self.list_external_jar_dependencies(self.binary, confs=confs):
+    for entry in self._get_jar_paths(confs=confs):
       jar = entry.get('default')
       if jar:
         cp_jar = os.path.join(external_jar_dir, os.path.basename(jar))
@@ -287,6 +325,7 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
 
   def execute(self):
     """Stages IDE project artifacts to a project directory and generates IDE configuration files."""
+    self._prepare_project()
     checkstyle_enabled = len(Phase.goals_of_type(Checkstyle)) > 0
     if checkstyle_enabled:
       checkstyle_classpath = self.tool_classpath(self.checkstyle_bootstrap_key)
@@ -299,7 +338,6 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
       scalac_classpath = []
 
     self._project.set_tool_classpaths(checkstyle_classpath, scalac_classpath)
-
     targets = self.context.targets()
     self.map_internal_jars(targets)
     self.map_external_jars()
@@ -348,6 +386,9 @@ class SourceSet(object):
 
     return self._excludes
 
+  def __str__(self):
+    return str((self.root_dir, self.source_base, self.path))
+
 
 class Project(object):
   """Models a generic IDE project that is comprised of a set of BUILD targets."""
@@ -362,10 +403,12 @@ class Project(object):
         yield ext
 
   def __init__(self, name, has_python, skip_java, skip_scala, root_dir,
-               checkstyle_suppression_files, debug_port, targets, transitive, workunit_factory):
+               checkstyle_suppression_files, debug_port, targets, transitive, workunit_factory,
+               target_util):
     """Creates a new, unconfigured, Project based at root_dir and comprised of the sources visible
     to the given targets."""
 
+    self.target_util = target_util
     self.name = name
     self.root_dir = root_dir
     self.targets = OrderedSet(targets)
@@ -409,21 +452,33 @@ class Project(object):
 
     analyzed = OrderedSet()
     targeted = set()
+    targeted_tuples = {}
+
+    def relative_sources(target):
+      sources = target.payload.sources_relative_to_buildroot()
+      return [os.path.relpath(source, target.target_base) for source in sources]
 
     def source_target(target):
-      return ((self.transitive or target in self.targets) and
+      result = ((self.transitive or target in self.targets) and
               target.has_sources() and
-              (not target.is_codegen and
-               not (self.skip_java and is_java(target)) and
+              (not (self.skip_java and is_java(target)) and
                not (self.skip_scala and is_scala(target))))
+      return result
 
     def configure_source_sets(relative_base, sources, is_test):
       absolute_base = os.path.join(self.root_dir, relative_base)
       paths = set([os.path.dirname(source) for source in sources])
       for path in paths:
         absolute_path = os.path.join(absolute_base, path)
-        if absolute_path not in targeted:
+        pieces = (relative_base, path)
+        # Previously this if-statement was testing against absolute_path's presence in targeted.
+        # This broke in the (very weird) edge-case where two different sources have the same
+        # absolute path, but choose the split between relative_base and path differently. It's
+        # really important that we distinguish between them still, because the package name changes.
+        # TODO(Garrett Malmquist): Fix the underlying bugs in pants that make this necessary.
+        if pieces not in targeted_tuples:
           targeted.add(absolute_path)
+          targeted_tuples[pieces] = sources
           self.sources.append(SourceSet(self.root_dir, relative_base, path, is_test))
 
     def find_source_basedirs(target):
@@ -431,48 +486,69 @@ class Project(object):
       if source_target(target):
         absolute_base = os.path.join(self.root_dir, target.target_base)
         dirs.update([os.path.join(absolute_base, os.path.dirname(source))
-                      for source in target.sources])
+                      for source in relative_sources(target)])
       return dirs
 
     def configure_target(target):
       if target not in analyzed:
         analyzed.add(target)
-
         self.has_scala = not self.skip_scala and (self.has_scala or is_scala(target))
 
         if target.has_resources:
           resources_by_basedir = defaultdict(set)
           for resources in target.resources:
-            resources_by_basedir[resources.target_base].update(resources.sources)
+            resources_by_basedir[target.target_base].update(relative_sources(resources))
           for basedir, resources in resources_by_basedir.items():
             self.resource_extensions.update(Project.extract_resource_extensions(resources))
             configure_source_sets(basedir, resources, is_test=False)
 
-        if target.sources:
+        if target.has_sources():
           test = target.is_test
           self.has_tests = self.has_tests or test
-          configure_source_sets(target.target_base, target.sources, is_test=test)
+          base = target.target_base
+          configure_source_sets(base, relative_sources(target), is_test=test)
 
-        # Other BUILD files may specify sources in the same directory as this target.  Those BUILD
+        # Other BUILD files may specify sources in the same directory as this target. Those BUILD
         # files might be in parent directories (globs('a/b/*.java')) or even children directories if
         # this target globs children as well.  Gather all these candidate BUILD files to test for
         # sources they own that live in the directories this targets sources live in.
         target_dirset = find_source_basedirs(target)
-        candidates = Target.get_all_addresses(target.address.build_file)
+        if target.address.is_synthetic:
+          return [] # Siblings don't make sense for synthetic addresses.
+        candidates = self.target_util.get_all_addresses(target.address.build_file)
         for ancestor in target.address.build_file.ancestors():
-          candidates.update(Target.get_all_addresses(ancestor))
+          candidates.update(self.target_util.get_all_addresses(ancestor))
         for sibling in target.address.build_file.siblings():
-          candidates.update(Target.get_all_addresses(sibling))
+          candidates.update(self.target_util.get_all_addresses(sibling))
         for descendant in target.address.build_file.descendants():
-          candidates.update(Target.get_all_addresses(descendant))
-
+          candidates.update(self.target_util.get_all_addresses(descendant))
         def is_sibling(target):
           return source_target(target) and target_dirset.intersection(find_source_basedirs(target))
 
-        return filter(is_sibling, [Target.get(a) for a in candidates if a != target.address])
+        return filter(is_sibling, [self.target_util.get(a) for a in candidates
+                                                           if a != target.address])
 
     for target in self.targets:
       target.walk(configure_target, predicate=source_target)
+
+    def full_path(source_set):
+      return os.path.join(source_set.root_dir, source_set.source_base, source_set.path)
+
+    # Check if there are any overlapping source_sets, and output an error message if so.
+    # Overlapping source_sets cause serious problems with package name inference.
+    overlap_error = ('SourceSets {current} and {previous} evaluate to the same full path.'
+                     ' This can be caused by multiple BUILD targets claiming the same source,'
+                     ' e.g., if a BUILD target in a parent directory contains an rglobs() while'
+                     ' a BUILD target in a subdirectory of that uses a globs() which claims the'
+                     ' same sources. This may cause package names to be inferred incorrectly (e.g.,'
+                     ' you might see src.com.foo.bar.Main instead of com.foo.bar.Main).')
+    source_full_paths = {}
+    for source_set in sorted(self.sources, key=full_path):
+      full = full_path(source_set)
+      if full in source_full_paths:
+        previous_set = source_full_paths[full]
+        self.context.log.error(overlap_error.format(current=source_set, previous=previous_set))
+      source_full_paths[full] = source_set
 
     # We need to figure out excludes, in doing so there are 2 cases we should not exclude:
     # 1.) targets depend on A only should lead to an exclude of B
@@ -513,7 +589,6 @@ class Project(object):
     for target in self.targets:
       target.walk(lambda target: targets.add(target), source_target)
     targets.update(analyzed - targets)
-
     self.sources.extend(SourceSet(get_buildroot(), p, None, False) for p in extra_source_paths)
     self.sources.extend(SourceSet(get_buildroot(), p, None, True) for p in extra_test_paths)
 

--- a/src/python/pants/backend/jvm/tasks/idea_gen.py
+++ b/src/python/pants/backend/jvm/tasks/idea_gen.py
@@ -13,10 +13,10 @@ from xml.dom import minidom
 
 from twitter.common.dirutil import safe_mkdir
 
+from pants.backend.jvm.tasks.ide_gen import IdeGen, Project, SourceSet
 from pants.base.build_environment import get_buildroot
 from pants.base.config import ConfigOption
 from pants.base.generator import Generator, TemplateData
-from pants.backend.jvm.tasks.ide_gen import IdeGen, Project, SourceSet
 
 
 _TEMPLATE_BASEDIR = 'templates/idea'
@@ -234,11 +234,11 @@ class IdeaGen(IdeGen):
       iml = self._generate_to_tempfile(Generator(pkgutil.get_data(__name__, self.module_template),
           module = configured_module.extend(extra_components = extra_module_components)))
 
+    self.context.log.info('Generated IntelliJ project in {directory}'
+                           .format(directory=self.gen_project_workdir))
+
     shutil.move(ipr, self.project_filename)
     shutil.move(iml, self.module_filename)
-
-    print('\nGenerated project at %s%s' % (self.gen_project_workdir, os.sep))
-
     return self.project_filename if self.open else None
 
   def _generate_to_tempfile(self, generator):

--- a/src/python/pants/backend/jvm/tasks/templates/idea/module-12.mustache
+++ b/src/python/pants/backend/jvm/tasks/templates/idea/module-12.mustache
@@ -49,14 +49,16 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       <excludeFolder url="file://{{module.root_dir}}/{{.}}"/>
       {{/exclude_paths}}
     {{/module.content_roots}}
-      <!-- TODO(John Sirois): Kill this exclude hack - its valid to map generated sources under
-           .pants.d as generated sources for example - which IDEA 13+ understands. -->
-      <excludeFolder url="file://${module.root_dir}/.pants.d" />
-
       <excludeFolder url="file://$MODULE_DIR$/external-libs" />
       <excludeFolder url="file://$MODULE_DIR$/external-libsources" />
       <excludeFolder url="file://$MODULE_DIR$/internal-libs" />
       <excludeFolder url="file://$MODULE_DIR$/internal-libsources" />
+      # TODO(Garrett Malmquist): Do this in a generic way, rather than hard-coding particular
+      # directories.
+      <excludeFolder url="file://${module.root_dir}/.pants.d/compile" />
+      <excludeFolder url="file://${module.root_dir}/.pants.d/ivy" />
+      <excludeFolder url="file://${module.root_dir}/.pants.d/python" />
+      <excludeFolder url="file://${module.root_dir}/.pants.d/resources" />
     </content>
 
     <orderEntry type="inheritedJdk"/>

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -59,6 +59,7 @@ python_test_suite(
 python_test_suite(
   name = 'integration',
   dependencies = [
+    pants(':idea_integration'),
     pants(':jar_publish_integration'),
     pants(':jvm_bundle_integration'),
     pants(':scala_repl_integration'),
@@ -268,6 +269,14 @@ python_tests(
     pants('src/python/pants/backend/core/tasks:filter'),
     pants('src/python/pants/backend/core/targets:common'),
     pants('src/python/pants/base:build_file_aliases'),
+  ],
+)
+
+python_tests(
+  name = 'idea_integration',
+  sources = ['test_idea_integration.py'],
+  dependencies = [
+    pants('tests/python/pants_test:int-test'),
   ],
 )
 

--- a/tests/python/pants_test/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/tasks/test_idea_integration.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from twitter.common.contextutil import temporary_dir
+
+import os
+import shutil
+import subprocess
+
+from pants.base.build_environment import get_buildroot
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class IdeaIntegrationTest(PantsRunIntegrationTest):
+
+  def _idea_test(self, specs, project_dir=None):
+    """Helper method that tests idea generation on the input spec list."""
+    if project_dir is None:
+      project_dir = os.path.join('.pants.d', 'tmp', 'test-idea')
+
+    if not os.path.exists(project_dir):
+      os.makedirs(project_dir)
+    with temporary_dir(root_dir=project_dir) as path:
+      pants_run = self.run_pants(['goal', 'idea',] + specs
+          + ['--idea-project-dir={dir}'.format(dir=path), '--no-idea-open',])
+      self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
+                        "goal idea expected success, got {0}\n"
+                        "got stderr:\n{1}\n"
+                        "got stdout:\n{2}\n".format(pants_run.returncode,
+                                                    pants_run.stderr_data,
+                                                    pants_run.stdout_data))
+      # TODO(Garrett Malmquist): Actually validate the contents of the project files, rather than just
+      # checking if they exist.
+      expected_files = ('project.iml', 'project.ipr',)
+      self.assertTrue(os.path.exists(path),
+          'Failed to find project_dir at {dir}.'.format(dir=path))
+      self.assertTrue(all(os.path.exists(os.path.join(path, name))
+          for name in expected_files))
+
+  # Testing IDEA integration on lots of different targets which require different functionalities to
+  # make sure that everything that needs to happen for idea gen does happen.
+
+  def test_idea_on_alternate_project_dir(self):
+    alt_dir = os.path.join('.pants.d', 'tmp', 'some', 'random', 'directory', 'for', 'idea', 'stuff')
+    self._idea_test(['src/java/com/pants/examples/testproject/hello::'], project_dir=alt_dir)
+
+  def test_idea_on_protobuf(self):
+    self._idea_test(['src/java/com/pants/examples/protobuf::'])
+
+  def test_idea_on_jaxb(self): # Make sure it works without ::, pulling deps as necessary.
+    self._idea_test(['src/java/com/pants/examples/jaxb/main'])
+
+  def test_idea_on_unicode(self):
+    self._idea_test(['src/java/com/pants/testproject/unicode::'])
+
+  def test_idea_on_hello(self):
+    self._idea_test(['src/java/com/pants/examples/hello::'])
+
+  def test_idea_on_annotations(self):
+    self._idea_test(['src/java/com/pants/examples/annotation::'])
+
+  def test_idea_on_all_examples(self):
+    self._idea_test(['src/java/com/pants/examples::'])


### PR DESCRIPTION
This mostly involved updating outdated references, and making utility functions to mimick functionality refactored long ago.

Source and Javadoc jars are not mapped in, and I'm not quite sure how to get that working again. I'd appreciate any input on that matter.

The code in idea_gen and ide_gen isn't very clean, because it wasn't very clean in the first place. It would be good to go back at some point and tidy it up.

Idea gen is also much more efficient than it used to be, thanks to the round manager: it now avoids compiling or jarring anything, which saves tons of time. It would still be nice to include a flag to optionally disable codegen, but I'm not sure how (un)trivial that is at this juncture.
