### PR TITLE
Updated junit-runner, exclude guava

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -51,7 +51,7 @@ jar_library(name='finagle-thrift',
             ])
 
 # common rev for all com.google.guava%guava* artifacts
-GUAVA_REV = '15.0'
+GUAVA_REV = '16.0'
 
 jar_library(name='guava',
             jars = [

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -25,6 +25,7 @@ jar_library(name = 'emma',
 
 jar_library(name = 'benchmark-caliper-0.5',
             jars = [
+              # TODO(Eric Ayers) Caliper is old and breaks with guava 16. Add jmh support?
               jar(org = 'com.google.caliper', name = 'caliper', rev = '0.5-rc1')
                 .exclude(org='com.google.guava', name='guava')
             ])
@@ -66,9 +67,16 @@ jar_library(name = 'junit',
             jars = [
               jar(org = 'junit', name = 'junit-dep', rev = '4.10'),
               jar(org = 'org.hamcrest', name = 'hamcrest-core', rev = '1.2'),
-              jar(org = 'com.google.guava', name = 'guava', rev = '16.0'),
-              jar(org = 'com.twitter.common', name = 'junit-runner', rev = '0.0.41')
-                .exclude(org='com.google.guava', name='guava'),
+              jar(org = 'com.twitter.common', name = 'junit-runner', rev = '0.0.41'),
+
+              # TODO(Eric Ayers) We need to rename/shaed the dependencies of junit-runner
+              #      or use a custom classloader for junit runner to permanently
+              #      address guava version conflicts in guava
+              #
+              # junit-runner version 0.0.41 uses guava 16.0 by default
+              # If your user code needs to use a more recent version of guava, you can force
+              # the version in the next line.
+              jar(org = 'com.google.guava', name = 'guava', rev = '16.0', force = True),
             ])
 
 jar_library(name = 'scala-specs-2.9.3',


### PR DESCRIPTION
Our repo uses guava 17.0.  junit-runner puts guava 15.0 first in the classpath when running tests
