### PR TITLE
Trigger CI: Add changes-in-diffspec option to what-changed

### DIFF
--- a/src/python/pants/backend/core/tasks/what_changed.py
+++ b/src/python/pants/backend/core/tasks/what_changed.py
@@ -23,6 +23,8 @@ class ChangedFileTaskMixin(object):
              help='Stop searching for owners once a source is mapped to at least owning target.')
     register('--changes-since', '--parent',
              help='Calculate changes since this tree-ish/scm ref (defaults to current HEAD/tip).')
+    register('--diffspec',
+             help='Calculate changes contained within given scm spec (commit range/sha/ref/etc).')
 
   _mapper_cache = None
   @property
@@ -37,8 +39,11 @@ class ChangedFileTaskMixin(object):
       raise TaskError('No workspace provided.')
     if not self.context.scm:
       raise TaskError('No SCM available.')
-    since = self.get_options().changes_since or self.context.scm.current_rev_identifier()
-    return self.context.workspace.touched_files(since)
+    if self.get_options().diffspec:
+      return self.context.workspace.changes_in(self.get_options().diffspec)
+    else:
+      since = self.get_options().changes_since or self.context.scm.current_rev_identifier()
+      return self.context.workspace.touched_files(since)
 
   def _changed_targets(self):
     """Determine unique target addresses changed mapping scm changed files to targets"""

--- a/src/python/pants/goal/workspace.py
+++ b/src/python/pants/goal/workspace.py
@@ -23,6 +23,10 @@ class Workspace(AbstractClass):
   def touched_files(self, parent):
     """Returns the paths modified between the parent state and the current workspace state."""
 
+  @abstractmethod
+  def changes_in(self, rev_or_range):
+    """Returns the paths modified by some revision, revision range or other identifier."""
+
 
 class ScmWorkspace(Workspace):
   """A workspace that uses an Scm to determine the touched files."""
@@ -43,3 +47,9 @@ class ScmWorkspace(Workspace):
                                      relative_to=get_buildroot())
     except Scm.ScmException as e:
       raise self.WorkspaceError("Problem detecting changed files.", e)
+
+  def changes_in(self, rev_or_range):
+    try:
+      return self._scm.changes_in(rev_or_range, relative_to=get_buildroot())
+    except Scm.ScmException as e:
+      raise self.WorkspaceError("Problem detecting changes in {}.".format(rev_or_range), e)

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -97,6 +97,9 @@ class Git(Scm):
                                 raise_type=Scm.LocalException)
     return None if branch == 'HEAD' else branch
 
+  def fix_git_relative_path(self, worktree_path, relative_to):
+    return os.path.relpath(os.path.join(self._worktree, worktree_path), relative_to)
+
   def changed_files(self, from_commit=None, include_untracked=False, relative_to=None):
     relative_to = relative_to or self._worktree
     rel_suffix = ['--', relative_to]
@@ -117,9 +120,13 @@ class Git(Scm):
                                      raise_type=Scm.LocalException)
       files.update(untracked.split())
     # git will report changed files relative to the worktree: re-relativize to relative_to
-    def fix_git_relative_path(worktree_path):
-      return os.path.relpath(os.path.join(self._worktree, worktree_path), relative_to)
-    return set(fix_git_relative_path(f) for f in files)
+    return set(self.fix_git_relative_path(f, relative_to) for f in files)
+
+  def changes_in(self, diffspec, relative_to=None):
+    relative_to = relative_to or self._worktree
+    cmd = ['diff-tree', '--no-commit-id', '--name-only', '-r', diffspec]
+    files = self._check_output(cmd, raise_type=Scm.LocalException).split()
+    return set(self.fix_git_relative_path(f.strip(), relative_to) for f in files)
 
   def changelog(self, from_commit=None, files=None):
     args = ['whatchanged', '--stat', '--find-renames', '--find-copies']

--- a/src/python/pants/scm/scm.py
+++ b/src/python/pants/scm/scm.py
@@ -58,6 +58,14 @@ class Scm(AbstractClass):
     """
 
   @abstractmethod
+  def changes_in(self, diffspec, relative_to=None):
+    """Returns a list of files changed by some diffspec (eg sha, range, ref, etc)
+
+    :param str diffspec: Some diffspec meaningful to the SCM.
+    :param str relative_to: a path to which results should be relative (instead of SCM root)
+    """
+
+  @abstractmethod
   def changelog(self, from_commit=None, files=None):
     """Produces a changelog from the given commit or the 1st commit if none is specified until the
     present workspace commit for the changes affecting the given files.


### PR DESCRIPTION
Instead of looking at changes in the workspace relative to some parent ref/treeish, this
allows finding targets changed by some diffspec that is meaningful to the scm, eg a commit
SHA, a commit range, or other ref/ref-range.