### PR TITLE
[Trigger CI] Some refactoring of IvyUtils.

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -7,13 +7,15 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
+import copy
 import errno
+import logging
 import os
 import pkgutil
 import threading
 import xml
 
-from twitter.common.collections import OrderedDict, OrderedSet, maybe_list
+from twitter.common.collections import OrderedDict, OrderedSet
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -29,6 +31,9 @@ from pants.util.dirutil import safe_mkdir, safe_open
 IvyModuleRef = namedtuple('IvyModuleRef', ['org', 'name', 'rev'])
 IvyArtifact = namedtuple('IvyArtifact', ['path', 'classifier'])
 IvyModule = namedtuple('IvyModule', ['ref', 'artifacts', 'callers'])
+
+
+logger = logging.getLogger(__name__)
 
 
 class IvyInfo(object):
@@ -96,17 +101,6 @@ class IvyUtils(object):
   IVY_TEMPLATE_PACKAGE_NAME = __name__
   IVY_TEMPLATE_PATH = os.path.join('tasks', 'templates', 'ivy_resolve', 'ivy.mustache')
 
-  def __init__(self, config, log):
-    self._log = log
-
-    self._transitive = config.getbool('ivy-resolve', 'transitive', default=True)
-    self._args = config.getlist('ivy-resolve', 'args', default=[])
-    self._jvm_options = config.getlist('ivy-resolve', 'jvm_args', default=[])
-    # Disable cache in File.getCanonicalPath(), makes Ivy work with -symlink option properly on ng.
-    self._jvm_options.append('-Dsun.io.useCanonCaches=false')
-    self._workdir = os.path.join(config.getdefault('pants_workdir'), 'ivy')
-    self._template_path = self.IVY_TEMPLATE_PATH
-
   @staticmethod
   def _generate_exclude_template(exclude):
     return TemplateData(org=exclude.org, name=exclude.name)
@@ -114,18 +108,6 @@ class IvyUtils(object):
   @staticmethod
   def _generate_override_template(jar):
     return TemplateData(org=jar.org, module=jar.module, version=jar.version)
-
-  @staticmethod
-  def is_classpath_artifact(path):
-    """Subclasses can override to determine whether a given artifact represents a classpath
-    artifact."""
-    return path.endswith('.jar') or path.endswith('.war')
-
-  @classmethod
-  def is_mappable_artifact(cls, org, name, path):
-    """Subclasses can override to determine whether a given artifact represents a mappable
-    artifact."""
-    return cls.is_classpath_artifact(path)
 
   @staticmethod
   @contextmanager
@@ -219,21 +201,9 @@ class IvyUtils(object):
         ret.add_module(IvyModule(IvyModuleRef(org, name, rev), artifacts, callers))
     return ret
 
-  def _extract_classpathdeps(self, targets):
-    """Subclasses can override to filter out a set of targets that should be resolved for classpath
-    dependencies.
-    """
-    def is_classpath(target):
-      return (target.is_jar or
-              target.is_internal and any(jar for jar in target.jar_dependencies if jar.rev))
-
-    classpath_deps = OrderedSet()
-    for target in targets:
-      classpath_deps.update(t for t in target.resolve() if t.is_concrete and is_classpath(t))
-    return classpath_deps
-
-  def _generate_ivy(self, targets, jars, excludes, ivyxml, confs):
-    org, name = self.identify(targets)
+  @classmethod
+  def generate_ivy(cls, targets, jars, excludes, ivyxml, confs):
+    org, name = cls.identify(targets)
 
     # As it turns out force is not transitive - it only works for dependencies pants knows about
     # directly (declared in BUILD files - present in generated ivy.xml). The user-level ivy docs
@@ -245,10 +215,10 @@ class IvyUtils(object):
     # [2] https://svn.apache.org/repos/asf/ant/ivy/core/branches/2.3.0/
     #     src/java/org/apache/ivy/core/module/descriptor/DependencyDescriptor.java
     # [3] http://ant.apache.org/ivy/history/2.3.0/ivyfile/override.html
-    dependencies = [self._generate_jar_template(jar, confs) for jar in jars]
-    overrides = [self._generate_override_template(dep) for dep in dependencies if dep.force]
+    dependencies = [cls._generate_jar_template(jar, confs) for jar in jars]
+    overrides = [cls._generate_override_template(dep) for dep in dependencies if dep.force]
 
-    excludes = [self._generate_exclude_template(exclude) for exclude in excludes]
+    excludes = [cls._generate_exclude_template(exclude) for exclude in excludes]
 
     template_data = TemplateData(
         org=org,
@@ -262,12 +232,13 @@ class IvyUtils(object):
 
     safe_mkdir(os.path.dirname(ivyxml))
     with open(ivyxml, 'w') as output:
-      generator = Generator(pkgutil.get_data(__name__, self._template_path),
+      generator = Generator(pkgutil.get_data(__name__, cls.IVY_TEMPLATE_PATH),
                             root_dir=get_buildroot(),
                             lib=template_data)
       generator.write(output)
 
-  def _calculate_classpath(self, targets):
+  @classmethod
+  def _calculate_classpath(cls, targets):
     jars = OrderedDict()
     excludes = set()
 
@@ -278,7 +249,7 @@ class IvyUtils(object):
       coordinate = (jar.org, jar.name)
       existing = jars.get(coordinate)
       jars[coordinate] = jar if not existing else (
-        self._resolve_conflict(existing=existing, proposed=jar)
+        cls._resolve_conflict(existing=existing, proposed=jar)
       )
 
     def collect_jars(target):
@@ -296,7 +267,8 @@ class IvyUtils(object):
 
     return jars.values(), excludes
 
-  def _resolve_conflict(self, existing, proposed):
+  @staticmethod
+  def _resolve_conflict(existing, proposed):
     if proposed == existing:
       if proposed.force:
         return proposed
@@ -306,19 +278,19 @@ class IvyUtils(object):
         proposed.org, proposed.name, existing.rev, proposed.rev
       ))
     elif existing.force:
-      self._log.debug('Ignoring rev %s for %s#%s already forced to %s' % (
+      logger.debug('Ignoring rev %s for %s#%s already forced to %s' % (
         proposed.rev, proposed.org, proposed.name, existing.rev
       ))
       return existing
     elif proposed.force:
-      self._log.debug('Forcing %s#%s from %s to %s' % (
+      logger.debug('Forcing %s#%s from %s to %s' % (
         proposed.org, proposed.name, existing.rev, proposed.rev
       ))
       return proposed
     else:
       try:
         if Revision.lenient(proposed.rev) > Revision.lenient(existing.rev):
-          self._log.debug('Upgrading %s#%s from rev %s  to %s' % (
+          logger.debug('Upgrading %s#%s from rev %s  to %s' % (
             proposed.org, proposed.name, existing.rev, proposed.rev,
           ))
           return proposed
@@ -327,84 +299,42 @@ class IvyUtils(object):
       except Revision.BadRevision as e:
         raise TaskError('Failed to parse jar revision', e)
 
-  def _is_mutable(self, jar):
+  @staticmethod
+  def _is_mutable(jar):
     if jar.mutable is not None:
       return jar.mutable
     return False
 
-  def _generate_jar_template(self, jar, confs):
+  @classmethod
+  def _generate_jar_template(cls, jar, confs):
     template = TemplateData(
         org=jar.org,
         module=jar.name,
         version=jar.rev,
-        mutable=self._is_mutable(jar),
+        mutable=cls._is_mutable(jar),
         force=jar.force,
-        excludes=[self._generate_exclude_template(exclude) for exclude in jar.excludes],
+        excludes=[cls._generate_exclude_template(exclude) for exclude in jar.excludes],
         transitive=jar.transitive,
         artifacts=jar.artifacts,
         configurations=[conf for conf in jar.configurations if conf in confs])
     return template
 
-  def mapto_dir(self):
-    """Subclasses can override to establish an isolated jar mapping directory."""
-    return os.path.join(self._workdir, 'mapped-jars')
-
-  def mapjars(self, genmap, target, executor, workunit_factory=None, jars=None):
-    """Resolves jars for the target and stores their locations in genmap.
-    :param genmap: The jar_dependencies ProductMapping entry for the required products.
-    :param target: The target whose jar dependencies are being retrieved.
-    :param jars: If specified, resolves the given jars rather than
-    :type jars: List of :class:`pants.backend.jvm.targets.jar_dependency.JarDependency` (jar())
-      objects.
-    """
-    mapdir = os.path.join(self.mapto_dir(), target.id)
-    safe_mkdir(mapdir, clean=True)
-    ivyargs = [
-      '-retrieve', '%s/[organisation]/[artifact]/[conf]/'
-                   '[organisation]-[artifact]-[revision](-[classifier]).[ext]' % mapdir,
-      '-symlink',
-    ]
-    confs = target.payload.get_field_value('configurations') or []
-    self.exec_ivy(mapdir,
-                  [target],
-                  ivyargs,
-                  confs=maybe_list(confs),
-                  ivy=Bootstrapper.default_ivy(executor),
-                  workunit_factory=workunit_factory,
-                  workunit_name='map-jars',
-                  jars=jars)
-
-    for org in os.listdir(mapdir):
-      orgdir = os.path.join(mapdir, org)
-      if os.path.isdir(orgdir):
-        for name in os.listdir(orgdir):
-          artifactdir = os.path.join(orgdir, name)
-          if os.path.isdir(artifactdir):
-            for conf in os.listdir(artifactdir):
-              confdir = os.path.join(artifactdir, conf)
-              for f in os.listdir(confdir):
-                if self.is_mappable_artifact(org, name, f):
-                  # TODO(John Sirois): kill the org and (org, name) exclude mappings in favor of a
-                  # conf whitelist
-                  genmap.add(org, confdir).append(f)
-                  genmap.add((org, name), confdir).append(f)
-
-                  genmap.add(target, confdir).append(f)
-                  genmap.add((target, conf), confdir).append(f)
-                  genmap.add((org, name, conf), confdir).append(f)
-
   ivy_lock = threading.RLock()
 
-  def exec_ivy(self,
+  @classmethod
+  def exec_ivy(cls,
                target_workdir,
                targets,
+               jvm_options,
                args,
                confs=None,
                ivy=None,
                workunit_name='ivy',
                workunit_factory=None,
-               symlink_ivyxml=False,
                jars=None):
+    ivy_jvm_options = copy.copy(jvm_options) if jvm_options else []
+    # Disable cache in File.getCanonicalPath(), makes Ivy work with -symlink option properly on ng.
+    ivy_jvm_options.append('-Dsun.io.useCanonCaches=false')
 
     ivy = ivy or Bootstrapper.default_ivy()
     if not isinstance(ivy, Ivy):
@@ -414,7 +344,7 @@ class IvyUtils(object):
     ivyxml = os.path.join(target_workdir, 'ivy.xml')
 
     if not jars:
-      jars, excludes = self._calculate_classpath(targets)
+      jars, excludes = cls._calculate_classpath(targets)
     else:
       excludes = set()
 
@@ -425,31 +355,14 @@ class IvyUtils(object):
     ivy_args.extend(confs_to_resolve)
 
     ivy_args.extend(args)
-    if not self._transitive:
-      ivy_args.append('-notransitive')
-    ivy_args.extend(self._args)
-
-    def safe_link(src, dest):
-      try:
-        os.unlink(dest)
-      except OSError as e:
-        if e.errno != errno.ENOENT:
-          raise
-      os.symlink(src, dest)
 
     with IvyUtils.ivy_lock:
-      self._generate_ivy(targets, jars, excludes, ivyxml, confs_to_resolve)
-      runner = ivy.runner(jvm_options=self._jvm_options, args=ivy_args)
+      cls.generate_ivy(targets, jars, excludes, ivyxml, confs_to_resolve)
+      runner = ivy.runner(jvm_options=ivy_jvm_options, args=ivy_args)
       try:
         result = util.execute_runner(runner,
                                      workunit_factory=workunit_factory,
                                      workunit_name=workunit_name)
-
-        # Symlink to the current ivy.xml file (useful for IDEs that read it).
-        if symlink_ivyxml:
-          ivyxml_symlink = os.path.join(self._workdir, 'ivy.xml')
-          safe_link(ivyxml, ivyxml_symlink)
-
         if result != 0:
           raise TaskError('Ivy returned %d' % result)
       except runner.executor.Error as e:

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -275,6 +275,7 @@ python_library(
   name = 'ivy_task_mixin',
   sources = ['ivy_task_mixin.py'],
   dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm:ivy_utils',
     'src/python/pants/base:cache_manager',
     'src/python/pants/ivy',

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -244,14 +244,7 @@ python_library(
   sources = ['ivy_imports.py'],
   dependencies = [
     ':ivy_task_mixin',
-    ':jvm_tool_task_mixin',
     ':nailgun_task',
-    'src/python/pants/backend/jvm:ivy_utils',
-    'src/python/pants:binary_util',
-    'src/python/pants/base:cache_manager',
-    'src/python/pants/ivy',
-    'src/python/pants/fs',
-    'src/python/pants/util:dirutil',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -16,7 +16,7 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 
 
-class BootstrapJvmTools(Task, IvyTaskMixin):
+class BootstrapJvmTools(IvyTaskMixin, Task):
 
   @classmethod
   def product_types(cls):

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -5,21 +5,8 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import os
-
 from pants.backend.jvm.ivy_utils import IvyUtils
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
-
-
-class ImportsUtil(IvyUtils):
-  def __init__(self, context):
-    super(ImportsUtil, self).__init__(context.config, context.log)
-
-  def is_mappable_artifact(self, org, name, path):
-    return path.endswith('.jar') and super(ImportsUtil, self).is_mappable_artifact(org, name, path)
-
-  def mapto_dir(self):
-    return os.path.join(self._workdir, 'mapped-imports')
 
 
 class IvyImports(NailgunTask):
@@ -52,7 +39,7 @@ class IvyImports(NailgunTask):
 
     resolve_for = self.context.targets(lambda t: t.has_label('has_imports'))
     if resolve_for:
-      imports_util = ImportsUtil(self.context)
+      ivy_utils = IvyUtils(self.context.config, self.context.log)
       imports_map = self.context.products.get('ivy_imports')
       executor = self.create_java_executor()
       for target in resolve_for:
@@ -60,6 +47,6 @@ class IvyImports(NailgunTask):
         self.context.log.info('Mapping import jars for {target}: \n  {jars}'.format(
             target=nice_target_name(target),
             jars='\n  '.join(self._str_jar(s) for s in jars)))
-        imports_util.mapjars(imports_map, target, executor,
-                             workunit_factory=self.context.new_workunit,
-                             jars=jars)
+        ivy_utils.mapjars(imports_map, target, executor,
+                          workunit_factory=self.context.new_workunit,
+                          jars=jars)

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -5,11 +5,11 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from pants.backend.jvm.ivy_utils import IvyUtils
+from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 
 
-class IvyImports(NailgunTask):
+class IvyImports(IvyTaskMixin, NailgunTask):
   """Resolves a jar of .proto files for each target in the context which has imports (ie, for each
   JavaProtobufLibrary target).
   """
@@ -39,7 +39,6 @@ class IvyImports(NailgunTask):
 
     resolve_for = self.context.targets(lambda t: t.has_label('has_imports'))
     if resolve_for:
-      ivy_utils = IvyUtils(self.context.config, self.context.log)
       imports_map = self.context.products.get('ivy_imports')
       executor = self.create_java_executor()
       for target in resolve_for:
@@ -47,6 +46,6 @@ class IvyImports(NailgunTask):
         self.context.log.info('Mapping import jars for {target}: \n  {jars}'.format(
             target=nice_target_name(target),
             jars='\n  '.join(self._str_jar(s) for s in jars)))
-        ivy_utils.mapjars(imports_map, target, executor,
-                          workunit_factory=self.context.new_workunit,
-                          jars=jars)
+        self.mapjars(imports_map, target, executor,
+                     workunit_factory=self.context.new_workunit,
+                     jars=jars)

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -23,7 +23,7 @@ from pants.ivy.bootstrapper import Bootstrapper
 from pants.util.dirutil import safe_mkdir
 
 
-class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
+class IvyResolve(IvyTaskMixin, NailgunTask, JvmToolTaskMixin):
   _CONFIG_SECTION = 'ivy-resolve'
 
   @classmethod
@@ -65,8 +65,6 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
     self._open = self.get_options().open
     self._report = self._open or self.get_options().report
 
-    self._ivy_utils = IvyUtils(config=self.context.config, log=self.context.log)
-
     # Typically this should be a local cache only, since classpaths aren't portable.
     self.setup_artifact_cache()
 
@@ -94,7 +92,6 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
     ivy_classpath, relevant_targets = self.ivy_resolve(
       targets,
       executor=executor,
-      symlink_ivyxml=True,
       workunit_name='ivy-resolve',
     )
 
@@ -113,10 +110,7 @@ class IvyResolve(NailgunTask, IvyTaskMixin, JvmToolTaskMixin):
     if create_jardeps_for:
       genmap = self.context.products.get('jar_dependencies')
       for target in filter(create_jardeps_for, targets):
-        # TODO: Add mapjars to IvyTaskMixin? Or get rid of the mixin? It's weird that we use
-        # self.ivy_resolve for some ivy invocations but this for others.
-        self._ivy_utils.mapjars(genmap, target, executor=executor,
-                                workunit_factory=self.context.new_workunit)
+        self.mapjars(genmap, target, executor=executor, workunit_factory=self.context.new_workunit)
 
   def check_artifact_cache_for(self, invalidation_check):
     # Ivy resolution is an output dependent on the entire target set, and is not divisible

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -47,6 +47,7 @@ migrations = {
   ('junit-run', 'jvm_args'): ('test.junit', 'jvm_options'),
   ('scala-repl', 'jvm_args'): ('repl.scala', 'jvm_options'),
   ('scrooge-gen', 'jvm_args'): ('scrooge-gen', 'jvm_options'),
+  ('ivy-resolve', 'jvm_args'): ('resolve.ivy', 'jvm_options'),
 
   ('jvm-run', 'confs'): ('run.jvm', 'confs'),
   ('benchmark-run', 'confs'): ('bench', 'confs'),

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -27,6 +27,13 @@ class JvmToolTaskTestBase(TaskTestBase):
     real_config = self.config()
     super(JvmToolTaskTestBase, self).setUp()
 
+    # Use a synthetic subclass for bootstrapping within the test, to isolate this from
+    # any bootstrapping the pants run executing the test might need.
+    self.bootstrap_task_type, bootstrap_scope = self.synthesize_task_subtype(BootstrapJvmTools)
+    # TODO: We assume that no added jvm_options are necessary to bootstrap successfully in a test.
+    # This may not be true forever.  But getting the 'real' value here is tricky, as we have no
+    # access to the enclosing pants run's options here.
+    self.set_options_for_scope(bootstrap_scope, jvm_options=[])
     JvmToolTaskMixin.reset_registered_tools()
 
     def link_or_copy(src, dest):
@@ -85,7 +92,8 @@ class JvmToolTaskTestBase(TaskTestBase):
     # instead it should probably just be using an Engine.
     task = self.create_task(context, workdir)
     task.invalidate()
-    BootstrapJvmTools(context, workdir).execute()
+    bootstrap_workdir = os.path.join(workdir, '_bootstrap_jvm_tools')
+    self.bootstrap_task_type(context, bootstrap_workdir).execute()
     return task
 
   def execute(self, context):

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -27,14 +27,22 @@ class TaskTestBase(BaseTest):
 
   def setUp(self):
     super(TaskTestBase, self).setUp()
+    self._testing_task_type, self.options_scope = self.synthesize_task_subtype(self.task_type())
 
-    # Create a synthetic subclass of the task type, with a unique scope, to ensure
-    # proper test isolation (unfortunately we currently rely on class-level state in Task.)
+  def synthesize_task_subtype(self, task_type):
+    """Creates a synthetic subclass of the task type.
+
+    The returned type has a unique options scope, to ensure proper test isolation (unfortunately
+    we currently rely on class-level state in Task.)
+
     # TODO: Get rid of this once we re-do the Task lifecycle.
-    self.options_scope = str(uuid.uuid4())
-    subclass_name = b'test_{0}_{1}'.format(self.task_type().__name__, self.options_scope)
-    self._testing_task_type = type(subclass_name, (self.task_type(),),
-                                   {'options_scope': self.options_scope})
+
+    :param task_type: The task type to subtype.
+    :return: A pair (type, options_scope)
+    """
+    options_scope = uuid.uuid4().hex
+    subclass_name = b'test_{0}_{1}'.format(task_type.__name__, options_scope)
+    return type(subclass_name, (task_type,), {'options_scope': options_scope}), options_scope
 
   def set_options(self, **kwargs):
     self.set_options_for_scope(self.options_scope, **kwargs)

--- a/tests/python/pants_test/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/tasks/test_ivy_utils.py
@@ -48,13 +48,11 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
 
     self.simple = self.target('src/java/targets:simple')
     context = self.context()
-    self.ivy_utils = IvyUtils(context.config, logging.Logger('test'))
 
   def test_force_override(self):
     jars = list(self.simple.payload.jars)
     with temporary_file_path() as ivyxml:
-      self.ivy_utils._generate_ivy([self.simple], jars=jars, excludes=[], ivyxml=ivyxml,
-                                   confs=['default'])
+      IvyUtils.generate_ivy([self.simple], jars=jars, excludes=[], ivyxml=ivyxml, confs=['default'])
 
       doc = ET.parse(ivyxml).getroot()
 
@@ -91,16 +89,16 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
     v2.rev = "2"
 
     # If neither version is forced, use the latest version
-    self.assertIs(v2, self.ivy_utils._resolve_conflict(v1, v2))
-    self.assertIs(v2, self.ivy_utils._resolve_conflict(v2, v1))
+    self.assertIs(v2, IvyUtils._resolve_conflict(v1, v2))
+    self.assertIs(v2, IvyUtils._resolve_conflict(v2, v1))
 
     # If an earlier version is forced, use the forced version
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v1_force, v2))
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v2, v1_force))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v1_force, v2))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v2, v1_force))
 
     # If the same version is forced, use the forced version
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v1, v1_force))
-    self.assertIs(v1_force, self.ivy_utils._resolve_conflict(v1_force, v1))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v1, v1_force))
+    self.assertIs(v1_force, IvyUtils._resolve_conflict(v1_force, v1))
 
   def test_does_not_visit_diamond_dep_twice(self):
     ivy_info = self.parse_ivy_report('tests/python/pants_test/tasks/ivy_utils_resources/report_with_diamond.xml')


### PR DESCRIPTION
- IvyUtils is now just a repository of classmethods, and is not instantiated.
  This is a better idiom for something called "Utils", and most of the
  instance methods didn't need to be anyway.
- The relevant dynamic code has been moved to IvyTaskMixin, where it can
  directly use the task's context, without dipping directly into pants.ini.
- The ImportUtils subclass is no longer needed: The differentiation of
  workdirs now comes simply because IvyResolve and IvyImports are two
  distinct tasks, with two distinct workdirs. IvyUtils no longer reads
  its workdir out of config, but uses the task's workdir.
- The mixin now registers a --jvm-options option, to allow its subtypes
  (currently IvyResolve and BootstrapJvmTools) to tweak the JVM when
  running Ivy. To get this registration to work, the mixin was moved
  before the Task superclass in the mro.
- Got rid of the ivy.xml symlink hack.

The purpose, and result, of these changes, was to remove some direct
accesses to pants.ini. However this change also has the nice effect of
getting rid of the weird IvyUtils/IvyTaskMixin dichotomy and making
things more uniform. Ivy code is now quite a bit easier to reason about.