### PR TITLE
Kill all nailgun tasks after an integration test run 

### DIFF
--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -37,6 +37,7 @@ python_library(
   name = 'int-test',
   sources = ['pants_run_integration_test.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:build_environment',
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -12,6 +12,7 @@ import subprocess
 import unittest2 as unittest
 
 from pants.fs.archive import ZIP
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open, safe_mkdir
@@ -25,6 +26,13 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
   PANTS_SUCCESS_CODE = 0
   PANTS_SCRIPT_NAME = 'pants'
+
+  @classmethod
+  def tearDownClass(cls):
+    # When integration tests run in a private buildroot, they leave nailgun tasks running that
+    # won't be cleaned up until someone runs ./pants goal ng-killall.
+    NailgunTask.killall()
+    super(PantsRunIntegrationTest, cls).tearDownClass()
 
   @classmethod
   def has_python_version(cls, version):


### PR DESCRIPTION
to keep from leaking NGServer instances
