### PR TITLE
Add --show-invalid-targets option

### DIFF
--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -340,6 +340,12 @@ class TaskBase(AbstractClass):
         if num_invalid_partitions > 1:
           msg_elements.append(' in %d target partitions' % num_invalid_partitions)
         msg_elements.append('.')
+        global_options = self.context.options.for_global_scope()
+        if 'show_invalid_targets' in global_options:  # not True when running tests
+          if global_options.show_invalid_targets:
+            msg_elements.append('\n')
+            for t in targets:
+              msg_elements.append("  {0}\n".format(t.address.spec))
         self.context.log.info(*msg_elements)
 
     # Yield the result, and then mark the targets as up to date.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -65,3 +65,5 @@ def register_global_options(register):
            default=10 * 365 * 86400,  # 10 years.
            help='the time in seconds before we consider re-resolving an open-ended '
                 'requirement, e.g. "flask>=0.2" if a matching distribution is available on disk.')
+  register('--show-invalid-targets', action='store_true',
+           help='When targets are invalidated by the cache manager, print them to the console.')

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -107,3 +107,8 @@ class OptionValueContainer(object):
       return val.value
     else:
       return val
+
+  def __contains__(self, key):
+    if key == '_forwardings':
+      return False
+    return key in self._forwardings

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -36,6 +36,8 @@ def create_options(options):
           self.__dict__ = options[scope]
         def __getitem__(self, key):
           return getattr(self, key)
+        def __contains__(self, key):
+          return key in options[scope]
       return TestOptionValues()
 
     def for_global_scope(self):
@@ -43,6 +45,7 @@ def create_options(options):
 
     def __getitem__(self, key):
       return self.for_scope(key)
+
   return TestOptions()
 
 

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -83,3 +83,12 @@ class OptionValueContainerTest(unittest.TestCase):
     o.baz['b'] = 222  # Add to original dict.
     self.assertEqual(1, p.foo)
     self.assertEqual({'a': 111}, p.baz)  # Ensure dict was copied.
+
+  def test_contains(self):
+    o = OptionValueContainer()
+    self.assertNotIn('foo', o)
+    self.assertNotIn('_forwardings', o)
+
+    o.add_forwardings({'foo': 'bar'})
+    self.assertIn('foo', o)
+    self.assertNotIn('_forwardings', o)


### PR DESCRIPTION
This adds a global option to show the targets that are being invalidated in
the build cache.
Also reformats the help in InvalidationCheck so that it will display properly
in IntelliJ