### PR TITLE
Kill pants custom repos and cross-platform pex setup.

### DIFF
--- a/3rdparty/python/twitter/commons/requirements.txt
+++ b/3rdparty/python/twitter/commons/requirements.txt
@@ -1,9 +1,3 @@
-# To toggle to private releases, un-comment these search override flags and remove version
-# constraints from the requirements below.
-
-#--find-links https://pantsbuild.github.io/cheeseshop/third_party/twitter-commons/0da0aff8fc7cce4d2d3991e36bc13f021ec66133/index.html
-#--no-index
-
 twitter.common.collections>=0.3.1,<0.4
 twitter.common.config>=0.3.1,<0.4
 twitter.common.confluence>=0.3.1,<0.4

--- a/pants.ini
+++ b/pants.ini
@@ -196,14 +196,6 @@ scala_maximum_heap_size_mb: 1024
 java_maximum_heap_size_mb: 1024
 
 
-[python-repos]
-repos: [
-  'https://pantsbuild.github.io/cheeseshop/third_party/python/dist/index.html',
-  'https://pantsbuild.github.io/cheeseshop/third_party/python/index.html']
-
-indices: ['https://pypi.python.org/simple/']
-
-
 [python-ipython]
 entry_point: IPython:start_ipython
 requirements: ['ipython==1.0.0']

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -62,18 +62,9 @@ PANTS_COMPATIBILITY = 'CPython>=2.6,<3,>=3.3'
 # pip installers, ie: it is why this works to get `pants` on your PATH:
 # $ pip install pantsbuild.pants
 # $ pants
-# NB: The platforms below are _only_ used when building a pex from this target.  They are
-# not used in the sdist generation.
 python_binary(
   name = 'pants',
   entry_point = 'pants.bin.pants_exe:main',
-  # TODO(John Sirois): Nuke this - we don't publish pexes so we need not build cross-platform pexes.
-  platforms=[
-    'current',
-    'linux-x86_64',
-    'macosx-10.4-x86_64',
-  ],
-  compatibility=PANTS_COMPATIBILITY,
   dependencies = [
     ':pants_binary_deps',
   ],


### PR DESCRIPTION
Kill obsolete custom cheeseshop and pex args.

We no longer use commons from HEAD so kill the custom
cheeseshop --find-links.

We no longer build cross-platform pexes, so kill vestiges.

https://rbcommons.com/s/twitter/r/1216/