### PR TITLE
    Change Distribution.cached to compare using Revision objects

### DIFF
--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -76,7 +76,8 @@ class Distribution(object):
 
     for path in filter(None, search_path()):
       try:
-        dist = cls(bin_path=path, minimum_version=minimum_version, maximum_version=maximum_version, jdk=jdk)
+        dist = cls(bin_path=path, minimum_version=minimum_version,
+                   maximum_version=maximum_version, jdk=jdk)
         dist.validate()
         log.debug('Located %s for constraints: minimum_version'
                   ' %s, maximum_version %s, jdk %s' % (dist, minimum_version, maximum_version, jdk))

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -76,7 +76,7 @@ class Distribution(object):
 
     for path in filter(None, search_path()):
       try:
-        dist = cls(path, minimum_version=minimum_version, maximum_version=maximum_version, jdk=jdk)
+        dist = cls(bin_path=path, minimum_version=minimum_version, maximum_version=maximum_version, jdk=jdk)
         dist.validate()
         log.debug('Located %s for constraints: minimum_version'
                   ' %s, maximum_version %s, jdk %s' % (dist, minimum_version, maximum_version, jdk))

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -33,16 +33,20 @@ class Distribution(object):
   @classmethod
   def cached(cls, minimum_version=None, maximum_version=None, jdk=False):
     def scan_constraint_match():
+      # Convert strings to Revision objects for apples-to-apples comparison.
+      max_version = cls._parse_java_version("maximum_version", maximum_version)
+      min_version = cls._parse_java_version("minimum_version", minimum_version)
+
       for dist in cls._CACHE.values():
-        if minimum_version and dist.version < minimum_version:
+        if min_version and dist.version < min_version:
           continue
-        if maximum_version and dist.version > maximum_version:
+        if max_version and dist.version > max_version:
           continue
         if jdk and not dist.jdk:
           continue
         return dist
 
-    key = (minimum_version, jdk)
+    key = (minimum_version, maximum_version, jdk)
     dist = cls._CACHE.get(key)
     if not dist:
       dist = scan_constraint_match()
@@ -89,7 +93,7 @@ class Distribution(object):
     #  http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
     # These version strings comply with semver except that the traditional pre-release semver
     # slot (the 4th) can be delimited by an _ in the case of update releases of the jdk.
-    # We accomodate that difference here.
+    # We accommodate that difference here.
     if isinstance(version, Compatibility.string):
       version = Revision.semver(version.replace('_', '-'))
     if version and not isinstance(version, Revision):
@@ -122,8 +126,6 @@ class Distribution(object):
     self._system_properties = None
     self._version = None
     self._validated_binaries = {}
-
-
 
   @property
   def jdk(self):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -163,7 +163,7 @@ class MockDistributionTest(unittest.TestCase):
       with self.env(PATH=jdk):
         Distribution.cached(maximum_version='1.7.0_55')
 
-    with pytest.raises(Distribution.Error):
+    with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(maximum_version='1.6.0_20')
@@ -175,13 +175,18 @@ class MockDistributionTest(unittest.TestCase):
       with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.6.0_19', maximum_version='1.7.0_66')
 
-    with pytest.raises(Distribution.Error):
+    with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
       with self.distribution(executables=self.exe('java', '1.7.0_18')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
+
+    with self.assertRaises(ValueError):
+      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
+        with self.env(PATH=jdk):
+          Distribution.cached(minimum_version=1.7, maximum_version=1.8)
 
 def exe_path(name):
   process = subprocess.Popen(['which', name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -154,6 +154,31 @@ class MockDistributionTest(unittest.TestCase):
       with env(JAVA_HOME=jdk):
         Distribution.locate()
 
+  def test_cached(self):
+    with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
+      Distribution.cached(maximum_version='1.8.0_20')
+
+    with pytest.raises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
+        Distribution.cached(maximum_version='1.6.0_20')
+
+    with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
+      Distribution.cached(minimum_version='1.6.0_20')
+
+    with pytest.raises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
+        Distribution.cached(minimum_version='1.8.0_20')
+
+    with self.distribution(executables=self.exe('java', '1.7.0_20')) as jdk:
+      Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
+
+    with pytest.raises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_22')) as jdk:
+        Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
+
+    with pytest.raises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_18')) as jdk:
+        Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
 
 def exe_path(name):
   process = subprocess.Popen(['which', name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -38,7 +38,7 @@ class MockDistributionTest(unittest.TestCase):
     return cls.EXE(name, contents=contents)
 
   @contextmanager
-  def env(*args, **kwargs):
+  def env(self, **kwargs):
     environment = dict(JDK_HOME=None, JAVA_HOME=None, PATH=None)
     environment.update(**kwargs)
     with environment_as(**environment):
@@ -167,9 +167,11 @@ class MockDistributionTest(unittest.TestCase):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(maximum_version='1.6.0_20')
+
+    with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
-        with self.env(PATH=jdk):
-          Distribution.cached(minimum_version='1.8.0_20')
+          with self.env(PATH=jdk):
+            Distribution.cached(minimum_version='1.8.0_20')
 
     with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
       with self.env(PATH=jdk):
@@ -179,6 +181,8 @@ class MockDistributionTest(unittest.TestCase):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
+
+    with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_18')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')


### PR DESCRIPTION

    When spinning up distributions, Distribution.cached returns
    previously instantiated jdk distros. The proper distro to return
    was determined by comparing min/max arguments. The problem is that
    cached() is generally passed strings . Those strings were being
    compared with Revision objects. This should have raised an
    exception b/c Revision.__cmp__ is overloaded so as to
    compare _components.

    This exception was never raised though, because Pants was almost
    always just returning the Distribution that was cached during
    setup. The _CACHE.key was just (minimum_version, jdk) which
    is (None, True) or (None, False) for all situations I could find.

    This conspired to cause pants to not respect any max_version
    constraints. The solution is to cast the max/min version args
    of Distribution.cached to full Revision objects for easy
    apples-to-apples comparison. The _CACHE.key has been expanded to
    (minimum_version, maximum_version, jdk) so as to honor all
    constraints.