### PR TITLE
Fix .proto files with unicode characters

### DIFF
--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -272,10 +272,11 @@ def calculate_java_genfiles(protobuf_parse):
     yield os.path.join(basepath, '{0}.java'.format(classname))
 
 def _same_contents(a, b):
+  """Perform a comparison of the two files"""
   with open(a, 'r') as f:
-    a_data = f.read().replace(' ', '')
+    a_data = f.read()
   with open(b, 'r') as f:
-    b_data = f.read().replace(' ', '')
+    b_data = f.read()
   return a_data == b_data
 
 def check_duplicate_conflicting_protos(sources_by_base, sources, log):

--- a/testprojects/src/java/com/pants/testproject/utf8proto/BUILD
+++ b/testprojects/src/java/com/pants/testproject/utf8proto/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='utf8proto',
+  basename='utf8proto-example',
+  dependencies=[
+    'testprojects/src/protobuf/com/pants/testproject/utf8proto',
+    '3rdparty:protobuf-java',
+  ],
+  source='ExampleUtf8Proto.java',
+  main='com.pants.testproject.utf8proto.ExampleUtf8Proto',
+)

--- a/testprojects/src/java/com/pants/testproject/utf8proto/ExampleUtf8Proto.java
+++ b/testprojects/src/java/com/pants/testproject/utf8proto/ExampleUtf8Proto.java
@@ -1,0 +1,14 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.pants.testproject.utf8proto;
+
+class ExampleUtf8Proto {
+
+  private ExampleUtf8Proto() {
+  }
+
+  public static void main(String[] args) {
+    System.out.println(Utf8.Utf8Example.newBuilder().setValue("¡Hola, Mundo!").build());
+  }
+}

--- a/testprojects/src/protobuf/com/pants/testproject/utf8proto/BUILD
+++ b/testprojects/src/protobuf/com/pants/testproject/utf8proto/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_protobuf_library(name='utf8proto',
+  sources=globs('*.proto'),
+)

--- a/testprojects/src/protobuf/com/pants/testproject/utf8proto/Utf8.proto
+++ b/testprojects/src/protobuf/com/pants/testproject/utf8proto/Utf8.proto
@@ -1,0 +1,13 @@
+// Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.pants.testproject.utf8proto;
+
+/**
+ * Utf-8 chars in comments: Não trabaja?
+ */
+
+// The protobuf parser doesn't handle utf-8 names for types or fields.
+message Utf8Example {
+  optional string value = 1;
+}

--- a/tests/python/pants_test/tasks/test_protobuf_gen.py
+++ b/tests/python/pants_test/tasks/test_protobuf_gen.py
@@ -6,12 +6,12 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
+from textwrap import dedent
 import unittest2 as unittest
 
 from pants.backend.codegen.tasks.protobuf_gen import calculate_genfiles, _same_contents
 from pants.base.validation import assert_list
 from pants.util.contextutil import temporary_dir, temporary_file
-
 
 
 class ProtobufGenCalculateGenfilesTestBase(unittest.TestCase):
@@ -169,24 +169,33 @@ class ProtobufGenCalculateJavaTest(ProtobufGenCalculateGenfilesTestBase):
   def test_same_contents(self):
     with temporary_dir() as workdir:
       with open(os.path.join(workdir, 'dup1.proto'), 'w') as dup1:
-        dup1.write(
-          '''
+        dup1.write(dedent('''
             package com.twitter.lean;
             option java_multiple_files = true;
             enum Jake { FOO=1;}
             message joe_bob {}
-          '''
-        )
-        dup1.close()
-        with open(os.path.join(workdir, 'dup2.proto'), 'w') as dup2:
-          dup2.write(
-            '''
-              package com.twitter.lean;
-              option java_multiple_files = true;
-              enum Jake { FOO=1;}
-              message joe_bob {}
-            '''
-          )
-          dup2.close()
+          '''))
+      with open(os.path.join(workdir, 'dup2.proto'), 'w') as dup2:
+        dup2.write(dedent('''
+            package com.twitter.lean;
+            option java_multiple_files = true;
+            enum Jake { FOO=1;}
+            message joe_bob {}
+          '''))
+      self.assertTrue(_same_contents(dup1.name, dup2.name))
 
-          self.assertTrue(_same_contents(dup1.name, dup2.name))
+  def test_not_same_contents(self):
+    with temporary_dir() as workdir:
+      with open(os.path.join(workdir, 'dup1.proto'), 'w') as dup1:
+        dup1.write(dedent('''
+            package com.twitter.lean;
+            option java_multiple_files = true;
+            enum Jake { FOO=1;}
+            message joe_bob {}
+          '''))
+      with open(os.path.join(workdir, 'dup2.proto'), 'w') as dup2:
+        dup2.write(dedent('''
+            package com.twitter.lean;
+            message joe_bob {}
+          '''))
+      self.assertFalse(_same_contents(dup1.name, dup2.name))


### PR DESCRIPTION
We've run into an issue with a .proto file with unicode characters in the comments. This test puts unicode characters in several places to try and shake out all the bugs.
