### PR TITLE
Upgrade pex to 0.8.6.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ mock==1.0.1
 mox==0.5.3
 # Until https://github.com/pantsbuild/pex/issues/28 is addressed, we cannot
 # do pex<0.9.0.
-pex>=0.8.5,<0.8.999999
+pex>=0.8.6,<0.8.999999
 psutil==1.1.3
 lockfile==0.10.2
 Pygments==1.4

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -71,6 +71,7 @@ def _run(exiter):
   result = goal_runner.run()
   exiter.do_exit(result)
 
+
 def main():
   exiter = _Exiter()
   try:

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -78,7 +78,8 @@ class PantsRunIntegrationTest(unittest.TestCase):
     proc = subprocess.Popen(pants_command, env=env, stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
     (stdout_data, stderr_data) = proc.communicate(stdin_data)
-    return PantsResult(pants_command, proc.returncode, stdout_data.decode("utf-8"), stderr_data.decode("utf-8"))
+    return PantsResult(pants_command, proc.returncode, stdout_data.decode("utf-8"),
+                       stderr_data.decode("utf-8"))
 
   def run_pants(self, command, config=None, stdin_data=None, extra_env=None, **kwargs):
     """Runs pants in a subprocess.

--- a/tests/python/pants_test/tasks/test_ivy_resolve_integration.py
+++ b/tests/python/pants_test/tasks/test_ivy_resolve_integration.py
@@ -19,7 +19,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.run_pants_with_workdir([
           'compile', 'testprojects/src/java/com/pants/testproject/cycle1'], workdir)
       self.assert_failure(pants_run)
-      self.assertTrue('CycleException' in pants_run.stderr_data)
+      self.assertIn('Cycle detected', pants_run.stderr_data)
 
   def test_java_compile_with_ivy_report(self):
     # Ensure the ivy report file gets generated
@@ -52,7 +52,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
         'examples/src/scala::'
     ])
     self.assert_failure(pants_run)
-    self.assertTrue('Unrecognized option: -blablabla' in pants_run.stdout_data)
+    self.assertIn('Unrecognized option: -blablabla', pants_run.stdout_data)
 
   def test_ivy_confs_success(self):
     pants_run = self.run_pants([


### PR DESCRIPTION
This picks up a fix to honor custom sys.excepthooks - which pants
supplies to handle untrapped errors with more user-friendly display.

https://rbcommons.com/s/twitter/r/1778/