### PR TITLE
Lock around chroot.dump()

### DIFF
--- a/src/python/pants/backend/python/binary_builder.py
+++ b/src/python/pants/backend/python/binary_builder.py
@@ -50,7 +50,11 @@ class PythonBinaryBuilder(object):
 
   def run(self):
     print('Building PythonBinary %s:' % self.target)
-    env = self.chroot.dump()
+    self.context.acquire_lock()
+    try:
+      env = self.chroot.dump()
+    finally:
+      self.context.release_lock()
     filename = os.path.join(self.distdir, '%s.pex' % self.target.name)
     env.build(filename)
     print('Wrote %s' % filename)

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -58,5 +58,9 @@ class PythonBinaryCreate(PythonTask):
         conn_timeout=self.conn_timeout)
 
       pex_path = os.path.join(self._distdir, '%s.pex' % binary.name)
-      chroot.dump()
+      try:
+        self.context.acquire_lock()
+        chroot.dump()
+      finally:
+        self.context.release_lock()
       builder.build(pex_path)

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -51,7 +51,11 @@ class PythonRepl(PythonTask):
           interpreter=interpreter,
           conn_timeout=self.conn_timeout)
 
-        chroot.dump()
+        self.context.acquire_lock()
+        try:
+          chroot.dump()
+        finally:
+          self.context.release_lock()
         builder.freeze()
         pex = PEX(builder.path(), interpreter=interpreter)
         self.context.release_lock()

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -43,7 +43,11 @@ class PythonRun(PythonTask):
           interpreter=interpreter,
           conn_timeout=self.conn_timeout)
 
-        chroot.dump()
+        self.context.acquire_lock()
+        try:
+          chroot.dump()
+        finally:
+          self.context.release_lock()
         builder.freeze()
         pex = PEX(builder.path(), interpreter=interpreter)
         self.context.release_lock()


### PR DESCRIPTION
This fixes a hang seen with

./pants goal clean-all

then
./pants goal test tests/python/pants_test:all

concurrently in two separate terminals. 

```
 WARN] renaming /Users/zundel/Src/pants/.pants.d/python/downloads/c699663d6d38e43f558da42783e08ec4.tmp to /Users/zundel/Src/pants/.pants.d/python/downloads/c699663d6d38e43f558da42783e08ec4
 WARN] renaming /Users/zundel/Src/pants/.pants.d/python/downloads/5b4a1025d475bbc0f0414cf0d6014753.tmp to /Users/zundel/Src/pants/.pants.d/python/downloads/5b4a1025d475bbc0f0414cf0d6014753
 WARN] renaming /Users/zundel/Src/pants/.pants.d/python/downloads/b29e9ff44154529c90874ba190ad21b0.tmp to /Users/zundel/Src/pants/.pants.d/python/downloads/b29e9ff44154529c90874ba190ad21b0
 WARN] renaming /Users/zundel/Src/pants/.pants.d/python/downloads/04bdfcd97292998a59cdfae0e79f0b38.tmp to /Users/zundel/Src/pants/.pants.d/python/downloads/04bdfcd97292998a59cdfae0e79f0b38
 WARN] renaming /Users/zundel/Src/pants/.pants.d/python/downloads/c6297b1180f340b42734ae33e908b6b4.tmp to /Users/zundel/Src/pants/.pants.d/python/downloads/c6297b1180f340b42734ae33e908b6b4
 WARN] renaming /Users/zundel/Src/pants/.pants.d/python/downloads/f272affd1813d333f0295772b5fd0eda.tmp to /Users/zundel/Src/pants/.pants.d/python/downloads/f272affd1813d333f0295772b5fd0eda
Exception in thread Thread-24:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/Users/zundel/Src/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pex/http/crawler.py", line 45, in execute
    hrefs, rel_hrefs = self.execute(url)
  File "/Users/zundel/Src/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pex/http/crawler.py", line 152, in execute
    return self._remote_execute(url)
  File "/Users/zundel/Src/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pex/http/crawler.py", line 137, in _remote_execute
    with contextlib.closing(self._open(url, conn_timeout=self._conn_timeout)) as index_fp:
  File "/Users/zundel/Src/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pex/http/http.py", line 222, in open
    self.cache(url, conn_timeout=conn_timeout)
  File "/Users/zundel/Src/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pex/http/http.py", line 211, in cache
    self.encode_url(url, conn_timeout=conn_timeout)
  File "/Users/zundel/Src/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pex/http/http.py", line 193, in encode_url
    os.rename(target_tmp, target)
OSError: [Errno 2] No such file or directory
```