### PR TITLE
Trigger CI: Refactor WhatChanged into base class, use LazySoruceMapper

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -339,11 +339,9 @@ python_library(
   name = 'what_changed',
   sources = ['what_changed.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    ':common',
     ':console_task',
-    'src/python/pants/base:build_file',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:lazy_source_mapper',
     'src/python/pants/base:target',
-    'src/python/pants/goal:workspace',
   ],
 )

--- a/src/python/pants/backend/core/tasks/what_changed.py
+++ b/src/python/pants/backend/core/tasks/what_changed.py
@@ -9,97 +9,59 @@ from collections import defaultdict
 import os
 
 from pants.backend.core.tasks.console_task import ConsoleTask
-from pants.base.build_environment import get_buildroot
-from pants.base.build_file import BuildFile
 from pants.base.exceptions import TaskError
-from pants.goal.workspace import Workspace
+from pants.base.lazy_source_mapper import LazySourceMapper
 
 
-class WhatChanged(ConsoleTask):
+class ChangedFileTaskMixin(object):
+  """A mixin for tasks which require the set of targets (or files) changed according to SCM.
+
+  Changes are calculated relative to a ref/tree-ish (defaults to HEAD), and changed files are then
+  mapped to targets using LazySourceMapper. LazySourceMapper can optionally be used in "fast" mode,
+  which stops searching for additional owners for a given source once a one is found.
+  """
+  @classmethod
+  def register_change_file_options(cls, register):
+    register('--fast', action='store_true', default=False,
+             help='Stop searching for owners once a source is mapped to at least owning target.')
+    register('--changes-since', '--parent',
+             help='Calculate changes since this tree-ish/scm ref (defaults to current HEAD/tip).')
+
+  _mapper_cache = None
+  @property
+  def _mapper(self):
+    if self._mapper_cache is None:
+      self._mapper_cache = LazySourceMapper(self.context, self.get_options().fast)
+    return self._mapper_cache
+
+  def _changed_files(self):
+    """Determines the changed files using the SCM workspace and options."""
+    if not self.context.workspace:
+      raise TaskError('No workspace provided.')
+    if not self.context.scm:
+      raise TaskError('No SCM available.')
+    since = self.get_options().changes_since or self.context.scm.current_rev_identifier()
+    return self.context.workspace.touched_files(since)
+
+  def _changed_targets(self):
+    """Determine unique target addresses changed mapping scm changed files to targets"""
+    targets_for_source = self._mapper.target_addresses_for_source
+    return set(addr for src in self._changed_files() for addr in targets_for_source(src))
+
+
+class WhatChanged(ConsoleTask, ChangedFileTaskMixin):
   """Emits the targets that have been modified since a given commit."""
   @classmethod
   def register_options(cls, register):
     super(WhatChanged, cls).register_options(register)
-    register('--parent', default='HEAD',
-             help='Calculate changes against this tree-ish.')
+    cls.register_change_file_options(register)
     register('--files', action='store_true', default=False,
              help='Show changed files instead of the targets that own them.')
 
-  def __init__(self, *args, **kwargs):
-    super(WhatChanged, self).__init__(*args, **kwargs)
-    self._parent = self.get_options().parent
-    self._show_files = self.get_options().files
-    self._workspace = self.context.workspace
-    self._filemap = {}
-    self._loaded_build_files = set()
-    self._owning_targets = defaultdict(set)
-
   def console_output(self, _):
-    if not self._workspace:
-      raise TaskError('No workspace provided.')
-
-    touched_files = self._get_touched_files()
-    if self._show_files:
-      for path in touched_files:
-        yield path
+    if self.get_options().files:
+      for f in sorted(self._changed_files()):
+        yield f
     else:
-      touched_targets = set()
-      for path in touched_files:
-        self._load_build_files(path)
-
-      self._compute_owning_targets()
-
-      for path in touched_files:
-        for touched_target in self._owning_targets[path]:
-          if touched_target not in touched_targets:
-            touched_targets.add(touched_target)
-            yield touched_target.address.spec
-
-  def _get_touched_files(self):
-    try:
-      return self._workspace.touched_files(self._parent)
-    except Workspace.WorkspaceError as e:
-      raise TaskError(e)
-
-  def _load_build_files(self, path):
-    build_graph = self.context.build_graph
-    build_file_parser = self.context.build_file_parser
-    for build_file in self._candidate_owners(path):
-      if not build_file in self._loaded_build_files:
-        self._loaded_build_files.add(build_file)
-        address_map = build_file_parser.parse_build_file(build_file)
-        for address, _ in address_map.items():
-          build_graph.inject_address_closure(address)
-
-  def _compute_owning_targets(self):
-    build_graph = self.context.build_graph
-    for target in build_graph.targets():
-      # HACK: Python targets currently wrap old-style file resources in a synthetic
-      # resources target, but they do so lazily, when target.resources is first accessed.
-      # We force that access here, so that the targets will show up in the subsequent
-      # invocation of build_graph.targets().
-      if target.has_resources:
-        _ = target.resources
-
-    for target in build_graph.sorted_targets():
-      realtarget = target.concrete_derived_from
-      for source_file in target.sources_relative_to_buildroot():
-        self._owning_targets[source_file].add(realtarget)
-      if not target.is_synthetic:
-        self._owning_targets[target.address.build_file.relpath].add(realtarget)
-
-  def _candidate_owners(self, path):
-    build_file = BuildFile.from_cache(get_buildroot(),
-                                      relpath=os.path.dirname(path),
-                                      must_exist=False)
-    if build_file.exists():
-      yield build_file
-    for sibling in build_file.siblings():
-      yield sibling
-    for ancestor in build_file.ancestors():
-      yield ancestor
-
-  def _owns(self, target, path):
-    if target not in self._filemap:
-      self._filemap[target] = set(target.sources_relative_to_buildroot())
-    return path in self._filemap[target]
+      for addr in sorted(self._changed_targets()):
+        yield addr.spec

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -70,6 +70,9 @@ class Git(Scm):
       from twitter.common import log as c_log
       self._log = c_log
 
+  def current_rev_identifier(self):
+    return 'HEAD'
+
   @property
   def commit_id(self):
     return self._check_output(['rev-parse', 'HEAD'], raise_type=Scm.LocalException)

--- a/src/python/pants/scm/scm.py
+++ b/src/python/pants/scm/scm.py
@@ -23,6 +23,10 @@ class Scm(AbstractClass):
     """Indicates a problem performing a local scm operation."""
 
   @abstractproperty
+  def current_rev_identifier(self):
+    """Identifier for the tip/head of the current branch eg. "HEAD" in git"""
+
+  @abstractproperty
   def commit_id(self):
     """Returns the id of the current commit."""
 

--- a/tests/python/pants_test/tasks/test_what_changed.py
+++ b/tests/python/pants_test/tasks/test_what_changed.py
@@ -10,15 +10,15 @@ from textwrap import dedent
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
 from pants.backend.codegen.targets.python_thrift_library import PythonThriftLibrary
 from pants.backend.core.targets.resources import Resources
-from pants.backend.core.tasks.what_changed import WhatChanged, Workspace
+from pants.backend.core.tasks.what_changed import WhatChanged
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.source_root import SourceRoot
+from pants.goal.workspace import Workspace
 from pants_test.tasks.test_base import ConsoleTaskTest
-
 
 class BaseWhatChangedTest(ConsoleTaskTest):
   @property


### PR DESCRIPTION
Switch to using LazySourceMapper to map changed files to targets.
LazySourceMapper is designed to map sources to targets without
loading any more of the BUILD graph than is required, which is
ideal for a what-changed use-case.

Refactoring the what-changed calculation into base class should make
it easier to support other tasks that require the set of changed
targets (or files). The WhatChanged task itself is now just a small
stub on top of it.
