### PR TITLE
Factor in the jvm version string into the nailgun executor fingerprint

### DIFF
--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -77,10 +77,18 @@ class NailgunExecutor(Executor):
     return None
 
   @staticmethod
-  def _fingerprint(jvm_args, classpath):
+  def _fingerprint(jvm_args, classpath, java_version):
+    """Compute a fingerprint for this invocation of a Java task.
+
+    :param list jvm_args:  JVM arguments passed to the java invocation
+    :param list classpath: The -cp arguments passed to the java invocation
+    :param Revision java_version: return value from Distribution.version()
+    :return: a hexstring representing a fingerprint of the java invocation
+    """
     digest = hashlib.sha1()
     digest.update(''.join(sorted(jvm_args)))
     digest.update(''.join(sorted(classpath)))  # TODO(John Sirois): hash classpath contents?
+    digest.update(repr(java_version))
     return digest.hexdigest()
 
   @staticmethod
@@ -199,7 +207,7 @@ class NailgunExecutor(Executor):
 
   def _get_nailgun_client(self, jvm_args, classpath, stdout, stderr):
     classpath = self._nailgun_classpath + classpath
-    new_fingerprint = self._fingerprint(jvm_args, classpath)
+    new_fingerprint = self._fingerprint(jvm_args, classpath, self._distribution.version)
 
     endpoint = self._get_nailgun_endpoint()
     running = endpoint and self._check_pid(endpoint.pid)


### PR DESCRIPTION
Our environment uses java 8, but sometimes folks use pants for the first time with a different version of java installed on path and get this error:

```
 Unexpected compilation error:
            java.lang.IllegalArgumentException: invalid source release: 8
```

The fi on the mac is to fix JDK_HOME in the environment:

```
export JDK_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/
```

The confusing part is that after they fix the setting of JAVA_HOME the problem persists, and that is because a nailgun is already running for jmake with the wrong version of java.  I attempted to fix this issue before by factoring in the path to the jdk, but for some installations of java on the the mac, they cleverly use the same path to the  java executable in /usr/bin/java but use the JDK_HOME environment variable to redirect to a different java distribution.

This change will look at the java.version system property and use it in computing the fingerprint to tell if the nailgun executor is stale.  It uses a method already built-in to the Distirbution class that checks the property value and caches it for the distribution.  
