### PR TITLE
Made a small change to stop problems we were getting compiling our annot...

### DIFF
--- a/src/python/pants/backend/core/tasks/prepare_resources.py
+++ b/src/python/pants/backend/core/tasks/prepare_resources.py
@@ -27,6 +27,11 @@ class PrepareResources(Task):
 
   def prepare(self, round_manager):
     round_manager.require_data('exclusives_groups')
+    # NOTE(Garrett Malmquist): This is a fake dependency to force resources to occur after jvm
+    # compile. It solves some problems we've been having getting our annotation processors to
+    # compile consistently due to extraneous resources polluting the classpath. Perhaps this could
+    # be fixed more elegantly whenever we get a formal classpath object?
+    round_manager.require_data('classes_by_target')
 
   def execute(self):
     if self.context.products.is_required_data('resources_by_target'):


### PR DESCRIPTION
...ation processors.

This is related to the pants-devel discussion 'Nondeterministic Phase Execution Order'. Briefly:
when the resources phase happens to precede the compile phase, resources in .pants.d  pollute the
jmake classpath when compiling some of Square's internal annotation processors. This makes jmake
quite irate, so this code stops that from happening.

This fix is not terribly elegant, in that it doesn't address the underlying problem of resources
getting on the classpath in the first place. Perhaps this problem will go away when a formal
classpath object is created.
