### PR TITLE
bump virtualenv version to 12.0.5

### DIFF
--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Wrapper for self-bootstrapping virtualenv
 set -e
-VIRTUALENV_VERSION=1.11.6
+VIRTUALENV_VERSION=12.0.5
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.python.org/packages/source/v/virtualenv}
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)


### PR DESCRIPTION
1.11.6 bundles a version of pip that has a bad implementation of uninstall_rollback which causes problems with certain types of resolvable dependency conflicts. Attempting to create the venv fails in a place where it isn't possible to fix easily because the file containing the bug is wiped out during venv creation.

This is the cause of:

  Exception:
  Traceback (most recent call last):
    File "~/oss/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pip/basecommand.py", line 122, in main
      status = self.run(options, args)
    File "~/oss/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pip/commands/install.py", line 283, in run
      requirement_set.install(install_options, global_options, root=options.root_path)
    File "~/oss/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pip/req.py", line 1439, in install
      requirement.rollback_uninstall()
    File "~/oss/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pip/req.py", line 603, in rollback_uninstall
      self.uninstalled.rollback()
    File "~/oss/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pip/req.py", line 1855, in rollback
      pth.rollback()
  AttributeError: 'str' object has no attribute 'rollback'

  Storing debug log for failure in ~/.pip/pip.log

  Failed to install requirements from ~/oss/pants/3rdparty/python/requirements.txt.

Testing Done:
ran ./pants with PANTS_DEV=1 with this change and saw venv creation succeed

Reviewed at https://rbcommons.com/s/twitter/r/1621/