### PR TITLE
Narrow setup 'Operating System' classfiers to known-good.

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -32,8 +32,13 @@ python_library(
     classifiers=[
       'Intended Audience :: Developers',
       'License :: OSI Approved :: Apache Software License',
-      'Operating System :: OS Independent',
+      # We know for a fact these OSs work but, for example, know Windows
+      # does not work yet.  Take the conservative approach and only list OSs
+      # we know pants works with for now.
+      'Operating System :: MacOS :: MacOS X',
+      'Operating System :: POSIX :: Linux',
       'Programming Language :: Python',
+      'Topic :: Software Development :: Build Tools',
     ]
   ).with_binaries(
     # TODO(John Sirois): Switch back when target cycles have been sorted out.
@@ -64,8 +69,14 @@ python_library(
     classifiers=[
       'Intended Audience :: Developers',
       'License :: OSI Approved :: Apache Software License',
-      'Operating System :: OS Independent',
+      # We know for a fact these OSs work but, for example, know Windows
+      # does not work yet.  Take the conservative approach and only list OSs
+      # we know pants works with for now.
+      'Operating System :: MacOS :: MacOS X',
+      'Operating System :: POSIX :: Linux',
       'Programming Language :: Python',
+      'Topic :: Software Development :: Build Tools',
+      'Topic :: Software Development :: Testing',
     ]
   )
 )


### PR DESCRIPTION
We know for a fact pants does not work out of the box on Windows
as reported here:
  https://groups.google.com/d/topic/pants-devel/N6CKjY5j2ps/discussion

For now, restrict the claimed OS support to those we know pants
works with / we have CI for.

Also add appropriate 'Topic' classifiers.

https://rbcommons.com/s/twitter/r/1075/
