### PR TITLE
Trigger CI: Optionally provide more safety when replacing target_roots

### DIFF
--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -32,6 +32,7 @@ python_library(
   name = 'context',
   sources = ['context.py'],
   dependencies = [
+    ':error',
     ':products',
     ':workspace',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',

--- a/src/python/pants/goal/error.py
+++ b/src/python/pants/goal/error.py
@@ -8,3 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 class GoalError(Exception):
   """Raised to indicate a goal has failed."""
+
+
+class TargetRootReplacementError(Exception):
+  """Raised to indicate an attempt to replace target roots after they were read."""

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -241,6 +241,7 @@ python_tests(
     ':base',
     'src/python/pants/base:config',
     'src/python/pants/goal:context',
+    'src/python/pants/goal:error',
   ]
 )
 


### PR DESCRIPTION
Allow callers to replace_roots to ensure they are not violating
other callers assumptions, specifically by asserting that targets
have not previously been read by another task.

Opt-in for now, but easily switched to opt-out later if it seems
like a good idea.
