### PR TITLE
[Trigger CI] More gentle refactoring of IvyUtils.

### DIFF
--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -42,7 +42,6 @@ python_library(
     'src/python/pants/base:revision',
     'src/python/pants/base:target',
     'src/python/pants/ivy',
-    'src/python/pants/java:util',
     'src/python/pants/util:dirutil',
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -13,7 +13,6 @@ from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.exceptions import TaskError
-from pants.base.workunit import WorkUnit
 
 
 class BootstrapJvmTools(IvyTaskMixin, Task):
@@ -74,7 +73,6 @@ class BootstrapJvmTools(IvyTaskMixin, Task):
           workunit_name = 'bootstrap-%s' % str(key)
           cache['classpath'] = self.ivy_resolve(targets,
                                                 silent=True,
-                                                workunit_name=workunit_name,
-                                                workunit_labels=[WorkUnit.BOOTSTRAP])[0]
+                                                workunit_name=workunit_name)[0]
         return cache['classpath']
     return bootstrap_classpath

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -46,6 +46,4 @@ class IvyImports(IvyTaskMixin, NailgunTask):
         self.context.log.info('Mapping import jars for {target}: \n  {jars}'.format(
             target=nice_target_name(target),
             jars='\n  '.join(self._str_jar(s) for s in jars)))
-        self.mapjars(imports_map, target, executor,
-                     workunit_factory=self.context.new_workunit,
-                     jars=jars)
+        self.mapjars(imports_map, target, executor, jars=jars)

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -133,7 +133,7 @@ class IvyResolve(IvyTaskMixin, NailgunTask, JvmToolTaskMixin):
     if create_jardeps_for:
       genmap = self.context.products.get('jar_dependencies')
       for target in filter(create_jardeps_for, targets):
-        self.mapjars(genmap, target, executor=executor, workunit_factory=self.context.new_workunit)
+        self.mapjars(genmap, target, executor=executor)
 
   def check_artifact_cache_for(self, invalidation_check):
     # Ivy resolution is an output dependent on the entire target set, and is not divisible

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -161,7 +161,7 @@ class IvyTaskMixin(object):
                    '[organisation]-[artifact]-[revision](-[classifier]).[ext]' % mapdir,
       '-symlink',
     ]
-    confs = maybe_list(target.payload.get_field_value('configurations')) or []
+    confs = maybe_list(target.payload.get_field_value('configurations') or [])
     self.exec_ivy(mapdir,
                   [target],
                   executor=executor,

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -6,6 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 from collections import defaultdict
+import copy
 import logging
 import os
 import shutil
@@ -20,8 +21,9 @@ from pants.base.cache_manager import VersionedTargetSet
 from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.ivy.bootstrapper import Bootstrapper
-from pants.java.executor import Executor
+from pants.java.util import execute_runner
 from pants.util.dirutil import safe_mkdir
+
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,6 @@ class IvyTaskMixin(object):
                   executor=None,
                   silent=False,
                   workunit_name=None,
-                  workunit_labels=None,
                   confs=None):
     if not targets:
       return ([], set())
@@ -76,11 +77,7 @@ class IvyTaskMixin(object):
     # the generated module, which in turn determines the location of the XML report file
     # ivy generates. We recompute this name from targets later in order to find that file.
     # TODO: This is fragile. Refactor so that we're not computing the name twice.
-    if executor and not isinstance(executor, Executor):
-      raise ValueError('The executor must be an Executor instance, given %s of type %s'
-                       % (executor, type(executor)))
-    ivy = Bootstrapper.default_ivy(java_executor=executor,
-                                   bootstrap_workunit_factory=self.context.new_workunit)
+    ivy = Bootstrapper.default_ivy(bootstrap_workunit_factory=self.context.new_workunit)
 
     ivy_workdir = os.path.join(self.context.options.for_global_scope().pants_workdir, 'ivy')
 
@@ -108,22 +105,14 @@ class IvyTaskMixin(object):
       if invalidation_check.invalid_vts or not os.path.exists(raw_target_classpath_file):
         args = ['-cachepath', raw_target_classpath_file_tmp]
 
-        def exec_ivy():
-          IvyUtils.exec_ivy(
-              target_workdir=target_workdir,
-              targets=global_vts.targets,
-              args=args,
-              jvm_options=self.get_options().jvm_options,
-              ivy=ivy,
-              workunit_name='ivy',
-              workunit_factory=self.context.new_workunit,
-              confs=confs)
-
-        if workunit_name:
-          with self.context.new_workunit(name=workunit_name, labels=workunit_labels or []):
-            exec_ivy()
-        else:
-          exec_ivy()
+        self.exec_ivy(
+            target_workdir=target_workdir,
+            targets=global_vts.targets,
+            args=args,
+            executor=executor,
+            ivy=ivy,
+            workunit_name=workunit_name,
+            confs=confs)
 
         if not os.path.exists(raw_target_classpath_file_tmp):
           raise TaskError('Ivy failed to create classpath file at %s'
@@ -156,7 +145,7 @@ class IvyTaskMixin(object):
     artifact."""
     return path.endswith('.jar') or path.endswith('.war')
 
-  def mapjars(self, genmap, target, executor, workunit_factory=None, jars=None):
+  def mapjars(self, genmap, target, executor, jars=None):
     """Resolves jars for the target and stores their locations in genmap.
 
     :param genmap: The jar_dependencies ProductMapping entry for the required products.
@@ -172,16 +161,15 @@ class IvyTaskMixin(object):
                    '[organisation]-[artifact]-[revision](-[classifier]).[ext]' % mapdir,
       '-symlink',
     ]
-    confs = target.payload.get_field_value('configurations') or []
-    IvyUtils.exec_ivy(mapdir,
-                      [target],
-                      jvm_options=self.get_options().jvm_options,
-                      args=ivyargs,
-                      confs=maybe_list(confs),
-                      ivy=Bootstrapper.default_ivy(executor),
-                      workunit_factory=workunit_factory,
-                      workunit_name='map-jars',
-                      jars=jars)
+    confs = maybe_list(target.payload.get_field_value('configurations')) or []
+    self.exec_ivy(mapdir,
+                  [target],
+                  executor=executor,
+                  args=ivyargs,
+                  confs=confs,
+                  ivy=Bootstrapper.default_ivy(),
+                  workunit_name='map-jars',
+                  jars=jars)
 
     for org in os.listdir(mapdir):
       orgdir = os.path.join(mapdir, org)
@@ -202,3 +190,41 @@ class IvyTaskMixin(object):
                   genmap.add((target, conf), confdir).append(f)
                   genmap.add((org, name, conf), confdir).append(f)
 
+  def exec_ivy(self,
+               target_workdir,
+               targets,
+               args,
+               executor=None,
+               confs=None,
+               ivy=None,
+               workunit_name='ivy',
+               jars=None):
+    ivy_jvm_options = copy.copy(self.get_options().jvm_options)
+    # Disable cache in File.getCanonicalPath(), makes Ivy work with -symlink option properly on ng.
+    ivy_jvm_options.append('-Dsun.io.useCanonCaches=false')
+
+    ivy = ivy or Bootstrapper.default_ivy()
+    ivyxml = os.path.join(target_workdir, 'ivy.xml')
+
+    if not jars:
+      jars, excludes = IvyUtils.calculate_classpath(targets)
+    else:
+      excludes = set()
+
+    ivy_args = ['-ivy', ivyxml]
+
+    confs_to_resolve = confs or ['default']
+    ivy_args.append('-confs')
+    ivy_args.extend(confs_to_resolve)
+    ivy_args.extend(args)
+
+    with IvyUtils.ivy_lock:
+      IvyUtils.generate_ivy(targets, jars, excludes, ivyxml, confs_to_resolve)
+      runner = ivy.runner(jvm_options=ivy_jvm_options, args=ivy_args, executor=executor)
+      try:
+        result = execute_runner(runner, workunit_factory=self.context.new_workunit,
+                                workunit_name=workunit_name)
+        if result != 0:
+          raise TaskError('Ivy returned %d' % result)
+      except runner.executor.Error as e:
+        raise TaskError(e)

--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -20,16 +20,9 @@ class Ivy(object):
   class Error(Exception):
     """Indicates an error executing an ivy command."""
 
-  def __init__(self, classpath, java_executor=None, ivy_settings=None, ivy_cache_dir=None):
+  def __init__(self, classpath, ivy_settings=None, ivy_cache_dir=None):
     """Configures an ivy wrapper for the ivy distribution at the given classpath."""
-
     self._classpath = maybe_list(classpath)
-
-    self._java = java_executor or SubprocessExecutor()
-    if not isinstance(self._java, Executor):
-      raise ValueError('java_executor must be an Executor instance, given %s of type %s'
-                       % (self._java, type(self._java)))
-
     self._ivy_settings = ivy_settings
     if self._ivy_settings and not isinstance(self._ivy_settings, Compatibility.string):
       raise ValueError('ivy_settings must be a string, given %s of type %s'
@@ -66,13 +59,13 @@ class Ivy(object):
       if result != 0:
         raise self.Error('Ivy command failed with exit code %d%s'
                          % (result, ': ' + ' '.join(args) if args else ''))
-    except self._java.Error as e:
+    except executor.Error as e:
       raise self.Error('Problem executing ivy: %s' % e)
 
   def runner(self, jvm_options=None, args=None, executor=None):
     """Creates an ivy commandline client runner for the given args."""
     args = args or []
-    executor = executor or self._java
+    executor = executor or SubprocessExecutor()
     if not isinstance(executor, Executor):
       raise ValueError('The executor argument must be an Executor instance, given %s of type %s'
                        % (executor, type(executor)))

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -53,9 +53,9 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
     distribution = Distribution.cached(jdk=True)
     executor = SubprocessExecutor(distribution=distribution)
     classpath_file_abs_path = os.path.join(test_abs_path, 'junit.classpath')
-    ivy = Bootstrapper.default_ivy(java_executor=executor)
+    ivy = Bootstrapper.default_ivy()
     ivy.execute(args=['-cachepath', classpath_file_abs_path,
-                      '-dependency', 'junit', 'junit-dep', '4.10'])
+                      '-dependency', 'junit', 'junit-dep', '4.10'], executor=executor)
     with open(classpath_file_abs_path) as fp:
       classpath = fp.read()
 


### PR DESCRIPTION
- Moved ivy execution logic into the mixin, allowing its interface to
  be simplified.
- An Ivy instance no longer encapsulates an executor. Clients can pass
  an executor into Ivy.execute() instead.
- Don't bootstrap Ivy with the executor intended for it to run in after
  bootstrapping.  Use a subprocess executor instead, like for all other
  bootstrapping.  Allows us to not pass an executor around quite so much.

This is another step on the way to reworking the ivy/jvmtask/nailgun triad of
confusion.