### PR TITLE
mark some missing-deps testprojects as expected to fail

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -167,6 +167,7 @@ if [[ "${skip_testprojects:-false}" == "false" ]]; then
   # Targets that are intended to fail
   negative_test_targets=(
     testprojects/src/thrift/com/pants/thrift_linter:
+    testprojects/src/java/com/pants/testproject/missingdepswhitelist.*
   )
 
   targets_to_exclude=(


### PR DESCRIPTION
Let's see if Travis-CI is OK with me turning off some targets.