### PR TITLE
Miscellaneous fixes to protobuf codegen.

### DIFF
--- a/src/java/com/pants/testproject/proto-ordering/BUILD
+++ b/src/java/com/pants/testproject/proto-ordering/BUILD
@@ -1,0 +1,8 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This is here to test a common use-case in maven-style directory structures, wherein targets in
+# root directories exist purely to consolidate targets in other locations.
+dependencies(name='proto-ordering',
+  dependencies=['src/protobuf/com/pants/testproject/proto-ordering:protos'],
+)

--- a/src/protobuf/com/pants/testproject/proto-ordering/BUILD
+++ b/src/protobuf/com/pants/testproject/proto-ordering/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_protobuf_library(name='protos',
+  sources=['testproto5.proto', 'testproto6.proto',],
+  dependencies=[
+    'src/protobuf/com/pants/testproject/proto-ordering/a',
+    'src/protobuf/com/pants/testproject/proto-ordering/b',
+  ],
+)

--- a/src/protobuf/com/pants/testproject/proto-ordering/a/BUILD
+++ b/src/protobuf/com/pants/testproject/proto-ordering/a/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_protobuf_library(name='a',
+  sources=['testproto1.proto', 'testproto2.proto',],
+  imports=['3rdparty:protobuf-test-import',],
+)

--- a/src/protobuf/com/pants/testproject/proto-ordering/a/testproto1.proto
+++ b/src/protobuf/com/pants/testproject/proto-ordering/a/testproto1.proto
@@ -1,0 +1,6 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+// This proto intentionally left blank; it's just used to test the ordering of the protoc
+// invocation.

--- a/src/protobuf/com/pants/testproject/proto-ordering/a/testproto2.proto
+++ b/src/protobuf/com/pants/testproject/proto-ordering/a/testproto2.proto
@@ -1,0 +1,6 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+// This proto intentionally left blank; it's just used to test the ordering of the protoc
+// invocation.

--- a/src/protobuf/com/pants/testproject/proto-ordering/b/BUILD
+++ b/src/protobuf/com/pants/testproject/proto-ordering/b/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_protobuf_library(name='b',
+  sources=['zestproto3.proto', 'testproto4.proto',],
+)

--- a/src/protobuf/com/pants/testproject/proto-ordering/b/testproto4.proto
+++ b/src/protobuf/com/pants/testproject/proto-ordering/b/testproto4.proto
@@ -1,0 +1,6 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+// This proto intentionally left blank; it's just used to test the ordering of the protoc
+// invocation.

--- a/src/protobuf/com/pants/testproject/proto-ordering/b/zestproto3.proto
+++ b/src/protobuf/com/pants/testproject/proto-ordering/b/zestproto3.proto
@@ -1,0 +1,9 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+// This proto name starts with a 'z' to ensure that ordering
+// prioritizes dependency reference order over alphabetization.
+
+
+// This proto intentionally left blank; it's just used to test the ordering of the protoc
+// invocation.

--- a/src/protobuf/com/pants/testproject/proto-ordering/testproto5.proto
+++ b/src/protobuf/com/pants/testproject/proto-ordering/testproto5.proto
@@ -1,0 +1,6 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+// This proto intentionally left blank; it's just used to test the ordering of the protoc
+// invocation.

--- a/src/protobuf/com/pants/testproject/proto-ordering/testproto6.proto
+++ b/src/protobuf/com/pants/testproject/proto-ordering/testproto6.proto
@@ -1,0 +1,6 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+// This proto intentionally left blank; it's just used to test the ordering of the protoc
+// invocation.

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -45,6 +45,9 @@ class IvyImports(NailgunTask):
     return 'jar' + str((jar.org, jar.name, jar.rev))
 
   def execute(self):
+    def nice_target_name(t):
+      return t.address.spec
+
     resolve_for = self.context.targets(lambda t: t.has_label('has_imports'))
     if resolve_for:
       imports_util = ImportsUtil(self.context)
@@ -52,9 +55,9 @@ class IvyImports(NailgunTask):
       executor = self.create_java_executor()
       for target in resolve_for:
         jars = target.imports
-        self.context.log.info('Fetching import jars for {target}: {jars}'.format(
-            target=target,
-            jars=', '.join(self._str_jar(s) for s in jars)))
+        self.context.log.info('Mapping import jars for {target}: \n  {jars}'.format(
+            target=nice_target_name(target),
+            jars='\n  '.join(self._str_jar(s) for s in jars)))
         imports_util.mapjars(imports_map, target, executor,
                              workunit_factory=self.context.new_workunit,
                              jars=jars)

--- a/src/python/pants/base/build_graph.py
+++ b/src/python/pants/base/build_graph.py
@@ -8,6 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import logging
 from collections import defaultdict
 
+from twitter.common.collections import OrderedDict
 from twitter.common.collections import OrderedSet
 
 from pants.base.address import SyntheticAddress
@@ -26,7 +27,7 @@ class BuildGraph(object):
     self.reset()
 
   def reset(self):
-    self._target_by_address = {}
+    self._target_by_address = OrderedDict()
     self._target_dependencies_by_address = defaultdict(set)
     self._target_dependees_by_address = defaultdict(set)
     self._derived_from_by_derivative_address = {}

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -190,7 +190,7 @@ class JavaProtobufLibraryPayload(JvmTargetPayload):
     for config in sorted(self.configurations):
       hasher.update(config)
     for jar in sorted(self.imports):
-      hasher.update(jar.id)
+      hasher.update(bytes(hash(jar)))
     return hasher.hexdigest()
 
 

--- a/tests/python/pants_test/tasks/test_protobuf_integration.py
+++ b/tests/python/pants_test/tasks/test_protobuf_integration.py
@@ -6,6 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
+import re
 import subprocess
 
 from pants.base.build_environment import get_buildroot
@@ -15,7 +16,8 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class ProtobufIntegrationTest(PantsRunIntegrationTest):
   def test_bundle_protobuf_normal(self):
     pants_run = self.run_pants(
-        ['goal', 'bundle', 'src/java/com/pants/examples/protobuf:protobuf-example', '--bundle-deployjar'])
+        ['goal', 'bundle', 'src/java/com/pants/examples/protobuf:protobuf-example',
+         '--bundle-deployjar', '--print-exception-stacktrace',])
     self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
                       "goal bundle run expected success, got {0}\n"
                       "got stderr:\n{1}\n"
@@ -35,7 +37,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
   def test_bundle_protobuf_imports(self):
     pants_run = self.run_pants(
         ['goal', 'bundle', 'src/java/com/pants/examples/protobuf:protobuf-imports-example',
-         '--bundle-deployjar'])
+         '--bundle-deployjar', '--print-exception-stacktrace',])
     self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
                       "goal bundle run expected success, got {0}\n"
                       "got stderr:\n{1}\n"
@@ -51,3 +53,55 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
     java_out = java_run.stdout.read()
     self.assertEquals(java_retcode, 0)
     self.assertTrue("very test" in java_out)
+
+  def test_source_ordering(self):
+    pants_run = self.run_pants([
+        'goal', 'gen', 'src/java/com/pants/testproject/proto-ordering', '--level=debug',
+         '--print-exception-stacktrace', '--gen-protoc-lang=java',
+    ])
+    self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
+                      "goal bundle run expected success, got {0}\n"
+                      "got stderr:\n{1}\n"
+                      "got stdout:\n{2}\n".format(pants_run.returncode,
+                                                  pants_run.stderr_data,
+                                                  pants_run.stdout_data))
+    def find_protoc_blocks(lines):
+      block = []
+      for line in lines:
+        if block:
+          if line.strip():
+            block.append(line.strip())
+          else:
+            yield block
+            block = []
+          continue
+        if re.search(r'Executing: .*?\bprotoc', line):
+          block.append(line)
+
+    # Scraping debug statements for protoc compilation. Notably, debugs are in stderr, not stdout.
+    all_blocks = list(find_protoc_blocks(pants_run.stderr_data.split('\n')))
+    self.assertEquals(len(all_blocks), 1,
+        'Expected there to be exactly one protoc compilation group! (Were {count}.)\n{out}'
+        .format(count=len(all_blocks), out=pants_run.stderr_data))
+
+    block = all_blocks[0]
+    seen_extracted = False
+    last_proto = -1
+    for line in block:
+      # Make sure import bases appear after the bases for actual sources.
+      if line.startswith('--proto_path='):
+        if re.search(r'\bextracted\b', line):
+          seen_extracted = True
+        else:
+          self.assertFalse(seen_extracted,
+              'Local protoc bases must be ordered before imported bases!')
+        continue
+      # Check to make sure, eg, testproto4.proto never preceedes testproto2.proto.
+      protofile = re.search(r'\d+[.]proto$', line)
+      if protofile:
+        protofile = protofile.group()
+        number = int(protofile[:protofile.find('.')])
+        self.assertTrue(number > last_proto, '{proto} succeeded proto #{number}!'.format(
+            proto=line, number=last_proto))
+        last_proto = number
+    self.assertEquals(last_proto, 6, 'Not all protos were seen!')


### PR DESCRIPTION
Sorted protobuf paths and resources, and handled collisions deterministically. This process generates
copious warning/error log output where appropriate, as protobuf collisions are something the user should
definitely be aware of.

The imports property of java_protobuf_library was changed slightly to not cache its list of jars if it doesn't
manage to resolve one of its targets. This solves a problem where it incorrectly saves an empty list if it's
poked before the build graph loads.

Modified the log outputs of ivy imports to be more accurate/helpful.

Reduced occurance of extraneous/incorrect 'unconsumed gen targets' warning (it still happens, not as much).
