### PR TITLE
When resolving a tool dep, report back the pants.ini section with a reference that is failing.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -20,6 +20,7 @@ from pants.backend.codegen.tasks.code_gen import CodeGen
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.address import SyntheticAddress
+from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.target import Target
@@ -48,6 +49,12 @@ def _copytree(from_base, to_base):
 
 
 class ApacheThriftGen(CodeGen):
+
+
+  class DepLookupError(AddressLookupError):
+    """Thrown when a dependency can't be found"""
+    pass
+
   GenInfo = namedtuple('GenInfo', ['gen', 'deps'])
   ThriftSession = namedtuple('ThriftSession', ['outdir', 'cmd', 'process'])
 
@@ -88,12 +95,21 @@ class ApacheThriftGen(CodeGen):
     gen_info = self.context.config.getdict('thrift-gen', key)
     gen = gen_info['gen']
     deps = {}
+
     for category, depspecs in gen_info['deps'].items():
       dependencies = OrderedSet()
       deps[category] = dependencies
       for depspec in depspecs:
-        dependencies.update(self.context.resolve(depspec))
-    return self.GenInfo(gen, deps)
+        try:
+          dependencies.update(self.context.resolve(depspec))
+        except AddressLookupError as e:
+          raise self.DepLookupError("{message}\n  referenced from [{section}] key: {key}"
+                                    "in pants.ini" .format(message=e, section='thrift-gen',
+                                                           key="gen->deps->{category}"
+                                                           .format(cateegory=category)))
+      return self.GenInfo(gen, deps)
+
+
 
   _gen_java = None
   @property

--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -20,6 +20,7 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.address import SyntheticAddress
+from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.target import Target
@@ -40,6 +41,11 @@ _PROTOBUF_GEN_JAVADEPS_DEFAULT='3rdparty:protobuf-{version}'
 _PROTOBUF_GEN_PYTHONDEPS_DEFAULT = []
 
 class ProtobufGen(CodeGen):
+
+  class DepLookupError(AddressLookupError):
+    """Thrown when a dependency can't be found"""
+    pass
+
   @classmethod
   def setup_parser(cls, option_group, args, mkflag):
     option_group.add_option(mkflag('lang'), dest='protobuf_gen_langs', default=[],
@@ -74,11 +80,15 @@ class ProtobufGen(CodeGen):
     round_manager.require_data('ivy_imports')
 
   def resolve_deps(self, key, default=[]):
-    deps = OrderedSet()
-    for dep in self.context.config.getlist('protobuf-gen', key, default=maybe_list(default)):
-      if dep:
-        deps.update(self.context.resolve(dep))
-    return deps
+    try:
+      deps = OrderedSet()
+      for dep in self.context.config.getlist('protobuf-gen', key, default=maybe_list(default)):
+        if dep:
+          deps.update(self.context.resolve(dep))
+      return deps
+    except AddressLookupError as e:
+      raise self.DepLookupError("{message}\n  referenced from [{section}] key: {key} in pants.ini"
+                                .format(message=e, section='protobuf-gen', key=key))
 
   @property
   def javadeps(self):

--- a/src/python/pants/backend/codegen/tasks/scrooge_gen.py
+++ b/src/python/pants/backend/codegen/tasks/scrooge_gen.py
@@ -19,6 +19,7 @@ from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.address import SyntheticAddress
+from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.thrift_util import calculate_compile_sources
@@ -72,6 +73,12 @@ _TARGET_TYPE_FOR_LANG = dict(scala=ScalaLibrary, java=JavaLibrary)
 
 
 class ScroogeGen(NailgunTask, JvmToolTaskMixin):
+
+
+  class DepLookupError(AddressLookupError):
+    """Thrown when a dependency can't be found"""
+    pass
+
   GenInfo = namedtuple('GenInfo', ['gen', 'deps'])
 
   class PartialCmd(namedtuple('PC', ['compiler', 'language', 'rpc_style', 'namespace_map'])):
@@ -105,10 +112,10 @@ class ScroogeGen(NailgunTask, JvmToolTaskMixin):
                                   for name, config in _CONFIG_FOR_COMPILER.items())
 
     for name, compiler in self.compiler_for_name.items():
-      bootstrap_tools = self.context.config.getlist(
-        compiler.config_section, 'bootstrap-tools',
-        default=['//:{spec}'.format(spec=compiler.profile)])
-      self.register_jvm_tool(compiler.name, bootstrap_tools)
+      self.register_jvm_tool_from_config(compiler.name, self.context.config,
+                                         ini_section=compiler.config_section,
+                                         ini_key='bootstrap-tools',
+                                         default=['//:{spec}'.format(spec=compiler.profile)])
 
     self.defaults = JavaThriftLibrary.Defaults(self.context.config)
 
@@ -258,7 +265,13 @@ class ScroogeGen(NailgunTask, JvmToolTaskMixin):
         dependencies = OrderedSet()
         deps[category] = dependencies
         for depspec in depspecs:
-          dependencies.update(self.context.resolve(depspec))
+          try:
+            dependencies.update(self.context.resolve(depspec))
+          except AddressLookupError as e:
+            raise self.DepLookupError("{message}\n  referenced from [{section}] key: {key}" \
+                                      "in pants.ini" .format(message=e, section='thrift-gen',
+                                                             key="gen->deps->{category}"
+                                                             .format(cateegory=category)))
       return self.GenInfo(gen, deps)
 
     return self._inject_target(gentarget, dependees,

--- a/src/python/pants/backend/codegen/tasks/thrift_linter.py
+++ b/src/python/pants/backend/codegen/tasks/thrift_linter.py
@@ -44,10 +44,9 @@ class ThriftLinter(NailgunTask, JvmToolTaskMixin):
     super(ThriftLinter, self).__init__(*args, **kwargs)
 
     self._bootstrap_key = 'scrooge-linter'
-
-    bootstrap_tools = self.context.config.getlist(self._CONFIG_SECTION, 'bootstrap-tools',
-                                                  default=['//:scrooge-linter'])
-    self.register_jvm_tool(self._bootstrap_key, bootstrap_tools)
+    self.register_jvm_tool_from_config(self._bootstrap_key, self.context.config,
+                                       self._CONFIG_SECTION, 'bootstrap-tools',
+                                       default=['//:scrooge-linter'])
 
   @property
   def config_section(self):

--- a/src/python/pants/backend/core/wrapped_globs.py
+++ b/src/python/pants/backend/core/wrapped_globs.py
@@ -39,6 +39,9 @@ class Globs(FilesetRelPathWrapper):
 
   E.g., ``sources = globs('*java'),`` to get .java files in this directory.
   """
+  def wrapper(*globspecs, **kw):
+    import pdb; pdb.set_trace()
+    Fileset.globs(*globspecs, **kw)
   wrapped_fn = Fileset.globs
 
 

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -47,14 +47,15 @@ class BenchmarkRun(JvmTask, JvmToolTaskMixin):
                                    default=['-Xmx1g', '-XX:MaxPermSize=256m'])
 
     self._benchmark_bootstrap_key = 'benchmark-tool'
-    benchmark_bootstrap_tools = config.getlist('benchmark-run', 'bootstrap-tools',
-                                               default=['//:benchmark-caliper-0.5'])
-    self.register_jvm_tool(self._benchmark_bootstrap_key,
-                                                  benchmark_bootstrap_tools)
+    self.register_jvm_tool_from_config(self._benchmark_bootstrap_key, config,
+                           ini_section='benchmark-run',
+                           ini_key='bootstrap-tools',
+                           default=['//:benchmark-caliper-0.5'])
     self._agent_bootstrap_key = 'benchmark-agent'
-    agent_bootstrap_tools = config.getlist('benchmark-run', 'agent_profile',
-                                           default=[':benchmark-java-allocation-instrumenter-2.1'])
-    self.register_jvm_tool(self._agent_bootstrap_key, agent_bootstrap_tools)
+    self.register_jvm_tool_from_config(self._agent_bootstrap_key, config,
+                           ini_section='benchmark-run',
+                           ini_key='agent_profile',
+                           default=[':benchmark-java-allocation-instrumenter-2.1'])
 
     # TODO(Steve Gury):
     # Find all the target classes from the Benchmark target itself

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -38,9 +38,10 @@ class Checkstyle(NailgunTask, JvmToolTaskMixin):
     super(Checkstyle, self).__init__(*args, **kwargs)
 
     self._checkstyle_bootstrap_key = 'checkstyle'
-    bootstrap_tools = self.context.config.getlist('checkstyle', 'bootstrap-tools',
-                                                  default=['//:twitter-checkstyle'])
-    self.register_jvm_tool(self._checkstyle_bootstrap_key, bootstrap_tools)
+    self.register_jvm_tool_from_config(self._checkstyle_bootstrap_key, self.context.config,
+                                       ini_section='checkstyle',
+                                       ini_key='bootstrap-tools',
+                                       default=['//:twitter-checkstyle'])
 
     self._configuration_file = self.context.config.get(self._CONFIG_SECTION, 'configuration')
 

--- a/src/python/pants/backend/jvm/tasks/ide_gen.py
+++ b/src/python/pants/backend/jvm/tasks/ide_gen.py
@@ -168,16 +168,18 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
     self.debug_port = self.context.config.getint('ide', 'debug_port', default=jvm_config_debug_port)
 
     self.checkstyle_bootstrap_key = 'checkstyle'
-    checkstyle = self.context.config.getlist('checkstyle', 'bootstrap-tools',
-                                             default=['//:twitter-checkstyle'])
-    self.register_jvm_tool(self.checkstyle_bootstrap_key, checkstyle)
+    self.register_jvm_tool_from_config(self.checkstyle_bootstrap_key, self.context.config,
+                           ini_section='checkstyle',
+                           ini_key='bootstrap-tools',
+                           default=['//:twitter-checkstyle'])
 
     self.scalac_bootstrap_key = None
     if not self.skip_scala:
       self.scalac_bootstrap_key = 'scalac'
-      scalac = self.context.config.getlist('scala-compile', 'compile-bootstrap-tools',
-                                           default=['//:scala-compiler-2.9.3'])
-      self.register_jvm_tool(self.scalac_bootstrap_key, scalac)
+      self.register_jvm_tool_from_config(self.scalac_bootstrap_key, self.context.config,
+                                         ini_section='scala-compile',
+                                         ini_key='compile-bootstrap-tools',
+                                         default=['//:scala-compiler-2.9.3'])
 
   def prepare(self, round_manager):
     if self.python:

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -77,9 +77,10 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
     self._report = self._open or self.context.options.ivy_resolve_report
 
     self._ivy_bootstrap_key = 'ivy'
-    ivy_bootstrap_tools = self.context.config.getlist(self._CONFIG_SECTION,
-                                                      'bootstrap-tools', default=['//:xalan'])
-    self.register_jvm_tool(self._ivy_bootstrap_key, ivy_bootstrap_tools)
+    self.register_jvm_tool_from_config(self._ivy_bootstrap_key, self.context.config,
+                           ini_section=self._CONFIG_SECTION,
+                           ini_key='bootstrap-tools',
+                           default=['//:xalan'])
 
     self._ivy_utils = IvyUtils(config=self.context.config,
                                options=self.context.options,

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -215,11 +215,10 @@ class JarTask(NailgunTask):
 
     # TODO(John Sirois): Consider poking a hole for custom jar-tool jvm args - namely for Xmx
     # control.
-
-    jar_bootstrap_tools = self.context.config.getlist(self._CONFIG_SECTION,
-                                                      'bootstrap-tools',
-                                                      default=['//:jar-tool'])
-    self.register_jvm_tool(self._JAR_TOOL_CLASSPATH_KEY, jar_bootstrap_tools)
+    self.register_jvm_tool_from_config(self._JAR_TOOL_CLASSPATH_KEY, self.context.config,
+                                       ini_section=self._CONFIG_SECTION,
+                                       ini_key='bootstrap-tools',
+                                       default=['//:jar-tool'])
 
   @property
   def config_section(self):

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -119,13 +119,21 @@ class _JUnitRunner(object):
                             help="An arbitrary argument to pass directly to the test runner. "
                                    "This option can be specified multiple times.")
 
+  def register_jvm_tool(self, key, ini_section, ini_key, default):
+    tool = self._context.config.getlist(ini_section, ini_key, default)
+    self._task_exports.register_jvm_tool(key,
+                                         tool,
+                                         ini_section=ini_section,
+                                         ini_key=ini_key)
+
   def __init__(self, task_exports, context):
     self._task_exports = task_exports
     self._context = context
     self._junit_bootstrap_key = 'junit'
-    task_exports.register_jvm_tool(self._junit_bootstrap_key,
-                             context.config.getlist('junit-run', 'junit-bootstrap-tools',
-                                                    default=['//:junit']))
+    self.register_jvm_tool(self._junit_bootstrap_key,
+                           ini_section='junit-run',
+                           ini_key='junit-bootstrap-tools',
+                           default=['//:junit'])
     self._jvm_args = context.config.getlist('junit-run', 'jvm_args', default=[])
     if context.options.junit_run_jvmargs:
       self._jvm_args.extend(context.options.junit_run_jvmargs)
@@ -401,9 +409,10 @@ class Emma(_Coverage):
   def __init__(self, task_exports, context, **kwargs):
     super(Emma, self).__init__(task_exports, context, **kwargs)
     self._emma_bootstrap_key = 'emma'
-    task_exports.register_jvm_tool(self._emma_bootstrap_key,
-                                   context.config.getlist('junit-run', 'emma-bootstrap-tools',
-                                                          default=['//:emma']))
+    self.register_jvm_tool(self._emma_bootstrap_key,
+                           ini_section='junit-run',
+                           ini_key='emma-bootstrap-tools',
+                           default=['//:emma'])
 
   def instrument(self, targets, tests, junit_classpath):
     safe_mkdir(self._coverage_instrument_dir, clean=True)
@@ -482,9 +491,10 @@ class Cobertura(_Coverage):
     super(Cobertura, self).__init__(task_exports, context, **kwargs)
     self._cobertura_bootstrap_key = 'cobertura'
     self._coverage_datafile = os.path.join(self._coverage_dir, 'cobertura.ser')
-    task_exports.register_jvm_tool(self._cobertura_bootstrap_key,
-                                   context.config.getlist('junit-run', 'cobertura-bootstrap-tools',
-                                                          default=['//:cobertura']))
+    self.register_jvm_tool_from_config(self._cobertura_bootstrap_key,
+                                       ini_section='junit-run',
+                                       ini_key='cobertura-bootstrap-tools',
+                                       default=['//:cobertura'])
     self._rootdirs = defaultdict(OrderedSet)
     self._include_filters = []
     self._exclude_filters = []

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
@@ -92,16 +92,16 @@ class JavaCompile(JvmCompile):
     self._depfile = os.path.join(self._analysis_dir, 'global_depfile')
 
     self._jmake_bootstrap_key = 'jmake'
-    external_tools = self.context.config.getlist('java-compile',
-                                                 'jmake-bootstrap-tools',
-                                                 default=['//:jmake'])
-    self.register_jvm_tool(self._jmake_bootstrap_key, external_tools)
+    self.register_jvm_tool_from_config(self._jmake_bootstrap_key, self.context.config,
+                                       ini_section='java-compile',
+                                       ini_key='jmake-bootstrap-tools',
+                                       default=['//:jmake'])
 
     self._compiler_bootstrap_key = 'java-compiler'
-    compiler_bootstrap_tools = self.context.config.getlist('java-compile',
-                                                           'compiler-bootstrap-tools',
-                                                           default=['//:java-compiler'])
-    self.register_jvm_tool(self._compiler_bootstrap_key, compiler_bootstrap_tools)
+    self.register_jvm_tool_from_config(self._compiler_bootstrap_key, self.context.config,
+                                       ini_section='java-compile',
+                                       ini_key='compiler-bootstrap-tools',
+                                       default=['//:java-compiler'])
 
     self.configure_args(args_defaults=_JAVA_COMPILE_ARGS_DEFAULT,
                         warning_defaults=_JAVA_COMPILE_WARNING_ARGS_DEFAULT,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
@@ -16,6 +16,7 @@ from twitter.common.collections import OrderedDict
 from pants.backend.jvm.jvm_tool_bootstrapper import JvmToolBootstrapper
 from pants.backend.jvm.scala.target_platform import TargetPlatform
 from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
@@ -46,13 +47,17 @@ class ZincUtils(object):
     self._compile_bootstrap_key = 'scalac'
     self._compile_bootstrap_tools = TargetPlatform(config=context.config).compiler_specs
     self._jvm_tool_bootstrapper.register_jvm_tool(self._compile_bootstrap_key,
-                                                  self._compile_bootstrap_tools)
+                                                  self._compile_bootstrap_tools,
+                                                  ini_section='scala-compile',
+                                                  ini_key='compile-bootstrap-tools')
 
     # The zinc version (and the scala version it needs, which may differ from the target version).
     self._zinc_bootstrap_key = 'zinc'
-    zinc_bootstrap_tools = context.config.getlist('scala-compile', 'zinc-bootstrap-tools',
-                                                  default=['//:zinc'])
-    self._jvm_tool_bootstrapper.register_jvm_tool(self._zinc_bootstrap_key, zinc_bootstrap_tools)
+    self._jvm_tool_bootstrapper.register_jvm_tool_from_config(self._zinc_bootstrap_key,
+                                                              context.config,
+                                                              ini_section='scala-compile',
+                                                              ini_key='zinc-bootstrap-tools',
+                                                              default=['//:zinc'])
 
     # Compiler plugins.
     plugins_bootstrap_tools = context.config.getlist('scala-compile',
@@ -61,7 +66,9 @@ class ZincUtils(object):
     if plugins_bootstrap_tools:
       self._plugins_bootstrap_key = 'plugins'
       self._jvm_tool_bootstrapper.register_jvm_tool(self._plugins_bootstrap_key,
-                                                    plugins_bootstrap_tools)
+                                                    plugins_bootstrap_tools,
+                                                    ini_section='scala-compile',
+                                                    ini_key='scalac-plugin-bootstrap-tools')
     else:
       self._plugins_bootstrap_key = None
 
@@ -130,7 +137,14 @@ class ZincUtils(object):
     # Go through all the bootstrap tools required to compile.
     for target in self._compile_bootstrap_tools:
       # Resolve to their actual targets.
-      resolved_libs = [t for t in self.context.resolve(target) if isinstance(t, JarLibrary)]
+      try:
+        deps = self.context.resolve(target)
+      except AddressLookupError as e:
+        raise self.DepLookupError("{message}\n  referenced from [{section}] key: {key} in pants.ini"
+                                  .format(message=e, section='scala-compile',
+                                          key='compile-bootstrap-tools'))
+
+      resolved_libs = [ t for t in deps if isinstance(t, JarLibrary)]
       for lib in resolved_libs:
         for jar in lib.jar_dependencies:
           ret.append(jar.cache_key())

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -17,12 +17,18 @@ class JvmToolTaskMixin(object):
       self._jvm_tool_bootstrapper = JvmToolBootstrapper(self.context.products)
     return self._jvm_tool_bootstrapper
 
-  def register_jvm_tool(self, key, target_addrs):
-    self.jvm_tool_bootstrapper.register_jvm_tool(key, target_addrs)
+  def register_jvm_tool(self, key, target_addrs, ini_section=None, ini_key=None):
+    self.jvm_tool_bootstrapper.register_jvm_tool(key, target_addrs,
+                                                 ini_section=ini_section, ini_key=ini_key)
+
+  def register_jvm_tool_from_config(self, key, config, ini_section, ini_key, default):
+    self.jvm_tool_bootstrapper.register_jvm_tool_from_config(key, config,
+                                                             ini_section=ini_section,
+                                                             ini_key=ini_key,
+                                                             default=default)
 
   def tool_classpath(self, key, executor=None):
     return self.jvm_tool_bootstrapper.get_jvm_tool_classpath(key, executor)
 
   def lazy_tool_classpath(self, key, executor=None):
     return self.jvm_tool_bootstrapper.get_lazy_jvm_tool_classpath(key, executor)
-

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -29,9 +29,11 @@ class ScalaRepl(JvmTask, JvmToolTaskMixin):
         self.jvm_args.extend(safe_shlex_split(arg))
     self.confs = self.context.config.getlist('scala-repl', 'confs', default=['default'])
     self._bootstrap_key = 'scala-repl'
-    bootstrap_tools = self.context.config.getlist('scala-repl', 'bootstrap-tools',
-                                                  default=['//:scala-repl-2.9.3'])
-    self.register_jvm_tool(self._bootstrap_key, bootstrap_tools)
+    self.register_jvm_tool_from_config(self._bootstrap_key, self.context.config,
+                                       ini_section='scala-repl',
+                                       ini_key='bootstrap-tools',
+                                       default=['//:scala-repl-2.9.3'])
+
     self.main = self.context.config.get('scala-repl', 'main')
     self.args = self.context.config.getlist('scala-repl', 'args', default=[])
     if self.context.options.run_args:

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -59,7 +59,7 @@ class Scalastyle(NailgunTask, JvmToolTaskMixin):
           self._excludes.add(re.compile(pattern.strip()))
 
     self._scalastyle_bootstrap_key = 'scalastyle'
-    self.register_jvm_tool(self._scalastyle_bootstrap_key, [':scalastyle'])
+    self.register_jvm_tool(self._scalastyle_bootstrap_key, ['//:scalastyle'])
 
   @property
   def config_section(self):

--- a/src/python/pants/backend/jvm/tasks/specs_run.py
+++ b/src/python/pants/backend/jvm/tasks/specs_run.py
@@ -44,9 +44,10 @@ class SpecsRun(JvmTask, JvmToolTaskMixin):
     super(SpecsRun, self).__init__(*args, **kwargs)
 
     self._specs_bootstrap_key = 'specs'
-    bootstrap_tools = self.context.config.getlist('specs-run', 'bootstrap-tools',
-                                                  default=['//:scala-specs-2.9.3'])
-    self.register_jvm_tool(self._specs_bootstrap_key, bootstrap_tools)
+    self.register_jvm_tool_from_config(self._specs_bootstrap_key, self.context.config,
+                                       ini_section='specs-run',
+                                       ini_key='bootstrap-tools',
+                                       default=['//:scala-specs-2.9.3'])
 
     self.confs = self.context.config.getlist('specs-run', 'confs', default=['default'])
 


### PR DESCRIPTION
Added a convenience method to pull a dependency list from pants.ini and
  report the section/key info along to register_jvm_tool()
