### PR TITLE
Pants itself uses python2.7, kill unittest2 imports.

### DIFF
--- a/examples/tests/python/example_test/hello/greet/greet.py
+++ b/examples/tests/python/example_test/hello/greet/greet.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import unittest2 as unittest
+import unittest
 
 from example.hello.greet.greet import greet
 

--- a/examples/tests/python/example_test/usethriftpy/use_thrift_test.py
+++ b/examples/tests/python/example_test/usethriftpy/use_thrift_test.py
@@ -3,13 +3,13 @@
 
 # Illustrate using Thrift-generated code from Python.
 
-import unittest2 as unittest
+import unittest
 
 from com.pants.examples.distance.ttypes import Distance
 from com.pants.examples.precipitation.ttypes import Precipitation
 from com.pants.examples.keywords.keywords.ttypes import Keywords
 from com.pants.examples.keywords.another.ttypes import Another
-from thrift.protocol import TProtocol
+
 
 class UseThriftTest(unittest.TestCase):
   def test_make_it_rain(self):

--- a/tests/python/internal_backend_test/sitegen/test_sitegen.py
+++ b/tests/python/internal_backend_test/sitegen/test_sitegen.py
@@ -5,9 +5,8 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
-
 import json
+import unittest
 
 import bs4
 

--- a/tests/python/pants_test/android/tasks/test_aapt_gen.py
+++ b/tests/python/pants_test/android/tasks/test_aapt_gen.py
@@ -7,7 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 
 import os
-import unittest2 as unittest
+import unittest
 
 from pants.backend.android.tasks.aapt_gen import AaptGen
 

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -8,7 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 from contextlib import contextmanager
 import os
 import pytest
-import unittest2 as unittest
+import unittest
 
 from twitter.common.collections import maybe_list
 

--- a/tests/python/pants_test/backend/codegen/tasks/test_protobuf_parse.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_protobuf_parse.py
@@ -8,7 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 import pytest
 from textwrap import dedent
-import unittest2 as unittest
+import unittest
 
 from pants.backend.codegen.tasks.protobuf_parse import (MESSAGE_PARSER, ProtobufParse,
                                                         camelcase, get_outer_class_name,

--- a/tests/python/pants_test/backend/jvm/test_jvm_debug_config.py
+++ b/tests/python/pants_test/backend/jvm/test_jvm_debug_config.py
@@ -6,11 +6,12 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 from textwrap import dedent
-import unittest2 as unittest
+import unittest
 
 from pants.backend.jvm.jvm_debug_config import JvmDebugConfig
 
 from pants_test.base.context_utils import create_config
+
 
 class JvmDebugConfigTest(unittest.TestCase):
   def test_debug_config_default(self):

--- a/tests/python/pants_test/base/test_abbreviate_target_ids.py
+++ b/tests/python/pants_test/base/test_abbreviate_target_ids.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.base.abbreviate_target_ids import abbreviate_target_ids
 

--- a/tests/python/pants_test/base/test_address.py
+++ b/tests/python/pants_test/base/test_address.py
@@ -7,7 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 from contextlib import contextmanager
 import os
-import unittest2 as unittest
+import unittest
 
 from pants.base.address import BuildFileAddress, SyntheticAddress, parse_spec
 from pants.base.build_file import BuildFile

--- a/tests/python/pants_test/base/test_build_configuration.py
+++ b/tests/python/pants_test/base/test_build_configuration.py
@@ -7,7 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 from contextlib import contextmanager
 import os
-import unittest2 as unittest
+import unittest
 
 from pants.base.address import SyntheticAddress
 from pants.base.build_configuration import BuildConfiguration

--- a/tests/python/pants_test/base/test_build_file.py
+++ b/tests/python/pants_test/base/test_build_file.py
@@ -8,7 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 import shutil
 import tempfile
-import unittest2 as unittest
+import unittest
 
 from twitter.common.collections import OrderedSet
 

--- a/tests/python/pants_test/base/test_build_file_aliases.py
+++ b/tests/python/pants_test/base/test_build_file_aliases.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.target import Target

--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import unittest2 as unittest
+import unittest
 
 from pants.base.build_root import BuildRoot
 from pants.util.contextutil import environment_as, pushd, temporary_dir

--- a/tests/python/pants_test/base/test_extension_loader.py
+++ b/tests/python/pants_test/base/test_extension_loader.py
@@ -9,17 +9,27 @@ from contextlib import contextmanager
 import uuid
 import sys
 import types
+import unittest
 
-import unittest2 as unittest
+from pkg_resources import (
+    yield_lines,
+    working_set,
+    Distribution,
+    WorkingSet,
+    EmptyProvider,
+    VersionConflict)
 
 from pants.base.build_configuration import BuildConfiguration
 from pants.base.build_file_aliases import BuildFileAliases
-from pants.base.extension_loader import load_backend, load_plugins, PluginNotFound, PluginLoadOrderError
+from pants.base.extension_loader import (
+    load_backend,
+    load_plugins,
+    PluginNotFound,
+    PluginLoadOrderError)
 from pants.base.exceptions import BuildConfigurationError
 from pants.base.target import Target
 from pants.goal.task_registrar import TaskRegistrar
 from pants.goal.goal import Goal
-from pkg_resources import yield_lines, working_set, Distribution, WorkingSet, EmptyProvider, VersionConflict
 
 
 class MockMetadata(EmptyProvider):

--- a/tests/python/pants_test/base/test_generator.py
+++ b/tests/python/pants_test/base/test_generator.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.base.generator import TemplateData
 

--- a/tests/python/pants_test/base/test_revision.py
+++ b/tests/python/pants_test/base/test_revision.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 import pytest
 

--- a/tests/python/pants_test/base/test_run_info.py
+++ b/tests/python/pants_test/base/test_run_info.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.base.run_info import RunInfo
 from pants.util.contextutil import temporary_file_path

--- a/tests/python/pants_test/base/test_source_root.py
+++ b/tests/python/pants_test/base/test_source_root.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import unittest2 as unittest
+import unittest
 
 from twitter.common.collections import OrderedSet
 

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 import os
 from tempfile import mkdtemp
 from textwrap import dedent
-import unittest2 as unittest
+import unittest
 
 from twitter.common.collections import OrderedSet
 

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -5,12 +5,12 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from contextlib import contextmanager
 import SimpleHTTPServer
 import SocketServer
+from contextlib import contextmanager
 import os
-import unittest2 as unittest
 from threading import Thread
+import unittest
 
 from pants.base.build_invalidator import CacheKey
 from pants.cache.artifact_cache import call_use_cached_files, call_insert
@@ -24,12 +24,14 @@ from pants.util.dirutil import safe_mkdir
 from pants_test.testutils.mock_logger import MockLogger
 from pants_test.base.context_utils import create_context
 
+
 class MockPinger(object):
   def __init__(self, hosts_to_times):
     self._hosts_to_times = hosts_to_times
   # Returns a fake ping time such that the last host is always the 'fastest'.
   def pings(self, hosts):
     return map(lambda host: (host, self._hosts_to_times.get(host, 9999)), hosts)
+
 
 # A very trivial server that serves files under the cwd.
 class SimpleRESTHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
@@ -59,8 +61,10 @@ class SimpleRESTHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
       self.send_error(404, 'File not found')
     self.end_headers()
 
+
 TEST_CONTENT1 = 'muppet'
 TEST_CONTENT2 = 'kermit'
+
 
 class TestArtifactCache(unittest.TestCase):
   @contextmanager

--- a/tests/python/pants_test/engine/base_engine_test.py
+++ b/tests/python/pants_test/engine/base_engine_test.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.goal.task_registrar import TaskRegistrar
 from pants.goal.goal import Goal

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import unittest2 as unittest
+import unittest
 
 from pants.fs.archive import TAR, TBZ2, TGZ, ZIP
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/fs/test_expand_path.py
+++ b/tests/python/pants_test/fs/test_expand_path.py
@@ -7,7 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 from contextlib import contextmanager
 
 import os
-import unittest2 as unittest
+import unittest
 
 from pants.fs.fs import expand_path
 from pants.util.contextutil import environment_as, pushd, temporary_dir

--- a/tests/python/pants_test/fs/test_safe_filename.py
+++ b/tests/python/pants_test/fs/test_safe_filename.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import unittest2 as unittest
+import unittest
 
 import pytest
 

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 import os
 import subprocess
 import textwrap
-import unittest2 as unittest
+import unittest
 
 import pytest
 from twitter.common.collections import maybe_list

--- a/tests/python/pants_test/java/test_executor.py
+++ b/tests/python/pants_test/java/test_executor.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 import os
 import subprocess
 import textwrap
-import unittest2 as unittest
+import unittest
 
 from pants.java.distribution.distribution import Distribution
 from pants.java.executor import SubprocessExecutor

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import shlex
-import unittest2 as unittest
+import unittest
 
 from pants.option.arg_splitter import ArgSplitter
 

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 from pants.option.custom_types import dict_type, list_type
 from pants.option.errors import ParseError
 

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import copy
-import unittest2 as unittest
+import unittest
 
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.ranked_value import RankedValue

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -8,7 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import shlex
 import tempfile
 from textwrap import dedent
-import unittest2 as unittest
+import unittest
 
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 from textwrap import dedent
-import unittest2 as unittest
+import unittest
 
 from pants.base.config import Config
 from pants.option.options_bootstrapper import OptionsBootstrapper

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from operator import eq, ne
 import os
 import subprocess
-import unittest2 as unittest
+import unittest
 
 from pants.fs.archive import ZIP
 from pants.base.build_environment import get_buildroot

--- a/tests/python/pants_test/python/test_antlr_builder.py
+++ b/tests/python/pants_test/python/test_antlr_builder.py
@@ -5,10 +5,11 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 import antlr3
 import antlr3.tree
+
 from pants.backend.python.test.Eval import Eval
 from pants.backend.python.test.ExprLexer import ExprLexer
 from pants.backend.python.test.ExprParser import ExprParser
@@ -18,6 +19,7 @@ from pants.backend.python.test.ExprParser import ExprParser
 # generated ANTLR code. This module shares a namespace prefix with the generated
 # ANTLR code, and so will be masked by it if namespace packages are broken.
 from pants.backend.python.python_setup import PythonSetup
+
 
 class AntlrBuilderTest(unittest.TestCase):
   def test_generated_parser(self):

--- a/tests/python/pants_test/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/python/test_interpreter_cache.py
@@ -5,15 +5,12 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import contextlib
-import shutil
-import tempfile
-import unittest2 as unittest
+import unittest
+
+import mock
 
 from pants.backend.python.interpreter_cache import PythonInterpreter, PythonInterpreterCache
 from pants.util.contextutil import temporary_dir
-
-import mock
 
 
 class TestInterpreterCache(unittest.TestCase):

--- a/tests/python/pants_test/python/test_resolver.py
+++ b/tests/python/pants_test/python/test_resolver.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pex.platforms import Platform
 

--- a/tests/python/pants_test/python/test_thrift_namespace_packages.py
+++ b/tests/python/pants_test/python/test_thrift_namespace_packages.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.birds.duck.ttypes import Duck
 from pants.birds.goose.ttypes import Goose

--- a/tests/python/pants_test/reporting/test_linkify.py
+++ b/tests/python/pants_test/reporting/test_linkify.py
@@ -8,13 +8,14 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import os
 import shutil
 import tempfile
-import unittest2 as unittest
+import unittest
 
 from pants.reporting.linkify import linkify
 
 
 def ensure_dir_exists(path):
   os.makedirs(path)
+
 
 def ensure_file_exists(path):
   ensure_dir_exists(os.path.dirname(path))

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -10,7 +10,7 @@ from itertools import izip_longest
 import os
 import re
 import subprocess
-import unittest2 as unittest
+import unittest
 
 import pytest
 

--- a/tests/python/pants_test/tasks/jvm_compile/scala/test_zinc_analysis.py
+++ b/tests/python/pants_test/tasks/jvm_compile/scala/test_zinc_analysis.py
@@ -8,7 +8,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 import contextlib
 import os
 import tarfile
-import unittest2 as unittest
+import unittest
 
 from pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis import ZincAnalysis
 from pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis_parser import ZincAnalysisParser

--- a/tests/python/pants_test/tasks/test_config.py
+++ b/tests/python/pants_test/tasks/test_config.py
@@ -7,7 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import textwrap
 
-import unittest2 as unittest
+import unittest
 
 from pants.base.config import Config
 from pants.util.contextutil import temporary_file

--- a/tests/python/pants_test/tasks/test_jar_library_with_overrides.py
+++ b/tests/python/pants_test/tasks/test_jar_library_with_overrides.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.base import ParseContext
 from pants.backend.jvm.targets.exclude import Exclude

--- a/tests/python/pants_test/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/tasks/test_jar_publish.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import unittest2 as unittest
+import unittest
 
 from mock import Mock
 import pytest

--- a/tests/python/pants_test/tasks/test_jaxb_gen.py
+++ b/tests/python/pants_test/tasks/test_jaxb_gen.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.backend.codegen.tasks.jaxb_gen import JaxbGen
 from pants.util.contextutil import temporary_file

--- a/tests/python/pants_test/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/tasks/test_markdown_to_html.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.backend.core.tasks import markdown_to_html
 

--- a/tests/python/pants_test/tasks/test_protobuf_gen.py
+++ b/tests/python/pants_test/tasks/test_protobuf_gen.py
@@ -7,7 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import os
 from textwrap import dedent
-import unittest2 as unittest
+import unittest
 
 from twitter.common.collections import OrderedSet
 

--- a/tests/python/pants_test/test_thrift_util.py
+++ b/tests/python/pants_test/test_thrift_util.py
@@ -6,7 +6,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 import os
-import unittest2 as unittest
+import unittest
 
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import subprocess
 import sys
-import unittest2 as unittest
+import unittest
 
 from pants.util.contextutil import environment_as, pushd, temporary_dir, temporary_file, Timer
 

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -10,7 +10,7 @@ import os
 import tempfile
 
 import mox
-import unittest2 as unittest
+import unittest
 
 from pants.util import dirutil
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/util/test_keywords.py
+++ b/tests/python/pants_test/util/test_keywords.py
@@ -7,7 +7,7 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
 
 import os
 from textwrap import dedent
-import unittest2 as unittest
+import unittest
 
 from mock import call, mock_open, patch
 

--- a/tests/python/pants_test/util/test_strutil.py
+++ b/tests/python/pants_test/util/test_strutil.py
@@ -5,7 +5,7 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-import unittest2 as unittest
+import unittest
 
 from pants.util.strutil import camelcase
 


### PR DESCRIPTION
The pants.backend.python.test_builder.PythonTestBuilder has a valid need
to depend on unittest2 for codebases _using_ pants to run tests that are
pre-2.7 or v3 pre-3.3. The pants test code itself does not have this
need since we dropped 2.6 support and require a 3.3+ interpreter if
running under 3 - eventually

https://rbcommons.com/s/twitter/r/1689/