### PR TITLE
Introduce isort to check *.py import ordering.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,10 @@
+# See the menu of settings available here:
+#   https://github.com/timothycrosley/isort/wiki/isort-Settings
+
+[settings]
+line_length=100
+indent=2
+lines_after_imports=2
+known_first_party=internal_backend,pants,pants_test
+known_third_party=twitter.common
+default_section=THIRDPARTY

--- a/build-support/bin/check_header.sh
+++ b/build-support/bin/check_header.sh
@@ -8,8 +8,8 @@ expected_header=$(cat <<EOF
 # Copyright YYYY Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 EOF
 )

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -109,6 +109,7 @@ if [ ! -z "${R}" ]; then
 fi
 
 build-support/bin/check_header.sh || exit 1
+build-support/bin/isort.sh || exit 1
 
 # Sanity checks
 ./pants.pex clean-all ${PANTS_ARGS[@]} || die "Failed to clean-all."

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+
+source ${ROOT}/build-support/common.sh
+
+function usage() {
+  echo "Checks import sort order for python files, optionally fixing incorrect"
+  echo "sorts."
+  echo
+  echo "Usage: $0 (-h|-f)"
+  echo " -h    print out this help message"
+  echo " -f    instead of erroring on files with bad import sort order, fix"
+  echo "       those files"
+  if (( $# > 0 )); then
+    die "$@"
+  else
+    exit 0
+  fi
+} 
+
+isort_args=(
+  --check-only
+)
+
+while getopts "hf" opt
+do
+  case ${opt} in
+    h) usage ;;
+    f) isort_args=() ;;
+    *) usage "Invalid option: -${OPTARG}" ;;
+  esac 
+done
+
+REQUIREMENTS=(
+  "isort==3.9.5"
+)
+
+VENV_DIR="${ROOT}/build-support/isort.venv"
+
+function fingerprint_data() {
+  openssl md5 | cut -d' ' -f2
+}
+
+function activate_venv() {
+  source "${VENV_DIR}/bin/activate"
+}
+
+function create_venv() {
+  rm -rf "${VENV_DIR}"
+  "${ROOT}/build-support/virtualenv" "${VENV_DIR}"
+} 
+
+function activate_isort() {
+  for req in ${REQUIREMENTS[@]}
+  do
+    fingerprint="$(echo "${fingerprint}${req}" | fingerprint_data)"
+  done
+
+ bootsrapped_file="${VENV_DIR}/BOOTSTRAPPED.${fingerprint}"
+ if ! [ -f "${bootsrapped_file}" ]
+ then
+   create_venv || die "Failed to create venv."
+   activate_venv || die "Failed to activate venv."
+   for req in ${REQUIREMENTS[@]}
+   do
+     pip install ${req} || die "Failed to install requirements from ${req}."
+   done
+   touch "${bootsrapped_file}"
+ else
+   activate_venv || die "Failed to activate venv."
+ fi
+}
+
+activate_isort
+
+isort ${isort_args[@]} --recursive src tests pants-plugins
+

--- a/pants-plugins/src/python/internal_backend/optional/register.py
+++ b/pants-plugins/src/python/internal_backend/optional/register.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.checkstyle import Checkstyle
 from pants.backend.jvm.tasks.scalastyle import Scalastyle

--- a/pants-plugins/src/python/internal_backend/repositories/register.py
+++ b/pants-plugins/src/python/internal_backend/repositories/register.py
@@ -2,14 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
 from pants.backend.jvm.repository import Repository
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.build_manual import manual
+
 
 public_repo = Repository(name = 'public',
                          url = 'http://maven.twttr.com',
@@ -33,4 +34,3 @@ def build_file_aliases():
       'testing': testing_repo,
     },
   )
-

--- a/pants-plugins/src/python/internal_backend/sitegen/register.py
+++ b/pants-plugins/src/python/internal_backend/sitegen/register.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from internal_backend.sitegen.tasks.sitegen import SiteGen
 from pants.goal.task_registrar import TaskRegistrar as task

--- a/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
+++ b/pants-plugins/src/python/internal_backend/sitegen/tasks/sitegen.py
@@ -2,15 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
-"""Static Site Generator for the Pants Build documentation site.
-
-Suggested use:
-  cd pants
-  ./build-support/bin/publish_docs.sh  # invokes sitegen.py
-"""
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import collections
 import datetime
@@ -24,6 +17,14 @@ import pystache
 
 from pants.backend.core.tasks.task import Task
 from pants.base.exceptions import TaskError
+
+
+"""Static Site Generator for the Pants Build documentation site.
+
+Suggested use:
+  cd pants
+  ./build-support/bin/publish_docs.sh  # invokes sitegen.py
+"""
 
 
 class SiteGen(Task):

--- a/pants-plugins/tests/python/internal_backend_test/sitegen/test_sitegen.py
+++ b/pants-plugins/tests/python/internal_backend_test/sitegen/test_sitegen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import json
 import unittest
@@ -11,6 +11,7 @@ import unittest
 import bs4
 
 from internal_backend.sitegen.tasks import sitegen
+
 
 CONFIG_JSON = """
 {

--- a/src/python/pants/backend/android/android_config_util.py
+++ b/src/python/pants/backend/android/android_config_util.py
@@ -2,8 +2,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import textwrap

--- a/src/python/pants/backend/android/distribution/android_distribution.py
+++ b/src/python/pants/backend/android/distribution/android_distribution.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/android/keystore/keystore_resolver.py
+++ b/src/python/pants/backend/android/keystore/keystore_resolver.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/android/register.py
+++ b/src/python/pants/backend/android/register.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.android.targets.android_binary import AndroidBinary
 from pants.backend.android.targets.android_resources import AndroidResources
-from pants.backend.android.tasks.aapt_gen import AaptGen
 from pants.backend.android.tasks.aapt_builder import AaptBuilder
+from pants.backend.android.tasks.aapt_gen import AaptGen
 from pants.backend.android.tasks.dx_compile import DxCompile
 from pants.backend.android.tasks.sign_apk import SignApkTask
 from pants.base.build_file_aliases import BuildFileAliases

--- a/src/python/pants/backend/android/targets/android_binary.py
+++ b/src/python/pants/backend/android/targets/android_binary.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.android.targets.android_target import AndroidTarget
 

--- a/src/python/pants/backend/android/targets/android_resources.py
+++ b/src/python/pants/backend/android/targets/android_resources.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
-from pants.base.exceptions import TargetDefinitionException
 from pants.backend.android.targets.android_target import AndroidTarget
+from pants.base.exceptions import TargetDefinitionException
 
 
 class AndroidResources(AndroidTarget):

--- a/src/python/pants/backend/android/targets/android_target.py
+++ b/src/python/pants/backend/android/targets/android_target.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from xml.dom.minidom import parse

--- a/src/python/pants/backend/android/tasks/aapt_builder.py
+++ b/src/python/pants/backend/android/tasks/aapt_builder.py
@@ -2,13 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os
 import subprocess
-
 
 from pants.backend.android.targets.android_binary import AndroidBinary
 from pants.backend.android.targets.android_resources import AndroidResources

--- a/src/python/pants/backend/android/tasks/aapt_gen.py
+++ b/src/python/pants/backend/android/tasks/aapt_gen.py
@@ -2,12 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os
 import subprocess
+
+from twitter.common.collections import OrderedSet
 
 from pants.backend.android.targets.android_resources import AndroidResources
 from pants.backend.android.tasks.aapt_task import AaptTask
@@ -20,8 +22,6 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 from pants.util.dirutil import safe_mkdir
-
-from twitter.common.collections import OrderedSet
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/backend/android/tasks/aapt_task.py
+++ b/src/python/pants/backend/android/tasks/aapt_task.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
@@ -57,4 +57,3 @@ class AaptTask(AndroidTask):
       target_sdk = self._forced_target_sdk
     android_jar = os.path.join('platforms', 'android-' + target_sdk, 'android.jar')
     return self._android_dist.register_android_tool(android_jar)
-

--- a/src/python/pants/backend/android/tasks/android_task.py
+++ b/src/python/pants/backend/android/tasks/android_task.py
@@ -2,11 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.backend.core.tasks.task import Task
 from pants.backend.android.distribution.android_distribution import AndroidDistribution
+from pants.backend.core.tasks.task import Task
+
 
 class AndroidTask(Task):
   """Base class for Android tasks that may require the Android SDK."""

--- a/src/python/pants/backend/android/tasks/dx_compile.py
+++ b/src/python/pants/backend/android/tasks/dx_compile.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -2,8 +2,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os

--- a/src/python/pants/backend/authentication/netrc_util.py
+++ b/src/python/pants/backend/authentication/netrc_util.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import collections
 import os
-
-from netrc import netrc as NetrcDb, NetrcParseError
+from netrc import netrc as NetrcDb
+from netrc import NetrcParseError
 
 
 class Netrc(object):

--- a/src/python/pants/backend/authentication/register.py
+++ b/src/python/pants/backend/authentication/register.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.authentication.netrc_util import Netrc
 from pants.base.build_file_aliases import BuildFileAliases

--- a/src/python/pants/backend/codegen/register.py
+++ b/src/python/pants/backend/codegen/register.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.codegen.targets.java_antlr_library import JavaAntlrLibrary
 from pants.backend.codegen.targets.java_protobuf_library import JavaProtobufLibrary

--- a/src/python/pants/backend/codegen/targets/java_antlr_library.py
+++ b/src/python/pants/backend/codegen/targets/java_antlr_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 

--- a/src/python/pants/backend/codegen/targets/java_protobuf_library.py
+++ b/src/python/pants/backend/codegen/targets/java_protobuf_library.py
@@ -2,17 +2,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
+
 import six
 
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.backend.jvm.targets.jar_library import JarLibrary
-
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/codegen/targets/java_ragel_library.py
+++ b/src/python/pants/backend/codegen/targets/java_ragel_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.build_manual import manual

--- a/src/python/pants/backend/codegen/targets/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/java_thrift_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.config import Config

--- a/src/python/pants/backend/codegen/targets/java_wire_library.py
+++ b/src/python/pants/backend/codegen/targets/java_wire_library.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 from textwrap import dedent
 
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
-
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/codegen/targets/jaxb_library.py
+++ b/src/python/pants/backend/codegen/targets/jaxb_library.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import sys
 from hashlib import sha1
 from types import GeneratorType
-import sys
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/codegen/targets/python_antlr_library.py
+++ b/src/python/pants/backend/codegen/targets/python_antlr_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/codegen/targets/python_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/python_thrift_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.python.targets.python_target import PythonTarget
 

--- a/src/python/pants/backend/codegen/tasks/antlr_gen.py
+++ b/src/python/pants/backend/codegen/tasks/antlr_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os

--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict, namedtuple
 import errno
 import os
 import re
 import subprocess
+from collections import defaultdict, namedtuple
 
 from twitter.common import log
 from twitter.common.collections import OrderedSet
@@ -26,6 +26,7 @@ from pants.base.exceptions import TaskError
 from pants.base.target import Target
 from pants.thrift_util import calculate_compile_roots, select_thrift_binary
 from pants.util.dirutil import safe_mkdir, safe_walk
+
 
 INCLUDE_RE = re.compile(r'include (?:"(.*?)"|\'(.*?)\')')
 

--- a/src/python/pants/backend/codegen/tasks/code_gen.py
+++ b/src/python/pants/backend/codegen/tasks/code_gen.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os.path
 from collections import defaultdict
 
+from pants.backend.core.tasks.task import Task
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
-from pants.backend.core.tasks.task import Task
 
 
 class CodeGen(Task):

--- a/src/python/pants/backend/codegen/tasks/jaxb_gen.py
+++ b/src/python/pants/backend/codegen/tasks/jaxb_gen.py
@@ -2,12 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re
-# python documentation says xml parsing is insecure, but this should be safe usage because we're
 # just running it on code in our repositories, not on externally acquired data.
 from xml.dom.minidom import parse
 
@@ -20,6 +19,10 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.java.distribution.distribution import Distribution
 from pants.util.dirutil import safe_mkdir
+
+
+# python documentation says xml parsing is insecure, but this should be safe usage because we're
+
 
 
 class JaxbGen(CodeGen, NailgunTask):

--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict, OrderedDict
-from hashlib import sha1
 import itertools
 import os
 import re
 import subprocess
+from collections import OrderedDict, defaultdict
+from hashlib import sha1
 
 from twitter.common import log
 from twitter.common.collections import OrderedSet, maybe_list

--- a/src/python/pants/backend/codegen/tasks/protobuf_parse.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_parse.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re
@@ -110,4 +110,3 @@ def update_type_list(match, type_depth, outer_types):
 def get_outer_class_name(source):
   filename = re.sub(r'\.proto$', '', os.path.basename(source))
   return camelcase(filename)
-

--- a/src/python/pants/backend/codegen/tasks/ragel_gen.py
+++ b/src/python/pants/backend/codegen/tasks/ragel_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re

--- a/src/python/pants/backend/codegen/tasks/scrooge_gen.py
+++ b/src/python/pants/backend/codegen/tasks/scrooge_gen.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict, namedtuple
 import hashlib
 import os
 import re
 import tempfile
+from collections import defaultdict, namedtuple
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/codegen/tasks/thrift_linter.py
+++ b/src/python/pants/backend/codegen/tasks/thrift_linter.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.base.exceptions import TaskError
-from pants.base.workunit import WorkUnit
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnit
 
 
 class ThriftLinter(NailgunTask, JvmToolTaskMixin):

--- a/src/python/pants/backend/codegen/tasks/wire_gen.py
+++ b/src/python/pants/backend/codegen/tasks/wire_gen.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict, OrderedDict
 import itertools
 import logging
 import os
+from collections import OrderedDict, defaultdict
 
 from twitter.common.collections import OrderedSet, maybe_list
 

--- a/src/python/pants/backend/core/from_target.py
+++ b/src/python/pants/backend/core/from_target.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import six
 

--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import sys
 
+from pants.backend.core.from_target import FromTarget
 from pants.backend.core.targets.dependencies import Dependencies, DeprecatedDependencies
 from pants.backend.core.targets.doc import Page, Wiki, WikiArtifact
 from pants.backend.core.targets.prep_command import PrepCommand
@@ -28,13 +29,12 @@ from pants.backend.core.tasks.noop import NoopCompile, NoopTest
 from pants.backend.core.tasks.pathdeps import PathDeps
 from pants.backend.core.tasks.paths import Path, Paths
 from pants.backend.core.tasks.prepare_resources import PrepareResources
-from pants.backend.core.tasks.reporting_server import RunServer, KillServer
+from pants.backend.core.tasks.reporting_server import KillServer, RunServer
 from pants.backend.core.tasks.roots import ListRoots
 from pants.backend.core.tasks.run_prep_command import RunPrepCommand
 from pants.backend.core.tasks.sorttargets import SortTargets
 from pants.backend.core.tasks.targets_help import TargetsHelp
 from pants.backend.core.tasks.what_changed import WhatChanged
-from pants.backend.core.from_target import FromTarget
 from pants.backend.core.wrapped_globs import Globs, RGlobs, ZGlobs
 from pants.base.build_environment import get_buildroot, pants_version
 from pants.base.build_file_aliases import BuildFileAliases

--- a/src/python/pants/backend/core/targets/dependencies.py
+++ b/src/python/pants/backend/core/targets/dependencies.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 

--- a/src/python/pants/backend/core/targets/doc.py
+++ b/src/python/pants/backend/core/targets/doc.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.lang import Compatibility
 
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.payload import Payload
-from pants.base.payload_field import combine_hashes, PayloadField, PrimitiveField, SourcesField
+from pants.base.payload_field import PayloadField, PrimitiveField, SourcesField, combine_hashes
 from pants.base.target import Target
 
 

--- a/src/python/pants/backend/core/targets/prep_command.py
+++ b/src/python/pants/backend/core/targets/prep_command.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField

--- a/src/python/pants/backend/core/targets/resources.py
+++ b/src/python/pants/backend/core/targets/resources.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.payload import Payload
 from pants.base.payload_field import SourcesField

--- a/src/python/pants/backend/core/tasks/builddictionary.py
+++ b/src/python/pants/backend/core/tasks/builddictionary.py
@@ -2,19 +2,19 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pkg_resources import resource_string
 import os
 import re
 
-from pants.backend.core.tasks.reflect import (assemble_buildsyms,
-                                              gen_glopts_reference_data,
+from pkg_resources import resource_string
+
+from pants.backend.core.tasks.reflect import (assemble_buildsyms, gen_glopts_reference_data,
                                               gen_tasks_options_reference_data)
 from pants.backend.core.tasks.task import Task
-from pants.util.dirutil import safe_open
 from pants.base.generator import Generator, TemplateData
+from pants.util.dirutil import safe_open
 
 
 # x may be a str or a unicode, so don't hard-code str.lower or unicode.lower.

--- a/src/python/pants/backend/core/tasks/changed_target_goals.py
+++ b/src/python/pants/backend/core/tasks/changed_target_goals.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 
-from pants.backend.core.tasks.noop import (NoopExecTask, NoopCompile, NoopTest)
+from pants.backend.core.tasks.noop import NoopCompile, NoopExecTask, NoopTest
 from pants.backend.core.tasks.what_changed import ChangedFileTaskMixin
 
 

--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/core/tasks/confluence_publish.py
+++ b/src/python/pants/backend/core/tasks/confluence_publish.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import textwrap

--- a/src/python/pants/backend/core/tasks/console_task.py
+++ b/src/python/pants/backend/core/tasks/console_task.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
 import os

--- a/src/python/pants/backend/core/tasks/deferred_sources_mapper.py
+++ b/src/python/pants/backend/core/tasks/deferred_sources_mapper.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 
@@ -70,4 +70,3 @@ class DeferredSourcesMapper(Task):
       sources, rel_unpack_dir = unpacked_sources[sources_target]
       SourceRoot.register_mutable(rel_unpack_dir)
       payload_field.populate(sources, rel_unpack_dir)
-

--- a/src/python/pants/backend/core/tasks/dependees.py
+++ b/src/python/pants/backend/core/tasks/dependees.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
+from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/core/tasks/filemap.py
+++ b/src/python/pants/backend/core/tasks/filemap.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/core/tasks/filter.py
+++ b/src/python/pants/backend/core/tasks/filter.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import operator
 import re

--- a/src/python/pants/backend/core/tasks/group_task.py
+++ b/src/python/pants/backend/core/tasks/group_task.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import os
 from abc import abstractmethod, abstractproperty
 from collections import defaultdict
-import os
 
-from pants.backend.core.tasks.task import TaskBase, Task
+from pants.backend.core.tasks.task import Task, TaskBase
 from pants.base.build_graph import sort_targets
 from pants.base.workunit import WorkUnit
 from pants.goal.goal import Goal

--- a/src/python/pants/backend/core/tasks/list_goals.py
+++ b/src/python/pants/backend/core/tasks/list_goals.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.goal.goal import Goal

--- a/src/python/pants/backend/core/tasks/listtargets.py
+++ b/src/python/pants/backend/core/tasks/listtargets.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.base.exceptions import TaskError
 from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.base.exceptions import TaskError
 
 
 class ListTargets(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/markdown_to_html.py
+++ b/src/python/pants/backend/core/tasks/markdown_to_html.py
@@ -2,29 +2,29 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import codecs
 import os
 import re
 
-from docutils.core import publish_parts
 import markdown
+from docutils.core import publish_parts
 from pkg_resources import resource_string
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
-from pygments.lexers import guess_lexer_for_filename, PythonLexer, TextLexer
+from pygments.lexers import PythonLexer, TextLexer, guess_lexer_for_filename
 from pygments.styles import get_all_styles
 from pygments.util import ClassNotFound
 
 from pants import binary_util
+from pants.backend.core.targets.doc import Page
+from pants.backend.core.tasks.task import Task
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
-from pants.backend.core.targets.doc import Page
-from pants.backend.core.tasks.task import Task
 from pants.util.dirutil import safe_mkdir, safe_open
 
 

--- a/src/python/pants/backend/core/tasks/minimal_cover.py
+++ b/src/python/pants/backend/core/tasks/minimal_cover.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.tasks.console_task import ConsoleTask
 

--- a/src/python/pants/backend/core/tasks/noop.py
+++ b/src/python/pants/backend/core/tasks/noop.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.tasks.task import Task
 

--- a/src/python/pants/backend/core/tasks/pathdeps.py
+++ b/src/python/pants/backend/core/tasks/pathdeps.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.tasks.console_task import ConsoleTask
 

--- a/src/python/pants/backend/core/tasks/paths.py
+++ b/src/python/pants/backend/core/tasks/paths.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import copy
+from collections import defaultdict
 
 from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.base.exceptions import TaskError

--- a/src/python/pants/backend/core/tasks/prepare_resources.py
+++ b/src/python/pants/backend/core/tasks/prepare_resources.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
 import shutil
+from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/core/tasks/reflect.py
+++ b/src/python/pants/backend/core/tasks/reflect.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import argparse
-from collections import OrderedDict
 import inspect
 import re
+from collections import OrderedDict
 
 from docutils.core import publish_parts
 
@@ -18,9 +18,9 @@ from pants.base.exceptions import TaskError
 from pants.base.generator import TemplateData
 from pants.base.target import Target
 from pants.goal.goal import Goal
-from pants.option.options_bootstrapper import OptionsBootstrapper, register_bootstrap_options
-from pants.option.options import Options
 from pants.option.global_options import register_global_options
+from pants.option.options import Options
+from pants.option.options_bootstrapper import OptionsBootstrapper, register_bootstrap_options
 from pants.option.parser import Parser
 
 

--- a/src/python/pants/backend/core/tasks/reporting_server.py
+++ b/src/python/pants/backend/core/tasks/reporting_server.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import multiprocessing
 import os

--- a/src/python/pants/backend/core/tasks/roots.py
+++ b/src/python/pants/backend/core/tasks/roots.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.base.source_root import SourceRoot
 from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.base.source_root import SourceRoot
 
 
 class ListRoots(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/run_prep_command.py
+++ b/src/python/pants/backend/core/tasks/run_prep_command.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple
 import os
 import subprocess
+from collections import namedtuple
 
 from pants.backend.core.tasks.task import Task
 from pants.base.exceptions import TaskError

--- a/src/python/pants/backend/core/tasks/scm_publish.py
+++ b/src/python/pants/backend/core/tasks/scm_publish.py
@@ -2,13 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from abc import abstractmethod
 import re
+from abc import abstractmethod
 
 from pants.base.exceptions import TaskError
+
 
 class Version(object):
   @staticmethod

--- a/src/python/pants/backend/core/tasks/sorttargets.py
+++ b/src/python/pants/backend/core/tasks/sorttargets.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from collections import defaultdict
 
 from twitter.common.util import topological_sort
 
-from pants.base.target import Target
 from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.base.target import Target
 
 
 class SortTargets(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/targets_help.py
+++ b/src/python/pants/backend/core/tasks/targets_help.py
@@ -2,16 +2,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-from pkg_resources import resource_string
-import pystache
 import re
+
+import pystache
+from pkg_resources import resource_string
 
 from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.core.tasks.reflect import assemble_buildsyms
+
 
 class TargetsHelp(ConsoleTask):
   """Show online help for symbols usable in BUILD files (java_library, etc)."""

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -2,24 +2,24 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from abc import abstractmethod
-from contextlib import contextmanager
 import itertools
 import os
 import sys
 import threading
+from abc import abstractmethod
+from contextlib import contextmanager
 
 from twitter.common.collections.orderedset import OrderedSet
 from twitter.common.lang import AbstractClass
 
 from pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
-from pants.base.cache_manager import (InvalidationCacheManager, InvalidationCheck)
+from pants.base.cache_manager import InvalidationCacheManager, InvalidationCheck
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
-from pants.cache.artifact_cache import call_insert, call_use_cached_files, UnreadableArtifact
+from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
 from pants.cache.cache_setup import create_artifact_cache
 from pants.cache.read_write_artifact_cache import ReadWriteArtifactCache
 from pants.reporting.reporting_utils import items_to_report_element

--- a/src/python/pants/backend/core/tasks/what_changed.py
+++ b/src/python/pants/backend/core/tasks/what_changed.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import re
 

--- a/src/python/pants/backend/core/wrapped_globs.py
+++ b/src/python/pants/backend/core/wrapped_globs.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from hashlib import sha1
 
 import six
 from twitter.common.lang import Compatibility
 
-from pants.base.payload_field import PayloadField, stable_json_sha1
 from pants.backend.jvm.repository import Repository
+from pants.base.payload_field import PayloadField, stable_json_sha1
 
 
 class Artifact(PayloadField):

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -2,17 +2,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict, namedtuple, OrderedDict
-from contextlib import contextmanager
 import errno
 import logging
 import os
 import pkgutil
 import threading
 import xml
+from collections import OrderedDict, defaultdict, namedtuple
+from contextlib import contextmanager
 
 from twitter.common.collections import OrderedSet, maybe_list
 
@@ -325,4 +325,3 @@ class IvyUtils(object):
         artifacts=jar.artifacts,
         configurations=maybe_list(confs))
     return template
-

--- a/src/python/pants/backend/jvm/jvm_debug_config.py
+++ b/src/python/pants/backend/jvm/jvm_debug_config.py
@@ -2,8 +2,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
 
 # TOOD(Eric Ayers): There is no task or goal named 'jvm' as used in the config section where these parameters are located.
 # We might need to rename these whem merging together the config and the new options system.

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.tasks.group_task import GroupTask
 from pants.backend.jvm.artifact import Artifact
@@ -12,23 +12,17 @@ from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.benchmark import Benchmark
 from pants.backend.jvm.targets.credentials import Credentials
 from pants.backend.jvm.targets.exclude import Exclude
-from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.java_tests import JavaTests
-from pants.backend.jvm.targets.jvm_binary import (
-    Bundle,
-    DirectoryReMapper,
-    Duplicate,
-    JvmApp,
-    JvmBinary,
-    JarRules,
-    Skip)
+from pants.backend.jvm.targets.jvm_binary import (Bundle, DirectoryReMapper, Duplicate, JarRules,
+                                                  JvmApp, JvmBinary, Skip)
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.targets.scala_tests import ScalaTests
 from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
+from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.jvm.tasks.benchmark_run import BenchmarkRun
 from pants.backend.jvm.tasks.binary_create import BinaryCreate
 from pants.backend.jvm.tasks.bootstrap_jvm_tools import BootstrapJvmTools
@@ -57,8 +51,8 @@ from pants.backend.jvm.tasks.scaladoc_gen import ScaladocGen
 from pants.backend.jvm.tasks.specs_run import SpecsRun
 from pants.backend.jvm.tasks.unpack_jars import UnpackJars
 from pants.base.build_file_aliases import BuildFileAliases
-from pants.goal.task_registrar import TaskRegistrar as task
 from pants.goal.goal import Goal
+from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():

--- a/src/python/pants/backend/jvm/repository.py
+++ b/src/python/pants/backend/jvm/repository.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/scala/target_platform.py
+++ b/src/python/pants/backend/jvm/scala/target_platform.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.config import Config
 

--- a/src/python/pants/backend/jvm/targets/annotation_processor.py
+++ b/src/python/pants/backend/jvm/targets/annotation_processor.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 

--- a/src/python/pants/backend/jvm/targets/benchmark.py
+++ b/src/python/pants/backend/jvm/targets/benchmark.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 

--- a/src/python/pants/backend/jvm/targets/credentials.py
+++ b/src/python/pants/backend/jvm/targets/credentials.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.target import Target
 

--- a/src/python/pants/backend/jvm/targets/exclude.py
+++ b/src/python/pants/backend/jvm/targets/exclude.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class Exclude(object):

--- a/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
+++ b/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -2,11 +2,10 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import sys
-
 from collections import defaultdict
 
 from twitter.common.collections import OrderedSet

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import six
 
@@ -78,4 +78,3 @@ class JarLibrary(Target):
       jar_deps.update(target.jar_dependencies)
 
     return list(jar_deps)
-

--- a/src/python/pants/backend/jvm/targets/jarable.py
+++ b/src/python/pants/backend/jvm/targets/jarable.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from abc import abstractproperty
 

--- a/src/python/pants/backend/jvm/targets/java_agent.py
+++ b/src/python/pants/backend/jvm/targets/java_agent.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.lang import Compatibility
 
+from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.validation import assert_list
-from pants.backend.jvm.targets.java_library import JavaLibrary
 
 
 class JavaAgent(JavaLibrary):

--- a/src/python/pants/backend/jvm/targets/java_library.py
+++ b/src/python/pants/backend/jvm/targets/java_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 

--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.collections import maybe_list
 from twitter.common.lang import Compatibility

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from hashlib import sha1
 import os
 import re
+from hashlib import sha1
 
 from twitter.common.dirutil import Fileset
 from twitter.common.lang import AbstractClass, Compatibility

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.targets.resources import Resources
 from pants.backend.jvm.targets.exclude import Exclude
+from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.backend.jvm.targets.jarable import Jarable
 from pants.base.payload import Payload
 from pants.base.payload_field import ConfigurationsField, ExcludesField
 from pants.base.target import Target
-from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.jarable import Jarable
 
 
 class JvmTarget(Target, Jarable):
@@ -101,5 +101,3 @@ class JvmTarget(Target, Jarable):
   @property
   def excludes(self):
     return self.payload.excludes
-
-

--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.scala.target_platform import TargetPlatform
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary

--- a/src/python/pants/backend/jvm/targets/scala_tests.py
+++ b/src/python/pants/backend/jvm/targets/scala_tests.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 

--- a/src/python/pants/backend/jvm/targets/scalac_plugin.py
+++ b/src/python/pants/backend/jvm/targets/scalac_plugin.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 

--- a/src/python/pants/backend/jvm/targets/unpacked_jars.py
+++ b/src/python/pants/backend/jvm/targets/unpacked_jars.py
@@ -2,16 +2,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
+
 import six
 
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.base.payload import Payload
-from pants.base.payload_field import PrimitiveField, DeferredSourcesField
+from pants.base.payload_field import DeferredSourcesField, PrimitiveField
 from pants.base.target import Target
+
 
 logger = logging.getLogger(__name__)
 
@@ -74,4 +76,3 @@ class UnpackedJars(Target):
                                                        self.payload.raw_libraries,
                                                        self._build_graph)
     return self._libraries
-

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import shutil
 
-from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.jvm_task import JvmTask
+from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.exceptions import TaskError
 from pants.java.util import execute_java
 

--- a/src/python/pants/backend/jvm/tasks/binary_create.py
+++ b/src/python/pants/backend/jvm/tasks/binary_create.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import threading
+from collections import defaultdict
 
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/tasks/check_published_deps.py
+++ b/src/python/pants/backend/jvm/tasks/check_published_deps.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.targets.jar_library import JarLibrary

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/tasks/dependencies.py
+++ b/src/python/pants/backend/jvm/tasks/dependencies.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/jvm/tasks/depmap.py
+++ b/src/python/pants/backend/jvm/tasks/depmap.py
@@ -2,18 +2,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import json
 import os
+from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.resources import Resources
+from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_binary import JvmApp

--- a/src/python/pants/backend/jvm/tasks/detect_duplicates.py
+++ b/src/python/pants/backend/jvm/tasks/detect_duplicates.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
+from collections import defaultdict
 
 from pex.compatibility import to_bytes
 

--- a/src/python/pants/backend/jvm/tasks/eclipse_gen.py
+++ b/src/python/pants/backend/jvm/tasks/eclipse_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import pkgutil
@@ -11,9 +11,9 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
+from pants.backend.jvm.tasks.ide_gen import IdeGen
 from pants.base.build_environment import get_buildroot
 from pants.base.generator import Generator, TemplateData
-from pants.backend.jvm.tasks.ide_gen import IdeGen
 from pants.util.dirutil import safe_delete, safe_mkdir, safe_open
 
 

--- a/src/python/pants/backend/jvm/tasks/ensime_gen.py
+++ b/src/python/pants/backend/jvm/tasks/ensime_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import pkgutil
@@ -12,9 +12,9 @@ from collections import defaultdict
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil import safe_open
 
+from pants.backend.jvm.tasks.ide_gen import IdeGen
 from pants.base.build_environment import get_buildroot
 from pants.base.generator import Generator, TemplateData
-from pants.backend.jvm.tasks.ide_gen import IdeGen
 
 
 _TEMPLATE_BASEDIR = os.path.join('templates', 'ensime')
@@ -131,4 +131,3 @@ class EnsimeGen(IdeGen):
 
     apply_template(self.project_filename, self.project_template, project=configured_project)
     print('\nGenerated ensime project at %s%s' % (self.gen_project_workdir, os.sep))
-

--- a/src/python/pants/backend/jvm/tasks/filedeps.py
+++ b/src/python/pants/backend/jvm/tasks/filedeps.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import itertools
 import os

--- a/src/python/pants/backend/jvm/tasks/ide_gen.py
+++ b/src/python/pants/backend/jvm/tasks/ide_gen.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import logging
 import os
 import shutil
+from collections import defaultdict
 
 from twitter.common.collections.orderedset import OrderedSet
 

--- a/src/python/pants/backend/jvm/tasks/idea_gen.py
+++ b/src/python/pants/backend/jvm/tasks/idea_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import pkgutil
@@ -11,15 +11,15 @@ import shutil
 import tempfile
 from xml.dom import minidom
 
-from pants.backend.jvm.tasks.ide_gen import IdeGen, Project
 from pants.backend.jvm.targets.java_tests import JavaTests
 from pants.backend.jvm.targets.scala_tests import ScalaTests
+from pants.backend.jvm.tasks.ide_gen import IdeGen, Project
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.base.build_environment import get_buildroot
 from pants.base.generator import Generator, TemplateData
 from pants.base.source_root import SourceRoot
-from pants.util.dirutil import safe_mkdir, safe_walk
 from pants.scm.git import Git
+from pants.util.dirutil import safe_mkdir, safe_walk
 
 
 _TEMPLATE_BASEDIR = 'templates/idea'

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
 import shutil
 import time
+from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import copy
 import logging
 import os
 import shutil
 import threading
+from collections import defaultdict
 
 from twitter.common.collections import maybe_list
 

--- a/src/python/pants/backend/jvm/tasks/jar_create.py
+++ b/src/python/pants/backend/jvm/tasks/jar_create.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
+from contextlib import contextmanager
 
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jar_task import JarTask

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -2,10 +2,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict, OrderedDict
 import functools
 import getpass
 import hashlib
@@ -15,12 +14,12 @@ import pkgutil
 import shutil
 import sys
 import traceback
+from collections import OrderedDict, defaultdict
 
 from twitter.common.collections import OrderedSet
 from twitter.common.config import Properties
 from twitter.common.log.options import LogOptions
 
-from pants.scm.scm import Scm
 from pants.backend.core.tasks.scm_publish import Namedver, ScmPublish, Semver
 from pants.backend.jvm.ivy_utils import IvyUtils
 from pants.backend.jvm.targets.jarable import Jarable
@@ -37,6 +36,7 @@ from pants.base.generator import Generator, TemplateData
 from pants.base.target import Target
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy import Ivy
+from pants.scm.scm import Scm
 from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree
 from pants.util.strutil import ensure_text
 

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -2,19 +2,19 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from abc import abstractmethod, abstractproperty
-from contextlib import contextmanager
 import os
 import tempfile
+from abc import abstractmethod, abstractproperty
+from contextlib import contextmanager
 
 from twitter.common.collections import maybe_list
 from twitter.common.lang import AbstractClass, Compatibility
 
-from pants.backend.jvm.targets.jvm_binary import Duplicate, Skip, JarRules
 from pants.backend.jvm.targets.java_agent import JavaAgent
+from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, Skip
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit

--- a/src/python/pants/backend/jvm/tasks/javadoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/javadoc_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.jvmdoc_gen import Jvmdoc, JvmdocGen
 

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from abc import abstractmethod
-from collections import defaultdict, namedtuple
 import copy
 import fnmatch
 import os
 import sys
+from abc import abstractmethod
+from collections import defaultdict, namedtuple
 
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil import safe_delete, safe_rmtree

--- a/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
@@ -2,17 +2,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import os
 from collections import OrderedDict
 from contextlib import contextmanager
-import os
 
 from twitter.common.collections.orderedset import OrderedSet
 
-from pants.backend.jvm.tasks.jar_task import JarTask
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
+from pants.backend.jvm.tasks.jar_task import JarTask
 
 
 class JvmBinaryTask(JarTask):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class Analysis(object):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_parser.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_parser.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import shutil

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/anonymizer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/anonymizer.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import base64
 import os

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
@@ -161,4 +161,3 @@ class JavaCompile(JvmCompile):
     with safe_open(processor_info_file, 'w') as f:
       for processor in processors:
         f.write('%s\n' % processor.strip())
-

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
+from collections import defaultdict
 
 from pants.backend.jvm.tasks.jvm_compile.analysis import Analysis
 from pants.base.build_environment import get_buildroot

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis_parser.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis_parser.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
 import re
+from collections import defaultdict
 
-from pants.base.build_environment import get_buildroot
 from pants.backend.jvm.tasks.jvm_compile.analysis_parser import AnalysisParser, ParseError
 from pants.backend.jvm.tasks.jvm_compile.java.jmake_analysis import JMakeAnalysis
+from pants.base.build_environment import get_buildroot
 
 
 class JMakeAnalysisParser(AnalysisParser):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import itertools
 import os
 import shutil
 import sys
 import uuid
+from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
@@ -2,18 +2,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
+from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
+from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.base.build_environment import get_buildroot
 from pants.base.build_graph import sort_targets
 from pants.base.exceptions import TaskError

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_fingerprint_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_fingerprint_strategy.py
@@ -2,13 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import hashlib
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-
 from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.base.hash_utils import hash_all
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/resource_mapping.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/resource_mapping.py
@@ -2,13 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
-from textwrap import dedent
 import os
 import re
+from collections import defaultdict
+from textwrap import dedent
+
 
 class ResourceMapping(object):
   RESOURCES_BY_CLASS_NAME_RE = re.compile(r'^(?P<classname>[\w+.\$]+) -> (?P<path>.+)$')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/anonymize_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/anonymize_analysis.py
@@ -2,14 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import glob
 import itertools
 import os
 import sys
-
 
 from pants.backend.jvm.tasks.jvm_compile.anonymizer import Anonymizer
 from pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis_parser import ZincAnalysisParser

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import itertools
 import json
@@ -12,9 +12,9 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.build_environment import get_buildroot
 from pants.backend.jvm.tasks.jvm_compile.analysis import Analysis
 from pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis_diff import ZincAnalysisElementDiff
+from pants.base.build_environment import get_buildroot
 
 
 class ZincAnalysisElement(object):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_diff.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_diff.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from collections import OrderedDict
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_parser.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_parser.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import json
 import os
@@ -11,7 +11,10 @@ import re
 from collections import defaultdict
 
 from pants.backend.jvm.tasks.jvm_compile.analysis_parser import AnalysisParser, ParseError
-from pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis import APIs, Compilations, CompileSetup, Relations, SourceInfos, Stamps, ZincAnalysis
+from pants.backend.jvm.tasks.jvm_compile.scala.zinc_analysis import (APIs, Compilations,
+                                                                     CompileSetup, Relations,
+                                                                     SourceInfos, Stamps,
+                                                                     ZincAnalysis)
 
 
 class ZincAnalysisParser(AnalysisParser):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import closing
-from itertools import chain
 import os
 import textwrap
+from contextlib import closing
+from itertools import chain
 from xml.etree import ElementTree
 
 from twitter.common.collections import OrderedDict

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.exceptions import TaskError
 from pants.option.options import Options

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -2,15 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import collections
 import contextlib
 import multiprocessing
 import os
 import subprocess
-
 
 from pants import binary_util
 from pants.backend.jvm.tasks.jvm_task import JvmTask

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from abc import abstractproperty
 import os
+from abc import abstractproperty
 
-from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.core.tasks.task import Task, TaskBase
+from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.exceptions import TaskError
 from pants.java import util
 from pants.java.distribution.distribution import Distribution

--- a/src/python/pants/backend/jvm/tasks/provides.py
+++ b/src/python/pants/backend/jvm/tasks/provides.py
@@ -2,17 +2,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import sys
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.ivy_utils import IvyModuleRef, IvyUtils
+from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.util.contextutil import open_zip64
 from pants.util.dirutil import safe_mkdir

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.java.util import execute_java
-from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.jvm_task import JvmTask
+from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.target import Target
 from pants.console.stty_utils import preserve_stty_settings
+from pants.java.util import execute_java
 
 
 class ScalaRepl(JvmTask, JvmToolTaskMixin):

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.jvmdoc_gen import Jvmdoc, JvmdocGen
 

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re

--- a/src/python/pants/backend/jvm/tasks/specs_run.py
+++ b/src/python/pants/backend/jvm/tasks/specs_run.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.jvm_task import JvmTask
+from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 from pants.binary_util import safe_args

--- a/src/python/pants/backend/jvm/tasks/unpack_jars.py
+++ b/src/python/pants/backend/jvm/tasks/unpack_jars.py
@@ -2,20 +2,20 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os
 import re
 import shutil
 
+from twitter.common.dirutil.fileset import fnmatch_translate_extended
+
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.base.build_environment import get_buildroot
 from pants.fs.archive import ZIP
-
-from twitter.common.dirutil.fileset import fnmatch_translate_extended
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/backend/maven_layout/maven_layout.py
+++ b/src/python/pants/backend/maven_layout/maven_layout.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
@@ -54,4 +54,3 @@ def maven_layout(parse_context, basedir=''):
   root('src/test/python', Page, PythonLibrary, PythonTests)
   root('src/test/resources', Page, Resources)
   root('src/test/scala', JavaTests, Page, ScalaLibrary, ScalaTests, Benchmark)
-

--- a/src/python/pants/backend/maven_layout/register.py
+++ b/src/python/pants/backend/maven_layout/register.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.maven_layout.maven_layout import maven_layout
 from pants.base.build_file_aliases import BuildFileAliases

--- a/src/python/pants/backend/python/antlr_builder.py
+++ b/src/python/pants/backend/python/antlr_builder.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import sys

--- a/src/python/pants/backend/python/binary_builder.py
+++ b/src/python/pants/backend/python/binary_builder.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import tempfile
@@ -12,9 +12,9 @@ import time
 from pex.interpreter import PythonInterpreter
 from pex.pex_builder import PEXBuilder
 
-from pants.base.config import Config
 from pants.backend.python.python_chroot import PythonChroot
 from pants.backend.python.targets.python_binary import PythonBinary
+from pants.base.config import Config
 
 
 class PythonBinaryBuilder(object):

--- a/src/python/pants/backend/python/code_generator.py
+++ b/src/python/pants/backend/python/code_generator.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import shutil

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -2,11 +2,10 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-from pkg_resources import Requirement
 import shutil
 
 from pex.archiver import Archiver
@@ -15,6 +14,7 @@ from pex.installer import EggInstaller
 from pex.interpreter import PythonIdentity, PythonInterpreter
 from pex.iterator import Iterator
 from pex.package import EggPackage, SourcePackage
+from pkg_resources import Requirement
 
 from pants.backend.python.python_setup import PythonSetup
 from pants.backend.python.resolver import context_from_config, fetchers_from_config

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from hashlib import sha1
 import json
+from hashlib import sha1
 
 from pants.base.build_manual import manual
 from pants.base.payload_field import PayloadField

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import logging
 import os
 import shutil
 import sys
 import tempfile
+from collections import defaultdict
 
 from pex.interpreter import PythonInterpreter
 from pex.pex_builder import PEXBuilder

--- a/src/python/pants/backend/python/python_egg.py
+++ b/src/python/pants/backend/python/python_egg.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from glob import glob as fsglob

--- a/src/python/pants/backend/python/python_requirement.py
+++ b/src/python/pants/backend/python/python_requirement.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pkg_resources import Requirement
 

--- a/src/python/pants/backend/python/python_requirements.py
+++ b/src/python/pants/backend/python/python_requirements.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -2,15 +2,10 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.targets.dependencies import Dependencies
-from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
-from pants.backend.python.tasks.pytest_run import PytestRun
-from pants.backend.python.tasks.python_repl import PythonRepl
-from pants.backend.python.tasks.python_run import PythonRun
-from pants.backend.python.tasks.python_setup import PythonSetup
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import python_requirements
@@ -18,6 +13,11 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
+from pants.backend.python.tasks.pytest_run import PytestRun
+from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
+from pants.backend.python.tasks.python_repl import PythonRepl
+from pants.backend.python.tasks.python_run import PythonRun
+from pants.backend.python.tasks.python_setup import PythonSetup
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 

--- a/src/python/pants/backend/python/resolver.py
+++ b/src/python/pants/backend/python/resolver.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pex.fetcher import Fetcher, PyPIFetcher
 from pex.crawler import Crawler
+from pex.fetcher import Fetcher, PyPIFetcher
 from pex.http import Context
 from pex.interpreter import PythonInterpreter
 from pex.iterator import Iterator

--- a/src/python/pants/backend/python/sdist_builder.py
+++ b/src/python/pants/backend/python/sdist_builder.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/backend/python/targets/python_library.py
+++ b/src/python/pants/backend/python/targets/python_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.python.targets.python_target import PythonTarget
 

--- a/src/python/pants/backend/python/targets/python_requirement_library.py
+++ b/src/python/pants/backend/python/targets/python_requirement_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.base.payload import Payload

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -2,21 +2,20 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pex.interpreter import PythonIdentity
 from twitter.common.collections import maybe_list
 from twitter.common.lang import Compatibility
 
-from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.core.targets.resources import Resources
+from pants.backend.python.python_artifact import PythonArtifact
 from pants.base.address import SyntheticAddress
+from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField, SourcesField
 from pants.base.target import Target
-from pants.base.exceptions import TargetDefinitionException
 
 
 class PythonTarget(Target):

--- a/src/python/pants/backend/python/targets/python_tests.py
+++ b/src/python/pants/backend/python/targets/python_tests.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.collections import maybe_list
 

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
-from pants.base.exceptions import TaskError
-from pants.base.workunit import WorkUnit
-from pants.backend.python.test_builder import PythonTestBuilder
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.python_task import PythonTask
+from pants.backend.python.test_builder import PythonTestBuilder
+from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnit
 from pants.util.contextutil import environment_as
 from pants.util.strutil import safe_shlex_split
 

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import time

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pex.pex import PEX
 

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import signal
 

--- a/src/python/pants/backend/python/tasks/python_setup.py
+++ b/src/python/pants/backend/python/tasks/python_setup.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import ast
-from collections import defaultdict
 import itertools
 import os
 import pprint
 import shutil
+from collections import defaultdict
 
 from pex.compatibility import string, to_bytes
 from pex.installer import InstallerBase, Packager

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import tempfile
+from contextlib import contextmanager
 
 from pex.pex_builder import PEXBuilder
 from twitter.common.collections import OrderedSet

--- a/src/python/pants/backend/python/test_builder.py
+++ b/src/python/pants/backend/python/test_builder.py
@@ -2,21 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-try:
-  import configparser
-except ImportError:
-  import ConfigParser as configparser
-
-from contextlib import contextmanager
 import itertools
 import logging
 import os
 import shutil
-from textwrap import dedent
 import traceback
+from contextlib import contextmanager
+from textwrap import dedent
 
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
@@ -28,8 +23,17 @@ from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.base.config import Config
 from pants.base.target import Target
-from pants.util.contextutil import temporary_file, temporary_dir, environment_as
+from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir, safe_open
+
+
+try:
+  import configparser
+except ImportError:
+  import ConfigParser as configparser
+
+
+
 
 
 # Initialize logging, since tests do not run via pants_exe (where it is usually done)

--- a/src/python/pants/backend/python/thrift_builder.py
+++ b/src/python/pants/backend/python/thrift_builder.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import functools
 import os
@@ -12,8 +12,8 @@ import shutil
 import subprocess
 import sys
 
-from pants.backend.python.code_generator import CodeGenerator
 from pants.backend.codegen.targets.python_thrift_library import PythonThriftLibrary
+from pants.backend.python.code_generator import CodeGenerator
 from pants.base.build_environment import get_buildroot
 from pants.thrift_util import select_thrift_binary
 from pants.util.dirutil import safe_mkdir, safe_walk

--- a/src/python/pants/base/abbreviate_target_ids.py
+++ b/src/python/pants/base/abbreviate_target_ids.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 def abbreviate_target_ids(arr):

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple
 import os
+from collections import namedtuple
 
 from twitter.common.lang import AbstractClass
 

--- a/src/python/pants/base/address_lookup_error.py
+++ b/src/python/pants/base/address_lookup_error.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class AddressLookupError(Exception):

--- a/src/python/pants/base/addressable.py
+++ b/src/python/pants/base/addressable.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.lang import AbstractClass
 
@@ -46,4 +46,3 @@ class Addressable(AbstractClass):
       to skip capturing and naming this instance.
     """
     return None
-

--- a/src/python/pants/base/build_configuration.py
+++ b/src/python/pants/base/build_configuration.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple
 import inspect
 import logging
+from collections import namedtuple
 
 from pants.base.addressable import AddressableCallProxy
 from pants.base.build_file_aliases import BuildFileAliases

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import sys

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -2,19 +2,20 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
-from glob import glob1
 import logging
-import marshal
 import os
 import re
+from collections import defaultdict
+from glob import glob1
 
+import marshal
 from pex.interpreter import PythonIdentity
-from pants.util.dirutil import safe_walk
 from twitter.common.collections import OrderedSet
+
+from pants.util.dirutil import safe_walk
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/base/build_file_address_mapper.py
+++ b/src/python/pants/base/build_file_address_mapper.py
@@ -2,15 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-
-from pants.base.address import BuildFileAddress, parse_spec, SyntheticAddress
+from pants.base.address import BuildFileAddress, SyntheticAddress, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
+from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.base.build_file_parser import BuildFileParser
-from pants.base.build_environment import get_buildroot
 
 
 # Note: Significant effort has been made to keep the types BuildFile, BuildGraph, Address, and

--- a/src/python/pants/base/build_file_aliases.py
+++ b/src/python/pants/base/build_file_aliases.py
@@ -2,12 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
-from collections import namedtuple
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import functools
+from collections import namedtuple
 
 
 class BuildFileAliases(namedtuple('BuildFileAliases',

--- a/src/python/pants/base/build_file_parser.py
+++ b/src/python/pants/base/build_file_parser.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 

--- a/src/python/pants/base/build_graph.py
+++ b/src/python/pants/base/build_graph.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict, OrderedDict
 import logging
 import traceback
+from collections import OrderedDict, defaultdict
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/base/build_invalidator.py
+++ b/src/python/pants/base/build_invalidator.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
 import hashlib

--- a/src/python/pants/base/build_manual.py
+++ b/src/python/pants/base/build_manual.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class manual(object):

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from contextlib import contextmanager

--- a/src/python/pants/base/cache_manager.py
+++ b/src/python/pants/base/cache_manager.py
@@ -2,19 +2,21 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import sys
+
+from pants.base.build_graph import sort_targets
+from pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
+from pants.base.target import Target
+
 
 try:
   import cPickle as pickle
 except ImportError:
   import pickle
 
-from pants.base.build_graph import sort_targets
-from pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
-from pants.base.target import Target
 
 
 class VersionedTargetSet(object):

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -2,20 +2,21 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import logging
 import os
 import re
 import traceback
+from collections import defaultdict
 
-from twitter.common.collections import maybe_list, OrderedSet
+from twitter.common.collections import OrderedSet, maybe_list
 
 from pants.base.address import BuildFileAddress, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file import BuildFile
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/base/config.py
+++ b/src/python/pants/base/config.py
@@ -2,13 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
-try:
-  import ConfigParser
-except ImportError:
-  import configparser as ConfigParser
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import getpass
 import itertools
@@ -16,6 +11,14 @@ import os
 
 from pants.base.build_environment import get_buildroot
 from pants.util.strutil import is_text_or_binary
+
+
+try:
+  import ConfigParser
+except ImportError:
+  import configparser as ConfigParser
+
+
 
 
 def reset_default_bootstrap_option_values(defaults, values=None, buildroot=None):

--- a/src/python/pants/base/double_dag.py
+++ b/src/python/pants/base/double_dag.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.abbreviate_target_ids import abbreviate_target_ids
 

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class TaskError(Exception):

--- a/src/python/pants/base/extension_loader.py
+++ b/src/python/pants/base/extension_loader.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pkg_resources import working_set, Requirement
 import traceback
 
+from pkg_resources import Requirement, working_set
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_configuration import BuildConfiguration

--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from abc import abstractmethod
+
 from twitter.common.lang import AbstractClass
 
 

--- a/src/python/pants/base/generator.py
+++ b/src/python/pants/base/generator.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import pprint
 

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import hashlib
 

--- a/src/python/pants/base/lazy_source_mapper.py
+++ b/src/python/pants/base/lazy_source_mapper.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
+from collections import defaultdict
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile

--- a/src/python/pants/base/mustache.py
+++ b/src/python/pants/base/mustache.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import pkgutil

--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class ParseContext(object):

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from hashlib import sha1
+
 
 class PayloadFieldAlreadyDefinedError(Exception): pass
 

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -2,16 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from abc import abstractmethod
-from hashlib import sha1
 import json
 import os
+from abc import abstractmethod
+from hashlib import sha1
 
 import six
-
 from twitter.common.collections import OrderedSet
 from twitter.common.lang import AbstractClass
 

--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import re
 from itertools import izip_longest

--- a/src/python/pants/base/run_info.py
+++ b/src/python/pants/base/run_info.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import getpass
 import os

--- a/src/python/pants/base/source_root.py
+++ b/src/python/pants/base/source_root.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
@@ -327,4 +327,3 @@ class SourceRoot(object):
   @classmethod
   def _dump(cls):
     return cls._SOURCE_ROOT_TREE._dump()
-

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from hashlib import sha1
 import os
 import sys
+from hashlib import sha1
 
 from twitter.common.lang import Compatibility
 

--- a/src/python/pants/base/target_addressable.py
+++ b/src/python/pants/base/target_addressable.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.lang import Compatibility
 

--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.fileset import Fileset
 from twitter.common.lang import Compatibility
+
 
 def assert_list(obj, expected_type=Compatibility.string, can_be_none=True, default=(),
     allowable=(list, Fileset, OrderedSet, set, tuple), raise_type=ValueError):

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-import threading
 import multiprocessing
-from multiprocessing.pool import ThreadPool
 import os
 import signal
 import sys
+import threading
+from multiprocessing.pool import ThreadPool
 
 from pants.reporting.report import Report
 

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -2,14 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re
 import time
 import uuid
-
 
 from pants.rwbuf.read_write_buffer import FileBackedRWBuf
 from pants.util.dirutil import safe_mkdir_for

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -2,13 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os
 import sys
-from pants.base.build_graph import BuildGraph
 
 from twitter.common import log
 from twitter.common.lang import Compatibility
@@ -20,17 +19,18 @@ from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.base.build_file_address_mapper import BuildFileAddressMapper
 from pants.base.build_file_parser import BuildFileParser
+from pants.base.build_graph import BuildGraph
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.config import Config
 from pants.base.extension_loader import load_plugins_and_backends
 from pants.base.workunit import WorkUnit
 from pants.engine.round_engine import RoundEngine
 from pants.goal.context import Context
-from pants.goal.initialize_reporting import update_reporting, initial_reporting
 from pants.goal.goal import Goal
+from pants.goal.initialize_reporting import initial_reporting, update_reporting
 from pants.goal.run_tracker import RunTracker
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.global_options import register_global_options
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.report import Report
 from pants.util.dirutil import safe_mkdir
 

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os

--- a/src/python/pants/binary_util.py
+++ b/src/python/pants/binary_util.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import closing, contextmanager
 import os
-import subprocess
-
 import posixpath
+import subprocess
+from contextlib import closing, contextmanager
+
 from twitter.common import log
 from twitter.common.collections import OrderedSet
 from twitter.common.lang import Compatibility
@@ -18,6 +18,7 @@ from pants.base.config import Config
 from pants.base.exceptions import TaskError
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_delete, safe_open
+
 
 if Compatibility.PY3:
   import urllib.request as urllib_request

--- a/src/python/pants/cache/artifact.py
+++ b/src/python/pants/cache/artifact.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
 import os

--- a/src/python/pants/cache/artifact_cache.py
+++ b/src/python/pants/cache/artifact_cache.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import os
 import sys
+
 
 # Note throughout the distinction between the artifact_root (which is where the artifacts are
 # originally built and where the cache restores them to) and the cache root path/URL (which is
@@ -156,4 +157,3 @@ def call_insert(tup):
   """
   cache, key, files, overwrite = tup
   return cache.insert(key, files, overwrite)
-

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import urlparse
@@ -12,6 +12,7 @@ from pants.cache.artifact_cache import ArtifactCacheError
 from pants.cache.local_artifact_cache import LocalArtifactCache, TempLocalArtifactCache
 from pants.cache.pinger import Pinger
 from pants.cache.restful_artifact_cache import RESTfulArtifactCache
+
 
 class EmptyCacheSpecError(ArtifactCacheError):
   pass

--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -2,19 +2,20 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import logging
 import os
 import shutil
 import uuid
+from contextlib import contextmanager
 
 from pants.cache.artifact import TarballArtifact
 from pants.cache.artifact_cache import ArtifactCache, UnreadableArtifact
-from pants.util.dirutil import safe_delete, safe_mkdir, safe_mkdir_for
 from pants.util.contextutil import temporary_file
+from pants.util.dirutil import safe_delete, safe_mkdir, safe_mkdir_for
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/cache/pinger.py
+++ b/src/python/pants/cache/pinger.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import httplib
 from multiprocessing.pool import ThreadPool

--- a/src/python/pants/cache/read_write_artifact_cache.py
+++ b/src/python/pants/cache/read_write_artifact_cache.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.cache.artifact_cache import ArtifactCache
 

--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
 import urlparse
@@ -12,9 +12,11 @@ import requests
 from requests import RequestException
 
 from pants.cache.artifact import TarballArtifact
-from pants.cache.artifact_cache import ArtifactCache, ArtifactCacheError, NonfatalArtifactCacheError, UnreadableArtifact
+from pants.cache.artifact_cache import (ArtifactCache, ArtifactCacheError,
+                                        NonfatalArtifactCacheError, UnreadableArtifact)
 from pants.cache.local_artifact_cache import TempLocalArtifactCache
 from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/console/stty_utils.py
+++ b/src/python/pants/console/stty_utils.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import subprocess
+from contextlib import contextmanager
 
 
 @contextmanager

--- a/src/python/pants/engine/engine.py
+++ b/src/python/pants/engine/engine.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from abc import abstractmethod
 

--- a/src/python/pants/engine/round_engine.py
+++ b/src/python/pants/engine/round_engine.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple, OrderedDict
 import os
+from collections import OrderedDict, namedtuple
 
 from twitter.common.collections.orderedset import OrderedSet
 

--- a/src/python/pants/engine/round_manager.py
+++ b/src/python/pants/engine/round_manager.py
@@ -2,10 +2,10 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple, defaultdict
+from collections import defaultdict, namedtuple
 
 from pants.goal.goal import Goal
 

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -2,15 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-
-"""Support for wholesale archive creation and extraction in a uniform API across archive types."""
-
+import os
 from abc import abstractmethod
 from collections import OrderedDict
-import os
 from zipfile import ZIP_DEFLATED
 
 from twitter.common.lang import AbstractClass
@@ -18,6 +15,12 @@ from twitter.common.lang import AbstractClass
 from pants.util.contextutil import open_tar, open_zip64
 from pants.util.dirutil import safe_walk
 from pants.util.strutil import ensure_text
+
+
+"""Support for wholesale archive creation and extraction in a uniform API across archive types."""
+
+
+
 
 
 class Archiver(AbstractClass):

--- a/src/python/pants/fs/fs.py
+++ b/src/python/pants/fs/fs.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import hashlib
 import os

--- a/src/python/pants/goal/aggregated_timings.py
+++ b/src/python/pants/goal/aggregated_timings.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from collections import defaultdict

--- a/src/python/pants/goal/artifact_cache_stats.py
+++ b/src/python/pants/goal/artifact_cache_stats.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from collections import defaultdict, namedtuple

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import sys
@@ -15,13 +15,13 @@ from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.build_graph import BuildGraph
 from pants.base.source_root import SourceRoot
 from pants.base.target import Target
+from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnit
 from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.java.distribution.distribution import Distribution
 from pants.process.pidlock import OwnerPrintingPIDLockFile
 from pants.reporting.report import Report
-from pants.base.worker_pool import SubprocPool
 
 
 class Context(object):

--- a/src/python/pants/goal/error.py
+++ b/src/python/pants/goal/error.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class GoalError(Exception):

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -2,9 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.goal.error import GoalError
 

--- a/src/python/pants/goal/initialize_reporting.py
+++ b/src/python/pants/goal/initialize_reporting.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
 import os

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from collections import defaultdict

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
+import httplib
 import json
 import os
 import sys
@@ -14,8 +15,6 @@ import time
 import urllib
 from contextlib import contextmanager
 from urlparse import urlparse
-
-import httplib
 
 from pants.base.config import Config
 from pants.base.run_info import RunInfo

--- a/src/python/pants/goal/task_registrar.py
+++ b/src/python/pants/goal/task_registrar.py
@@ -2,18 +2,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import functools
 import inspect
 import sys
-from textwrap import dedent
 import traceback
+from textwrap import dedent
 
+from pants.backend.core.tasks.task import Task
 from pants.goal.error import GoalError
 from pants.goal.goal import Goal
-from pants.backend.core.tasks.task import Task
 
 
 class TaskRegistrar(object):

--- a/src/python/pants/goal/workspace.py
+++ b/src/python/pants/goal/workspace.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from abc import abstractmethod
 

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import hashlib
 import os

--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from twitter.common.collections import maybe_list
 from twitter.common.lang import Compatibility

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import pkgutil

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from abc import abstractmethod, abstractproperty
-from contextlib import contextmanager
 import os
 import subprocess
+from abc import abstractmethod, abstractproperty
+from contextlib import contextmanager
 
 from twitter.common import log
 from twitter.common.collections import maybe_list

--- a/src/python/pants/java/jar/manifest.py
+++ b/src/python/pants/java/jar/manifest.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from contextlib import closing
 

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import select

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -2,21 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import hashlib
 import os
 import re
 import time
-
 from collections import namedtuple
 
 import psutil
-
-# TODO: Once we integrate standard logging into our reporting framework, we  can consider making
-#  some of the log.debug() below into log.info(). Right now it just looks wrong on the console.
-
 from twitter.common import log
 from twitter.common.collections import maybe_list
 from twitter.common.lang import Compatibility
@@ -25,6 +20,12 @@ from pants.base.build_environment import get_buildroot
 from pants.java.executor import Executor, SubprocessExecutor
 from pants.java.nailgun_client import NailgunClient
 from pants.util.dirutil import safe_open
+
+
+# TODO: Once we integrate standard logging into our reporting framework, we  can consider making
+#  some of the log.debug() below into log.info(). Right now it just looks wrong on the console.
+
+
 
 
 class NailgunExecutor(Executor):

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/src/python/pants/net/http/fetcher.py
+++ b/src/python/pants/net/http/fetcher.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import closing, contextmanager
 import hashlib
 import os
 import sys
 import tempfile
 import time
+from contextlib import closing, contextmanager
 
 import requests
 from twitter.common.lang import Compatibility

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple
 import sys
+from collections import namedtuple
 
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.option.errors import ParseError
 from pants.base.config import Config
+from pants.option.errors import ParseError
 
 
 def _parse_error(s, msg):

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 class RegistrationError(Exception):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.option.options import Options
 

--- a/src/python/pants/option/help_formatter.py
+++ b/src/python/pants/option/help_formatter.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import argparse
 

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import sys
 

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.option.ranked_value import RankedValue
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import copy
 import sys
@@ -11,7 +11,7 @@ import sys
 from pants.base.build_environment import pants_release
 from pants.goal.goal import Goal
 from pants.option import custom_types
-from pants.option.arg_splitter import ArgSplitter, GLOBAL_SCOPE
+from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.parser_hierarchy import ParserHierarchy
 

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import sys
 
+from pants.base.build_environment import get_buildroot
 from pants.base.config import Config
 from pants.option.arg_splitter import GLOBAL_SCOPE
-from pants.base.build_environment import get_buildroot
 from pants.option.options import Options
 from pants.option.parser import Parser
 

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import copy
 from argparse import ArgumentParser, _HelpAction
 from collections import namedtuple
-import copy
+
 import six
 
 from pants.option.arg_splitter import GLOBAL_SCOPE

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.parser import Parser

--- a/src/python/pants/option/ranked_value.py
+++ b/src/python/pants/option/ranked_value.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import copy
 

--- a/src/python/pants/process/pidlock.py
+++ b/src/python/pants/process/pidlock.py
@@ -2,15 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-import sys
 import logging
+import sys
 
 import lockfile
-from lockfile import pidlockfile
 import psutil
+from lockfile import pidlockfile
+
 
 logger = logging.getLogger(__name__)
 
@@ -38,4 +39,3 @@ class OwnerPrintingPIDLockFile(pidlockfile.PIDLockFile):
       return ' '.join(process.cmdline)
     except psutil.NoSuchProcess:
       return None
-

--- a/src/python/pants/process/xargs.py
+++ b/src/python/pants/process/xargs.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
 import subprocess

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import cgi
-from collections import defaultdict, namedtuple
 import os
 import re
 import uuid
+from collections import defaultdict, namedtuple
 
 from pants.base.build_environment import get_buildroot
 from pants.base.mustache import MustacheRenderer

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -2,13 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re
 
 from pants.base.build_file import BuildFile
+
 
 # A regex to recognize substrings that are probably URLs or file paths. Broken down for readability.
 _PREFIX = r'(https?://)?/?' # http://, https:// or / or nothing.

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from collections import namedtuple
+
+from colors import cyan, green, red, yellow
 
 from pants.base.workunit import WorkUnit
 from pants.reporting.report import Report
 from pants.reporting.reporter import Reporter
-
-from colors import cyan, green, red, yellow
 
 
 class PlainTextReporter(Reporter):

--- a/src/python/pants/reporting/quiet_reporter.py
+++ b/src/python/pants/reporting/quiet_reporter.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import sys
 from collections import namedtuple
 
+from colors import red
+
 from pants.reporting.report import Report
 from pants.reporting.reporter import Reporter
-
-from colors import red
 
 
 class QuietReporter(Reporter):

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import threading
 

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from collections import namedtuple
 

--- a/src/python/pants/reporting/reporting_server.py
+++ b/src/python/pants/reporting/reporting_server.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import BaseHTTPServer
 import itertools
 import json
+import mimetypes
 import os
 import pkgutil
 import re
@@ -16,9 +17,7 @@ import urlparse
 from collections import namedtuple
 from datetime import date, datetime
 
-import mimetypes
 import pystache
-
 
 from pants.base.build_environment import get_buildroot
 from pants.base.mustache import MustacheRenderer

--- a/src/python/pants/reporting/reporting_utils.py
+++ b/src/python/pants/reporting/reporting_utils.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 def items_to_report_element(items, item_type):

--- a/src/python/pants/rwbuf/read_write_buffer.py
+++ b/src/python/pants/rwbuf/read_write_buffer.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import threading
 
 from twitter.common.lang import Compatibility
+
 
 StringIO = Compatibility.StringIO
 

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import subprocess

--- a/src/python/pants/scm/scm.py
+++ b/src/python/pants/scm/scm.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from abc import abstractmethod, abstractproperty
 

--- a/src/python/pants/thrift_util.py
+++ b/src/python/pants/thrift_util.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -2,10 +2,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import closing, contextmanager
 import os
 import shutil
 import tarfile
@@ -13,6 +12,7 @@ import tempfile
 import time
 import uuid
 import zipfile
+from contextlib import closing, contextmanager
 
 from twitter.common.lang import Compatibility
 

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -2,17 +2,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import atexit
-from collections import defaultdict
 import errno
 import os
 import shutil
 import stat
 import tempfile
 import threading
+from collections import defaultdict
 
 from pants.util.strutil import ensure_text
 

--- a/src/python/pants/util/fileutil.py
+++ b/src/python/pants/util/fileutil.py
@@ -2,8 +2,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import shutil

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import re
-import six
 import shlex
+
+import six
 
 
 def ensure_binary(text_or_binary):

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 
 VERSION = '0.0.28'

--- a/tests/python/pants_test/android/android_integration_test.py
+++ b/tests/python/pants_test/android/android_integration_test.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/tests/python/pants_test/android/tasks/test_aapt_builder_integration.py
+++ b/tests/python/pants_test/android/tasks/test_aapt_builder_integration.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
+
 import pytest
 
 from pants_test.android.android_integration_test import AndroidIntegrationTest

--- a/tests/python/pants_test/android/tasks/test_aapt_gen.py
+++ b/tests/python/pants_test/android/tasks/test_aapt_gen.py
@@ -2,9 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest

--- a/tests/python/pants_test/android/tasks/test_dx_compile_integration.py
+++ b/tests/python/pants_test/android/tasks/test_dx_compile_integration.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
+
 import pytest
 
 from pants_test.android.android_integration_test import AndroidIntegrationTest

--- a/tests/python/pants_test/android/tasks/test_sign_apk.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk.py
@@ -2,8 +2,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import textwrap
 

--- a/tests/python/pants_test/android/tasks/test_sign_apk_integration.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk_integration.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
+
 import pytest
 
 from pants_test.android.android_integration_test import AndroidIntegrationTest

--- a/tests/python/pants_test/android/test_android_config_util.py
+++ b/tests/python/pants_test/android/test_android_config_util.py
@@ -2,8 +2,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import textwrap
 import unittest

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
-import pytest
 import unittest
+from contextlib import contextmanager
 
+import pytest
 from twitter.common.collections import maybe_list
 
 from pants.backend.android.distribution.android_distribution import AndroidDistribution

--- a/tests/python/pants_test/android/test_keystore_resolver.py
+++ b/tests/python/pants_test/android/test_keystore_resolver.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
 import textwrap
 import unittest
+from contextlib import contextmanager
 
 from pants.backend.android.keystore.keystore_resolver import KeystoreResolver
 from pants.util.contextutil import temporary_file

--- a/tests/python/pants_test/authentication/test_netrc_util.py
+++ b/tests/python/pants_test/authentication/test_netrc_util.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import re
+from contextlib import contextmanager
 
 import pytest
 from mock import MagicMock, mock_open, patch

--- a/tests/python/pants_test/backend/codegen/targets/test_java_protobuf_library.py
+++ b/tests/python/pants_test/backend/codegen/targets/test_java_protobuf_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 
@@ -105,5 +105,3 @@ class JavaProtobufLibraryTest(BaseTest):
     self.assertIsInstance(target, JavaProtobufLibrary)
     traversable_specs = [spec for spec in target.traversable_specs]
     self.assertSequenceEqual([':import_jars'], traversable_specs)
-
-

--- a/tests/python/pants_test/backend/codegen/targets/test_java_wire_library.py
+++ b/tests/python/pants_test/backend/codegen/targets/test_java_wire_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/backend/codegen/tasks/test_protobuf_parse.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_protobuf_parse.py
@@ -2,17 +2,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-import pytest
-from textwrap import dedent
 import unittest
+from textwrap import dedent
 
-from pants.backend.codegen.tasks.protobuf_parse import (MESSAGE_PARSER, ProtobufParse,
-                                                        camelcase, get_outer_class_name,
-                                                        update_type_list)
+import pytest
+
+from pants.backend.codegen.tasks.protobuf_parse import (MESSAGE_PARSER, ProtobufParse, camelcase,
+                                                        get_outer_class_name, update_type_list)
 from pants.util.contextutil import temporary_dir
 
 

--- a/tests/python/pants_test/backend/codegen/tasks/test_wire_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_wire_gen.py
@@ -2,13 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.codegen.tasks.wire_gen import WireGen, calculate_genfiles
 from pants.base.validation import assert_list
 from pants.util.contextutil import temporary_file
-
 from pants_test.tasks.test_base import TaskTest
 
 

--- a/tests/python/pants_test/backend/core/test_prep.py
+++ b/tests/python/pants_test/backend/core/test_prep.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/tests/python/pants_test/backend/core/test_wrapped_globs.py
+++ b/tests/python/pants_test/backend/core/test_wrapped_globs.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.wrapped_globs import Globs
 from pants.backend.jvm.targets.java_library import JavaLibrary

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_target.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_target.py
@@ -2,16 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 
 from pants.backend.core.register import build_file_aliases as register_core
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.base.address import SyntheticAddress, BuildFileAddress
+from pants.base.address import BuildFileAddress, SyntheticAddress
 from pants.base.build_file_aliases import BuildFileAliases
-
 from pants_test.base_test import BaseTest
 
 
@@ -41,4 +40,3 @@ class JvmTargetTest(BaseTest):
     target = self.build_graph.get_target(SyntheticAddress.parse('//:foo'))
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':resource_target'], list(target.traversable_dependency_specs))
-

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 
@@ -12,7 +12,6 @@ from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.base.address import BuildFileAddress
-
 from pants_test.base_test import BaseTest
 
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_fingerprint_strategy.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_fingerprint_strategy.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.jvm_compile.jvm_fingerprint_strategy import JvmFingerprintStrategy

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_zinc_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_zinc_utils.py
@@ -2,11 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
 
 from mock import patch
-import os
 
 from pants.backend.jvm.tasks.jvm_compile.scala.zinc_utils import ZincUtils
 from pants_test.base_test import BaseTest

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent

--- a/tests/python/pants_test/backend/jvm/tasks/test_ide_gen.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ide_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.java_tests import JavaTests

--- a/tests/python/pants_test/backend/jvm/tasks/test_idea_gen.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_idea_gen.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+from pants.backend.core.targets.resources import Resources
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.java_tests import JavaTests
 from pants.backend.jvm.tasks.ide_gen import SourceSet
 from pants.backend.jvm.tasks.idea_gen import IdeaGen
-from pants.backend.core.targets.resources import Resources
 from pants.base.source_root import SourceRoot
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
 import os
 import subprocess
 import sys
+from collections import defaultdict
 from textwrap import dedent
 
 from pants.backend.core.targets.resources import Resources

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
@@ -2,9 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.unpack_jars import UnpackJars
 from pants.engine.round_manager import RoundManager

--- a/tests/python/pants_test/backend/jvm/test_jvm_debug_config.py
+++ b/tests/python/pants_test/backend/jvm/test_jvm_debug_config.py
@@ -2,14 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from textwrap import dedent
 import unittest
+from textwrap import dedent
 
 from pants.backend.jvm.jvm_debug_config import JvmDebugConfig
-
 from pants_test.base.context_utils import create_config
 
 

--- a/tests/python/pants_test/backend/python/test_python_requirement_list.py
+++ b/tests/python/pants_test/backend/python/test_python_requirement_list.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 
@@ -11,6 +11,7 @@ from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
+
 
 class PythonRequirementListTest(BaseTest):
   @property

--- a/tests/python/pants_test/backend/python/test_test_builder.py
+++ b/tests/python/pants_test/backend/python/test_test_builder.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import glob
 import os
-from textwrap import dedent
 import xml.dom.minidom as DOM
+from textwrap import dedent
 
 import coverage
 from pex.interpreter import PythonInterpreter
@@ -18,7 +18,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.test_builder import PythonTestBuilder
 from pants.base.build_file_aliases import BuildFileAliases
-from pants.util.contextutil import pushd, environment_as
+from pants.util.contextutil import environment_as, pushd
 from pants_test.base_test import BaseTest
 
 

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -2,11 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import io
 import sys
+
 from twitter.common.collections import maybe_list
 from twitter.common.lang import Compatibility
 

--- a/tests/python/pants_test/base/test_abbreviate_target_ids.py
+++ b/tests/python/pants_test/base/test_abbreviate_target_ids.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/base/test_address.py
+++ b/tests/python/pants_test/base/test_address.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
 import unittest
+from contextlib import contextmanager
 
 from pants.base.address import BuildFileAddress, SyntheticAddress, parse_spec
 from pants.base.build_file import BuildFile

--- a/tests/python/pants_test/base/test_build_configuration.py
+++ b/tests/python/pants_test/base/test_build_configuration.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
 import unittest
+from contextlib import contextmanager
 
 from pants.base.address import SyntheticAddress
 from pants.base.build_configuration import BuildConfiguration

--- a/tests/python/pants_test/base/test_build_file.py
+++ b/tests/python/pants_test/base/test_build_file.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import shutil

--- a/tests/python/pants_test/base/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/base/test_build_file_address_mapper.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent
@@ -12,7 +12,6 @@ from pants.backend.core.targets.dependencies import Dependencies
 from pants.base.address import BuildFileAddress, SyntheticAddress
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file_address_mapper import BuildFileAddressMapper
-
 from pants_test.base_test import BaseTest
 
 
@@ -111,4 +110,3 @@ class BuildFileAddressMapperTest(BaseTest):
     self.assertIsInstance(BuildFileAddressMapper.InvalidBuildFileReference(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.InvalidAddressError(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.BuildFileScanError(), AddressLookupError)
-

--- a/tests/python/pants_test/base/test_build_file_aliases.py
+++ b/tests/python/pants_test/base/test_build_file_aliases.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/base/test_build_file_parser.py
+++ b/tests/python/pants_test/base/test_build_file_parser.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent
@@ -22,6 +22,7 @@ from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.build_file_parser import BuildFileParser
 from pants.base.target import Target
 from pants_test.base_test import BaseTest
+
 
 # TODO(Eric Ayers) Explicit unit tests are missing for registered_alises, parse_spec,
 # parse_build_file_family

--- a/tests/python/pants_test/base/test_build_invalidator.py
+++ b/tests/python/pants_test/base/test_build_invalidator.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import hashlib
 import os

--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re
@@ -184,4 +184,3 @@ Invalid BUILD files for \[::\]$""", re.DOTALL)
   def test_bad_build_files_fail_fast(self):
     with self.assertRaisesRegexp(self.spec_parser.BadSpecError, self.FAIL_FAST_RE):
       list(self.spec_parser.parse_addresses('::', True))
-

--- a/tests/python/pants_test/base/test_double_dag.py
+++ b/tests/python/pants_test/base/test_double_dag.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.double_dag import DoubleDag
 from pants.reporting.report import Report

--- a/tests/python/pants_test/base/test_extension_loader.py
+++ b/tests/python/pants_test/base/test_extension_loader.py
@@ -2,34 +2,26 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
-import uuid
 import sys
 import types
 import unittest
+import uuid
+from contextlib import contextmanager
 
-from pkg_resources import (
-    yield_lines,
-    working_set,
-    Distribution,
-    WorkingSet,
-    EmptyProvider,
-    VersionConflict)
+from pkg_resources import (Distribution, EmptyProvider, VersionConflict, WorkingSet, working_set,
+                           yield_lines)
 
 from pants.base.build_configuration import BuildConfiguration
 from pants.base.build_file_aliases import BuildFileAliases
-from pants.base.extension_loader import (
-    load_backend,
-    load_plugins,
-    PluginNotFound,
-    PluginLoadOrderError)
 from pants.base.exceptions import BuildConfigurationError
+from pants.base.extension_loader import (PluginLoadOrderError, PluginNotFound, load_backend,
+                                         load_plugins)
 from pants.base.target import Target
-from pants.goal.task_registrar import TaskRegistrar
 from pants.goal.goal import Goal
+from pants.goal.task_registrar import TaskRegistrar
 
 
 class MockMetadata(EmptyProvider):
@@ -238,4 +230,3 @@ class LoaderTest(unittest.TestCase):
     registered_aliases = self.build_configuration.registered_aliases()
     self.assertEqual(Target, registered_aliases.targets['pluginalias'])
     self.assertEqual(100, registered_aliases.objects['FROMPLUGIN'])
-

--- a/tests/python/pants_test/base/test_fingerprint_strategy.py
+++ b/tests/python/pants_test/base/test_fingerprint_strategy.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants_test.base_test import BaseTest

--- a/tests/python/pants_test/base/test_generator.py
+++ b/tests/python/pants_test/base/test_generator.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import mox
 

--- a/tests/python/pants_test/base/test_lazy_source_mapper.py
+++ b/tests/python/pants_test/base/test_lazy_source_mapper.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.base.build_file_aliases import BuildFileAliases
 from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.lazy_source_mapper import LazySourceMapper
 from pants_test.base_test import BaseTest
 
@@ -87,4 +87,3 @@ class LazySourceMapperTest(BaseTest):
     self.owner(['a/b:b'], 'a/b/bar.py')
     self.owner([':top'], 'foo.py')
     self.owner([':top', 'a/b:b'], 'a/b/bar.py')
-

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.wrapped_globs import Globs
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -104,4 +104,3 @@ class PayloadTest(BaseTest):
     self.assertEquals(None, payload.get_field_value('field_doesnt_exist'))
     self.assertEquals('nothing', payload.get_field('field_doesnt_exist', default='nothing'))
     self.assertEquals('nothing', payload.get_field_value('field_doesnt_exist', default='nothing'))
-

--- a/tests/python/pants_test/base/test_payload_field.py
+++ b/tests/python/pants_test/base/test_payload_field.py
@@ -2,20 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.exclude import Exclude
 from pants.backend.jvm.targets.jar_dependency import Artifact, JarDependency
 from pants.backend.jvm.targets.jvm_binary import Bundle
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.base.payload import Payload, PayloadFieldAlreadyDefinedError, PayloadFrozenError
-from pants.base.payload_field import (BundleField,
-                                      ExcludesField,
-                                      JarsField,
-                                      PrimitiveField,
-                                      PythonRequirementsField,
-                                      SourcesField)
+from pants.base.payload_field import (BundleField, ExcludesField, JarsField, PrimitiveField,
+                                      PythonRequirementsField, SourcesField)
 from pants_test.base_test import BaseTest
 
 

--- a/tests/python/pants_test/base/test_revision.py
+++ b/tests/python/pants_test/base/test_revision.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/base/test_run_info.py
+++ b/tests/python/pants_test/base/test_run_info.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/base/test_source_root.py
+++ b/tests/python/pants_test/base/test_source_root.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.address import parse_spec, SyntheticAddress
+from pants.base.address import SyntheticAddress, parse_spec
 from pants.base.addressable import AddressableCallProxy
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.source_root import SourceRoot, SourceRootTree

--- a/tests/python/pants_test/base/test_spec_exclude_integration.py
+++ b/tests/python/pants_test/base/test_spec_exclude_integration.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
-from shutil import rmtree
 import subprocess
 import tempfile
+from contextlib import contextmanager
+from shutil import rmtree
 
 from pants.base.build_environment import get_buildroot
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 
@@ -14,7 +14,6 @@ from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.payload import Payload
 from pants.base.payload_field import DeferredSourcesField
 from pants.base.target import Target
-
 from pants_test.base_test import BaseTest
 
 
@@ -85,4 +84,3 @@ class TargetTest(BaseTest):
                                        deferred_sources_address=SyntheticAddress.parse('//:foo'))
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':foo'], list(target.traversable_dependency_specs))
-

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -2,30 +2,30 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import os
+import unittest
 from collections import defaultdict
 from contextlib import contextmanager
-import os
 from tempfile import mkdtemp
 from textwrap import dedent
-import unittest
 
 from twitter.common.collections import OrderedSet
 
 from pants.backend.core.targets.dependencies import Dependencies
 from pants.base.address import SyntheticAddress
-from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError
-from pants.base.build_file_address_mapper import BuildFileAddressMapper
 from pants.base.build_configuration import BuildConfiguration
+from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
+from pants.base.build_file_address_mapper import BuildFileAddressMapper
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.build_file_parser import BuildFileParser
 from pants.base.build_graph import BuildGraph
 from pants.base.build_root import BuildRoot
 from pants.base.config import Config
+from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
 from pants.base.target import Target
 from pants.goal.goal import Goal

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -2,27 +2,28 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import os
 import SimpleHTTPServer
 import SocketServer
-from contextlib import contextmanager
-import os
-from threading import Thread
 import unittest
+from contextlib import contextmanager
+from threading import Thread
 
 from pants.base.build_invalidator import CacheKey
-from pants.cache.artifact_cache import call_use_cached_files, call_insert
-from pants.cache.cache_setup import (create_artifact_cache, select_best_url, EmptyCacheSpecError,
-                                     LocalCacheSpecRequiredError, CacheSpecFormatError,
-                                     InvalidCacheSpecError, RemoteCacheSpecRequiredError)
+from pants.cache.artifact_cache import call_insert, call_use_cached_files
+from pants.cache.cache_setup import (CacheSpecFormatError, EmptyCacheSpecError,
+                                     InvalidCacheSpecError, LocalCacheSpecRequiredError,
+                                     RemoteCacheSpecRequiredError, create_artifact_cache,
+                                     select_best_url)
 from pants.cache.local_artifact_cache import LocalArtifactCache, TempLocalArtifactCache
 from pants.cache.restful_artifact_cache import InvalidRESTfulCacheProtoError, RESTfulArtifactCache
 from pants.util.contextutil import pushd, temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir
-from pants_test.testutils.mock_logger import MockLogger
 from pants_test.base.context_utils import create_context
+from pants_test.testutils.mock_logger import MockLogger
 
 
 class MockPinger(object):

--- a/tests/python/pants_test/engine/base_engine_test.py
+++ b/tests/python/pants_test/engine/base_engine_test.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 
-from pants.goal.task_registrar import TaskRegistrar
 from pants.goal.goal import Goal
+from pants.goal.task_registrar import TaskRegistrar
 
 
 class EngineTestBase(unittest.TestCase):

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.base.exceptions import TaskError
 from pants.engine.engine import Engine

--- a/tests/python/pants_test/engine/test_round_engine.py
+++ b/tests/python/pants_test/engine/test_round_engine.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import itertools
 

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest

--- a/tests/python/pants_test/fs/test_expand_path.py
+++ b/tests/python/pants_test/fs/test_expand_path.py
@@ -2,13 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
-from contextlib import contextmanager
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest
+from contextlib import contextmanager
 
 from pants.fs.fs import expand_path
 from pants.util.contextutil import environment_as, pushd, temporary_dir

--- a/tests/python/pants_test/fs/test_safe_filename.py
+++ b/tests/python/pants_test/fs/test_safe_filename.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest

--- a/tests/python/pants_test/goal/test_products.py
+++ b/tests/python/pants_test/goal/test_products.py
@@ -2,8 +2,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/graph/test_build_graph.py
+++ b/tests/python/pants_test/graph/test_build_graph.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple
-from contextlib import contextmanager
 import os
 import subprocess
 import textwrap
 import unittest
+from collections import namedtuple
+from contextlib import contextmanager
 
 import pytest
 from twitter.common.collections import maybe_list

--- a/tests/python/pants_test/java/test_executor.py
+++ b/tests/python/pants_test/java/test_executor.py
@@ -2,18 +2,18 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
 import subprocess
 import textwrap
 import unittest
+from contextlib import contextmanager
 
 from pants.java.distribution.distribution import Distribution
 from pants.java.executor import SubprocessExecutor
-from pants.util.contextutil import temporary_dir, environment_as
+from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import chmod_plus_x, safe_open
 
 

--- a/tests/python/pants_test/jvm/jar_task_test_base.py
+++ b/tests/python/pants_test/jvm/jar_task_test_base.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
 import os

--- a/tests/python/pants_test/jvm/nailgun_task_test_base.py
+++ b/tests/python/pants_test/jvm/nailgun_task_test_base.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 

--- a/tests/python/pants_test/jvm/test_artifact.py
+++ b/tests/python/pants_test/jvm/test_artifact.py
@@ -2,12 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
-
 from pants_test.base_test import BaseTest
 
 

--- a/tests/python/pants_test/net/http/test_fetcher.py
+++ b/tests/python/pants_test/net/http/test_fetcher.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import closing
 import os
+from contextlib import closing
 
 import mox
 import pytest

--- a/tests/python/pants_test/option/fake_config.py
+++ b/tests/python/pants_test/option/fake_config.py
@@ -2,8 +2,9 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
 
 class FakeConfig(object):
   """Useful for providing fake config values while testing the options system."""

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import shlex
 import unittest

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
+
 from pants.option.custom_types import dict_type, list_type
 from pants.option.errors import ParseError
 

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import copy
 import unittest

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import shlex
 import tempfile
-from textwrap import dedent
 import unittest
+from textwrap import dedent
 
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from textwrap import dedent
 import unittest
+from textwrap import dedent
 
 from pants.base.config import Config
 from pants.option.options_bootstrapper import OptionsBootstrapper

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -2,19 +2,19 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import namedtuple
-from operator import eq, ne
 import os
 import subprocess
 import unittest
+from collections import namedtuple
+from operator import eq, ne
 
-from pants.fs.archive import ZIP
 from pants.base.build_environment import get_buildroot
+from pants.fs.archive import ZIP
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_open, safe_mkdir
+from pants.util.dirutil import safe_mkdir, safe_open
 
 
 PantsResult = namedtuple('PantsResult', ['command', 'returncode', 'stdout_data', 'stderr_data'])

--- a/tests/python/pants_test/process/test_xargs.py
+++ b/tests/python/pants_test/process/test_xargs.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import errno
 import os

--- a/tests/python/pants_test/python/die.py
+++ b/tests/python/pants_test/python/die.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import sys
 

--- a/tests/python/pants_test/python/echo_interpreter_version.py
+++ b/tests/python/pants_test/python/echo_interpreter_version.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import sys
+
 
 # Useful for testing which interpreter the pex machinery selects.
 

--- a/tests/python/pants_test/python/test_antlr_builder.py
+++ b/tests/python/pants_test/python/test_antlr_builder.py
@@ -2,14 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 
 import antlr3
 import antlr3.tree
 
+# ANTLR code, and so will be masked by it if namespace packages are broken.
+from pants.backend.python.python_setup import PythonSetup
 from pants.backend.python.test.Eval import Eval
 from pants.backend.python.test.ExprLexer import ExprLexer
 from pants.backend.python.test.ExprParser import ExprParser
@@ -17,8 +19,6 @@ from pants.backend.python.test.ExprParser import ExprParser
 
 # We import this gratuitously, just to test that namespace packages work correctly in the
 # generated ANTLR code. This module shares a namespace prefix with the generated
-# ANTLR code, and so will be masked by it if namespace packages are broken.
-from pants.backend.python.python_setup import PythonSetup
 
 
 class AntlrBuilderTest(unittest.TestCase):

--- a/tests/python/pants_test/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/python/test_interpreter_cache.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/python/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/python/test_interpreter_selection_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import subprocess
@@ -63,5 +63,3 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
                '--interpreter=CPython>=2.6,<3',
                '--interpreter=CPython>=3.3']
     return self.run_pants(command=command, config=config)
-
-

--- a/tests/python/pants_test/python/test_python_repl_integration.py
+++ b/tests/python/pants_test/python/test_python_repl_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 

--- a/tests/python/pants_test/python/test_python_run_integration.py
+++ b/tests/python/pants_test/python/test_python_run_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import pytest
 

--- a/tests/python/pants_test/python/test_python_setup.py
+++ b/tests/python/pants_test/python/test_python_setup.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import os
 from collections import OrderedDict
 from contextlib import contextmanager
-import os
 
 from mock import MagicMock, Mock, call
 from twitter.common.collections import OrderedSet

--- a/tests/python/pants_test/python/test_resolver.py
+++ b/tests/python/pants_test/python/test_resolver.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/python/test_thrift_namespace_packages.py
+++ b/tests/python/pants_test/python/test_thrift_namespace_packages.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/reporting/test_linkify.py
+++ b/tests/python/pants_test/reporting/test_linkify.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import shutil

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -2,20 +2,20 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
-from itertools import izip_longest
 import os
 import re
 import subprocess
 import unittest
+from contextlib import contextmanager
+from itertools import izip_longest
 
 import pytest
 
-from pants.scm.scm import Scm
 from pants.scm.git import Git
+from pants.scm.scm import Scm
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import safe_mkdtemp, safe_open, safe_rmtree, touch
 

--- a/tests/python/pants_test/targets/test_jar_library.py
+++ b/tests/python/pants_test/targets/test_jar_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 
@@ -13,7 +13,6 @@ from pants.base.address import SyntheticAddress
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.target import Target
-
 from pants_test.base_test import BaseTest
 
 

--- a/tests/python/pants_test/targets/test_java_agent.py
+++ b/tests/python/pants_test/targets/test_java_agent.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.base.build_file_aliases import BuildFileAliases

--- a/tests/python/pants_test/targets/test_java_tests.py
+++ b/tests/python/pants_test/targets/test_java_tests.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.wrapped_globs import Globs
 from pants.backend.jvm.targets.java_tests import JavaTests

--- a/tests/python/pants_test/targets/test_java_thrift_library.py
+++ b/tests/python/pants_test/targets/test_java_thrift_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/targets/test_jvm_app.py
+++ b/tests/python/pants_test/targets/test_jvm_app.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/targets/test_python_binary.py
+++ b/tests/python/pants_test/targets/test_python_binary.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import pytest
 
+from pants.backend.python.targets.python_binary import PythonBinary
 from pants.base.address import SyntheticAddress
 from pants.base.exceptions import TargetDefinitionException
-from pants.backend.python.targets.python_binary import PythonBinary
 from pants_test.base_test import BaseTest
 
 

--- a/tests/python/pants_test/targets/test_python_target.py
+++ b/tests/python/pants_test/targets/test_python_target.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-import pytest
 from textwrap import dedent
+
+import pytest
 
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository

--- a/tests/python/pants_test/targets/test_scala_library.py
+++ b/tests/python/pants_test/targets/test_scala_library.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/targets/test_scala_library_integration.py
+++ b/tests/python/pants_test/targets/test_scala_library_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 

--- a/tests/python/pants_test/targets/test_sort_targets.py
+++ b/tests/python/pants_test/targets/test_sort_targets.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import pytest
+
 from pants.base.build_graph import CycleException, sort_targets
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/targets/test_wiki_page.py
+++ b/tests/python/pants_test/targets/test_wiki_page.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 
-from pants.backend.core.targets.doc import Wiki, WikiArtifact, Page
+from pants.backend.core.targets.doc import Page, Wiki, WikiArtifact
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file_aliases import BuildFileAliases

--- a/tests/python/pants_test/task_test_base.py
+++ b/tests/python/pants_test/task_test_base.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import uuid
 

--- a/tests/python/pants_test/tasks/false.py
+++ b/tests/python/pants_test/tasks/false.py
@@ -3,11 +3,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import sys
+
 
 #This works just like /bin/false, but Windows users might not have that
 
-import sys
 
 sys.exit(1)

--- a/tests/python/pants_test/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/tests/python/pants_test/tasks/jvm_compile/scala/test_zinc_analysis.py
+++ b/tests/python/pants_test/tasks/jvm_compile/scala/test_zinc_analysis.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import contextlib
 import os

--- a/tests/python/pants_test/tasks/test_antlr_gen.py
+++ b/tests/python/pants_test/tasks/test_antlr_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re

--- a/tests/python/pants_test/tasks/test_antlr_integration.py
+++ b/tests/python/pants_test/tasks/test_antlr_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 

--- a/tests/python/pants_test/tasks/test_base.py
+++ b/tests/python/pants_test/tasks/test_base.py
@@ -2,29 +2,28 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import subprocess
 from contextlib import closing
-
 from StringIO import StringIO
 
 from twitter.common.collections import maybe_list
 
-from pants.backend.core.tasks.task import Task
-
 from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.backend.core.tasks.task import Task
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.target import Target
 from pants.goal.context import Context
 from pants.goal.goal import Goal
 from pants.option.global_options import register_global_options
-from pants.option.options_bootstrapper import OptionsBootstrapper, register_bootstrap_options
 from pants.option.options import Options
-from pants_test.base_test import BaseTest
+from pants.option.options_bootstrapper import OptionsBootstrapper, register_bootstrap_options
 from pants_test.base.context_utils import create_config, create_run_tracker
+from pants_test.base_test import BaseTest
+
 
 def is_exe(name):
   result = subprocess.call(['which', name], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)

--- a/tests/python/pants_test/tasks/test_binary_create.py
+++ b/tests/python/pants_test/tasks/test_binary_create.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.binary_create import BinaryCreate
 from pants_test.task_test_base import TaskTestBase

--- a/tests/python/pants_test/tasks/test_builddict.py
+++ b/tests/python/pants_test/tasks/test_builddict.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from contextlib import closing
 from StringIO import StringIO
@@ -13,6 +13,7 @@ from pants.backend.core.tasks import builddictionary, reflect
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.python.register import build_file_aliases as register_python
 from pants_test.tasks.test_base import BaseTest, TaskTest
+
 
 OUTDIR = '/tmp/dist'
 

--- a/tests/python/pants_test/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/tasks/test_bundle_create.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants.backend.jvm.tasks.bundle_create import BundleCreate
+from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants_test.task_test_base import TaskTestBase
 
 

--- a/tests/python/pants_test/tasks/test_cache_manager.py
+++ b/tests/python/pants_test/tasks/test_cache_manager.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import shutil
 import tempfile

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
+
 import pytest
 
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/tasks/test_check_published_deps.py
+++ b/tests/python/pants_test/tasks/test_check_published_deps.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent

--- a/tests/python/pants_test/tasks/test_config.py
+++ b/tests/python/pants_test/tasks/test_config.py
@@ -2,11 +2,10 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import textwrap
-
 import unittest
 
 from pants.base.config import Config

--- a/tests/python/pants_test/tasks/test_console_task.py
+++ b/tests/python/pants_test/tasks/test_console_task.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-from Queue import Empty, Queue
 import threading
+from Queue import Empty, Queue
 
 import pytest
 

--- a/tests/python/pants_test/tasks/test_context.py
+++ b/tests/python/pants_test/tasks/test_context.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/tasks/test_dependees.py
+++ b/tests/python/pants_test/tasks/test_dependees.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/tasks/test_dependencies.py
+++ b/tests/python/pants_test/tasks/test_dependencies.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.core.targets.dependencies import Dependencies as DepBag
 from pants.backend.jvm.targets.jar_dependency import JarDependency
@@ -13,7 +13,6 @@ from pants.backend.jvm.tasks.dependencies import Dependencies
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-
 from pants_test.tasks.test_base import ConsoleTaskTest
 
 

--- a/tests/python/pants_test/tasks/test_depmap.py
+++ b/tests/python/pants_test/tasks/test_depmap.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import json
 import os

--- a/tests/python/pants_test/tasks/test_depmap_integration.py
+++ b/tests/python/pants_test/tasks/test_depmap_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import json
 import os

--- a/tests/python/pants_test/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/tasks/test_detect_duplicates.py
@@ -2,17 +2,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from contextlib import contextmanager
 import os
 import tempfile
+from contextlib import contextmanager
 
 from pants.backend.jvm.tasks.detect_duplicates import DuplicateDetector
 from pants.base.exceptions import TaskError
-from pants.util.dirutil import safe_rmtree, touch
 from pants.util.contextutil import open_zip64
+from pants.util.dirutil import safe_rmtree, touch
 from pants_test.task_test_base import TaskTestBase
 
 

--- a/tests/python/pants_test/tasks/test_eclipse_integration.py
+++ b/tests/python/pants_test/tasks/test_eclipse_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/tests/python/pants_test/tasks/test_ensime_integration.py
+++ b/tests/python/pants_test/tasks/test_ensime_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/tests/python/pants_test/tasks/test_filedeps.py
+++ b/tests/python/pants_test/tasks/test_filedeps.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent

--- a/tests/python/pants_test/tasks/test_filemap.py
+++ b/tests/python/pants_test/tasks/test_filemap.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent

--- a/tests/python/pants_test/tasks/test_filter.py
+++ b/tests/python/pants_test/tasks/test_filter.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/tasks/test_group_task.py
+++ b/tests/python/pants_test/tasks/test_group_task.py
@@ -2,13 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-import itertools, uuid
+import itertools
+import uuid
 
-from pants.backend.core.tasks.group_task import GroupMember, GroupIterator, GroupTask
 from pants.backend.core.targets.dependencies import Dependencies
+from pants.backend.core.tasks.group_task import GroupIterator, GroupMember, GroupTask
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.python.targets.python_library import PythonLibrary

--- a/tests/python/pants_test/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/tasks/test_idea_integration.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-import xml.dom.minidom as minidom
 import re
+import xml.dom.minidom as minidom
 
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/tasks/test_ivy_resolve_integration.py
+++ b/tests/python/pants_test/tasks/test_ivy_resolve_integration.py
@@ -2,14 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re
 
 from pants.util.contextutil import temporary_dir
-
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 

--- a/tests/python/pants_test/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/tasks/test_ivy_utils.py
@@ -2,14 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import logging
-from textwrap import dedent
 import xml.etree.ElementTree as ET
+from textwrap import dedent
 
 from mock import Mock
+
 from pants.backend.core.register import build_file_aliases as register_core
 from pants.backend.jvm.ivy_utils import IvyModuleRef, IvyUtils
 from pants.backend.jvm.register import build_file_aliases as register_jvm

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
+import os
 from collections import defaultdict
 from contextlib import closing, contextmanager
-import os
 from textwrap import dedent
 
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary

--- a/tests/python/pants_test/tasks/test_jar_library_with_overrides.py
+++ b/tests/python/pants_test/tasks/test_jar_library_with_overrides.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 
-from pants.base import ParseContext
 from pants.backend.jvm.targets.exclude import Exclude
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.base import ParseContext
 
 
 class JarLibraryWithOverrides(unittest.TestCase):

--- a/tests/python/pants_test/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/tasks/test_jar_publish.py
@@ -2,14 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest
 
-from mock import Mock
 import pytest
+from mock import Mock
 
 from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.jvm.artifact import Artifact

--- a/tests/python/pants_test/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/tasks/test_jar_publish_integration.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
+
 import pytest
 
 from pants.base.build_environment import get_buildroot

--- a/tests/python/pants_test/tasks/test_jar_task.py
+++ b/tests/python/pants_test/tasks/test_jar_task.py
@@ -2,13 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from collections import defaultdict
-from contextlib import contextmanager
 import os
 import re
+from collections import defaultdict
+from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.backend.jvm.tasks.jar_task import JarTask

--- a/tests/python/pants_test/tasks/test_jaxb_gen.py
+++ b/tests/python/pants_test/tasks/test_jaxb_gen.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 
@@ -78,4 +78,3 @@ class JaxbGenJavaTest(JaxbGenTestBase):
       'com/actual/package/Aardvark.java',
       'com/actual/package/Apple.java'
     )
-

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
@@ -128,4 +128,3 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         '--test-junit-jvm-options=-Dcwd.test.enabled=true',
         '--test-junit-cwd',])
     self.assert_success(pants_run)
-

--- a/tests/python/pants_test/tasks/test_jvm_bundle_integration.py
+++ b/tests/python/pants_test/tasks/test_jvm_bundle_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -29,4 +29,3 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
       bundle_name='example{proj}'.format(proj=name)
       stdout = self.bundle_and_run(target, bundle_name)
       self.assertEquals(stdout, 'Hello world!: resource from example {name}\n'.format(name=name))
-

--- a/tests/python/pants_test/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/tasks/test_jvm_run.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/tests/python/pants_test/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/tasks/test_jvm_run_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -59,4 +59,3 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
                                  '--run-jvm-cwd='
                                  'testprojects/src/java/com/pants/testproject/cwdexample/subdir')
     self.assertIn('Found readme.txt', stdout_data)
-

--- a/tests/python/pants_test/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/tasks/test_jvm_task.py
@@ -2,9 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
-
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.base.exceptions import TaskError

--- a/tests/python/pants_test/tasks/test_jvmdoc_gen.py
+++ b/tests/python/pants_test/tasks/test_jvmdoc_gen.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 
 from pants.backend.jvm.tasks.jvmdoc_gen import Jvmdoc, JvmdocGen
 from pants.base.exceptions import TaskError
-from pants_test.task_test_base import TaskTestBase
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
+from pants_test.task_test_base import TaskTestBase
 
 
 dummydoc = Jvmdoc(tool_name='dummydoc', product_type='dummydoc')

--- a/tests/python/pants_test/tasks/test_list_goals.py
+++ b/tests/python/pants_test/tasks/test_list_goals.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import pytest
 

--- a/tests/python/pants_test/tasks/test_listtargets.py
+++ b/tests/python/pants_test/tasks/test_listtargets.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent

--- a/tests/python/pants_test/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/tasks/test_markdown_to_html.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 
 from pants.backend.core.tasks import markdown_to_html
+
 
 ABC = """able
 baker

--- a/tests/python/pants_test/tasks/test_markdown_to_html_integration.py
+++ b/tests/python/pants_test/tasks/test_markdown_to_html_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 

--- a/tests/python/pants_test/tasks/test_minimal_cover.py
+++ b/tests/python/pants_test/tasks/test_minimal_cover.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/tasks/test_protobuf_gen.py
+++ b/tests/python/pants_test/tasks/test_protobuf_gen.py
@@ -2,24 +2,22 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-from textwrap import dedent
 import unittest
+from textwrap import dedent
 
 from twitter.common.collections import OrderedSet
 
-
 from pants.backend.codegen.targets.java_protobuf_library import JavaProtobufLibrary
-from pants.backend.codegen.tasks.protobuf_gen import _same_contents, calculate_genfiles, ProtobufGen
+from pants.backend.codegen.tasks.protobuf_gen import ProtobufGen, _same_contents, calculate_genfiles
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.source_root import SourceRoot
 from pants.base.validation import assert_list
 from pants.util.contextutil import temporary_dir, temporary_file
-from pants.util.dirutil import safe_rmtree, safe_mkdir
-
+from pants.util.dirutil import safe_mkdir, safe_rmtree
 from pants_test.tasks.test_base import TaskTest
 
 

--- a/tests/python/pants_test/tasks/test_protobuf_integration.py
+++ b/tests/python/pants_test/tasks/test_protobuf_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import re

--- a/tests/python/pants_test/tasks/test_ragel_gen.py
+++ b/tests/python/pants_test/tasks/test_ragel_gen.py
@@ -2,25 +2,25 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
-import pytest
 from textwrap import dedent
 
+import pytest
 from mock import MagicMock
 from twitter.common.collections import OrderedSet
 
 from pants.backend.codegen.targets.java_ragel_library import JavaRagelLibrary
-from pants.backend.codegen.tasks.ragel_gen import calculate_genfile, RagelGen
+from pants.backend.codegen.tasks.ragel_gen import RagelGen, calculate_genfile
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.goal.context import Context
 from pants.util.contextutil import temporary_file
-from pants_test.tasks.test_base import TaskTest, is_exe
 from pants.util.dirutil import safe_rmtree
+from pants_test.tasks.test_base import TaskTest, is_exe
 
 
 ragel_file_contents = dedent("""
@@ -127,4 +127,3 @@ class RagelGenTest(TaskTest):
       fp.write(ragel_file_contents)
       fp.flush()
       self.assertEquals(calculate_genfile(fp.name), 'com/example/atoi/Parser.java')
-

--- a/tests/python/pants_test/tasks/test_reflect.py
+++ b/tests/python/pants_test/tasks/test_reflect.py
@@ -2,11 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.backend.core.tasks import reflect
 from pants.backend.core.register import build_file_aliases as register_core
+from pants.backend.core.tasks import reflect
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.goal.goal import Goal

--- a/tests/python/pants_test/tasks/test_roots.py
+++ b/tests/python/pants_test/tasks/test_roots.py
@@ -2,16 +2,16 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from contextlib import contextmanager
 
+from pants.backend.core.tasks.roots import ListRoots
 from pants.base.build_environment import get_buildroot
 from pants.base.source_root import SourceRoot
 from pants.base.target import Target
-from pants.backend.core.tasks.roots import ListRoots
 from pants_test.tasks.test_base import ConsoleTaskTest
 
 

--- a/tests/python/pants_test/tasks/test_scala_repl_integration.py
+++ b/tests/python/pants_test/tasks/test_scala_repl_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/tasks/test_scrooge_gen.py
+++ b/tests/python/pants_test/tasks/test_scrooge_gen.py
@@ -2,12 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 from textwrap import dedent
 
+import pytest
+from mock import MagicMock, patch
 from twitter.common.collections import OrderedSet
 
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
@@ -19,11 +21,7 @@ from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants.goal.context import Context
 from pants.util.dirutil import safe_rmtree
-
 from pants_test.tasks.test_base import TaskTest
-
-import pytest
-from mock import MagicMock, patch
 
 
 # TODO (tdesai) Issue-240: Use JvmToolTaskTestBase for ScroogeGenTest

--- a/tests/python/pants_test/tasks/test_sorttargets.py
+++ b/tests/python/pants_test/tasks/test_sorttargets.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/tasks/test_targets_help.py
+++ b/tests/python/pants_test/tasks/test_targets_help.py
@@ -2,13 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os.path
 
 from pants.backend.core.tasks.targets_help import TargetsHelp
 from pants_test.tasks.test_base import ConsoleTaskTest
+
 
 # The build_file_parser doesn't have any symbols defined; all we have
 # are the PREDEFS, things like "dependencies: Old name for 'target'".

--- a/tests/python/pants_test/tasks/test_thrift_linter_integration.py
+++ b/tests/python/pants_test/tasks/test_thrift_linter_integration.py
@@ -2,10 +2,11 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
 
 class ThriftLinterTest(PantsRunIntegrationTest):
 

--- a/tests/python/pants_test/tasks/test_what_changed.py
+++ b/tests/python/pants_test/tasks/test_what_changed.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from textwrap import dedent
 

--- a/tests/python/pants_test/tasks/test_wire_integration.py
+++ b/tests/python/pants_test/tasks/test_wire_integration.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import subprocess

--- a/tests/python/pants_test/tasks/true.py
+++ b/tests/python/pants_test/tasks/true.py
@@ -3,11 +3,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import sys
+
 
 #This works just like /bin/true, but Windows users might not have that
 
-import sys
 
 sys.exit(0)

--- a/tests/python/pants_test/test_binary_util.py
+++ b/tests/python/pants_test/test_binary_util.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 from pants.binary_util import BinaryUtil
 from pants_test.base_test import BaseTest

--- a/tests/python/pants_test/test_maven_layout.py
+++ b/tests/python/pants_test/test_maven_layout.py
@@ -2,12 +2,12 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
-from pants.backend.maven_layout.maven_layout import maven_layout
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.java_tests import JavaTests
+from pants.backend.maven_layout.maven_layout import maven_layout
 from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/test_thrift_util.py
+++ b/tests/python/pants_test/test_thrift_util.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import unittest
 
+from pants.thrift_util import find_includes, find_root_thrifts
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open
-from pants.thrift_util import find_includes, find_root_thrifts
 
 
 class ThriftUtilTest(unittest.TestCase):

--- a/tests/python/pants_test/testutils/mock_logger.py
+++ b/tests/python/pants_test/testutils/mock_logger.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import sys
 

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import os
 import shutil
@@ -11,8 +11,8 @@ import subprocess
 import sys
 import unittest
 
-from pants.util.contextutil import (environment_as, open_zip64, pushd, temporary_dir,
-                                    temporary_file, Timer)
+from pants.util.contextutil import (Timer, environment_as, open_zip64, pushd, temporary_dir,
+                                    temporary_file)
 
 
 class ContextutilTest(unittest.TestCase):

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -2,15 +2,15 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import atexit
 import os
 import tempfile
+import unittest
 
 import mox
-import unittest
 
 from pants.util import dirutil
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/util/test_fileutil.py
+++ b/tests/python/pants_test/util/test_fileutil.py
@@ -2,8 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 

--- a/tests/python/pants_test/util/test_strutil.py
+++ b/tests/python/pants_test/util/test_strutil.py
@@ -2,12 +2,13 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from __future__ import (nested_scopes, generators, division, absolute_import, with_statement,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
 
 import unittest
 
 from pants.util.strutil import camelcase
+
 
 # TODO(Eric Ayers): Backfill tests for other methods in strutil.py
 
@@ -29,5 +30,3 @@ class StrutilTest(unittest.TestCase):
     self.assertEquals('FooBar', camelcase('-foo-bar'))
     self.assertEquals('FooBar', camelcase('foo--bar'))
     self.assertEquals('FooBar', camelcase('foo-_bar'))
-
-


### PR DESCRIPTION
This change adds build-support/bin/isort.sh and incorporates it in
build-support/bin/isort.sh. By default the script runs in check mode and
exits non-zero if there are one or more files with non-conformant import
order. The script also has a fix mode that will fixup files not in
compliance. This mode was run in this change to normalize the repo.

https://rbcommons.com/s/twitter/r/1722/