### PR TITLE
Use `.travis.yml` notifications for `.travis.osx.yml`

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -16,8 +16,5 @@ script: |
   java -version
   ./build-support/bin/ci.sh -d
 
-notifications:
-  email:
-    # TODO(John Sirois): update this list to match .travis.yml
-    - john.sirois@gmail.com
-
+# The `notifications:` configuration will be programatically copied over from `.travis.yml` for
+# central maintenance of distribution lists, see: `build-support/bin/ci-sync.sh`.

--- a/build-support/bin/ci-sync.sh
+++ b/build-support/bin/ci-sync.sh
@@ -46,11 +46,26 @@ then
   exit 0
 fi
 
+function prepare_osx_yaml() {
+  # NB: we can freely `pip install` in our Travis CI ephemeral build environment.
+  pip install PyYAML && python << EOF
+import yaml
+with open('.travis.yml') as fp:
+  config_linux = yaml.safe_load(fp)
+with open('.travis.osx.yml') as fp:
+  config_osx = yaml.safe_load(fp) 
+# We maintain notifications mailing lists centrally in the main `.travis.yml` config.
+config_osx['notifications'] = config_linux['notifications']
+with open('.travis.yml', 'w') as fp:
+  yaml.safe_dump(config_osx, fp)
+EOF
+}
+
 echo "Syncing OSX CI to $(git rev-parse HEAD) for CI build ${TRAVIS_BUILD_NUMBER}." && \
-cp .travis.osx.yml .travis.yml && \
+prepare_osx_yaml && \
 git config --local user.email "${GH_EMAIL}" && \
 git config --local user.name "${GH_USER}" && \
-git commit -am "Prepare pants OSX mirror for CI." && \
+git commit -am "Sync of https://github.com/pantsbuild/pants/commit/$(git rev-parse HEAD)" && \
 git config --local credential.helper "store --file=.git/credentials" && \
 echo "https://${GH_TOKEN}:@github.com" > .git/credentials && \
 git push -f https://github.com/pantsbuild/pants-for-travis-osx-ci.git HEAD:master


### PR DESCRIPTION
This copies over the notifications settings of the main
`.travis.yml` to `.travis.osx.yml` so that we can maintain
them centrally.

The change also tweaks the commit message to aid in quick
linking / correspondence of a pantsbuild/pants-for-travis-osx-ci
commit to a pantsbuild/pants commit.

https://rbcommons.com/s/twitter/r/1067/
