### PR TITLE
Add coverage annotations for python_tests targets.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ pex>=0.7.0,<0.8
 psutil==1.1.3
 Pygments==1.4
 pystache==0.5.3
-pytest==2.5.2
+pytest>=2.6
 pytest-cov==1.6
 python_daemon==1.5.5
 requests>=2.3.0,<2.4

--- a/src/python/pants/backend/python/targets/python_tests.py
+++ b/src/python/pants/backend/python/targets/python_tests.py
@@ -24,7 +24,8 @@ class PythonTests(PythonTarget):
     :type dependencies: list of target specs
     :param coverage: the module(s) whose coverage should be generated, e.g.
       'twitter.common.log' or ['twitter.common.log', 'twitter.common.http']
-    :param dict exclusives: An optional dict of exclusives tags. See :ref:`howto_check_exclusives` for details.
+    :param dict exclusives: An optional dict of exclusives tags. See :ref:`howto_check_exclusives`
+      for details.
     """
     self._coverage = maybe_list(coverage) if coverage is not None else []
     super(PythonTests, self).__init__(**kwargs)

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -5,14 +5,16 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
+import logging
 import os
 import sys
-
-from twitter.common import log
 
 from pants.base.build_root import BuildRoot
 from pants.scm.scm import Scm
 from pants.version import VERSION as _VERSION
+
+
+logger = logging.getLogger(__name__)
 
 
 def pants_version():
@@ -49,10 +51,10 @@ def get_scm():
     if worktree and os.path.isdir(worktree):
       git = Git(worktree=worktree)
       try:
-        log.info('Detected git repository at %s on branch %s' % (worktree, git.branch_name))
+        logger.info('Detected git repository at %s on branch %s' % (worktree, git.branch_name))
         set_scm(git)
       except git.LocalException as e:
-        log.info('Failed to load git repository at %s: %s' % (worktree, e))
+        logger.info('Failed to load git repository at %s: %s' % (worktree, e))
   return _SCM
 
 

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -1,11 +1,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 python_library(
-  name = 'option',
-  sources = globs('*.py'),
-  dependencies = [
+  name='option',
+  sources=globs('*.py'),
+  dependencies=[
     '3rdparty/python:argparse',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/goal',
   ]
 )

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'base_test',
-  sources = ['base_test.py'],
-  dependencies = [
+  name='base_test',
+  sources=['base_test.py'],
+  dependencies=[
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/core/tasks:check_exclusives',
     'src/python/pants/base:address',
@@ -25,9 +25,9 @@ python_library(
 )
 
 python_library(
-  name = 'int-test',
-  sources = ['pants_run_integration_test.py'],
-  dependencies = [
+  name='int-test',
+  sources=['pants_run_integration_test.py'],
+  dependencies=[
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
@@ -35,41 +35,51 @@ python_library(
 )
 
 python_tests(
-  name = 'test_binary_util',
-  sources = ['test_binary_util.py',],
-  dependencies = [
+  name='test_binary_util',
+  sources=['test_binary_util.py',],
+  dependencies=[
     ':base_test',
     'src/python/pants:binary_util',
-    'src/python/pants/base:exceptions'
+  ],
+  coverage=[
+    'pants.binary_util',
   ]
 )
 
+# TODO(John Sirois): re-locate, this tests the jvm backend.
 python_tests(
-  name = 'test_maven_layout',
-  sources = ['test_maven_layout.py'],
-  dependencies = [
+  name='test_maven_layout',
+  sources=['test_maven_layout.py'],
+  dependencies=[
     ':base_test',
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/maven_layout',
     'src/python/pants/base:build_file_aliases',
+  ],
+  coverage=[
+    'pants.backend.maven_layout',
   ]
 )
 
 python_tests(
-  name = 'test_thrift_util',
-  sources = ['test_thrift_util.py'],
-  dependencies = [
+  name='test_thrift_util',
+  sources=['test_thrift_util.py'],
+  dependencies=[
     ':base_test',
     '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants:thrift_util',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.thrift_util',
   ]
 )
 
 python_tests(
-  name = 'test_utf8_header',
-  sources = ['test_utf8_header.py'],
-  dependencies = [
+  name='test_utf8_header',
+  sources=['test_utf8_header.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_address_mapper',
@@ -80,8 +90,8 @@ python_tests(
 )
 
 target(
-  name = 'integration',
-  dependencies = [
+  name='integration',
+  dependencies=[
     'tests/python/pants_test/android:integration',
     'tests/python/pants_test/commands:integration',
     'tests/python/pants_test/targets:integration',
@@ -90,9 +100,9 @@ target(
   ]
 )
 
-python_test_suite(
-  name = 'all',
-  dependencies = [
+target(
+  name='all',
+  dependencies=[
     ':test_binary_util',
     ':test_maven_layout',
     ':test_thrift_util',

--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -1,41 +1,46 @@
-# coding=utf-8
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'android',
-  dependencies = [
+target(
+  name='android',
+  dependencies=[
     ':android_distribution',
     'tests/python/pants_test/android/tasks',
   ]
 )
 
-python_test_suite(
-  name = 'integration',
-  dependencies = [
+target(
+  name='integration',
+  dependencies=[
     'tests/python/pants_test/android/tasks:integration',
   ]
 )
 
 python_tests(
-  name = 'android_integration_test',
-  sources = [
+  name='android_integration_test',
+  sources=[
     'android_integration_test.py',
   ],
-  dependencies = [
+  dependencies=[
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.android',
+  ]
 )
 
 python_tests(
-  name = 'android_distribution',
-  sources = [
+  name='android_distribution',
+  sources=[
     'test_android_distribution.py',
   ],
-  dependencies = [
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/android:android_distribution',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.backend.android.distribution.android_distribution',
   ]
 )

--- a/tests/python/pants_test/android/tasks/BUILD
+++ b/tests/python/pants_test/android/tasks/BUILD
@@ -1,16 +1,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
+target(
   name='tasks',
   dependencies=[
     ':aapt_gen',
   ],
 )
 
-python_test_suite(
-  name = 'integration',
-  dependencies = [
+target(
+  name='integration',
+  dependencies=[
     ':dx_compile_integration',
     ':aapt_builder_integration',
     ':jarsigner_integration',
@@ -18,13 +18,16 @@ python_test_suite(
 )
 
 python_tests(
-  name = 'aapt_builder_integration',
-  sources = [
+  name='aapt_builder_integration',
+  sources=[
     'test_aapt_builder_integration.py',
   ],
-  dependencies = [
+  dependencies=[
     'tests/python/pants_test/android:android_integration_test',
   ],
+  coverage=[
+    'pants.backend.android.tasks.aapt_builder',
+  ]
 )
 
 python_tests(
@@ -35,26 +38,35 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/android/tasks:all',
   ],
+  coverage=[
+    'pants.backend.android.tasks.aapt_gen',
+  ]
 )
 
 python_tests(
-  name = 'dx_compile_integration',
-  sources = [
+  name='dx_compile_integration',
+  sources=[
     'test_dx_compile_integration.py',
   ],
-  dependencies = [
+  dependencies=[
     'tests/python/pants_test/android:android_integration_test',
   ],
+  coverage=[
+    'pants.backend.android.tasks.dx_compile',
+  ]
 )
 
 
 python_tests(
-  name = 'jarsigner_integration',
-  sources = [
+  name='jarsigner_integration',
+  sources=[
     'test_jarsigner_integration.py',
   ],
-  dependencies = [
+  dependencies=[
     'tests/python/pants_test/android:android_integration_test',
     'tests/python/pants_test/tasks:base',
   ],
+  coverage=[
+    'pants.backend.android.tasks.jarsigner_task',
+  ]
 )

--- a/tests/python/pants_test/authentication/BUILD
+++ b/tests/python/pants_test/authentication/BUILD
@@ -2,10 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'netrc',
-  sources = ['test_netrc_util.py'],
-  dependencies = [
+  name='netrc',
+  sources=['test_netrc_util.py'],
+  dependencies=[
     '3rdparty/python:mock',
     'src/python/pants/backend/authentication:authentication',
+  ],
+  coverage=[
+    'pants.backend.authentication.netrc_util',
   ]
 )

--- a/tests/python/pants_test/backend/BUILD
+++ b/tests/python/pants_test/backend/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'backend',
-  dependencies = [
+target(
+  name='backend',
+  dependencies=[
     'tests/python/pants_test/backend/core',
     'tests/python/pants_test/backend/jvm',
   ]

--- a/tests/python/pants_test/backend/core/BUILD
+++ b/tests/python/pants_test/backend/core/BUILD
@@ -9,10 +9,13 @@ target(
 )
 
 python_tests(
-  name = 'wrapped_globs',
-  sources = ['test_wrapped_globs.py'],
-  dependencies = [
+  name='wrapped_globs',
+  sources=['test_wrapped_globs.py'],
+  dependencies=[
     'src/python/pants/backend/core',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.core.wrapped_globs',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/BUILD
+++ b/tests/python/pants_test/backend/jvm/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'jvm',
-  dependencies = [
+target(
+  name='jvm',
+  dependencies=[
     'tests/python/pants_test/backend/jvm/tasks',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -1,18 +1,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'tasks',
-  dependencies = [
+target(
+  name='tasks',
+  dependencies=[
     ':junit_run',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile',
   ]
 )
 
 python_tests(
-  name = 'junit_run',
-  sources = ['test_junit_run.py'],
-  dependencies = [
+  name='junit_run',
+  sources=['test_junit_run.py'],
+  dependencies=[
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/jvm/tasks:junit_run',
     'src/python/pants/goal:products',
@@ -20,5 +20,8 @@ python_tests(
     'src/python/pants/java:distribution',
     'src/python/pants/java:executor',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.junit_run',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -9,10 +9,13 @@ target(
 )
 
 python_tests(
-  name = 'jvm_fingerprint_strategy',
-  sources = ['test_jvm_fingerprint_strategy.py'],
-  dependencies = [
+  name='jvm_fingerprint_strategy',
+  sources=['test_jvm_fingerprint_strategy.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/tasks/jvm_compile:jvm_fingerprint_strategy',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.jvm_compile.jvm_fingerprint_strategy',
   ]
 )

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'context_utils',
-  sources = ['context_utils.py'],
-  dependencies = [
+  name='context_utils',
+  sources=['context_utils.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/base:config',
@@ -16,16 +16,16 @@ python_library(
   ]
 )
 
-python_test_suite(
-  name = 'all',
-  dependencies = [
+target(
+  name='all',
+  dependencies=[
     ':base',
   ],
 )
 
-python_test_suite(
-  name = 'base',
-  dependencies = [
+target(
+  name='base',
+  dependencies=[
     ':abbreviate_target_ids',
     ':address',
     ':build_configuration',
@@ -47,30 +47,36 @@ python_test_suite(
 )
 
 python_tests(
-  name = 'abbreviate_target_ids',
-  sources = ['test_abbreviate_target_ids.py'],
-  dependencies = [
+  name='abbreviate_target_ids',
+  sources=['test_abbreviate_target_ids.py'],
+  dependencies=[
     'src/python/pants/base:abbreviate_target_ids',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.abbreviate_target_ids',
   ]
 )
 
 python_tests(
-  name = 'address',
-  sources = ['test_address.py'],
-  dependencies = [
+  name='address',
+  sources=['test_address.py'],
+  dependencies=[
     'src/python/pants/base:address',
     'src/python/pants/base:build_root',
     'tests/python/pants_test:base_test',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.base.address',
   ]
 )
 
 python_tests(
-  name = 'build_configuration',
-  sources = ['test_build_configuration.py'],
-  dependencies = [
+  name='build_configuration',
+  sources=['test_build_configuration.py'],
+  dependencies=[
     'src/python/pants/base:address',
     'src/python/pants/base:build_configuration',
     'src/python/pants/base:build_file',
@@ -79,42 +85,54 @@ python_tests(
     'src/python/pants/base:target',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.base.build_configuration',
   ]
 )
 
 python_tests(
-  name = 'build_file',
-  sources = ['test_build_file.py'],
-  dependencies = [
+  name='build_file',
+  sources=['test_build_file.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_file',
     'tests/python/pants_test:base_test',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.base.build_file',
   ]
 )
 
 python_tests(
-  name = 'build_file_address_mapper',
-  sources = ['test_build_file_address_mapper.py'],
-  dependencies = [
+  name='build_file_address_mapper',
+  sources=['test_build_file_address_mapper.py'],
+  dependencies=[
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.build_file_address_mapper',
   ]
 )
 
 python_tests(
-  name = 'build_file_aliases',
-  sources = ['test_build_file_aliases.py'],
-  dependencies = [
+  name='build_file_aliases',
+  sources=['test_build_file_aliases.py'],
+  dependencies=[
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:target',
+  ],
+  coverage=[
+    'pants.base.build_file_aliases',
   ]
 )
 
 
 python_tests(
-  name = 'build_file_parser',
-  sources = ['test_build_file_parser.py'],
-  dependencies = [
+  name='build_file_parser',
+  sources=['test_build_file_parser.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_file',
     'src/python/pants/backend/jvm/targets:java',
@@ -125,46 +143,57 @@ python_tests(
     'src/python/pants/base:target',
     'tests/python/pants_test:base_test',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.base.build_file_parser',
   ]
 )
 
 python_tests(
-  name = 'build_invalidator',
-  sources = ['test_build_invalidator.py'],
-  dependencies = [
+  name='build_invalidator',
+  sources=['test_build_invalidator.py'],
+  dependencies=[
     'src/python/pants/base:build_invalidator',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.build_invalidator',
   ]
 )
 
 python_tests(
-  name = 'build_root',
-  sources = ['test_build_root.py'],
-  dependencies = [
+  name='build_root',
+  sources=['test_build_root.py'],
+  dependencies=[
     'src/python/pants/base:build_root',
     'tests/python/pants_test:base_test',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.base.build_root',
   ]
 )
 
 python_tests(
-  name = 'cmd_line_spec_parser',
-  sources = ['test_cmd_line_spec_parser.py'],
-  dependencies = [
+  name='cmd_line_spec_parser',
+  sources=['test_cmd_line_spec_parser.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:cmd_line_spec_parser',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.cmd_line_spec_parser',
   ]
 )
 
 python_tests(
-  name = 'dev_backend_loader',
-  sources = ['test_dev_backend_loader.py'],
-  dependencies = [
+  name='dev_backend_loader',
+  sources=['test_dev_backend_loader.py'],
+  dependencies=[
     'src/python/pants/base:build_configuration',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:dev_backend_loader',
@@ -172,66 +201,87 @@ python_tests(
     'src/python/pants/base:target',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
+  ],
+  coverage=[
+    '',
   ]
 )
 
 python_tests(
-  name = 'double_dag',
-  sources = ['test_double_dag.py'],
-  dependencies = [
+  name='double_dag',
+  sources=['test_double_dag.py'],
+  dependencies=[
     'src/python/pants/base:double_dag',
     'src/python/pants/reporting',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test/testutils',
+  ],
+  coverage=[
+    'pants.base.dev_backend_loader',
   ]
 )
 
 python_tests(
-  name = 'generator',
-  sources = ['test_generator.py'],
-  dependencies = [
+  name='generator',
+  sources=['test_generator.py'],
+  dependencies=[
     'src/python/pants/base:generator',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.generator',
   ]
 )
 
 python_tests(
-  name = 'hash_utils',
-  sources = ['test_hash_utils.py'],
-  dependencies = [
+  name='hash_utils',
+  sources=['test_hash_utils.py'],
+  dependencies=[
     '3rdparty/python:mox',
     'src/python/pants/base:hash_utils',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.hash_utils',
   ]
 )
 
 python_tests(
-  name = 'payload',
-  sources = ['test_payload.py'],
-  dependencies = [
+  name='payload',
+  sources=['test_payload.py'],
+  dependencies=[
     'src/python/pants/backend/core',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:payload',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.payload',
   ]
 )
 
 python_tests(
-  name = 'revision',
-  sources = ['test_revision.py'],
-  dependencies = [
+  name='revision',
+  sources=['test_revision.py'],
+  dependencies=[
     'src/python/pants/base:revision',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.revision',
   ]
 )
 
 python_tests(
-  name = 'run_info',
-  sources = ['test_run_info.py'],
-  dependencies = [
+  name='run_info',
+  sources=['test_run_info.py'],
+  dependencies=[
     'src/python/pants/base:run_info',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.base.run_info',
   ]
 )

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -8,7 +8,6 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 
 from pants.base.address import SyntheticAddress
-from pants.base.build_file import BuildFile
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.target import Target

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -2,14 +2,17 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'cache',
-  sources = globs('*.py'),
-  dependencies = [
+  name='cache',
+  sources=globs('*.py'),
+  dependencies=[
     'src/python/pants/base:build_invalidator',
     'src/python/pants/cache',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test/testutils',
+  ],
+  coverage=[
+    'pants.cache',
   ]
 )

--- a/tests/python/pants_test/commands/BUILD
+++ b/tests/python/pants_test/commands/BUILD
@@ -1,43 +1,46 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'all',
-  dependencies = [
+target(
+  name='all',
+  dependencies=[
     ':commands',
   ]
 )
 
-python_test_suite(
-  name = 'commands',
-  dependencies = [
+target(
+  name='commands',
+  dependencies=[
     ':test_goal',
     ':test_setup_py',
   ]
 )
 
-python_test_suite(
-  name = 'integration',
-  dependencies = [
+target(
+  name='integration',
+  dependencies=[
     ':test_spec_exclude_integration',
   ]
 )
 
 python_tests(
-  name = 'test_goal',
-  sources = [ 'test_goal.py' ],
-  dependencies = [
+  name='test_goal',
+  sources=['test_goal.py'],
+  dependencies=[
     'src/python/pants/backend/jvm:plugin',
     'src/python/pants/commands:goal_runner',
     'src/python/pants/goal',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.commands.goal_runner',
   ]
 )
 
 python_tests(
-  name = 'test_setup_py',
-  sources = [ 'test_setup_py.py' ],
-  dependencies = [
+  name='test_setup_py',
+  sources=['test_setup_py.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:mock',
@@ -50,13 +53,19 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.python.commands.setup_py',
   ]
 )
 
 python_tests(
-  name = 'test_spec_exclude_integration',
-  sources = [ 'test_spec_exclude_integration.py' ],
-  dependencies = [
+  name='test_spec_exclude_integration',
+  sources=['test_spec_exclude_integration.py'],
+  dependencies=[
     'tests/python/pants_test:int-test',
+  ],
+  coverage=[
+    'pants.commands.goal_runner',
   ]
 )

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -2,40 +2,48 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'engine_test_base',
-  sources = ['base_engine_test.py'],
-  dependencies = [
+  name='engine_test_base',
+  sources=['base_engine_test.py'],
+  dependencies=[
+    'tests/python/pants_test:base_test',
+    'tests/python/pants_test/base:context_utils',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
   ]
 )
 
-python_test_suite(
-  name = 'engine',
-  dependencies = [
+target(
+  name='engine',
+  dependencies=[
     ':test_engine',
     ':test_round_engine',
   ]
 )
 
 python_tests(
-  name = 'test_engine',
-  sources = ['test_engine.py'],
-  dependencies = [
+  name='test_engine',
+  sources=['test_engine.py'],
+  dependencies=[
     ':engine_test_base',
     'src/python/pants/base:exceptions',
     'src/python/pants/engine',
     'tests/python/pants_test/base:context_utils',
   ],
+  coverage=[
+    'pants.engine.engine',
+  ]
 )
 
 python_tests(
-  name = 'test_round_engine',
-  sources = ['test_round_engine.py'],
-  dependencies = [
+  name='test_round_engine',
+  sources=['test_round_engine.py'],
+  dependencies=[
     ':engine_test_base',
     'src/python/pants/engine',
     'src/python/pants/backend/core/tasks:common',
     'tests/python/pants_test:base_test',
   ],
+  coverage=[
+    'pants.engine.round_engine',
+  ]
 )

--- a/tests/python/pants_test/fs/BUILD
+++ b/tests/python/pants_test/fs/BUILD
@@ -2,11 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'fs',
-  sources = globs('*.py'),
-  dependencies = [
+  name='fs',
+  sources=globs('*.py'),
+  dependencies=[
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.fs',
   ]
 )

--- a/tests/python/pants_test/graph/BUILD
+++ b/tests/python/pants_test/graph/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'graph',
-  sources = ['test_build_graph.py'],
-  dependencies = [
+  name='graph',
+  sources=['test_build_graph.py'],
+  dependencies=[
     'src/python/pants/base:address',
     'src/python/pants/base:build_file_parser',
     'src/python/pants/base:build_graph',
@@ -14,4 +14,7 @@ python_tests(
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test'
   ],
+  coverage=[
+    'pants.base.build_graph',
+  ]
 )

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -1,21 +1,24 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'java',
-  dependencies = [
+target(
+  name='java',
+  dependencies=[
     ':executor',
     'tests/python/pants_test/java/distribution',
   ]
 )
 
 python_tests(
-  name = 'executor',
-  sources = ['test_executor.py'],
-  dependencies = [
+  name='executor',
+  sources=['test_executor.py'],
+  dependencies=[
     'src/python/pants/java:distribution',
     'src/python/pants/java:executor',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.java.executor',
   ]
 )

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -2,13 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'distribution',
-  sources = globs('*.py'),
-  dependencies = [
+  name='distribution',
+  sources=globs('*.py'),
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:revision',
     'src/python/pants/java:distribution',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.java.distribution',
   ]
 )

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'jvm_tool_task_test_base',
-  sources = ['jvm_tool_task_test_base.py'],
-  dependencies = [
+  name='jvm_tool_task_test_base',
+  sources=['jvm_tool_task_test_base.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
     'src/python/pants/base:dev_backend_loader',
     'src/python/pants/util:dirutil',
@@ -13,18 +13,18 @@ python_library(
 )
 
 python_library(
-  name = 'nailgun_task_test_base',
-  sources = ['nailgun_task_test_base.py'],
-  dependencies = [
+  name='nailgun_task_test_base',
+  sources=['nailgun_task_test_base.py'],
+  dependencies=[
     ':jvm_tool_task_test_base',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
   ]
 )
 
 python_library(
-  name = 'jar_task_test_base',
-  sources = ['jar_task_test_base.py'],
-  dependencies = [
+  name='jar_task_test_base',
+  sources=['jar_task_test_base.py'],
+  dependencies=[
     ':nailgun_task_test_base',
   ]
 )

--- a/tests/python/pants_test/net/BUILD
+++ b/tests/python/pants_test/net/BUILD
@@ -1,9 +1,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'net',
-  dependencies = [
+target(
+  name='net',
+  dependencies=[
     'tests/python/pants_test/net/http',
   ],
 )

--- a/tests/python/pants_test/net/http/BUILD
+++ b/tests/python/pants_test/net/http/BUILD
@@ -2,13 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'http',
-  sources = globs('*.py'),
-  dependencies = [
+  name='http',
+  sources=globs('*.py'),
+  dependencies=[
     '3rdparty/python:mox',
     '3rdparty/python:requests',
     '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/net',
     'src/python/pants/util:contextutil',
+  ],
+  coverage=[
+    'pants.net.http',
   ]
 )

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -2,10 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'option',
-  sources = globs('*.py'),
-  dependencies = [
+  name='option',
+  sources=globs('*.py'),
+  dependencies=[
     '3rdparty/python:pytest',
     'src/python/pants/option',
   ],
+  coverage=[
+    'pants.option',
+  ]
 )

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -8,8 +8,6 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import shlex
 import unittest2 as unittest
 
-import pytest
-
 from pants.option.options import Options
 
 

--- a/tests/python/pants_test/process/BUILD
+++ b/tests/python/pants_test/process/BUILD
@@ -2,10 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'process',
-  sources = globs('*.py'),
-  dependencies = [
+  name='process',
+  sources=globs('*.py'),
+  dependencies=[
     '3rdparty/python:mox',
     'src/python/pants/process',
+  ],
+  coverage=[
+    'pants.process',
   ]
 )

--- a/tests/python/pants_test/python/BUILD
+++ b/tests/python/pants_test/python/BUILD
@@ -1,16 +1,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'all',
-  dependencies = [
+target(
+  name='all',
+  dependencies=[
     ':python',
   ],
 )
 
-python_test_suite(
-  name = 'python',
-  dependencies = [
+target(
+  name='python',
+  dependencies=[
     ':test_antlr_builder',
     ':test_resolver',
     ':test_thrift_builder',
@@ -18,9 +18,9 @@ python_test_suite(
   ]
 )
 
-python_test_suite(
-  name = 'integration',
-  dependencies = [
+target(
+  name='integration',
+  dependencies=[
     ':interpreter_selection_integration',
     ':python_repl_integration',
     ':python_run_integration',
@@ -29,39 +29,41 @@ python_test_suite(
 
 # XXX this tests the code running the test, not the code under test!
 python_tests(
-  name = 'test_antlr_builder',
-  sources = ['test_antlr_builder.py'],
-  dependencies = [
+  name='test_antlr_builder',
+  sources=['test_antlr_builder.py'],
+  dependencies=[
     '3rdparty/python:antlr-3.1.3',
     'testprojects/src/antlr/pants/backend/python/test:csv',
     'testprojects/src/antlr/pants/backend/python/test:eval',
-    'src/python/pants/backend/python:python_setup',
   ],
 )
 
 # XXX this tests the code running the test, not the code under test!
 python_tests(
-  name = 'test_thrift_namespace_packages',
-  sources = ['test_thrift_namespace_packages.py'],
-  dependencies = [
+  name='test_thrift_namespace_packages',
+  sources=['test_thrift_namespace_packages.py'],
+  dependencies=[
     'testprojects/src/thrift/com/pants/testing:duck-py',
     'testprojects/src/thrift/com/pants/testing:goose-py',
   ],
 )
 
-python_tests(name = 'test_resolver',
-  sources = ['test_resolver.py'],
-  dependencies = [
+python_tests(name='test_resolver',
+  sources=['test_resolver.py'],
+  dependencies=[
     '3rdparty/python:pex',
     'src/python/pants/base:config',
     'src/python/pants/backend/python:resolver',
     'src/python/pants/util:contextutil',
   ],
+  coverage=[
+    'pants.backend.python.resolver',
+  ]
 )
 
-python_tests(name = 'test_thrift_builder',
-  sources = ['test_thrift_builder.py'],
-  dependencies = [
+python_tests(name='test_thrift_builder',
+  sources=['test_thrift_builder.py'],
+  dependencies=[
     '3rdparty/python:mock',
     '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.config',
@@ -70,77 +72,90 @@ python_tests(name = 'test_thrift_builder',
     'src/python/pants/base:build_file_aliases',
     'tests/python/pants_test/base:context_utils',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.python.thrift_builder',
   ]
 )
 
 python_library(
-  name = 'echo_interpreter_version_lib',
-  sources = ['echo_interpreter_version.py'],
-  dependencies = [],
+  name='echo_interpreter_version_lib',
+  sources=['echo_interpreter_version.py'],
+  dependencies=[],
   # Play with this to test interpreter selection in the pex machinery.
-  compatibility = ['CPython>=2.6,<3']
+  compatibility=['CPython>=2.6,<3']
 )
 
 python_tests(
-  name = 'interpreter_selection_integration',
-  sources = ['test_interpreter_selection_integration.py'],
-  dependencies = [
+  name='interpreter_selection_integration',
+  sources=['test_interpreter_selection_integration.py'],
+  dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.python.tasks.python_binary_create',
+    'pants.backend.python.tasks.python_task',
+  ]
 )
 
 python_tests(
-  name = 'python_run_integration',
-  sources = ['test_python_run_integration.py'],
-  dependencies = [
+  name='python_run_integration',
+  sources=['test_python_run_integration.py'],
+  dependencies=[
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.python.tasks.python_run',
+  ]
 )
 
 python_tests(
-  name = 'python_repl_integration',
-  sources = ['test_python_repl_integration.py'],
-  dependencies = [
+  name='python_repl_integration',
+  sources=['test_python_repl_integration.py'],
+  dependencies=[
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.python.tasks.python_repl',
+  ]
 )
 
 # Used by interpreter_selection_integration.
 python_binary(
-  name = 'echo_interpreter_version_2.6',
-  dependencies = [
+  name='echo_interpreter_version_2.6',
+  dependencies=[
     ':echo_interpreter_version_lib',
   ],
-  entry_point = 'pants_test.python.echo_interpreter_version',
-  compatibility = ['CPython>=2.6,<3']
+  entry_point='pants_test.python.echo_interpreter_version',
+  compatibility=['CPython>=2.6,<3']
 )
 
 # Used by interpreter_selection_integration.
 python_binary(
-  name = 'echo_interpreter_version_2.7',
-  dependencies = [
+  name='echo_interpreter_version_2.7',
+  dependencies=[
     ':echo_interpreter_version_lib',
   ],
-  entry_point = 'pants_test.python.echo_interpreter_version',
-  compatibility = ['CPython>=2.7,<3']
+  entry_point='pants_test.python.echo_interpreter_version',
+  compatibility=['CPython>=2.7,<3']
 )
 
 # Useful for manual testing.
 python_binary(
-  name = 'echo_interpreter_version',
-  dependencies = [
+  name='echo_interpreter_version',
+  dependencies=[
     ':echo_interpreter_version_lib',
   ],
-  entry_point = 'pants_test.python.echo_interpreter_version',
+  entry_point='pants_test.python.echo_interpreter_version',
 )
 
 # Useful for manual testing.
 python_binary(
-  name = 'deliberately_conficting_compatibility',
-  dependencies = [
+  name='deliberately_conficting_compatibility',
+  dependencies=[
     ':echo_interpreter_version_lib',
   ],
-  entry_point = 'pants_test.python.echo_interpreter_version',
-  compatibility = ['CPython<2.6']
+  entry_point='pants_test.python.echo_interpreter_version',
+  compatibility=['CPython<2.6']
 )

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -2,9 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'reporting',
-  sources = globs('*.py'),
-  dependencies = [
+  name='reporting',
+  sources=globs('*.py'),
+  dependencies=[
     'src/python/pants/reporting',
+  ],
+  coverage=[
+    'pants.reporting',
   ]
 )

--- a/tests/python/pants_test/scm/BUILD
+++ b/tests/python/pants_test/scm/BUILD
@@ -1,20 +1,23 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_test_suite(
-  name = 'scm',
-  dependencies = [
+target(
+  name='scm',
+  dependencies=[
     ':test_git',
   ]
 )
 
 python_tests(
-  name = 'test_git',
-  sources = ['test_git.py'],
-  dependencies = [
+  name='test_git',
+  sources=['test_git.py'],
+  dependencies=[
     'src/python/pants/scm',
     'src/python/pants/scm:git',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.scm.git',
   ]
 )

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -2,15 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'base',
-  dependencies = [
+  name='base',
+  dependencies=[
     'tests/python/pants_test:base_test',
   ],
 )
 
-python_test_suite(
-  name = 'targets',
-  dependencies = [
+target(
+  name='targets',
+  dependencies=[
     ':artifact',
     ':exclusive',
     ':jar_library',
@@ -26,136 +26,171 @@ python_test_suite(
   ]
 )
 
-python_test_suite(
-  name = 'integration',
-  dependencies = [
+target(
+  name='integration',
+  dependencies=[
     ':scala_library_integration',
   ],
 )
 
 python_tests(
-  name = 'artifact',
-  sources = ['test_artifact.py'],
-  dependencies = [
+  name='artifact',
+  sources=['test_artifact.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/jvm/targets:jvm',
+  ],
+  coverage=[
+    'pants.backend.jvm.targets.artifact',
   ]
 )
 
 python_tests(
-  name = 'jvm_app',
-  sources = ['test_jvm_app.py'],
-  dependencies = [
+  name='jvm_app',
+  sources=['test_jvm_app.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core:plugin',
     'src/python/pants/backend/jvm:plugin',
     'src/python/pants/base:exceptions',
+  ],
+  coverage=[
+    'pants.backend.jvm.targets.jvm_binary',
   ]
 )
 
+# TODO(John Sirois): re-locate, this really tests the verbs use of the nouns.
 python_tests(
-  name = 'exclusive',
-  sources = ['test_exclusive.py'],
-  dependencies = [
+  name='exclusive',
+  sources=['test_exclusive.py'],
+  dependencies=[
     'src/python/pants/base:config',
     'src/python/pants/backend/core/tasks:check_exclusives',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.core.tasks.check_exclusives',
   ]
 )
 
+# TODO(John Sirois): re-locate, this tests the BuildGraph.
 python_tests(
-  name = 'sort_targets',
-  sources = ['test_sort_targets.py'],
-  dependencies = [
+  name='sort_targets',
+  sources=['test_sort_targets.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:target',
     'src/python/pants/base:build_graph',
     'src/python/pants/base:payload',
     'src/python/pants/backend/core/targets:common',
+  ],
+  coverage=[
+    'pants.base.build_graph',
   ]
 )
 
 python_tests(
-  name = 'jar_library',
-  sources = ['test_jar_library.py'],
-  dependencies = [
+  name='jar_library',
+  sources=['test_jar_library.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:target',
     'src/python/pants/backend/jvm/targets:jvm',
+  ],
+  coverage=[
+    'pants.backend.jvm.targets.jar_library',
   ]
 )
 
 python_tests(
-  name = 'java_thrift_library',
-  sources = ['test_java_thrift_library.py'],
-  dependencies = [
+  name='java_thrift_library',
+  sources=['test_java_thrift_library.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:build_file_aliases',
     'tests/python/pants_test/base:context_utils',
+  ],
+  coverage=[
+    'pants.backend.codegen.targets.java_thrift_library',
   ]
 )
 
 python_tests(
-  name = 'java_agent',
-  sources = ['test_java_agent.py'],
+  name='java_agent',
+  sources=['test_java_agent.py'],
   dependencies=[
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.jvm.targets.java_agent',
   ]
 )
 
 python_tests(
-  name = 'java_tests',
-  sources = ['test_java_tests.py'],
-  dependencies = [
+  name='java_tests',
+  sources=['test_java_tests.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core',
     'src/python/pants/backend/jvm/targets:java',
     'tests/python/pants_test/base:context_utils',
+  ],
+  coverage=[
+    'pants.backend.jvm.targets.java_tests',
   ]
 )
 
 python_tests(
-  name = 'python_binary',
-  sources = ['test_python_binary.py'],
-  dependencies = [
+  name='python_binary',
+  sources=['test_python_binary.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:target',
     'src/python/pants/backend/python/targets:python',
+  ],
+  coverage=[
+    'pants.backend.python.targets.python_binary',
   ]
 )
 
 python_tests(
-  name = 'scala_library',
-  sources = ['test_scala_library.py'],
-  dependencies = [
+  name='scala_library',
+  sources=['test_scala_library.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/base:build_file_aliases',
+  ],
+  coverage=[
+    'pants.backend.jvm.targets.scala_library',
   ]
 )
 
+# TODO(John Sirois): re-locate, this really tests the verbs use of the nouns.
 python_tests(
-  name = 'scala_library_integration',
-  sources = ['test_scala_library_integration.py'],
-  dependencies = [
+  name='scala_library_integration',
+  sources=['test_scala_library_integration.py'],
+  dependencies=[
     'tests/python/pants_test:int-test',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.jvm_compile.scala.scala_compile',
   ]
 )
 
-
 python_tests(
-  name = 'python_target',
-  sources = ['test_python_target.py'],
-  dependencies = [
+  name='python_target',
+  sources=['test_python_target.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/python/targets:python',
@@ -163,15 +198,21 @@ python_tests(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',
     'src/python/pants/base:target',
+  ],
+  coverage=[
+    'pants.backend.python.targets.python_target',
   ]
 )
 
 python_tests(
-  name = 'wiki_page',
-  sources = ['test_wiki_page.py'],
-  dependencies = [
+  name='wiki_page',
+  sources=['test_wiki_page.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.confluence',
     'src/python/pants/backend/core/targets:common',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.core.targets.doc',
   ]
 )

--- a/tests/python/pants_test/targets/test_python_binary.py
+++ b/tests/python/pants_test/targets/test_python_binary.py
@@ -7,7 +7,6 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import pytest
 
-from pants.base.address import SyntheticAddress
 from pants.base.exceptions import TargetDefinitionException
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants_test.base_test import BaseTest

--- a/tests/python/pants_test/targets/test_scala_library_integration.py
+++ b/tests/python/pants_test/targets/test_scala_library_integration.py
@@ -10,7 +10,8 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class TestScalaLibraryIntegrationTest(PantsRunIntegrationTest):
   def test_bundle(self):
-    pants_run = self.run_pants(['goal', 'compile', 'testprojects/src/scala/com/pants/testproject/javasources'])
+    pants_run = self.run_pants(['goal', 'compile',
+                                'testprojects/src/scala/com/pants/testproject/javasources'])
     self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
                       "goal compile expected success, got {0}\n"
                       "got stderr:\n{1}\n"

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'base',
-  sources = ['test_base.py'],
-  dependencies = [
+  name='base',
+  sources=['test_base.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/core/tasks:task',
@@ -19,9 +19,9 @@ python_library(
   ]
 )
 
-python_test_suite(
-  name = 'tasks',
-  dependencies = [
+target(
+  name='tasks',
+  dependencies=[
     ':antlr_gen',
     ':binary_create',
     ':builddict',
@@ -62,9 +62,9 @@ python_test_suite(
   ],
 )
 
-python_test_suite(
-  name = 'integration',
-  dependencies = [
+target(
+  name='integration',
+  dependencies=[
     ':eclipse_integration',
     ':ensime_integration',
     ':idea_integration',
@@ -78,30 +78,36 @@ python_test_suite(
 )
 
 python_tests(
-  name = 'antlr_gen',
-  sources = ['test_antlr_gen.py'],
-  dependencies = [
+  name='antlr_gen',
+  sources=['test_antlr_gen.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     ':base',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/codegen/tasks:antlr_gen',
     'tests/python/pants_test/jvm:nailgun_task_test_base',
   ],
-)
-
-python_tests(
-  name = 'binary_create',
-  sources = ['test_binary_create.py'],
-  dependencies = [
-    ':base',
-    'src/python/pants/backend/jvm/tasks:binary_create',
+  coverage=[
+    'pants.backend.codegen.tasks.antlr_gen',
   ]
 )
 
 python_tests(
-  name = 'builddict',
-  sources = ['test_builddict.py'],
-  dependencies = [
+  name='binary_create',
+  sources=['test_binary_create.py'],
+  dependencies=[
+    ':base',
+    'src/python/pants/backend/jvm/tasks:binary_create',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.binary_create',
+  ]
+)
+
+python_tests(
+  name='builddict',
+  sources=['test_builddict.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core:plugin',
     'src/python/pants/backend/core/tasks:builddictionary',
@@ -109,117 +115,151 @@ python_tests(
     'src/python/pants/backend/python:plugin',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
+  ],
+  coverage=[
+    'pants.backend.core.tasks.builddictionary',
   ]
 )
 
 python_tests(
-  name = 'bundle_create',
-  sources = ['test_bundle_create.py'],
-  dependencies = [
+  name='bundle_create',
+  sources=['test_bundle_create.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/jvm/tasks:bundle_create',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.bundle_create',
   ]
 )
 
 python_tests(
-  name = 'jvm_bundle_integration',
-  sources = ['test_jvm_bundle_integration.py'],
-  dependencies = [
+  name='jvm_bundle_integration',
+  sources=['test_jvm_bundle_integration.py'],
+  dependencies=[
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.bundle_create',
+  ]
 )
 
 python_tests(
-  name = 'jvm_run_integration',
-  sources = ['test_jvm_run_integration.py'],
-  dependencies = [
+  name='jvm_run_integration',
+  sources=['test_jvm_run_integration.py'],
+  dependencies=[
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.jvm_run',
+  ]
 )
 
 python_tests(
-  name = 'scala_repl_integration',
-  sources = ['test_scala_repl_integration.py'],
-  dependencies = [
+  name='scala_repl_integration',
+  sources=['test_scala_repl_integration.py'],
+  dependencies=[
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.scala_repl',
+  ]
 )
 
+# TODO(John Sirois): re-locate, this tests pants.base.
 python_tests(
-  name = 'cache_manager',
-  sources = ['test_cache_manager.py'],
-  dependencies = [
+  name='cache_manager',
+  sources=['test_cache_manager.py'],
+  dependencies=[
     ':base',
     'tests/python/pants_test/testutils',
     'src/python/pants/base:build_invalidator',
     'src/python/pants/base:cache_manager',
+  ],
+  coverage=[
+    'pants.base.cache_manager',
   ]
 )
 
 python_tests(
-  name = 'check_exclusives',
-  sources = ['test_check_exclusives.py'],
-  dependencies = [
+  name='check_exclusives',
+  sources=['test_check_exclusives.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:config',
     'src/python/pants/goal:context',
     'src/python/pants/backend/core/tasks:check_exclusives',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.backend.core.tasks.check_exclusives',
   ]
 )
 
 python_tests(
-  name = 'check_published_deps',
-  sources = ['test_check_published_deps.py'],
-  dependencies = [
+  name='check_published_deps',
+  sources=['test_check_published_deps.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:check_published_deps',
     'src/python/pants/base:build_file_aliases',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.check_published_deps',
   ]
 )
 
 # XXX Uh shouldn't this be in base?
 python_tests(
-  name = 'config',
-  sources = ['test_config.py'],
-  dependencies = [
+  name='config',
+  sources=['test_config.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:config',
     'src/python/pants/util:contextutil',
+  ],
+  coverage=[
+    'pants.base.config',
   ]
 )
 
 python_tests(
-  name = 'console_task',
-  sources = ['test_console_task.py'],
-  dependencies = [
+  name='console_task',
+  sources=['test_console_task.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core/tasks:console_task',
+  ],
+  coverage=[
+    'pants.backend.core.tasks.console_task',
   ]
 )
 
 # XXX this should be in goal
 python_tests(
-  name = 'context',
-  sources = ['test_context.py'],
-  dependencies = [
+  name='context',
+  sources=['test_context.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:config',
     'src/python/pants/goal:context',
+  ],
+  coverage=[
+    'pants.goal.context',
   ]
 )
 
 python_tests(
-  name = 'dependees',
-  sources = ['test_dependees.py'],
-  dependencies = [
+  name='dependees',
+  sources=['test_dependees.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/core/targets:common',
@@ -229,13 +269,16 @@ python_tests(
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_aliases',
+  ],
+  coverage=[
+    'pants.backend.core.tasks.dependees',
   ]
 )
 
 python_tests(
-  name = 'dependencies',
-  sources = ['test_dependencies.py'],
-  dependencies = [
+  name='dependencies',
+  sources=['test_dependencies.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/jvm/targets:jvm',
@@ -244,13 +287,16 @@ python_tests(
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/base:exceptions',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.dependencies',
   ]
 )
 
 python_tests(
-  name = 'depmap',
-  sources = ['test_depmap.py'],
-  dependencies = [
+  name='depmap',
+  sources=['test_depmap.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core:plugin',
     'src/python/pants/backend/core/targets:common',
@@ -261,25 +307,31 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:depmap',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/base:build_file_aliases',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.depmap',
   ]
 )
 
 python_tests(
-  name = 'detect_duplicates',
-  sources = ['test_detect_duplicates.py'],
-  dependencies = [
+  name='detect_duplicates',
+  sources=['test_detect_duplicates.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:exceptions',
     'src/python/pants/backend/jvm/tasks:detect_duplicates',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/base:context_utils',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.detect_duplicates',
+  ]
 )
 
 python_tests(
-  name = 'filedeps',
-  sources = ['test_filedeps.py'],
-  dependencies = [
+  name='filedeps',
+  sources=['test_filedeps.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/core/targets:common',
@@ -289,6 +341,9 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:filedeps',
     'src/python/pants/base:build_file_aliases',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.filedeps',
+  ]
 )
 
 python_tests(
@@ -301,12 +356,15 @@ python_tests(
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:build_file_aliases',
   ],
+  coverage=[
+    'pants.backend.core.tasks.filemap',
+  ]
 )
 
 python_tests(
-  name = 'filter',
-  sources = ['test_filter.py'],
-  dependencies = [
+  name='filter',
+  sources=['test_filter.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/python/targets:python',
@@ -314,52 +372,67 @@ python_tests(
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/base:build_file_aliases',
   ],
+  coverage=[
+    'pants.backend.core.tasks.filter',
+  ]
 )
 
 python_tests(
-  name = 'idea_integration',
-  sources = ['test_idea_integration.py'],
-  dependencies = [
+  name='idea_integration',
+  sources=['test_idea_integration.py'],
+  dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.idea_gen',
+  ]
 )
 
 python_tests(
-  name = 'eclipse_integration',
-  sources = ['test_eclipse_integration.py'],
-  dependencies = [
+  name='eclipse_integration',
+  sources=['test_eclipse_integration.py'],
+  dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.eclipse_gen',
+  ]
 )
 
 python_tests(
-  name = 'ensime_integration',
-  sources = ['test_ensime_integration.py'],
-  dependencies = [
+  name='ensime_integration',
+  sources=['test_ensime_integration.py'],
+  dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.ensime_gen',
+  ]
 )
 
 python_tests(
-  name = 'ivy_utils',
-  sources = ['test_ivy_utils.py'],
-  dependencies = [
+  name='ivy_utils',
+  sources=['test_ivy_utils.py'],
+  dependencies=[
     'src/python/pants/backend/core:plugin',
     'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/jvm:ivy_utils',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test/base:context_utils',
+  ],
+  coverage=[
+    'pants.backend.jvm.ivy_utils',
   ]
 )
 
 python_tests(
-  name = 'jar_create',
-  sources = ['test_jar_create.py'],
-  dependencies = [
+  name='jar_create',
+  sources=['test_jar_create.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/android/targets:android',
     'src/python/pants/backend/codegen/targets:java',
@@ -378,46 +451,58 @@ python_tests(
     'tests/python/pants_test/base:context_utils',
     'tests/python/pants_test/jvm:jar_task_test_base',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.jar_create',
+  ]
 )
 
 python_tests(
-  name = 'jar_publish',
-  sources = ['test_jar_publish.py'],
-  dependencies = [
+  name='jar_publish',
+  sources=['test_jar_publish.py'],
+  dependencies=[
     '3rdparty/python:mock',
     ':base',
     'src/python/pants/backend/jvm/tasks:jar_publish',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.jar_publish',
+  ]
 )
 
 python_tests(
-  name = 'jar_publish_integration',
-  sources = ['test_jar_publish_integration.py'],
-  dependencies = [
+  name='jar_publish_integration',
+  sources=['test_jar_publish_integration.py'],
+  dependencies=[
     ':base',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.jvm.tasks.jar_publish',
+  ]
 )
 
 python_tests(
-  name = 'list_goals',
-  sources = ['test_list_goals.py'],
-  dependencies = [
+  name='list_goals',
+  sources=['test_list_goals.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core/tasks:list_goals',
     'src/python/pants/backend/core/tasks:common',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
   ],
+  coverage=[
+    'pants.backend.core.tasks.list_goals',
+  ]
 )
 
 python_tests(
-  name = 'listtargets',
-  sources = ['test_listtargets.py'],
-  dependencies = [
+  name='listtargets',
+  sources=['test_listtargets.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core/tasks:listtargets',
     'src/python/pants/backend/jvm/targets:java',
@@ -425,73 +510,94 @@ python_tests(
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:target',
   ],
-)
-
-python_tests(
-  name = 'markdown_to_html',
-  sources = ['test_markdown_to_html.py'],
-  dependencies = [
-    ':base',
-    'src/python/pants/backend/core/tasks:markdown_to_html',
+  coverage=[
+    'pants.backend.core.tasks.listtargets',
   ]
 )
 
 python_tests(
-  name = 'minimal_cover',
-  sources = ['test_minimal_cover.py'],
-  dependencies = [
+  name='markdown_to_html',
+  sources=['test_markdown_to_html.py'],
+  dependencies=[
+    ':base',
+    'src/python/pants/backend/core/tasks:markdown_to_html',
+  ],
+  coverage=[
+    'pants.backend.core.tasks.markdown_to_html',
+  ]
+)
+
+python_tests(
+  name='minimal_cover',
+  sources=['test_minimal_cover.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/core/tasks:minimal_cover',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:build_file_aliases',
   ],
+  coverage=[
+    'pants.backend.core.tasks.minimal_cover',
+  ]
 )
 
 python_tests(
-  name = 'protobuf_gen',
-  sources = ['test_protobuf_gen.py'],
-  dependencies = [
+  name='protobuf_gen',
+  sources=['test_protobuf_gen.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/codegen/tasks:protobuf_gen',
     'src/python/pants/util:contextutil',
   ],
+  coverage=[
+    'pants.backend.codegen.tasks.protobuf_gen',
+  ]
 )
 
 python_tests(
-  name = 'protobuf_integration',
-  sources = ['test_protobuf_integration.py'],
-  dependencies = [
+  name='protobuf_integration',
+  sources=['test_protobuf_integration.py'],
+  dependencies=[
     'tests/python/pants_test:int-test',
   ],
+  coverage=[
+    'pants.backend.codegen.tasks.protobuf_gen',
+  ]
 )
 
 python_tests(
-  name = 'jaxb_gen',
-  sources = ['test_jaxb_gen.py'],
-  dependencies = [
+  name='jaxb_gen',
+  sources=['test_jaxb_gen.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/codegen/tasks:jaxb_gen',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/util:contextutil',
   ],
+  coverage=[
+    'pants.backend.codegen.tasks.jaxb_gen',
+  ]
 )
 
 python_tests(
-  name = 'roots',
-  sources = ['test_roots.py'],
-  dependencies = [
+  name='roots',
+  sources=['test_roots.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:target',
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/core/tasks:roots',
   ],
+  coverage=[
+    'pants.backend.core.tasks.roots',
+  ]
 )
 
 python_tests(
-  name = 'scrooge_gen',
-  sources = ['test_scrooge_gen.py'],
-  dependencies = [
+  name='scrooge_gen',
+  sources=['test_scrooge_gen.py'],
+  dependencies=[
     '3rdparty/python:mock',
     ':base',
     'src/python/pants/backend/codegen/targets:java',
@@ -500,35 +606,44 @@ python_tests(
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
   ],
+  coverage=[
+    'pants.backend.codegen.tasks.scrooge_gen',
+  ]
 )
 
 python_tests(
-  name = 'sorttargets',
-  sources = ['test_sorttargets.py'],
-  dependencies = [
+  name='sorttargets',
+  sources=['test_sorttargets.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/core/tasks:sorttargets',
     'src/python/pants/base:build_file_aliases',
   ],
+  coverage=[
+    'pants.backend.core.tasks.sorttargets',
+  ]
 )
 
 python_tests(
-  name = 'targets_help',
-  sources = ['test_targets_help.py'],
-  dependencies = [
+  name='targets_help',
+  sources=['test_targets_help.py'],
+  dependencies=[
     ':base',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:target',
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/core/tasks:targets_help',
   ],
+  coverage=[
+    'pants.backend.core.tasks.targets_help',
+  ]
 )
 
 python_tests(
-  name = 'what_changed',
-  sources = ['test_what_changed.py'],
-  dependencies = [
+  name='what_changed',
+  sources=['test_what_changed.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/codegen/targets:python',
@@ -541,12 +656,15 @@ python_tests(
     'src/python/pants/base:source_root',
     'src/python/pants/base:target',
   ],
+  coverage=[
+    'pants.backend.core.tasks.what_changed',
+  ]
 )
 
 python_tests(
-  name = 'jar_task',
-  sources = ['test_jar_task.py'],
-  dependencies = [
+  name='jar_task',
+  sources=['test_jar_task.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_task',
     'src/python/pants/base:build_file_aliases',
@@ -554,13 +672,16 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.jar_task',
   ]
 )
 
 python_tests(
-  name = 'group_task',
-  sources = ['test_group_task.py'],
-  dependencies = [
+  name='group_task',
+  sources=['test_group_task.py'],
+  dependencies=[
     'src/python/pants/backend/core/tasks:check_exclusives',
     'src/python/pants/backend/core/tasks:group_task',
     'src/python/pants/backend/jvm/targets:java',
@@ -569,26 +690,32 @@ python_tests(
     'src/python/pants/base:target',
     'src/python/pants/engine:engine',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.core.tasks.group_task',
   ]
 )
 
 python_tests(
-  name = 'jvm_run',
-  sources = ['test_jvm_run.py'],
-  dependencies = [
+  name='jvm_run',
+  sources=['test_jvm_run.py'],
+  dependencies=[
     ':base',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jvm_run',
     'src/python/pants/engine',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.jvm_run',
   ]
 )
 
-python_tests(
-  name = 'jvm_task',
-  sources = ['test_jvm_task.py'],
-  dependencies = [
+python_library(
+  name='jvm_task',
+  sources=['test_jvm_task.py'],
+  dependencies=[
     'src/python/pants/backend/core/tasks:check_exclusives',
     'src/python/pants/backend/jvm/tasks:jvm_task',
     'src/python/pants/util:dirutil',
@@ -597,21 +724,23 @@ python_tests(
 )
 
 python_tests(
-  name = 'jvmdoc_gen',
-  sources = ['test_jvmdoc_gen.py'],
-  dependencies = [
+  name='jvmdoc_gen',
+  sources=['test_jvmdoc_gen.py'],
+  dependencies=[
     'src/python/pants/backend/core/tasks:check_exclusives',
     'src/python/pants/backend/jvm/tasks:jvmdoc_gen',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.jvmdoc_gen',
   ]
 )
 
-
 python_tests(
-  name = 'ragel_gen',
-  sources = ['test_ragel_gen.py'],
-  dependencies = [
+  name='ragel_gen',
+  sources=['test_ragel_gen.py'],
+  dependencies=[
     ':base',
     '3rdparty/python:mock',
     'src/python/pants/backend/codegen/targets:java',
@@ -623,4 +752,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
   ],
+  coverage=[
+    'pants.backend.codegen.tasks.ragel_gen',
+  ]
 )

--- a/tests/python/pants_test/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/tasks/jvm_compile/java/BUILD
@@ -1,17 +1,23 @@
-python_test_suite(
-  name = 'java',
-  dependencies = [
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name='java',
+  dependencies=[
     ':test_java_compile_integration',
   ],
 )
 
 python_tests(
-  name = 'test_java_compile_integration',
-  sources = ['test_java_compile_integration.py'],
-  dependencies = [
+  name='test_java_compile_integration',
+  sources=['test_java_compile_integration.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/tasks/jvm_compile:java',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test/base:context_utils',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.jvm_compile.java',
   ]
 )

--- a/tests/python/pants_test/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/tasks/jvm_compile/scala/BUILD
@@ -1,15 +1,22 @@
-python_test_suite(
-  name = 'scala',
-  dependencies = [
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name='scala',
+  dependencies=[
     ':test_zinc_analysis',
   ],
 )
 
 python_tests(
-  name = 'test_zinc_analysis',
-  sources = ['test_zinc_analysis.py'],
-  dependencies = [
+  name='test_zinc_analysis',
+  sources=['test_zinc_analysis.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/tasks/jvm_compile:scala',
     'src/python/pants/util:contextutil',
+  ],
+  coverage=[
+    'pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis',
+    'pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis_parser',
   ]
 )

--- a/tests/python/pants_test/tasks/test_scrooge_gen.py
+++ b/tests/python/pants_test/tasks/test_scrooge_gen.py
@@ -18,7 +18,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants.goal.context import Context
-from pants.util.dirutil import safe_mkdtemp, safe_rmtree
+from pants.util.dirutil import safe_rmtree
 
 from pants_test.base_test import BaseTest
 from pants_test.tasks.test_base import prepare_task

--- a/tests/python/pants_test/test_binary_util.py
+++ b/tests/python/pants_test/test_binary_util.py
@@ -5,9 +5,6 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import os
-
-from pants.base.config import Config
 from pants.binary_util import BinaryUtil
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'testutils',
-  sources = globs('*.py'),
-  dependencies = [
+  name='testutils',
+  sources=globs('*.py'),
+  dependencies=[
     'src/python/pants/base:target',
     'src/python/pants/reporting',
     'src/python/pants/backend/core/targets:common',

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -2,27 +2,33 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name = 'util',
-  dependencies = [
+  name='util',
+  dependencies=[
     ':contextutil',
     ':dirutil',
   ]
 )
 
 python_tests(
-  name = 'contextutil',
-  sources = ['test_contextutil.py'],
-  dependencies = [
+  name='contextutil',
+  sources=['test_contextutil.py'],
+  dependencies=[
     'src/python/pants/util:contextutil',
+  ],
+  coverage=[
+    'pants.util.contextutil',
   ]
 )
 
 python_tests(
-  name = 'dirutil',
-  sources = ['test_dirutil.py'],
-  dependencies = [
+  name='dirutil',
+  sources=['test_dirutil.py'],
+  dependencies=[
     '3rdparty/python:mox',
     '3rdparty/python:pytest',
     'src/python/pants/util:dirutil',
+  ],
+  coverage=[
+    'pants.util.dirutil',
   ]
 )


### PR DESCRIPTION
This also fixes up dependency issues found from running test
targets individually as well as uniformizing BUILD format for
tests.

https://rbcommons.com/s/twitter/r/978/