### PR TITLE
Trigger CI: Some refactoring of IvyUtils.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -16,7 +16,7 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 
 
-class BootstrapJvmTools(Task, IvyTaskMixin):
+class BootstrapJvmTools(IvyTaskMixin, Task):
 
   @classmethod
   def product_types(cls):

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -5,21 +5,8 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import os
-
 from pants.backend.jvm.ivy_utils import IvyUtils
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
-
-
-class ImportsUtil(IvyUtils):
-  def __init__(self, context):
-    super(ImportsUtil, self).__init__(context.config, context.log)
-
-  def is_mappable_artifact(self, org, name, path):
-    return path.endswith('.jar') and super(ImportsUtil, self).is_mappable_artifact(org, name, path)
-
-  def mapto_dir(self):
-    return os.path.join(self._workdir, 'mapped-imports')
 
 
 class IvyImports(NailgunTask):
@@ -52,7 +39,7 @@ class IvyImports(NailgunTask):
 
     resolve_for = self.context.targets(lambda t: t.has_label('has_imports'))
     if resolve_for:
-      imports_util = ImportsUtil(self.context)
+      ivy_utils = IvyUtils(self.context.config, self.context.log)
       imports_map = self.context.products.get('ivy_imports')
       executor = self.create_java_executor()
       for target in resolve_for:
@@ -60,6 +47,6 @@ class IvyImports(NailgunTask):
         self.context.log.info('Mapping import jars for {target}: \n  {jars}'.format(
             target=nice_target_name(target),
             jars='\n  '.join(self._str_jar(s) for s in jars)))
-        imports_util.mapjars(imports_map, target, executor,
-                             workunit_factory=self.context.new_workunit,
-                             jars=jars)
+        ivy_utils.mapjars(imports_map, target, executor,
+                          workunit_factory=self.context.new_workunit,
+                          jars=jars)

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -23,7 +23,7 @@ from pants.ivy.bootstrapper import Bootstrapper
 from pants.util.dirutil import safe_mkdir
 
 
-class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
+class IvyResolve(IvyTaskMixin, NailgunTask, JvmToolTaskMixin):
   _CONFIG_SECTION = 'ivy-resolve'
 
   @classmethod
@@ -65,8 +65,6 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
     self._open = self.get_options().open
     self._report = self._open or self.get_options().report
 
-    self._ivy_utils = IvyUtils(config=self.context.config, log=self.context.log)
-
     # Typically this should be a local cache only, since classpaths aren't portable.
     self.setup_artifact_cache()
 
@@ -94,7 +92,6 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
     ivy_classpath, relevant_targets = self.ivy_resolve(
       targets,
       executor=executor,
-      symlink_ivyxml=True,
       workunit_name='ivy-resolve',
     )
 
@@ -113,10 +110,7 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
     if create_jardeps_for:
       genmap = self.context.products.get('jar_dependencies')
       for target in filter(create_jardeps_for, targets):
-        # TODO: Add mapjars to IvyTaskMixin? Or get rid of the mixin? It's weird that we use
-        # self.ivy_resolve for some ivy invocations but this for others.
-        self._ivy_utils.mapjars(genmap, target, executor=executor,
-                                workunit_factory=self.context.new_workunit)
+        self.mapjars(genmap, target, executor=executor, workunit_factory=self.context.new_workunit)
 
   def check_artifact_cache_for(self, invalidation_check):
     # Ivy resolution is an output dependent on the entire target set, and is not divisible

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -6,7 +6,6 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 from collections import defaultdict
-from hashlib import sha1
 import logging
 import os
 import shutil
@@ -20,6 +19,7 @@ from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.java.executor import Executor
+from pants.util.dirutil import safe_mkdir
 
 logger = logging.getLogger(__name__)
 
@@ -51,13 +51,18 @@ class IvyResolveFingerprintStrategy(FingerprintStrategy):
 
 
 class IvyTaskMixin(object):
+  @classmethod
+  def register_options(cls, register):
+    super(IvyTaskMixin, cls).register_options(register)
+    register('--jvm-options', action='append', metavar='<option>...',
+             help='Run Ivy with these extra jvm options.')
+
   # Protect writes to the global map of jar path -> symlinks to that jar.
   symlink_map_lock = threading.Lock()
 
   def ivy_resolve(self,
                   targets,
                   executor=None,
-                  symlink_ivyxml=False,
                   silent=False,
                   workunit_name=None,
                   workunit_labels=None):
@@ -75,7 +80,6 @@ class IvyTaskMixin(object):
                                    bootstrap_workunit_factory=self.context.new_workunit)
 
     ivy_workdir = os.path.join(self.context.options.for_global_scope().pants_workdir, 'ivy')
-    ivy_utils = IvyUtils(config=self.context.config, log=self.context.log)
 
     fingerprint_strategy = IvyResolveFingerprintStrategy()
 
@@ -102,14 +106,14 @@ class IvyTaskMixin(object):
         args = ['-cachepath', raw_target_classpath_file_tmp]
 
         def exec_ivy():
-          ivy_utils.exec_ivy(
+          IvyUtils.exec_ivy(
               target_workdir=target_workdir,
               targets=global_vts.targets,
               args=args,
+              jvm_options=self.get_options().jvm_options,
               ivy=ivy,
               workunit_name='ivy',
-              workunit_factory=self.context.new_workunit,
-              symlink_ivyxml=symlink_ivyxml)
+              workunit_factory=self.context.new_workunit)
 
         if workunit_name:
           with self.context.new_workunit(name=workunit_name, labels=workunit_labels or []):
@@ -139,4 +143,56 @@ class IvyTaskMixin(object):
 
     with IvyUtils.cachepath(target_classpath_file) as classpath:
       stripped_classpath = [path.strip() for path in classpath]
-      return ([path for path in stripped_classpath if ivy_utils.is_classpath_artifact(path)], global_vts.targets)
+      return ([path for path in stripped_classpath if self.is_classpath_artifact(path)], global_vts.targets)
+
+  @staticmethod
+  def is_classpath_artifact(path):
+    """Subclasses can override to determine whether a given artifact represents a classpath
+    artifact."""
+    return path.endswith('.jar') or path.endswith('.war')
+
+  def mapjars(self, genmap, target, executor, workunit_factory=None, jars=None):
+    """Resolves jars for the target and stores their locations in genmap.
+
+    :param genmap: The jar_dependencies ProductMapping entry for the required products.
+    :param target: The target whose jar dependencies are being retrieved.
+    :param jars: If specified, resolves the given jars rather than
+    :type jars: List of :class:`pants.backend.jvm.targets.jar_dependency.JarDependency` (jar())
+      objects.
+    """
+    mapdir = os.path.join(self.workdir, 'mapped-jars', target.id)
+    safe_mkdir(mapdir, clean=True)
+    ivyargs = [
+      '-retrieve', '%s/[organisation]/[artifact]/[conf]/'
+                   '[organisation]-[artifact]-[revision](-[classifier]).[ext]' % mapdir,
+      '-symlink',
+      ]
+    IvyUtils.exec_ivy(mapdir,
+                      [target],
+                      jvm_options=self.get_options().jvm_options,
+                      args=ivyargs,
+                      confs=target.payload.configurations,
+                      ivy=Bootstrapper.default_ivy(executor),
+                      workunit_factory=workunit_factory,
+                      workunit_name='map-jars',
+                      jars=jars)
+
+    for org in os.listdir(mapdir):
+      orgdir = os.path.join(mapdir, org)
+      if os.path.isdir(orgdir):
+        for name in os.listdir(orgdir):
+          artifactdir = os.path.join(orgdir, name)
+          if os.path.isdir(artifactdir):
+            for conf in os.listdir(artifactdir):
+              confdir = os.path.join(artifactdir, conf)
+              for f in os.listdir(confdir):
+                if self.is_classpath_artifact(f):
+                  # TODO(John Sirois): kill the org and (org, name) exclude mappings in favor of a
+                  # conf whitelist
+                  genmap.add(org, confdir).append(f)
+                  genmap.add((org, name), confdir).append(f)
+
+                  genmap.add(target, confdir).append(f)
+                  genmap.add((target, conf), confdir).append(f)
+                  genmap.add((org, name, conf), confdir).append(f)
+

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -47,6 +47,7 @@ migrations = {
   ('junit-run', 'jvm_args'): ('test.junit', 'jvm_options'),
   ('scala-repl', 'jvm_args'): ('repl.scala', 'jvm_options'),
   ('scrooge-gen', 'jvm_args'): ('scrooge-gen', 'jvm_options'),
+  ('ivy-resolve', 'jvm_args'): ('resolve.ivy', 'jvm_options'),
 
   ('jvm-run', 'confs'): ('run.jvm', 'confs'),
   ('benchmark-run', 'confs'): ('bench', 'confs'),

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -27,6 +27,13 @@ class JvmToolTaskTestBase(TaskTestBase):
     real_config = self.config()
     super(JvmToolTaskTestBase, self).setUp()
 
+    # Use a synthetic subclass for bootstrapping within the test, to isolate this from
+    # any bootstrapping the pants run executing the test might need.
+    self.bootstrap_task_type, bootstrap_scope = self.synthesize_task_subtype(BootstrapJvmTools)
+    # TODO: We assume that no added jvm_options are necessary to bootstrap successfully in a test.
+    # This may not be true forever.  But getting the 'real' value here is tricky, as we have no
+    # access to the enclosing pants run's options here.
+    self.set_options_for_scope(bootstrap_scope, jvm_options=[])
     JvmToolTaskMixin.reset_registered_tools()
 
     def link_or_copy(src, dest):
@@ -85,7 +92,8 @@ class JvmToolTaskTestBase(TaskTestBase):
     # instead it should probably just be using an Engine.
     task = self.create_task(context, workdir)
     task.invalidate()
-    BootstrapJvmTools(context, workdir).execute()
+    bootstrap_workdir = os.path.join(workdir, '_bootstrap_jvm_tools')
+    self.bootstrap_task_type(context, bootstrap_workdir).execute()
     return task
 
   def execute(self, context):

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -27,14 +27,22 @@ class TaskTestBase(BaseTest):
 
   def setUp(self):
     super(TaskTestBase, self).setUp()
+    self._testing_task_type, self.options_scope = self.synthesize_task_subtype(self.task_type())
 
-    # Create a synthetic subclass of the task type, with a unique scope, to ensure
-    # proper test isolation (unfortunately we currently rely on class-level state in Task.)
+  def synthesize_task_subtype(self, task_type):
+    """Creates a synthetic subclass of the task type.
+
+    The returned type has a unique options scope, to ensure proper test isolation (unfortunately
+    we currently rely on class-level state in Task.)
+
     # TODO: Get rid of this once we re-do the Task lifecycle.
-    self.options_scope = str(uuid.uuid4())
-    subclass_name = b'test_{0}_{1}'.format(self.task_type().__name__, self.options_scope)
-    self._testing_task_type = type(subclass_name, (self.task_type(),),
-                                   {'options_scope': self.options_scope})
+
+    :param task_type: The task type to subtype.
+    :return: A pair (type, options_scope)
+    """
+    options_scope = uuid.uuid4().hex
+    subclass_name = b'test_{0}_{1}'.format(task_type.__name__, options_scope)
+    return type(subclass_name, (task_type,), {'options_scope': options_scope}), options_scope
 
   def set_options(self, **kwargs):
     self.set_options_for_scope(self.options_scope, **kwargs)

--- a/tests/python/pants_test/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/tasks/test_ivy_utils.py
@@ -48,13 +48,11 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
 
     self.simple = self.target('src/java/targets:simple')
     context = self.context()
-    self.ivy_utils = IvyUtils(context.config, logging.Logger('test'))
 
   def test_force_override(self):
     jars = list(self.simple.payload.jars)
     with temporary_file_path() as ivyxml:
-      self.ivy_utils._generate_ivy([self.simple], jars=jars, excludes=[], ivyxml=ivyxml,
-                                   confs=['default'])
+      IvyUtils.generate_ivy([self.simple], jars=jars, excludes=[], ivyxml=ivyxml, confs=['default'])
 
       doc = ET.parse(ivyxml).getroot()
 
@@ -91,16 +89,16 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
     v2.rev = "2"
 
     # If neither version is forced, use the latest version
-    self.assertIs(v2, self.ivy_utils._resolve_conflict(v1, v2))
-    self.assertIs(v2, self.ivy_utils._resolve_conflict(v2, v1))
+    self.assertIs(v2, IvyUtils._resolve_conflict(v1, v2))
+    self.assertIs(v2, IvyUtils._resolve_conflict(v2, v1))
 
     # If an earlier version is forced, use the forced version
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v1_force, v2))
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v2, v1_force))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v1_force, v2))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v2, v1_force))
 
     # If the same version is forced, use the forced version
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v1, v1_force))
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v1_force, v1))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v1, v1_force))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v1_force, v1))
 
   def test_does_not_visit_diamond_dep_twice(self):
     ivy_info = self.parse_ivy_report('tests/python/pants_test/tasks/ivy_utils_resources/report_with_diamond.xml')


### PR DESCRIPTION
- IvyUtils is now just a repository of classmethods, and is not instantiated.
  This is a better idiom for something called "Utils", and most of the
  instance methods didn't need to be anyway.
- The relevant dynamic code has been moved to IvyTaskMixin, where it can
  directly use the task's context, without dipping directly into pants.ini.
- The ImportUtils subclass is no longer needed: The differentiation of
  workdirs now comes simply because IvyResolve and IvyImports are two
  distinct tasks, with two distinct workdirs. IvyUtils no longer reads
  its workdir out of config, but uses the task's workdir.
- The mixin now registers a --jvm-options option, to allow its subtypes
  (currently IvyResolve and BootstrapJvmTools) to tweak the JVM when
  running Ivy. To get this registration to work, the mixin was moved
  before the Task superclass in the mro.
- Got rid of the ivy.xml symlink hack.

The purpose, and result, of these changes, was to remove some direct
accesses to pants.ini. However this change also has the nice effect of
getting rid of the weird IvyUtils/IvyTaskMixin dichotomy and making
things more uniform. Ivy code is now quite a bit easier to reason about.