### PR TITLE
Trigger CI: remove the ivy_home property from context.

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -137,8 +137,8 @@ class IvyUtils(object):
         yield (path.strip() for path in cp.read().split(os.pathsep) if path.strip())
 
   @staticmethod
-  def symlink_cachepath(ivy_home, inpath, symlink_dir, outpath):
-    """Symlinks all paths listed in inpath that are under ivy_home into symlink_dir.
+  def symlink_cachepath(ivy_cache_dir, inpath, symlink_dir, outpath):
+    """Symlinks all paths listed in inpath that are under ivy_cache_dir into symlink_dir.
 
     Preserves all other paths. Writes the resulting paths to outpath.
     Returns a map of path -> symlink to that path.
@@ -148,10 +148,10 @@ class IvyUtils(object):
       paths = filter(None, infile.read().strip().split(os.pathsep))
     new_paths = []
     for path in paths:
-      if not path.startswith(ivy_home):
+      if not path.startswith(ivy_cache_dir):
         new_paths.append(path)
         continue
-      symlink = os.path.join(symlink_dir, os.path.relpath(path, ivy_home))
+      symlink = os.path.join(symlink_dir, os.path.relpath(path, ivy_cache_dir))
       try:
         os.makedirs(os.path.dirname(symlink))
       except OSError as e:

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -51,7 +51,7 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
 
   @classmethod
   def product_types(cls):
-    return ['compile_classpath', 'ivy_jar_products', 'jar_dependencies']
+    return ['compile_classpath', 'ivy_jar_products', 'jar_dependencies', 'ivy_cache_dir']
 
   def __init__(self, *args, **kwargs):
     super(IvyResolve, self).__init__(*args, **kwargs)
@@ -85,6 +85,7 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
 
     executor = self.create_java_executor()
     targets = self.context.targets()
+    self.context.products.safe_create_data('ivy_cache_dir', lambda: self._cachedir)
     compile_classpath = self.context.products.get_data('compile_classpath',
                                                        lambda: OrderedSet())
 

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -123,7 +123,7 @@ class IvyTaskMixin(object):
     # Make our actual classpath be symlinks, so that the paths are uniform across systems.
     # Note that we must do this even if we read the raw_target_classpath_file from the artifact
     # cache. If we cache the target_classpath_file we won't know how to create the symlinks.
-    symlink_map = IvyUtils.symlink_cachepath(self.context.ivy_home, raw_target_classpath_file,
+    symlink_map = IvyUtils.symlink_cachepath(ivy.ivy_cache_dir, raw_target_classpath_file,
                                              symlink_dir, target_classpath_file)
     with IvyTaskMixin.symlink_map_lock:
       all_symlinks_map = self.context.products.get_data('symlink_map') or defaultdict(list)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
@@ -14,13 +14,13 @@ from pants.util.contextutil import temporary_dir
 
 class AnalysisTools(object):
   """Analysis manipulation methods required by JvmCompile."""
-  _IVY_HOME_PLACEHOLDER = '/_IVY_HOME_PLACEHOLDER'
+  _IVY_CACHE_DIR_PLACEHOLDER = '/_IVY_HOME_PLACEHOLDER'
   _PANTS_HOME_PLACEHOLDER = '/_PANTS_HOME_PLACEHOLDER'
 
-  def __init__(self, context, parser, analysis_cls):
+  def __init__(self, java_home, ivy_cache_dir, parser, analysis_cls):
     self.parser = parser
-    self._java_home = context.java_home
-    self._ivy_home = context.ivy_home
+    self._java_home = java_home
+    self._ivy_cache_dir = ivy_cache_dir
     self._pants_home = get_buildroot()
     self._analysis_cls = analysis_cls
 
@@ -61,7 +61,7 @@ class AnalysisTools(object):
       # in those rare cases.
       rebasings = [
         (self._java_home, None),
-        (self._ivy_home, self._IVY_HOME_PLACEHOLDER),
+        (self._ivy_cache_dir, self._IVY_CACHE_DIR_PLACEHOLDER),
         (self._pants_home, self._PANTS_HOME_PLACEHOLDER),
         ]
       # Work on a tmpfile, for safety.
@@ -72,7 +72,7 @@ class AnalysisTools(object):
     with temporary_dir() as tmp_analysis_dir:
       tmp_analysis_file = os.path.join(tmp_analysis_dir, 'analysis')
       rebasings = [
-        (AnalysisTools._IVY_HOME_PLACEHOLDER, self._ivy_home),
+        (AnalysisTools._IVY_CACHE_DIR_PLACEHOLDER, self._ivy_cache_dir),
         (AnalysisTools._PANTS_HOME_PLACEHOLDER, self._pants_home),
         ]
       # Work on a tmpfile, for safety.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
@@ -86,7 +86,8 @@ class JavaCompile(JvmCompile):
     self._depfile = os.path.join(self._analysis_dir, 'global_depfile')
 
   def create_analysis_tools(self):
-    return AnalysisTools(self.context, JMakeAnalysisParser(self._classes_dir), JMakeAnalysis)
+    return AnalysisTools(self.context.java_home, self.ivy_cache_dir,
+                         JMakeAnalysisParser(self._classes_dir), JMakeAnalysis)
 
   def extra_products(self, target):
     ret = []

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -254,6 +254,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
 
   def prepare(self, round_manager):
     round_manager.require_data('compile_classpath')
+    round_manager.require_data('ivy_cache_dir')
 
     # Require codegen we care about
     # TODO(John Sirois): roll this up in Task - if the list of labels we care about for a target
@@ -451,7 +452,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
               actual_deps = self._analysis_parser.parse_deps_from_path(analysis_file,
                   lambda: self._compute_classpath_elements_by_class(cp_entries))
               with self.context.new_workunit(name='find-missing-dependencies'):
-                self._dep_analyzer.check(sources, actual_deps)
+                self._dep_analyzer.check(sources, actual_deps, self.ivy_cache_dir)
 
             # Kick off the background artifact cache write.
             if self.artifact_cache_writes_enabled():
@@ -772,6 +773,13 @@ class JvmCompile(NailgunTaskBase, GroupMember):
   @property
   def _analysis_parser(self):
     return self._analysis_tools.parser
+
+  @property
+  def ivy_cache_dir(self):
+    ret = self.context.products.get_data('ivy_cache_dir')
+    if ret is None:
+      raise TaskError('ivy_cache_dir product accessed before it was created.')
+    return ret
 
   def _sources_for_targets(self, targets):
     """Returns a map target->sources for the specified targets."""

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
@@ -133,7 +133,7 @@ class JvmDependencyAnalyzer(object):
       transitive_deps_by_target[target] = transitive_deps
     return transitive_deps_by_target
 
-  def check(self, srcs, actual_deps):
+  def check(self, srcs, actual_deps, ivy_cache_dir):
     """Check for missing deps.
 
     See docstring for _compute_missing_deps for details.
@@ -144,7 +144,7 @@ class JvmDependencyAnalyzer(object):
 
       buildroot = get_buildroot()
       def shorten(path):  # Make the output easier to read.
-        for prefix in [buildroot, self._context.ivy_home]:
+        for prefix in [buildroot, ivy_cache_dir]:
           if path.startswith(prefix):
             return os.path.relpath(path, prefix)
         return path

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
@@ -50,7 +50,8 @@ class ScalaCompile(JvmCompile):
                                  log_level=self.get_options().level)
 
   def create_analysis_tools(self):
-    return AnalysisTools(self.context, ZincAnalysisParser(self._classes_dir), ZincAnalysis)
+    return AnalysisTools(self.context.java_home, self.ivy_cache_dir,
+                         ZincAnalysisParser(self._classes_dir), ZincAnalysis)
 
   def extra_compile_time_classpath_elements(self):
     # Classpath entries necessary for our compiler plugins.

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -24,8 +24,6 @@ from pants.process.pidlock import OwnerPrintingPIDLockFile
 from pants.reporting.report import Report
 from pants.base.worker_pool import SubprocPool
 
-# Override with ivy -> cache_dir
-_IVY_CACHE_DIR_DEFAULT=os.path.expanduser('~/.ivy2/pants')
 
 class Context(object):
   """Contains the context for a single run of pants.
@@ -151,11 +149,6 @@ class Context(object):
     # e.g., for the purpose of rebasing. In practice, this seems to work fine.
     # Note that for our purposes we take the parent of java.home.
     return os.path.realpath(os.path.dirname(self.java_sysprops['java.home']))
-
-  @property
-  def ivy_home(self):
-    return os.path.realpath(self.config.get('ivy', 'cache_dir',
-                                            default=_IVY_CACHE_DIR_DEFAULT))
 
   @property
   def spec_excludes(self):

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -122,9 +122,11 @@ class Bootstrapper(object):
     By default the ivy.cache_dir value found in pants.ini but can be overridden via the
     PANTS_IVY_CACHE_DIR environment variable.  If neither is specified defaults to ivy's built
     in default cache dir; ie: ~/.ivy2/cache.
+
+    TODO: Make this a regular option.
     """
     return (os.getenv('PANTS_IVY_CACHE_DIR')
-            or self._config.get('ivy', 'cache_dir', default=os.path.expanduser('~/.ivy2/cache')))
+            or self._config.get('ivy', 'cache_dir', default=os.path.expanduser('~/.ivy2/pants')))
 
   def _bootstrap_ivy_classpath(self, executor, workunit_factory, retry=True):
     # TODO(John Sirois): Extract a ToolCache class to control the path structure:


### PR DESCRIPTION
It's now a product, populated by IvyResolve, for downstream tasks that
happen to need to know about the ivy cache dir for various reasons.

This has several benefits:

- Context is a pants-wide concept, and ivy is a jvm-backend-specific concept,
  so there's no reason for it to be privileged in this way.

- We were previously inferring the ivy cache dir in two difference places -
  context and bootstrapper. Now we only do it in one place. This caused real
  bugs (which is how I came to make this change in the first place).

- We had inconsistent terminology: "ivy_home" vs "ivy_cache_dir". Now everything
  uses the latter term.