### PR TITLE
Fixup travis config to actually run under different pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: python
 
-python:
-  - "2.6"
-  - "2.7"
+# It turns out python hosts in travis have all the pythons listed
+# below automgically available so we can pick a random python here
+# for our default but still have access to the gamut.
+python: 2.7
+# ./build-support/bin/ci.sh bootraps via ./pants which respects PY.
+env:
+  - PY=python2.6
+  - PY=python2.7
+# There is work to do to enable the 3.x's including hooking up 2to3
+# translation of some of the requirments.txt deps like
+# antlr-python-runtime.
+#  - PY=python3.3
+#  - PY=python3.4
 
-jdk:
-  - openjdk6
-  - openjdk7
+jdk: openjdk7
 
 script: |
   java -version; ./build-support/bin/ci.sh -d

--- a/pants
+++ b/pants
@@ -48,6 +48,8 @@ PANTS_BINARY=src/python/pants/bin:pants
 PANTS_PEX="${HERE}/pants.pex"
 FAILED_BOOTSTRAP_SENTINEL="${HERE}/.pants.d/BOOTSTRAP_FAILED"
 
+# NB: This env var is used by the activate_pants_venv via
+# build-support/virtualenv
 PY=${PY:-$(which python)}
 
 if [[ ! -z "${WRAPPER_REQUIREMENTS}" ]]; then


### PR DESCRIPTION
Previously despite setting the default `python` version in
.travis.yml, the build-support/virtualenv script used to bootstrap
pants was always picking python 2.7.

https://rbcommons.com/s/twitter/r/798/