### PR TITLE
Move excludes logic into cmd_line_spec_parser so it can filter out broken build targets.

### DIFF
--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -5,7 +5,10 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
+from collections import defaultdict
+import logging
 import os
+import re
 import traceback
 
 from twitter.common.collections import maybe_list, OrderedSet
@@ -13,6 +16,8 @@ from twitter.common.collections import maybe_list, OrderedSet
 from pants.base.address import BuildFileAddress, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file import BuildFile
+
+logger = logging.getLogger(__name__)
 
 
 # Note: In general, 'spec' should not be a user visible term, it is usually appropriate to
@@ -43,14 +48,38 @@ class CmdLineSpecParser(object):
   The above expression would choose every target under src except for src/broken:test
   """
 
+  # Target specs are mapped to the patterns which match them, if any. This variable is a key for
+  # specs which don't match any exclusion regexps. We know it won't already be in the list of
+  # patterns, because the asterisks in its name make it an invalid regexp.
+  _UNMATCHED_KEY = '** unmatched **'
 
   class BadSpecError(Exception):
     """Indicates an invalid command line address selector."""
 
-  def __init__(self, root_dir, address_mapper, spec_excludes=None):
+  def __init__(self, root_dir, address_mapper, spec_excludes=None, exclude_target_regexps=None):
     self._root_dir = os.path.realpath(root_dir)
     self._address_mapper = address_mapper
     self._spec_excludes = spec_excludes
+    self._exclude_target_regexps = exclude_target_regexps or []
+
+    def setup_exclude_patterns():
+      patterns = []
+      for pattern in self._exclude_target_regexps:
+        patterns.append(re.compile(pattern))
+      return patterns
+    self._exclude_patterns = setup_exclude_patterns()
+    self._excluded_target_map = defaultdict(set)  # pattern -> targets (for debugging)
+
+  def _not_excluded_address(self, address):
+    return self._not_excluded_spec(address.spec)
+
+  def _not_excluded_spec(self, spec):
+    for pattern in self._exclude_patterns:
+      if pattern.search(spec) is not None:
+        self._excluded_target_map[pattern.pattern].add(spec)
+        return False
+    self._excluded_target_map[CmdLineSpecParser._UNMATCHED_KEY].add(spec)
+    return True
 
   def parse_addresses(self, specs, fail_fast=False):
     """Process a list of command line specs and perform expansion.  This method can expand a list
@@ -71,8 +100,26 @@ class CmdLineSpecParser(object):
       else:
         for address in self._parse_spec(spec, fail_fast):
           addresses.add(address)
-    for result in addresses - addresses_to_remove:
-      yield result
+
+    results = filter(self._not_excluded_address,  addresses - addresses_to_remove)
+
+    # Print debug information about the excluded targets
+    if self._exclude_patterns:
+      logger.debug('excludes:\n  {excludes}'
+                   .format(excludes='\n  '.join(self._exclude_target_regexps)))
+      targets = ', '.join(self._excluded_target_map[CmdLineSpecParser._UNMATCHED_KEY])
+      logger.debug('Targets after excludes: {targets}'.format(targets=targets))
+      for pattern, targets in self._excluded_target_map.iteritems():
+        excluded_count = 0
+        if pattern != CmdLineSpecParser._UNMATCHED_KEY:
+          logger.debug('Targets excluded by pattern {pattern}\n  {targets}'
+                       .format(pattern=pattern,
+                               targets='\n  '.join(targets)))
+          excluded_count += len(targets)
+      logger.debug('Excluded {count} target{plural}.'
+                   .format(count=excluded_count,
+                           plural=('s' if excluded_count != 1 else '')))
+    return results
 
   def _parse_spec(self, spec, fail_fast=False):
     def normalize_spec_path(path):
@@ -108,7 +155,8 @@ class CmdLineSpecParser(object):
 
       for build_file in build_files:
         try:
-          addresses.update(self._address_mapper.addresses_in_spec_path(build_file.spec_path))
+          if self._not_excluded_spec(build_file.spec_path):
+            addresses.update(self._address_mapper.addresses_in_spec_path(build_file.spec_path))
         except (BuildFile.BuildFileError, AddressLookupError) as e:
           if fail_fast:
             raise self.BadSpecError(e)

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -5,10 +5,8 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from collections import defaultdict
 import logging
 import os
-import re
 import sys
 from pants.base.build_graph import BuildGraph
 
@@ -149,7 +147,8 @@ class GoalRunner(object):
 
     with self.run_tracker.new_workunit(name='setup', labels=[WorkUnit.SETUP]):
       spec_parser = CmdLineSpecParser(self.root_dir, self.address_mapper,
-                                      spec_excludes=self.get_spec_excludes())
+                                      spec_excludes=self.get_spec_excludes(),
+                                      exclude_target_regexps=self.global_options.exclude_target_regexp)
       with self.run_tracker.new_workunit(name='parse', labels=[WorkUnit.SETUP]):
         for spec in specs:
           for address in spec_parser.parse_addresses(spec, fail_fast):
@@ -220,42 +219,8 @@ class GoalRunner(object):
           return True
       return False
 
-    # Target specs are mapped to the patterns which match them, if any. This variable is a key for
-    # specs which don't match any exclusion regexes. We know it won't already be in the list of
-    # patterns, because the asterisks in its name make it an invalid regex.
-    _UNMATCHED_KEY = '** unmatched **'
-
-    def targets_by_pattern(targets, patterns):
-      mapping = defaultdict(list)
-      for target in targets:
-        matched_pattern = None
-        for pattern in patterns:
-          if re.search(pattern, target.address.spec) is not None:
-            matched_pattern = pattern
-            break
-        if matched_pattern is None:
-          mapping[_UNMATCHED_KEY].append(target)
-        else:
-          mapping[matched_pattern].append(target)
-      return mapping
-
     is_explain = self.global_options.explain
     update_reporting(self.global_options, is_quiet_task() or is_explain, self.run_tracker)
-
-    if self.global_options.exclude_target_regexp:
-      excludes = self.global_options.exclude_target_regexp
-      log.debug('excludes:\n  {excludes}'.format(excludes='\n  '.join(excludes)))
-      by_pattern = targets_by_pattern(self.targets, excludes)
-      self.targets = by_pattern[_UNMATCHED_KEY]
-      # The rest of this if-statement is just for debug logging.
-      log.debug('Targets after excludes: {targets}'.format(
-          targets=', '.join(t.address.spec for t in self.targets)))
-      excluded_count = sum(len(by_pattern[p]) for p in excludes)
-      log.debug('Excluded {count} target{plural}.'.format(count=excluded_count,
-          plural=('s' if excluded_count != 1 else '')))
-      for pattern in excludes:
-        log.debug('Targets excluded by pattern {pattern}\n  {targets}'.format(pattern=pattern,
-            targets='\n  '.join(t.address.spec for t in by_pattern[pattern])))
 
     context = Context(
       config=self.config,


### PR DESCRIPTION

This is a revamp of https://rbcommons.com/s/twitter/r/930/.  The difference is that
this is now much easier after the options refactoring.