### PR TITLE
Add assert_list to ensure an argument is a list

### DIFF
--- a/src/python/pants/backend/jvm/targets/BUILD
+++ b/src/python/pants/backend/jvm/targets/BUILD
@@ -33,6 +33,7 @@ python_library(
     pants('src/python/pants/base:exceptions'),
     pants('src/python/pants/base:payload'),
     pants('src/python/pants/base:target'),
+    pants('src/python/pants/base:validation'),
   ],
 )
 
@@ -67,5 +68,6 @@ python_library(
     pants('src/python/pants/base:address'),
     pants('src/python/pants/base:exceptions'),
     pants('src/python/pants/base:target'),
+    pants('src/python/pants/base:validation'),
   ],
 )

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -5,6 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
+from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.base.payload import JarLibraryPayload
 from pants.base.target import Target
 
@@ -19,7 +20,7 @@ class JarLibrary(Target):
     :param jars: List of :ref:`jar <bdict_jar>`\s to depend upon.
     :param exclusives: An optional map of exclusives tags. See CheckExclusives for details.
     """
-    payload = JarLibraryPayload(jars or [])
+    payload = JarLibraryPayload(self.assert_list(jars, expected_type=JarDependency))
     super(JarLibrary, self).__init__(payload=payload, *args, **kwargs)
     self.add_labels('jars', 'jvm')
 

--- a/src/python/pants/backend/jvm/targets/java_agent.py
+++ b/src/python/pants/backend/jvm/targets/java_agent.py
@@ -8,6 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 from twitter.common.lang import Compatibility
 
 from pants.base.exceptions import TargetDefinitionException
+from pants.base.validation import assert_list
 from pants.backend.jvm.targets.java_library import JavaLibrary
 
 
@@ -55,10 +56,10 @@ class JavaAgent(JavaLibrary):
 
     super(JavaAgent, self).__init__(
         name=name,
-        sources=sources,
+        sources=self.assert_list(sources),
         provides=None,
-        excludes=excludes,
-        resources=resources,
+        excludes=self.assert_list(excludes),
+        resources=self.assert_list(resources),
         exclusives=exclusives,
         **kwargs)
 

--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -10,6 +10,7 @@ from twitter.common.lang import Compatibility
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TargetDefinitionException
+from pants.base.validation import assert_list
 
 
 class JavaTests(JvmTarget):
@@ -34,7 +35,7 @@ class JavaTests(JvmTarget):
       file resources to place in this module's jar.
     :param exclusives: An optional map of exclusives tags. See CheckExclusives for details.
    """
-    _sources = maybe_list(sources or [], expected_type=Compatibility.string)
+    _sources = self.assert_list(sources)
 
     super(JavaTests, self).__init__(sources=_sources, **kwargs)
 

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -8,7 +8,6 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 import re
 
-from twitter.common.collections import maybe_list
 from twitter.common.dirutil import Fileset
 from twitter.common.lang import AbstractClass, Compatibility
 
@@ -19,6 +18,7 @@ from pants.base.build_manual import manual
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import BundlePayload
 from pants.base.target import Target
+from pants.base.validation import assert_list
 
 
 class JarRule(AbstractClass):
@@ -142,7 +142,7 @@ class JarRules(object):
     :returns: JarRules
     """
     default_dup_action = Duplicate.validate_action(default_dup_action or Duplicate.SKIP)
-    additional_rules = maybe_list(additional_rules or [], expected_type=(Duplicate, Skip))
+    additional_rules = assert_list(additional_rules, expected_type=(Duplicate, Skip))
 
     rules = [Skip(r'^META-INF/[^/]+\.SF$'),  # signature file
              Skip(r'^META-INF/[^/]+\.DSA$'),  # default signature alg. file
@@ -180,7 +180,7 @@ class JarRules(object):
       no explicit rules apply to the entry.
     """
     self._default_dup_action = Duplicate.validate_action(default_dup_action)
-    self._rules = maybe_list(rules, expected_type=JarRule) if rules else []
+    self._rules = assert_list(rules, expected_type=JarRule)
 
   @property
   def default_dup_action(self):
@@ -241,7 +241,7 @@ class JvmBinary(JvmTarget):
     :type configurations: tuple of strings
     """
     sources = [source] if source else None
-    super(JvmBinary, self).__init__(name=name, sources=sources, **kwargs)
+    super(JvmBinary, self).__init__(name=name, sources=self.assert_list(sources), **kwargs)
 
     if main and not isinstance(main, Compatibility.string):
       raise TargetDefinitionException(self, 'main must be a fully qualified classname')
@@ -258,7 +258,7 @@ class JvmBinary(JvmTarget):
 
     self.main = main
     self.basename = basename or name
-    self.deploy_excludes = maybe_list(deploy_excludes, Exclude) if deploy_excludes else []
+    self.deploy_excludes = self.assert_list(deploy_excludes, expected_type=Exclude)
     self.deploy_jar_rules = deploy_jar_rules or JarRules.default()
 
 

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -8,10 +8,12 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 from twitter.common.lang import Compatibility
 
 from pants.backend.core.targets.resources import Resources
+from pants.backend.jvm.targets.exclude import Exclude
 from pants.base.address import SyntheticAddress
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import JvmTargetPayload
 from pants.base.target import Target
+from pants.base.validation import assert_list
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jarable import Jarable
 
@@ -44,14 +46,14 @@ class JvmTarget(Target, Jarable):
     """
 
     sources_rel_path = sources_rel_path or address.spec_path
-    payload = JvmTargetPayload(sources=sources,
+    payload = JvmTargetPayload(sources=self.assert_list(sources),
                                sources_rel_path=sources_rel_path,
                                provides=provides,
-                               excludes=excludes,
-                               configurations=configurations)
+                               excludes=self.assert_list(excludes, expected_type=Exclude),
+                               configurations=self.assert_list(configurations))
     super(JvmTarget, self).__init__(address=address, payload=payload, **kwargs)
 
-    self._resource_specs = resources or []
+    self._resource_specs = self.assert_list(resources)
     self.add_labels('jvm')
 
   _jar_dependencies = None

--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -9,6 +9,7 @@ from pants.backend.jvm.scala.target_platform import TargetPlatform
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.base.address import SyntheticAddress
 from pants.base.exceptions import TargetDefinitionException
+from pants.base.validation import assert_list
 
 
 class ScalaLibrary(ExportableJvmLibrary):
@@ -46,7 +47,7 @@ class ScalaLibrary(ExportableJvmLibrary):
       targets containing resources that belong on this library's classpath.
     :param exclusives: An optional list of exclusives tags.
     """
-    self._java_sources_specs = java_sources or []
+    self._java_sources_specs = self.assert_list(java_sources)
     super(ScalaLibrary, self).__init__(**kwargs)
     self.add_labels('scala')
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -185,6 +185,7 @@ python_library(
     pants('3rdparty/python/twitter/commons:twitter.common.collections'),
     pants('3rdparty/python/twitter/commons:twitter.common.lang'),
     pants(':build_environment'),
+    pants(':validation'),
   ]
 )
 
@@ -272,5 +273,14 @@ python_library(
   dependencies = [
     pants('src/python/pants/rwbuf'),
     pants('src/python/pants/util:dirutil'),
+  ],
+)
+
+python_library(
+  name='validation',
+  sources=['validation.py'],
+  dependencies=[
+    pants('3rdparty/python/twitter/commons:twitter.common.collections'),
+    pants('3rdparty/python/twitter/commons:twitter.common.dirutil'),
   ],
 )

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -9,11 +9,11 @@ from abc import abstractmethod
 import os
 from hashlib import sha1
 
-from twitter.common.collections import maybe_list, OrderedSet
-from twitter.common.lang import AbstractClass, Compatibility
+from twitter.common.collections import OrderedSet
+from twitter.common.lang import AbstractClass
 
 from pants.base.build_environment import get_buildroot
-
+from pants.base.validation import assert_list
 
 def hash_sources(root_path, rel_path, sources):
   hasher = sha1()
@@ -55,7 +55,7 @@ class Payload(AbstractClass):
 class SourcesPayload(Payload):
   def __init__(self, sources_rel_path, sources):
     self.sources_rel_path = sources_rel_path
-    self.sources = maybe_list(sources or [], expected_type=Compatibility.string)
+    self.sources = assert_list(sources)
     self.excludes = OrderedSet()
 
   @property
@@ -102,7 +102,7 @@ class JvmTargetPayload(SourcesPayload):
                provides=None,
                excludes=None,
                configurations=None):
-    super(JvmTargetPayload, self).__init__(sources_rel_path, sources)
+    super(JvmTargetPayload, self).__init__(sources_rel_path, assert_list(sources))
     self.provides = provides
     self.excludes = OrderedSet(excludes)
     self.configurations = OrderedSet(configurations)
@@ -205,4 +205,3 @@ class PythonRequirementLibraryPayload(Payload):
     hasher = sha1()
     hasher.update(bytes(hash(tuple(self.requirements))))
     return hasher.hexdigest()
-

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -9,12 +9,16 @@ import collections
 from hashlib import sha1
 import os
 
+from twitter.common.lang import Compatibility
+
 from pants.base.build_environment import get_buildroot
 from pants.base.build_manual import manual
+from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import hash_all
 from pants.base.payload import EmptyPayload
 from pants.base.source_root import SourceRoot
+from pants.base.validation import assert_list
 
 
 class AbstractTarget(object):
@@ -173,6 +177,9 @@ class Target(AbstractTarget):
 
     self._cached_fingerprint_map = {}
     self._cached_transitive_fingerprint_map = {}
+
+  def assert_list(self, maybe_list, expected_type=Compatibility.string):
+    return assert_list(maybe_list, expected_type, raise_type=lambda msg: TargetDefinitionException(self, msg))
 
   def compute_invalidation_hash(self, fingerprint_strategy=None):
     fingerprint_strategy = fingerprint_strategy or DefaultFingerprintStrategy()
@@ -382,4 +389,5 @@ class Target(AbstractTarget):
     return not self.__eq__(other)
 
   def __repr__(self):
-    return "%s(%s)" % (type(self).__name__, self.address)
+    addr = self.address if hasattr(self, 'address') else 'address not yet set'
+    return "%s(%s)" % (type(self).__name__, addr)

--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from twitter.common.collections import OrderedSet
+from twitter.common.dirutil.fileset import Fileset
+from twitter.common.lang import Compatibility
+
+def assert_list(obj, expected_type=Compatibility.string, can_be_none=True, default=(),
+    allowable=(list, Fileset, OrderedSet, set, tuple), raise_type=ValueError):
+  """
+  This function is used to ensure that parameters set by users in BUILD files are of acceptable types.
+  :param obj           : the object that may be a list. It will pass if it is of type in allowable.
+  :param expected_type : this is the expected type of the returned list contents.
+  :param can_be_none   : this defines whether or not the obj can be None. If True, return default.
+  :param default       : this is the default to return if can_be_none is True and obj is None.
+  :param allowable     : the acceptable types for obj. We do not want to allow any iterable (eg string).
+  :param raise_type    : the error to throw if the type is not correct.
+  """
+  val = obj
+  if val is None:
+    if can_be_none:
+      val = list(default)
+    else:
+      raise raise_type('Expected an object of acceptable type %s, received None and can_be_none is False' % allowable)
+
+  if [typ for typ in allowable if isinstance(val, typ)]:
+    lst = list(val)
+    for e in lst:
+      if not isinstance(e, expected_type):
+        raise raise_type('Expected a list containing values of type %s, instead got a value %s of %s' %
+          (expected_type, e, e.__class__))
+    return lst
+  else:
+    raise raise_type('Expected an object of acceptable type %s, received %s instead' % (allowable, val))

--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -5,17 +5,19 @@
 python_test_suite(
   name = 'android',
   dependencies = [
-    pants(':android_distribution'),
+    ':android_distribution',
   ]
 )
 
 python_tests(
   name = 'android_distribution',
-  sources = 'test_android_distribution.py',
+  sources = [
+    'test_android_distribution.py',
+  ],
   dependencies = [
-    pants('3rdparty/python/twitter/commons:twitter.common.collections'),
-    pants('src/python/pants/backend/android:android_distribution'),
-    pants('src/python/pants/util:contextutil'),
-    pants('src/python/pants/util:dirutil'),
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/android:android_distribution',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
   ]
 )

--- a/tests/python/pants_test/android/tasks/BUILD
+++ b/tests/python/pants_test/android/tasks/BUILD
@@ -2,16 +2,18 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_test_suite(
-  name = 'tasks',
-  dependencies = [
-    pants(':aapt_gen'),
+  name='tasks',
+  dependencies=[
+    ':aapt_gen',
   ],
 )
 
 python_tests(
-  name = 'aapt_gen',
-  sources = 'test_aapt_gen.py',
-  dependencies = [
+  name='aapt_gen',
+  sources=[
+    'test_aapt_gen.py',
+  ],
+  dependencies=[
     pants('src/python/pants/backend/android/tasks:all'),
   ],
 )

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -10,6 +10,7 @@ import pytest
 from pants.backend.core.wrapped_globs import Globs
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.build_file_aliases import BuildFileAliases
+from pants.base.exceptions import TargetDefinitionException
 from pants_test.base_test import BaseTest
 
 
@@ -31,7 +32,7 @@ class PayloadTest(BaseTest):
   def test_no_nested_globs(self):
     # nesting no longer allowed
     self.add_to_build_file('z/BUILD', 'java_library(name="z", sources=[globs("*")])')
-    with pytest.raises(ValueError):
+    with pytest.raises(TargetDefinitionException):
       self.build_file_parser.scan(self.build_root)
 
   def test_flat_globs_list(self):
@@ -40,5 +41,5 @@ class PayloadTest(BaseTest):
     self.build_file_parser.scan(self.build_root)
 
   def test_single_source(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources="Source.scala")')
+    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=["Source.scala"])')
     self.build_file_parser.scan(self.build_root)


### PR DESCRIPTION
This enforces fields like sources, resources, to be a list (or an acceptable set of types which can be turned into a list).

This avoids the case where resources = 'valid/pointer' is resolved as resources = ['v', 'a',,,] while still enforcing that the field is a list.
