### PR TITLE
[Trigger CI] Don't plumb an executor through when bootstrapping tools.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -67,13 +67,12 @@ class BootstrapJvmTools(IvyTaskMixin, Task):
     cache = {}
     cache_lock = threading.Lock()
 
-    def bootstrap_classpath(executor=None):
+    def bootstrap_classpath():
       with cache_lock:
         if 'classpath' not in cache:
           targets = list(self._resolve_tool_targets(tools, key, scope))
           workunit_name = 'bootstrap-%s' % str(key)
           cache['classpath'] = self.ivy_resolve(targets,
-                                                executor=executor,
                                                 silent=True,
                                                 workunit_name=workunit_name,
                                                 workunit_labels=[WorkUnit.BOOTSTRAP])[0]

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -150,7 +150,7 @@ class IvyResolve(IvyTaskMixin, NailgunTask, JvmToolTaskMixin):
       with open(report, 'w') as report_handle:
         print(no_deps_xml, file=report_handle)
 
-    tool_classpath = self.tool_classpath('xalan', executor=self.create_java_executor())
+    tool_classpath = self.tool_classpath('xalan')
 
     reports = []
     org, name = IvyUtils.identify(targets)

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -10,7 +10,6 @@ import os
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.jvm_debug_config import JvmDebugConfig
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError
 from pants.util.strutil import safe_shlex_split
 
 

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -30,14 +30,14 @@ class JvmToolTaskMixin(object):
     """Needed only for test isolation."""
     JvmToolTaskMixin._tool_keys = []
 
-  def tool_classpath(self, key, scope=None, executor=None):
+  def tool_classpath(self, key, scope=None):
     """Get a classpath for the tool previously registered under key in the given scope.
 
     Returns a list of paths.
     """
-    return self.lazy_tool_classpath(key, scope, executor)()
+    return self.lazy_tool_classpath(key, scope)()
 
-  def lazy_tool_classpath(self, key, scope=None, executor=None):
+  def lazy_tool_classpath(self, key, scope=None):
     """Get a lazy classpath for the tool previously registered under the key in the given scope.
 
     Returns a no-arg callable. Invoking it returns a list of paths.
@@ -49,4 +49,4 @@ class JvmToolTaskMixin(object):
     if not callback:
       raise TaskError('No bootstrap callback registered for {key} in {scope}'.format(
         key=key, scope=scope))
-    return lambda: callback(executor=executor)
+    return callback


### PR DESCRIPTION
- There was only one case where we were actually using this, which was
  when IvyResolve bootstraps xalan, and uses its own nailgun instead of
  a subprocess JVM like all the other tools. This seems arbitrary.

- A tool gets bootstrapped only once after a clean-all, and there are only
  a handful of tools, so there's no need to use a nailgun.  The complexity
  of a nailgun is only worth it for things that are going to run a lot
  even without cleaning, such as the java compiler.

- This simplifies the code slightly, ahead of a larger simplification I'd
  like to do to the ivy/nailgun/jvmtask triad.