### PR TITLE
Add an 'advanced' parameter to registering options

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
@@ -73,8 +73,8 @@ class JavaCompile(JvmCompile):
   @classmethod
   def register_options(cls, register):
     super(JavaCompile, cls).register_options(register)
-    register('--source', help='Provide source compatibility with this release.')
-    register('--target', help='Generate class files for this JVM version.')
+    register('--source', help='Provide source compatibility with this release.', advanced=True)
+    register('--target', help='Generate class files for this JVM version.', advanced=True)
     cls.register_jvm_tool(register, 'jmake')
     cls.register_jvm_tool(register, 'java-compiler')
 

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -30,6 +30,7 @@ from pants.goal.goal import Goal
 from pants.goal.initialize_reporting import initial_reporting, update_reporting
 from pants.goal.run_tracker import RunTracker
 from pants.option.global_options import register_global_options
+from pants.option.help_formatter import PantsHelpFormatter
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.report import Report
 from pants.util.dirutil import safe_mkdir
@@ -73,6 +74,8 @@ class GoalRunner(object):
     # Now that we have the known scopes we can get the full options.
     self.options = options_bootstrapper.get_full_options(known_scopes=known_scopes)
     self.register_options()
+
+    PantsHelpFormatter.show_advanced_output(visible=bootstrap_options.is_help_advanced)
 
     self.run_tracker = RunTracker.from_config(self.config)
     report = initial_reporting(self.config, self.run_tracker)

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -51,6 +51,7 @@ class ArgSplitter(object):
     self._known_scopes = set(known_scopes + ['help'])
     self._unconsumed_args = []  # In reverse order, for efficient popping off the end.
     self._is_help = False  # True if the user asked for help.
+    self._is_help_advanced = False # True if the user asked for --help-advanced
     self._is_help_all = False  # True if the user asked for --help-all.
 
     # For historical reasons we allow --scope-flag-name anywhere on the cmd line,
@@ -64,6 +65,10 @@ class ArgSplitter(object):
   @property
   def is_help(self):
     return self._is_help
+
+  @property
+  def is_help_advanced(self):
+    return self._is_help_advanced
 
   @property
   def is_help_all(self):
@@ -111,6 +116,8 @@ class ArgSplitter(object):
       assign_flag_to_scope(flag, GLOBAL_SCOPE)
     if '--help-all' in global_flags:
       self._is_help_all = True
+    if '--help-advanced' in global_flags:
+      self._is_help_advanced = True
     scope, flags = self._consume_scope()
     while scope:
       if scope.lower() == 'help':

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -96,6 +96,7 @@ class Options(object):
 
     self._is_help = splitter.is_help
     self._is_help_all = splitter.is_help_all
+    self._is_help_advanced = splitter.is_help_advanced
     self._parser_hierarchy = ParserHierarchy(env, config, known_scopes)
     self._values_by_scope = {}  # Arg values, parsed per-scope on demand.
     self._bootstrap_option_values = bootstrap_option_values
@@ -140,6 +141,11 @@ class Options(object):
   def is_help(self):
     """Whether the command line indicates a request for help."""
     return self._is_help
+
+  @property
+  def is_help_advanced(self):
+    """Whether the command line indicates a request for advanced help."""
+    return self._is_help_advanced
 
   @property
   def is_help_all(self):

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -40,11 +40,13 @@ def register_bootstrap_options(register, buildroot=None):
            help='Use pantsrc files.')
   register('--pantsrc-files', action='append', metavar='<path>',
            default=['/etc/pantsrc', '~/.pants.rc'],
-           help='Override config with values from these files. Later files override eariler ones.')
+           help='Override config with values from these files. Later files override earlier ones.')
   register('--pythonpath', action='append',
            help='Add these directories to PYTHONPATH to search for plugins.')
   register('--target-spec-file', action='append', dest='target_spec_files',
            help='Read additional specs from this file, one per line')
+  register('--help-advanced', action='store_true',
+           help='Display advanced options in help output.')
 
 
 class OptionsBootstrapper(object):

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -110,7 +110,13 @@ class Parser(object):
     # registered on it too, which would create unnecessarily repetitive help messages.
     self._help_argparser = CustomArgumentParser(conflict_handler='resolve',
                                                 formatter_class=PantsHelpFormatter)
+
+    # Options are registered in two groups.  The first group will always be displayed in the help
+    # output.  The second group is for advanced options are not normally displayed because they
+    # are complex or may impact the compiler output.
     self._help_argparser_group = self._help_argparser.add_argument_group(title=scope)
+    self._help_argparser_advanced_group = \
+      self._help_argparser.add_argument_group(title='*{0}'.format(scope))
 
     # If True, we have at least one option to show help for.
     self._has_help_options = False
@@ -155,7 +161,11 @@ class Parser(object):
     return self._help_argparser.format_help() if self._has_help_options else ''
 
   def register(self, *args, **kwargs):
-    """Register an option, using argparse params."""
+    """Register an option, using argparse params.
+
+    Custom extensions to argparse params:
+    :param advanced: if True, the option will be usually be suppressed when displaying help.
+    """
     if self._frozen:
       raise RegistrationError('Cannot register option {0} in scope {1} after registering options '
                               'in any of its inner scopes.'.format(args[0], self._scope))
@@ -165,6 +175,9 @@ class Parser(object):
     while ancestor:
       ancestor._freeze()
       ancestor = ancestor._parent_parser
+
+    # Pull out our custom arguments, they aren't valid for argparse.
+    advanced = kwargs.pop('advanced', False)
 
     self._validate(args, kwargs)
     dest = self._set_dest(args, kwargs)
@@ -182,7 +195,13 @@ class Parser(object):
     # default may be overridden in inner scopes.
     raw_default = self._compute_default(dest, is_invertible, kwargs).value
     kwargs_with_default = dict(kwargs, default=raw_default)
-    self._help_argparser_group.add_argument(*help_args, **kwargs_with_default)
+
+    if advanced:
+      arg_group = self._help_argparser_advanced_group
+    else:
+      arg_group = self._help_argparser_group
+    arg_group.add_argument(*help_args, **kwargs_with_default)
+
     self._has_help_options = True
 
     # Register the option for the purpose of parsing, on this and all enclosed scopes.

--- a/tests/python/pants_test/option/test_help_formatter.py
+++ b/tests/python/pants_test/option/test_help_formatter.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+from argparse import ArgumentParser
+
+from pants.option.help_formatter import PantsHelpFormatter
+
+
+class OptionHelpFormatterTest(unittest.TestCase):
+
+  _def_show_advanced_output = PantsHelpFormatter._show_advanced_output
+
+  def setUp(self):
+    PantsHelpFormatter.show_advanced_output(visible=False)
+
+  def tearDown(self):
+    PantsHelpFormatter.show_advanced_output(visible=OptionHelpFormatterTest._def_show_advanced_output)
+
+  def test_suppress_advanced(self):
+    argparser = ArgumentParser(formatter_class=PantsHelpFormatter)
+    group = argparser.add_argument_group(title='foo')
+    advanced_group = argparser.add_argument_group(title='*foo')
+    group.add_argument('--bar', help='help for argument bar')
+    advanced_group.add_argument('--baz', help='help for argument baz')
+
+    help_output = argparser.format_help()
+    self.assertIn('--bar', help_output)
+    self.assertNotIn('(ADVANCED)', help_output)
+    self.assertNotIn('--baz', help_output)
+
+    # turn on help printing
+    PantsHelpFormatter.show_advanced_output()
+    help_output = argparser.format_help()
+    self.assertIn('--bar', help_output)
+    self.assertIn('(ADVANCED)', help_output)
+    self.assertIn('--baz', help_output)


### PR DESCRIPTION
Advanced options to not normally display with help messages.  They are usually
intended to be set for the entire repo in pants.ini and shouldn't be specified
on the command line because they are difficult to configure or may affect
the hermeticity of the build.