### PR TITLE
Fix TestAndroidBase task_type override miss.

### DIFF
--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -30,14 +30,14 @@ python_tests(
   ],
 )
 
-python_tests(
+python_library(
   name = 'android_base',
   sources = [
     'test_android_base.py',
   ],
   dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/android/targets:android',
-    'src/python/pants/backend/android/tasks:all',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/tasks:base'

--- a/tests/python/pants_test/android/test_android_base.py
+++ b/tests/python/pants_test/android/test_android_base.py
@@ -21,10 +21,6 @@ from pants_test.tasks.test_base import TaskTest
 class TestAndroidBase(TaskTest):
   """Base class for Android tests that provides some mock structures useful for testing."""
 
-  def task_type(cls):
-    """Subclasses must return the type of the Task subclass under test."""
-    return AndroidTask
-
   @contextmanager
   def android_binary(self):
     """Represent an android_binary target, providing a mock version of the required manifest."""

--- a/tests/python/pants_test/android/test_android_base.py
+++ b/tests/python/pants_test/android/test_android_base.py
@@ -12,9 +12,8 @@ from contextlib import contextmanager
 from twitter.common.collections import maybe_list
 
 from pants.backend.android.targets.android_binary import AndroidBinary
-from pants.backend.android.tasks.android_task import AndroidTask
 from pants.util.contextutil import temporary_dir, temporary_file
-from pants.util.dirutil import chmod_plus_x, safe_open, touch
+from pants.util.dirutil import chmod_plus_x, touch
 from pants_test.tasks.test_base import TaskTest
 
 


### PR DESCRIPTION
The override attempt was against a classmethod but itself was an
instancemethod.  This was harmless, but also un-needed.  The base class
raises and this is a better default, forcing leaves to implement.

https://rbcommons.com/s/twitter/r/1751/