### PR TITLE
Kill goal dependencies.

### DIFF
--- a/examples/src/python/example/pants_publish_plugin/register.py
+++ b/examples/src/python/example/pants_publish_plugin/register.py
@@ -8,6 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 from example.pants_publish_plugin.extra_test_jar_example import ExtraTestJarExample
 from pants.goal.task_registrar import TaskRegistrar as task
 
+
 # Register this custom task on the 'jar' phase. When the RoundEngine reaches this phase, it will
 # execute all tasks that have previously registered for this phase.
 def register_goals():

--- a/src/python/internal_backend/optional/register.py
+++ b/src/python/internal_backend/optional/register.py
@@ -11,10 +11,5 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def register_goals():
-  task(name='checkstyle', action=Checkstyle,
-       dependencies=['gen', 'resolve']
-  ).install('compile')
-
-  task(name='scalastyle', action=Scalastyle,
-       dependencies=['bootstrap']
-  ).install('compile')
+  task(name='checkstyle', action=Checkstyle).install('compile')
+  task(name='scalastyle', action=Scalastyle).install('compile')

--- a/src/python/pants/backend/android/register.py
+++ b/src/python/pants/backend/android/register.py
@@ -27,12 +27,6 @@ def build_file_aliases():
 
 def register_goals():
   task(name='aapt', action=AaptGen).install('gen')
-
-  task(name='dex', action=DxCompile,
-       dependencies=['compile']).install('dex')
-
-  task(name='apk', action=AaptBuilder,
-       dependencies=['dex']).install('bundle')
-
-  task(name='sign', action=JarsignerTask,
-       dependencies=['bundle']).install('sign')
+  task(name='dex', action=DxCompile).install('dex')
+  task(name='apk', action=AaptBuilder).install('bundle')
+  task(name='sign', action=JarsignerTask).install('sign')

--- a/src/python/pants/backend/codegen/register.py
+++ b/src/python/pants/backend/codegen/register.py
@@ -43,22 +43,17 @@ def build_file_aliases():
 def register_goals():
   task(name='thrift', action=ApacheThriftGen).install('gen').with_description('Generate code.')
 
-  task(name='thrift-linter', action=ThriftLinter
-  ).install().with_description('Check thrift files for non-recommended usage patterns.')
+  task(name='thrift-linter', action=ThriftLinter).install().with_description(
+      'Check thrift files for non-recommended usage patterns.')
 
-  task(name='scrooge', dependencies=['bootstrap'], action=ScroogeGen).install('gen')
+  task(name='scrooge', action=ScroogeGen).install('gen')
 
   # TODO(Garrett Malmquist): 'protoc' depends on a nonlocal goal (imports is in the jvm register).
   # This should be cleaned up, with protobuf stuff moved to its own backend. (See John's comment on
   # RB 592).
-  task(name='protoc', dependencies=['imports'], action=ProtobufGen
-  ).install('gen')
+  task(name='protoc', action=ProtobufGen).install('gen')
 
-  task(name='antlr', dependencies=['bootstrap'], action=AntlrGen
-  ).install('gen')
-
+  task(name='antlr', action=AntlrGen).install('gen')
   task(name='ragel', action=RagelGen).install('gen')
-
   task(name='jaxb', action=JaxbGen).install('gen')
-
   task(name='wire', action=WireGen).install('gen')

--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -92,21 +92,18 @@ def build_file_aliases():
 
 def register_goals():
   # Getting help.
-  task(name='goals', action=ListGoals
-  ).install().with_description('List all documented goals.')
+  task(name='goals', action=ListGoals).install().with_description('List all documented goals.')
 
-  task(name='targets', action=TargetsHelp
-  ).install().with_description('List target types and BUILD file symbols (python_tests, jar, etc).')
+  task(name='targets', action=TargetsHelp).install().with_description(
+      'List target types and BUILD file symbols (python_tests, jar, etc).')
 
-  task(name='builddict', action=BuildBuildDictionary
-  ).install()
-
+  task(name='builddict', action=BuildBuildDictionary).install()
 
   # Cleaning.
-  invalidate = task(name='invalidate', action=Invalidator, dependencies=['ng-killall'])
+  invalidate = task(name='invalidate', action=Invalidator)
   invalidate.install().with_description('Invalidate all targets.')
 
-  clean_all = task(name='clean-all', action=Cleaner, dependencies=['invalidate']).install()
+  clean_all = task(name='clean-all', action=Cleaner).install()
   clean_all.with_description('Clean all build output.')
   clean_all.install(invalidate, first=True)
 
@@ -116,66 +113,59 @@ def register_goals():
             file=sys.stderr)
       print('Please update your usages to `clean-all`.', file=sys.stderr)
       super(AsyncCleaner, self).execute()
-  clean_all_async = task(name='clean-all-async', action=AsyncCleaner, dependencies=['invalidate']
-  ).install().with_description('[deprecated] Clean all build output in a background process.')
+  clean_all_async = task(name='clean-all-async', action=AsyncCleaner).install().with_description(
+      '[deprecated] Clean all build output in a background process.')
   clean_all_async.install(invalidate, first=True)
 
   # Reporting.
+  task(name='server', action=RunServer, serialize=False).install().with_description(
+      'Run the pants reporting server.')
 
-  task(name='server', action=RunServer, serialize=False
-  ).install().with_description('Run the pants reporting server.')
-
-  task(name='killserver', action=KillServer, serialize=False
-  ).install().with_description('Kill the reporting server.')
-
+  task(name='killserver', action=KillServer, serialize=False).install().with_description(
+      'Kill the reporting server.')
 
   # Bootstrapping.
-  task(name='prepare', action=PrepareResources
-  ).install('resources')
+  task(name='prepare', action=PrepareResources).install('resources')
 
-  task(name='markdown', action=MarkdownToHtml
-  ).install('markdown').with_description('Generate html from markdown docs.')
-
+  task(name='markdown', action=MarkdownToHtml).install('markdown').with_description(
+      'Generate html from markdown docs.')
 
   # Linting.
-  task(name='buildlint', action=BuildLint, dependencies=['compile']
-  ).install()
+  task(name='buildlint', action=BuildLint).install()
 
   task(name='pathdeps', action=PathDeps).install('pathdeps').with_description(
-    'Print out all paths containing BUILD files the target depends on.')
+      'Print out all paths containing BUILD files the target depends on.')
 
-  task(name='list', action=ListTargets
-  ).install('list').with_description('List available BUILD targets.')
-
+  task(name='list', action=ListTargets).install('list').with_description(
+      'List available BUILD targets.')
 
   # Build graph information.
+  task(name='path', action=Path).install().with_description(
+      'Find a dependency path from one target to another.')
 
-  task(name='path', action=Path
-  ).install().with_description('Find a dependency path from one target to another.')
+  task(name='paths', action=Paths).install().with_description(
+      'Find all dependency paths from one target to another.')
 
-  task(name='paths', action=Paths
-  ).install().with_description('Find all dependency paths from one target to another.')
+  task(name='dependees', action=ReverseDepmap).install().with_description(
+      "Print the target's dependees.")
 
-  task(name='dependees', action=ReverseDepmap
-  ).install().with_description("Print the target's dependees.")
+  task(name='filemap', action=Filemap).install().with_description(
+      'Outputs a mapping from source file to owning target.')
 
-  task(name='filemap', action=Filemap
-  ).install().with_description('Outputs a mapping from source file to owning target.')
+  task(name='minimize', action=MinimalCover).install().with_description(
+      'Print the minimal cover of the given targets.')
 
-  task(name='minimize', action=MinimalCover
-  ).install().with_description('Print the minimal cover of the given targets.')
+  task(name='filter', action=Filter).install().with_description(
+      'Filter the input targets based on various criteria.')
 
-  task(name='filter', action=Filter
-  ).install().with_description('Filter the input targets based on various criteria.')
+  task(name='sort', action=SortTargets).install().with_description(
+      'Topologically sort the targets.')
 
-  task(name='sort', action=SortTargets
-  ).install().with_description("Topologically sort the targets.")
+  task(name='roots', action=ListRoots).install('roots').with_description(
+      "Print the workspace's source roots and associated target types.")
 
-  task(name='roots', action=ListRoots
-  ).install('roots').with_description("Print the workspace's source roots and associated target types.")
+  task(name='run_prep_command', action=RunPrepCommand).install('test', first=True).with_description(
+      "Run a command before tests")
 
-  task(name='run_prep_command', action=RunPrepCommand
-  ).install('test', first=True).with_description("Run a command before tests")
-
-  task(name='changed', action=WhatChanged
-  ).install().with_description('Print the targets changed since some prior commit.')
+  task(name='changed', action=WhatChanged).install().with_description(
+      'Print the targets changed since some prior commit.')

--- a/src/python/pants/backend/core/tasks/list_goals.py
+++ b/src/python/pants/backend/core/tasks/list_goals.py
@@ -38,42 +38,48 @@ class ListGoals(ConsoleTask):
         yield '  %s' % ' '.join(undocumented)
 
     def graph():
-      def get_cluster_name(goal):
-        return 'cluster_%s' % goal.name.replace('-', '_')
-
-      def get_node_name(goal, task_name):
-        name = '%s_%s' % (goal.name, task_name)
-        return name.replace('-', '_')
-
-      yield '\n'.join([
-        'digraph G {',
-        '  rankdir=LR;',
-        '  graph [compound=true];',
-        ])
-      for goal in Goal.all():
-        yield '\n'.join([
-          '  subgraph %s {' % get_cluster_name(goal),
-          '    node [style=filled];',
-          '    color = blue;',
-          '    label = "%s";' % goal.name,
-        ])
-        for name in goal.ordered_task_names():
-          yield '    %s [label="%s"];' % (get_node_name(goal, name), name)
-        yield '  }'
-
-      edges = set()
-      for goal in Goal.all():
-        tail_task_name = goal.ordered_task_names()[-1]
-        for dep in goal.dependencies:
-          edge = 'ltail=%s lhead=%s' % (get_cluster_name(goal), get_cluster_name(dep))
-          if edge not in edges:
-            # We display edges between clusters (representing goals), but dot still requires
-            # us to specify them between nodes (representing tasks) and then add ltail, lhead
-            # annotations.  We connect the last task in the dependee to the first task in
-            # the dependency, as this leads to the neatest-looking graph.
-            yield '  %s -> %s [%s];' % (get_node_name(goal, tail_task_name),
-                                        get_node_name(dep, dep.ordered_task_names()[0]), edge)
-          edges.add(edge)
-      yield '}'
+      # TODO(John Sirois): re-work and re-enable: https://github.com/pantsbuild/pants/issues/918
+      # def get_cluster_name(goal):
+      #   return 'cluster_%s' % goal.name.replace('-', '_')
+      #
+      # def get_node_name(goal, task_name):
+      #   name = '%s_%s' % (goal.name, task_name)
+      #   return name.replace('-', '_')
+      #
+      # yield '\n'.join([
+      #   'digraph G {',
+      #   '  rankdir=LR;',
+      #   '  graph [compound=true];',
+      #   ])
+      # for goal in Goal.all():
+      #   yield '\n'.join([
+      #     '  subgraph %s {' % get_cluster_name(goal),
+      #     '    node [style=filled];',
+      #     '    color = blue;',
+      #     '    label = "%s";' % goal.name,
+      #   ])
+      #   for name in goal.ordered_task_names():
+      #     yield '    %s [label="%s"];' % (get_node_name(goal, name), name)
+      #   yield '  }'
+      #
+      # edges = set()
+      # for goal in Goal.all():
+      #   tail_task_name = goal.ordered_task_names()[-1]
+      #   for dep in goal.dependencies:
+      #     edge = 'ltail=%s lhead=%s' % (get_cluster_name(goal), get_cluster_name(dep))
+      #     if edge not in edges:
+      #       # We display edges between clusters (representing goals), but dot still requires
+      #       # us to specify them between nodes (representing tasks) and then add ltail, lhead
+      #       # annotations.  We connect the last task in the dependee to the first task in
+      #       # the dependency, as this leads to the neatest-looking graph.
+      #       yield '  %s -> %s [%s];' % (get_node_name(goal, tail_task_name),
+      #                                   get_node_name(dep, dep.ordered_task_names()[0]), edge)
+      #     edges.add(edge)
+      # yield '}'
+      yield 'Graph support is currently broken but will be resurrected pending engine rework'
+      yield 'You can follow progress towards this milestone here:'
+      yield '  https://github.com/pantsbuild/pants/milestones/engine%20rework'
+      yield 'You can follow final fix-up of --graph here:'
+      yield '  https://github.com/pantsbuild/pants/issues/918'
 
     return graph() if self.get_options().graph else report()

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -43,22 +43,8 @@ def build_file_aliases():
 
 
 def register_goals():
-  task(name='python-binary-create', action=PythonBinaryCreate,
-       dependencies=['bootstrap', 'resources']
-  ).install('binary')
-
-  task(name='pytest', action=PytestRun,
-       dependencies=['bootstrap', 'resources']
-  ).install('test')
-
-  task(name='py', action=PythonRun,
-       dependencies=['bootstrap', 'resources']
-  ).install('run')
-
-  task(name='python-repl', action=PythonRepl,
-       dependencies=['bootstrap', 'resources']
-  ).install('repl')
-
-  task(name='setup-py', action=PythonSetup,
-       dependencies=['bootstrap', 'resources']
-  ).install()
+  task(name='python-binary-create', action=PythonBinaryCreate).install('binary')
+  task(name='pytest', action=PytestRun).install('test')
+  task(name='py', action=PythonRun).install('run')
+  task(name='python-repl', action=PythonRepl).install('repl')
+  task(name='setup-py', action=PythonSetup).install()

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -55,7 +55,6 @@ class _Goal(object):
     """
     self.name = name
     self.description = None
-    self.dependencies = set()  # The Goals this Goal depends on.
     self.serialize = False
     self._task_type_by_name = {}  # name -> Task subclass.
     self._ordered_task_names = []  # The task names, in the order imposed by registration.
@@ -109,7 +108,6 @@ class _Goal(object):
       otn.append(task_name)
 
     self._task_type_by_name[task_name] = task_type
-    self.dependencies.update(task_registrar.dependencies)
 
     if task_registrar.serialize:
       self.serialize = True
@@ -126,10 +124,8 @@ class _Goal(object):
 
     Allows external plugins to modify the execution plan. Use with caution.
 
-    Note: Does not remove goal dependencies or relax a serialization requirement that originated
+    Note: Does not relax a serialization requirement that originated
     from the uninstalled task's install() call.
-    TODO(benjy): Should it? We're moving away from explicit goal deps towards a
-                 product consumption-production model anyway.
     """
     if name in self._task_type_by_name:
       self._task_type_by_name[name].options_scope = None

--- a/src/python/pants/goal/task_registrar.py
+++ b/src/python/pants/goal/task_registrar.py
@@ -7,6 +7,9 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import functools
 import inspect
+import sys
+from textwrap import dedent
+import traceback
 
 from pants.goal.error import GoalError
 from pants.goal.goal import Goal
@@ -18,14 +21,13 @@ class TaskRegistrar(object):
     """
     :param name: the name of the task.
     :param action: the Task action object to invoke this task.
-    :param dependencies: the names of other goals which must be achieved before invoking this
-                         task's goal.
+    :param dependencies: DEPRECATED
+      the names of other goals which must be achieved before invoking this task's goal.
     :param serialize: a flag indicating whether or not the action to achieve this goal requires
       the global lock. If true, the action will block until it can acquire the lock.
     """
     self.serialize = serialize
     self.name = name
-    self.dependencies = [Goal.by_name(d) for d in dependencies] if dependencies else []
 
     if isinstance(type(action), type) and issubclass(action, Task):
       self._task = action
@@ -53,8 +55,24 @@ class TaskRegistrar(object):
 
       self._task = FuncTask
 
+    if dependencies:
+      # TODO(John Sirois): kill this warning and the kwarg after a deprecation cycle.
+      print(dedent('''
+          WARNING: Registered dependencies are now ignored and only `Task.product_types`
+          and product requirements as expressed in `Task.prepare` are used to
+          infer Task dependencies.
+
+          Please fix this registration:
+            {reg}
+            {location}
+          ''').format(reg=self,
+                     location=traceback.format_list([traceback.extract_stack()[-2]])[0]),
+            file=sys.stderr)
+
   def __repr__(self):
-    return "TaskRegistrar(%s; %s)" % (self.name, ','.join(map(str, self.dependencies)))
+    return 'TaskRegistrar({name}, {action} serialize={serialize})'.format(name=self.name,
+                                                                          action=self._task,
+                                                                          serialize=self.serialize)
 
   @property
   def task_type(self):

--- a/src/python/pants/goal/task_registrar.py
+++ b/src/python/pants/goal/task_registrar.py
@@ -66,7 +66,7 @@ class TaskRegistrar(object):
             {reg}
             {location}
           ''').format(reg=self,
-                     location=traceback.format_list([traceback.extract_stack()[-2]])[0]),
+                      location=traceback.format_list([traceback.extract_stack()[-2]])[0]),
             file=sys.stderr)
 
   def __repr__(self):

--- a/tests/python/pants_test/tasks/test_list_goals.py
+++ b/tests/python/pants_test/tasks/test_list_goals.py
@@ -5,6 +5,8 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
+import pytest
+
 from pants.backend.core.tasks.list_goals import ListGoals
 from pants.backend.core.tasks.task import Task
 from pants.goal.goal import Goal
@@ -78,6 +80,9 @@ class ListGoalsTest(ConsoleTaskTest):
       args=['--test-all'],
     )
 
+  # TODO(John Sirois): Re-enable when fixing up ListGoals `--graph` in
+  # https://github.com/pantsbuild/pants/issues/918
+  @pytest.mark.xfail
   def test_list_goals_graph(self):
     Goal.clear()
 


### PR DESCRIPTION
These have not been used since the new options system went in and only cause confusion.
This change strips uses in pants itself but keeps the TaskRegistrar parameter around
for a deprecation cycle, printing a warning to those still using the now-ignored parameter.

https://rbcommons.com/s/twitter/r/1577/