### PR TITLE
Upgrade to pex 0.8.5.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ mock==1.0.1
 mox==0.5.3
 # Until https://github.com/pantsbuild/pex/issues/28 is addressed, we cannot
 # do pex<0.9.0.
-pex>=0.8.4,<0.8.999999
+pex>=0.8.5,<0.8.999999
 psutil==1.1.3
 lockfile==0.10.2
 Pygments==1.4


### PR DESCRIPTION
This has no functional changes for pants use.  The only change is to the
pex utility itself to support python 2.6 clients.  This just keeps pants
up to date.

https://rbcommons.com/s/twitter/r/1721/