### PR TITLE
Update android target definitions

### DIFF
--- a/src/android/example/BUILD
+++ b/src/android/example/BUILD
@@ -5,6 +5,7 @@
 android_binary(
   name='hello',
   sources=rglobs('src/*.java'),
+  manifest='AndroidManifest.xml',
   dependencies = [
     ':resources',
   ],
@@ -12,5 +13,7 @@ android_binary(
 
 android_resources(
   name='resources',
+  manifest='AndroidManifest.xml',
+  resource_dir='res'
 )
 

--- a/src/python/pants/backend/android/targets/android_resources.py
+++ b/src/python/pants/backend/android/targets/android_resources.py
@@ -8,6 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 
 from pants.base.build_manual import manual
+from pants.base.exceptions import TargetDefinitionException
 from pants.backend.android.targets.android_target import AndroidTarget
 
 
@@ -16,18 +17,18 @@ class AndroidResources(AndroidTarget):
   """Processes android resources to generate R.java"""
 
   def __init__(self,
-               address=None,
-               resource_dir='res',
+               resource_dir=None,
                **kwargs):
     """
-    :param resource_dir: path/to/directory containing Android target's resource files.
-      Set to 'res' by default.
-    :type resource_dir: string.
+    :param string resource_dir: path/to/directory containing Android resource files,
+     often named 'res'.
     :param dependencies: Other targets that this target depends on.
     :type dependencies: list of target specs
     """
-
-    #Is there a way to easily grab this full path without exposing address?
-    self.resource_dir = os.path.join(address.spec_path, resource_dir)
-    super(AndroidResources, self).__init__(address=address, **kwargs)
-
+    super(AndroidResources, self).__init__(**kwargs)
+    address =  kwargs['address']
+    try:
+      self.resource_dir = os.path.join(address.spec_path, resource_dir)
+    except AttributeError:
+      raise TargetDefinitionException(self, 'An android_resources target must specify a \'resource_dir\' that contains '
+             'the target\'s resource files.')

--- a/src/python/pants/backend/android/targets/android_target.py
+++ b/src/python/pants/backend/android/targets/android_target.py
@@ -8,6 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 from xml.dom.minidom import parse
 
+from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import JvmTargetPayload
 from pants.base.target import Target
 
@@ -29,7 +30,7 @@ class AndroidTarget(Target):
                provides=None,
                # most recent build_tools_version should be defined elsewhere
                build_tools_version="19.1.0",
-               manifest='AndroidManifest.xml',
+               manifest=None,
                release_type="debug",
                **kwargs):
     """
@@ -60,16 +61,17 @@ class AndroidTarget(Target):
     self.build_tools_version = build_tools_version
     self.release_type = release_type
 
+    try:
+      os.path.isfile(os.path.join(address.spec_path, manifest))
+    except AttributeError:
+      raise TargetDefinitionException(self, 'Android targets must specify a \'manifest\' '
+                                  'that points to the \'AndroidManifest.xml\'')
     self.manifest = os.path.join(self.address.spec_path, manifest)
-    if not os.path.isfile(self.manifest):
-      raise self.BadManifestError('Missing manifest at: {0!r}. Android targets require an '
-                                  '\'AndroidManifest.xml\''.format(self.manifest))
-    # TODO (mateor): varying manifest location means we should support variable manifest names
-
     self.package = self.get_package_name()
     self.target_sdk = self.get_target_sdk()
 
-  # parsing as done in Donut testrunner
+  # Parsing as in Android Donut's testrunner:
+  # https://github.com/android/platform_development/blob/master/testrunner/android_manifest.py
   def get_package_name(self):
     """Returns the package name of the Android target."""
     tgt_manifest = parse(self.manifest).getElementsByTagName('manifest')
@@ -85,3 +87,6 @@ class AndroidTarget(Target):
       raise self.BadManifestError('There is no \'targetSdkVersion\' attribute in manifest at: {0!r}'
                                   .format(self.manifest))
     return tgt_manifest[0].getAttribute('android:targetSdkVersion')
+
+  def is_android(self):
+    return True


### PR DESCRIPTION
This gets rid of a couple of the "sensible defaults". I believe
in them as useful, but they have could proven confusing for anyone
with a non-traditional (or just maven-style) layout.

This requires all android targets to explicitly define a "manifest"
field. Android_resource targets must further define a
"resource_dir". I named it "resource_dir" instead of "resources"
to contrast with what pants expects elsewhere: the tool that
processes android resources expects a directory as input, not
a list of files. The aapt tool spiders down the dir, so the
user must specify which directory holds those resources.

Somewhere down the line, I would like to support common layouts
by default.
