### PR TITLE
Got ivy to map in javadoc and source jars for pants goal idea.

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -240,7 +240,7 @@ class IvyUtils(object):
         module=name,
         version='latest.integration',
         publications=None,
-        configurations=confs,
+        configurations=list(confs), # Mustache doesn't like sets.
         dependencies=dependencies,
         excludes=excludes,
         overrides=overrides)
@@ -327,7 +327,7 @@ class IvyUtils(object):
         excludes=[self._generate_exclude_template(exclude) for exclude in jar.excludes],
         transitive=jar.transitive,
         artifacts=jar.artifacts,
-        configurations=[conf for conf in jar.configurations if conf in confs])
+        configurations=list(confs))
     override = self._overrides.get((jar.org, jar.name))
     return override(template) if override else template
 
@@ -353,7 +353,7 @@ class IvyUtils(object):
     self.exec_ivy(mapdir,
                   [target],
                   ivyargs,
-                  confs=target.payload.configurations,
+                  confs=list(target.payload.configurations),
                   ivy=Bootstrapper.default_ivy(executor),
                   workunit_factory=workunit_factory,
                   workunit_name='map-jars',
@@ -406,9 +406,9 @@ class IvyUtils(object):
     ivy_args = ['-ivy', ivyxml]
 
     confs_to_resolve = confs or ['default']
+
     ivy_args.append('-confs')
     ivy_args.extend(confs_to_resolve)
-
     ivy_args.extend(args)
     if not self._transitive:
       ivy_args.append('-notransitive')

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -9,8 +9,8 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.build_manual import manual
 from pants.backend.jvm.targets.exclude import Exclude
+from pants.base.build_manual import manual
 
 
 class Artifact(object):
@@ -114,12 +114,6 @@ class JarDependency(object):
         self.declared_exclusives[k] |= exclusives[k]
 
   @property
-  def configurations(self):
-    confs = OrderedSet(self._configurations)
-    confs.update(artifact.conf for artifact in self.artifacts if artifact.conf)
-    return list(confs)
-
-  @property
   def classifier(self):
     """Returns the maven classifier for this jar dependency.
 
@@ -152,17 +146,15 @@ class JarDependency(object):
 
   @manual.builddict()
   def with_sources(self):
-    """This requests the artifact have its source jar fetched.
+    """This historically requested the artifact have its source jar fetched.
     (This implies there *is* a source jar to fetch.) Used in contexts
-    that can use source jars (as of 2013, just eclipse and idea goals)."""
-    self._configurations.append('sources')
+    that can use source jars (as of 2014, just eclipse and idea goals)."""
     return self
 
   def with_docs(self):
-    """This requests the artifact have its javadoc jar fetched.
+    """This historically requested the artifact have its javadoc jar fetched.
     (This implies there *is* a javadoc jar to fetch.) Used in contexts
     that can use source jars (as of 2014, just eclipse and idea goals)."""
-    self._configurations.append('javadoc')
     return self
 
   @manual.builddict()

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -54,7 +54,8 @@ class IvyTaskMixin(object):
                   symlink_ivyxml=False,
                   silent=False,
                   workunit_name=None,
-                  workunit_labels=None):
+                  workunit_labels=None,
+                  confs=None):
     # NOTE: Always pass all the targets to exec_ivy, as they're used to calculate the name of
     # the generated module, which in turn determines the location of the XML report file
     # ivy generates. We recompute this name from targets later in order to find that file.
@@ -102,8 +103,8 @@ class IvyTaskMixin(object):
               ivy=ivy,
               workunit_name='ivy',
               workunit_factory=self.context.new_workunit,
-              symlink_ivyxml=symlink_ivyxml)
-
+              symlink_ivyxml=symlink_ivyxml,
+              confs=confs)
         if workunit_name:
           with self.context.new_workunit(name=workunit_name, labels=workunit_labels or []):
             exec_ivy()

--- a/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
+++ b/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
@@ -22,7 +22,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       {{#lib.configurations}}
       <conf name="{{.}}"/>
       {{/lib.configurations}}
-     </configurations>
+    </configurations>
   {{/lib.configurations?}}
 
   {{#lib.publications?}}
@@ -55,13 +55,18 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       <conf name="{{.}}" mapped="{{.}}"/>
       {{/configurations}}
       {{#artifacts}}
+      <!--
+      The conf = ... in the block below is a hack around a bug John described on RB 716. The bug has
+      something to do with artifacts not being fetched unless .with_artifacts is called multiple
+      times.
+      -->
       <artifact
         {{#name}}name="{{.}}"{{/name}}
         {{#ext}}ext="{{.}}"{{/ext}}
         {{#url}}url="{{.}}"{{/url}}
         {{#type_}}type="{{.}}"{{/type_}}
         {{#classifier}}m:classifier="{{.}}"{{/classifier}}
-        {{#conf}}conf="{{.}}"{{/conf}}
+        conf="{{#configurations}}{{.}}->{{.}};{{/configurations}}"
       />
       {{/artifacts}}
       {{#excludes}}

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -16,6 +16,11 @@ python_library(
 )
 
 python_library(
+  name = 'address_lookup_error',
+  sources = ['address_lookup_error.py'],
+)
+
+python_library(
   name = 'addressable',
   sources = ['addressable.py'],
   dependencies = [
@@ -54,6 +59,7 @@ python_library(
     '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.lang',
+    ':address_lookup_error',
   ]
 )
 
@@ -62,6 +68,7 @@ python_library(
   sources = ['build_file_address_mapper.py'],
   dependencies = [
     ':address',
+    ':address_lookup_error',
     ':build_file',
     ':build_environment',
   ]
@@ -90,6 +97,7 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':address',
+    ':address_lookup_error',
   ]
 )
 

--- a/src/python/pants/base/address_lookup_error.py
+++ b/src/python/pants/base/address_lookup_error.py
@@ -1,0 +1,12 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+
+class AddressLookupError(Exception):
+  """Raised by various modules when an address can't be resolved.  Use this common base class so
+   other modules can trap the error at each node along the path and construct a useful diagnostic.
+  """

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -20,7 +20,8 @@ logger = logging.getLogger(__name__)
 
 class BuildFile(object):
 
-  class MissingBuildFileError(IOError):
+  class MissingBuildFileError(Exception):
+    """Raised when a BUILD file cannot be found at the path in the spec."""
     pass
 
   _BUILD_FILE_PREFIX = 'BUILD'
@@ -66,12 +67,12 @@ class BuildFile(object):
   def __init__(self, root_dir, relpath=None, must_exist=True):
     """Creates a BuildFile object representing the BUILD file set at the specified path.
 
-    root_dir: The base directory of the project
-    relpath: The path relative to root_dir where the BUILD file is found - this can either point
+    :param string root_dir: The base directory of the project
+    :param string relpath: The path relative to root_dir where the BUILD file is found - this can either point
         directly at the BUILD file or else to a directory which contains BUILD files
-    must_exist: If True, the specified BUILD file must exist or else an IOError is thrown
-    raises IOError if the path is not absolute
-    raises MissingBuildFileError if the path does not house a BUILD file and must_exist is True
+    :param bool must_exist: If True, the specified BUILD file must exist or else an IOError is thrown
+    :raises IOError: if the root_dir path is not absolute
+    :raises MissingBuildFileError: if the path does not house a BUILD file and must_exist is True
     """
 
     if not os.path.isabs(root_dir):

--- a/src/python/pants/base/build_file_address_mapper.py
+++ b/src/python/pants/base/build_file_address_mapper.py
@@ -5,19 +5,22 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from threading import Event
 
 from pants.base.address import BuildFileAddress, parse_spec, SyntheticAddress
+from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file import BuildFile
 from pants.base.build_environment import get_buildroot
-
-
-class AddressLookupError(Exception): pass
 
 
 class BuildFileAddressMapper(object):
   """Maps addresses in the pants virtual address space to corresponding BUILD file declarations.
   """
+
+  class AddressNotInBuildFile(AddressLookupError):
+    pass
+
+  class InvalidBuildFileReference(AddressLookupError):
+    pass
 
   def __init__(self, build_file_parser):
     self._build_file_parser = build_file_parser
@@ -28,10 +31,16 @@ class BuildFileAddressMapper(object):
     return self._build_file_parser._root_dir
 
   def resolve(self, address):
-    """Maps an address in the virtual address space to an object."""
+    """Maps an address in the virtual address space to an object.
+    :param Address address: the address to lookup in a BUILD file
+    :raises AddressLookupError: if the path to the address is not found.
+    :returns: Addressable from a build file specified by address
+    """
     address_map = self.address_map_from_spec_path(address.spec_path)
     if address not in address_map:
-      raise AddressLookupError("Failed to resolve address {address}".format(address=address))
+      raise self.AddressNotInBuildFile(
+        "Target name '{target_name}' not found in BUILD file in {spec_path}"
+        .format(address=address.target_name, spec_path=address.spec_path))
     else:
       return address_map[address]
 
@@ -55,13 +64,24 @@ class BuildFileAddressMapper(object):
     return self.address_map_from_spec_path(spec_path).keys()
 
   def spec_to_address(self, spec, relative_to=''):
-    """A helper method for mapping a spec to the correct BuildFileAddress."""
+    """A helper method for mapping a spec to the correct BuildFileAddress.
+    :param spec: a spec to lookup in the map.
+    :raises AddressLookupError: if the BUILD file cannot be found in the path specified by the spec
+    :returns a new BuildFileAddress instanace
+    """
     spec_path, name = parse_spec(spec, relative_to=relative_to)
-    build_file = BuildFile.from_cache(self.root_dir, spec_path)
+    try:
+      build_file = BuildFile.from_cache(self.root_dir, spec_path)
+    except BuildFile.MissingBuildFileError as e:
+      raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
+                                           .format(message=e, spec=spec))
     return BuildFileAddress(build_file, name)
 
   def specs_to_addresses(self, specs, relative_to=''):
-    """The equivalent of `spec_to_address` for a group of specs all relative to the same path."""
+    """The equivalent of `spec_to_address` for a group of specs all relative to the same path.
+    :param spec: iterable of Addresses.
+    :raises AddressLookupError: if the BUILD file cannot be found in the path specified by the spec
+    """
     for spec in specs:
       yield self.spec_to_address(spec, relative_to=relative_to)
 

--- a/src/python/pants/commands/goal_runner.py
+++ b/src/python/pants/commands/goal_runner.py
@@ -75,13 +75,10 @@ class GoalRunner(Command):
       # Here, it's possible we have a goal and target with the same name. For now, always give
       # priority to the goal, but give a warning if they might have meant the target (if the BUILD
       # file exists).
-      try:
-        BuildFile.from_cache(get_buildroot(), spec)
-        msg = (' Command-line argument "{spec}" is ambiguous, and was assumed to be a goal.'
-               ' If this is incorrect, disambiguate it with the "--" argument to separate goals'
-               ' from targets.')
-        logger.warning(msg.format(spec=spec))
-      except IOError: pass # Awesome, it's unambiguous.
+      if BuildFile.from_cache(get_buildroot(), spec, must_exist=False).exists():
+        logger.warning(' Command-line argument "{spec}" is ambiguous, and was assumed to be a '
+                       'goal.  If this is incorrect, disambiguate it with the "--" argument to '
+                       'separate goals from targets.'.format(spec=spec))
       return False
 
     for i, arg in enumerate(args):

--- a/testprojects/src/java/com/pants/testproject/missing_sources/BUILD
+++ b/testprojects/src/java/com/pants/testproject/missing_sources/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='missing_sources',
+  sources=[],
+  dependencies=[':ant'],
+)
+
+jar_library(name='ant',
+  jars=[
+    jar(org='ant', name='ant', rev='1.6.4').with_sources(),
+  ],
+)

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -16,6 +16,7 @@ python_library(
     'src/python/pants/base:config',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:target',
+    'src/python/pants/goal:goal',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/base:context_utils',

--- a/tests/python/pants_test/base/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/base/test_build_file_address_mapper.py
@@ -5,13 +5,12 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import os
 from textwrap import dedent
-import unittest2 as unittest
 
 from pants.backend.core.targets.dependencies import Dependencies
-from pants.base.build_file_address_mapper import AddressLookupError
-from pants.base.addressable import Addressable
+from pants.base.address import BuildFileAddress
+from pants.base.address_lookup_error import AddressLookupError
+from pants.base.build_file_address_mapper import BuildFileAddressMapper
 
 from pants_test.base_test import BaseTest
 
@@ -20,8 +19,21 @@ class BuildFileAddressMapperTest(BaseTest):
   def setUp(self):
     super(BuildFileAddressMapperTest, self).setUp()
 
-  def test_target_addressable(self):
+  def test_resolve(self):
     build_file = self.add_to_build_file('BUILD', dedent(
+      ''' dependencies(
+        name = 'foo'
+      )
+      '''
+    ))
+
+    address = BuildFileAddress(build_file, 'foo')
+    addressable = self.address_mapper.resolve(address)
+    self.assertEquals(address.target_name, addressable.addressable_name)
+    self.assertEqual(addressable.target_type, Dependencies)
+
+  def test_resolve_spec(self):
+    self.add_to_build_file('BUILD', dedent(
       '''
       dependencies(
         name = 'foozle'
@@ -38,4 +50,26 @@ class BuildFileAddressMapperTest(BaseTest):
 
     dependencies_addressable = self.address_mapper.resolve_spec('//:foozle')
     self.assertEqual(dependencies_addressable.target_type, Dependencies)
+
+  def test_raises_address_lookup_error(self):
+    # reference a BUILD file that doesn't exist
+    self.assertIsInstance(BuildFileAddressMapper.AddressNotInBuildFile, AddressLookupError)
+    with self.assertRaisesRegexp(BuildFileAddressMapper.AddressNotInBuildFile,
+                                 '^BUILD file does not exist at: .*/non-existent-path'
+                                 '\s+when translating spec //non-existent-path:a'):
+      self.address_mapper.spec_to_address('//non-existent-path:a')
+
+    build_file = self.add_to_build_file('BUILD', dedent(
+      '''
+      dependencies(
+        name = 'foo'
+      )
+      '''
+    ))
+
+    # Create an address that doesn't exist in an existing BUILD file
+    self.assertIsInstance(BuildFileAddressMapper.InvalidBuildFileReference, AddressLookupError)
+    address = BuildFileAddress(build_file, 'bar')
+    with self.assertRaises(BuildFileAddressMapper.InvalidBuildFileReference):
+      self.address_mapper.resolve(address)
 


### PR DESCRIPTION
This involved a fair amount of finagling with conf variables spread across ivy_* and ide files,
and some changes to the ivy mustache. The mechanism by which confs are currently passed around
does not seem very robust. The whole system would probably benefit from some refactoring to
abstract away ivy's inner workings and streamline generic mapping settings; it would be nice to
have an abstract interface for mapping jar files. This could  also make it easier to deal with
failing downloads, parallelization, or using a different jar mapping tool, but all that can
wait for an entirely different review.

Also cleaned up some style issues that got missed in the last patch for the idea goal.