### PR TITLE
Refactor setting of python-path in pants.ini

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -52,13 +52,11 @@ class GoalRunner(object):
 
     # Force config into the cache so we (and plugin/backend loading code) can use it.
     # TODO: Plumb options in explicitly.
-    options_bootstrapper.get_bootstrap_options()
+    bootstrap_options = options_bootstrapper.get_bootstrap_options()
     self.config = Config.from_cache()
 
     # Add any extra paths to python path (eg for loading extra source backends)
-    extra_paths = self.config.getlist('backends', 'python-path', [])
-    if extra_paths:
-      sys.path.extend(extra_paths)
+    sys.path.extend(bootstrap_options.for_global_scope().pythonpath)
 
     # Load plugins and backends.
     backend_packages = self.config.getlist('backends', 'packages', [])

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -104,6 +104,8 @@ migrations = {
   ('ivy-resolve', 'write_artifact_caches'): ('resolve.ivy', 'write_artifact_caches'),
   ('java-compile', 'write_artifact_caches'): ('compile.java', 'write_artifact_caches'),
   ('scala-compile', 'write_artifact_caches'): ('compile.scala', 'write_artifact_caches'),
+
+  ('backend', 'python-path'): ('DEFAULT', 'pythonpath')
 }
 
 notes = {

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -40,7 +40,8 @@ def register_bootstrap_options(register, buildroot=None):
   register('--pantsrc-files', action='append', metavar='<path>',
            default=['/etc/pantsrc', '~/.pants.rc'],
            help='Override config with values from these files. Later files override eariler ones.')
-
+  register('--pythonpath', action='append',
+           help='Add these directories to PYTHONPATH to search for plugins.')
 
 class OptionsBootstrapper(object):
   """An object that knows how to create options in two stages: bootstrap, and then full options."""


### PR DESCRIPTION
We recently added the ability to set pythonpath in pants.ini.
This change was made to document the setting.  Unfortunately, the previous
name was hyphenated, and the new options system would translate that into an
underscore automatically.  I removed the separator to simplify this, plus
it should be easier to remember as PYTHONPATH in the environment doesn't
have a separator anyway.