### PR TITLE
Allow configuring goal aliases via pants.ini

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -133,8 +133,19 @@ class GoalRunner(object):
     logger = logging.getLogger(__name__)
 
     goals = self.options.goals
-    specs = self.options.target_specs
+    raw_specs = self.options.target_specs
     fail_fast = self.options.for_global_scope().fail_fast
+
+    specs = []
+    aliases = self.options.for_global_scope().goal_aliases
+    if aliases:
+      for spec in raw_specs:
+        if spec in aliases:
+          goals.append(aliases[spec])
+        else:
+          specs.append(spec)
+    else:
+      specs = raw_specs
 
     for goal in goals:
       if BuildFile.from_cache(get_buildroot(), goal, must_exist=False).exists():

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -5,6 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
+from pants.option.options import Options
 
 def register_global_options(register):
   register('-t', '--timeout', type=int, metavar='<seconds>',
@@ -51,3 +52,4 @@ def register_global_options(register):
   register('--fail-fast', action='store_true',
            help='When parsing specs, will stop on the first erronous BUILD file encountered. '
                 'Otherwise, will parse all builds in a spec and then throw an Exception.')
+  register('--goal-aliases', type=Options.dict, default={}, help="Alias goal names")


### PR DESCRIPTION
Trigger CI

This is likely not going upstream, but rather just for migrating foursquare off sc/st and on to 
compile-changed/test-changed goals.

Usually unrecognized args (eg not scopes or -foo) become target specs.
If pants.ini configures goal_aliases, look for specs that match aliases
and if found remove them from specs and add their configured goal names
to the goals.

This might be prettier if we instead told the arg splitter about aliases,
by including them in known-scopes, rather than rescuing them from specs
but this is good enough for now, and that approach has potential to muck
with other args, as it adds the aliases as a scope, which affects more than
just which list they themselves get sorted into.