### PR TITLE
Fix spurious Products requirements.

### DIFF
--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -186,7 +186,7 @@ class Products(object):
 
     def combine(first, second):
       return lambda target: first(target) or second(target)
-    return reduce(combine, self.predicates_for_type[typename], lambda target: False)
+    return reduce(combine, predicates, lambda target: False)
 
   def get(self, typename):
     """Returns a ProductMapping for the given type name."""

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -165,26 +165,32 @@ class Products(object):
   def require(self, typename, predicate=None):
     """Registers a requirement that file products of the given type by mapped.
 
-    If a target predicate is supplied, only targets matching the predicate are mapped.
+    If target predicates are supplied, only targets matching at least one of the predicates are
+    mapped.
     """
-    if predicate:
-      self.predicates_for_type[typename].append(predicate)
-    return self.products.setdefault(typename, Products.ProductMapping(typename))
+    # TODO(John Sirois): This is a broken API.  If one client does a require with no predicate and
+    # another requires with a predicate, the producer will only produce for the latter.  The former
+    # presumably intended to have all products of this type mapped.  Kill the predicate portion of
+    # the api by moving to the new tuple-based engine where all tasks require data for a specific
+    # set of targets.
+    self.predicates_for_type[typename].append(predicate or (lambda target: False))
 
   def isrequired(self, typename):
-    """Returns a predicate that selects targets required for the given type if mappings are required.
+    """Returns a predicate selecting targets required for the given type if mappings are required.
 
     Otherwise returns None.
     """
-    if typename not in self.products:
+    predicates = self.predicates_for_type[typename]
+    if not predicates:
       return None
+
     def combine(first, second):
       return lambda target: first(target) or second(target)
     return reduce(combine, self.predicates_for_type[typename], lambda target: False)
 
   def get(self, typename):
     """Returns a ProductMapping for the given type name."""
-    return self.require(typename)
+    return self.products.setdefault(typename, Products.ProductMapping(typename))
 
   def require_data(self, typename):
     """ Registers a requirement that data produced by tasks is required.

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -119,6 +119,7 @@ python_test_suite(
     'tests/python/pants_test/engine',
     'tests/python/pants_test/fs',
     'tests/python/pants_test/graph',
+    'tests/python/pants_test/goal',
     'tests/python/pants_test/java',
     'tests/python/pants_test/net',
     'tests/python/pants_test/option',

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_tests(
+  name='goal',
+  sources=globs('*.py'),
+  dependencies=[
+    'src/python/pants/goal:products',
+  ]
+)

--- a/tests/python/pants_test/goal/test_products.py
+++ b/tests/python/pants_test/goal/test_products.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.goal.products import Products
+
+
+class ProductsTest(unittest.TestCase):
+  def setUp(self):
+    self.products = Products()
+
+  def test_require(self):
+    self.products.require('foo')
+
+    predicate = self.products.isrequired('foo')
+    self.assertIsNotNone(predicate)
+    self.assertFalse(predicate(42))
+
+    self.assertIsNone(self.products.isrequired('bar'))
+
+    # require should not cross-contaminate require_data
+    self.assertFalse(self.products.is_required_data('foo'))
+    self.assertFalse(self.products.is_required_data('bar'))
+
+  def test_require_predicate(self):
+    self.products.require('foo', predicate=lambda x: x == 42)
+
+    predicate = self.products.isrequired('foo')
+    self.assertIsNotNone(predicate)
+    self.assertTrue(predicate(42))
+    self.assertFalse(predicate(0))
+
+  def test_require_multiple_predicates(self):
+    self.products.require('foo', predicate=lambda x: x == 1)
+    self.products.require('foo', predicate=lambda x: x == 2)
+    self.products.require('foo', predicate=lambda x: x == 3)
+
+    predicate = self.products.isrequired('foo')
+    self.assertIsNotNone(predicate)
+    self.assertFalse(predicate(0))
+    self.assertTrue(predicate(1))
+    self.assertTrue(predicate(2))
+    self.assertTrue(predicate(3))
+    self.assertFalse(predicate(4))
+
+  def test_get(self):
+    foo_product_mapping1 = self.products.get('foo')
+    foo_product_mapping2 = self.products.get('foo')
+
+    self.assertIsInstance(foo_product_mapping1, Products.ProductMapping)
+    self.assertIs(foo_product_mapping1, foo_product_mapping2)
+
+  def test_get_does_not_require(self):
+    self.assertIsNone(self.products.isrequired('foo'))
+    self.products.get('foo')
+    self.assertIsNone(self.products.isrequired('foo'))
+    self.products.require('foo')
+    self.assertIsNotNone(self.products.isrequired('foo'))
+
+  def test_require_data(self):
+    self.products.require_data('foo')
+
+    self.assertTrue(self.products.is_required_data('foo'))
+    self.assertFalse(self.products.is_required_data('bar'))
+
+    # require_data should not cross-contaminate require
+    self.assertIsNone(self.products.isrequired('foo'))
+    self.assertIsNone(self.products.isrequired('bar'))
+
+  def test_get_data(self):
+    self.assertIsNone(self.products.get_data('foo'))
+
+    data1 = self.products.get_data('foo', dict)
+    data2 = self.products.get_data('foo', dict)
+
+    self.assertIsInstance(data1, dict)
+    self.assertIs(data1, data2)
+
+  def test_get_data_does_not_require_data(self):
+    self.assertFalse(self.products.is_required_data('foo'))
+    self.products.get_data('foo')
+    self.assertFalse(self.products.is_required_data('foo'))
+    self.products.require_data('foo')
+    self.assertTrue(self.products.is_required_data('foo'))


### PR DESCRIPTION
The trio or require, isrequired and get - the original members of
products - are tricky and they have invalid semantics in the
product-driven RoundEngine.

This change fixes things such that a `.get(<typename>)` does not have
the effect of causing a subsequent `.isrequired(<typename>)` check to be
truthy.

Going forward, the idea of requiring a product for a subset of targets -
the role of the `.require` predicate today - will be subsumed by the
tuple-based engine.

https://rbcommons.com/s/twitter/r/1662/