### PR TITLE
Add a CI action to support CI against OSX.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -1,0 +1,13 @@
+language: objective-c
+
+script: |
+  sw_vers
+  python --version
+  java -version
+  ./build-support/bin/ci.sh -d
+
+notifications:
+  email:
+    # TODO(John Sirois): update this list to match .travis.yml
+    - john.sirois@gmail.com
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,29 @@ install:
   - pip install coveralls
 
 script: |
-  java -version; ./build-support/bin/ci.sh -d
+  uname -a
+  java -version
+  ./build-support/bin/ci.sh -d
+
+env:
+  global:
+    # Credentials for OSX syncing: GH_USER, GH_EMAIL, GH_TOKEN
+    - secure: VvwbndU++a2/iNAjk9cd67ATiipDwqcKnxDR4/J2Ik3GH10wHEDUhJ1+MK4WLhedfaOakDOEmarZQS3GwtgvCHO3knpTJuJc8d/bCfZovYuSqdi//BEv4dS7hDt6tQeJfkbBjG0T4yNjPJ3W9R9KDWCy/vj2CUm90BGg2CmxUbg=
+
+after_script: |
+  # Only sync pantsbuild/pants-for-travis-osx-ci on pushes to pantsbuild/pants master
+  if [[ TRAVIS_PULL_REQUEST == "false" && TRAVIS_BRANCH == "master" && TRAVIS_OS_NAME == "linux" ]]
+  then
+    ./build-support/bin/ci-sync.sh
+  fi
 
 notifications:
   email:
-      - john.sirois@gmail.com
-      - lhosken@twitter.com
-      - zundel@squareup.com
-      - benjyw@gmail.com
-      - areitz@twitter.com
+    - john.sirois@gmail.com
+    - lhosken@twitter.com
+    - zundel@squareup.com
+    - benjyw@gmail.com
+    - areitz@twitter.com
 
 after_success:
   coveralls

--- a/build-support/bin/ci-sync.sh
+++ b/build-support/bin/ci-sync.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cp .travis.osx.yml .travis.yml && \
+GIT_AUTHOR_NAME="${GH_USER}" GIT_AUTHOR_EMAIL=${GH_EMAIL} git commit -am "Prepare pants OSX mirror for CI." && \
+git config credential.helper "store --file=.git/credentials" && \
+echo "https://${GH_TOKEN}:@github.com" > .git/credentials
+git push -f https://github.com/pantsbuild/pants-for-travis-osx-ci.git HEAD:master


### PR DESCRIPTION
This adds a sync action run on any push to pantsbuild/pants
master that replaces pantsbuild/pants-for-travis-osx-ci master
modifying the active .travis.yml to trigger an OSX CI run.

https://rbcommons.com/s/twitter/r/1058/
