### PR TITLE
Simplify isort config.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,5 +6,4 @@ line_length=100
 indent=2
 lines_after_imports=2
 known_first_party=internal_backend,pants,pants_test
-known_third_party=twitter.common
 default_section=THIRDPARTY


### PR DESCRIPTION
This results in net 0 change to sorts, it just simplifies the config -
no need to single twitter.common out with `default_section=THIRDPARTY`
configured.

https://rbcommons.com/s/twitter/r/1731/