### PR TITLE
Add a try/raise to catch exception from calling os on None object

### DIFF
--- a/src/python/pants/backend/android/targets/android_target.py
+++ b/src/python/pants/backend/android/targets/android_target.py
@@ -9,7 +9,6 @@ import os
 from xml.dom.minidom import parse
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.base.exceptions import TargetDefinitionException
 
 
 class AndroidTarget(JvmTarget):
@@ -47,13 +46,12 @@ class AndroidTarget(JvmTarget):
     self.add_labels('android')
     self.build_tools_version = build_tools_version
     self.release_type = release_type
-
     try:
-      os.path.isfile(os.path.join(address.spec_path, manifest))
+      self.manifest = os.path.join(address.spec_path, manifest)
+      assert os.path.isfile(self.manifest) is True
     except:
-      raise TargetDefinitionException(self, 'Android targets must specify a \'manifest\' '
-                                            'that points to the \'AndroidManifest.xml\'.')
-    self.manifest = os.path.join(self.address.spec_path, manifest)
+      raise ValueError(self, ("BUILD files of Android targets must have a 'manifest' field "
+                              "with the relative location of the 'AndroidManifest.xml' file."))
     self.package = self.get_package_name()
     self.target_sdk = self.get_target_sdk()
 


### PR DESCRIPTION
If someone defines an Android target without specifying a 'manifest'
field in the BUILD file, they only got a cryptic error. The exception was
never called because the error came earlier, when calling os.path on a None
object. This ensures that the user sees the error message we mean them to.
