### PR TITLE
Improve the python run error message.

### DIFF
--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -54,9 +54,12 @@ class PythonRun(PythonTask):
           try:
             result = po.wait()
             if result != 0:
-              raise TaskError('python {args} ... exited non-zero ({code})' %
-                              dict(args=args, code=result),
-                              exit_code=result)
+              msg = '{interpreter} {entry_point} {args} ... exited non-zero ({code})'.format(
+                        interpreter=interpreter.binary,
+                        entry_point=binary.entry_point,
+                        args=' '.join(args),
+                        code=result)
+              raise TaskError(msg, exit_code=result)
           except KeyboardInterrupt:
             po.send_signal(signal.SIGINT)
             raise


### PR DESCRIPTION
Previously `%` and `.format` syntaxes were mixed, this is now corrected.
Additionally the error message is improved to include the actual python
binary used to perform the run, the entry point that was run and a more
friendly list of arguments to the entry point.

https://rbcommons.com/s/twitter/r/1777/