### PR TITLE
Trigger CI: Skip topo sort when not transitively invalidating

### DIFF
--- a/tests/python/pants_test/tasks/test_cache_manager.py
+++ b/tests/python/pants_test/tasks/test_cache_manager.py
@@ -74,7 +74,7 @@ class InvalidationCacheManagerTest(BaseTest):
       print('[%s]' % ' '.join(strs))
 
     # Verify basic data structure soundness.
-    all_vts = self.cache_manager._sort_and_validate_targets(targets)
+    all_vts = self.cache_manager._wrap_targets(targets)
     invalid_vts = filter(lambda vt: not vt.valid, all_vts)
     self.assertEquals(5, len(invalid_vts))
     self.assertEquals(5, len(all_vts))


### PR DESCRIPTION
A simple sort is much cheaper and good enough when not transitively invalidating.
