### PR TITLE
Fixup ci isort check.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -67,6 +67,10 @@ fi
 
 banner "CI BEGINS"
 
+banner "Checking python code formatting"
+build-support/bin/check_header.sh || exit 1
+build-support/bin/isort.sh || die "To fix import sort order, run \`build-support/bin/isort.sh -f\`"
+
 # TODO(John sirois): Re-plumb build such that it grabs constraints from the built python_binary
 # target(s).
 INTERPRETER_CONSTRAINTS=(
@@ -107,9 +111,6 @@ if [ ! -z "${R}" ]; then
   echo "$R"
   exit 1
 fi
-
-build-support/bin/check_header.sh || exit 1
-build-support/bin/isort.sh || die "To fix import sort order, run `build-support/bin/isort.sh -f`"
 
 # Sanity checks
 ./pants.pex clean-all ${PANTS_ARGS[@]} || die "Failed to clean-all."


### PR DESCRIPTION
The advice to run the isort in fix mode was not properly escaped and the
fix command would actually run inside backticks - this is now fixed.

Additionally moved the formatting checks to run 1st in ci in their own
section.  These checks are fast and folks will want to know about and
correct these errors before running any other part of ci.

https://rbcommons.com/s/twitter/r/1728/