### PR TITLE
Trigger CI: Quick&dirty retry pip installs during env creation

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -64,7 +64,7 @@ function activate_pants_venv() {
     create_venv || die "Failed to create venv."
     activate_venv || die "Failed to activate venv."
     for req in ${REQUIREMENTS[@]}; do
-      pip install ${pip_extra} -r "${req}" || die "Failed to install requirements from ${req}."
+      pip install ${pip_extra} -r "${req}" || pip install ${pip_extra} -r "${req}" || die "Failed to install requirements from ${req}."
     done
     touch "${BOOTSTRAPPED_FILE}"
   else


### PR DESCRIPTION
8 out of 10 of my most recent CI builds have failed due to antlr3.org timeouts installing antlr-python-runtime
