### PR TITLE
Fix bad BUILD file and failed test for AaptGen tests

### DIFF
--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -6,6 +6,7 @@ python_test_suite(
   name = 'android',
   dependencies = [
     ':android_distribution',
+    pants('tests/python/pants_test/android/tasks:tasks'),
   ]
 )
 

--- a/tests/python/pants_test/android/tasks/test_aapt_gen.py
+++ b/tests/python/pants_test/android/tasks/test_aapt_gen.py
@@ -21,12 +21,12 @@ class AaptGenCalculateGenfilesTest(unittest.TestCase):
   def test_calculate_genfile(self):
     self.assert_files(
       'com.pants.examples.hello',
-      os.path.join('bin', 'com', 'pants', 'examples', 'hello', 'R.java'))
+      os.path.join('com', 'pants', 'examples', 'hello', 'R.java'))
 
     with self.assertRaises(AssertionError):
       self.assert_files(
         'com.pants.examples.hello',
-        os.path.join('bin','com', 'pants', 'examples', 'hello'))
+        os.path.join('bin', 'com', 'pants', 'examples', 'hello'))
 
 
   def test_package_path(self):


### PR DESCRIPTION
This is off, has been for a little while. A change broke
the test, but it had an inconsistent BUILD file so that
test was never getting called by the CI.

I have a big refactor of the entire Aapt pipeline
coming up with the AaptBuild task, which I am writing tests
for now. But this should go in soon, because the this test
does fail if the user calls something like
'goal test tests::', etc.
