### PR TITLE
Config.get_required now to raise error for any blank option.

### DIFF
--- a/src/python/pants/base/config.py
+++ b/src/python/pants/base/config.py
@@ -181,7 +181,8 @@ class Config(object):
     :raises: :class:`pants.base.config.Config.ConfigError` if option is not found.
     """
     val = self.get(section, option, type=type)
-    if val is None or val == "":
+    # Empty str catches blank options. If blank entries are ok, use get(..., default='') instead.
+    if val is None or val == '':
       raise Config.ConfigError('Required option %s.%s is not defined.' % (section, option))
     return val
 

--- a/src/python/pants/base/config.py
+++ b/src/python/pants/base/config.py
@@ -181,7 +181,7 @@ class Config(object):
     :raises: :class:`pants.base.config.Config.ConfigError` if option is not found.
     """
     val = self.get(section, option, type=type)
-    if val is None:
+    if val is None or val == "":
       raise Config.ConfigError('Required option %s.%s is not defined.' % (section, option))
     return val
 

--- a/tests/python/pants_test/tasks/test_config.py
+++ b/tests/python/pants_test/tasks/test_config.py
@@ -28,6 +28,7 @@ class ConfigTest(unittest.TestCase):
         disclaimer:
           Let it be known
           that.
+        blank_section:
 
         [a]
         list: [1, 2, 3, %(answer)s]
@@ -89,6 +90,17 @@ that.""",
     self.assertEquals(dict(a=1, b=42, c=['42', 42]), self.config.getdict('b', 'dict'))
     self._check_defaults(self.config.get, {})
     self._check_defaults(self.config.get, dict(a=42))
+
+  def test_get_required(self):
+    self.assertEquals('foo', self.config.get_required('a', 'name'))
+    self.assertEquals(42, self.config.get_required('a', 'answer', type=int))
+    with self.assertRaises(Config.ConfigError):
+      self.config.get_required('a', 'answer', type=dict)
+    with self.assertRaises(Config.ConfigError):
+      self.config.get_required('a', 'no_section')
+    with self.assertRaises(Config.ConfigError):
+      self.config.get_required('a', 'blank_section')
+
 
   def _check_defaults(self, accessor, default):
     self.assertEquals(None, accessor('c', 'fast'))


### PR DESCRIPTION
As it stood, get_required would not raise a ConfigError for strings
(the default) if the option was left blank, unlike other data types.
A str option that was left blank was parsed as '' and any error
catching was left to the tooling. This adds an explicit check for
times where get_required() could return an empty string instead of the
expected None.

If a blank option is a viable choice, I think get(...default="") is
a better choice for those situations. I added a set of get_required
tests as well.