### PR TITLE
nested class should use fully-qualified class name when referring to base class

### DIFF
--- a/src/python/pants/binary_util.py
+++ b/src/python/pants/binary_util.py
@@ -53,7 +53,7 @@ class BinaryUtil(object):
 
   class BinaryNotFound(TaskError):
     def __init__(self, binary, accumulated_errors):
-      super(BinaryNotFound, self).__init__(
+      super(BinaryUtil.BinaryNotFound, self).__init__(
           'Failed to fetch binary {binary} from any source: ({sources})'
           .format(binary=binary, sources=', '.join(accumulated_errors)))
 


### PR DESCRIPTION
This is a fix for issue #367

Objects of class __BinaryNotFound__ can not be instantiated because the constructor does not qualify the class name with its parent when it invokes the constructor of the superclass. 