### PR TITLE
Fixup travis config to actually run under different pythons, was always ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: python
 
-# It turns out python hosts in travis have all the pythons
-# listed below automgically available so we can pick a
-# random python here for our default but still have access
-# to the gamut.
+# It turns out python hosts in travis have all the pythons listed
+# below automgically available so we can pick a random python here
+# for our default but still have access to the gamut.
 python: 2.7
+# ./build-support/bin/ci.sh bootraps via ./pants which respects PY.
 env:
   - PY=python2.6
   - PY=python2.7
-  - PY=python3.3
-  - PY=python3.4
+# There is work to do to enable the 3.x's including hooking up 2to3
+# translation of some of the requirments.txt deps like
+# antlr-python-runtime.
+#  - PY=python3.3
+#  - PY=python3.4
 
 jdk: openjdk7
 


### PR DESCRIPTION
...picking 2.6.9.
