### PR TITLE
Adds the --<goal>-use-source-root for IDE project generation tasks.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -207,6 +207,7 @@ python_library(
     ':jvm_binary_task',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:source_root',
     'src/python/pants/base:target',
     'src/python/pants/goal', # XXX?
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',

--- a/src/python/pants/backend/jvm/tasks/ide_gen.py
+++ b/src/python/pants/backend/jvm/tasks/ide_gen.py
@@ -19,6 +19,7 @@ from pants.backend.jvm.tasks.jvm_binary_task import JvmBinaryTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
+from pants.base.source_root import SourceRoot
 from pants.base.target import Target
 from pants.goal.goal import Goal
 from pants.util.dirutil import safe_mkdir
@@ -90,6 +91,22 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
                             help="[%default] Includes scala sources in the project; otherwise "
                                  "compiles them and adds them to the project classpath.")
 
+    option_group.add_option(mkflag("use-source-root"), mkflag("use-source-root", negate=True),
+                            default=False, action="callback", callback=mkflag.set_bool,
+                            dest='ide_gen_use_source_root',
+                            help="[%default] Use source_root() settings to collapse source"
+                                 "paths in project and determine which paths are used for "
+                                 "tests.  This is usually what you want if your repo uses "
+                                 "a maven style directory layout.")
+    option_group.add_option(mkflag("infer-test-from-siblings"),
+                            mkflag("infer-test-from-siblings", negate=True),
+                            default=True, action="callback", callback=mkflag.set_bool,
+                            dest='ide_infer_test_from_siblings',
+                            help="[%default] When determining if a path should be added to the "
+                                 "IDE, check to see if any of its sibling source_root() entries "
+                                 "define test targets.  This is usually what you want so that "
+                                 "resource directories under test source roots are picked up as "
+                                 "test paths.")
 
   class Error(TaskError):
     """IdeGen Error."""
@@ -117,6 +134,7 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
     self.python = self.context.options.ide_gen_python
     self.skip_java = not self.context.options.ide_gen_java
     self.skip_scala = not self.context.options.ide_gen_scala
+    self.use_source_root = self.context.options.ide_gen_use_source_root
 
     self.java_language_level = self.context.options.ide_gen_java_language_level
     if self.context.options.ide_gen_java_jdk:
@@ -178,6 +196,7 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
                       self.python,
                       self.skip_java,
                       self.skip_scala,
+                      self.use_source_root,
                       get_buildroot(),
                       checkstyle_suppression_files,
                       debug_port,
@@ -368,14 +387,12 @@ class ClasspathEntry(object):
 class SourceSet(object):
   """Models a set of source files."""
 
-  TEST_BASES = set()
-
   def __init__(self, root_dir, source_base, path, is_test):
     """
-      root_dir: the full path to the root directory of the project containing this source set
-      source_base: the relative path from root_dir to the base of this source set
-      path: the relative path from the source_base to the base of the sources in this set
-      is_test: true iff the sources contained by this set implement test cases
+    :param string root_dir: full path to the root of the project containing this source set
+    :param string source_base: the relative path from root_dir to the base of this source set
+    :param string path: relative path from the source_base to the base of the sources in this set
+    :param bool is_test: true iff the sources contained by this set implement test cases
     """
 
     self.root_dir = root_dir
@@ -383,13 +400,10 @@ class SourceSet(object):
     self.path = path
     self.is_test = is_test
     self._excludes = []
-    if is_test:
-      SourceSet.TEST_BASES.add(self.source_base)
 
   @property
   def excludes(self):
     """Paths relative to self.path that are excluded from this source set."""
-
     return self._excludes
 
   @property
@@ -419,7 +433,31 @@ class Project(object):
         _, ext = os.path.splitext(resource)
         yield ext
 
-  def __init__(self, name, has_python, skip_java, skip_scala, root_dir,
+  @staticmethod
+  def _collapse_by_source_root(source_sets):
+    """Collapse SourceSets with common source roots into one SourceSet instance.
+
+    Use the registered source roots to collapse all source paths under a root.
+    If any test type of target is allowed under the root, the path is determined to be
+    a test path.  This method will give unpredictable results if source root entries overlap.
+
+    :param list source_sets: SourceSets to analyze
+    :returns: list of SourceSets collapsed to the source root paths.
+    """
+
+    roots_found = set()  # remember the roots we've already encountered
+    collapsed_source_sets = []
+    for source in source_sets:
+      query = os.path.join(source.source_base, source.path)
+      source_root = SourceRoot.find_by_path(query)
+      if not source_root:
+        collapsed_source_sets.append(source)
+      elif not source_root in roots_found:
+        roots_found.add(source_root)
+        collapsed_source_sets.append(SourceSet(source.root_dir, source_root, "", source.is_test))
+    return collapsed_source_sets
+
+  def __init__(self, name, has_python, skip_java, skip_scala, use_source_root, root_dir,
                checkstyle_suppression_files, debug_port, targets, transitive, workunit_factory,
                target_util):
     """Creates a new, unconfigured, Project based at root_dir and comprised of the sources visible
@@ -440,6 +478,7 @@ class Project(object):
     self.has_python = has_python
     self.skip_java = skip_java
     self.skip_scala = skip_scala
+    self.use_source_root = use_source_root
     self.has_scala = False
     self.has_tests = False
 
@@ -617,6 +656,8 @@ class Project(object):
     targets.update(analyzed - targets)
     self.sources.extend(SourceSet(get_buildroot(), p, None, False) for p in extra_source_paths)
     self.sources.extend(SourceSet(get_buildroot(), p, None, True) for p in extra_test_paths)
+    if self.use_source_root:
+      self.sources = Project._collapse_by_source_root(self.sources)
     self.sources = dedup_sources(self.sources)
 
     return targets

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -4,9 +4,21 @@
 python_test_suite(
   name = 'tasks',
   dependencies = [
+    ':ide_gen',
     ':junit_run',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile',
   ]
+)
+
+python_tests(
+  name = 'ide_gen',
+  sources = ['test_ide_gen.py'],
+  dependencies = [
+    'src/python/pants/backend/core/targets:common',
+    'src/python/pants/backend/jvm/tasks:ide_gen',
+    'src/python/pants/backend/jvm/targets:java',
+    'tests/python/pants_test:base_test',
+    ]
 )
 
 python_tests(
@@ -22,3 +34,4 @@ python_tests(
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
   ]
 )
+

--- a/tests/python/pants_test/backend/jvm/tasks/test_ide_gen.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ide_gen.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+
+from pants.base.source_root import SourceRoot
+
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.targets.java_tests import JavaTests
+from pants.backend.jvm.tasks.ide_gen import Project, SourceSet
+from pants.backend.jvm.tasks.idea_gen import IdeaGen
+from pants.backend.core.targets.resources import Resources
+
+
+from pants_test.base_test import BaseTest
+
+
+class IdeGenTest(BaseTest):
+
+  def test_collapse_source_root(self):
+    source_set_list = []
+    self.assertEquals([], Project._collapse_by_source_root(source_set_list))
+
+    SourceRoot.register("src/java", JavaLibrary)
+    SourceRoot.register("tests/java", JavaTests)
+    source_sets = [
+      SourceSet("/repo-root", "src/java", "com/pants/app", False),
+      SourceSet("/repo-root", "tests/java", "com/pants/app", True),
+      SourceSet("/repo-root", "some/other", "path", False),
+    ]
+
+    results = Project._collapse_by_source_root(source_sets)
+
+    self.assertEquals(SourceSet("/repo-root", "src/java", "", False), results[0])
+    self.assertFalse(results[0].is_test)
+    self.assertEquals(SourceSet("/repo-root", "tests/java", "", True), results[1])
+    self.assertTrue(results[1].is_test)
+    # If there is no registered source root, the SourceSet should be returned unmodified
+    self.assertEquals(source_sets[2], results[2])
+    self.assertFalse(results[2].is_test)
+
+  def test_source_set(self):
+    source_set1 = SourceSet("repo-root", "path/to/build", "com/pants/project", False)
+    # only the first 3 parameters are considered keys
+    self.assertEquals(("repo-root", "path/to/build", "com/pants/project"), source_set1._key_tuple)
+    source_set2 = SourceSet("repo-root", "path/to/build", "com/pants/project", True)
+    # Don't consider the test flag
+    self.assertEquals(source_set1, source_set2)
+
+
+
+class IdeaGenTest(BaseTest):
+  def test_sibling_is_test(self):
+    SourceRoot.register("src/java", JavaLibrary)
+    SourceRoot.register("src/resources", Resources)
+    SourceRoot.register("tests/java", JavaTests, JavaLibrary)
+    SourceRoot.register("tests/resources", Resources)
+
+    self.assertFalse(IdeaGen._sibling_is_test(SourceSet("repo-root", "src/java/com/pats", "project/lib", False)))
+    self.assertFalse(IdeaGen._sibling_is_test(SourceSet("repo-root", "src/resources/com/pants", "project/lib", False)))
+    # Surprise! It doesn't matter what you pass for is_test when constructing the source set,
+    # its deteching that one of the siblings under /tests/ is configured with a JavaTests target.
+    self.assertTrue(IdeaGen._sibling_is_test(SourceSet("repo-root", "tests/java/com/pants", "project/lib", False)))
+    self.assertTrue(IdeaGen._sibling_is_test(SourceSet("repo-root", "tests/resources/com/pants", "project/lib", False)))

--- a/tests/python/pants_test/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/tasks/test_idea_integration.py
@@ -6,6 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
+import xml.dom.minidom as minidom
 
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -13,7 +14,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class IdeaIntegrationTest(PantsRunIntegrationTest):
 
-  def _idea_test(self, specs, project_dir=None):
+  def _idea_test(self, specs, project_dir=None, check_func=None):
     """Helper method that tests idea generation on the input spec list."""
     if project_dir is None:
       project_dir = os.path.join('.pants.d', 'tmp', 'test-idea')
@@ -22,7 +23,8 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
       os.makedirs(project_dir)
     with temporary_dir(root_dir=project_dir) as path:
       pants_run = self.run_pants(['goal', 'idea',] + specs
-          + ['--no-pantsrc', '--idea-project-dir={dir}'.format(dir=path), '--no-idea-open',])
+          + ['--no-pantsrc', '--idea-project-dir={dir}'.format(dir=path), '--no-idea-open',
+             '--print-exception-stacktrace', ])
       self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
                         "goal idea expected success, got {0}\n"
                         "got stderr:\n{1}\n"
@@ -36,6 +38,8 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
           'Failed to find project_dir at {dir}.'.format(dir=path))
       self.assertTrue(all(os.path.exists(os.path.join(path, name))
           for name in expected_files))
+      if check_func:
+        check_func(path)
 
   # Testing IDEA integration on lots of different targets which require different functionalities to
   # make sure that everything that needs to happen for idea gen does happen.
@@ -70,3 +74,43 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
 
   def test_idea_on_scaladepsonboth(self):
     self._idea_test(['testprojects/src/scala/com/pants/testproject/scaladepsonboth::'])
+
+  def test_idea_on_maven_layout(self):
+    def do_check(path):
+      """
+          The contents of the .iml file should have sourceFolder entries that look like:
+          <sourceFolder url=".../src/main/java"  isTestSource="False"/>
+          <sourceFolder url=".../src/main/resources"  isTestSource="False"/>
+          <sourceFolder url=".../src/test/java"  isTestSource="True"/>
+          <sourceFolder url=".../src/test/resources"  isTestSource="True"/>
+          ...
+      """
+      foundSourceContent = False
+      dom = minidom.parse(os.path.join(path, 'project.iml'))
+      module = dom.getElementsByTagName('module')[0]
+      components = module.getElementsByTagName('component')
+
+      for component in components:
+        if component.getAttribute('name') == 'NewModuleRootManager':
+          content = module.getElementsByTagName('content')[0]
+          sourceFolders = content.getElementsByTagName('sourceFolder')
+          for sourceFolder in sourceFolders:
+            foundSourceContent = True
+            url = sourceFolder.getAttribute('url')
+            is_test_source = sourceFolder.getAttribute('isTestSource')
+            if url.endswith("src/main/java") or url.endswith("src/main/resources"):
+              self.assertEquals("False", is_test_source,
+                               msg="wrong test flag: url={url} isTestSource={is_test_source}"
+                               .format(url=url, is_test_source=is_test_source))
+            elif url.endswith("src/test/java") or url.endswith("src/test/resources"):
+              self.assertEquals("True", is_test_source,
+                              msg="wrong test flag: url={url} isTestSource={is_test_source}"
+                              .format(url=url, is_test_source=is_test_source))
+            else:
+              self.fail("Unexpected sourceContent tag: url={url} isTestSource={is_test_source}"
+              .format(url=url, is_test_source=is_test_source))
+      self.assertTrue(foundSourceContent)
+
+    self._idea_test(['testprojects/maven_layout/resource_collision::', '--idea-use-source-root',
+                     '--idea-infer-test-from-siblings',],
+                    check_func=do_check)


### PR DESCRIPTION
The option will put one entry for each source_root registered that has an active path in the project.
This is useful for Maven style layouts.
