### PR TITLE
Upgrade to the latest virtualenv.

### DIFF
--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Wrapper for self-bootstrapping virtualenv
 set -e
-VIRTUALENV_VERSION=12.0.5
+VIRTUALENV_VERSION=12.0.7
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.python.org/packages/source/v/virtualenv}
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)


### PR DESCRIPTION
This was prompted by messages like so:
```console
...
‘virtualenv-12.0.5’ -> ‘virtualenv.dist’
~/dev/3rdparty/pants
New python executable in
/home/jsirois/dev/3rdparty/pants/build-support/pants_dev_deps.venv/bin/python2.7
Also creating executable in
/home/jsirois/dev/3rdparty/pants/build-support/pants_dev_deps.venv/bin/python
Installing setuptools, pip...done.
You are using pip version 6.0.6, however version 6.0.8 is available.
You should consider upgrading via the 'pip install --upgrade pip'
command.
...
```

The actual changes in the 2 point releases are bumping the pip dep as
well as the setuptools dep.

This was split off from https://rbcommons.com/s/twitter/r/1715/

https://rbcommons.com/s/twitter/r/1718/