### PR TITLE
Cache ivy report dependency traversals consistently

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -43,19 +43,21 @@ class IvyInfo(object):
       self._deps_by_caller[caller].add(module.ref)
 
   def traverse_dependency_graph(self, ref, collector, memo=None, visited=None):
-    """Traverses module graph, starting with ref, collecting values for each ref into the sets created by the collector function.
+    """Traverses module graph, starting with ref, collecting values for each ref into the sets
+    created by the collector function.
 
     :param ref an IvyModuleRef to start traversing the ivy dependency graph
     :param collector a function that takes a ref and returns a new set of values to collect for that ref,
            which will also be updated with all the dependencies accumulated values
     :param memo is a dict of ref -> set that memoizes the results of each node in the graph.
            If provided, allows for retaining cache across calls.
+    :returns the accumulated set for ref
     """
 
     if memo is None:
       memo = dict()
 
-    memoized_value = memo.get(ref, ())
+    memoized_value = memo.get(ref)
     if memoized_value:
       return memoized_value
 
@@ -68,7 +70,7 @@ class IvyInfo(object):
     visited.add(ref)
 
     acc = collector(ref)
-    for dep in self._deps_by_caller.get(ref, []):
+    for dep in self._deps_by_caller.get(ref, ()):
       acc.update(self.traverse_dependency_graph(dep, collector, memo, visited))
     memo[ref] = acc
     return acc

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -189,7 +189,7 @@ class IvyUtils(object):
   def parse_xml_report(cls, targets, conf):
     """Returns the IvyInfo representing the info in the xml report, or None if no report exists."""
     path = cls.xml_report_path(targets, conf)
-    cls._parse_xml_report(path)
+    return cls._parse_xml_report(path)
 
   @classmethod
   def _parse_xml_report(cls, path):

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -35,20 +35,52 @@ class IvyInfo(object):
   def __init__(self):
     self.modules_by_ref = {}  # Map from ref to referenced module.
     # Map from ref of caller to refs of modules required by that caller.
-    self.deps_by_caller = defaultdict(OrderedSet)
+    self._deps_by_caller = defaultdict(OrderedSet)
 
   def add_module(self, module):
     self.modules_by_ref[module.ref] = module
     for caller in module.callers:
-      self.deps_by_caller[caller].add(module.ref)
+      self._deps_by_caller[caller].add(module.ref)
 
-  def get_jars_for_ivy_module(self, jar):
-    ref = IvyModuleRef(jar.org, jar.name, jar.rev)
-    deps = OrderedSet()
-    for dep in self.deps_by_caller.get(ref, []):
-      deps.add(dep)
-      deps.update(self.get_jars_for_ivy_module(dep))
-    return deps
+  def traverse_dependency_graph(self, ref, collector, memo=None, visited=None):
+    """Traverses module graph, starting with ref, collecting values for each ref into the sets created by the collector function.
+
+    :param ref an IvyModuleRef to start traversing the ivy dependency graph
+    :param collector a function that takes a ref and returns a new set of values to collect for that ref,
+           which will also be updated with all the dependencies accumulated values
+    :param memo is a table of ref -> collection that memoizes the results of each node in the graph.
+           If provided, allows for retaining cache across calls.
+    """
+
+    if memo is None:
+      memo = dict()
+
+    memoized_value = memo.get(ref, ())
+    if memoized_value:
+      return memoized_value
+
+    visited = visited or set()
+    if ref in visited:
+      # Ivy allows for circular dependencies
+      # If we're here, that means we're resolving something that
+      # transitively depends on itself
+      return set()
+    visited.add(ref)
+
+    acc = collector(ref)
+    for dep in self._deps_by_caller.get(ref, []):
+      acc.update(self.traverse_dependency_graph(dep, collector, memo, visited))
+    memo[ref] = acc
+    return acc
+
+  def get_jars_for_ivy_module(self, jar, memo=None):
+    ref = jar
+    def create_collection(dep):
+      s = OrderedSet()
+      if ref != dep:
+        s.add(dep)
+      return s
+    return self.traverse_dependency_graph(jar, create_collection, memo)
 
 
 class IvyUtils(object):
@@ -150,6 +182,10 @@ class IvyUtils(object):
   def parse_xml_report(cls, targets, conf):
     """Returns the IvyInfo representing the info in the xml report, or None if no report exists."""
     path = cls.xml_report_path(targets, conf)
+    cls._parse_xml_report(path)
+
+  @classmethod
+  def _parse_xml_report(cls, path):
     if not os.path.exists(path):
       return None
 

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -48,7 +48,7 @@ class IvyInfo(object):
     :param ref an IvyModuleRef to start traversing the ivy dependency graph
     :param collector a function that takes a ref and returns a new set of values to collect for that ref,
            which will also be updated with all the dependencies accumulated values
-    :param memo is a table of ref -> collection that memoizes the results of each node in the graph.
+    :param memo is a dict of ref -> set that memoizes the results of each node in the graph.
            If provided, allows for retaining cache across calls.
     """
 
@@ -74,6 +74,11 @@ class IvyInfo(object):
     return acc
 
   def get_jars_for_ivy_module(self, jar, memo=None):
+    """Collects dependency references of the passed jar
+    :param jar an IvyModuleRef for a third party dependency.
+    :param memo a dict of ref -> set that memoizes dependencies for each ref as they are resolved.
+    """
+
     ref = jar
     def create_collection(dep):
       s = OrderedSet()

--- a/src/python/pants/backend/jvm/tasks/depmap.py
+++ b/src/python/pants/backend/jvm/tasks/depmap.py
@@ -221,7 +221,7 @@ class Depmap(ConsoleTask):
     targets_map = {}
     resource_target_map = {}
     ivy_info = IvyUtils.parse_xml_report(targets, 'default')
-
+    ivy_jar_memo = {}
     def process_target(current_target):
       """
       :type current_target:pants.base.target.Target
@@ -244,7 +244,7 @@ class Depmap(ConsoleTask):
           return OrderedSet()
         transitive_jars = OrderedSet()
         for jar in jar_lib.jar_dependencies:
-          transitive_jars.update(ivy_info.get_jars_for_ivy_module(jar))
+          transitive_jars.update(ivy_info.get_jars_for_ivy_module(jar, memo=ivy_jar_memo))
         return transitive_jars
 
       info = {

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
@@ -86,19 +86,9 @@ class JvmDependencyAnalyzer(object):
         deps_by_ref_memo = {}
 
         def get_transitive_jars_by_ref(ref1, visited=None):
-          if ref1 in deps_by_ref_memo:
-            return deps_by_ref_memo[ref1]
-          else:
-            visited = visited or set()
-            if ref1 in visited:
-              return set()  # Ivy allows circular deps.
-            visited.add(ref1)
-            jars = set()
-            jars.update(ivyinfo.modules_by_ref[ref1].artifacts)
-            for dep in ivyinfo.deps_by_caller.get(ref1, []):
-              jars.update(get_transitive_jars_by_ref(dep, visited))
-            deps_by_ref_memo[ref1] = jars
-            return jars
+          def create_collection(current_ref):
+            return set(ivyinfo.modules_by_ref[current_ref].artifacts)
+          return ivyinfo.traverse_dependency_graph(ref1, create_collection, memo=deps_by_ref_memo)
 
         target_key = (ref.org, ref.name)
         if target_key in jarlibs_by_id:

--- a/src/python/pants/backend/jvm/tasks/provides.py
+++ b/src/python/pants/backend/jvm/tasks/provides.py
@@ -92,13 +92,14 @@ class Provides(Task):
     return jar_paths
 
   def get_jar_paths_for_ivy_module(self, ivyinfo, ref):
-    jar_paths = OrderedSet()
-    module = ivyinfo.modules_by_ref[ref]
-    jar_paths.update([a.path for a in module.artifacts])
+    def create_collection(current_ref):
+      module = ivyinfo.modules_by_ref[current_ref]
+      return OrderedSet([a.path for a in module.artifacts])
+
     if self.transitive:
-      for dep in ivyinfo.deps_by_caller.get(ref, []):
-        jar_paths.update(self.get_jar_paths_for_ivy_module(ivyinfo, dep))
-    return jar_paths
+      return ivyinfo.traverse_dependency_graph(ref, create_collection)
+    else:
+      return create_collection(ref)
 
   def list_jar(self, path):
     with open_jar(path, 'r') as jar:

--- a/tests/python/pants_test/tasks/ivy_utils_resources/report_with_cycle.xml
+++ b/tests/python/pants_test/tasks/ivy_utils_resources/report_with_cycle.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="ivy-report.xsl"?>
+<ivy-report version="1.0">
+  <info organisation="toplevel" module="toplevelmodule" revision="latest" />
+  <dependencies>
+    <module organisation="org1" name="name1">
+      <revision name="0.0.1">
+        <caller organisation="toplevel" name="toplevelmodule" callerrev="latest"/>
+        <artifacts>
+          <artifact location="ivy2cache_path/org1/name1.jar"></artifact>
+        </artifacts>
+      </revision>
+    </module>
+    <module organisation="org2" name="name2">
+      <revision name="0.0.1">
+        <caller organisation="org1" name="name1" callerrev="0.0.1"/>
+        <caller organisation="org3" name="name3" callerrev="0.0.1"/>
+        <artifacts>
+          <artifact location="ivy2cache_path/org2/name2.jar"></artifact>
+        </artifacts>
+      </revision>
+    </module>
+    <module organisation="org3" name="name3">
+      <revision name="0.0.1">
+        <caller organisation="org2" name="name2" callerrev="0.0.1"/>
+        <artifacts>
+          <artifact location="ivy2cache_path/org3/name3.jar"></artifact>
+        </artifacts>
+      </revision>
+    </module>
+  </dependencies>
+</ivy-report>

--- a/tests/python/pants_test/tasks/ivy_utils_resources/report_with_diamond.xml
+++ b/tests/python/pants_test/tasks/ivy_utils_resources/report_with_diamond.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="ivy-report.xsl"?>
+<ivy-report version="1.0">
+  <info organisation="toplevel" module="toplevelmodule" revision="latest" />
+  <dependencies>
+    <module organisation="org1" name="name1">
+      <revision name="0.0.1">
+        <caller organisation="toplevel" name="toplevelmodule" callerrev="latest"/>
+        <artifacts>
+          <artifact location="ivy2cache_path/org1/name1.jar"></artifact>
+        </artifacts>
+      </revision>
+    </module>
+    <module organisation="org2" name="name2">
+      <revision name="0.0.1">
+        <caller organisation="org1" name="name1" callerrev="0.0.1"/>
+        <caller organisation="org3" name="name3" callerrev="0.0.1"/>
+        <artifacts>
+          <artifact location="ivy2cache_path/org2/name2.jar"></artifact>
+        </artifacts>
+      </revision>
+    </module>
+    <module organisation="org3" name="name3">
+      <revision name="0.0.1">
+        <caller organisation="org2" name="name2" callerrev="0.0.1"/>
+        <artifacts>
+          <artifact location="ivy2cache_path/org3/name3.jar"></artifact>
+        </artifacts>
+      </revision>
+    </module>
+  </dependencies>
+</ivy-report>

--- a/tests/python/pants_test/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/tasks/test_ivy_utils.py
@@ -108,19 +108,19 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
     ref = IvyModuleRef("toplevel", "toplevelmodule", "latest")
     seen = set()
     def collector(r):
-      self.assertTrue(r not in seen)
+      self.assertNotIn(r, seen)
       seen.add(r)
       return set([r])
 
     result = ivy_info.traverse_dependency_graph(ref, collector)
 
     self.assertEqual(
-          set([
+          {
             IvyModuleRef("toplevel", "toplevelmodule", "latest"),
             IvyModuleRef(org='org1', name='name1', rev='0.0.1'),
             IvyModuleRef(org='org2', name='name2', rev='0.0.1'),
             IvyModuleRef(org='org3', name='name3', rev='0.0.1')
-          ]),
+          },
           result)
 
   def test_does_not_follow_cycle(self):
@@ -129,19 +129,19 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
     ref = IvyModuleRef("toplevel", "toplevelmodule", "latest")
     seen = set()
     def collector(r):
-      self.assertTrue(r not in seen)
+      self.assertNotIn(r, seen)
       seen.add(r)
       return set([r])
 
     result = ivy_info.traverse_dependency_graph(ref, collector)
 
     self.assertEqual(
-          set([
+          {
             IvyModuleRef("toplevel", "toplevelmodule", "latest"),
             IvyModuleRef(org='org1', name='name1', rev='0.0.1'),
             IvyModuleRef(org='org2', name='name2', rev='0.0.1'),
             IvyModuleRef(org='org3', name='name3', rev='0.0.1')
-          ]),
+          },
           result)
 
   def test_memo_reused_across_calls(self):
@@ -157,16 +157,16 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
 
     self.assertIs(result1, result2)
     self.assertEqual(
-          set([
+          {
             IvyModuleRef(org='org1', name='name1', rev='0.0.1'),
             IvyModuleRef(org='org2', name='name2', rev='0.0.1'),
             IvyModuleRef(org='org3', name='name3', rev='0.0.1')
-          ]),
+          },
           result1)
 
   def parse_ivy_report(self, path):
     ivy_info = IvyUtils._parse_xml_report(path)
-    self.assertNotEqual(None, ivy_info)
+    self.assertIsNotNone(ivy_info)
     return ivy_info
 
   def find_single(self, elem, xpath):


### PR DESCRIPTION
For depmap calls using project-info, ~30% of the time was taken by retraversing the dependency graph from the ivy report xml. This encapsulates memoizing and cycle handling into a single method, and replaces the memoization / cycle handling done outside ivy utils with calls to the new method. It also adds a few tests for reports with cycles and diamond dependencies.