### PR TITLE
Trigger CI: Compile/Test "changed" targets

### DIFF
--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -14,6 +14,7 @@ from pants.backend.core.targets.prep_command import PrepCommand
 from pants.backend.core.targets.resources import Resources
 from pants.backend.core.tasks.build_lint import BuildLint
 from pants.backend.core.tasks.builddictionary import BuildBuildDictionary
+from pants.backend.core.tasks.changed_target_goals import CompileChanged, TestChanged
 from pants.backend.core.tasks.clean import Cleaner, Invalidator
 from pants.backend.core.tasks.confluence_publish import ConfluencePublish
 from pants.backend.core.tasks.dependees import ReverseDepmap
@@ -23,6 +24,7 @@ from pants.backend.core.tasks.list_goals import ListGoals
 from pants.backend.core.tasks.listtargets import ListTargets
 from pants.backend.core.tasks.markdown_to_html import MarkdownToHtml
 from pants.backend.core.tasks.minimal_cover import MinimalCover
+from pants.backend.core.tasks.noop import NoopCompile, NoopTest
 from pants.backend.core.tasks.pathdeps import PathDeps
 from pants.backend.core.tasks.paths import Path, Paths
 from pants.backend.core.tasks.prepare_resources import PrepareResources
@@ -169,3 +171,13 @@ def register_goals():
 
   task(name='changed', action=WhatChanged).install().with_description(
       'Print the targets changed since some prior commit.')
+
+  # Stub for other goals to schedule 'compile'. See noop.py for more on why this is useful.
+  task(name='compile', action=NoopCompile).install('compile')
+  task(name='compile-changed', action=CompileChanged).install().with_description(
+    'Compile changed targets.')
+
+  # Stub for other goals to schedule 'test'. See noop.py for more on why this is useful.
+  task(name='test', action=NoopTest).install('test')
+  task(name='test-changed', action=TestChanged).install().with_description(
+    'Test changed targets.')

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -6,6 +6,7 @@ target(
   dependencies = [
     ':build_lint',
     ':builddictionary',
+    ':changed_target_goals',
     ':clean',
     ':common',
     ':confluence_publish',
@@ -18,6 +19,7 @@ target(
     ':listtargets',
     ':markdown_to_html',
     ':minimal_cover',
+    ':noop',
     ':pathdeps',
     ':paths',
     ':prepare_resources',
@@ -198,6 +200,14 @@ python_library(
 )
 
 python_library(
+  name = 'noop',
+  sources = ['noop.py'],
+  dependencies = [
+    ':common',
+  ],
+)
+
+python_library(
   name = 'pathdeps',
   sources = ['pathdeps.py'],
   dependencies = [
@@ -327,5 +337,15 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:lazy_source_mapper',
     'src/python/pants/base:target',
+  ],
+)
+
+python_library(
+  name='changed_target_goals',
+  sources=['changed_target_goals.py'],
+  dependencies=[
+    ':common',
+    ':noop',
+    ':what_changed',
   ],
 )

--- a/src/python/pants/backend/core/tasks/changed_target_goals.py
+++ b/src/python/pants/backend/core/tasks/changed_target_goals.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from pants.backend.core.tasks.noop import (NoopExecTask, NoopCompile, NoopTest)
+from pants.backend.core.tasks.what_changed import ChangedFileTaskMixin
+
+
+class ChangedTargetTask(NoopExecTask, ChangedFileTaskMixin):
+  """A base class for tasks that find changed targets to act on.
+
+  Frequently other tasks already exist that actually do the desired work eg "compile" or "test".
+
+  A subclass of ChangedTargetTask can be used to create a new goal that runs existing tasks
+  on what the SCM indicates are changed targets rather than what the user specifies.
+
+  This is done by scheduling that goal or task, unaltered, and running it as usual, with the
+  exception that context.target_roots have been first set to the SCM-derived "changed" targets.
+
+  This is achieved by this task first finding changed targets, then calling context.replace_targets,
+  before then asking the round manager to schedule the desired task or goal with a standard
+  require_data call. This is done in the prepare() method of this task, after which the run proceeds
+  as usual, though with different target roots, until finally getting to this task's execute, which
+  is a noop.
+
+  For asking the round manager to schedule a particular goal, it can be helpful to have some known
+  product_type in that goal. See noop.py and NoopExecTask for noop tasks that can easily be
+  installed in a goal to make it provide some known product type.
+  """
+  @classmethod
+  def register_options(cls, register):
+    super(ChangedTargetTask, cls).register_options(register)
+    cls.register_change_file_options(register)
+
+  def prepare(self, round_manager):
+    super(ChangedTargetTask, self).prepare(round_manager)
+    changed = self._changed_targets()
+    self.context.replace_targets([self.context.build_graph.get_target(addr) for addr in changed])
+    readable = ''.join(sorted('\n\t* {}'.format(addr.reference()) for addr in changed))
+    self.context.log.info('Operating on changed {} target(s): {}'.format(len(changed), readable))
+
+
+class CompileChanged(ChangedTargetTask):
+  """Find and compile changed targets."""
+  def prepare(self, round_manager):
+    super(CompileChanged, self).prepare(round_manager)  # Replaces target roots.
+    round_manager.require_data(NoopCompile.product_types()[0])
+
+
+class TestChanged(ChangedTargetTask):
+  """Find and test changed targets."""
+  def prepare(self, round_manager):
+    super(TestChanged, self).prepare(round_manager) # Replaces target roots.
+    round_manager.require_data(NoopTest.product_types()[0])

--- a/src/python/pants/backend/core/tasks/noop.py
+++ b/src/python/pants/backend/core/tasks/noop.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+from pants.backend.core.tasks.task import Task
+
+
+class NoopExecTask(Task):
+  """A base class for tasks which do nothing but produce some product_type(s).
+
+    Useful when scheduling a specific goal, as one can install subclasses of this which produce a
+    known product_type into that goal, then depend on those products elsewhere.
+
+    Generally tasks depend on a specific product or products, as opposed to a given goal, and do
+    not need this, but some tasks, eg "compile changed targets" just know they want the "compile"
+    goal to be run, rather than a specific product, eg jvm classfiles.
+  """
+  def execute(self):
+    pass
+
+
+class NoopCompile(NoopExecTask):
+  """A no-op that provides a product type that can be used to force scheduling."""
+  @classmethod
+  def product_types(cls):
+    return ['ran_compile']
+
+
+class NoopTest(NoopExecTask):
+  """A no-op that provides a product type that can be used to force scheduling."""
+  @classmethod
+  def product_types(cls):
+    return ['ran_tests']

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -139,6 +139,15 @@ python_tests(
 )
 
 python_tests(
+  name = 'changed_target_integration',
+  sources = ['test_changed_target_integration.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ],
+)
+
+python_tests(
   name = 'junit_tests_integration',
   sources = ['test_junit_tests_integration.py'],
   dependencies = [

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
+                        print_function, unicode_literals)
+
+import os
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
+  def ref_for_greet_change(self):
+    # Unfortunately, as in being an integration test, it is difficult to mock the SCM used.
+    # Thus this will use the pants commit log, so we need a commit that changes greet example.
+    # Any comment/whitespace/etc change is enough though, as long as we know the SHA.
+    return '14cc5bc23561918dc7134427bfcb268506fcbcaa'
+
+  def greet_classfile(self, workdir, filename):
+    path = 'compile/jvm/java/classes/com/pants/examples/hello/greet'.split('/')
+    return os.path.join(workdir, *(path + [filename]))
+
+  def test_compile_changed(self):
+    cmd = ['compile-changed', '--diffspec={}'.format(self.ref_for_greet_change())]
+
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      # Nothing exists.
+      self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
+      self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
+
+      run = self.run_pants_with_workdir(cmd, workdir)
+      self.assert_success(run)
+
+      # The directly changed target's produced classfile exists.
+      self.assertTrue(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
+      self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
+
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      # Nothing exists.
+      self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
+      self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
+
+      run = self.run_pants_with_workdir(cmd + ['--include-dependees=direct'], workdir)
+      self.assert_success(run)
+
+      # The changed target's and its direct dependees' (eg its tests) classfiles exist.
+      self.assertTrue(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
+      self.assertTrue(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
+
+  def test_test_changed(self):
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      cmd = ['test-changed', '--diffspec={}'.format(self.ref_for_greet_change())]
+      junit_out = os.path.join(workdir, 'test', 'junit',
+        'com.pants.examples.hello.greet.GreetingTest.out.txt')
+
+      self.assertFalse(os.path.exists(junit_out))
+
+      run = self.run_pants_with_workdir(cmd, workdir)
+      self.assert_success(run)
+
+      self.assertFalse(os.path.exists(junit_out))
+
+      run = self.run_pants_with_workdir(cmd + ['--include-dependees=direct'], workdir)
+      self.assert_success(run)
+
+      self.assertTrue(os.path.exists(junit_out))


### PR DESCRIPTION
I think pretty much everyone has implmented some variation on this in wrappers, but with  some refactoring recently in WhatChanged and elsehwere, actual implementation of this as a proper task is pretty trivial now -- the comments are longer then the code.

- SCM changed target calculation is provided by a mixin (the same as is used by WhatChanged).
- The actual "compile" or "test" is just done by the existing goal -- this just asks round manager to schedule that.

Thus "compile-changed" doesn't subclass a compile task, or even have any "compile" related functionality, but rather just asks the round manager to run "compile" for it after it replaces the target roots by consulting WhatChanged at the begining of its `prepare` method.

I'm not super crazy about doing the root replacement in `prepare` -- ideally I'd prefer a dedicated method on Task that can optionally return alternative target roots. Tasks that want to find their own targets, like those in this change, would override that, then the round engine could ensure at-most-one target returned non-None and do the swap. However that currently isn't possible (discussed further here: https://docs.google.com/a/foursquare.com/document/d/1HM_vR8h5GR3JD8_yXXxoGWIieAiR5Bipdf6gwf51W3Y/edit#)

Thanks to https://rbcommons.com/s/twitter/r/1543/, the approach used here should be safe though -- that change should at least ensure that if one of these tasks were mis-scheduled, it would crash and fail tests quickly, rather than potentially harming correctness more sublety later.