### PR TITLE
Update help message for ./pants goal goals

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -177,7 +177,7 @@ class Options(object):
       print('  ./pants [option ...] [goal ...] [target...]  Attempt the specified goals.')
       print('  ./pants help                                 Get help.')
       print('  ./pants help [goal]                          Get help for the specified goal.')
-      print('  ./pants goals                                List all installed goals.')
+      print('  ./pants goal goals                           List all installed goals.')
       print('')
       print('  [target] accepts two special forms:')
       print('    dir:  to include all targets in the specified directory.')


### PR DESCRIPTION
Before, the online help said to run `./pants goals`

```
./pants goals

...<wait 20 seconds>...

Traceback (most recent call last):
  File "/Users/zundel/Src/Pants/pants.pex/.bootstrap/_pex/pex.py", line 225, in execute
    self.execute_entry(entry_point, args)
  File "/Users/zundel/Src/Pants/pants.pex/.bootstrap/_pex/pex.py", line 273, in execute_entry
    runner(entry_point)
  File "/Users/zundel/Src/Pants/pants.pex/.bootstrap/_pex/pex.py", line 296, in execute_pkg_resources
    runner()
  File "/Users/zundel/Src/Pants/pants.pex/pants/bin/pants_exe.py", line 201, in main
  File "/Users/zundel/Src/Pants/pants.pex/pants/bin/pants_exe.py", line 166, in _run
  File "/Users/zundel/Src/Pants/pants.pex/pants/backend/python/commands/build.py", line 83, in __init__
  File "/Users/zundel/Src/Pants/pants.pex/pants/base/cmd_line_spec_parser.py", line 71, in parse_addresses
  File "/Users/zundel/Src/Pants/pants.pex/pants/base/cmd_line_spec_parser.py", line 136, in _parse_spec
BadSpecError: BUILD file does not exist at: /Users/zundel/Src/pants/goals/BUILD
```
