### PR TITLE
Clean up cached config in test class tear down.

### DIFF
--- a/src/python/pants/backend/core/tasks/reflect.py
+++ b/src/python/pants/backend/core/tasks/reflect.py
@@ -13,6 +13,7 @@ from docutils.core import publish_parts
 from twitter.common.collections.ordereddict import OrderedDict
 
 from pants.base.build_manual import get_builddict_info
+from pants.base.config import Config
 from pants.base.exceptions import TaskError
 from pants.base.generator import TemplateData
 from pants.base.target import Target
@@ -420,7 +421,11 @@ def get_syms(build_file_parser):
 
 
 def bootstrap_option_values():
-  return OptionsBootstrapper(buildroot='<buildroot>').get_bootstrap_options().for_global_scope()
+  try:
+    return OptionsBootstrapper(buildroot='<buildroot>').get_bootstrap_options().for_global_scope()
+  finally:
+    Config.reset_default_bootstrap_option_values()
+
 
 def gen_goals_glopts_reference_data():
   option_parser = Parser(env={}, config={}, scope='', parent_parser=None)
@@ -458,6 +463,7 @@ def gref_template_data_from_options(scope, argparser):
     title=title,
     options=option_l,
     pantsref=pantsref)
+
 
 def gen_tasks_goals_reference_data():
   """Generate the template data for the goals reference rst doc."""

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -43,12 +43,6 @@ class BaseTest(unittest.TestCase):
     # TODO(John Sirois): Yuck. Get rid of this after plumbing options through in the right places.
     Config.cache(Config.load())
 
-  @classmethod
-  def tearDownClass(cls):
-    super(BaseTest, cls).tearDownClass()
-    # TODO(John Sirois): Yuck. Get rid of this after plumbing options through in the right places.
-    Config.cache(None)
-
   def build_path(self, relpath):
     """Returns the canonical BUILD file path for the given relative build path."""
     if os.path.basename(relpath).startswith('BUILD'):

--- a/tests/python/pants_test/jvm/nailgun_task_test_base.py
+++ b/tests/python/pants_test/jvm/nailgun_task_test_base.py
@@ -18,6 +18,5 @@ class NailgunTaskTestBase(JvmToolTaskTestBase):
 
   @classmethod
   def tearDownClass(cls):
-    super(NailgunTaskTestBase, cls).tearDownClass()
     # Kill any nailguns launched in our ephemeral build root
     NailgunTask.killall()


### PR DESCRIPTION
This takes over from https://github.com/pantsbuild/pants/pull/858
