### PR TITLE
change thrift_linter.py to use new register_options

### DIFF
--- a/src/python/pants/backend/codegen/tasks/thrift_linter.py
+++ b/src/python/pants/backend/codegen/tasks/thrift_linter.py
@@ -26,14 +26,11 @@ class ThriftLinter(NailgunTask, JvmToolTaskMixin):
     return target.is_thrift
 
   @classmethod
-  def setup_parser(cls, option_group, args, mkflag):
-    super(ThriftLinter, cls).setup_parser(option_group, args, mkflag)
-
-    option_group.add_option(mkflag('strict'), mkflag('strict', negate=True),
-                            dest='thrift_linter_strict',
-                            default=None,
-                            action='callback', callback=mkflag.set_bool,
-                            help='[%default] Fail the goal if thrift linter errors are found.')
+  def register_options(cls, register):
+      super(ThriftLinter, cls).register_options(register)
+      register('--strict', default=None, action='store_true',
+               help='Fail the goal if thrift linter errors are found.',
+               legacy='thrift_linter_strict')
 
   @classmethod
   def product_types(cls):


### PR DESCRIPTION
2nd attempt. Integration test runs with this version. The trick was I had added `default=False` in previous branch, which was inappropriate and ended up breaking the logic for falling back to a value defined in BUILD file. So now it explicitly initializes it to `None`.
