### PR TITLE
Fix the regression introduced in https://rbcommons.com/s/twitter/r/1186/

### DIFF
--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -18,7 +18,8 @@ class BenchmarkRun(JvmTask, JvmToolTaskMixin):
   @classmethod
   def register_options(cls, register):
     super(BenchmarkRun, cls).register_options(register)
-    register('--target', legacy='target_class', help='Name of the benchmark class.')
+    register('--target', legacy='target_class',
+             help='Name of the benchmark class. This is a mandatory argument.')
 
     register('--memory', default=False, action='store_true', legacy='memory_profiling',
              help='Enable memory profiling.')
@@ -42,6 +43,8 @@ class BenchmarkRun(JvmTask, JvmToolTaskMixin):
     # TODO(Steve Gury):
     # Find all the target classes from the Benchmark target itself
     # https://jira.twitter.biz/browse/AWESOME-1938
+    if not self.get_options().target:
+      raise ValueError('Mandatory argument --bench-target must be specified.')
     self.args.insert(0, self.get_options().target)
     if self.get_options().memory:
       self.args.append('--measureMemory')


### PR DESCRIPTION
The original code in benchmark_run.py was:

  option_group.add_option(mkflag("target"), dest="target_class", action="append",
                            help="Name of the benchmark class.")
  ...
  ...
  self.caliper_args = self.context.options.target_class
  self.caliper_args += [ str1, str2 ]
  self.caliper_args.extend([str3, str4])
  ...
  ...
  # eventually deep in the callstack, a maybe_list(caliper_args) is called.

For whatever reason, we used "append" and the target_class is a list (even though
it should be a single string argument). But anyhow, it works, since the it was an
assignment "self.caliper_args = self.context.options.target_class"

Now the change introduced in the RB, while keeping the target still a list, it
changes the line "self.caliper_args = self.context.options.target_class" to

  self.args.insert(0, self.get_options().target)

Note even though it's called "target", it's actually an list. Thus we're inserting
a list as an element into a list. Later the maybe_list failed.
