### PR TITLE
trigger ci: LazySourceMapper and tests

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -194,6 +194,15 @@ python_library(
 )
 
 python_library(
+  name = 'lazy_source_mapper',
+  sources = ['lazy_source_mapper.py'],
+  dependencies = [
+    ':build_file',
+    ':build_environment',
+  ]
+)
+
+python_library(
   name = 'mustache',
   sources = ['mustache.py'],
   dependencies = [
@@ -275,6 +284,7 @@ python_library(
     ':build_manual',
     ':fingerprint_strategy',
     ':hash_utils',
+    ':lazy_source_mapper',
     ':payload',
     ':source_root',
     ':target_addressable',

--- a/src/python/pants/base/lazy_source_mapper.py
+++ b/src/python/pants/base/lazy_source_mapper.py
@@ -1,0 +1,106 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from collections import defaultdict
+import os
+
+from pants.base.build_environment import get_buildroot
+from pants.base.build_file import BuildFile
+
+class LazySourceMapper(object):
+  """A utility for lazily making a best-effort mapping of source files to targets that own them.
+
+  This attempts to avoid loading more than needed by lazily searching for and loading BUILD files
+  adjacent to or in parent directories (up to the buildroot) of a source to construct a (partial)
+  mapping of sources to owning targets.
+
+  If in stop-after-match mode, a search will not traverse into parent directories once an owner
+  is identified. THIS MAY FAIL TO FIND ADDITIONAL OWNERS in parent directories, or only find them
+  when other sources are also mapped first, which cause those owners to be loaded. Some repositories
+  may be able to use this to avoid expensive walks, but others may need to prefer correctness.
+
+  A LazySourceMapper reuses computed mappings and only searches a given path once as
+  populating the BuildGraph is expensive, so in general there should only be one instance of it.
+  """
+
+  def __init__(self, context, stop_after_match=False):
+    """Initialize LazySourceMapper
+
+    :param Context context: A Context object as provided to Task instances.
+    """
+    self._stop_after_match = stop_after_match
+    self._build_graph = context.build_graph
+    self._address_mapper = context.address_mapper
+    self._source_to_address = defaultdict(set)
+    self._mapped_paths = set()
+    self._searched_sources = set()
+
+  def _find_owners(self, source):
+    """Searches for BUILD files adjacent or above a source in the file hierarchy.
+    - Walks up the directory tree until it reaches a previously searched path.
+    - Stops after looking in the buildroot.
+
+    If self._stop_after_match is set, stops searching once a source is mapped, even if the parent
+    has yet to be searched. See class docstring for discussion.
+
+    :param str source: The source at which to start the search.
+    """
+    # Bail instantly if a source has already been searched
+    if source in self._searched_sources:
+      return
+    self._searched_sources.add(source)
+
+    root = get_buildroot()
+    path = os.path.dirname(source)
+
+    # a top-level source has empty dirname, so do/while instead of straight while loop.
+    walking = True
+    while walking:
+      # It is possible
+      if path not in self._mapped_paths:
+        candidate = BuildFile.from_cache(root_dir=root, relpath=path, must_exist=False)
+        if candidate.exists():
+          self._map_sources_from_family(candidate.family())
+        self._mapped_paths.add(path)
+      elif not self._stop_after_match:
+        # If not in stop-after-match mode, once a path is seen visited, all parents can be assumed.
+        return
+
+      # See class docstring
+      if self._stop_after_match and source in self._source_to_address:
+        return
+
+      walking = bool(path)
+      path = os.path.dirname(path)
+
+  def _map_sources_from_family(self, build_files):
+    """Populate mapping of source to owning addresses with targets from given BUILD files.
+
+    :param iterable<BuildFile> build_files: a family of BUILD files from which to map sources.
+    """
+    for build_file in build_files:
+      address_map = self._address_mapper._address_map_from_spec_path(build_file.spec_path)
+      for address, addressable in address_map.values():
+        self._build_graph.inject_address_closure(address)
+        target = self._build_graph._target_addressable_to_target(address, addressable)
+        if target.has_resources:
+          for resource in target.resources:
+            for item in resource.sources_relative_to_buildroot():
+              self._source_to_address[item].add(target.address)
+
+        for target_source in target.sources_relative_to_buildroot():
+          self._source_to_address[target_source].add(target.address)
+        if not target.is_synthetic:
+          self._source_to_address[target.address.build_file.relpath].add(target.address)
+
+  def target_addresses_for_source(self, source, must_find=False):
+    """Attempt to find targets which own a source by searching up directory structure to buildroot.
+
+    :param string source: The source to look up.
+    """
+    self._find_owners(source)
+    return self._source_to_address[source]

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -365,7 +365,7 @@ class Target(AbstractTarget):
     """
     :return: True if this target did not originate from a BUILD file.
     """
-    return self.address.is_synthetic
+    return self.concrete_derived_from.address != self.address
 
   @property
   def is_original(self):

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -114,6 +114,17 @@ python_tests(
 )
 
 python_tests(
+  name = 'lazy_source_mapper',
+  sources = ['test_lazy_source_mapper.py'],
+  dependencies = [
+    'tests/python/pants_test:base_test',
+    'src/python/pants/base:target',
+    'src/python/pants/base:build_file_aliases',
+    'src/python/pants/backend/jvm/targets:java',
+  ]
+)
+
+python_tests(
   name = 'build_file_aliases',
   sources = ['test_build_file_aliases.py'],
   dependencies = [

--- a/tests/python/pants_test/base/test_lazy_source_mapper.py
+++ b/tests/python/pants_test/base/test_lazy_source_mapper.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+import os
+from textwrap import dedent
+
+from pants.base.build_file_aliases import BuildFileAliases
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.base.lazy_source_mapper import LazySourceMapper
+
+from pants_test.base_test import BaseTest
+
+class LazySourceMapperTest(BaseTest):
+  @property
+  def alias_groups(self):
+    return BuildFileAliases.create(
+      targets={
+        'java_library': JavaLibrary,
+      },
+    )
+
+  def setUp(self):
+    super(LazySourceMapperTest, self).setUp()
+    self.set_mapper()
+
+  def set_mapper(self, fast=False):
+    self.mapper = LazySourceMapper(self.context(), stop_after_match=fast)
+
+  def owner(self, owner, f):
+    self.assertEqual(set(owner), set(i.spec for i in self.mapper.target_addresses_for_source(f)))
+
+  def test_joint_ownership(self):
+    # A simple target with two sources.
+    self.create_library('lib/rpc', 'java_library', 'rpc', ['err.py', 'http.py'])
+    # Another target with sources but also claims one already owned from above.
+    self.create_library('lib', 'java_library', 'lib', ['a.py', 'b.py', 'rpc/net.py', 'rpc/err.py'])
+
+    # Sole ownership of new files.
+    self.owner(['lib:lib'], 'lib/a.py')
+    self.owner(['lib:lib'], 'lib/rpc/net.py')
+    self.owner(['lib/rpc:rpc'], 'lib/rpc/http.py')
+    # Joint ownership of overlap file
+    self.owner(['lib/rpc:rpc', 'lib:lib'], 'lib/rpc/err.py')
+
+    # An unclaimed file in same dir is not claimed.
+    self.create_file('lib/rpc/json.py')
+    self.owner([], 'lib/rpc/json.py')
+
+  def test_nested(self):
+    # A root-level BUILD file's sources are found or not correctly.
+    self.create_library('date', 'java_library', 'date', ['day.py','time/unit/hour.py'])
+    self.create_file('date/time/unit/minute.py')
+    # Shallow, simple source still works.
+    self.owner(['date:date'], 'date/day.py')
+    # Nested claimed source works.
+    self.owner(['date:date'], 'date/time/unit/hour.py')
+    # Unclaimed nested sibling correctly unclaimed.
+    self.owner([], 'date/time/unit/minute.py')
+
+
+  def test_with_root_level_build(self):
+    self.create_library('', 'java_library', 'top', ['foo.py', 'text/common/const/emoji.py'])
+    self.create_library('text', 'java_library', 'text', ['localize.py'])
+    self.create_library('text/common/const', 'java_library', 'const', ['emoji.py', 'ascii.py'])
+    self.create_library('text/common/helper', 'java_library', 'helper', ['trunc.py'])
+    self.create_file('bar.py')
+
+    self.owner(['text/common/helper:helper'], 'text/common/helper/trunc.py')
+    self.owner([':top', 'text/common/const:const'], 'text/common/const/emoji.py')
+    self.owner([':top'], 'foo.py')
+    self.owner([], 'bar.py')
+
+  def test_fast_vs_correct(self):
+    self.create_library('', 'java_library', 'top', ['foo.py', 'a/b/bar.py'])
+    self.create_library('a/b', 'java_library', 'b', ['bar.py', 'baz.py'])
+
+    # With fast=False, order doesn't matter.
+    self.set_mapper(fast=False)
+    self.owner([':top', 'a/b:b'], 'a/b/bar.py')
+    self.owner([':top'], 'foo.py')
+    self.set_mapper(fast=False)
+    self.owner([':top'], 'foo.py')
+    self.owner([':top', 'a/b:b'], 'a/b/bar.py')
+
+
+    # With fast=False, loading a parent first vs after now affects results.
+    self.set_mapper(fast=True)
+    self.owner(['a/b:b'], 'a/b/bar.py')
+    self.owner([':top'], 'foo.py')
+    self.owner([':top', 'a/b:b'], 'a/b/bar.py')
+


### PR DESCRIPTION
A LazySourceMapper attempts to find targets which own sources without
loading any more than is needed and caches its results.

This is intended for use in tasks like what-changed or (in the future)
goals which discover target to act on (eg 'compile-changed') or other
uses cases which want to map a source file to a target as cheaply as possible.
