### PR TITLE
Added source root tests, updated the internal data structure to include a tree

### DIFF
--- a/src/python/pants/base/source_root.py
+++ b/src/python/pants/base/source_root.py
@@ -13,6 +13,106 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException
 
 
+class SourceRootTree(object):
+  """A helper data structure for SourceRoot that creates a tree from the SourceRoot paths
+  where each subdirectory is a node.  This helps to quickly determine which types are
+  allowed along a path.
+  """
+
+  class DuplicateSourceRootError(Exception):
+    pass
+
+  class NestedSourceRootError(Exception):
+    pass
+
+
+  class Node(object):
+    """Node in the tree that represents a directory"""
+
+    def __init__(self, key):
+      self.key = key
+      self.children = {}
+      self.is_leaf = False
+      self.types = None
+
+    def set_leaf(self, types):
+      self.is_leaf = True
+      self.types = types
+
+    def get(self, key):
+      return self.children.get(key)
+
+    def get_or_add(self, key):
+      child = self.get(key)
+      if not child:
+        child = SourceRootTree.Node(key)
+        self.children[key] = child
+      return child
+
+    def __eq__(self, other):
+      return self.key == other.key
+
+
+  def __init__(self):
+    self._root = self.Node(key="ROOT")
+
+  def add_root(self, source_root, types):
+    """Add a single source root to the tree.
+
+    :param string source_root:  a path in the source root tree
+    :param types: target types allowed at this source root
+    :type types: set of classes derived from Target
+    """
+    curr_node = self._root
+    dir_list = os.path.normpath(source_root).split(os.path.sep)
+    for subdir in dir_list:
+      curr_node = curr_node.get_or_add(subdir)
+
+    if curr_node.is_leaf and types != curr_node.types:
+      raise self.DuplicateSourceRootError("{source_root} already exists in tree."
+                                          .format(source_root=source_root))
+    elif curr_node.children:
+      # TODO(Eric Ayers) print the list of conflicting source_roots already registered.
+      raise self.NestedSourceRootError("{source_root} is nested inside an existing"
+                                       "source_root."
+                                       .format(source_root=source_root))
+    curr_node.set_leaf(types)
+
+  def get_root_and_types(self, path):
+    """Finds the source root that matches the prefix of the given path.
+
+    This method is intended primariy for debugging.
+
+    :param string path: a source root path starting from the root of the repo.
+    :returns: the source_root, set of types valid along that path, or None if no SourceRoot has been registered.
+    """
+    found = curr_node = self._root
+    found_path = []
+    dir_list = os.path.normpath(path).split(os.path.sep)
+    for subdir in dir_list:
+      curr_node = curr_node.get(subdir)
+      if not curr_node:
+        break
+      found = curr_node
+      found_path.append(subdir)
+
+    if found.is_leaf:
+      return os.path.sep.join(found_path), found.types
+    return None, None
+
+  def _dump(self):
+    """:returns: a text version of the tree for debugging"""
+
+    def do_dump(node, buf, level):
+      buf += "{pad}{key} leaf={is_leaf}\n".format(pad=''.rjust(level),
+                                                  key=node.key, is_leaf=node.is_leaf)
+      for child in node.children.values():
+        buf += do_dump(child, buf, level + 1)
+      return buf
+
+    return do_dump(self._root, '', 0)
+
+
 class SourceRoot(object):
   """Allows registration of a source root for a set of targets.
 
@@ -29,6 +129,7 @@ class SourceRoot(object):
   _ROOTS_BY_TYPE = {}
   _TYPES_BY_ROOT = {}
   _SEARCHED = set()
+  _SOURCE_ROOT_TREE = SourceRootTree()
 
   def __init__(self, parse_context):
     self.rel_path = parse_context.rel_path
@@ -39,7 +140,10 @@ class SourceRoot(object):
     SourceRoot.register(os.path.join(self.rel_path, basedir), *allowed_target_types)
 
   def here(self, *allowed_target_types):
-    """Registers the cwd as a source root for the given target types."""
+    """Registers the cwd as a source root for the given target types.
+
+    :param allowed_target_types: instances of AddressableCallProxy to register for this BUILD file.
+    """
     allowed_target_types = [proxy._addressable_type.get_target_type()
                             for proxy in allowed_target_types]
     SourceRoot.register(self.rel_path, *allowed_target_types)
@@ -50,49 +154,44 @@ class SourceRoot(object):
     cls._ROOTS_BY_TYPE = {}
     cls._TYPES_BY_ROOT = {}
     cls._SEARCHED = set()
+    cls._SOURCE_ROOT_TREE = SourceRootTree()
 
   @classmethod
   def find(cls, target):
     """Finds the source root for the given target.
 
-    If none is registered, returns the parent directory of the target's BUILD file.
+    :param Target target: the target whose source_root you are querying.
+    :returns: the source root that is a prefix of the target, or the parent directory of the
+    target's BUILD file if none is registered.
     """
-
     target_path = target.address.spec_path
+    found_source_root, allowed_types = cls._SOURCE_ROOT_TREE.get_root_and_types(target_path)
+    if not found_source_root:
+      # If the source root is not registered, use the path from the spec.
+      found_source_root = target_path
 
-    def _find():
-      for root_dir, types in cls._TYPES_BY_ROOT.items():
-        if target_path.startswith(root_dir):  # The only candidate root for this target.
-          # Validate the target type, if restrictions were specified.
-          if types and not isinstance(target, tuple(types)):
-            # TODO: Find a way to use the BUILD file aliases in the error message, instead
-            # of target.__class__.__name__. E.g., java_tests instead of JavaTests.
-            raise TargetDefinitionException(target,
-                'Target type %s not allowed under %s' % (target.__class__.__name__, root_dir))
-          return root_dir
-      return None
-
-    # Try already registered roots
-    root = _find()
-    if root:
-      return root
-
-    # Finally, resolve files relative to the BUILD file parent dir as the target base
-    return target_path
+    if allowed_types and not isinstance(target, allowed_types):
+      # TODO: Find a way to use the BUILD file aliases in the error message, instead
+      # of target.__class__.__name__. E.g., java_tests instead of JavaTests.
+      raise TargetDefinitionException(target,
+                                      'Target type {target_type} not allowed under {source_root}'
+                                      .format(target_type=target.__class__.__name__,
+                                              source_root=found_source_root))
+    return found_source_root
 
   @classmethod
   def types(cls, root):
-    """Returns the set of target types rooted at root."""
+    """:returns: the set of target types rooted at root."""
     return cls._TYPES_BY_ROOT[root]
 
   @classmethod
   def roots(cls, target_type):
-    """Returns the set of roots for given target type."""
+    """":returns: the set of roots for given target type."""
     return cls._ROOTS_BY_TYPE[target_type]
 
   @classmethod
   def all_roots(cls):
-    """Returns a mapping from source roots to the associated target types."""
+    """:returns: a mapping from source roots to the associated target types."""
     return dict(cls._TYPES_BY_ROOT)
 
   @classmethod
@@ -109,9 +208,9 @@ class SourceRoot(object):
   def _register(cls, source_root_dir, *allowed_target_types):
     """Registers a source root.
 
-    :source_root_dir The source root directory against which we resolve source paths,
+    :param string source_root_dir: The source root directory against which we resolve source paths,
                      relative to the build root.
-    :allowed_target_types Optional list of target types. If specified, we enforce that
+    :param list allowed_target_types: Optional list of target types. If specified, we enforce that
                           only targets of those types appear under this source root.
     """
     # Verify that source_root_dir doesn't reach outside buildroot.
@@ -136,3 +235,6 @@ class SourceRoot(object):
         roots = OrderedSet()
         cls._ROOTS_BY_TYPE[allowed_target_type] = roots
       roots.add(source_root_dir)
+
+    cls._SOURCE_ROOT_TREE.add_root(source_root_dir, allowed_target_types)
+

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -141,6 +141,7 @@ class Target(AbstractTarget):
 
   @property
   def target_base(self):
+    """:returns: the source root path for this target."""
     return SourceRoot.find(self)
 
   @classmethod

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -43,6 +43,7 @@ python_test_suite(
     ':payload',
     ':revision',
     ':run_info',
+    ':source_root',
   ]
 )
 
@@ -234,4 +235,16 @@ python_tests(
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
   ]
+)
+
+python_tests(
+  name = 'source_root',
+  sources = ['test_source_root.py'],
+  dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/base:address',
+    'src/python/pants/base:addressable',
+    'src/python/pants/base:source_root',
+    'src/python/pants/base:target',
+    ]
 )

--- a/tests/python/pants_test/base/test_source_root.py
+++ b/tests/python/pants_test/base/test_source_root.py
@@ -1,0 +1,138 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+import unittest2 as unittest
+
+from twitter.common.collections import OrderedSet
+
+from pants.base.address import parse_spec, SyntheticAddress
+from pants.base.addressable import AddressableCallProxy
+from pants.base.exceptions import TargetDefinitionException
+from pants.base.source_root import SourceRoot, SourceRootTree
+from pants.base.target import Target
+
+
+class TestTarget(Target):
+  def __init__(self, spec):
+    spec_path, target_name = parse_spec(spec)
+    super(TestTarget, self).__init__(target_name, SyntheticAddress.parse(spec), None)
+
+
+class NotTestTarget(Target):
+  def __init__(self, spec):
+    spec_path, target_name = parse_spec(spec)
+    super(NotTestTarget, self).__init__(target_name, SyntheticAddress.parse(spec), None)
+
+
+class SourceRootTest(unittest.TestCase):
+  """Tests for SourceRoot.  SourceRoot is a singleton so we must make sure this
+  test cleans up after itself.
+  """
+
+  def tearDown(self):
+    SourceRoot.reset()
+
+  def _assert_source_root_empty(self):
+    self.assertEqual({}, SourceRoot.all_roots())
+    with self.assertRaises(KeyError):
+      self.assertEqual(set(), SourceRoot.types("tests"))
+    with self.assertRaises(KeyError):
+      self.assertEqual(set(), SourceRoot.roots(TestTarget))
+
+  def test_register(self):
+    self._assert_source_root_empty()
+
+    SourceRoot.register("tests", TestTarget)
+
+    self.assertEquals({"tests": OrderedSet([TestTarget])}, SourceRoot.all_roots())
+    self.assertEquals(OrderedSet([TestTarget]), SourceRoot.types("tests"))
+    self.assertEquals(OrderedSet(["tests"]), SourceRoot.roots(TestTarget))
+
+  def test_reset(self):
+    self._assert_source_root_empty()
+    SourceRoot.register("tests", TestTarget)
+    self.assertEquals({"tests": OrderedSet([TestTarget])}, SourceRoot.all_roots())
+
+    SourceRoot.reset()
+
+    self._assert_source_root_empty()
+
+  def test_here(self):
+
+    class MockParseContext(object):
+      def __init__(self):
+        self.rel_path = "mock/foo"
+    target = TestTarget("//mock/foo/bar:baz")
+    proxy = AddressableCallProxy(addressable_type=target.get_addressable_type(),
+                                 build_file=None,
+                                 registration_callback=None)
+    self.assertEqual("mock/foo/bar", SourceRoot.find(target))
+    SourceRoot(MockParseContext()).here(proxy)
+    self.assertEqual("mock/foo", SourceRoot.find(target))
+
+  def test_find(self):
+    # When no source_root is registered, it should just return the path from the address
+    self.assertEqual("tests/foo/bar", SourceRoot.find(TestTarget("//tests/foo/bar:baz")))
+    SourceRoot.register("tests/foo", TestTarget)
+    # After the source root is registered, you should get the source root
+    self.assertEquals("tests/foo", SourceRoot.find(TestTarget("//tests/foo/bar:baz")))
+    with self.assertRaises(TargetDefinitionException):
+      SourceRoot.find(NotTestTarget("//tests/foo/foobar:qux"))
+
+  def test_source_root_tree_node(self):
+    root = SourceRootTree.Node("ROOT")
+    self.assertIsNone(root.get("child1"))
+    self.assertIsNone(root.get("child2"))
+    child = root.get_or_add("child1")
+    self.assertIsNotNone(child)
+    self.assertEquals(child, root.get("child1"))
+    self.assertIsNone(root.get("child2"))
+    grandchild = child.get_or_add("grandchild")
+    self.assertIsNone(root.get("grandchild"))
+    self.assertEquals(grandchild, child.get("grandchild"))
+    # Retrieve the same object on re-insertion
+    self.assertEquals(grandchild, child.get_or_add("grandchild"))
+
+  def test_source_root_tree(self):
+    tree = SourceRootTree()
+    self.assertEquals((None, None), tree.get_root_and_types(""))
+    self.assertEquals((None, None), tree.get_root_and_types("tests/language"))
+    self.assertEquals((None, None), tree.get_root_and_types("tests/language/foo"))
+    self.assertEquals((None, None), tree.get_root_and_types("src/language"))
+    self.assertEquals((None, None), tree.get_root_and_types("src"))
+    tree.add_root("tests/language", set([NotTestTarget, TestTarget]))
+    self.assertEquals(("tests/language", OrderedSet([NotTestTarget, TestTarget])),
+                      tree.get_root_and_types("tests/language"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals(("tests/language", set([NotTestTarget, TestTarget])),
+                      tree.get_root_and_types("tests/language/foo"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals((None, None), tree.get_root_and_types("src"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals((None, None), tree.get_root_and_types("src/bar"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals((None, None), tree.get_root_and_types("s"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    tree.add_root("src/language", set([NotTestTarget]))
+    self.assertEquals(("tests/language", OrderedSet([NotTestTarget, TestTarget])),
+                      tree.get_root_and_types("tests/language"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals(("tests/language", OrderedSet([NotTestTarget, TestTarget])),
+                       tree.get_root_and_types("tests/language/foo"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals(("src/language", OrderedSet([NotTestTarget])),
+                      tree.get_root_and_types("src/language"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals(("src/language", OrderedSet([NotTestTarget])),
+                      tree.get_root_and_types("src/language/bar"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    self.assertEquals((None, None), tree.get_root_and_types("src"),
+                      msg="Failed for tree: {dump}".format(dump=tree._dump()))
+    with self.assertRaises(SourceRootTree.DuplicateSourceRootError):
+      tree.add_root("tests/language", set([NotTestTarget]))
+    with self.assertRaises(SourceRootTree.NestedSourceRootError):
+      tree.add_root("tests", set([NotTestTarget]))


### PR DESCRIPTION
This shaves about 5 seconds off of a compile in our environment (1000+ source roots) when there is no work to be done.
