### PR TITLE
[Trigger CI] Rename the few remaining "jvm_args" variables to "jvm_options".

### DIFF
--- a/examples/src/scala/com/pants/example/JvmRunExample.scala
+++ b/examples/src/scala/com/pants/example/JvmRunExample.scala
@@ -4,8 +4,8 @@
 package com.pants.example
 
 // A simple jvm binary to test the jvm_run task on. Try, e.g.,
-// ./pants goal run  src/scala/com/pants/example:jvm-run-example \\
-//   -ldebug --jvm-run-jvmargs=-Dfoo=bar --jvm-run-args="Foo Bar"
+// ./pants run src/scala/com/pants/example:jvm-run-example \\
+//   -ldebug --jvm-run-jvm-options=-Dfoo=bar --jvm-run-args="Foo Bar"
 
 object JvmRunExample {
   def main(args: Array[String]) {

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -409,7 +409,7 @@ class JarPublish(JarTask, ScmPublish):
                                                     'restrict_push_branches'))
     self.cachedir = os.path.join(self.workdir, 'cache')
 
-    self._jvmargs = self.context.config.getlist(self._CONFIG_SECTION, 'ivy_jvmargs', default=[])
+    self._jvm_options = self.context.config.getlist(self._CONFIG_SECTION, 'ivy_jvmargs', default=[])
 
     if self.get_options().local:
       local_repo = dict(
@@ -535,27 +535,27 @@ class JarPublish(JarTask, ScmPublish):
         safe_mkdir(os.path.dirname(path))
         shutil.copy(os.path.join(basedir, artifact), path)
 
-  def _ivy_jvm_args(self, repo):
-    """Get the JVM arguments for ivy authentication, if needed"""
-    # Get authentication for the publish repo if needed
+  def _ivy_jvm_options(self, repo):
+    """Get the JVM options for ivy authentication, if needed."""
+    # Get authentication for the publish repo if needed.
     if not repo.get('auth'):
-      return self._jvmargs
+      return self._jvm_options
 
-    jvm_args = self._jvmargs
+    jvm_options = self._jvm_options
     user = repo.get('username')
     password = repo.get('password')
     if user and password:
-      jvm_args.append('-Dlogin=%s' % user)
-      jvm_args.append('-Dpassword=%s' % password)
+      jvm_options.append('-Dlogin=%s' % user)
+      jvm_options.append('-Dpassword=%s' % password)
     else:
       raise TaskError('Unable to publish to %s. %s' %
                       (repo.get('resolver'), repo.get('help', '')))
-    return jvm_args
+    return jvm_options
 
   def publish(self, ivyxml_path, jar, entry, repo, published):
     """Run ivy to publish a jar.  ivyxml_path is the path to the ivy file; published
     is a list of jars published so far (including this one). entry is a pushdb entry."""
-    jvm_args = self._ivy_jvm_args(repo)
+    jvm_options = self._ivy_jvm_options(repo)
     resolver = repo['resolver']
     path = repo.get('path')
 
@@ -583,7 +583,7 @@ class JarPublish(JarTask, ScmPublish):
       args.append('-overwrite')
 
     try:
-      ivy.execute(jvm_options=jvm_args, args=args,
+      ivy.execute(jvm_options=jvm_options, args=args,
                   workunit_factory=self.context.new_workunit, workunit_name='jar-publish')
     except Ivy.Error as e:
       raise TaskError('Failed to push {0}! {1}'.format(pushdb_coordinate(jar, entry), e))

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -271,10 +271,10 @@ class JarTask(NailgunTask):
 
         args.append(path)
 
-        jvm_args = self.context.config.getlist('jar-tool', 'jvm_args', default=['-Xmx64M'])
+        jvm_options = self.context.config.getlist('jar-tool', 'jvm_args', default=['-Xmx64M'])
         self.runjava(self.tool_classpath('jar-tool'),
                      'com.twitter.common.jar.tool.Main',
-                     jvm_options=jvm_args,
+                     jvm_options=jvm_options,
                      args=args,
                      workunit_name='jar-tool',
                      workunit_labels=[WorkUnit.TOOL, WorkUnit.JVM, WorkUnit.NAILGUN])

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -72,15 +72,6 @@ class NailgunTaskBase(TaskBase, JvmToolTaskMixin):
       client = SubprocessExecutor(self._dist)
     return client
 
-  @property
-  def jvm_args(self):
-    """Default jvm args the nailgun will be launched with.
-
-    By default no special jvm args are used.  If a value for ``jvm_args`` is specified in pants.ini
-    globally in the ``DEFAULT`` section or in the ``nailgun`` section, then that list will be used.
-    """
-    return self.context.config.getlist('nailgun', 'jvm_args', default=[])
-
   def runjava(self, classpath, main, jvm_options=None, args=None, workunit_name=None,
               workunit_labels=None):
     """Runs the java main using the given classpath and args.

--- a/testprojects/src/scala/com/pants/testproject/publish/JvmRunExample.scala
+++ b/testprojects/src/scala/com/pants/testproject/publish/JvmRunExample.scala
@@ -4,8 +4,8 @@
 package com.pants.testproject.publish
 
 // A simple jvm binary to test the jvm_run task on. Try, e.g.,
-// ./pants goal run  src/scala/com/pants/example:jvm-run-example \\
-//   -ldebug --jvm-run-jvmargs=-Dfoo=bar --jvm-run-args="Foo Bar"
+// ./pants run src/scala/com/pants/example:jvm-run-example \\
+//   -ldebug --jvm-run-jvm-options=-Dfoo=bar --jvm-run-args="Foo Bar"
 
 object JvmRunExample {
   def main(args: Array[String]) {


### PR DESCRIPTION
also fixes some related stale comments.

Note: doesn't change the names of the few remaining jvm_args config keys,
that will happen later. This change is just about reducing naming confusion
in the code.