### PR TITLE
Fix issue 668: make release.sh execute packaged pants without loading in...

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -25,7 +25,9 @@ PKG_PANTS=(
 function pkg_pants_install_test() {
   PIP_ARGS="$@"
   pip install ${PIP_ARGS} pantsbuild.pants==$(local_version) && \
-  pants goal list //:: && [[ "$(pants --version 2>/dev/null)" == "$(local_version)" ]]
+  execute_packaged_pants_without_internal_backends goal list src:: && \
+  [[ "$(execute_packaged_pants_without_internal_backends --version 2>/dev/null)" \
+    == "$(local_version)" ]]
 }
 
 PKG_PANTS_TESTINFRA=(
@@ -67,6 +69,18 @@ function banner() {
 
 function run_local_pants() {
   PANTS_DEV=1 ${ROOT}/pants "$@"
+}
+
+# When we do (dry-run) testing, we need to run the packaged pants.
+# It doesn't have internal backend plugins so when we execute it
+# at the repo build root, the root pants.ini will ask it load
+# internal backend packages, which it doesn't have, and it'll fail.
+# To solve that problem, we override pants.ini with an empty list of
+# additional backends option.
+function execute_packaged_pants_without_internal_backends() {
+  NO_INTERNAL_BACKEND_PANTS_INI=$(mktemp -t pants.no.internal.backends.ini) && \
+  echo -e "[backends]\npackages: []" > $NO_INTERNAL_BACKEND_PANTS_INI && \
+  PANTS_CONFIG_OVERRIDE=$NO_INTERNAL_BACKEND_PANTS_INI pants "$@"
 }
 
 function pkg_name() {

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -78,9 +78,7 @@ function run_local_pants() {
 # To solve that problem, we override pants.ini with an empty list of
 # additional backends option.
 function execute_packaged_pants_without_internal_backends() {
-  NO_INTERNAL_BACKEND_PANTS_INI=$(mktemp -t pants.no.internal.backends.ini) && \
-  echo -e "[backends]\npackages: []" > $NO_INTERNAL_BACKEND_PANTS_INI && \
-  PANTS_CONFIG_OVERRIDE=$NO_INTERNAL_BACKEND_PANTS_INI pants "$@"
+  PANTS_CONFIG_OVERRIDE=pants.no.internal.backend.ini pants "$@"
 }
 
 function pkg_name() {

--- a/pants.no.internal.backend.ini
+++ b/pants.no.internal.backend.ini
@@ -1,0 +1,9 @@
+# When we do (dry-run) testing, we need to run the packaged pants.
+# It doesn't have internal backend plugins so when we execute it
+# at the repo build root, the root pants.ini will ask it load
+# internal backend packages, which it doesn't have, and it'll fail.
+# To solve that problem, we override pants.ini with an empty list of
+# additional backends option.
+
+[backends]
+packages: []


### PR DESCRIPTION
...ternal backends during testing

The introduction of src/python/internal_backend plugins broke build-support/bin/release.sh.
Release.sh, during dry-run and real testing, fails to execute packaged pants, because it
doesn't have internal_backend packaged within but the repo root pants.ini still asks it
to load them.

The fix is to use PANTS_CONFIG_OVERRIDE during such execution with an empty plugin list.