### PR TITLE
Add zip64 support to ZipFile constructor

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -157,6 +157,7 @@ python_library(
     '3rdparty/python:pex',
     'src/python/pants/base:exceptions',
     'src/python/pants/java:jar',
+    'src/python/pants/util:contextutil',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/detect_duplicates.py
+++ b/src/python/pants/backend/jvm/tasks/detect_duplicates.py
@@ -106,7 +106,7 @@ class DuplicateDetector(JvmBinaryTask):
     for basedir, externaljar in  self.list_external_jar_dependencies(binary_target):
       external_dep = os.path.join(basedir, externaljar)
       self.context.log.debug('  scanning %s' % external_dep)
-      with closing(ZipFile(external_dep)) as dep_zip:
+      with closing(ZipFile(external_dep, allowZip64=True)) as dep_zip:
         for qualified_file_name in dep_zip.namelist():
           # Zip entry names can come in any encoding and in practice we find some jars that have
           # utf-8 encoded entry names, some not.  As a result we cannot simply decode in all cases

--- a/src/python/pants/backend/jvm/tasks/detect_duplicates.py
+++ b/src/python/pants/backend/jvm/tasks/detect_duplicates.py
@@ -6,15 +6,14 @@ from __future__ import (nested_scopes, generators, division, absolute_import, wi
                         print_function, unicode_literals)
 
 from collections import defaultdict
-from contextlib import closing
 import os
-from zipfile import ZipFile
 
 from pex.compatibility import to_bytes
 
 from pants.backend.jvm.tasks.jvm_binary_task import JvmBinaryTask
 from pants.base.exceptions import TaskError
 from pants.java.jar.manifest import Manifest
+from pants.util.contextutil import open_zip64
 
 
 EXCLUDED_FILES = ['dependencies,license,notice,.DS_Store,notice.txt,cmdline.arg.info.txt.1,'
@@ -106,7 +105,7 @@ class DuplicateDetector(JvmBinaryTask):
     for basedir, externaljar in  self.list_external_jar_dependencies(binary_target):
       external_dep = os.path.join(basedir, externaljar)
       self.context.log.debug('  scanning %s' % external_dep)
-      with closing(ZipFile(external_dep, allowZip64=True)) as dep_zip:
+      with open_zip64(external_dep) as dep_zip:
         for qualified_file_name in dep_zip.namelist():
           # Zip entry names can come in any encoding and in practice we find some jars that have
           # utf-8 encoded entry names, some not.  As a result we cannot simply decode in all cases

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -26,7 +26,7 @@ from pants.base.worker_pool import Work
 from pants.goal.products import MultipleRootedProducts
 from pants.option.options import Options
 from pants.reporting.reporting_utils import items_to_report_element
-from pants.util.contextutil import open_zip, temporary_dir
+from pants.util.contextutil import open_zip64, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_rmtree, safe_walk
 
 
@@ -733,7 +733,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
       for cp_entry in self.find_all_bootstrap_jars() + classpath_entries:
         # Per the classloading spec, a 'jar' in this context can also be a .zip file.
         if os.path.isfile(cp_entry) and ((cp_entry.endswith('.jar') or cp_entry.endswith('.zip'))):
-          with open_zip(cp_entry, 'r') as jar:
+          with open_zip64(cp_entry, 'r') as jar:
             for cls in jar.namelist():
               # First jar with a given class wins, just like when classloading.
               if cls.endswith(b'.class') and not cls in self._upstream_class_to_path:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
@@ -20,7 +20,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnit
-from pants.util.contextutil import open_zip as open_jar
+from pants.util.contextutil import open_zip64 as open_jar
 from pants.util.dirutil import relativize_paths, safe_open
 
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
@@ -20,7 +20,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnit
-from pants.util.contextutil import open_zip64 as open_jar
+from pants.util.contextutil import open_zip64
 from pants.util.dirutil import relativize_paths, safe_open
 
 
@@ -207,7 +207,7 @@ class ZincUtils(object):
     # plugin_jars is the universe of all possible plugins and their transitive deps.
     # Here we select the ones to actually use.
     for jar in self.plugin_jars():
-      with open_jar(jar, 'r') as jarfile:
+      with open_zip64(jar, 'r') as jarfile:
         try:
           with closing(jarfile.open(_PLUGIN_INFO_FILE, 'r')) as plugin_info_file:
             plugin_info = ElementTree.parse(plugin_info_file).getroot()

--- a/src/python/pants/backend/jvm/tasks/provides.py
+++ b/src/python/pants/backend/jvm/tasks/provides.py
@@ -13,7 +13,7 @@ from twitter.common.collections import OrderedSet
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.ivy_utils import IvyModuleRef, IvyUtils
-from pants.util.contextutil import open_zip as open_jar
+from pants.util.contextutil import open_zip64 as open_jar
 from pants.util.dirutil import safe_mkdir
 
 

--- a/src/python/pants/backend/jvm/tasks/provides.py
+++ b/src/python/pants/backend/jvm/tasks/provides.py
@@ -13,7 +13,7 @@ from twitter.common.collections import OrderedSet
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.ivy_utils import IvyModuleRef, IvyUtils
-from pants.util.contextutil import open_zip64 as open_jar
+from pants.util.contextutil import open_zip64
 from pants.util.dirutil import safe_mkdir
 
 
@@ -117,5 +117,5 @@ class Provides(Task):
       return create_collection(ref)
 
   def list_jar(self, path):
-    with open_jar(path, 'r') as jar:
+    with open_zip64(path, 'r') as jar:
       return jar.namelist()

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -15,7 +15,7 @@ from zipfile import ZIP_DEFLATED
 
 from twitter.common.lang import AbstractClass
 
-from pants.util.contextutil import open_tar, open_zip
+from pants.util.contextutil import open_tar, open_zip64
 from pants.util.dirutil import safe_walk
 from pants.util.strutil import ensure_text
 
@@ -67,7 +67,7 @@ class ZipArchiver(Archiver):
     :param function filter_func: optional filter with the filename as the parameter.  Returns True if
       the file should be extracted.
     """
-    with open_zip(path) as archive_file:
+    with open_zip64(path) as archive_file:
       for name in archive_file.namelist():
         # While we're at it, we also perform this safety test.
         if name.startswith(b'/') or name.startswith(b'..'):
@@ -86,7 +86,7 @@ class ZipArchiver(Archiver):
 
   def create(self, basedir, outdir, name, prefix=None):
     zippath = os.path.join(outdir, '%s.zip' % name)
-    with open_zip(zippath, 'w', compression=ZIP_DEFLATED) as zip:
+    with open_zip64(zippath, 'w', compression=ZIP_DEFLATED) as zip:
       for root, _, files in safe_walk(basedir):
         root = ensure_text(root)
         for file in files:

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -157,7 +157,8 @@ def open_zip64(path_or_file, allowZip64=True, *args, **kwargs):
     Passes through positional and kwargs to openZip.
   """
   kwargs['allowZip64'] = allowZip64
-  open_zip(path_or_file, args, kwargs)
+  with open_zip(path_or_file, *args, **kwargs) as zf:
+    yield zf
 
 
 @contextmanager

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -151,7 +151,7 @@ def open_zip(path_or_file, *args, **kwargs):
     zf.close()
 
 @contextmanager
-def open_zip64True(path_or_file, *args, **kwargs):
+def open_zip64(path_or_file, *args, **kwargs):
   """
     A with-context for zip files with allowZip64 True.
     Passes through positional and kwargs to openZip.

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -162,7 +162,6 @@ def open_zip64(path_or_file, *args, **kwargs):
   with open_zip(path_or_file, *args, allowZip64=allowZip64, **kwargs) as zf:
     yield zf
 
-
 @contextmanager
 def open_tar(path_or_file, *args, **kwargs):
   """

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -151,13 +151,15 @@ def open_zip(path_or_file, *args, **kwargs):
     zf.close()
 
 @contextmanager
-def open_zip64(path_or_file, allowZip64=True, *args, **kwargs):
+def open_zip64True(path_or_file, *args, **kwargs):
   """
-    A with-context for zip files with allowZip64 set to True by default.
+    A with-context for zip files with allowZip64 True.
     Passes through positional and kwargs to openZip.
   """
-  kwargs['allowZip64'] = allowZip64
-  with open_zip(path_or_file, *args, **kwargs) as zf:
+  allowZip64 = True
+  if 'allowZip64' in kwargs:
+     allowZip64 = kwargs.pop('allowZip64')
+  with open_zip(path_or_file, *args, allowZip64=allowZip64, **kwargs) as zf:
     yield zf
 
 

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -157,9 +157,7 @@ def open_zip64(path_or_file, *args, **kwargs):
     A with-context for zip files with allowZip64 True.
     Passes through positional and kwargs to openZip.
   """
-  allowZip64 = True
-  if 'allowZip64' in kwargs:
-     allowZip64 = kwargs.pop('allowZip64')
+  allowZip64 = kwargs.pop('allowZip64', True)
   with open_zip(path_or_file, *args, allowZip64=allowZip64, **kwargs) as zf:
     yield zf
 

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -150,6 +150,15 @@ def open_zip(path_or_file, *args, **kwargs):
   finally:
     zf.close()
 
+@contextmanager
+def open_zip64(path_or_file, allowZip64=True, *args, **kwargs):
+  """
+    A with-context for zip files with allowZip64 set to True by default.
+    Passes through positional and kwargs to openZip.
+  """
+  kwargs['allowZip64'] = allowZip64
+  open_zip(path_or_file, args, kwargs)
+
 
 @contextmanager
 def open_tar(path_or_file, *args, **kwargs):

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -150,6 +150,7 @@ def open_zip(path_or_file, *args, **kwargs):
   finally:
     zf.close()
 
+
 @contextmanager
 def open_zip64(path_or_file, *args, **kwargs):
   """
@@ -161,6 +162,7 @@ def open_zip64(path_or_file, *args, **kwargs):
      allowZip64 = kwargs.pop('allowZip64')
   with open_zip(path_or_file, *args, allowZip64=allowZip64, **kwargs) as zf:
     yield zf
+
 
 @contextmanager
 def open_tar(path_or_file, *args, **kwargs):

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -321,6 +321,7 @@ python_tests(
     ':base',
     'src/python/pants/base:exceptions',
     'src/python/pants/backend/jvm/tasks:detect_duplicates',
+    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/base:context_utils',
   ],

--- a/tests/python/pants_test/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/tasks/test_detect_duplicates.py
@@ -40,7 +40,7 @@ class DuplicateDetectorTest(TaskTestBase):
     touch(unicode_class_path)
 
     def generate_jar(path, *class_name):
-      with closing(ZipFile(generate_path(path), 'w')) as zipfile:
+      with closing(ZipFile(generate_path(path), 'w', allowZip64=True)) as zipfile:
         for clazz in class_name:
           zipfile.write(clazz)
         return zipfile.filename

--- a/tests/python/pants_test/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/tasks/test_detect_duplicates.py
@@ -5,14 +5,14 @@
 from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
                         print_function, unicode_literals)
 
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 import os
 import tempfile
-from zipfile import ZipFile
 
 from pants.backend.jvm.tasks.detect_duplicates import DuplicateDetector
 from pants.base.exceptions import TaskError
 from pants.util.dirutil import safe_rmtree, touch
+from pants.util.contextutil import open_zip64
 from pants_test.task_test_base import TaskTestBase
 
 
@@ -40,7 +40,7 @@ class DuplicateDetectorTest(TaskTestBase):
     touch(unicode_class_path)
 
     def generate_jar(path, *class_name):
-      with closing(ZipFile(generate_path(path), 'w', allowZip64=True)) as zipfile:
+      with open_zip64(generate_path(path), 'w') as zipfile:
         for clazz in class_name:
           zipfile.write(clazz)
         return zipfile.filename

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -11,8 +11,8 @@ import subprocess
 import sys
 import unittest
 
-from pants.util.contextutil import environment_as, open_zip, open_zip64True, \
-  pushd, temporary_dir, temporary_file, Timer
+from pants.util.contextutil import (environment_as, open_zip64, pushd, temporary_dir,
+                                    temporary_file, Timer)
 
 
 class ContextutilTest(unittest.TestCase):
@@ -138,13 +138,13 @@ class ContextutilTest(unittest.TestCase):
     self.assertLess(t.finish, clock.time())
 
   def test_open_zip64Default(self):
-    with open_zip64True('test', 'w') as zf:
+    with open_zip64('test', 'w') as zf:
       self.assertTrue(zf._allowZip64)
 
   def test_open_zip64True(self):
-    with open_zip64True('test', 'w', allowZip64=True) as zf:
+    with open_zip64('test', 'w', allowZip64=True) as zf:
       self.assertTrue(zf._allowZip64)
 
   def test_open_zip64False(self):
-    with open_zip64True('test', 'w', allowZip64=False) as zf:
+    with open_zip64('test', 'w', allowZip64=False) as zf:
       self.assertFalse(zf._allowZip64)

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -11,7 +11,8 @@ import subprocess
 import sys
 import unittest
 
-from pants.util.contextutil import environment_as, pushd, temporary_dir, temporary_file, Timer
+from pants.util.contextutil import environment_as, open_zip, open_zip64True, \
+  pushd, temporary_dir, temporary_file, Timer
 
 
 class ContextutilTest(unittest.TestCase):
@@ -135,3 +136,15 @@ class ContextutilTest(unittest.TestCase):
       self.assertTrue(t.finish is None)
     self.assertGreater(t.elapsed, 0.2)
     self.assertLess(t.finish, clock.time())
+
+  def test_open_zip64Default(self):
+    with open_zip64True('test', 'w') as zf:
+      self.assertTrue(zf._allowZip64)
+
+  def test_open_zip64True(self):
+    with open_zip64True('test', 'w', allowZip64=True) as zf:
+      self.assertTrue(zf._allowZip64)
+
+  def test_open_zip64False(self):
+    with open_zip64True('test', 'w', allowZip64=False) as zf:
+      self.assertFalse(zf._allowZip64)


### PR DESCRIPTION
In Twitter Production machines python was upgraded to 2.7.9 and we started seeing LargeZipFile exception
In python 2.7.9 following bug was fixed 
http://bugs.python.org/issue21866.
Summary: ZipFile correctly throws an exception if allowZip64 is False and the file count exceeds 65535.