### PR TITLE
Adding a list of dirs to exclude from the '::' scan.  The CmdLineSpecParser

### DIFF
--- a/src/python/pants/base/build_file_address_mapper.py
+++ b/src/python/pants/base/build_file_address_mapper.py
@@ -167,7 +167,7 @@ class BuildFileAddressMapper(object):
     for spec in specs:
       yield self.spec_to_address(spec, relative_to=relative_to)
 
-  def scan_addresses(self, root=None):
+  def scan_addresses(self, root=None, spec_excludes=None):
     """Recursively gathers all addresses visible under `root` of the virtual address space.
     :raises AddressLookupError: if there is a problem parsing a BUILD file
     :param path root: defaults to the root directory of the pants project.
@@ -175,7 +175,7 @@ class BuildFileAddressMapper(object):
     addresses = set()
     root = root or get_buildroot()
     try:
-      for build_file in BuildFile.scan_buildfiles(root):
+      for build_file in BuildFile.scan_buildfiles(root, spec_excludes=spec_excludes):
         for address in self.addresses_in_spec_path(build_file.spec_path):
           addresses.add(address)
     except BuildFile.BuildFileError as e:

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -46,9 +46,10 @@ class CmdLineSpecParser(object):
   class BadSpecError(Exception):
     """Indicates an invalid command line address selector."""
 
-  def __init__(self, root_dir, address_mapper):
+  def __init__(self, root_dir, address_mapper, spec_excludes=None):
     self._root_dir = os.path.realpath(root_dir)
     self._address_mapper = address_mapper
+    self._spec_excludes = spec_excludes
 
   def parse_addresses(self, specs, fail_fast=False):
     """Process a list of command line specs and perform expansion.  This method can expand a list
@@ -100,7 +101,7 @@ class CmdLineSpecParser(object):
         raise self.BadSpecError('Can only recursive glob directories and {0} is not a valid dir'
                                 .format(spec_dir))
       try:
-        build_files = BuildFile.scan_buildfiles(self._root_dir, spec_dir)
+        build_files = BuildFile.scan_buildfiles(self._root_dir, spec_dir, spec_excludes=self._spec_excludes)
       except (BuildFile.BuildFileError, AddressLookupError) as e:
         raise self.BadSpecError(e)
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -76,7 +76,8 @@ class Context(object):
   # repository of attributes?
   def __init__(self, config, options, run_tracker, target_roots, requested_goals=None,
                lock=None, log=None, target_base=None, build_graph=None, build_file_parser=None,
-               address_mapper=None, console_outstream=None, scm=None, workspace=None):
+               address_mapper=None, console_outstream=None, scm=None, workspace=None,
+               spec_excludes=None):
     self._config = config
     self._options = options
     self.build_graph = build_graph
@@ -93,7 +94,7 @@ class Context(object):
     self._console_outstream = console_outstream or sys.stdout
     self._scm = scm or get_scm()
     self._workspace = workspace or (ScmWorkspace(self._scm) if self._scm else None)
-
+    self._spec_excludes = spec_excludes
     self.replace_targets(target_roots)
 
   @property
@@ -172,6 +173,10 @@ class Context(object):
   def ivy_home(self):
     return os.path.realpath(self.config.get('ivy', 'cache_dir',
                                             default=_IVY_CACHE_DIR_DEFAULT))
+
+  @property
+  def spec_excludes(self):
+    return self._spec_excludes
 
   def __str__(self):
     ident = Target.identify(self.targets())

--- a/tests/python/pants_test/base/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/base/test_build_file_address_mapper.py
@@ -67,6 +67,13 @@ class BuildFileAddressMapperTest(BaseTest):
                            BuildFileAddress(subdir_suffix_build_file, 'baz')]),
                       self.address_mapper.scan_addresses(root=self.build_root))
 
+  def test_scan_addresses_with_excludes(self):
+    root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
+    subdir_build_file = self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
+    spec_excludes = [ os.path.join(self.build_root, 'subdir')]
+    self.assertEquals(set([BuildFileAddress(root_build_file, 'foo')]),
+                      self.address_mapper.scan_addresses(root=self.build_root, spec_excludes=spec_excludes))
+
   def test_raises_invalid_build_file_reference(self):
     # reference a BUILD file that doesn't exist
     with self.assertRaisesRegexp(BuildFileAddressMapper.InvalidBuildFileReference,

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -132,6 +132,19 @@ class CmdLineSpecParserTest(BaseTest):
     self.assertEqual(sort(SyntheticAddress.parse(addr) for addr in expected),
                      sort(self.spec_parser.parse_addresses(cmdline_spec_list)))
 
+  def test_pants_dot_d_excluded(self):
+    expected_specs=[':root', 'a', 'a:b', 'a/b', 'a/b:c']
+
+    # This bogus BUILD file gets in the way of parsing.
+    self.add_to_build_file('.pants.d/some/dir', 'COMPLETELY BOGUS BUILDFILE)\n')
+    with self.assertRaises(CmdLineSpecParser.BadSpecError):
+      self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
+
+    self.spec_parser = CmdLineSpecParser(self.build_root, self.address_mapper,
+                                         spec_excludes=[os.path.join(self.build_root, '.pants.d')])
+    self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
+
+
 class CmdLineSpecParserBadBuildTest(BaseTest):
   def setUp(self):
     super(CmdLineSpecParserBadBuildTest, self).setUp()

--- a/tests/python/pants_test/test_utf8_header.py
+++ b/tests/python/pants_test/test_utf8_header.py
@@ -31,7 +31,8 @@ class Utf8HeaderTest(unittest.TestCase):
     address_mapper = BuildFileAddressMapper(build_file_parser)
     build_graph = BuildGraph(address_mapper=address_mapper)
 
-    for address in address_mapper.scan_addresses(get_buildroot()):
+    for address in address_mapper.scan_addresses(
+        get_buildroot(), spec_excludes=[config.getdefault('pants_workdir')]):
       build_graph.inject_address_closure(address)
 
     def has_hand_coded_python_files(tgt):


### PR DESCRIPTION
Passes along the workdir as the one dir to exclude by default.
