### PR TITLE
Upgrade jmake to version that works with java 1.5+

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -15,7 +15,7 @@ jar_library(name = 'xalan',
             jars = [jar(org = 'xalan', name = 'xalan', rev = '2.7.1')])
 
 jar_library(name = 'jmake',
-            jars = [jar(org = 'org.pantsbuild', name = 'jmake', rev = '1.3.8-7')])
+            jars = [jar(org = 'org.pantsbuild', name = 'jmake', rev = '1.3.8-8')])
 
 jar_library(name = 'java-compiler',
             jars = [jar(org = 'com.twitter.common.tools', name = 'java-compiler', rev = '0.0.12')])


### PR DESCRIPTION
This upgrades from 1.3.8-7 to 1.3.8-8 - no functional changes, just a release with java 1.5+ compatible classfiles.  See this issue for details: https://github.com/pantsbuild/jmake/issues/13

https://rbcommons.com/s/twitter/r/1628/