### PR TITLE
Kill leftover imports handling from early efforts.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -242,7 +242,6 @@ class ProtobufGen(CodeGen):
                                       derived_from=target,
                                       sources=genfiles,
                                       dependencies=self.pythondeps)
-    tgt.jar_dependencies.update(target.imports)
     for dependee in dependees:
       dependee.inject_dependency(tgt.address)
     return tgt


### PR DESCRIPTION
PythonLibrary targets have never had jar_dependencies so
this was likely a broken code-path since inception in
https://rbcommons.com/s/twitter/r/592/

https://rbcommons.com/s/twitter/r/1614/