### PR TITLE
Updates error message when referencing the wrong path to a BUILD file

### DIFF
--- a/tests/python/pants_test/base/test_build_file.py
+++ b/tests/python/pants_test/base/test_build_file.py
@@ -8,7 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 import shutil
 import tempfile
-import unittest
+import unittest2
 
 from twitter.common.collections import OrderedSet
 
@@ -16,7 +16,7 @@ from pants.base.build_file import BuildFile
 from pants.util.dirutil import safe_mkdir, touch
 
 
-class BuildFileTest(unittest.TestCase):
+class BuildFileTest(unittest2.TestCase):
 
   @classmethod
   def makedirs(cls, path):
@@ -51,6 +51,9 @@ class BuildFileTest(unittest.TestCase):
     BuildFileTest.touch('grandparent/parent/child2/child3/BUILD')
     BuildFileTest.makedirs('grandparent/parent/child2/BUILD')
     BuildFileTest.makedirs('grandparent/parent/child4')
+    BuildFileTest.makedirs('path-that-does-exist')
+    BuildFileTest.touch('path-that-does-exist/BUILD.invalid.suffix')
+
 
   @classmethod
   def tearDownClass(cls):
@@ -92,6 +95,14 @@ class BuildFileTest(unittest.TestCase):
   def testMustExistFalse(self):
     buildfile = BuildFile(BuildFileTest.root_dir, "path-that-does-not-exist/BUILD", must_exist=False)
     self.assertEquals(OrderedSet([buildfile]), buildfile.family())
+
+  def testMustExistTrue(self):
+    with self.assertRaises(BuildFile.MissingBuildFileError):
+      BuildFile(BuildFileTest.root_dir, "path-that-does-not-exist/BUILD", must_exist=True)
+    with self.assertRaises(BuildFile.MissingBuildFileError):
+      BuildFile(BuildFileTest.root_dir, "path-that-does-exist/BUILD", must_exist=True)
+    with self.assertRaises(BuildFile.MissingBuildFileError):
+      BuildFile(BuildFileTest.root_dir, "path-that-does-exist/BUILD.invalid.suffix", must_exist=True)
 
   def testSuffixOnly(self):
     BuildFileTest.makedirs('suffix-test')


### PR DESCRIPTION
When you put a bad path in target you get the error:

Exception message: BUILD file does not exist at: /Users/zundel/Src/Pants/maven_src/resource_collision/example_b/src/main/java/com/pants/exampleb

This isn't much help if you don't know where the reference came from - you'll have to grep through all your BUILD files.

This updates the message to include the referencing target in the error:

Exception message: BUILD file does not exist at: /Users/zundel/Src/Pants/maven_src/resource_collision/example_b/src/main/java/com/pants/exampleb referenced from maven_src/resource_collision/example_a/src/main/java/com/pants/duplicatepaths/examplea:examplea
