### PR TITLE
Remove goal keyword from CLI help.

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -239,7 +239,7 @@ class Options(object):
       print('  ./pants [option ...] [goal ...] [target...]  Attempt the specified goals.')
       print('  ./pants help                                 Get help.')
       print('  ./pants help [goal]                          Get help for the specified goal.')
-      print('  ./pants goal goals                           List all installed goals.')
+      print('  ./pants goals                                List all installed goals.')
       print('')
       print('  [target] accepts two special forms:')
       print('    dir:  to include all targets in the specified directory.')


### PR DESCRIPTION
./pants -h still recomended './pants goal goals'.
Now corrected to './pants goals'.