### PR TITLE
Fixup migrate_config to use new Config API.

### DIFF
--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -9,7 +9,7 @@ import sys
 
 from colors import cyan, green
 
-from pants.base.config import Config
+from pants.base.config import Config, SingleFileConfig
 from pants.option import custom_types
 from pants.option.errors import ParseError
 
@@ -63,13 +63,14 @@ notes = {
 
 
 def check_config_file(path):
-  config = Config.load(configpaths=[path])
+  cp = Config.create_parser()
+  with open(path, 'r') as ini:
+    cp.readfp(ini)
+  config = SingleFileConfig(path, cp)
 
   print('Checking config file at {0} for unmigrated keys.'.format(path), file=sys.stderr)
   def section(s):
     return cyan('[{0}]'.format(s))
-
-  cp = config.configparser
 
   for (src_section, src_key), (dst_section, dst_key) in migrations.items():
     def has_non_default_option(section, key):


### PR DESCRIPTION
When support for multiple config files was added
migrate_config broke accessing a no-longer available
`Config.configparser` field.

https://rbcommons.com/s/twitter/r/1514/
