### PR TITLE
Fixup `Task.invalidated` UI.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -320,6 +320,7 @@ python_library(
     'src/python/pants/base:cache_manager',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:hash_utils',
+    'src/python/pants/base:payload_field',
     'src/python/pants/base:worker_pool',
     'src/python/pants/base:workunit',
     'src/python/pants/cache',


### PR DESCRIPTION
This has been broken since the introduction of `Payload`.  Restore
The "Invalidated 2 targets containing 2 payload files." UI to actually
present the count of source files and to list those files when the files
link is clicked.