### PR TITLE
create pantsbuild.pants.testinfra for writing tests of external plugins

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -42,6 +42,34 @@ python_library(
   )
 )
 
+python_library(
+  name='test_infra',
+  dependencies=[
+    'tests/python/pants_test:base_test',
+    'tests/python/pants_test/jvm:jar_task_test_base',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
+    'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+    'tests/python/pants_test/engine:engine_test_base',
+    'tests/python/pants_test/tasks:jvm_binary_test_base',
+  ],
+  provides=setup_py(
+    name='pantsbuild.pants.testinfra',
+    version=pants_version(),
+    description='Test support for writing pants plugins.',
+    long_description=read_contents('ABOUT.rst') + read_contents('CHANGELOG.rst'),
+    url='https://github.com/pantsbuild/pants',
+    license='Apache License, Version 2.0',
+    zip_safe=True,
+    namespace_packages=['pants_tests'],
+    classifiers=[
+      'Intended Audience :: Developers',
+      'License :: OSI Approved :: Apache Software License',
+      'Operating System :: OS Independent',
+      'Programming Language :: Python',
+    ]
+  )
+)
+
 page(name='readme',
   source='README.md',
 )

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -19,6 +19,14 @@ python_library(
   ]
 )
 
+python_library(
+  name = 'jvm_binary_test_base',
+  sources = ['jvm_binary_test_base.py'],
+  dependencies = [
+    'tests/python/pants_test/jvm:jar_task_test_base',
+  ]
+)
+
 python_test_suite(
   name = 'tasks',
   dependencies = [


### PR DESCRIPTION
create pantsbuild.pants.testinfra for writing tests of external plugins
