### PR TITLE
Introduce a PythonEval task.

### DIFF
--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -1,20 +1,29 @@
 python_library(
   name = 'python',
   sources = globs('*.py'),
+  resources = globs('templates/python_eval/*.mustache'),
   dependencies = [
     '3rdparty/python:pex',
+    '3rdparty/python:setuptools',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/backend/python:antlr_builder',
     'src/python/pants/backend/python:interpreter_cache',
+    'src/python/pants/backend/python:python_chroot',
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python:test_builder',
     'src/python/pants/backend/python:thrift_builder',
     'src/python/pants/backend/python/targets:python',
-    'src/python/pants/backend/codegen/targets:python',
-    'src/python/pants/backend/core/tasks:common',
+    'src/python/pants/backend/codegen/targets:python',#
+    'src/python/pants/backend/core/tasks:task',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/base:config',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:generator',
     'src/python/pants/base:target',
     'src/python/pants/base:workunit',
+    'src/python/pants/console:stty_utils',
     'src/python/pants/util:contextutil',
-    'src/python/pants/util:strutil',
+    'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -14,7 +14,7 @@ python_library(
     'src/python/pants/backend/python:test_builder',
     'src/python/pants/backend/python:thrift_builder',
     'src/python/pants/backend/python/targets:python',
-    'src/python/pants/backend/codegen/targets:python',#
+    'src/python/pants/backend/codegen/targets:python',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:config',

--- a/src/python/pants/backend/python/tasks/python_eval.py
+++ b/src/python/pants/backend/python/tasks/python_eval.py
@@ -1,0 +1,149 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import pkgutil
+
+from pex.pex import PEX
+
+from pants.backend.python.python_chroot import PythonChroot
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.tasks.python_task import PythonTask
+from pants.base.exceptions import TaskError
+from pants.base.generator import Generator, TemplateData
+from pants.base.workunit import WorkUnit
+from pants.util.contextutil import temporary_file
+
+
+class PythonEval(PythonTask):
+  class Error(TaskError):
+    """A richer failure exception type useful for tests."""
+
+    def __init__(self, *args, **kwargs):
+      compiled = kwargs.pop('compiled')
+      failed = kwargs.pop('failed')
+      super(PythonEval.Error, self).__init__(*args, **kwargs)
+      self.compiled = compiled
+      self.failed = failed
+
+  _EVAL_TEMPLATE_PATH = os.path.join('templates', 'python_eval', 'eval.py.mustache')
+
+  @staticmethod
+  def _is_evalable(target):
+    return isinstance(target, (PythonLibrary, PythonBinary))
+
+  @classmethod
+  def register_options(cls, register):
+    super(PythonEval, cls).register_options(register)
+    register('--fail-slow', action='store_true', default=False,
+             help='Compile all targets and present the full list of errors.')
+    register('--closure', action='store_true', default=False,
+             help='Eval all targets in the closure individually instead of just the targets '
+                  'specified on the command line.')
+
+  def execute(self):
+    targets = self.context.targets() if self.get_options().closure else self.context.target_roots
+    with self.invalidated(filter(self._is_evalable, targets),
+                          topological_order=True) as invalidation_check:
+      compiled = self._compile_targets(invalidation_check.invalid_vts)
+      return compiled  # Collected and returned for tests
+
+  def _compile_targets(self, invalid_vts):
+    with self.context.new_workunit(name='eval-targets', labels=[WorkUnit.MULTITOOL]):
+      compiled = []
+      failed = []
+      for vt in invalid_vts:
+        target = vt.target
+        return_code = self._compile_target(target)
+        if return_code == 0:
+          vt.update()  # Ensure partial progress is marked valid
+          compiled.append(target)
+        else:
+          if self.get_options().fail_slow:
+            failed.append(target)
+          else:
+            raise self.Error('Failed to eval {}'.format(target.address.spec),
+                             compiled=compiled,
+                             failed=[target])
+
+      if failed:
+        msg = 'Failed to evaluate {} targets:\n  {}'.format(
+            len(failed),
+            '\n  '.join(t.address.spec for t in failed))
+        raise self.Error(msg, compiled=compiled, failed=failed)
+
+      return compiled
+
+  def _compile_target(self, target):
+    with self.context.new_workunit(name=target.address.spec):
+      modules = []
+      if isinstance(target, PythonBinary):
+        source = 'entry_point {}'.format(target.entry_point)
+        components = target.entry_point.rsplit(':', 1)
+        module = components[0]
+        if len(components) == 2:
+          function = components[1]
+          data = TemplateData(source=source,
+                              import_statement='from {} import {}'.format(module, function))
+        else:
+          data = TemplateData(source=source, import_statement='import {}'.format(module))
+        modules.append(data)
+      else:
+        for path in target.sources_relative_to_source_root():
+          if path.endswith('.py'):
+            if os.path.basename(path) == '__init__.py':
+              module_path = os.path.dirname(path)
+            else:
+              module_path, _ = os.path.splitext(path)
+            source = 'file {}'.format(os.path.join(target.target_base, path))
+            module = module_path.replace(os.path.sep, '.')
+            data = TemplateData(source=source, import_statement='import {}'.format(module))
+            modules.append(data)
+
+      if not modules:
+        # Nothing to eval, so a trivial compile success.
+        return 0
+
+      interpreter = self.select_interpreter_for_targets([target])
+
+      if isinstance(target, PythonBinary):
+        pexinfo, platforms = target.pexinfo, target.platforms
+      else:
+        pexinfo, platforms = None, None
+
+      with self.temporary_pex_builder(interpreter=interpreter, pex_info=pexinfo) as builder:
+        with self.context.new_workunit(name='resolve'):
+          chroot = PythonChroot(
+              context=self.context,
+              targets=[target],
+              builder=builder,
+              platforms=platforms,
+              interpreter=interpreter)
+
+          chroot.dump()
+
+        with temporary_file() as imports_file:
+          generator = Generator(pkgutil.get_data(__name__, self._EVAL_TEMPLATE_PATH),
+                                chroot=chroot.path(),
+                                modules=modules)
+          generator.write(imports_file)
+          imports_file.close()
+
+          builder.set_executable(imports_file.name, '__pants_python_eval__.py')
+
+          builder.freeze()
+          pex = PEX(builder.path(), interpreter=interpreter)
+
+          with self.context.new_workunit(name='eval',
+                                         labels=[WorkUnit.COMPILER, WorkUnit.RUN, WorkUnit.TOOL],
+                                         cmd=' '.join(pex.cmdline())) as workunit:
+            returncode = pex.run(stdout=workunit.output('stdout'), stderr=workunit.output('stderr'))
+            workunit.set_outcome(WorkUnit.SUCCESS if returncode == 0 else WorkUnit.FAILURE)
+            if returncode != 0:
+              self.context.log.error('Failed to eval {}'.format(target.address.spec))
+            return returncode

--- a/src/python/pants/backend/python/tasks/templates/python_eval/eval.py.mustache
+++ b/src/python/pants/backend/python/tasks/templates/python_eval/eval.py.mustache
@@ -1,0 +1,44 @@
+from __future__ import print_function
+
+import inspect
+import os
+import sys
+import traceback
+
+
+def backtrace_to_here():
+  trace = inspect.trace(context=1)
+  trace.pop(0)  # discard this helper function frame
+
+  pre_processed = []
+  for info in trace:
+    frame = info[0]
+    tb = inspect.getframeinfo(frame)
+    filename = tb.filename
+    if filename.startswith('{{chroot}}'):
+      relpath = os.path.relpath(filename, '{{chroot}}')
+      filename = os.path.join('[srcroot]', relpath)
+    line_text = tb.code_context[tb.index]
+    pre_processed.append((filename, tb.lineno, tb.function, line_text))
+
+  return ''.join(traceback.format_list(pre_processed)).rstrip()
+
+
+def log(message=''):
+  print(message, file=sys.stderr)
+
+
+if __name__ == '__main__':
+  # TODO(John Sirois): Consider collecting all import errors before exiting non-zero.
+  {{#modules}}
+  try:
+    {{import_statement}}
+  except ImportError as e:
+    log()
+    log("Failed to eval '{{source}}':")
+    log(backtrace_to_here())
+    log(str(e))
+    sys.exit(1)
+
+  {{/modules}}
+  sys.exit(0)

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -6,6 +6,7 @@ target(
   dependencies=[
     ':test_builder',
     ':test_python_requirement_list',
+    'tests/python/pants_test/backend/python/tasks'
   ]
 )
 

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -1,0 +1,21 @@
+target(
+  name='tasks',
+  dependencies=[
+    ':python_eval'
+  ]
+)
+
+python_tests(
+  name='python_eval',
+  sources=['test_python_eval.py'],
+  dependencies=[
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/base:address',
+    'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:source_root',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/tasks:base'
+  ]
+)

--- a/tests/python/pants_test/backend/python/tasks/test_python_eval.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_eval.py
@@ -1,0 +1,234 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import shutil
+from textwrap import dedent
+
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.tasks.python_eval import PythonEval
+from pants.base.address import SyntheticAddress
+from pants.base.build_file_aliases import BuildFileAliases
+from pants.base.exceptions import TaskError
+from pants.base.source_root import SourceRoot
+from pants.util.dirutil import safe_mkdir
+from pants_test.tasks.test_base import TaskTest
+
+
+class PythonEvalTest(TaskTest):
+  @classmethod
+  def task_type(cls):
+    return PythonEval
+
+  @property
+  def alias_groups(self):
+    return BuildFileAliases.create(targets={'python_library': PythonLibrary,
+                                            'python_binary': PythonBinary})
+
+  def create_python_library(self, relpath, name, source, contents, dependencies=()):
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    python_library(
+      name='{name}',
+      sources=['__init__.py', '{source}'],
+      dependencies=[
+        {dependencies}
+      ]
+    )
+    """).format(name=name, source=source, dependencies=','.join(map(repr, dependencies))))
+
+    self.create_file(relpath=os.path.join(relpath, '__init__.py'))
+    self.create_file(relpath=os.path.join(relpath, source), contents=contents)
+    return self.target(SyntheticAddress(relpath, name).spec)
+
+  def create_python_binary(self, relpath, name, entry_point, dependencies=()):
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    python_binary(
+      name='{name}',
+      entry_point='{entry_point}',
+      dependencies=[
+        {dependencies}
+      ]
+    )
+    """).format(name=name, entry_point=entry_point, dependencies=','.join(map(repr, dependencies))))
+
+    return self.target(SyntheticAddress(relpath, name).spec)
+
+  def setUp(self):
+    super(PythonEvalTest, self).setUp()
+
+    # Re-use the main pants python cache to speed up interpreter selection and artifact resolution.
+    # TODO(John Sirois): Lift this up to TaskTest or else to a PythonTaskTest base class so more
+    # tests can pickup the speed improvement.
+    safe_mkdir(os.path.join(self.build_root, '.pants.d'))
+    shutil.copytree(os.path.join(self.real_build_root, '.pants.d', 'python'),
+                    os.path.join(self.build_root, '.pants.d', 'python'),
+                    symlinks=True)
+
+    SourceRoot.register('src', PythonBinary, PythonLibrary)
+
+    self.a_library = self.create_python_library('src/a', 'a', 'a.py', dedent("""
+    import inspect
+
+
+    def compile_time_check_decorator(cls):
+      if not inspect.isclass(cls):
+        raise TypeError('This decorator can only be applied to classes, given {}'.format(cls))
+      return cls
+    """))
+
+    self.b_library = self.create_python_library('src/b', 'b', 'b.py', dedent("""
+    from a.a import compile_time_check_decorator
+
+
+    @compile_time_check_decorator
+    class BarB(object):
+      pass
+    """))
+
+    self.b_library = self.create_python_library('src/c', 'c', 'c.py', dedent("""
+    from a.a import compile_time_check_decorator
+
+
+    @compile_time_check_decorator
+    def baz_c():
+      pass
+    """), dependencies=['//src/a'])
+
+    def fix_c_source():
+      self.create_file('src/c/c.py', contents=dedent("""
+      from a.a import compile_time_check_decorator
+
+      # Change from decorated function baz_c to decorated class BazC.
+      @compile_time_check_decorator
+      class BazC(object):
+        pass
+      """))
+    self.fix_c_source = fix_c_source
+
+    self.d_library = self.create_python_library('src/d', 'd', 'd.py', dedent("""
+    from a.a import compile_time_check_decorator
+
+
+    @compile_time_check_decorator
+    class BazD(object):
+      pass
+    """), dependencies=['//src/a'])
+
+    self.e_binary = self.create_python_binary('src/e', 'e', 'a.a', dependencies=['//src/a'])
+    self.f_binary = self.create_python_binary('src/f', 'f', 'a.a:compile_time_check_decorator',
+                                              dependencies=['//src/a'])
+    self.g_binary = self.create_python_binary('src/g', 'g', 'a.a:does_not_exist',
+                                              dependencies=['//src/a'])
+    self.h_binary = self.create_python_binary('src/h', 'h', 'a.a')
+
+  def tearDown(self):
+    super(PythonEvalTest, self).tearDown()
+    SourceRoot.reset()
+
+  def prepare_task(self, *args, **kwargs):
+    kwargs.update(build_graph=self.build_graph, build_file_parser=self.build_file_parser)
+    return super(PythonEvalTest, self).prepare_task(*args, **kwargs)
+
+  def test_noop(self):
+    python_eval = self.prepare_task(targets=[])
+    compiled = python_eval.execute()
+    self.assertEqual([], compiled)
+
+  def test_compile(self):
+    python_eval = self.prepare_task(targets=[self.a_library])
+    compiled = python_eval.execute()
+    self.assertEqual([self.a_library], compiled)
+
+  def test_compile_incremental(self):
+    python_eval = self.prepare_task(targets=[self.a_library])
+    compiled = python_eval.execute()
+    self.assertEqual([self.a_library], compiled)
+
+    python_eval = self.prepare_task(targets=[self.a_library])
+    compiled = python_eval.execute()
+    self.assertEqual([], compiled)
+
+  def test_compile_closure(self):
+    python_eval = self.prepare_task(args=['--test-closure'], targets=[self.d_library])
+    compiled = python_eval.execute()
+    self.assertEqual({self.d_library, self.a_library}, set(compiled))
+
+  def test_compile_fail_closure(self):
+    python_eval = self.prepare_task(args=['--test-closure'], targets=[self.b_library])
+
+    with self.assertRaises(TaskError) as e:
+      python_eval.execute()
+    self.assertEqual([self.a_library], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_compile_incremental_progress(self):
+    python_eval = self.prepare_task(args=['--test-closure'], targets=[self.b_library])
+
+    with self.assertRaises(TaskError) as e:
+      python_eval.execute()
+    self.assertEqual([self.a_library], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+    self.fix_c_source()
+    python_eval = self.prepare_task(args=['--test-closure'], targets=[self.b_library])
+
+    compiled = python_eval.execute()
+    self.assertEqual([self.b_library], compiled)
+
+  def test_compile_fail_missing_build_dep(self):
+    python_eval = self.prepare_task(targets=[self.b_library])
+
+    with self.assertRaises(python_eval.Error) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_compile_fail_compile_time_check_decorator(self):
+    python_eval = self.prepare_task(targets=[self.b_library])
+
+    with self.assertRaises(TaskError) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_compile_failslow(self):
+    python_eval = self.prepare_task(args=['--test-fail-slow'],
+                                    targets=[self.a_library, self.b_library, self.d_library])
+
+    with self.assertRaises(TaskError) as e:
+      python_eval.execute()
+    self.assertEqual({self.a_library, self.d_library}, set(e.exception.compiled))
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_entry_point_module(self):
+    python_eval = self.prepare_task(targets=[self.e_binary])
+
+    compiled = python_eval.execute()
+    self.assertEqual([self.e_binary], compiled)
+
+  def test_entry_point_function(self):
+    python_eval = self.prepare_task(targets=[self.f_binary])
+
+    compiled = python_eval.execute()
+    self.assertEqual([self.f_binary], compiled)
+
+  def test_entry_point_does_not_exist(self):
+    python_eval = self.prepare_task(targets=[self.g_binary])
+
+    with self.assertRaises(TaskError) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.g_binary], e.exception.failed)
+
+  def test_entry_point_missing_build_dep(self):
+    python_eval = self.prepare_task(targets=[self.h_binary])
+
+    with self.assertRaises(TaskError) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.h_binary], e.exception.failed)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -9,6 +9,7 @@ python_library(
     'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/base:cmd_line_spec_parser',
+    'src/python/pants/base:config',
     'src/python/pants/base:target',
     'src/python/pants/goal:context',
     'src/python/pants/goal',

--- a/tests/python/pants_test/tasks/test_base.py
+++ b/tests/python/pants_test/tasks/test_base.py
@@ -15,6 +15,7 @@ from twitter.common.collections import maybe_list
 from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.core.tasks.task import Task
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
+from pants.base.config import Config
 from pants.base.target import Target
 from pants.goal.context import Context
 from pants.goal.goal import Goal
@@ -37,6 +38,13 @@ class TaskTest(BaseTest):
   def task_type(cls):
     """Subclasses must return the type of the ConsoleTask subclass under test."""
     raise NotImplementedError()
+
+  def setUp(self):
+    super(TaskTest, self).setUp()
+
+    # The prepare_task method engages a series of objects that use option values so we ensure they
+    # are uniformly set here before calls to prepare_task occur in test methods.
+    Config.reset_default_bootstrap_option_values()
 
   def prepare_task(self,
                    config=None,


### PR DESCRIPTION
This task can be used to smoke out broken python code at "compile" time.
In particular, invalid imports (missing BUILD deps), top-level syntax
errors and top-level checks can be detected.