### PR TITLE
Fixup `Task.invalidated` UI.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -320,6 +320,7 @@ python_library(
     'src/python/pants/base:cache_manager',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:hash_utils',
+    'src/python/pants/base:payload_field',
     'src/python/pants/base:worker_pool',
     'src/python/pants/base:workunit',
     'src/python/pants/cache',

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -320,7 +320,6 @@ python_library(
     'src/python/pants/base:cache_manager',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:hash_utils',
-    'src/python/pants/base:payload_field',
     'src/python/pants/base:worker_pool',
     'src/python/pants/base:workunit',
     'src/python/pants/cache',

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -18,7 +18,6 @@ from twitter.common.lang import AbstractClass
 from pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
 from pants.base.cache_manager import InvalidationCacheManager, InvalidationCheck
 from pants.base.exceptions import TaskError
-from pants.base.payload_field import SourcesField
 from pants.base.worker_pool import Work
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
 from pants.cache.cache_setup import create_artifact_cache
@@ -335,18 +334,9 @@ class TaskBase(AbstractClass):
       for vt in invalidation_check.invalid_vts_partitioned:
         targets.extend(vt.targets)
 
-      payload_files = OrderedSet()
-      for target in targets:
-        for _, field in target.payload.fields:
-          if isinstance(field, SourcesField):
-            payload_files.update(field.relative_to_buildroot())
-
       if len(targets):
         msg_elements = ['Invalidated ',
                         items_to_report_element([t.address.reference() for t in targets], 'target')]
-        if len(payload_files) > 0:
-          msg_elements.append(' containing ')
-          msg_elements.append(items_to_report_element(payload_files, 'payload file'))
         if num_invalid_partitions > 1:
           msg_elements.append(' in %d target partitions' % num_invalid_partitions)
         msg_elements.append('.')


### PR DESCRIPTION
This has been broken since the introduction of `Payload`.  Restore
The "Invalidated 2 targets containing 2 payload files." UI to actually
present the count of source files and to list those files when the files
link is clicked.