### PR TITLE
Added a --spec-exclude command line flag to exclude specs by regular exp...

### DIFF
--- a/src/java/com/pants/testproject/phrases/BUILD
+++ b/src/java/com/pants/testproject/phrases/BUILD
@@ -1,0 +1,22 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='lesser-of-two',
+  main='com.pants.testproject.phrases.LesserOfTwo',
+  source='LesserOfTwo.java',
+)
+
+jvm_binary(name='once-upon-a-time',
+  main='com.pants.testproject.phrases.OnceUponATime',
+  source='OnceUponATime.java',
+)
+
+jvm_binary(name='ten-thousand',
+  main='com.pants.testproject.phrases.TenThousand',
+  source='TenThousand.java',
+)
+
+jvm_binary(name='there-was-a-duck',
+  main='com.pants.testproject.phrases.ThereWasADuck',
+  source='ThereWasADuck.java',
+)

--- a/src/java/com/pants/testproject/phrases/LesserOfTwo.java
+++ b/src/java/com/pants/testproject/phrases/LesserOfTwo.java
@@ -1,0 +1,10 @@
+package com.pants.testproject.phrases;
+
+/**
+ * Prints out a single line which is used to test the functionality of --spec-exclude.
+ */
+public class LesserOfTwo {
+  public static void main(String[] args) {
+    System.out.println("One must choose the lesser of two eval()s.");
+  }
+}

--- a/src/java/com/pants/testproject/phrases/OnceUponATime.java
+++ b/src/java/com/pants/testproject/phrases/OnceUponATime.java
@@ -1,0 +1,10 @@
+package com.pants.testproject.phrases;
+
+/**
+ * Prints out a single line which is used to test the functionality of --spec-exclude.
+ */
+public class OnceUponATime {
+  public static void main(String[] args) {
+    System.out.println("Once upon a time, in a far away land, there were some pants.");
+  }
+}

--- a/src/java/com/pants/testproject/phrases/TenThousand.java
+++ b/src/java/com/pants/testproject/phrases/TenThousand.java
@@ -1,0 +1,10 @@
+package com.pants.testproject.phrases;
+
+/**
+ * Prints out a single line which is used to test the functionality of --spec-exclude.
+ */
+public class TenThousand {
+  public static void main(String[] args) {
+    System.out.println("And now you must face my army of ten thousand BUILD files.");
+  }
+}

--- a/src/java/com/pants/testproject/phrases/ThereWasADuck.java
+++ b/src/java/com/pants/testproject/phrases/ThereWasADuck.java
@@ -1,0 +1,10 @@
+package com.pants.testproject.phrases;
+
+/**
+ * Prints out a single line which is used to test the functionality of --spec-exclude.
+ */
+public class ThereWasADuck {
+  public static void main(String[] args) {
+    System.out.println("And also, there was a duck.");
+  }
+}

--- a/src/python/pants/commands/goal.py
+++ b/src/python/pants/commands/goal.py
@@ -5,10 +5,12 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
+from collections import defaultdict
 from contextlib import contextmanager
 import inspect
 import logging
 import os
+import re
 import sys
 import traceback
 
@@ -22,8 +24,8 @@ from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask  # XXX(pl)
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
-from pants.base.config import Config
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
+from pants.base.config import Config
 from pants.base.rcfile import RcFile
 from pants.base.workunit import WorkUnit
 from pants.commands.command import Command
@@ -31,10 +33,10 @@ from pants.engine.engine import Engine
 from pants.engine.round_engine import RoundEngine
 from pants.goal.context import Context
 from pants.goal.goal import GoalError
-from pants.goal.phase import Phase
 from pants.goal.help import print_help
 from pants.goal.initialize_reporting import update_reporting
 from pants.goal.option_helpers import add_global_options
+from pants.goal.phase import Phase
 from pants.util.dirutil import safe_mkdir
 
 
@@ -236,8 +238,42 @@ class Goal(Command):
             return True
       return False
 
+    # Target specs are mapped to the patterns which match them, if any. This variable is a key for
+    # specs which don't match any exclusion regexes. We know it won't already be in the list of
+    # patterns, because the asterisks in its name make it an invalid regex.
+    _UNMATCHED_KEY = '** unmatched **'
+
+    def targets_by_pattern(targets, patterns):
+      mapping = defaultdict(list)
+      for target in targets:
+        matched_pattern = None
+        for pattern in patterns:
+          if re.search(pattern, target.address.spec) is not None:
+            matched_pattern = pattern
+            break
+        if matched_pattern is None:
+          mapping[_UNMATCHED_KEY].append(target)
+        else:
+          mapping[matched_pattern].append(target)
+      return mapping
+
     is_explain = self.options.explain
     update_reporting(self.options, is_console_task() or is_explain, self.run_tracker)
+
+    if self.options.target_excludes:
+      excludes = self.options.target_excludes
+      log.debug('excludes:\n  {excludes}'.format(excludes='\n  '.join(excludes)))
+      by_pattern = targets_by_pattern(self.targets, excludes)
+      self.targets = by_pattern[_UNMATCHED_KEY]
+      # The rest of this if-statement is just for debug logging.
+      log.debug('Targets after excludes: {targets}'.format(
+          targets=', '.join(t.address.spec for t in self.targets)))
+      excluded_count = sum(len(by_pattern[p]) for p in excludes)
+      log.debug('Excluded {count} target{plural}.'.format(count=excluded_count,
+          plural=('s' if excluded_count != 1 else '')))
+      for pattern in excludes:
+        log.debug('Targets excluded by pattern {pattern}\n  {targets}'.format(pattern=pattern,
+            targets='\n  '.join(t.address.spec for t in by_pattern[pattern])))
 
     context = Context(
       config=self.config,

--- a/src/python/pants/goal/option_helpers.py
+++ b/src/python/pants/goal/option_helpers.py
@@ -45,6 +45,10 @@ GLOBAL_OPTIONS = [
   Option('--read-from-artifact-cache', '--no-read-from-artifact-cache', action='callback',
          callback=_set_bool, dest='read_from_artifact_cache', default=True,
          help='Read build artifacts from cache, if available.'),
+  Option('--exclude-target-regexp', dest='target_excludes', type='str',
+         default=[], action='append',
+         help='Regex pattern to exclude from the target list (useful in conjunction with ::). '
+              'Multiple patterns may be specified by setting this flag multiple times.'),
   Option('--write-to-artifact-cache', '--no-write-to-artifact-cache', action='callback',
          callback=_set_bool, dest='write_to_artifact_cache', default=True,
          help='Write build artifacts to cache, if possible.'),

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -77,6 +77,7 @@ python_tests(
 dependencies(
   name = 'integration',
   dependencies = [
+    pants('tests/python/pants_test/commands:integration'),
     pants('tests/python/pants_test/targets:integration'),
     pants('tests/python/pants_test/tasks:integration'),
     pants('tests/python/pants_test/python:integration'),

--- a/tests/python/pants_test/commands/BUILD
+++ b/tests/python/pants_test/commands/BUILD
@@ -16,6 +16,13 @@ python_test_suite(
   ]
 )
 
+python_test_suite(
+  name = 'integration',
+  dependencies = [
+    pants(':test_spec_exclude_integration'),
+  ]
+)
+
 python_tests(
   name = 'test_goal',
   sources = [ 'test_goal.py' ],
@@ -43,5 +50,13 @@ python_tests(
     pants('src/python/pants/util:contextutil'),
     pants('src/python/pants/util:dirutil'),
     pants('tests/python/pants_test:base_test'),
+  ]
+)
+
+python_tests(
+  name = 'test_spec_exclude_integration',
+  sources = [ 'test_spec_exclude_integration.py' ],
+  dependencies = [
+    pants('tests/python/pants_test:int-test'),
   ]
 )

--- a/tests/python/pants_test/commands/test_spec_exclude_integration.py
+++ b/tests/python/pants_test/commands/test_spec_exclude_integration.py
@@ -1,0 +1,142 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from contextlib import contextmanager
+from shutil import rmtree
+
+import os
+import subprocess
+
+from pants.base.build_environment import get_buildroot
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class Bundles(object):
+  """Container class to hold test bundle specifications."""
+
+  phrase_path = 'src/java/com/pants/testproject/phrases'
+
+  class Bundle(object):
+    def __init__(self, spec, text):
+      self.spec = spec
+      self.text = text
+
+    def __hash__(self):
+      return hash((self.spec, self.text))
+
+    @property
+    def full_spec(self):
+      return '{project}:{name}'.format(project=Bundles.phrase_path, name=self.spec)
+
+  # Bundles and their magic strings to expect in run outputs.
+  lesser_of_two = Bundle('lesser-of-two',
+      "One must choose the lesser of two eval()s.")
+  once_upon_a_time = Bundle('once-upon-a-time',
+      "Once upon a time, in a far away land, there were some pants.")
+  ten_thousand = Bundle('ten-thousand',
+      "And now you must face my army of ten thousand BUILD files.")
+  there_was_a_duck = Bundle('there-was-a-duck',
+      "And also, there was a duck.")
+
+  all_bundles = [lesser_of_two, once_upon_a_time, ten_thousand, there_was_a_duck,]
+
+
+class SpecExcludeIntegrationTest(PantsRunIntegrationTest):
+  """Tests the functionality of the --spec-exclude flag in pants."""
+
+  def _bundle_path(self, bundle):
+    return os.path.join(get_buildroot(), 'dist', '{name}-bundle'.format(name=bundle))
+
+  @contextmanager
+  def _handle_bundles(self, names):
+    """Makes sure bundles don't exist to begin with, and deletes them afterward."""
+    paths = [self._bundle_path(name) for name in names]
+    jars = ['{name}.jar'.format(name=name) for name in names]
+    yield (paths, jars)
+    missing = []
+    for path in paths:
+      if os.path.exists(path):
+        rmtree(path)
+      else:
+        missing.append(path)
+    self.assertFalse(missing, "Some bundles weren't generated! {missing}"
+        .format(missing=', '.join(missing)))
+
+  def _test_bundle_existences(self, args, bundles):
+    all_bundles = set(bundle.spec for bundle in Bundles.all_bundles)
+    all_paths = [self._bundle_path(bundle) for bundle in all_bundles]
+
+    names = [bundle.spec for bundle in bundles]
+    outputs = [bundle.text for bundle in bundles]
+
+    for path in all_paths:
+      if os.path.exists(path):
+        rmtree(path)
+
+    with self._handle_bundles(names) as (paths, jars):
+      pants_run = self.run_pants(['goal', 'bundle',] + args)
+      self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
+                        "goal bundle expected success, got {0}\n"
+                        "got stderr:\n{1}\n"
+                        "got stdout:\n{2}\n".format(pants_run.returncode,
+                                                    pants_run.stderr_data,
+                                                    pants_run.stdout_data))
+      for path, jar, expected in zip(paths, jars, outputs):
+        java_run = subprocess.Popen(['java', '-jar', jar],
+                                    stdout=subprocess.PIPE,
+                                    cwd=path)
+        java_retcode = java_run.wait()
+        java_out = java_run.stdout.read()
+        self.assertEquals(java_retcode, 0)
+        self.assertTrue(expected in java_out, "Expected '{output}' from {jar}, not '{stdout}'."
+                                              .format(output=expected, jar=jar, stdout=java_out))
+
+    lingering = [path for path in all_paths if os.path.exists(path)]
+    self.assertTrue(not lingering, "Left with unexpected bundles! {bundles}"
+                                   .format(bundles=', '.join(lingering)))
+
+  def test_single_run(self):
+    """Test whether we can run a single target without special flags."""
+    self._test_bundle_existences(
+        [Bundles.lesser_of_two.full_spec,],
+        [Bundles.lesser_of_two,],
+    )
+
+  def test_double_run(self):
+    """Test whether we can run two targets without special flags."""
+    self._test_bundle_existences(
+        [Bundles.lesser_of_two.full_spec, Bundles.once_upon_a_time.full_spec,],
+        [Bundles.lesser_of_two, Bundles.once_upon_a_time,],
+    )
+
+  def test_all_run(self):
+    """Test whether we can run everything with ::."""
+    self._test_bundle_existences(
+        [Bundles.phrase_path + '::',],
+        Bundles.all_bundles,
+    )
+
+  def test_exclude_lesser(self):
+    self._test_bundle_existences(
+        [Bundles.phrase_path + '::', '--exclude-target-regexp=lesser',],
+        set(Bundles.all_bundles) - set([Bundles.lesser_of_two,]),
+    )
+
+  def test_exclude_thoe(self):
+    self._test_bundle_existences(
+        [Bundles.phrase_path + '::', r'--exclude-target-regexp=\bth[oe]',],
+        set(Bundles.all_bundles) - set([Bundles.there_was_a_duck, Bundles.ten_thousand,]),
+    )
+
+  def test_exclude_two(self):
+    self._test_bundle_existences([
+          Bundles.phrase_path + '::',
+          '--exclude-target-regexp=duck',
+          '--exclude-target-regexp=time',
+        ],
+        set(Bundles.all_bundles) - set([Bundles.there_was_a_duck, Bundles.once_upon_a_time,]),
+    )


### PR DESCRIPTION
...ression.

Multiple expressions can be specified by setting the flag more than once. This is in the same
vein as Eric's earlier work on excluding specs with the ^ expression, but this is more powerful
in that it (a) uses regexes, and (b) is an actual flag, and can therefore be specified in
.pants.rc.

Prompted by the need to exclude some automatically generated targets we have internally.
