### PR TITLE
Fixup JarPublish changelog rendering.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -780,9 +780,17 @@ class JarPublish(JarTask, ScmPublish):
           if no_changes:
             print(changelog)
           else:
-            print('\nChanges for %s since %s @ %s:\n\n%s' % (
-              coordinate(jar.org, jar.name), oldentry.version(), oldentry.sha, changelog
-            ))
+            # The changelog may contain non-ascii text, but the print function can, under certain
+            # circumstances, detect the correct output encoding to be ascii and thus blow up on
+            # non-ascii changelog characters.  Here we explicitly control the encoding to avoid
+            # print mis-interpretation.
+            # TODO(John Sirois): Consider introducing a pants/util `print_safe` helper for this.
+            message = '\nChanges for {} since {} @ {}:\n\n{}\n'.format(
+                coordinate(jar.org, jar.name), oldentry.version(), oldentry.sha, changelog)
+            # The stdout encoding can be detected as None when running without a tty (common in
+            # tests), in which case we want to force encoding with a unicode-supporting chodec.
+            encoding = sys.stdout.encoding or 'utf-8'
+            sys.stdout.write(message.encode(encoding))
           if not self.confirm_push(coordinate(jar.org, jar.name), newentry.version()):
             raise TaskError('User aborted push')
 

--- a/tests/python/pants_test/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/tasks/test_jar_publish_integration.py
@@ -153,7 +153,6 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
                                artifact_name='hello-greet-0.0.1-SNAPSHOT.jar',
                                success_expected=False)
 
-
   def publish_test(self, target, artifacts, pushdb_files, extra_options=None, extra_config=None,
                    extra_env=None, expected_primary_artifact_count=1, success_expected=True):
     """Tests that publishing the given target results in the expected output.
@@ -179,12 +178,14 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
       if success_expected:
         self.assert_success(pants_run, "'pants goal publish' expected success, but failed instead.")
       else:
-        self.assert_failure(pants_run, "'pants goal publish' expected failure, but succeeded instead.")
+        self.assert_failure(pants_run,
+                            "'pants goal publish' expected failure, but succeeded instead.")
         return
 
       # New pushdb directory should be created for all artifacts.
       for pushdb_file in pushdb_files:
-        self.assertTrue(os.path.exists(os.path.dirname(os.path.join(self.pushdb_root, pushdb_file))))
+        pushdb_dir = os.path.dirname(os.path.join(self.pushdb_root, pushdb_file))
+        self.assertTrue(os.path.exists(pushdb_dir))
 
       # But because we are doing local publishes, no pushdb files are created
       for pushdb_file in pushdb_files:


### PR DESCRIPTION
Previously, without a TTY, JarPublish would fail to render changelogs
with non-ascii characters.  Explicitly handle this case.