### PR TITLE
Bugfixes in calling super methods in traversable_specs and traversable_dependency_specs

### DIFF
--- a/src/python/pants/backend/core/targets/doc.py
+++ b/src/python/pants/backend/core/targets/doc.py
@@ -116,7 +116,7 @@ class Page(Target):
 
   @property
   def traversable_dependency_specs(self):
-    for spec in super(Page, self).traversable_specs:
+    for spec in super(Page, self).traversable_dependency_specs:
       yield spec
     for resource_spec in self._resource_specs:
       yield resource_spec

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -86,7 +86,7 @@ class JvmTarget(Target, Jarable):
 
   @property
   def traversable_dependency_specs(self):
-    for spec in super(JvmTarget, self).traversable_specs:
+    for spec in super(JvmTarget, self).traversable_dependency_specs:
       yield spec
     for resource_spec in self._resource_specs:
       yield resource_spec

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -87,6 +87,8 @@ class PythonTarget(Target):
 
   @property
   def traversable_specs(self):
+    for spec in super(PythonTarget, self).traversable_specs:
+      yield spec
     if self._provides:
       for spec in self._provides._binaries.values():
         address = SyntheticAddress.parse(spec, relative_to=self.address.spec_path)


### PR DESCRIPTION

These look like just oversights that didn't cause problems because their superclass was
target that in both cases returned an empty list.