### PR TITLE
Add a call to relpath so that we don't generate an overlong filename on mesos

### DIFF
--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -177,7 +177,7 @@ class ApacheThriftGen(CodeGen):
       relsource = os.path.relpath(source, get_buildroot())
 
       if lang == "python":
-        copied_source = os.path.join(self._workdir, relsource)
+        copied_source = os.path.relpath(os.path.join(self._workdir, relsource), get_buildroot())
         safe_mkdir(os.path.dirname(copied_source))
         shutil.copyfile(source, copied_source)
         replace_python_keywords_in_file(copied_source)


### PR DESCRIPTION
PR for travis