### PR TITLE
Fixup pants sys.excepthook for pex context.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ mock==1.0.1
 mox==0.5.3
 # Until https://github.com/pantsbuild/pex/issues/28 is addressed, we cannot
 # do pex<0.9.0.
-pex>=0.8.6,<0.8.999999
+pex>=0.8.5,<0.8.999999
 psutil==1.1.3
 lockfile==0.10.2
 Pygments==1.4

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ mock==1.0.1
 mox==0.5.3
 # Until https://github.com/pantsbuild/pex/issues/28 is addressed, we cannot
 # do pex<0.9.0.
-pex>=0.8.5,<0.8.999999
+pex>=0.8.6,<0.8.999999
 psutil==1.1.3
 lockfile==0.10.2
 Pygments==1.4


### PR DESCRIPTION
Fixup pants sys.excepthook for pex context.
    
This change pulls in a fix in pex itself that ensures our custom
excepthook is actually called and also fixes our excepthook to work when
called.  Previously all symbols used by the custom excepthook would turn
up as `None`.  This change captures references to all these symbols
before the custom excepthook is installed ensuring the code runs
properly in excepthook context.
