### PR TITLE
java_thrift_library: default settings live in .ini

### DIFF
--- a/src/python/pants/backend/codegen/targets/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/java_thrift_library.py
@@ -54,10 +54,13 @@ class JavaThriftLibrary(JvmTarget):
                thrift_linter_strict=None,
                **kwargs):
     """
-    :param compiler: The compiler used to compile the thrift files; default is 'thrift'
-      (The apache thrift compiler).
-    :param language: The language used to generate the output files; defaults to 'java'.
-    :param rpc_style: An optional rpc style to generate service stubs with.
+    :param compiler: The compiler used to compile the thrift files. Default is the ``.ini`` file's
+      ``[java-thrift-library] compiler`` setting, if any, else 'thrift' (the apache thrift
+      compiler).
+    :param language: The language used to generate the output files. Defaults to the ``.ini``
+      file's ``[java-thrift-library] language`` setting, if any, else 'java'.
+    :param rpc_style: An optional rpc style to generate service stubs with. Default is the
+       ``.ini`` file's ``[java-thrift-library] rpc_style`` setting, if any, else 'sync'.
     :param namespace_map: An optional dictionary of namespaces to remap {old: new}
     :param thrift_linter_strict: If True, fail if thrift linter produces any warnings.
     """


### PR DESCRIPTION
no way would this simple docstring change break anything. no way, Travis-CI