### PR TITLE
Got ivy to map in javadoc and source jars for pants goal idea.

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -23,8 +23,7 @@ def add_log4j_excludes(jar):
 jar_library(name='checkstyle',
             jars = [
               jar(org='com.puppycrawl.tools', name='checkstyle', rev='5.5')
-                .exclude(org='com.google.collections', name='google-collections')
-                .with_sources(),
+                .exclude(org='com.google.collections', name='google-collections'),
             ],
             dependencies = [
               # Needs this as the replacement for the excluded google-collections.
@@ -34,7 +33,7 @@ jar_library(name='checkstyle',
 
 jar_library(name='commons-lang',
             jars = [
-              jar(org='commons-lang', name='commons-lang', rev='2.5').with_sources()
+              jar(org='commons-lang', name='commons-lang', rev='2.5'),
             ]
            )
 
@@ -50,8 +49,7 @@ FINAGLE_REV = '6.8.1'
 
 jar_library(name='finagle-core',
             jars = [
-              jar(org='com.twitter', name='finagle-core_2.9.2', rev=FINAGLE_REV)
-                .with_sources(),
+              jar(org='com.twitter', name='finagle-core_2.9.2', rev=FINAGLE_REV),
             ],
             dependencies = [
               ':util-core'
@@ -59,7 +57,7 @@ jar_library(name='finagle-core',
 
 jar_library(name='finagle-thrift',
             jars = [
-              jar(org='com.twitter', name='finagle-thrift_2.9.2', rev=FINAGLE_REV)
+              jar(org='com.twitter', name='finagle-thrift_2.9.2', rev=FINAGLE_REV),
             ])
 
 # common rev for all com.google.guava%guava* artifacts
@@ -71,10 +69,10 @@ jar_library(name='guava',
                 org='com.google.guava', name='guava', rev=GUAVA_REV,
                 apidocs='http://docs.guava-libraries.googlecode.com/git-history/'
                           '%s/javadoc/' % GUAVA_REV
-              ).with_sources().with_docs(),
+              ),
 
               # Defined in provided scope so we provide here
-              jar(org='javax.inject', name='javax.inject', rev='1').with_sources(),
+              jar(org='javax.inject', name='javax.inject', rev='1'),
             ],
             dependencies = [
               ':jsr305',
@@ -83,18 +81,18 @@ jar_library(name='guava',
 
 jar_library(name='jsr305',
             jars = [
-              jar(org='com.google.code.findbugs', name='jsr305', rev='1.3.9')
+              jar(org='com.google.code.findbugs', name='jsr305', rev='1.3.9'),
             ]
            )
 
 jar_library(name='log4j',
             jars = [
-              add_log4j_excludes(jar(org='log4j', name='log4j', rev='1.2.15').with_sources())
+              add_log4j_excludes(jar(org='log4j', name='log4j', rev='1.2.15')),
             ])
 
 jar_library(name='protobuf-2.4.1',
             jars = [
-              jar(org='com.google.protobuf', name='protobuf-java', rev='2.4.1').with_sources()
+              jar(org='com.google.protobuf', name='protobuf-java', rev='2.4.1'),
             ]
            )
 
@@ -111,20 +109,20 @@ jar_library(name='protobuf-test-import',
 
 jar_library(name='scala-compiler',
             jars = [
-              jar(org='org.scala-lang', name='scala-compiler', rev='2.9.3').with_sources()
+              jar(org='org.scala-lang', name='scala-compiler', rev='2.9.3'),
             ]
            )
 
 jar_library(name='scala-library',
             jars = [
-              jar(org='org.scala-lang', name='scala-library', rev='2.9.3').with_sources()
+              jar(org='org.scala-lang', name='scala-library', rev='2.9.3'),
             ]
            )
 
 jar_library(name='scrooge-core',
             jars = [
               # used by scrooge-generator in BUILD.tools:scrooge-gen
-              jar(org='com.twitter', name='scrooge-core_2.9.2', rev='3.12.1').with_sources()
+              jar(org='com.twitter', name='scrooge-core_2.9.2', rev='3.12.1'),
             ]
           )
 
@@ -136,7 +134,7 @@ jar_library(name='shapeless',
 
 jar_library(name='slf4j-api',
             jars = [
-              jar(org='org.slf4j', name='slf4j-api', rev='1.6.1').with_sources()
+              jar(org='org.slf4j', name='slf4j-api', rev='1.6.1'),
             ]
 )
 
@@ -173,7 +171,9 @@ UTIL_REV = '6.8.1'
 
 jar_library(name='util-core',
             jars = [
-		    jar(org='com.twitter', name='util-core_2.9.2', rev=UTIL_REV).with_sources() ])
+              jar(org='com.twitter', name='util-core_2.9.2', rev=UTIL_REV),
+            ]
+           )
 
 
 ###############
@@ -185,7 +185,7 @@ jar_library(name='hamcrest-core',
 
 jar_library(name='junit',
             jars = [
-              jar(org='junit', name='junit-dep', rev='4.11').with_sources(),
+              jar(org='junit', name='junit-dep', rev='4.11'),
             ],
             dependencies = [
               ':hamcrest-core',
@@ -194,7 +194,7 @@ jar_library(name='junit',
 
 jar_library(name='specs_2.9',
             jars = [
-              jar(org='org.scala-tools.testing', name='specs_2.9.3', rev='1.6.9')
+              jar(org='org.scala-tools.testing', name='specs_2.9.3', rev='1.6.9'),
             ]
            )
 

--- a/BUILD
+++ b/BUILD
@@ -12,12 +12,12 @@ source_root('tests/python', page, python_library, python_tests, python_test_suit
 
 # Projects used by tests to exercise pants functionality
 source_root('testprojects/src/antlr', page, java_antlr_library, python_antlr_library)
-source_root('testprojects/src/java', annotation_processor, jvm_binary, java_library, page)
+source_root('testprojects/src/java', annotation_processor, jvm_binary, java_library, jar_library, page)
 source_root('testprojects/src/protobuf', java_protobuf_library, jar_library, page)
 source_root('testprojects/src/scala', jvm_binary, page, scala_library, benchmark)
 source_root('testprojects/src/thrift', java_thrift_library, page, python_thrift_library)
 
-source_root('testprojects/tests/java', java_library, junit_tests, page)
+source_root('testprojects/tests/java', java_library, junit_tests, page, jar_library)
 source_root('testprojects/tests/python', page, python_library, python_tests, python_test_suite, python_binary, resources)
 source_root('testprojects/tests/resources', page, resources)
 source_root('testprojects/tests/scala', page, junit_tests, scala_library, scala_specs)

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -15,7 +15,7 @@ import pkgutil
 import threading
 import xml
 
-from twitter.common.collections import OrderedDict, OrderedSet
+from twitter.common.collections import OrderedDict, OrderedSet, maybe_list
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -225,7 +225,7 @@ class IvyUtils(object):
         module=name,
         version='latest.integration',
         publications=None,
-        configurations=confs,
+        configurations=maybe_list(confs), # Mustache doesn't like sets.
         dependencies=dependencies,
         excludes=excludes,
         overrides=overrides)
@@ -316,7 +316,7 @@ class IvyUtils(object):
         excludes=[cls._generate_exclude_template(exclude) for exclude in jar.excludes],
         transitive=jar.transitive,
         artifacts=jar.artifacts,
-        configurations=[conf for conf in jar.configurations if conf in confs])
+        configurations=maybe_list(confs))
     return template
 
   ivy_lock = threading.RLock()
@@ -353,7 +353,6 @@ class IvyUtils(object):
     confs_to_resolve = confs or ['default']
     ivy_args.append('-confs')
     ivy_args.extend(confs_to_resolve)
-
     ivy_args.extend(args)
 
     with IvyUtils.ivy_lock:

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -9,8 +9,8 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.build_manual import manual
 from pants.backend.jvm.targets.exclude import Exclude
+from pants.base.build_manual import manual
 
 
 class Artifact(object):
@@ -49,6 +49,7 @@ class Artifact(object):
 
 class JarDependency(object):
   """A pre-built Maven repository dependency."""
+
 
   _HASH_KEYS = (
     'org',
@@ -105,12 +106,6 @@ class JarDependency(object):
     self.withDocs = self.with_docs
 
   @property
-  def configurations(self):
-    confs = OrderedSet(self._configurations)
-    confs.update(artifact.conf for artifact in self.artifacts if artifact.conf)
-    return list(confs)
-
-  @property
   def classifier(self):
     """Returns the maven classifier for this jar dependency.
 
@@ -143,17 +138,20 @@ class JarDependency(object):
 
   @manual.builddict()
   def with_sources(self):
-    """This requests the artifact have its source jar fetched.
+    """This historically requested the artifact have its source jar fetched.
     (This implies there *is* a source jar to fetch.) Used in contexts
-    that can use source jars (as of 2013, just eclipse and idea goals)."""
-    self._configurations += ('sources',)
+    that can use source jars (as of 2014, just eclipse and idea goals)."""
+    print("jar dependency org={org} name={name}:  with_sources() is now a noop and is deprecated."
+          .format(org=self.org, name=self.name))
     return self
 
+  @manual.builddict()
   def with_docs(self):
-    """This requests the artifact have its javadoc jar fetched.
+    """This historically requested the artifact have its javadoc jar fetched.
     (This implies there *is* a javadoc jar to fetch.) Used in contexts
     that can use source jars (as of 2014, just eclipse and idea goals)."""
-    self._configurations += ('javadoc',)
+    print("jar dependency org={org} name={name}:  with_docs() is now a noop and is deprecated."
+          .format(org=self.org, name=self.name))
     return self
 
   @manual.builddict()

--- a/src/python/pants/backend/jvm/tasks/ide_gen.py
+++ b/src/python/pants/backend/jvm/tasks/ide_gen.py
@@ -141,8 +141,13 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
       round_manager.require('java')
     if not self.skip_scala:
       round_manager.require('scala')
+    # TODO(Garrett Malmquist): Clean this up by using IvyUtils in the caller, passing it confs as
+    # the parameter. See John's comments on RB 716.
     round_manager.require_data('ivy_jar_products')
     round_manager.require('jar_dependencies')
+    round_manager.require('jar_map_default')
+    round_manager.require('jar_map_sources')
+    round_manager.require('jar_map_javadoc')
 
   def _prepare_project(self):
     targets, self._project = self.configure_project(
@@ -250,26 +255,26 @@ class IdeGen(JvmBinaryTask, JvmToolTaskMixin):
 
           self._project.internal_jars.add(ClasspathEntry(cp_jar, source_jar=cp_source_jar))
 
-  def _get_jar_paths(self, jars=None, confs=None):
+  def _get_jar_paths(self, confs=None):
     """Returns a list of dicts containing the paths of various jar file resources.
 
     Keys include 'default' (normal jar path), 'sources' (path to source jar), and 'javadoc'
     (path to doc jar). None of them are guaranteed to be present, but 'sources' and 'javadoc'
     will never be present if 'default' isn't.
 
-    :param jardeps: JarDependency objects to resolve paths for
     :param confs: List of key types to return (eg ['default', 'sources']). Just returns 'default' if
       left unspecified.
     """
-    # TODO(Garrett Malmquist): Get mapping working for source and javadoc jars.
     ivy_products = self.context.products.get_data('ivy_jar_products')
-    classpath_maps = []
-    for info_group in ivy_products.values():
+    classpath_maps = defaultdict(dict)
+    for conf, info_group in ivy_products.items():
+      if conf not in confs:
+        continue # We don't care about it.
       for info in info_group:
         for module in info.modules_by_ref.values():
           for artifact in module.artifacts:
-            classpath_maps.append({'default': artifact.path})
-    return classpath_maps
+            classpath_maps[(module.ref.org, module.ref.name, module.ref.rev,)][conf] = artifact.path
+    return classpath_maps.values()
 
   def map_external_jars(self):
     external_jar_dir = os.path.join(self.gen_project_workdir, 'external-libs')
@@ -516,6 +521,7 @@ class Project(object):
           base = target.target_base
           configure_source_sets(base, relative_sources(target), is_test=test)
 
+        # TODO(Garrett Malmquist): This is dead code, and should be redone/reintegrated.
         # Other BUILD files may specify sources in the same directory as this target. Those BUILD
         # files might be in parent directories (globs('a/b/*.java')) or even children directories if
         # this target globs children as well.  Gather all these candidate BUILD files to test for

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -67,7 +67,8 @@ class IvyTaskMixin(object):
                   executor=None,
                   silent=False,
                   workunit_name=None,
-                  workunit_labels=None):
+                  workunit_labels=None,
+                  confs=None):
     if not targets:
       return ([], set())
 
@@ -115,7 +116,8 @@ class IvyTaskMixin(object):
               jvm_options=self.get_options().jvm_options,
               ivy=ivy,
               workunit_name='ivy',
-              workunit_factory=self.context.new_workunit)
+              workunit_factory=self.context.new_workunit,
+              confs=confs)
 
         if workunit_name:
           with self.context.new_workunit(name=workunit_name, labels=workunit_labels or []):

--- a/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
+++ b/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
@@ -58,13 +58,18 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       <conf name="{{.}}" mapped="{{.}}"/>
       {{/configurations}}
       {{#artifacts}}
+      <!--
+      The conf = ... in the block below is a hack around a bug John described on RB 716. The bug has
+      something to do with artifacts not being fetched unless .with_artifacts is called multiple
+      times.
+      -->
       <artifact
         {{#name}}name="{{.}}"{{/name}}
         {{#ext}}ext="{{.}}"{{/ext}}
         {{#url}}url="{{.}}"{{/url}}
         {{#type_}}type="{{.}}"{{/type_}}
         {{#classifier}}m:classifier="{{.}}"{{/classifier}}
-        {{#conf}}conf="{{.}}"{{/conf}}
+        conf="{{#configurations}}{{.}}->{{.}};{{/configurations}}"
       />
       {{/artifacts}}
       {{#excludes}}

--- a/testprojects/src/java/com/pants/testproject/missing_sources/BUILD
+++ b/testprojects/src/java/com/pants/testproject/missing_sources/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(name='missing_sources',
+  dependencies=[':ant'],
+)
+
+jar_library(name='ant',
+  jars=[
+    jar(org='ant', name='ant', rev='1.6.4')
+  ],
+)

--- a/tests/python/pants_test/base/test_payload_field.py
+++ b/tests/python/pants_test/base/test_payload_field.py
@@ -98,48 +98,19 @@ class PayloadTest(BaseTest):
       JarsField([jar2]).fingerprint(),
     )
 
-  def test_jars_field_configuration_order(self):
-    """Like artifacts, JarDependencies throw away order information about their configurations.
-
-    But only in the hash key, the internal representation is in the order inserted.
+  def test_deprecated_jars_field_methods(self):
+    """with_sources() and with_docs() are now no-ops.  This test shows they don't affect
+    fingerprinting.
     """
-    jar1 = (JarDependency('com', 'foo', '1.0.0')
-              .with_docs()
-              .with_sources())
+    jar1 = (JarDependency('com', 'foo', '1.0.0'))
     jar2 = (JarDependency('com', 'foo', '1.0.0')
-              .with_sources()
-              .with_docs())
+            .with_sources()
+            .with_docs())
 
     self.assertEqual(
       JarsField([jar1]).fingerprint(),
       JarsField([jar2]).fingerprint(),
-    )
-
-  def test_jars_field_configuration(self):
-    jar1 = (JarDependency('com', 'foo', '1.0.0')
-              .with_sources())
-    jar2 = (JarDependency('com', 'foo', '1.0.0')
-              .with_docs())
-
-    self.assertNotEqual(
-      JarsField([jar1]).fingerprint(),
-      JarsField([jar2]).fingerprint(),
-    )
-
-  def test_jars_field_artifact_configuration(self):
-    """Like artifacts, JarDependencies throw away order information about their configurations.
-
-    But only in the hash key, the internal representation is in the order inserted.
-    """
-    jar1 = (JarDependency('com', 'foo', '1.0.0')
-              .with_sources())
-    jar2 = (JarDependency('com', 'foo', '1.0.0')
-              .with_docs())
-
-    self.assertNotEqual(
-      JarsField([jar1]).fingerprint(),
-      JarsField([jar2]).fingerprint(),
-    )
+      )
 
   def test_jars_field_apidocs(self):
     """apidocs are not properly rolled into the cache key right now.  Is this intentional?"""

--- a/tests/python/pants_test/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/tasks/test_idea_integration.py
@@ -7,6 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import os
 import xml.dom.minidom as minidom
+import re
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
@@ -24,7 +25,6 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
     :param check_func: method to call back with the directory where project files are written.
     :param dict config: pants.ini configuration parameters
     """
-
     project_dir = os.path.join(get_buildroot(), project_dir)
     if not os.path.exists(project_dir):
       os.makedirs(project_dir)
@@ -52,6 +52,7 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
       self.assertTrue(all(os.path.exists(os.path.join(workdir, name))
                           for name in expected_files),
                       msg="Failed to exec ./pants {all_flags}".format(all_flags=all_flags))
+
       if check_func:
         check_func(workdir)
 
@@ -124,8 +125,75 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
   def test_idea_on_all_examples(self):
     self._idea_test(['examples/src/java/com/pants/examples::'])
 
+  def _check_javadoc_and_sources(self, path, library_name):
+    """
+    :param path: path to the idea project directory
+    :param library_name: name of the library to check for (e.g. guava)
+    """
+    def _get_module_library_orderEntry(dom):
+      module = dom.getElementsByTagName('module')[0]
+      components = module.getElementsByTagName('component')
+      for component in components:
+        if component.getAttribute('name') == 'NewModuleRootManager':
+          for orderEntry in component.getElementsByTagName('orderEntry'):
+            if orderEntry.getAttribute('type') == 'module-library':
+              for library in orderEntry.getElementsByTagName('library'):
+                if library.getAttribute('name') == 'external':
+                  return library
+      return None
+
+    iml_file = os.path.join(path, 'project.iml')
+    self.assertTrue(os.path.exists(iml_file))
+    dom = minidom.parse(iml_file)
+    libraryElement = _get_module_library_orderEntry(dom)
+    sources = libraryElement.getElementsByTagName('SOURCES')[0]
+    sources_found = False
+    roots = sources.getElementsByTagName('root')
+    for root in roots:
+      url = root.getAttribute('url')
+      if re.match(r'.*\bexternal-libsources\b.*{library_name}\b.*-sources\.jar\b.*$'
+                      .format(library_name=library_name), url):
+        sources_found = True
+        break
+    self.assertTrue(sources_found)
+
+    javadoc = libraryElement.getElementsByTagName('JAVADOC')[0]
+    javadoc_found = False
+    for root in javadoc.getElementsByTagName('root'):
+      url = root.getAttribute('url')
+      if re.match(r'.*\bexternal-libjavadoc\b.*{library_name}\b.*-javadoc\.jar\b.*$'
+                      .format(library_name=library_name), url):
+        javadoc_found = True
+        break
+    self.assertTrue(javadoc_found)
+
+  # NOTE(Garrett Malmquist): The test below assumes that the annotation example's dependency on
+  # guava will never be removed. If it ever is, these tests will need to be changed to check for a
+  # different 3rdparty jar library.
+  # Testing for:
+  # <orderEntry type="module-library">
+  #  <library name="external">
+  #    ...
+  #   <JAVADOC>
+  #    <root url="jar://$MODULE_DIR$/external-libjavadoc/guava-16.0-javadoc.jar!/" />
+  #   </JAVADOC>
+  #   <SOURCES>
+  #     <root url="jar://$MODULE_DIR$/external-libsources/guava-16.0-sources.jar!/" />
+  #   </SOURCES>
+  #  </library>
+  # </orderEntry>
+  def test_idea_external_javadoc_and_sources(self):
+    def do_check(path):
+      self._check_javadoc_and_sources(path, 'guava')
+    self._idea_test(['examples/src/java/com/pants/examples/annotation::'],
+                    check_func=do_check)
+
   def test_idea_on_java_sources(self):
     self._idea_test(['testprojects/src/scala/com/pants/testproject/javasources::'])
+
+  def test_idea_missing_sources(self):
+    """Test what happens if we try to fetch sources from a jar that doesn't have any."""
+    self._idea_test(['testprojects/src/java/com/pants/testproject/missing_sources'])
 
   def test_idea_on_thriftdeptest(self):
     self._idea_test(['testprojects/src/java/com/pants/testproject/thriftdeptest::'])


### PR DESCRIPTION
This involved a fair amount of finagling with conf variables spread across ivy_* and ide files,
and some changes to the ivy mustache. The mechanism by which confs are currently passed around
does not seem very robust. The whole system would probably benefit from some refactoring to
abstract away ivy's inner workings and streamline generic mapping settings; it would be nice to
have an abstract interface for mapping jar files. This could  also make it easier to deal with
failing downloads, parallelization, or using a different jar mapping tool, but all that can
wait for an entirely different review.

Also cleaned up some style issues that got missed in the last patch for the idea goal.

Don't do extra work if no one wants sources.