### PR TITLE
Memoize fingerprints by the FPStrategy hash

### DIFF
--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -26,11 +26,10 @@ logger = logging.getLogger(__name__)
 
 class IvyResolveFingerprintStrategy(FingerprintStrategy):
   @classmethod
-  def name(cls):
-    return 'ivy_resolve'
-
-  @classmethod
   def product_types(cls):
+    # TODO(pl): This is almost certainly supposed to be on IvyTaskMixin,
+    # but it might mess up MRO linearization.
+    # It seems to be completely unused right now.
     return ['symlink_map']
 
   def compute_fingerprint(self, target):
@@ -40,6 +39,12 @@ class IvyResolveFingerprintStrategy(FingerprintStrategy):
       return target.payload.fingerprint(field_keys=('excludes', 'configurations'))
     else:
       return sha1().hexdigest()
+
+  def __hash__(self):
+    return hash(type(self))
+
+  def __eq__(self, other):
+    return type(self) == type(other)
 
 
 class IvyTaskMixin(object):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_fingerprint_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_fingerprint_strategy.py
@@ -6,33 +6,37 @@ import hashlib
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 
-from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
+from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.base.hash_utils import hash_all
 
 
-class JvmFingerprintStrategy(DefaultFingerprintStrategy):
-  """A FingerprintStrategy which delegates to DefaultFingerprintStrategy
-  with the addition of a list of platform data entries. These can be used to hold
-  things like java version."""
+class JvmFingerprintStrategy(FingerprintStrategy):
+  """A FingerprintStrategy with the addition of a list of platform data entries.
+
+  These can be used to hold things like java version.
+  """
 
   def __init__(self, platform_data=None):
     """
     platform_data - List of platform information, such as java version.
     Order does not matter as it will be sorted.
     """
-    self.platform_data = platform_data or []
-
-  @classmethod
-  def name(cls):
-    return 'jvm'
+    # TODO(pl): Encode all text to bytes, as python3 hashers do not accept non-bytes.
+    self.platform_data = tuple(sorted(platform_data or []))
 
   def compute_fingerprint(self, target):
-    super_fingerprint = super(JvmFingerprintStrategy, self).compute_fingerprint(target)
+    target_fp = target.payload.fingerprint()
 
     if not isinstance(target, JvmTarget):
-      return super_fingerprint
+      return target_fp
 
     hasher = hashlib.sha1()
-    hasher.update(super_fingerprint)
-    hasher.update(bytes(hash_all(sorted(self.platform_data))))
+    hasher.update(target_fp)
+    hasher.update(bytes(hash_all(self.platform_data)))
     return hasher.hexdigest()
+
+  def __hash__(self):
+    return hash((type(self), self.platform_data))
+
+  def __eq__(self, other):
+    return type(self) == type(other) and self.platform_data == other.platform_data

--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -12,15 +12,6 @@ from twitter.common.lang import AbstractClass
 class FingerprintStrategy(AbstractClass):
   """A helper object for doing per-task, finer grained invalidation of Targets."""
 
-  @classmethod
-  def name(cls):
-    """The name of this strategy.
-
-    This will ultimately appear in a human readable form in the fingerprint itself, for debugging
-    purposes.
-    """
-    raise NotImplemented
-
   @abstractmethod
   def compute_fingerprint(self, target):
     """Subclasses override this method to actually compute the Task specific fingerprint."""
@@ -28,15 +19,25 @@ class FingerprintStrategy(AbstractClass):
   def fingerprint_target(self, target):
     """Consumers of subclass instances call this to get a fingerprint labeled with the name"""
     return '{fingerprint}-{name}'.format(fingerprint=self.compute_fingerprint(target),
-                                         name=self.name())
+                                         name=type(self).__name__)
+
+  @abstractmethod
+  def __hash__(self):
+    """Subclasses must implement a hash so computed fingerprints can be safely memoized."""
+
+  @abstractmethod
+  def __eq__(self):
+    """Subclasses must implement an equality check so computed fingerprints can be safely memoized."""
 
 
 class DefaultFingerprintStrategy(FingerprintStrategy):
   """The default FingerprintStrategy, which delegates to target.payload.invalidation_hash()."""
 
-  @classmethod
-  def name(cls):
-    return 'default'
-
   def compute_fingerprint(self, target):
     return target.payload.fingerprint()
+
+  def __hash__(self):
+    return hash(type(self))
+
+  def __eq__(self, other):
+    return type(self) == type(other)

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -212,10 +212,9 @@ class Target(AbstractTarget):
 
   def invalidation_hash(self, fingerprint_strategy=None):
     fingerprint_strategy = fingerprint_strategy or DefaultFingerprintStrategy()
-    fp_name = fingerprint_strategy.name()
-    if fp_name not in self._cached_fingerprint_map:
-      self._cached_fingerprint_map[fp_name] = self.compute_invalidation_hash(fingerprint_strategy)
-    return self._cached_fingerprint_map[fp_name]
+    if fingerprint_strategy not in self._cached_fingerprint_map:
+      self._cached_fingerprint_map[fingerprint_strategy] = self.compute_invalidation_hash(fingerprint_strategy)
+    return self._cached_fingerprint_map[fingerprint_strategy]
 
   def mark_extra_invalidation_hash_dirty(self):
     pass
@@ -227,8 +226,7 @@ class Target(AbstractTarget):
 
   def transitive_invalidation_hash(self, fingerprint_strategy=None):
     fingerprint_strategy = fingerprint_strategy or DefaultFingerprintStrategy()
-    fp_name = fingerprint_strategy.name()
-    if fp_name not in self._cached_transitive_fingerprint_map:
+    if fingerprint_strategy not in self._cached_transitive_fingerprint_map:
       hasher = sha1()
       direct_deps = sorted(self.dependencies)
       for dep in direct_deps:
@@ -237,8 +235,8 @@ class Target(AbstractTarget):
       dependencies_hash = hasher.hexdigest()[:12]
       combined_hash = '{target_hash}.{deps_hash}'.format(target_hash=target_hash,
                                                          deps_hash=dependencies_hash)
-      self._cached_transitive_fingerprint_map[fp_name] = combined_hash
-    return self._cached_transitive_fingerprint_map[fp_name]
+      self._cached_transitive_fingerprint_map[fingerprint_strategy] = combined_hash
+    return self._cached_transitive_fingerprint_map[fingerprint_strategy]
 
   def mark_transitive_invalidation_hash_dirty(self):
     self._cached_transitive_fingerprint_map = {}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_fingerprint_strategy.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_fingerprint_strategy.py
@@ -28,3 +28,40 @@ class JvmFingerprintStrategyTest(BaseTest):
     hash_no_extra = fingerprinter_no_data.compute_fingerprint(a)
     hash_extra = fingerprinter_data.compute_fingerprint(a)
     self.assertEquals(hash_no_extra, hash_extra)
+
+  def test_hashing_and_equality(self):
+    self.assertEqual(
+      JvmFingerprintStrategy(),
+      JvmFingerprintStrategy(),
+    )
+    self.assertEqual(
+      hash(JvmFingerprintStrategy()),
+      hash(JvmFingerprintStrategy()),
+    )
+
+    self.assertNotEqual(
+      JvmFingerprintStrategy(),
+      JvmFingerprintStrategy(['test']),
+    )
+    self.assertNotEqual(
+      hash(JvmFingerprintStrategy()),
+      hash(JvmFingerprintStrategy(['test'])),
+    )
+
+    self.assertEqual(
+      JvmFingerprintStrategy(['test']),
+      JvmFingerprintStrategy(('test',)),
+    )
+    self.assertEqual(
+      hash(JvmFingerprintStrategy(['test'])),
+      hash(JvmFingerprintStrategy(('test',))),
+    )
+
+    self.assertEqual(
+      JvmFingerprintStrategy(['a', 'b']),
+      JvmFingerprintStrategy(['b', 'a']),
+    )
+    self.assertEqual(
+      hash(JvmFingerprintStrategy(['a', 'b'])),
+      hash(JvmFingerprintStrategy(['b', 'a'])),
+    )

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/base:target',
     'src/python/pants/goal:context',
     'src/python/pants/goal:run_tracker',
+    'src/python/pants/option',
     'src/python/pants/reporting',
     'src/python/pants/util:dirutil',
   ]
@@ -38,6 +39,7 @@ python_test_suite(
     ':cmd_line_spec_parser',
     ':dev_backend_loader',
     ':double_dag',
+    ':fingerprint_strategy',
     ':generator',
     ':hash_utils',
     ':payload',
@@ -187,6 +189,15 @@ python_tests(
     'src/python/pants/reporting',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test/testutils',
+  ]
+)
+
+python_tests(
+  name = 'fingerprint_strategy',
+  sources = ['test_fingerprint_strategy.py'],
+  dependencies = [
+    'src/python/pants/base:fingerprint_strategy',
+    'tests/python/pants_test:base_test',
   ]
 )
 

--- a/tests/python/pants_test/base/test_fingerprint_strategy.py
+++ b/tests/python/pants_test/base/test_fingerprint_strategy.py
@@ -1,0 +1,23 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
+from pants_test.base_test import BaseTest
+
+
+class FingerprintStrategyTest(BaseTest):
+  def test_subclass_equality(self):
+    class FPStrategyA(DefaultFingerprintStrategy): pass
+    class FPStrategyB(DefaultFingerprintStrategy): pass
+
+    self.assertNotEqual(FPStrategyA(), DefaultFingerprintStrategy())
+    self.assertNotEqual(FPStrategyA(), FPStrategyB())
+    self.assertEqual(FPStrategyA(), FPStrategyA())
+
+    self.assertNotEqual(hash(FPStrategyA()), hash(DefaultFingerprintStrategy()))
+    self.assertNotEqual(hash(FPStrategyA()), hash(FPStrategyB()))
+    self.assertEqual(hash(FPStrategyA()), hash(FPStrategyA()))


### PR DESCRIPTION
- Force **hash** and **eq** to be defined for FingerprintStrategy
  subclasses.
- Fix implementations of Target.{transitive_,}fingerprint and existing
  FingerprintStrategy subclasses.
