### PR TITLE
scm: add merge-base and origin url properties to git

### DIFF
--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -43,6 +43,19 @@ class Git(Scm):
     return self._check_output(['rev-parse', 'HEAD'], raise_type=Scm.LocalException)
 
   @property
+  def merge_base(self):
+    return self._check_output(['merge-base', 'master', 'HEAD'], raise_type=Scm.LocalException)
+
+  @property
+  def origin_push_url(self):
+    git_output = self._check_output(['remote', '--verbose'], raise_type=Scm.LocalException)
+    origin_push_line = [line.split()[1] for line in git_output.split('\n')
+                                        if 'origin' in line and '(push)' in line]
+    if len(origin_push_line) != 1:
+      raise Scm.LocalException('Unable to find origin remote amongst: ' + git_output)
+    return origin_push_line[0]
+
+  @property
   def tag_name(self):
     tag = self._check_output(['describe', '--tags', '--always'], raise_type=Scm.LocalException)
     return None if b'cannot' in tag else tag

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -123,6 +123,17 @@ class GitTest(unittest.TestCase):
 
     self.assertTrue(tip_sha in self.git.changelog())
 
+    merge_base = self.git.merge_base
+    self.assertTrue(merge_base)
+
+    self.assertTrue(merge_base in self.git.changelog())
+
+    try:
+      self.git.origin_push_url
+      self.assertTrue(False)
+    except Scm.LocalException:
+      self.assertTrue(True)
+
     self.assertTrue(self.git.tag_name.startswith('first-'), msg='un-annotated tags should be found')
     self.assertEqual('master', self.git.branch_name)
 


### PR DESCRIPTION
build passes: https://travis-ci.org/cheecheeo/pants/builds/31666560

This is necessary for a feature that will include the merge-base and repository url in pants-built artifacts.
