### PR TITLE
Update the build-support path to use bintray

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -8,9 +8,8 @@
 #   pants_workdir: the scratch space used to for live builds in this repo
 
 [DEFAULT]
-# TODO(John Sirois): Come up with a better public solution.
 pants_support_baseurls = [
-    'https://pantsbuild.github.io/binaries/build-support',
+    'https://dl.bintray.com/pantsbuild/bin/build-support',
   ]
 
 checkstyle_suppression_files = [


### PR DESCRIPTION
This is per @jsirois suggestion in https://groups.google.com/d/msg/pants-devel/khP3TuSqWmo/nLqgc671Og0J
