### PR TITLE
Revert change to ivy.mustache template from sources/javadoc change

### DIFF
--- a/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
+++ b/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
@@ -58,18 +58,13 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       <conf name="{{.}}" mapped="{{.}}"/>
       {{/configurations}}
       {{#artifacts}}
-      <!--
-      The conf = ... in the block below is a hack around a bug John described on RB 716. The bug has
-      something to do with artifacts not being fetched unless .with_artifacts is called multiple
-      times.
-      -->
       <artifact
         {{#name}}name="{{.}}"{{/name}}
         {{#ext}}ext="{{.}}"{{/ext}}
         {{#url}}url="{{.}}"{{/url}}
         {{#type_}}type="{{.}}"{{/type_}}
         {{#classifier}}m:classifier="{{.}}"{{/classifier}}
-        conf="{{#configurations}}{{.}}->{{.}};{{/configurations}}"
+        {{#conf}}conf="{{.}}"{{/conf}}
       />
       {{/artifacts}}
       {{#excludes}}


### PR DESCRIPTION
 This was the subject of some debate in rb716 and was committed in https://rbcommons.com/s/twitter/r/1613/

I noticed that it broke ivy resolution when trying to set a URL override for a jar file.