### PR TITLE
Fix Distribution tests

### DIFF
--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -23,6 +23,7 @@ python_tests(
     'android_integration_test.py',
   ],
   dependencies = [
+    'src/python/pants/java:distribution',
     'tests/python/pants_test:int-test',
   ],
 )

--- a/tests/python/pants_test/android/android_integration_test.py
+++ b/tests/python/pants_test/android/android_integration_test.py
@@ -10,6 +10,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import os
 
+from pants.java.distribution.distribution import Distribution
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -25,6 +26,8 @@ class AndroidIntegrationTest(PantsRunIntegrationTest):
   TARGET_SDK = '19'
   ANDROID_SDK_LOCATION = 'ANDROID_HOME'
 
+  JAVA_MIN = '1.6.0_00'
+  JAVA_MAX = '1.7.0_99'
   TEST_TARGET = 'examples/src/android/example:hello'
 
   @classmethod
@@ -36,5 +39,9 @@ class AndroidIntegrationTest(PantsRunIntegrationTest):
         if not os.path.isfile(os.path.join(android_sdk, tool)):
           return False
     else:
+      return False
+    try:
+      Distribution.cached(minimum_version=cls.JAVA_MIN, maximum_version=cls.JAVA_MAX)
+    except:
       return False
     return True

--- a/tests/python/pants_test/android/tasks/BUILD
+++ b/tests/python/pants_test/android/tasks/BUILD
@@ -55,6 +55,5 @@ python_tests(
   ],
   dependencies = [
     'tests/python/pants_test/android:android_integration_test',
-    'tests/python/pants_test/tasks:base',
   ],
 )

--- a/tests/python/pants_test/android/tasks/test_jarsigner_integration.py
+++ b/tests/python/pants_test/android/tasks/test_jarsigner_integration.py
@@ -9,7 +9,6 @@ import os
 import pytest
 
 from pants_test.android.android_integration_test import AndroidIntegrationTest
-from pants_test.tasks.test_base import is_exe
 
 
 class JarsignerIntegrationTest(AndroidIntegrationTest):
@@ -27,11 +26,10 @@ class JarsignerIntegrationTest(AndroidIntegrationTest):
     os.path.join('platforms', 'android-' + AndroidIntegrationTest.TARGET_SDK, 'android.jar')
   ]
 
-  JAVA = is_exe('java')
 
-  tools = AndroidIntegrationTest.requirements(TOOLS) and JAVA
+  requirements = AndroidIntegrationTest.requirements(TOOLS)
 
-  @pytest.mark.skipif('not JarsignerIntegrationTest.tools',
+  @pytest.mark.skipif('not JarsignerIntegrationTest.requirements',
                       reason='Jarsigner integration test requires the JDK, Android tools {0!r} '
                              'and ANDROID_HOME set in path.'.format(TOOLS))
   def test_jarsigner(self):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -118,7 +118,6 @@ class MockDistributionTest(unittest.TestCase):
         with self.env(PATH=jdk):
           Distribution.locate(minimum_version='1.7.0')
 
-    with pytest.raises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.8.0')) as jdk:
         with self.env(PATH=jdk):
           Distribution.locate(maximum_version='1.7.999')
@@ -161,22 +160,36 @@ class MockDistributionTest(unittest.TestCase):
     with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
       with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.7.0_25')
+      with self.env(PATH=jdk):
         Distribution.cached(maximum_version='1.7.0_55')
+
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
+        with self.env(PATH=jdk):
+          Distribution.cached(maximum_version='1.6.0_20')
+
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
+          with self.env(PATH=jdk):
+            Distribution.cached(minimum_version='1.8.0_20')
+
+    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
+      with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.6.0_19', maximum_version='1.7.0_66')
 
-        with self.assertRaises(Distribution.Error):
-          Distribution.cached(minimum_version='1.8.0_20')
-        with self.assertRaises(Distribution.Error):
-          Distribution.cached(maximum_version='1.6.0_20')
-        with self.assertRaises(Distribution.Error):
-          Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
-        with self.assertRaises(Distribution.Error):
-          Distribution.cached(minimum_version='1.7.0_40', maximum_version='1.8.0_21')
-
-        with self.assertRaises(Distribution.Error):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
+        with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
 
-        with self.assertRaises(ValueError):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('java', '1.7.0_18')) as jdk:
+        with self.env(PATH=jdk):
+          Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
+
+    with self.assertRaises(ValueError):
+      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
+        with self.env(PATH=jdk):
           Distribution.cached(minimum_version=1.7, maximum_version=1.8)
 
 def exe_path(name):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -118,6 +118,7 @@ class MockDistributionTest(unittest.TestCase):
         with self.env(PATH=jdk):
           Distribution.locate(minimum_version='1.7.0')
 
+    with pytest.raises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.8.0')) as jdk:
         with self.env(PATH=jdk):
           Distribution.locate(maximum_version='1.7.999')
@@ -163,30 +164,36 @@ class MockDistributionTest(unittest.TestCase):
       with self.env(PATH=jdk):
         Distribution.cached(maximum_version='1.7.0_55')
 
+  def test_cached_max(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(maximum_version='1.6.0_20')
 
+  def test_cached_min(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
           with self.env(PATH=jdk):
             Distribution.cached(minimum_version='1.8.0_20')
 
+  def test_cached_bounded(self):
     with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
       with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.6.0_19', maximum_version='1.7.0_66')
 
+  def test_cached_over_max(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
 
+  def test_cached_below_min(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_18')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
 
+  def test_cached_bad_input_type(self):
     with self.assertRaises(ValueError):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -66,7 +66,6 @@ class MockDistributionTest(unittest.TestCase):
   def tearDown(self):
     super(MockDistributionTest, self).tearDown()
     Distribution._CACHE = self._local_cache
-    self.assertEquals(self._local_cache, Distribution._CACHE)
 
   def test_validate_basic(self):
     with pytest.raises(Distribution.Error):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -118,7 +118,6 @@ class MockDistributionTest(unittest.TestCase):
         with self.env(PATH=jdk):
           Distribution.locate(minimum_version='1.7.0')
 
-    with pytest.raises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.8.0')) as jdk:
         with self.env(PATH=jdk):
           Distribution.locate(maximum_version='1.7.999')
@@ -164,36 +163,30 @@ class MockDistributionTest(unittest.TestCase):
       with self.env(PATH=jdk):
         Distribution.cached(maximum_version='1.7.0_55')
 
-  def test_cached_max(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(maximum_version='1.6.0_20')
 
-  def test_cached_min(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
           with self.env(PATH=jdk):
             Distribution.cached(minimum_version='1.8.0_20')
 
-  def test_cached_bounded(self):
     with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
       with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.6.0_19', maximum_version='1.7.0_66')
 
-  def test_cached_over_max(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
 
-  def test_cached_below_min(self):
     with self.assertRaises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.7.0_18')) as jdk:
         with self.env(PATH=jdk):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
 
-  def test_cached_bad_input_type(self):
     with self.assertRaises(ValueError):
       with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
         with self.env(PATH=jdk):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -118,6 +118,7 @@ class MockDistributionTest(unittest.TestCase):
         with self.env(PATH=jdk):
           Distribution.locate(minimum_version='1.7.0')
 
+    with pytest.raises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.8.0')) as jdk:
         with self.env(PATH=jdk):
           Distribution.locate(maximum_version='1.7.999')
@@ -160,36 +161,22 @@ class MockDistributionTest(unittest.TestCase):
     with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
       with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.7.0_25')
-      with self.env(PATH=jdk):
         Distribution.cached(maximum_version='1.7.0_55')
-
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-        with self.env(PATH=jdk):
-          Distribution.cached(maximum_version='1.6.0_20')
-
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
-          with self.env(PATH=jdk):
-            Distribution.cached(minimum_version='1.8.0_20')
-
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.6.0_19', maximum_version='1.7.0_66')
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-        with self.env(PATH=jdk):
+        with self.assertRaises(Distribution.Error):
+          Distribution.cached(minimum_version='1.8.0_20')
+        with self.assertRaises(Distribution.Error):
+          Distribution.cached(maximum_version='1.6.0_20')
+        with self.assertRaises(Distribution.Error):
+          Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
+        with self.assertRaises(Distribution.Error):
+          Distribution.cached(minimum_version='1.7.0_40', maximum_version='1.8.0_21')
+
+        with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.7.0_18')) as jdk:
-        with self.env(PATH=jdk):
-          Distribution.cached(minimum_version='1.7.0_19', maximum_version='1.7.0_21')
-
-    with self.assertRaises(ValueError):
-      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-        with self.env(PATH=jdk):
+        with self.assertRaises(ValueError):
           Distribution.cached(minimum_version=1.7, maximum_version=1.8)
 
 def exe_path(name):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -118,6 +118,7 @@ class MockDistributionTest(unittest.TestCase):
         with self.env(PATH=jdk):
           Distribution.locate(minimum_version='1.7.0')
 
+    with pytest.raises(Distribution.Error):
       with self.distribution(executables=self.exe('java', '1.8.0')) as jdk:
         with self.env(PATH=jdk):
           Distribution.locate(maximum_version='1.7.999')
@@ -157,6 +158,9 @@ class MockDistributionTest(unittest.TestCase):
         Distribution.locate()
 
   def test_cached(self):
+    # Clear cache so the machine's jdks don't get found during tests.
+    Distribution._CACHE = {}
+
     with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
       with self.env(PATH=jdk):
         Distribution.cached(minimum_version='1.7.0_25')


### PR DESCRIPTION
The env() context manager does not reset the environment
for future calls.There was no need to define multiple JDK versions
for these tests, so I just took the easy way and picked a distribution.

I am just fixing the test_cached tests. My guess is that the test_locate
method is working purely by happenstance as well. I did rescue an orphaned
test, but any furthe work will have to be done later. I wanted to
send up a patch that fixes the broken test for anyone suffering from it.