### PR TITLE
adding xml output for python coverage

### DIFF
--- a/src/python/pants/backend/python/test_builder.py
+++ b/src/python/pants/backend/python/test_builder.py
@@ -290,6 +290,9 @@ class PythonTestBuilder(object):
           safe_mkdir(target_dir)
           pex.run(args=['html', '-i', '--rcfile', coverage_rc, '-d', target_dir],
                   stdout=stdout, stderr=stderr)
+          coverage_xml = os.path.join(target_dir, 'coverage.xml')
+          pex.run(args=['xml', '-i', '--rcfile', coverage_rc, '-o', coverage_xml],
+                  stdout=stdout, stderr=stderr)
 
   @contextmanager
   def _test_runner(self, targets, stdout, stderr):


### PR DESCRIPTION
No reason to not also provide xml output!

It would be trivial to add --coverage-xml and --coverage-html options, as well as --coverage to turn on coverage instead of relying on PANTS_PY_COVERAGE carrying the instructions of how stuff should be covered. Should I?