### PR TITLE
switch src/* usages of Config.load to use Config.from_cache instead

### DIFF
--- a/src/python/pants/backend/codegen/targets/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/java_thrift_library.py
@@ -20,7 +20,7 @@ class JavaThriftLibrary(JvmTarget):
         raise ValueError('Expected a JavaThriftLibrary, got: %s of type %s' % (target, type(target)))
 
     def __init__(self, config=None):
-      self._config = config or Config.load()
+      self._config = config or Config.from_cache()
 
     def _get_default(self, key, fallback):
       return self._config.get('java-thrift-library', key, default=fallback)

--- a/src/python/pants/backend/jvm/scala/target_platform.py
+++ b/src/python/pants/backend/jvm/scala/target_platform.py
@@ -19,7 +19,7 @@ class TargetPlatform(object):
   """Encapsulates information about the configured default scala target platform."""
 
   def __init__(self, config=None):
-    self._config = config or Config.load()
+    self._config = config or Config.from_cache()
 
   @property
   def compiler_specs(self):

--- a/src/python/pants/backend/python/binary_builder.py
+++ b/src/python/pants/backend/python/binary_builder.py
@@ -28,7 +28,7 @@ class PythonBinaryBuilder(object):
       raise PythonBinaryBuilder.NotABinaryTargetException(
           "Target %s is not a PythonBinary!" % target)
 
-    config = Config.load()
+    config = Config.from_cache()
     self.distdir = config.getdefault('pants_distdir')
     distpath = tempfile.mktemp(dir=self.distdir, prefix=target.name)
 

--- a/src/python/pants/backend/python/commands/build.py
+++ b/src/python/pants/backend/python/commands/build.py
@@ -27,7 +27,7 @@ class Build(Command):
                      "  %prog build (options) [spec] (build args)\n"
                      "  %prog build (options) [spec]... -- (build args)")
     parser.add_option("-t", "--timeout", dest="conn_timeout", type="int",
-                      default=Config.load().getdefault('connection_timeout'),
+                      default=Config.from_cache().getdefault('connection_timeout'),
                       help="Number of seconds to wait for http connections.")
     parser.add_option('-i', '--interpreter', dest='interpreters', default=[], action='append',
                       help="Constrain what Python interpreters to use.  Uses Requirement "
@@ -50,7 +50,7 @@ class Build(Command):
 
     self._verbose = self.old_options.verbose
 
-    self.config = Config.load()
+    self.config = Config.from_cache()
 
     interpreters = self.old_options.interpreters or [b'']
     self.interpreter_cache = PythonInterpreterCache(self.config, logger=self.debug)

--- a/src/python/pants/backend/python/commands/py.py
+++ b/src/python/pants/backend/python/commands/py.py
@@ -34,7 +34,7 @@ class Py(Command):
                      '  %prog py (options) [spec] args\n')
     parser.disable_interspersed_args()
     parser.add_option('-t', '--timeout', dest='conn_timeout', type='int',
-                      default=Config.load().getdefault('connection_timeout'),
+                      default=Config.from_cache().getdefault('connection_timeout'),
                       help='Number of seconds to wait for http connections.')
     parser.add_option('--pex', dest='pex', default=False, action='store_true',
                       help='Dump a .pex of this chroot instead of attempting to execute it.')
@@ -59,7 +59,7 @@ class Py(Command):
     self.binary = None
     self.targets = []
     self.extra_requirements = []
-    self.config = Config.load()
+    self.config = Config.from_cache()
 
     interpreters = self.old_options.interpreters or [b'']
     self.interpreter_cache = PythonInterpreterCache(self.config, logger=self.debug)

--- a/src/python/pants/backend/python/commands/setup_py.py
+++ b/src/python/pants/backend/python/commands/setup_py.py
@@ -164,7 +164,7 @@ class SetupPy(Command):
 
   @classmethod
   def iter_generated_sources(cls, target, root, config=None):
-    config = config or Config.load()
+    config = config or Config.from_cache()
     # This is sort of facepalmy -- python.new will make this much better.
     for target_type, target_builder in cls.GENERATED_TARGETS.items():
       if isinstance(target, target_type):
@@ -266,7 +266,7 @@ class SetupPy(Command):
     if not self.args:
       self.error("A spec argument is required")
 
-    self._config = Config.load()
+    self._config = Config.from_cache()
     self._root = self.root_dir
 
     self.build_graph.inject_spec_closure(self.args[0])

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -62,7 +62,7 @@ class PythonChroot(object):
                platforms=None,
                interpreter=None,
                conn_timeout=None):
-    self._config = Config.load()
+    self._config = Config.from_cache()
     self._targets = targets
     self._extra_requirements = list(extra_requirements) if extra_requirements else []
     self._platforms = platforms

--- a/src/python/pants/backend/python/test_builder.py
+++ b/src/python/pants/backend/python/test_builder.py
@@ -277,7 +277,7 @@ class PythonTestBuilder(object):
           # producing just 1 console and 1 html report whether or not the tests are run in fast
           # mode.
           relpath = Target.maybe_readable_identify(targets)
-          pants_distdir = Config.load().getdefault('pants_distdir')
+          pants_distdir = Config.from_cache().getdefault('pants_distdir')
           target_dir = os.path.join(pants_distdir, 'coverage', relpath)
           safe_mkdir(target_dir)
           pex.run(args=['html', '-i', '--rcfile', coverage_rc, '-d', target_dir],

--- a/src/python/pants/base/config.py
+++ b/src/python/pants/base/config.py
@@ -118,6 +118,20 @@ class Config(object):
   class ConfigError(Exception):
     pass
 
+
+  _cache = {}
+
+  @classmethod
+  def clear_cache(cls):
+    cls._cache = {}
+
+  @classmethod
+  def from_cache(cls, configpath=None):
+    configpath = configpath or os.path.join(get_buildroot(), 'pants.ini')
+    if configpath not in cls._cache:
+      cls._cache[configpath] = cls.load(configpath)
+    return cls._cache[configpath]
+
   @staticmethod
   def load(configpath=None, defaults=None):
     """

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -134,7 +134,7 @@ def _run():
                     dest='log_exit',
                     help='Log an exit message on success or failure.')
 
-  config = Config.load()
+  config = Config.from_cache()
 
   # XXX(wickman) This should be in the command goal, not in pants_exe.py!
   run_tracker = RunTracker.from_config(config)

--- a/src/python/pants/binary_util.py
+++ b/src/python/pants/binary_util.py
@@ -74,14 +74,14 @@ class BinaryUtil(object):
       'pants_support_fetch_timeout_secs' in config if unspecified, or 30 seconds if that value isn't
       found in config.
     :param config: Config object to lookup parameters which are left unspecified as None. If config
-      is left unspecified, it defaults to pants.ini via Config.load().
+      is left unspecified, it defaults to pants.ini via Config.from_cache().
     :param binary_base_path_strategy: Optional function to override default select_binary_base_path
       behavior. Takes in parameters (base_path, version, name) and returns a relative path to a
       binary. This relative path is used both for appending to the baseurl to determine the full url
       to the binary, and as the path to the subfolder the binary is stored in under the bootstrap_dir.
     """
     if bootstrap_dir is None or baseurls is None or timeout is None:
-      config = config or Config.load()
+      config = config or Config.from_cache()
     if bootstrap_dir is None:
       bootstrap_dir = config.getdefault('pants_bootstrapdir')
     if baseurls is None:
@@ -196,7 +196,7 @@ def safe_args(args,
   :param delete: If True deletes any arg files created upon exit from this context; defaults to
     True.
   """
-  max_args = max_args or (config or Config.load()).getdefault('max_subprocess_args', int, 100)
+  max_args = max_args or (config or Config.from_cache()).getdefault('max_subprocess_args', int, 100)
   if len(args) > max_args:
     def create_argfile(fp):
       fp.write(delimiter.join(args))

--- a/src/python/pants/commands/command.py
+++ b/src/python/pants/commands/command.py
@@ -52,7 +52,7 @@ class Command(object):
     self.address_mapper = address_mapper
     self.build_graph = build_graph
 
-    config = Config.load()
+    config = Config.from_cache()
 
     with self.run_tracker.new_workunit(name='bootstrap', labels=[WorkUnit.SETUP]):
       # construct base parameters to be filled in for BuildGraph

--- a/src/python/pants/commands/goal_runner.py
+++ b/src/python/pants/commands/goal_runner.py
@@ -61,7 +61,7 @@ class GoalRunner(Command):
 
   def __init__(self, *args, **kwargs):
     self.targets = []
-    self.config = Config.load()
+    self.config = Config.from_cache()
     known_scopes = ['']
     for goal in Goal.all():
       # Note that enclosing scopes will appear before scopes they enclose.

--- a/src/python/pants/goal/option_helpers.py
+++ b/src/python/pants/goal/option_helpers.py
@@ -18,7 +18,7 @@ GLOBAL_OPTIONS = [
   Option('-h', '--help', action='store_true', dest='help', default=False,
          help='Show this help message.'),
   Option('-t', '--timeout', dest='conn_timeout', type='int',
-         default=Config.load().getdefault('connection_timeout'),
+         default=Config.from_cache().getdefault('connection_timeout'),
          help='Number of seconds to wait for http connections.'),
   Option('-x', '--time', action='store_true', dest='time', default=False,
          help='Times tasks and goals and outputs a report.'),

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -77,7 +77,7 @@ class Bootstrapper(object):
 
   def __init__(self):
     """Creates an ivy bootstrapper."""
-    self._config = Config.load()
+    self._config = Config.from_cache()
     self._bootstrap_jar_url = self._config.get('ivy', 'bootstrap_jar_url',
                                                default=self._DEFAULT_URL)
     self._timeout_secs = self._config.getint('ivy', 'bootstrap_fetch_timeout_secs', default=1)

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -44,7 +44,7 @@ migrations = {
 
 
 def check_config_file(path):
-  config = Config.load(configpath=path)
+  config = Config.from_cache(configpath=path)
 
   print('Checking config file at {0} for unmigrated keys.'.format(path), file=sys.stderr)
   def section(s):


### PR DESCRIPTION
Now all usages of Config.load in src use a cache if the config already has been parsed.

This doesn't change test usages, but since tests use temp directories, tests with different ini files don't interfer