### PR TITLE
TRIGGER CI: Migrate jvm_compile's direct config accesses to the options system.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -102,6 +102,7 @@ excludes: %(buildroot)s/build-support/scalastyle/excludes.txt
 
 [repl.scala]
 scala_repl: ["//:scala-repl-2.9.3"]
+jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m", "-Dscala.usejavacp=true" ]
 
 
 [compile.java]
@@ -115,10 +116,9 @@ target: 6
 compiler-bootstrap-tools: ["//:java-compiler"]
 
 
-[scala-compile]
+[compile.scala]
 runtime-deps: ["//:scala-library-2.9.3"]
-
-jvm_args: ["-Xmx2g", "-XX:MaxPermSize=256m", "-Dzinc.analysis.cache.limit=0"]
+jvm_options: ["-Xmx2g", "-XX:MaxPermSize=256m", "-Dzinc.analysis.cache.limit=0"]
 
 
 [jvm]
@@ -129,10 +129,6 @@ parallel_test_paths: True
 
 [run.jvm]
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
-
-
-[repl.scala]
-jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m", "-Dscala.usejavacp=true" ]
 
 
 [test.junit]

--- a/src/python/pants/backend/jvm/scala/target_platform.py
+++ b/src/python/pants/backend/jvm/scala/target_platform.py
@@ -36,5 +36,5 @@ class TargetPlatform(object):
 
     TODO: Convert this to an option, once we figure out how to plumb options through.
     """
-    return self._config.getlist('scala-compile', 'runtime-deps',
+    return self._config.getlist('compile.scala', 'runtime-deps',
                                 default=['//:scala-library-2.9.3'])

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
@@ -46,7 +46,6 @@ _JMAKE_ERROR_CODES.update((256 + code, msg) for code, msg in _JMAKE_ERROR_CODES.
 class JavaCompile(JvmCompile):
   _language = 'java'
   _file_suffix = '.java'
-  _config_section = 'java-compile'
 
     # Well known metadata file to auto-register annotation processors with a java 1.6+ compiler
   _PROCESSOR_INFO_FILE = 'META-INF/services/javax.annotation.processing.Processor'
@@ -85,10 +84,6 @@ class JavaCompile(JvmCompile):
     self._buildroot = get_buildroot()
 
     self._depfile = os.path.join(self._analysis_dir, 'global_depfile')
-
-  @property
-  def config_section(self):
-    return self._config_section
 
   def create_analysis_tools(self):
     return AnalysisTools(self.context, JMakeAnalysisParser(self._classes_dir), JMakeAnalysis)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -24,6 +24,7 @@ from pants.base.exceptions import TaskError
 from pants.base.target import Target
 from pants.base.worker_pool import Work
 from pants.goal.products import MultipleRootedProducts
+from pants.option.options import Options
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.contextutil import open_zip, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_rmtree, safe_walk
@@ -43,8 +44,14 @@ class JvmCompile(NailgunTaskBase, GroupMember):
              help='Roughly how many source files to attempt to compile together. Set to a large '
                   'number to compile all sources together. Set to 0 to compile target-by-target.')
 
+    register('--jvm-options', type=Options.list,
+             help='Run the compiler with these JVM options.')
+
     register('--args', action='append', default=list(cls.get_args_default(register.bootstrap)),
-             help='Args to pass to the compiler.')
+             help='Pass these args to the compiler.')
+
+    register('--confs', type=Options.list, default=['default'],
+             help='Compile for these Ivy confs.')
 
     register('--warnings', default=True, action='store_true',
              help='Compile with all configured warnings enabled.')
@@ -69,10 +76,17 @@ class JvmCompile(NailgunTaskBase, GroupMember):
                   'implementation detail. However it may still be useful to use this on '
                   'occasion. '.format(cls._language))
 
+    register('--missing_deps_whitelist', type=Options.list,
+             help="Don't report these targets even if they have missing deps.")
+
     register('--unnecessary-deps', choices=['off', 'warn', 'fatal'], default='off',
              help='Check for declared dependencies in {0} code that are not needed. This is a very '
                   'strict check. For example, generated code will often legitimately have BUILD '
                   'dependencies that are unused in practice.'.format(cls._language))
+
+    register('--changed_targets_heuristic_limit', type=int, default=0,
+             help='If non-zero, and we have fewer than this number of locally-changed targets, '
+                  'partition them separately, to preserve stability when compiling repeatedly.')
 
     register('--delete-scratch', default=True, action='store_true',
              help='Leave intermediate scratch files around, for debugging build problems.')
@@ -82,7 +96,6 @@ class JvmCompile(NailgunTaskBase, GroupMember):
   # --------------------------
   _language = None
   _file_suffix = None
-  _config_section = None
 
   @classmethod
   def name(cls):
@@ -112,6 +125,10 @@ class JvmCompile(NailgunTaskBase, GroupMember):
   def get_no_warning_args_default(cls):
     """Override to set default for --no-warning-args option."""
     return ()
+
+  @property
+  def config_section(self):
+    return self.options_scope
 
   def select(self, target):
     return target.has_sources(self._file_suffix)
@@ -164,7 +181,6 @@ class JvmCompile(NailgunTaskBase, GroupMember):
 
   def __init__(self, *args, **kwargs):
     super(JvmCompile, self).__init__(*args, **kwargs)
-    config_section = self.config_section
 
     # Various working directories.
     self._classes_dir = os.path.join(self.workdir, 'classes')
@@ -189,10 +205,10 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     self._partition_size_hint = self.get_options().partition_size_hint
 
     # JVM options for running the compiler.
-    self._jvm_options = self.context.config.getlist(config_section, 'jvm_args')
+    self._jvm_options = self.get_options().jvm_options
 
     # The ivy confs for which we're building.
-    self._confs = self.context.config.getlist(config_section, 'confs', default=['default'])
+    self._confs = self.get_options().confs
 
     self._args = list(self.get_options().args)
     if self.get_options().warnings:
@@ -210,8 +226,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     check_unnecessary_deps = munge_flag('unnecessary_deps')
 
     if check_missing_deps or check_missing_direct_deps or check_unnecessary_deps:
-      target_whitelist = self.context.config.getlist('jvm', 'missing_deps_target_whitelist', default=[])
-
+      target_whitelist = self.get_options().missing_deps_whitelist
       # Must init it here, so it can set requirements on the context.
       self._dep_analyzer = JvmDependencyAnalyzer(self.context,
                                                  check_missing_deps,
@@ -224,11 +239,10 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     # If non-zero, and we have fewer than this number of locally-changed targets,
     # then we partition them separately, to preserve stability in the face of repeated
     # compilations.
-    self._locally_changed_targets_heuristic_limit = self.context.config.getint(config_section,
-        'locally_changed_targets_heuristic_limit', 0)
+    self._changed_targets_heuristic_limit = self.get_options().changed_targets_heuristic_limit
 
     self._upstream_class_to_path = None  # Computed lazily as needed.
-    self.setup_artifact_cache_from_config(config_section=config_section)
+    self.setup_artifact_cache_from_config(config_section=self.config_section)
 
     # Sources (relative to buildroot) present in the last analysis that have since been deleted.
     # Populated in prepare_execute().
@@ -356,10 +370,10 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     # changes synced in from the SCM).
     # TODO(benjy): Should locally_changed_targets be available in all Tasks?
     locally_changed_targets = None
-    if self._locally_changed_targets_heuristic_limit:
+    if self._changed_targets_heuristic_limit:
       locally_changed_targets = self._find_locally_changed_targets(sources_by_target)
-      if locally_changed_targets and \
-              len(locally_changed_targets) > self._locally_changed_targets_heuristic_limit:
+      if (locally_changed_targets and
+          len(locally_changed_targets) > self._changed_targets_heuristic_limit):
         locally_changed_targets = None
 
     # Invalidation check. Everything inside the with block must succeed for the

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
@@ -17,7 +17,6 @@ from pants.backend.jvm.tasks.jvm_compile.scala.zinc_utils import ZincUtils
 class ScalaCompile(JvmCompile):
   _language = 'scala'
   _file_suffix = '.scala'
-  _config_section = 'scala-compile'
 
   @classmethod
   def get_args_default(cls, bootstrap_option_values):
@@ -49,10 +48,6 @@ class ScalaCompile(JvmCompile):
                                  jvm_options=self._jvm_options,
                                  color=color,
                                  log_level=self.get_options().level)
-
-  @property
-  def config_section(self):
-    return self._config_section
 
   def create_analysis_tools(self):
     return AnalysisTools(self.context, ZincAnalysisParser(self._classes_dir), ZincAnalysis)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
@@ -118,9 +118,8 @@ class ZincUtils(object):
       try:
         deps = self.context.resolve(target)
       except AddressLookupError as e:
-        raise self.DepLookupError("{message}\n  referenced from [{section}] key: {key} in pants.ini"
-                                  .format(message=e, section='scala-compile',
-                                          key='compile-bootstrap-tools'))
+        raise self.DepLookupError("{message}\n  specified by option --scalac in scope {scope}."
+                                  .format(message=e, scope=self._nailgun_task.options_scope))
 
       for lib in (t for t in deps if isinstance(t, JarLibrary)):
         for jar in lib.jar_dependencies:

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -15,10 +15,29 @@ from pants.option.errors import ParseError
 
 
 migrations = {
+  ('jvm', 'missing_deps_target_whitelist'): ('compile.java', 'missing_deps_whitelist'),
+
   ('java-compile', 'partition_size_hint'): ('compile.java', 'partition_size_hint'),
   ('java-compile', 'javac_args'): ('compile.java', 'args'),
+  ('java-compile', 'jvm_args'): ('compile.java', 'jvm_options'),
+  ('java-compile', 'confs'): ('compile.java', 'confs'),
+  ('java-compile', 'locally_changed_targets_heuristic_limit'): ('compile.java', 'changed_targets_heuristic_limit'),
   ('java-compile', 'warning_args'): ('compile.java', 'warning_args'),
   ('java-compile', 'no_warning_args'): ('compile.java', 'no_warning_args'),
+  ('java-compile', 'read_artifact_caches'): ('compile.java', 'read_artifact_caches'),
+  ('java-compile', 'write_artifact_caches'): ('compile.java', 'write_artifact_caches'),
+  ('java-compile', 'use_nailgun'): ('compile.java', 'use_nailgun'),
+
+  ('scala-compile', 'partition_size_hint'): ('compile.scala', 'partition_size_hint'),
+  ('scala-compile', 'jvm_args'): ('compile.scala', 'jvm_options'),
+  ('scala-compile', 'confs'): ('compile.scala', 'confs'),
+  ('scala-compile', 'locally_changed_targets_heuristic_limit'): ('compile.scala', 'changed_targets_heuristic_limit'),
+  ('scala-compile', 'warning_args'): ('compile.scala', 'warning_args'),
+  ('scala-compile', 'no_warning_args'): ('compile.scala', 'no_warning_args'),
+  ('scala-compile', 'runtime-deps'): ('compile.scala', 'runtime-deps'),
+  ('scala-compile', 'read_artifact_caches'): ('compile.scala', 'read_artifact_caches'),
+  ('scala-compile', 'write_artifact_caches'): ('compile.scala', 'write_artifact_caches'),
+  ('scala-compile', 'use_nailgun'): ('compile.scala', 'use_nailgun'),
 
   ('javadoc-gen', 'include_codegen'): ('gen.javadoc', 'include_codegen'),
   ('scaladoc-gen', 'include_codegen'): ('gen.scaladoc', 'include_codegen'),
@@ -78,6 +97,7 @@ migrations = {
   }
 
 notes = {
+  ('jvm', 'missing_deps_target_whitelist'): 'This should be split into compile.java or compile.scala',
   ('java-compile', 'javac_args'): 'source and target args should be moved to separate source: and '
                                   'target: options. Other args should be placed in args: and '
                                   'prefixed with -C.',

--- a/tests/python/pants_test/targets/test_scala_library.py
+++ b/tests/python/pants_test/targets/test_scala_library.py
@@ -34,7 +34,7 @@ class ScalaLibraryTest(BaseTest):
     super(ScalaLibraryTest, self).setUp()
 
     self.create_file('pants.ini', dedent('''
-        [scala-compile]
+        [compile.scala]
         runtime-deps: []
         '''))
 

--- a/tests/python/pants_test/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -49,7 +49,7 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
     resources_by_targets (see jvm_compile.py).
     """
     with temporary_dir() as cache_dir:
-      config = {'java-compile': {'write_artifact_caches': [cache_dir]}}
+      config = {'compile.java': {'write_artifact_caches': [cache_dir]}}
 
       with temporary_dir(root_dir=self.workdir_root()) as workdir:
         pants_run = self.run_pants_with_workdir(
@@ -65,7 +65,7 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
                                   'testprojects.src.java.com.pants.testproject.nocache.nocache')
       good_artifact_dir = os.path.join(cache_dir, 'JavaCompile',
                                   'testprojects.src.java.com.pants.testproject.nocache.cache_me')
-      config = {'java-compile': {'write_artifact_caches': [cache_dir]}}
+      config = {'compile.java': {'write_artifact_caches': [cache_dir]}}
 
       pants_run = self.run_pants(['compile',
                                   'testprojects/src/java/com/pants/testproject/nocache::'],
@@ -85,7 +85,7 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
     with temporary_dir() as cache_dir:
       artifact_dir = os.path.join(cache_dir, 'JavaCompile',
                                   'testprojects.src.java.com.pants.testproject.unicode.main.main')
-      config = {'java-compile': {'write_artifact_caches': [cache_dir]}}
+      config = {'compile.java': {'write_artifact_caches': [cache_dir]}}
 
       pants_run = self.run_pants(['compile',
                                   'testprojects/src/java/com/pants/testproject/unicode/main'],
@@ -112,7 +112,7 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
     with temporary_dir() as cache_dir:
       artifact_dir = os.path.join(cache_dir, 'JavaCompile',
                                   'testprojects.src.java.com.pants.testproject.annotation.main.main')
-      config = {'java-compile': {'write_artifact_caches': [cache_dir]}}
+      config = {'compile.java': {'write_artifact_caches': [cache_dir]}}
 
       pants_run = self.run_pants(['compile',
                                   'testprojects/src/java/com/pants/testproject/annotation/main'],
@@ -150,7 +150,7 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
     self.assert_failure(pants_run)
 
     # Now let's use the target whitelist, this should succeed.
-    config = {'jvm': {'missing_deps_target_whitelist': [whitelist]}}
+    config = {'compile.java': {'missing_deps_whitelist': [whitelist]}}
 
     pants_run = self.run_pants(args, config)
 

--- a/tests/python/pants_test/tasks/test_filedeps.py
+++ b/tests/python/pants_test/tasks/test_filedeps.py
@@ -58,7 +58,7 @@ class FileDepsTest(ConsoleTaskTest):
 
     self.create_file('pants.ini',
                      contents=dedent('''
-                       [scala-compile]
+                       [compile.scala]
                        runtime-deps: ['tools:scala-library']
                      '''),
                      mode='a')


### PR DESCRIPTION
Note that a couple of inherited config accesses (from Task and NailgunTask)
are still there, but their config section has been changed from java-compile
to compile.java (and similarly for scala). Thus the java-compile section
is now completely gone.