### PR TITLE
In IvyImports, make a single call to ivy to map all jar files.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -242,6 +242,7 @@ python_library(
   name = 'ivy_imports',
   sources = ['ivy_imports.py'],
   dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm:ivy_utils',
     ':nailgun_task',
     'src/python/pants:binary_util',

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -7,6 +7,8 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import os
 
+from twitter.common.collections import OrderedSet
+
 from pants.backend.jvm.ivy_utils import IvyUtils
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 
@@ -51,15 +53,18 @@ class IvyImports(NailgunTask):
       return t.address.spec
 
     resolve_for = self.context.targets(lambda t: t.has_label('has_imports'))
+
     if resolve_for:
       imports_util = ImportsUtil(self.context)
       imports_map = self.context.products.get('ivy_imports')
       executor = self.create_java_executor()
-      for target in resolve_for:
-        jars = target.imports
-        self.context.log.info('Mapping import jars for {target}: \n  {jars}'.format(
+      if resolve_for:
+        jars = OrderedSet()
+        for target in resolve_for:
+          self.context.log.info('  {target}: \n    {jars}'.format(
             target=nice_target_name(target),
-            jars='\n  '.join(self._str_jar(s) for s in jars)))
+            jars='\n    '.join(self._str_jar(s) for s in target.imports)))
+          jars |= target.imports
         imports_util.mapjars(imports_map, target, executor,
                              workunit_factory=self.context.new_workunit,
                              jars=jars)

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -6,6 +6,7 @@ python_test_suite(
   dependencies = [
     ':ide_gen',
     ':idea_gen',
+    ':ivy_imports',
     ':junit_run',
     ':scalastyle',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile',
@@ -34,6 +35,17 @@ python_tests(
     'src/python/pants/base:source_root',
     'tests/python/pants_test:base_test',
   ]
+)
+
+python_tests(
+  name = 'ivy_imports',
+  sources = ['test_ivy_imports.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/base:address',
+    'src/python/pants/backend/jvm/tasks:ivy_imports',
+    'tests/python/pants_test/jvm:nailgun_task_test_base',
+    ]
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+import os
+from textwrap import dedent
+
+from pants.backend.jvm.tasks.ivy_imports import IvyImports
+from pants.base.address import BuildFileAddress
+from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
+
+class IvyImportsTest(NailgunTaskTestBase):
+  """Tests for the IvyImports task"""
+
+  @classmethod
+  def task_type(cls):
+    return IvyImports
+
+  def _create_ivyimports_task(self, context=None, config=None, options=None):
+    context = context or self._create_context(config, options)
+    return self.create_task(context, self.build_root)
+
+  def test_ivy_imports(self):
+    # I chose these two imports randomly, feel free to change them if they pose an issue.
+    links = [
+      '.pants.d/ivy/mapped-imports/a.foo/com.google.guava/guava/default/com.google.guava-guava-12.0.jar',
+      '.pants.d/ivy/mapped-imports/a.foo/junit/junit/default/junit-junit-4.11.jar'
+    ]
+    for link in links:
+      if os.path.exists(link):
+        os.remove(link)
+        self.assertFalse(os.path.exists(link))
+    context = self.context()
+    build_file = self.add_to_build_file('a/BUILD', dedent('''
+      java_protobuf_library(
+        name='foo',
+        imports=[
+          ':bar',
+          ':baz',
+        ],
+      )
+      jar_library(
+        name='bar',
+        jars=[
+          jar(org='junit', name='junit-dep', rev='4.11'),
+        ],
+      )
+      jar_library(
+        name='baz',
+        jars=[
+          jar(org='com.google.guava', name='guava', rev='12.0'),
+        ],
+      )
+    '''))
+    target_address = BuildFileAddress(build_file, 'foo')
+    context.build_graph.inject_address_closure(target_address)
+    protobuf_library_target = context.build_graph.get_target(target_address)
+    context.replace_targets([protobuf_library_target])
+
+    self.execute(context)
+    for link in links:
+      self.assertTrue(os.path.exists(link), msg='Could not find {0}'.format(link))
+      self.assertTrue(os.path.islink(link), msg='Not a link {0}'.format(link))
+      self.assertTrue(os.path.lexists(link), msg='Not linked to a real file {0}'.format(link))
+
+


### PR DESCRIPTION
If you have many targets with jars to map in, this is a significant performance increase.
