### PR TITLE
doc: clean up comments that were just doc-include markers

### DIFF
--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -53,13 +53,11 @@ class ProtobufGen(CodeGen):
     register('--lang', action='append', choices=['python', 'java'],
              help='Force generation of protobuf code for these languages.')
 
-  # TODO https://github.com/pantsbuild/pants/issues/604 prep start
   @classmethod
   def prepare(cls, options, round_manager):
     super(ProtobufGen, cls).prepare(options, round_manager)
     round_manager.require_data('ivy_imports')
     round_manager.require_data('deferred_sources')
-  # TODO https://github.com/pantsbuild/pants/issues/604 prep finish
 
   def __init__(self, *args, **kwargs):
     """Generates Java and Python files from .proto files using the Google protobuf compiler."""

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -97,7 +97,6 @@ def build_file_aliases():
   )
 
 
-# TODO https://github.com/pantsbuild/pants/issues/604 register_goals
 def register_goals():
   ng_killall = task(name='ng-killall', action=NailgunKillall)
   ng_killall.install().with_description('Kill running nailgun servers.')

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -16,11 +16,9 @@ class IvyImports(IvyTaskMixin, NailgunTask):
 
   _CONFIG_SECTION = 'ivy-imports'
 
-  # TODO https://github.com/pantsbuild/pants/issues/604 product_types start
   @classmethod
   def product_types(cls):
     return ['ivy_imports']
-  # TODO https://github.com/pantsbuild/pants/issues/604 product_types finish
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/docs/dev_tasks.md
+++ b/src/python/pants/docs/dev_tasks.md
@@ -43,7 +43,7 @@ registers goals in its `register_goals` function. Here's an excerpt from
 [Pants' own JVM
 backend](https://github.com/pantsbuild/pants/blob/master/src/python/pants/backend/jvm/register.py):
 
-!inc[start-after=pants/issues/604 register_goals&end-before=Compilation](../backend/jvm/register.py)
+!inc[start-at=def register_goals&end-before=Compilation](../backend/jvm/register.py)
 
 That `task(...)` is a name for
 `pants.goal.task_registrar.TaskRegistrar`. Calling its `install` method
@@ -63,12 +63,12 @@ tell Pants about these inter-task dependencies...
 The "early" task class defines a `product_types` class method that
 returns a list of strings:
 
-!inc[start-after=pants/issues/604 product_types start&end-before=pants/issues/604 product_types finish](../backend/jvm/tasks/ivy_imports.py)
+!inc[start-at=def product_types&end-at=return](../backend/jvm/tasks/ivy_imports.py)
 
 The "late" task defines a `prepare` method that calls
 `round_manager.require_data` to "require" one of those same strings:
 
-!inc[start-after=pants/issues/604 prep start&end-before=pants/issues/604 prep finish](../backend/codegen/tasks/protobuf_gen.py)
+!inc[start-at=def prepare&end-at=ivy_imports](../backend/codegen/tasks/protobuf_gen.py)
 
 Pants uses this information to determine which tasks must run first to
 prepare data required by other tasks. (If one task requires data that no


### PR DESCRIPTION
Now that we include-in-docs differently, we don't need
those markers. So... stop using them, clean 'em up.

But first, let's see if Travis-CI agrees we don't need them.