### PR TITLE
Subclasses of Exception have strange deserialization

### DIFF
--- a/src/python/pants/cache/artifact_cache.py
+++ b/src/python/pants/cache/artifact_cache.py
@@ -21,7 +21,7 @@ class ArtifactCacheError(Exception):
 class NonfatalArtifactCacheError(Exception):
   pass
 
-class UnreadableArtifact(Exception):
+class UnreadableArtifact(object):
   """A False-y value to indicate a read-failure (vs a normal cache-miss)
 
   See docstring on `ArtifactCache.use_cached_files` for details.


### PR DESCRIPTION
We pass these back from subprocs so they need to ser/de correctly, but Exception has special
deserialization. UnreadableArtifact is basically just a sentinel value so subclassing Exception
just adds complexity
