### PR TITLE
Bandaid leaks of global Config state in tests.

### DIFF
--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -17,6 +17,7 @@ python_library(
   dependencies = [
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
+    'src/python/pants/base:config',
     'src/python/pants/base:extension_loader',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:task_test_base',

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -11,6 +11,7 @@ import shutil
 
 from pants.backend.jvm.tasks.bootstrap_jvm_tools import BootstrapJvmTools
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
+from pants.base.config import Config
 from pants.base.extension_loader import load_plugins_and_backends
 from pants.util.dirutil import safe_mkdir, safe_mkdtemp, safe_walk
 from pants_test.task_test_base import TaskTestBase
@@ -24,7 +25,10 @@ class JvmToolTaskTestBase(TaskTestBase):
     return load_plugins_and_backends().registered_aliases()
 
   def setUp(self):
+    # Ensure we get a read of the real pants.ini config
+    Config.reset_default_bootstrap_option_values()
     real_config = self.config()
+
     super(JvmToolTaskTestBase, self).setUp()
 
     # Use a synthetic subclass for bootstrapping within the test, to isolate this from


### PR DESCRIPTION
This ensures pants_test.jvm.jvm_tool_task_test_base.JvmToolTaskTestBase
gets a clean read of the real pants.ini config.