### PR TITLE
Add SignApk products and Zipalign task.

### DIFF
--- a/src/python/pants/backend/android/keystore/keystore_resolver.py
+++ b/src/python/pants/backend/android/keystore/keystore_resolver.py
@@ -39,7 +39,7 @@ class KeystoreResolver(object):
                                    "keystore definitions.".format(cls._CONFIG_SECTION))
     parser = SingleFileConfig(config_file, config)
     key_names = config.sections()
-    keys = []
+    keys = {}
 
     def create_key(key_name):
       """Instantiate Keystore objects."""
@@ -53,7 +53,7 @@ class KeystoreResolver(object):
 
     for name in key_names:
       try:
-        keys.append(create_key(name))
+        keys[name] = create_key(name)
       except Config.ConfigError as e:
         raise KeystoreResolver.Error(e)
     return keys

--- a/src/python/pants/backend/android/keystore/keystore_resolver.py
+++ b/src/python/pants/backend/android/keystore/keystore_resolver.py
@@ -35,8 +35,8 @@ class KeystoreResolver(object):
       with open(config_file, 'rb') as keystore_config:
         config.readfp(keystore_config)
     except IOError:
-      raise KeystoreResolver.Error("The \'--{0}\' option must point at a valid .ini file holding "
-                                   "keystore definitions.".format(cls._CONFIG_SECTION))
+      raise KeystoreResolver.Error('The \'--{0}\' option must point at a valid .ini file holding '
+                                   'keystore definitions.'.format(cls._CONFIG_SECTION))
     parser = SingleFileConfig(config_file, config)
     key_names = config.sections()
     keys = {}
@@ -95,8 +95,8 @@ class Keystore(object):
     if self._type is None:
       keystore_type = self._build_type.lower()
       if keystore_type not in ('release', 'debug'):
-        raise ValueError(self, "The 'build_type' must be one of (debug, release)"
-                               " instead of: '{0}'.".format(self._build_type))
+        raise ValueError(self, 'The build_type must be one of (debug, release) '
+                               'instead of: {0}.'.format(self._build_type))
       else:
         self._type = keystore_type
     return self._type

--- a/src/python/pants/backend/android/register.py
+++ b/src/python/pants/backend/android/register.py
@@ -26,7 +26,7 @@ def build_file_aliases():
 
 def register_goals():
   task(name='aapt', action=AaptGen).install('gen')
-  task(name='dex', action=DxCompile).install('compile')
+  task(name='dex', action=DxCompile).install('binary')
   task(name='apk', action=AaptBuilder).install()
   task(name='sign', action=SignApkTask).install()
-  task(name='zipalign', action=Zipalign).install('binary')
+  task(name='zipalign', action=Zipalign).install('bundle')

--- a/src/python/pants/backend/android/register.py
+++ b/src/python/pants/backend/android/register.py
@@ -26,7 +26,7 @@ def build_file_aliases():
 
 def register_goals():
   task(name='aapt', action=AaptGen).install('gen')
-  task(name='dex', action=DxCompile).install()
-  task(name='apk', action=AaptBuilder).install('bundle')
+  task(name='dex', action=DxCompile).install('compile')
+  task(name='apk', action=AaptBuilder).install()
   task(name='sign', action=SignApkTask).install()
   task(name='zipalign', action=Zipalign).install('binary')

--- a/src/python/pants/backend/android/register.py
+++ b/src/python/pants/backend/android/register.py
@@ -11,6 +11,7 @@ from pants.backend.android.tasks.aapt_builder import AaptBuilder
 from pants.backend.android.tasks.aapt_gen import AaptGen
 from pants.backend.android.tasks.dx_compile import DxCompile
 from pants.backend.android.tasks.sign_apk import SignApkTask
+from pants.backend.android.tasks.zipalign import Zipalign
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 
@@ -28,3 +29,4 @@ def register_goals():
   task(name='dex', action=DxCompile).install()
   task(name='apk', action=AaptBuilder).install('bundle')
   task(name='sign', action=SignApkTask).install()
+  task(name='zipalign', action=Zipalign).install('binary')

--- a/src/python/pants/backend/android/targets/android_resources.py
+++ b/src/python/pants/backend/android/targets/android_resources.py
@@ -27,5 +27,6 @@ class AndroidResources(AndroidTarget):
     try:
       self.resource_dir = os.path.join(address.spec_path, resource_dir)
     except AttributeError:
-      raise TargetDefinitionException(self, 'An android_resources target must specify a \'resource_dir\' that contains '
-             'the target\'s resource files.')
+      raise TargetDefinitionException(self, 'An android_resources target must specify a '
+                                            '\'resource_dir\' that contains the target\'s '
+                                            'resource files.')

--- a/src/python/pants/backend/android/tasks/BUILD
+++ b/src/python/pants/backend/android/tasks/BUILD
@@ -11,6 +11,7 @@ python_library(
     ':aapt_task',
     ':dx_compile',
     ':sign_apk',
+    ':zipalign',
   ],
 )
 
@@ -88,6 +89,18 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/java:distribution',
+    'src/python/pants/util:dirutil',
+  ],
+)
+
+python_library(
+  name = 'zipalign',
+  sources = ['zipalign.py'],
+  dependencies = [
+    'src/python/pants/backend/android/targets:android',
+    'src/python/pants/backend/android/tasks:android_task',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:workunit',
     'src/python/pants/util:dirutil',
   ],
 )

--- a/src/python/pants/backend/android/tasks/android_task.py
+++ b/src/python/pants/backend/android/tasks/android_task.py
@@ -15,8 +15,7 @@ class AndroidTask(Task):
   @classmethod
   def register_options(cls, register):
     super(AndroidTask, cls).register_options(register)
-    register('--sdk-path',
-             help='Use the Android SDK at this path.')
+    register('--sdk-path', help='Use the Android SDK at this path.')
 
   def __init__(self, *args, **kwargs):
     super(AndroidTask, self).__init__(*args, **kwargs)

--- a/src/python/pants/backend/android/tasks/dx_compile.py
+++ b/src/python/pants/backend/android/tasks/dx_compile.py
@@ -26,6 +26,7 @@ class DxCompile(AndroidTask, NailgunTask):
 
   @staticmethod
   def is_dextarget(target):
+    """Return True if target has class files to be compiled into dex."""
     return isinstance(target, AndroidBinary)
 
   @classmethod

--- a/src/python/pants/backend/android/tasks/dx_compile.py
+++ b/src/python/pants/backend/android/tasks/dx_compile.py
@@ -26,7 +26,6 @@ class DxCompile(AndroidTask, NailgunTask):
 
   @staticmethod
   def is_dextarget(target):
-    """Return true if target has class files to be compiled into dex"""
     return isinstance(target, AndroidBinary)
 
   @classmethod
@@ -58,8 +57,8 @@ class DxCompile(AndroidTask, NailgunTask):
   def config_section(self):
     return self._CONFIG_SECTION
 
-  def _render_args(self, out, classes):
-    dex_file = os.path.join(out, self.DEX_NAME)
+  def _render_args(self, outdir, classes):
+    dex_file = os.path.join(outdir, self.DEX_NAME)
     args = []
     # Glossary of dx.jar flags.
     #   : '--dex' to create a Dalvik executable.
@@ -67,7 +66,7 @@ class DxCompile(AndroidTask, NailgunTask):
     #            pass a list of classes as opposed to a top-level dir.
     #   : '--output' tells the dx.jar where to put and what to name the created file.
     #            See comment on self.classes_dex for restrictions.
-    args.extend(['--dex', '--no-strict', '--output=' + dex_file])
+    args.extend(['--dex', '--no-strict', '--output={0}'.format(dex_file)])
 
     # classes is a list of class files to be included in the created dex file.
     args.extend(classes)
@@ -92,8 +91,8 @@ class DxCompile(AndroidTask, NailgunTask):
         for vt in invalidation_check.invalid_vts:
           invalid_targets.extend(vt.targets)
         for target in invalid_targets:
-          out_dir = self.dx_out(target)
-          safe_mkdir(out_dir)
+          outdir = self.dx_out(target)
+          safe_mkdir(outdir)
           classes_by_target = self.context.products.get_data('classes_by_target')
           classes = []
 
@@ -102,7 +101,7 @@ class DxCompile(AndroidTask, NailgunTask):
             if target_classes:
 
               def add_classes(target_products):
-                for root, products in target_products.abs_paths():
+                for _, products in target_products.abs_paths():
                   for prod in products:
                     classes.append(prod)
 
@@ -111,7 +110,7 @@ class DxCompile(AndroidTask, NailgunTask):
           target.walk(add_to_dex)
           if not classes:
             raise TaskError("No classes were found for {0!r}.".format(target))
-          args = self._render_args(out_dir, classes)
+          args = self._render_args(outdir, classes)
           self._compile_dex(args, target.build_tools_version)
       for target in targets:
         self.context.products.get('dex').add(target, self.dx_out(target)).append(self.DEX_NAME)
@@ -125,4 +124,5 @@ class DxCompile(AndroidTask, NailgunTask):
     return self._android_dist.register_android_tool(dx_jar)
 
   def dx_out(self, target):
+    """Return the outdir for the DxCompile task."""
     return os.path.join(self.workdir, target.id)

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -124,9 +124,9 @@ class SignApkTask(Task):
         def get_products_path(target):
           """Get path of target's unsigned apks as created by AaptBuilder."""
           unsigned_apks = self.context.products.get('apk')
-          if unsigned_apks.get(target):
-            # This allows for multiple apks but we expect only one per target.
-            for tgts, products in unsigned_apks.get(target).items():
+          packages = unsigned_apks.get(target)
+          if packages:
+            for tgts, products in packages.items():
               for prod in products:
                 yield os.path.join(tgts, prod)
 

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -146,18 +146,13 @@ class SignApkTask(Task):
                 raise TaskError('The SignApk jarsigner process exited non-zero: {0}'
                                 .format(returncode))
 
-    # Keystores and targets have no concept of each other and keys only exist in this execute scope.
-    # We look at the products themselves in order to plug into the invalidation framework.
     for target in targets:
       release_path = self.sign_apk_out(target, 'release')
-      debug_path = self.sign_apk_out(target, 'debug')
       release_apk = self.package_name(target, 'release')
-      debug_apk = self.package_name(target, 'debug')
 
       if os.path.isfile(os.path.join(release_path, release_apk)):
         self.context.products.get('release_apk').add(target, release_path).append(release_apk)
-      elif os.path.isfile(os.path.join(debug_path, debug_apk)):
-        self.context.products.get('debug_apk').add(target, debug_path).append(debug_apk)
+
 
   def package_name(self, target, build_type):
     """Get package name with 'build_type', a string KeyResolver mandates is in (debug, release)."""

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -47,7 +47,7 @@ class SignApkTask(Task):
 
   @classmethod
   def product_types(cls):
-    return ['release_apk', 'debug_apk']
+    return ['release_apk']
 
   def __init__(self, *args, **kwargs):
     super(SignApkTask, self).__init__(*args, **kwargs)
@@ -164,5 +164,5 @@ class SignApkTask(Task):
       # If it is a release build, it goes to the workdir for zipalign to operate upon.
       return os.path.join(self.workdir, target.name, build_type)
     elif build_type == 'debug':
-      # Debug builds have completed all needed tasks so these products can go straight to dist.
+      # Debug builds have completed all needed tasks so it can go straight to dist.
       return os.path.join(self._distdir, target.name)

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -155,10 +155,8 @@ class SignApkTask(Task):
       debug_apk = self.package_name(target, 'debug')
 
       if os.path.isfile(os.path.join(release_path, release_apk)):
-        # If it is a release build, it goes to the workdir for zipalign to operate upon.
         self.context.products.get('release_apk').add(target, release_path).append(release_apk)
       elif os.path.isfile(os.path.join(debug_path, debug_apk)):
-        # Debug builds have completed all needed tasks so these products can go straight to dist.
         self.context.products.get('debug_apk').add(target, debug_path).append(debug_apk)
 
   def package_name(self, target, build_type):
@@ -168,6 +166,8 @@ class SignApkTask(Task):
   def sign_apk_out(self, target, build_type):
     """Compute the outdir for a target."""
     if build_type == 'release':
+      # If it is a release build, it goes to the workdir for zipalign to operate upon.
       return os.path.join(self.workdir, target.name, build_type)
     elif build_type == 'debug':
+      # Debug builds have completed all needed tasks so these products can go straight to dist.
       return os.path.join(self._distdir, target.name)

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -164,5 +164,5 @@ class SignApkTask(Task):
       # If it is a release build, it goes to the workdir for zipalign to operate upon.
       return os.path.join(self.workdir, target.name, build_type)
     elif build_type == 'debug':
-      # Debug builds have completed all needed tasks so it can go straight to dist.
+      # Debug builds have completed all needed tasks so they can go straight to dist.
       return os.path.join(self._distdir, target.name)

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -47,13 +47,13 @@ class SignApkTask(Task):
 
   @classmethod
   def product_types(cls):
-    return ['signed_apk']
+    return ['release_apk', 'debug_apk']
 
   def __init__(self, *args, **kwargs):
     super(SignApkTask, self).__init__(*args, **kwargs)
-    self._distdir = self.get_options().pants_distdir
     self._config_file = self.get_options().keystore_config_location
     self._dist = None
+    self._distdir = self.get_options().pants_distdir
 
   @property
   def config_file(self):
@@ -77,7 +77,7 @@ class SignApkTask(Task):
                                        jdk=True)
     return self._dist
 
-  def render_args(self, target, key, unsigned_apk, outdir):
+  def _render_args(self, target, key, unsigned_apk, outdir):
     """Create arg list for the jarsigner process.
 
     :param AndroidBinary target: Target to be signed.
@@ -90,9 +90,7 @@ class SignApkTask(Task):
     # is needed before passing a -tsa flag indiscriminately.
     # http://bugs.java.com/view_bug.do?bug_id=8023338
 
-    args = []
-    args.append(self.distribution.binary('jarsigner'))
-
+    args = [self.distribution.binary('jarsigner')]
     # These first two params are required flags for JDK 7+
     args.extend(['-sigalg', 'SHA1withRSA'])
     args.extend(['-digestalg', 'SHA1'])
@@ -100,8 +98,7 @@ class SignApkTask(Task):
     args.extend(['-keystore', key.keystore_location])
     args.extend(['-storepass', key.keystore_password])
     args.extend(['-keypass', key.key_password])
-    args.extend(['-signedjar', (os.path.join(outdir, target.app_name + '.' +
-                                             key.build_type + '.signed.apk'))])
+    args.extend(['-signedjar', os.path.join(outdir, self.package_name(target, key.build_type))])
     args.append(unsigned_apk)
     args.append(key.keystore_alias)
     logger.debug('Executing: {0}'.format(' '.join(args)))
@@ -137,9 +134,10 @@ class SignApkTask(Task):
         for unsigned_apk in packages:
           keystores = KeystoreResolver.resolve(self.config_file)
           for key in keystores:
-            outdir = (self.sign_apk_out(target, key.keystore_name))
+
+            outdir = self.sign_apk_out(target, keystores[key].build_type)
             safe_mkdir(outdir)
-            args = self.render_args(target, key, unsigned_apk, outdir)
+            args = self._render_args(target, keystores[key], unsigned_apk, outdir)
             with self.context.new_workunit(name='sign_apk',
                                            labels=[WorkUnit.MULTITOOL]) as workunit:
               returncode = subprocess.call(args, stdout=workunit.output('stdout'),
@@ -147,8 +145,29 @@ class SignApkTask(Task):
               if returncode:
                 raise TaskError('The SignApk jarsigner process exited non-zero: {0}'
                                 .format(returncode))
-              # I will handle the output products with the next CR for the final build step.
 
-  def sign_apk_out(self, target, key_name):
-    """Compute the outdir for a target, one outdir per keystore."""
-    return os.path.join(self._distdir, target.app_name, key_name)
+    # Keystores and targets have no concept of each other and keys only exist in this execute scope.
+    # We look at the products themselves in order to plug into the invalidation framework.
+    for target in targets:
+      release_path = self.sign_apk_out(target, 'release')
+      debug_path = self.sign_apk_out(target, 'debug')
+      release_apk = self.package_name(target, 'release')
+      debug_apk = self.package_name(target, 'debug')
+
+      if os.path.isfile(os.path.join(release_path, release_apk)):
+        # If it is a release build, it goes to the workdir for zipalign to operate upon.
+        self.context.products.get('release_apk').add(target, release_path).append(release_apk)
+      elif os.path.isfile(os.path.join(debug_path, debug_apk)):
+        # Debug builds have completed all needed tasks so these products can go straight to dist.
+        self.context.products.get('debug_apk').add(target, debug_path).append(debug_apk)
+
+  def package_name(self, target, build_type):
+    """Get package name with 'build_type', a string KeyResolver mandates is in (debug, release)."""
+    return '{0}.{1}.signed.apk'.format(target.app_name, build_type)
+
+  def sign_apk_out(self, target, build_type):
+    """Compute the outdir for a target."""
+    if build_type == 'release':
+      return os.path.join(self.workdir, target.name, build_type)
+    elif build_type == 'debug':
+      return os.path.join(self._distdir, target.name)

--- a/src/python/pants/backend/android/tasks/zipalign.py
+++ b/src/python/pants/backend/android/tasks/zipalign.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+import os
+import subprocess
+
+from pants.backend.android.targets.android_binary import AndroidBinary
+from pants.backend.android.tasks.android_task import AndroidTask
+from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnit
+from pants.util.dirutil import safe_mkdir
+
+
+logger = logging.getLogger(__name__)
+
+
+class Zipalign(AndroidTask):
+  """Task to run zipalign, an archive alignment tool."""
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(Zipalign, cls).prepare(options, round_manager)
+    # Zipalign no-ops on 'debug_apk' but requires both to bundle their tasks into 'binary' goal.
+    round_manager.require_data('release_apk')
+    round_manager.require_data('debug_apk')
+
+  @staticmethod
+  def is_zipaligntarget(target):
+    return isinstance(target, AndroidBinary)
+
+  def __init__(self, *args, **kwargs):
+    super(Zipalign, self).__init__(*args, **kwargs)
+    self._android_dist = self.android_sdk
+    self._distdir = self.get_options().pants_distdir
+
+  def _render_args(self, package, target):
+    """Create arg list for the zipalign process.
+
+     :param string package: Location of a signed apk product from the SignApk task.
+     :param AndroidBinary target: Target to be zipaligned.
+     """
+    # Glossary of used zipalign flags:
+    #   : '-f' is to force overwrite of existing outfile.
+    #   :  '4' is the mandated byte-alignment boundaries. If not 4, zipalign doesn't do anything.
+    #   :   Final two args are infile, outfile.
+    args = [self.zipalign_binary(target)]
+    args.extend(['-f', '4', ])
+    args.extend([package, os.path.join(self.zipalign_out(target),
+                                       '{0}.signed.apk'.format(target.app_name))])
+    logger.debug('Executing: {0}'.format(' '.join(args)))
+    return args
+
+  def execute(self):
+    targets = self.context.targets(self.is_zipaligntarget)
+    for target in targets:
+
+      def get_products_path(target):
+        """Get path of target's apks that are signed with release keystores by SignApk task."""
+        apks = self.context.products.get('release_apk')
+        if apks.get(target):
+          for tgts, products in apks.get(target).items():
+            for prod in products:
+              yield os.path.join(tgts, prod)
+
+      packages = list(get_products_path(target))
+      for package in packages:
+        safe_mkdir(self.zipalign_out(target))
+        args = self._render_args(package, target)
+        with self.context.new_workunit(name='zipalign', labels=[WorkUnit.MULTITOOL]) as workunit:
+          returncode = subprocess.call(args, stdout=workunit.output('stdout'),
+                                       stderr=workunit.output('stderr'))
+          if returncode:
+            raise TaskError('The zipalign process exited non-zero: {0}'
+                            .format(returncode))
+
+  def zipalign_binary(self, target):
+    """Return the appropriate zipalign binary."""
+    zipalign_binary = os.path.join('build-tools', target.build_tools_version, 'zipalign')
+    return self._android_dist.register_android_tool(zipalign_binary)
+
+  def zipalign_out(self, target):
+    """Compute the outdir for the zipalign task."""
+    return os.path.join(self._distdir, target.name)

--- a/src/python/pants/backend/android/tasks/zipalign.py
+++ b/src/python/pants/backend/android/tasks/zipalign.py
@@ -25,7 +25,6 @@ class Zipalign(AndroidTask):
   @classmethod
   def prepare(cls, options, round_manager):
     super(Zipalign, cls).prepare(options, round_manager)
-    # Zipalign no-ops on 'debug_apk' but requires both to bundle their tasks into 'binary' goal.
     round_manager.require_data('release_apk')
 
   @staticmethod

--- a/src/python/pants/backend/android/tasks/zipalign.py
+++ b/src/python/pants/backend/android/tasks/zipalign.py
@@ -27,7 +27,6 @@ class Zipalign(AndroidTask):
     super(Zipalign, cls).prepare(options, round_manager)
     # Zipalign no-ops on 'debug_apk' but requires both to bundle their tasks into 'binary' goal.
     round_manager.require_data('release_apk')
-    round_manager.require_data('debug_apk')
 
   @staticmethod
   def is_zipaligntarget(target):

--- a/src/python/pants/backend/android/tasks/zipalign.py
+++ b/src/python/pants/backend/android/tasks/zipalign.py
@@ -46,10 +46,9 @@ class Zipalign(AndroidTask):
     #   : '-f' is to force overwrite of existing outfile.
     #   :  '4' is the mandated byte-alignment boundaries. If not 4, zipalign doesn't do anything.
     #   :   Final two args are infile, outfile.
-    args = [self.zipalign_binary(target)]
-    args.extend(['-f', '4', ])
-    args.extend([package, os.path.join(self.zipalign_out(target),
-                                       '{0}.signed.apk'.format(target.app_name))])
+
+    outfile = os.path.join(self.zipalign_out(target), '{0}.signed.apk'.format(target.app_name))
+    args = [self.zipalign_binary(target), '-f', '4', package, outfile]
     logger.debug('Executing: {0}'.format(' '.join(args)))
     return args
 
@@ -60,8 +59,9 @@ class Zipalign(AndroidTask):
       def get_products_path(target):
         """Get path of target's apks that are signed with release keystores by SignApk task."""
         apks = self.context.products.get('release_apk')
-        if apks.get(target):
-          for tgts, products in apks.get(target).items():
+        packages = apks.get(target)
+        if packages:
+          for tgts, products in packages.items():
             for prod in products:
               yield os.path.join(tgts, prod)
 

--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -8,7 +8,7 @@ python_test_suite(
     ':android_config_util',
     ':android_distribution',
     ':keystore_resolver',
-    'tests/python/pants_test/android/tasks:tasks',
+    'tests/python/pants_test/android/tasks',
   ]
 )
 

--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -5,9 +5,10 @@
 python_test_suite(
   name = 'android',
   dependencies = [
+    ':android_config_util',
     ':android_distribution',
     ':keystore_resolver',
-    'tests/python/pants_test/android/tasks',
+    'tests/python/pants_test/android/tasks:tasks',
   ]
 )
 
@@ -30,6 +31,20 @@ python_tests(
 )
 
 python_tests(
+  name = 'android_base',
+  sources = [
+    'test_android_base.py',
+  ],
+  dependencies = [
+    'src/python/pants/backend/android/targets:android',
+    'src/python/pants/backend/android/tasks:all',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/tasks:base'
+  ]
+)
+
+python_tests(
   name = 'android_config_util',
   sources = [
     'test_android_config_util.py',
@@ -46,10 +61,9 @@ python_tests(
     'test_android_distribution.py',
   ],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/android:android_distribution',
     'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/android:android_base',
   ]
 )
 

--- a/tests/python/pants_test/android/android_integration_test.py
+++ b/tests/python/pants_test/android/android_integration_test.py
@@ -14,10 +14,9 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class AndroidIntegrationTest(PantsRunIntegrationTest):
   """Ensure a base SDK to run any Android integration tests.
 
-  The Android SDK is modular, finding an SDK on the PATH is no guarantee that there is
-  a dx.jar anywhere on disk. In this test we look for a set of default tools that will get the
-  job done or the test is skipped. The TARGET_SDK version must match the targetSDK value in the
-  AndroidManifest.xml of the target while the BUILD_TOOLS version is arbitrary.
+  The Android SDK is modular, finding an SDK on the PATH is no guarantee that any certain
+  tool is on disk. For integration tests we define a set of default tools and
+  if they cannot be found the integration test is skipped.
   """
   BUILD_TOOLS = '19.1.0'
   TARGET_SDK = '19'

--- a/tests/python/pants_test/android/tasks/BUILD
+++ b/tests/python/pants_test/android/tasks/BUILD
@@ -5,6 +5,8 @@ python_test_suite(
   name='tasks',
   dependencies=[
     ':aapt_gen',
+    ':sign_apk',
+    ':zipalign',
   ],
 )
 
@@ -14,6 +16,7 @@ python_test_suite(
     ':aapt_builder_integration',
     ':dx_compile_integration',
     ':sign_apk_integration',
+    ':zipalign_integration',
   ],
 )
 
@@ -53,12 +56,10 @@ python_tests(
     'test_sign_apk.py',
   ],
   dependencies = [
-    'src/python/pants/backend/android/targets:android',
     'src/python/pants/backend/android/tasks:sign_apk',
-    'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/tasks:base'
+    'tests/python/pants_test/android:android_base'
   ],
 )
 
@@ -66,6 +67,28 @@ python_tests(
   name = 'sign_apk_integration',
   sources = [
     'test_sign_apk_integration.py',
+  ],
+  dependencies = [
+    'tests/python/pants_test/android:android_integration_test',
+  ],
+)
+
+python_tests(
+  name = 'zipalign',
+  sources = [
+    'test_zipalign.py',
+  ],
+  dependencies = [
+    'src/python/pants/backend/android/tasks:zipalign',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/android:android_base',
+  ],
+)
+
+python_tests(
+  name = 'zipalign_integration',
+  sources = [
+    'test_zipalign_integration.py',
   ],
   dependencies = [
     'tests/python/pants_test/android:android_integration_test',

--- a/tests/python/pants_test/android/tasks/test_sign_apk.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk.py
@@ -101,20 +101,21 @@ class SignApkTest(TestAndroidBase):
 
   def test_render_args(self):
     with temporary_dir() as temp:
-      task = self.prepare_task(config=self._get_config(),
-                               build_graph=self.build_graph,
-                               build_file_parser=self.build_file_parser)
-    target = self.android_binary()
-    fake_key = self.FakeKeystore()
-    task._dist = self.FakeDistribution()
-    expected_args = ['path/to/jarsigner',
-                     '-sigalg', 'SHA1withRSA', '-digestalg', 'SHA1',
-                     '-keystore', '/path/to/key',
-                     '-storepass', 'keystore_password',
-                     '-keypass', 'key_password',
-                     '-signedjar']
-    expected_args.extend(['{0}/{1}.{2}.signed.apk'.format(temp, target.app_name,
-                                                          fake_key.build_type)])
-    expected_args.extend(['unsigned_apk_product', 'key_alias'])
-    self.assertEquals(expected_args, task._render_args(target, fake_key, 'unsigned_apk_product',
-                                                      temp))
+      with self.android_binary() as android_binary:
+        task = self.prepare_task(config=self._get_config(),
+                                   build_graph=self.build_graph,
+                                   build_file_parser=self.build_file_parser)
+        target = android_binary
+        fake_key = self.FakeKeystore()
+        task._dist = self.FakeDistribution()
+        expected_args = ['path/to/jarsigner',
+                         '-sigalg', 'SHA1withRSA', '-digestalg', 'SHA1',
+                         '-keystore', '/path/to/key',
+                         '-storepass', 'keystore_password',
+                         '-keypass', 'key_password',
+                         '-signedjar']
+        expected_args.extend(['{0}/{1}.{2}.signed.apk'.format(temp, target.app_name,
+                                                              fake_key.build_type)])
+        expected_args.extend(['unsigned_apk_product', 'key_alias'])
+        self.assertEquals(expected_args, task._render_args(target, fake_key, 'unsigned_apk_product',
+                                                           temp))

--- a/tests/python/pants_test/android/tasks/test_sign_apk_integration.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk_integration.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,

--- a/tests/python/pants_test/android/tasks/test_sign_apk_integration.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk_integration.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,

--- a/tests/python/pants_test/android/tasks/test_zipalign.py
+++ b/tests/python/pants_test/android/tasks/test_zipalign.py
@@ -26,29 +26,32 @@ class TestZipalign(TestAndroidBase):
 
   def test_zipalign_binary(self):
     with self.distribution() as dist:
-      task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
-                               build_graph=self.build_graph,
-                               build_file_parser=self.build_file_parser)
-      target = self.android_binary()
-      self.assertEqual(task.zipalign_binary(target),
-                       os.path.join(dist, 'build-tools', target.build_tools_version, 'zipalign'))
+      with self.android_binary() as android_binary:
+        task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
+                                   build_graph=self.build_graph,
+                                   build_file_parser=self.build_file_parser)
+        target = android_binary
+        self.assertEqual(task.zipalign_binary(target),
+                         os.path.join(dist, 'build-tools', target.build_tools_version, 'zipalign'))
 
   def test_zipalign_out(self):
     with self.distribution() as dist:
-      task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
-                               build_graph=self.build_graph,
-                               build_file_parser=self.build_file_parser)
-      target = self.android_binary()
-      self.assertEqual(task.zipalign_out(target), os.path.join(task._distdir, target.name))
+      with self.android_binary() as android_binary:
+        task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
+                                 build_graph=self.build_graph,
+                                 build_file_parser=self.build_file_parser)
+        target = android_binary
+        self.assertEqual(task.zipalign_out(target), os.path.join(task._distdir, target.name))
 
   def test_render_args(self):
     with self.distribution() as dist:
-      task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
-                               build_graph=self.build_graph,
-                               build_file_parser=self.build_file_parser)
-      target = self.android_binary()
-      expected_args = [os.path.join(dist, 'build-tools/', target.build_tools_version, 'zipalign'),
-                        '-f', '4', 'package/path',
-                        os.path.join(task._distdir, target.name,
-                                     '{0}.signed.apk'.format(target.name))]
-      self.assertEqual(task._render_args('package/path', target), expected_args)
+      with self.android_binary() as android_binary:
+        task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
+                                 build_graph=self.build_graph,
+                                 build_file_parser=self.build_file_parser)
+        target = android_binary
+        expected_args = [os.path.join(dist, 'build-tools', target.build_tools_version, 'zipalign'),
+                          '-f', '4', 'package/path',
+                          os.path.join(task._distdir, target.name,
+                                       '{0}.signed.apk'.format(target.name))]
+        self.assertEqual(task._render_args('package/path', target), expected_args)

--- a/tests/python/pants_test/android/tasks/test_zipalign.py
+++ b/tests/python/pants_test/android/tasks/test_zipalign.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.backend.android.tasks.zipalign import Zipalign
+from pants_test.android.test_android_base import TestAndroidBase
+
+
+class TestZipalign(TestAndroidBase):
+  """Test class for the Zipalign task."""
+
+  @classmethod
+  def task_type(cls):
+    return Zipalign
+
+  def test_zipalign_smoke(self):
+    task = self.prepare_task(build_graph=self.build_graph,
+                             build_file_parser=self.build_file_parser)
+    task.execute()
+
+
+  def test_zipalign_binary(self):
+    with self.distribution() as dist:
+      task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
+                               build_graph=self.build_graph,
+                               build_file_parser=self.build_file_parser)
+      target = self.android_binary()
+      self.assertEqual(task.zipalign_binary(target),
+                       os.path.join(dist, 'build-tools', target.build_tools_version, 'zipalign'))
+
+  def test_zipalign_out(self):
+    with self.distribution() as dist:
+      task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
+                               build_graph=self.build_graph,
+                               build_file_parser=self.build_file_parser)
+      target = self.android_binary()
+      self.assertEqual(task.zipalign_out(target), os.path.join(task._distdir, target.name))
+
+  def test_render_args(self):
+    with self.distribution() as dist:
+      task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
+                               build_graph=self.build_graph,
+                               build_file_parser=self.build_file_parser)
+      target = self.android_binary()
+      expected_args = [os.path.join(dist, 'build-tools/', target.build_tools_version, 'zipalign'),
+                        '-f', '4', 'package/path',
+                        os.path.join(task._distdir, target.name,
+                                     "{0}.signed.apk".format(target.name))]
+      self.assertEqual(task._render_args('package/path', target), expected_args)

--- a/tests/python/pants_test/android/tasks/test_zipalign.py
+++ b/tests/python/pants_test/android/tasks/test_zipalign.py
@@ -50,5 +50,5 @@ class TestZipalign(TestAndroidBase):
       expected_args = [os.path.join(dist, 'build-tools/', target.build_tools_version, 'zipalign'),
                         '-f', '4', 'package/path',
                         os.path.join(task._distdir, target.name,
-                                     "{0}.signed.apk".format(target.name))]
+                                     '{0}.signed.apk'.format(target.name))]
       self.assertEqual(task._render_args('package/path', target), expected_args)

--- a/tests/python/pants_test/android/tasks/test_zipalign_integration.py
+++ b/tests/python/pants_test/android/tasks/test_zipalign_integration.py
@@ -12,7 +12,7 @@ import pytest
 from pants_test.android.android_integration_test import AndroidIntegrationTest
 
 
-class SignApkIntegrationTest(AndroidIntegrationTest):
+class ZipalignIntegrationTest(AndroidIntegrationTest):
   """Integration test for SignApkTask.
 
   The Android SDK is modular, finding an SDK on the PATH is no guarantee that the tools you
@@ -23,18 +23,19 @@ class SignApkIntegrationTest(AndroidIntegrationTest):
 
   TOOLS = [
     os.path.join('build-tools', AndroidIntegrationTest.BUILD_TOOLS, 'aapt'),
+    os.path.join('build-tools', AndroidIntegrationTest.BUILD_TOOLS, 'zipalign'),
     os.path.join('build-tools', AndroidIntegrationTest.BUILD_TOOLS, 'lib', 'dx.jar'),
     os.path.join('platforms', 'android-' + AndroidIntegrationTest.TARGET_SDK, 'android.jar')
   ]
 
   requirements = AndroidIntegrationTest.requirements(TOOLS)
 
-  @pytest.mark.skipif('not SignApkIntegrationTest.requirements',
-                      reason='Jarsigner integration test requires the JDK, Android tools {0!r} '
+  @pytest.mark.skipif('not ZipalignIntegrationTest.requirements',
+                      reason='Zipalign integration test requires the JDK, Android tools {0!r} '
                              'and ANDROID_HOME set in path.'.format(TOOLS))
-  def test_sign_apk(self):
-    self.sign_apk_test(AndroidIntegrationTest.TEST_TARGET)
+  def test_zipalign(self):
+    self.zipalign_test(AndroidIntegrationTest.TEST_TARGET)
 
-  def sign_apk_test(self, target):
-    pants_run = self.run_pants(['sign', target])
+  def zipalign_test(self, target):
+    pants_run = self.run_pants(['binary', target])
     self.assert_success(pants_run)

--- a/tests/python/pants_test/android/test_android_base.py
+++ b/tests/python/pants_test/android/test_android_base.py
@@ -47,17 +47,17 @@ class TestAndroidBase(TaskTest):
 
   @contextmanager
   def distribution(self,
-                   installed_sdks=['18', '19'],
-                   installed_build_tools=['19.1.0'],
-                   files=['android.jar'],
-                   executables=['aapt', 'zipalign']):
+                   installed_sdks=('18', '19'),
+                   installed_build_tools=('19.1.0',),
+                   files=('android.jar',),
+                   executables=('aapt', 'zipalign')):
     """Mock Android SDK Distribution.
 
-    :param list[strings] installed_sdks: SDK versions of the files being mocked.
-    :param list[strings] installed_build_tools: Build tools version of any tools.
-    :param list[strings] files: The files are to mock non-executables and one will be created for
+    :param tuple[strings] installed_sdks: SDK versions of the files being mocked.
+    :param tuple[strings] installed_build_tools: Build tools version of any tools.
+    :param tuple[strings] files: The files are to mock non-executables and one will be created for
       each installed_sdks version.
-    :param list[strings] executables: Executables are any required tools and one is created for each
+    :param tuple[strings] executables: Executables are any required tools and one is created for each
       installed_build_tools version.
     """
     with temporary_dir() as sdk:
@@ -67,7 +67,6 @@ class TestAndroidBase(TaskTest):
       for version in installed_build_tools:
         for exe in maybe_list(executables or ()):
           path = os.path.join(sdk, 'build-tools', version, exe)
-          with safe_open(path, 'w') as fp:
-            fp.write('')
+          touch(path)
           chmod_plus_x(path)
       yield sdk

--- a/tests/python/pants_test/android/test_android_base.py
+++ b/tests/python/pants_test/android/test_android_base.py
@@ -25,6 +25,7 @@ class TestAndroidBase(TaskTest):
     """Subclasses must return the type of the Task subclass under test."""
     return AndroidTask
 
+  @contextmanager
   def android_binary(self):
     """Represent an android_binary target, providing a mock version of the required manifest."""
     with temporary_file() as fp:
@@ -42,7 +43,7 @@ class TestAndroidBase(TaskTest):
       target = self.make_target(spec=':binary',
                                 target_type=AndroidBinary,
                                 manifest=path)
-      return target
+      yield target
 
   @contextmanager
   def distribution(self,

--- a/tests/python/pants_test/android/test_android_base.py
+++ b/tests/python/pants_test/android/test_android_base.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import textwrap
+from contextlib import contextmanager
+
+from twitter.common.collections import maybe_list
+
+from pants.backend.android.targets.android_binary import AndroidBinary
+from pants.backend.android.tasks.android_task import AndroidTask
+from pants.util.contextutil import temporary_dir, temporary_file
+from pants.util.dirutil import chmod_plus_x, safe_open, touch
+from pants_test.tasks.test_base import TaskTest
+
+
+class TestAndroidBase(TaskTest):
+  """Base class for Android tests that provides some mock structures useful for testing."""
+
+  def task_type(cls):
+    """Subclasses must return the type of the Task subclass under test."""
+    return AndroidTask
+
+  def android_binary(self):
+    """Represent an android_binary target, providing a mock version of the required manifest."""
+    with temporary_file() as fp:
+      fp.write(textwrap.dedent(
+        """<?xml version="1.0" encoding="utf-8"?>
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+            package="com.pants.examples.hello" >
+            <uses-sdk
+                android:minSdkVersion="8"
+                android:targetSdkVersion="19" />
+        </manifest>
+        """))
+      path = fp.name
+      fp.close()
+      target = self.make_target(spec=':binary',
+                                target_type=AndroidBinary,
+                                manifest=path)
+      return target
+
+  @contextmanager
+  def distribution(self,
+                   installed_sdks=['18', '19'],
+                   installed_build_tools=['19.1.0'],
+                   files=['android.jar'],
+                   executables=['aapt', 'zipalign']):
+    """Mock Android SDK Distribution.
+
+    :param list[strings] installed_sdks: SDK versions of the files being mocked.
+    :param list[strings] installed_build_tools: Build tools version of any tools.
+    :param list[strings] files: The files are to mock non-executables and one will be created for
+      each installed_sdks version.
+    :param list[strings] executables: Executables are any required tools and one is created for each
+      installed_build_tools version.
+    """
+    with temporary_dir() as sdk:
+      for sdk_version in installed_sdks:
+        for android_file in files:
+          touch(os.path.join(sdk, 'platforms', 'android-' + sdk_version, android_file))
+      for version in installed_build_tools:
+        for exe in maybe_list(executables or ()):
+          path = os.path.join(sdk, 'build-tools', version, exe)
+          with safe_open(path, 'w') as fp:
+            fp.write('')
+          chmod_plus_x(path)
+      yield sdk

--- a/tests/python/pants_test/android/test_android_config_util.py
+++ b/tests/python/pants_test/android/test_android_config_util.py
@@ -45,4 +45,4 @@ class TestAndroidConfigUtil(unittest.TestCase):
 
   def test_no_permission_keystore_config(self):
     with self.assertRaises(AndroidConfigUtil.AndroidConfigError):
-      AndroidConfigUtil.setup_keystore_config("/outside/home/directory")
+      AndroidConfigUtil.setup_keystore_config('/outside/home/directory')

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -6,35 +6,16 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import unittest
 from contextlib import contextmanager
 
 import pytest
-from twitter.common.collections import maybe_list
 
 from pants.backend.android.distribution.android_distribution import AndroidDistribution
-from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import chmod_plus_x, safe_open, touch
+from pants.util.contextutil import environment_as
+from pants_test.android.test_android_base import TestAndroidBase
 
 
-class TestAndroidDistribution(unittest.TestCase):
-
-  @contextmanager
-  # default for testing purposes being sdk 18 and 19, with latest build-tools 19.1.0
-  def distribution(self, installed_sdks=('18', '19'),
-                   installed_build_tools=('19.1.0', ),
-                   files='android.jar',
-                   executables='aapt'):
-    with temporary_dir() as sdk:
-      for sdks in installed_sdks:
-        touch(os.path.join(sdk, 'platforms', 'android-' + sdks, files))
-      for build in installed_build_tools:
-        for exe in maybe_list(executables or ()):
-          path = os.path.join(sdk, 'build-tools', build, exe)
-          with safe_open(path, 'w') as fp:
-            fp.write('')
-          chmod_plus_x(path)
-      yield sdk
+class TestAndroidDistribution(TestAndroidBase):
 
   def test_tool_registration(self):
     with self.distribution() as sdk:

--- a/tests/python/pants_test/android/test_keystore_resolver.py
+++ b/tests/python/pants_test/android/test_keystore_resolver.py
@@ -59,12 +59,12 @@ class TestKeystoreResolver(unittest.TestCase):
       self.assertEquals(keystores['test-release'].build_type, 'release')
 
   def test_resolve_mixed_case(self):
-    with self.config_file(build_type="ReleASE") as config:
+    with self.config_file(build_type='ReleASE') as config:
       keystores = KeystoreResolver.resolve(config)
       self.assertEquals(keystores['test-release'].build_type, 'release')
 
   def test_bad_build_type(self):
-    with self.config_file(build_type="bad-build-type") as config:
+    with self.config_file(build_type='bad-build-type') as config:
       keystores = KeystoreResolver.resolve(config)
       with self.assertRaises(ValueError):
         keystores['default-debug'].build_type
@@ -76,7 +76,7 @@ class TestKeystoreResolver(unittest.TestCase):
         self.assertEqual(keystores['default-debug'].keystore_location, temp_location.name)
 
   def test_expanding_path(self):
-    with self.config_file(keystore_location="~/dir") as config:
+    with self.config_file(keystore_location='~/dir') as config:
       keystores = KeystoreResolver.resolve(config)
       self.assertEqual(keystores['default-debug'].keystore_location, os.path.expandvars('~/dir'))
 

--- a/tests/python/pants_test/android/test_keystore_resolver.py
+++ b/tests/python/pants_test/android/test_keystore_resolver.py
@@ -27,6 +27,15 @@ class TestKeystoreResolver(unittest.TestCase):
     with temporary_file() as fp:
       fp.write(textwrap.dedent(
         """
+
+        [test-release]
+
+        build_type: release
+        keystore_location: /some/path
+        keystore_alias: test
+        keystore_password: password
+        key_password: password
+
         [default-debug]
 
         build_type: {0}
@@ -42,44 +51,38 @@ class TestKeystoreResolver(unittest.TestCase):
   def test_resolve(self):
     with self.config_file() as config:
       keystores = KeystoreResolver.resolve(config)
-      for key in keystores:
-        self.assertEquals(key.build_type, 'debug')
+      self.assertEquals(keystores['default-debug'].build_type, 'debug')
 
   def test_resolve_release(self):
-    with self.config_file(build_type="release") as config:
+    with self.config_file() as config:
       keystores = KeystoreResolver.resolve(config)
-      for key in keystores:
-        self.assertEquals(key.build_type, 'release')
+      self.assertEquals(keystores['test-release'].build_type, 'release')
 
   def test_resolve_mixed_case(self):
-    with self.config_file(build_type="DeBuG") as config:
+    with self.config_file(build_type="ReleASE") as config:
       keystores = KeystoreResolver.resolve(config)
-      for key in keystores:
-        self.assertEquals(key.build_type, 'debug')
+      self.assertEquals(keystores['test-release'].build_type, 'release')
 
   def test_bad_build_type(self):
     with self.config_file(build_type="bad-build-type") as config:
       keystores = KeystoreResolver.resolve(config)
-      for key in keystores:
-        with self.assertRaises(ValueError):
-          key.build_type
+      with self.assertRaises(ValueError):
+        keystores['default-debug'].build_type
 
   def test_set_location(self):
     with temporary_file() as temp_location:
       with self.config_file(keystore_location=temp_location.name) as config:
         keystores = KeystoreResolver.resolve(config)
-        for key in keystores:
-          self.assertEqual(key.keystore_location, temp_location.name)
+        self.assertEqual(keystores['default-debug'].keystore_location, temp_location.name)
 
   def test_expanding_path(self):
     with self.config_file(keystore_location="~/dir") as config:
       keystores = KeystoreResolver.resolve(config)
-      for key in keystores:
-        self.assertEqual(key.keystore_location, os.path.expandvars('~/dir'))
+      self.assertEqual(keystores['default-debug'].keystore_location, os.path.expandvars('~/dir'))
 
   def test_bad_config_location(self):
     with self.assertRaises(KeystoreResolver.Error):
-        KeystoreResolver.resolve(os.path.join('no', 'config_file', 'here'))
+      KeystoreResolver.resolve(os.path.join('no', 'config_file', 'here'))
 
   def test_a_missing_field(self):
     with self.assertRaises(KeystoreResolver.Error):


### PR DESCRIPTION
Zipalign is the final step in the basic Android app build.
This step is only required on apks signed with release keystores.
SignApk now outputs two products, 'debug_apk' and 'release_apk'.
Zipalign requires them both so as to bundle their tasks into a
'binary' goal. But Zipalign only acts upon the 'release_apk'.

SignApk has to put any output apk products into context. As it
stands, the keystore objects and AndroidBinary targets have no
concept of each other. Keystore objects only exist in the
scope of the target's SignApk execute phase. In order to maintain
that, the SignApk has to check for the products on disk.
If it finds a product, then it adds that product to the context.

I also changed the return type of the KeystoreResolver into a dict.
Since it will usually return more than one keystore, it was easier
to test and use as a dictionary.