### PR TITLE
There are cases where we access a field on a payload that doesn't exist.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -197,7 +197,7 @@ class ApacheThriftGen(CodeGen):
                                          sources=files,
                                          provides=target.provides,
                                          dependencies=deps,
-                                         excludes=target.payload.excludes)
+                                         excludes=target.payload.get_field_value('excludes'))
     return self._inject_target(target, dependees, self.gen_java, 'java', create_target)
 
   def _create_python_target(self, target, dependees):

--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -247,7 +247,7 @@ class ProtobufGen(CodeGen):
                                       sources=genfiles,
                                       provides=target.provides,
                                       dependencies=deps,
-                                      excludes=target.payload.excludes)
+                                      excludes=target.payload.get_field_value('excludes'))
     for dependee in dependees:
       dependee.inject_dependency(tgt.address)
     return tgt

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -280,9 +280,9 @@ class IvyUtils(object):
           if jar.rev:
             add_jar(jar)
 
-      # Lift jvm target-level excludes up to the global excludes set
-      if target.is_jvm and target.payload.excludes:
-        excludes.update(target.payload.excludes)
+      target_excludes = target.payload.get_field_value('excludes')
+      if target_excludes:
+        excludes.update(target_excludes)
 
     for target in targets:
       target.walk(collect_jars)

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -38,6 +38,15 @@ class Payload(object):
     """
     return self._fields.get(key, default)
 
+  def get_field_value(self, key, default=None):
+    """Retrieves the value in the payload field if the field exists, otherwise returns the default.
+    """
+    if key in self._fields:
+      payload_field = self._fields[key]
+      if payload_field:
+        return payload_field.value
+    return default
+
   def add_fields(self, field_dict):
     """Add a mapping of field names to PayloadField instances."""
     for key, field in field_dict.items():

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -85,3 +85,23 @@ class PayloadTest(BaseTest):
   def test_single_source(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=["Source.scala"])')
     self.context().scan(self.build_root)
+
+  def test_missing_payload_field(self):
+    payload = Payload()
+    payload.add_field('foo', PrimitiveField('test-value'))
+    payload.add_field('bar', PrimitiveField(None))
+    self.assertEquals('test-value', payload.foo);
+    self.assertEquals('test-value', payload.get_field('foo').value)
+    self.assertEquals('test-value', payload.get_field_value('foo'))
+    self.assertEquals(None, payload.bar);
+    self.assertEquals(None, payload.get_field('bar').value)
+    self.assertEquals(None, payload.get_field_value('bar'))
+    self.assertEquals(None, payload.get_field('bar', default='nothing').value)
+    self.assertEquals(None, payload.get_field_value('bar', default='nothing'))
+    with self.assertRaises(KeyError):
+      self.assertEquals(None, payload.field_doesnt_exist)
+    self.assertEquals(None, payload.get_field('field_doesnt_exist'))
+    self.assertEquals(None, payload.get_field_value('field_doesnt_exist'))
+    self.assertEquals('nothing', payload.get_field('field_doesnt_exist', default='nothing'))
+    self.assertEquals('nothing', payload.get_field_value('field_doesnt_exist', default='nothing'))
+

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -371,6 +371,7 @@ python_tests(
   name = 'idea_integration',
   sources = ['test_idea_integration.py'],
   dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/tasks/test_idea_integration.py
@@ -238,3 +238,8 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
                     config= {
                       'idea': {'exclude_folders': ['exclude-folder-sentinel']}
                     })
+
+  def test_all_targets(self):
+    # The android targets won't evaluate correctly if the Android ADK is not installed
+    self._idea_test(['src::', 'tests::', 'examples::', 'testprojects::',
+                     '--exclude-target-regexp=.*android.*'])


### PR DESCRIPTION
Rather than try to figure out when target.payload.excludes exists,
this change just returns 'None' for a missing field.
