### PR TITLE
Refactor exceptions in build_file.py and build_file_parser.py to derive

### DIFF
--- a/src/python/pants/backend/core/tasks/filter.py
+++ b/src/python/pants/backend/core/tasks/filter.py
@@ -78,15 +78,15 @@ class Filter(ConsoleTask):
       try:
         spec_parser = CmdLineSpecParser(get_buildroot(), self.context.address_mapper)
         addresses = spec_parser.parse_addresses(spec)
-      except (IOError, ValueError, AddressLookupError) as e:
-        raise TaskError('Failed to parse spec: %s: %s' % (spec, e))
+      except AddressLookupError as e:
+        raise TaskError('Failed to parse address selector: {spec}\n {message}'.format(spec=spec, message=e))
       # filter specs may not have been parsed as part of the context: force parsing
       matches = set()
       for address in addresses:
         self.context.build_graph.inject_address_closure(address)
         matches.add(self.context.build_graph.get_target(address))
       if not matches:
-        raise TaskError('No matches for spec: %s' % spec)
+        raise TaskError('No matches for address selector: %s' % spec)
       return matches
 
     def filter_for_address(spec):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -18,10 +18,21 @@ from twitter.common.collections import OrderedSet
 logger = logging.getLogger(__name__)
 
 
+# Note: Significant effort has been made to keep the types BuildFile, BuildGraph, Address, and
+# Target separated appropriately.  Don't add references to those other types to this module.
+
 class BuildFile(object):
 
-  class MissingBuildFileError(Exception):
+  class BuildFileError(Exception):
+    """Base class for all exceptions raised in BuildFile to make exception handling easier"""
+    pass
+
+  class MissingBuildFileError(BuildFileError):
     """Raised when a BUILD file cannot be found at the path in the spec."""
+    pass
+
+  class InvalidRootDirError(BuildFileError):
+    """Raised when the root_dir specified to a BUILD file is not valid."""
     pass
 
   _BUILD_FILE_PREFIX = 'BUILD'
@@ -76,8 +87,8 @@ class BuildFile(object):
     """
 
     if not os.path.isabs(root_dir):
-      raise IOError('BuildFile root_dir {root_dir} must be an absolute path.'
-                    .format(root_dir=root_dir))
+      raise self.InvalidRootDirError('BuildFile root_dir {root_dir} must be an absolute path.'
+                                     .format(root_dir=root_dir))
 
     path = os.path.join(root_dir, relpath) if relpath else root_dir
     self._build_basename = BuildFile._BUILD_FILE_PREFIX

--- a/src/python/pants/base/build_file_address_mapper.py
+++ b/src/python/pants/base/build_file_address_mapper.py
@@ -9,22 +9,44 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 from pants.base.address import BuildFileAddress, parse_spec, SyntheticAddress
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file import BuildFile
+from pants.base.build_file_parser import BuildFileParser
 from pants.base.build_environment import get_buildroot
 
+
+# Note: Significant effort has been made to keep the types BuildFile, BuildGraph, Address, and
+# Target separated appropriately.  The BuildFileAddressMapper is intended to have knowledge
+# of just BuildFile, BuildFileParser and Address.
+#
+# Here are some guidelines to help maintain this abstraction:
+#  - Use the terminology 'address' instead of 'target' in symbols and user messages
+#  - Wrap exceptions from BuildFile and BuildFileParser with a subclass of AddressLookupError
+#     so that callers do not have to reference those modules
+#
+# Note: 'spec' should not be a user visible term, substitute 'address' instead.
 
 class BuildFileAddressMapper(object):
   """Maps addresses in the pants virtual address space to corresponding BUILD file declarations.
   """
 
   class AddressNotInBuildFile(AddressLookupError):
-    """ Raised when a target name cannot be found in an existing BUILD file.
-    """
+    """ Raised when an address cannot be found in an existing BUILD file."""
     pass
 
-  class InvalidBuildFileReference(AddressLookupError):
-    """ Raised when a BUILD file does not exist at the address referenced.
-    """
+
+  class EmptyBuildFileError(AddressLookupError):
+    """Raised if no addresses are defined in a BUILD file."""
     pass
+
+
+  class InvalidBuildFileReference(AddressLookupError):
+    """ Raised when a BUILD file does not exist at the address referenced."""
+    pass
+
+
+  class InvalidAddressError(AddressLookupError):
+    """ Raised when an address cannot be parsed."""
+    pass
+
 
   def __init__(self, build_file_parser):
     self._build_file_parser = build_file_parser
@@ -34,6 +56,54 @@ class BuildFileAddressMapper(object):
   def root_dir(self):
     return self._build_file_parser._root_dir
 
+  def _raise_incorrect_address_error(self, build_file, wrong_target_name, targets):
+    """Search through the list of targets and return those which originate from the same folder
+    which wrong_target_name resides in.
+
+    :raises: A helpful error message listing possible correct target addresses.
+    """
+    def path_parts(build):  # Gets a tuple of directory, filename.
+      build = str(build)
+      slash = build.rfind('/')
+      if slash < 0:
+        return '', build
+      return build[:slash], build[slash+1:]
+
+    def are_siblings(a, b):  # Are the targets in the same directory?
+      return path_parts(a)[0] == path_parts(b)[0]
+
+    valid_specs = []
+    all_same = True
+    # Iterate through all addresses, saving those which are similar to the wrong address.
+    for target in targets:
+      if are_siblings(target.build_file, build_file):
+        possibility = (path_parts(target.build_file)[1], target.spec[target.spec.rfind(':'):])
+        # Keep track of whether there are multiple BUILD files or just one.
+        if all_same and valid_specs and possibility[0] != valid_specs[0][0]:
+          all_same = False
+        valid_specs.append(possibility)
+
+    # Trim out BUILD extensions if there's only one anyway; no need to be redundant.
+    if all_same:
+      valid_specs = [('', tail) for head, tail in valid_specs]
+    # Might be neat to sort by edit distance or something, but for now alphabetical is fine.
+    valid_specs = [''.join(pair) for pair in sorted(valid_specs)]
+
+    # Give different error messages depending on whether BUILD file was empty.
+    if valid_specs:
+      one_of = ' one of' if len(valid_specs) > 1 else '' # Handle plurality, just for UX.
+      raise self.AddressNotInBuildFile(
+        '{target_name} was not found in BUILD file {build_file}. Perhaps you '
+        'meant{one_of}: \n  {specs}'.format(target_name=wrong_target_name,
+                                             build_file=build_file,
+                                             one_of=one_of,
+                                             specs='\n  '.join(valid_specs)))
+    # There were no targets in the BUILD file.
+    raise self.EmptyBuildFileError(
+      ':{target_name} was not found in BUILD file {build_file}, because that '
+      'BUILD file contains no addressable entities.'.format(target_name=wrong_target_name,
+                                                             build_file=build_file))
+
   def resolve(self, address):
     """Maps an address in the virtual address space to an object.
     :param Address address: the address to lookup in a BUILD file
@@ -42,15 +112,17 @@ class BuildFileAddressMapper(object):
     """
     address_map = self.address_map_from_spec_path(address.spec_path)
     if address not in address_map:
-      raise self.AddressNotInBuildFile(
-        "Target name '{target_name}' not found in BUILD file in {spec_path}"
-        .format(target_name=address.target_name, spec_path=address.spec_path))
+      build_file = BuildFile.from_cache(self.root_dir, address.spec_path, must_exist=False)
+      self._raise_incorrect_address_error(build_file, address.target_name, address_map)
     else:
       return address_map[address]
 
   def resolve_spec(self, spec):
     """Converts a spec to an address and maps it using `resolve`"""
-    address = SyntheticAddress.parse(spec)
+    try:
+      address = SyntheticAddress.parse(spec)
+    except ValueError as e:
+      raise self.InvalidAddressError(e)
     return self.resolve(address)
 
   def address_map_from_spec_path(self, spec_path):
@@ -59,7 +131,11 @@ class BuildFileAddressMapper(object):
     :returns {Address: <resolved Object>}:
     """
     if spec_path not in self._spec_path_to_address_map_map:
-      address_map = self._build_file_parser.address_map_from_spec_path(spec_path)
+      try:
+        address_map = self._build_file_parser.address_map_from_spec_path(spec_path)
+      except BuildFileParser.BuildFileParserError as e:
+        raise AddressLookupError("{message}\n Loading addresses from '{spec_path}' failed."
+                                  .format(message=e, spec_path=spec_path))
       self._spec_path_to_address_map_map[spec_path] = address_map
     return self._spec_path_to_address_map_map[spec_path]
 
@@ -76,7 +152,7 @@ class BuildFileAddressMapper(object):
     spec_path, name = parse_spec(spec, relative_to=relative_to)
     try:
       build_file = BuildFile.from_cache(self.root_dir, spec_path)
-    except BuildFile.MissingBuildFileError as e:
+    except BuildFile.BuildFileError as e:
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))
     return BuildFileAddress(build_file, name)
@@ -99,4 +175,3 @@ class BuildFileAddressMapper(object):
       for address in self.addresses_in_spec_path(build_file.spec_path):
         addresses.add(address)
     return addresses
-

--- a/tests/python/pants_test/backend/core/test_wrapped_globs.py
+++ b/tests/python/pants_test/backend/core/test_wrapped_globs.py
@@ -7,6 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 from pants.backend.core.wrapped_globs import Globs
 from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
 
@@ -50,34 +51,33 @@ class FilesetRelPathWrapperTest(BaseTest):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("dir/**/*.scala"))')
     self.context().scan(self.build_root)
 
-
-    # This is no longer allowed.
+  # This is no longer allowed.
   def test_parent_dir_glob(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../*.scala"))')
-    with self.assertRaises(ValueError):
+    with self.assertRaises(AddressLookupError):
       self.context().scan(self.build_root)
 
   def test_parent_dir_glob_question(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../?.scala"))')
-    with self.assertRaises(ValueError):
+    with self.assertRaises(AddressLookupError):
       self.context().scan(self.build_root)
 
   def test_parent_dir_bracket_glob_question(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../[dir1, dir2]/?.scala"))')
-    with self.assertRaises(ValueError):
+    with self.assertRaises(AddressLookupError):
       self.context().scan(self.build_root)
 
   def test_parent_dir_bracket(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../[dir1, dir2]/File.scala"))')
-    with self.assertRaises(ValueError):
+    with self.assertRaises(AddressLookupError):
       self.context().scan(self.build_root)
 
   def test_absolute_dir_glob(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("/root/*.scala"))')
-    with self.assertRaises(ValueError):
+    with self.assertRaises(AddressLookupError):
       self.context().scan(self.build_root)
 
   def test_absolute_dir_glob_question(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("/root/?.scala"))')
-    with self.assertRaises(ValueError):
+    with self.assertRaises(AddressLookupError):
       self.context().scan(self.build_root)

--- a/tests/python/pants_test/base/test_build_file.py
+++ b/tests/python/pants_test/base/test_build_file.py
@@ -165,3 +165,15 @@ class BuildFileTest(unittest.TestCase):
       BuildFileTest.buildfile('grandparent/parent/child1/BUILD.twitter'),
       BuildFileTest.buildfile('grandparent/parent/child2/child3/BUILD'),
       ]), buildfiles)
+
+  def test_invalid_root_dir_error(self):
+    BuildFileTest.touch('BUILD')
+    with self.assertRaises(BuildFile.InvalidRootDirError):
+      BuildFile('tmp', 'grandparent/BUILD')
+
+  def test_exception_class_hierarchy(self):
+    """Exception handling code depends on the fact that all exceptions from BuildFile are
+    subclassed from the BuildFileError base class.
+    """
+    self.assertIsInstance(BuildFile.InvalidRootDirError(), BuildFile.BuildFileError)
+    self.assertIsInstance(BuildFile.MissingBuildFileError(), BuildFile.BuildFileError)

--- a/tests/python/pants_test/base/test_build_file_parser.py
+++ b/tests/python/pants_test/base/test_build_file_parser.py
@@ -16,11 +16,9 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.address import BuildFileAddress
-from pants.base.addressable import Addressable
 from pants.base.build_file import BuildFile
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.build_file_parser import BuildFileParser
-from pants.base.exceptions import TargetDefinitionException
 from pants.base.target import Target
 from pants_test.base_test import BaseTest
 
@@ -35,12 +33,12 @@ class BuildFileParserBasicsTest(BaseTest):
     self.add_to_build_file('a/BUILD', 'target()')
     build_file_a = BuildFile(self.build_root, 'a/BUILD')
 
-    with pytest.raises(Addressable.AddressableInitError):
+    with pytest.raises(BuildFileParser.ExecuteError):
       self.build_file_parser.parse_build_file(build_file_a)
 
     self.add_to_build_file('b/BUILD', 'target(name="foo", "bad_arg")')
     build_file_b = BuildFile(self.build_root, 'b/BUILD')
-    with pytest.raises(SyntaxError):
+    with pytest.raises(BuildFileParser.BuildFileParserError):
       self.build_file_parser.parse_build_file(build_file_b)
 
     self.add_to_build_file('d/BUILD', dedent(
@@ -54,7 +52,7 @@ class BuildFileParserBasicsTest(BaseTest):
       '''
     ))
     build_file_d = BuildFile(self.build_root, 'd/BUILD')
-    with pytest.raises(TargetDefinitionException):
+    with pytest.raises(BuildFileParser.BuildFileParserError):
       self.build_file_parser.parse_build_file(build_file_d)
 
   def test_noop_parse(self):
@@ -128,7 +126,7 @@ class BuildFileParserTargetTest(BaseTest):
     self.add_to_build_file('BUILD', 'fake(name="foo")\n')
     self.add_to_build_file('BUILD', 'fake(name="foo")\n')
 
-    with pytest.raises(BuildFileParser.TargetConflictException):
+    with pytest.raises(BuildFileParser.AddressableConflictException):
       base_build_file = BuildFile(self.build_root, 'BUILD')
       self.build_file_parser.parse_build_file(base_build_file)
 
@@ -268,3 +266,80 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
     self.assertEqual(targets_created['create-java-libraries-scala'], ScalaLibrary)
 
     self.assertEqual(set(['3rdparty/baz']), self._paths)
+
+  def test_raises_build_file_scan_error(self):
+    with self.assertRaises(BuildFileParser.BuildFileScanError):
+      self.build_file_parser.address_map_from_spec_path('non-existent-path')
+
+  def test_raises_parse_error(self):
+    self.add_to_build_file('BUILD', 'foo(name = = "baz")')
+    build_file = BuildFile(self.build_root, 'BUILD')
+    with self.assertRaises(BuildFileParser.ParseError):
+      self.build_file_parser.parse_build_file(build_file)
+
+    # Test some corner cases for the context printing
+
+    # Error at beginning of BUILD file
+    build_file = self.add_to_build_file('begin/BUILD', dedent('''
+      *?&INVALID! = 'foo'
+      target(
+        name='bar',
+        dependencies= [
+          ':baz',
+        ],
+      )
+      '''))
+    with self.assertRaises(BuildFileParser.ParseError):
+      self.build_file_parser.parse_build_file(build_file)
+
+    # Error at end of BUILD file
+    build_file = self.add_to_build_file('end/BUILD', dedent('''
+      target(
+        name='bar',
+        dependencies= [
+          ':baz',
+        ],
+      )
+      *?&INVALID! = 'foo'
+      '''))
+    with self.assertRaises(BuildFileParser.ParseError):
+      self.build_file_parser.parse_build_file(build_file)
+
+    # Error in the middle of BUILD file > 6 lines
+    build_file = self.add_to_build_file('middle/BUILD', dedent('''
+      target(
+        name='bar',
+
+              *?&INVALID! = 'foo'
+
+        dependencies = [
+          ':baz',
+        ],
+      )
+      '''))
+    with self.assertRaises(BuildFileParser.ParseError):
+      self.build_file_parser.parse_build_file(build_file)
+
+    # Error in very short build file.
+    build_file = self.add_to_build_file('short/BUILD', dedent('''
+      target(name='bar', dependencies = [':baz'],) *?&INVALID! = 'foo'
+      '''))
+    with self.assertRaises(BuildFileParser.ParseError):
+      self.build_file_parser.parse_build_file(build_file)
+
+  def test_raises_execute_error(self):
+    self.add_to_build_file('BUILD', 'undefined_alias(name="baz")')
+    build_file = BuildFile(self.build_root, 'BUILD')
+    with self.assertRaises(BuildFileParser.ExecuteError):
+      self.build_file_parser.parse_build_file(build_file)
+
+
+  def test_build_file_parser_error_hierarcy(self):
+    """Exception handling code depends on the fact that all explicit exceptions from BuildFileParser are
+   subclassed from the BuildFileParserError base class.
+   """
+    self.assertIsInstance(BuildFileParser.BuildFileScanError(), BuildFileParser.BuildFileParserError)
+    self.assertIsInstance(BuildFileParser.AddressableConflictException(), BuildFileParser.BuildFileParserError)
+    self.assertIsInstance(BuildFileParser.SiblingConflictException(), BuildFileParser.BuildFileParserError)
+    self.assertIsInstance(BuildFileParser.ParseError(), BuildFileParser.BuildFileParserError)
+    self.assertIsInstance(BuildFileParser.ExecuteError(), BuildFileParser.BuildFileParserError)


### PR DESCRIPTION
  from a common baseclass and eliminate throwing IOError.
Catch errors from parse errors in the BUILD file and format
  context around the exception.
