### PR TITLE
Point to the new maven-central https endpoint.

### DIFF
--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -16,18 +16,14 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       <ibiblio name="maven2"
                m2compatible="true"
                usepoms="true"
-               root="http://repo1.maven.org/maven2/"/>
+               root="https://repo1.maven.org/maven2/"/>
 
+      <!-- This is just for twitter-hosted jvm tools - kill once they are published to maven
+           central. -->
       <ibiblio name="maven.twttr.com-maven"
                m2compatible="true"
                usepoms="true"
                root="http://maven.twttr.com/"/>
-
-      <!--  This is just for spy#spymemcached;2.8.1 -->
-      <ibiblio name="jboss-public"
-               m2compatible="true"
-               usepoms="true"
-               root="http://repository.jboss.org/nexus/content/groups/public/"/>
     </chain>
   </macrodef>
 

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -49,7 +49,7 @@ class Bootstrapper(object):
     """Indicates an error bootstrapping an ivy classpath."""
 
   _DEFAULT_VERSION = '2.3.0'
-  _DEFAULT_URL = ('http://repo1.maven.org/maven2/'
+  _DEFAULT_URL = ('https://repo1.maven.org/maven2/'
                   'org/apache/ivy/ivy/'
                   '%(version)s/ivy-%(version)s.jar' % {'version': _DEFAULT_VERSION})
 


### PR DESCRIPTION
Also kill an unused resolver copied over from twitter/commons.

https://rbcommons.com/s/twitter/r/824/
