### PR TITLE
using class binary name same as CmdLineProcessor

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/resource_mapping.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/resource_mapping.py
@@ -11,7 +11,8 @@ import os
 import re
 
 class ResourceMapping(object):
-  RESOURCES_BY_CLASS_NAME_RE = re.compile(r'^(?P<classname>[\w+.]+) -> (?P<path>.+)$')
+
+  RESOURCES_BY_CLASS_NAME_RE = re.compile(r'^(?P<classname>[\w+.\$]+) -> (?P<path>.+)$')
 
   def __init__(self, classes_dir):
     self._classes_dir = classes_dir

--- a/testprojects/src/java/com/pants/testproject/annotation/main/Main.java
+++ b/testprojects/src/java/com/pants/testproject/annotation/main/Main.java
@@ -14,4 +14,11 @@ public class Main {
   public static void main(String args[]) {
     System.out.println("Hello World!");
   }
+
+  /**
+   * Inner class marked with annotation.
+   */
+  @Deprecated
+  private static class TestInnerClass {
+  }
 }

--- a/testprojects/src/java/com/pants/testproject/annotation/processor/ResourceMappingProcessor.java
+++ b/testprojects/src/java/com/pants/testproject/annotation/processor/ResourceMappingProcessor.java
@@ -22,6 +22,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
@@ -36,8 +37,9 @@ public class ResourceMappingProcessor extends AbstractProcessor {
   private static final String REPORT_FILE_NAME = "deprecation_report.txt";
 
   private ProcessingEnvironment processingEnvironment = null;
+  private Elements elementUtils;
 
-  private static final class Resource {
+    private static final class Resource {
     private final FileObject resource;
     private final Writer writer;
 
@@ -105,6 +107,7 @@ public class ResourceMappingProcessor extends AbstractProcessor {
 
   @Override public void init(ProcessingEnvironment processingEnvironment) {
     this.processingEnvironment = processingEnvironment;
+    this.elementUtils = processingEnvironment.getElementUtils();
   }
 
   @Override public Set<String> getSupportedAnnotationTypes() {
@@ -126,7 +129,6 @@ public class ResourceMappingProcessor extends AbstractProcessor {
     try {
       Set<String> typeNames = new HashSet<String>();
       PrintWriter writer = closer.register(new PrintWriter(outputFile.openWriter()));
-      writer.println("{");
       for (TypeElement appAnnotation : annotations) {
         Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(appAnnotation);
         Set<TypeElement> elements = ElementFilter.typesIn(annotatedElements);
@@ -134,13 +136,12 @@ public class ResourceMappingProcessor extends AbstractProcessor {
           if (!(elem instanceof TypeElement))
             continue;
           TypeElement typeElem = (TypeElement) elem;
-          String typeName = typeElem.getQualifiedName().toString();
+          String typeName = elementUtils.getBinaryName(typeElem).toString();
           typeNames.add(typeName);
-          writer.println(typeName + "\n");
+          writer.println(typeName);
         }
       }
 
-      writer.println("}\n");
       closer.close();
 
       writeResourceMapping(typeNames, outputFile);

--- a/tests/python/pants_test/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -112,7 +112,14 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
           for name in files:
             path = os.path.join(dirpath, name)
             all_files.add(path)
-        self.assertIn(os.path.join(extract_dir, "compile/jvm/java/classes/deprecation_report.txt"), all_files)
+
+        report_file_name = os.path.join(extract_dir, 'compile/jvm/java/classes/deprecation_report.txt')
+        self.assertIn(report_file_name, all_files)
+
+        annotated_classes = [line.rstrip() for line in file(report_file_name).read().splitlines()]
+        self.assertEquals(
+          {'com.pants.testproject.annotation.main.Main', 'com.pants.testproject.annotation.main.Main$TestInnerClass'},
+          set(annotated_classes))
 
   def _whitelist_test(self, target, fatal_flag, whitelist):
     # We want to ensure that a project missing dependencies can be


### PR DESCRIPTION
./pants goal compile tests/java/com/twitter/common/args:small

```
           FAILURE
```

Traceback (most recent call last):
  File "/Users/peiyu/.pants.d/bin/pants.pex/pants-1.0.14rc2-science-hacks-201412101700-testing-py27.pex/.bootstrap/_pex/pex.py", line 225, in execute
    self.execute_entry(entry_point, args)
  File "/Users/peiyu/.pants.d/bin/pants.pex/pants-1.0.14rc2-science-hacks-201412101700-testing-py27.pex/.bootstrap/_pex/pex.py", line 273, in execute_entry
    runner(entry_point)
  File "/Users/peiyu/.pants.d/bin/pants.pex/pants-1.0.14rc2-science-hacks-201412101700-testing-py27.pex/.bootstrap/_pex/pex.py", line 296, in execute_pkg_resources
    runner()
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/bin/pants_exe.py", line 178, in main
    _run()
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/bin/pants_exe.py", line 155, in _run
    result = command.run()
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/commands/goal_runner.py", line 268, in run
    return engine.execute(context, self.goals)
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/engine/engine.py", line 48, in execute
    self.attempt(context, goals)
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/engine/round_engine.py", line 185, in attempt
    goal_executor.attempt(explain)
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/engine/round_engine.py", line 42, in attempt
    task.execute()
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/backend/core/tasks/group_task.py", line 352, in execute
    group_member.execute_chunk(chunk)
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 450, in execute_chunk
    self._register_products(vts.targets, analysis_file)
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 826, in _register_products
    resources = self._resources_by_class_file(cls, resource_mapping)
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py", line 811, in _resources_by_class_file
    return resource_mapping.get(class_name, [])
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/backend/jvm/tasks/jvm_compile/resource_mapping.py", line 100, in get
    return self.mappings.get(key, default)
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/backend/jvm/tasks/jvm_compile/resource_mapping.py", line 91, in mappings
    self._read_resource_mappings(mappings, f.readlines())
  File "/Users/peiyu/workspace/source2/science/.pex/install/pantsbuild.pants-0.0.24-py2-none-any.whl.849817490395e8d68ec48ae93a0abd0b1163da20/pantsbuild.pants-0.0.24-py2-none-any.whl/pants/backend/jvm/tasks/jvm_compile/resource_mapping.py", line 56, in _read_resource_mappings
    Expected classname -> path, got "{line}"'''.format(line=line)))
ValueError: 
Unable to parse resource mappings.
Expected classname -> path, got "com.twitter.common.args.ArgsTest$App -> /Users/peiyu/workspace/source2/science/.pants.d/compile/jvm/java/classes/com/twitter/common/args/apt/cmdline.arg.info.txt.2"
