### PR TITLE
Fixup JarPublish changelog rendering.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -781,9 +781,9 @@ class JarPublish(JarTask, ScmPublish):
             print(changelog)
           else:
             # The changelog may contain non-ascii text, but the print function can, under certain
-            # circumstances, detect the correct output encoding to be ascii and thus blow up on
+            # circumstances, incorrectly detect the output encoding to be ascii and thus blow up on
             # non-ascii changelog characters.  Here we explicitly control the encoding to avoid
-            # print mis-interpretation.
+            # the print function's mis-interpretation.
             # TODO(John Sirois): Consider introducing a pants/util `print_safe` helper for this.
             message = '\nChanges for {} since {} @ {}:\n\n{}\n'.format(
                 coordinate(jar.org, jar.name), oldentry.version(), oldentry.sha, changelog)

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -788,7 +788,7 @@ class JarPublish(JarTask, ScmPublish):
             message = '\nChanges for {} since {} @ {}:\n\n{}\n'.format(
                 coordinate(jar.org, jar.name), oldentry.version(), oldentry.sha, changelog)
             # The stdout encoding can be detected as None when running without a tty (common in
-            # tests), in which case we want to force encoding with a unicode-supporting chodec.
+            # tests), in which case we want to force encoding with a unicode-supporting codec.
             encoding = sys.stdout.encoding or 'utf-8'
             sys.stdout.write(message.encode(encoding))
           if not self.confirm_push(coordinate(jar.org, jar.name), newentry.version()):

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -780,9 +780,17 @@ class JarPublish(JarTask, ScmPublish):
           if no_changes:
             print(changelog)
           else:
-            print('\nChanges for %s since %s @ %s:\n\n%s' % (
-              coordinate(jar.org, jar.name), oldentry.version(), oldentry.sha, changelog
-            ))
+            # The changelog may contain non-ascii text, but the print function can, under certain
+            # circumstances, detect the correct output encoding to be ascii and thus blow up on
+            # non-ascii changelog characters.  Here we explicitly control the encoding to avoid
+            # print mis-interpretation.
+            # TODO(John Sirois): Consider introducing a pants/util `print_safe` helper for this.
+            message = '\nChanges for {} since {} @ {}:\n\n{}\n'.format(
+                coordinate(jar.org, jar.name), oldentry.version(), oldentry.sha, changelog)
+            # The stdout encoding can be detected as None when running without a tty (common in
+            # tests), in which case we want to force encoding with a unicode-supporting chodec.
+            encoding = sys.stdout.encoding or 'utf-8'
+            sys.stdout.write(message.encode(encoding))
           if not self.confirm_push(coordinate(jar.org, jar.name), newentry.version()):
             raise TaskError('User aborted push')
 

--- a/testprojects/src/java/com/pants/testproject/publish/hello/greet/Greeting.java
+++ b/testprojects/src/java/com/pants/testproject/publish/hello/greet/Greeting.java
@@ -32,10 +32,10 @@ public final class Greeting {
   }
 
   public static String greet(String greetee) {
-    return "Hello, " + greetee + "!";
+    return String.format("Hello, %s!", greetee);
   }
 
   private Greeting() {
-      // not called. placates checkstyle
+    // not called. placates checkstyle
   }
 }

--- a/testprojects/src/java/com/pants/testproject/publish/hello/greet/README.txt
+++ b/testprojects/src/java/com/pants/testproject/publish/hello/greet/README.txt
@@ -1,0 +1,3 @@
+Part of publishing is displaying a changelog to the user to confirm that the new version number
+makes sense according to semver.  This README is being comitted with a commit message that
+contains unicode to ensure changelogs with unicode characters can be displayed without error.

--- a/tests/python/pants_test/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/tasks/test_jar_publish_integration.py
@@ -153,7 +153,6 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
                                artifact_name='hello-greet-0.0.1-SNAPSHOT.jar',
                                success_expected=False)
 
-
   def publish_test(self, target, artifacts, pushdb_files, extra_options=None, extra_config=None,
                    extra_env=None, expected_primary_artifact_count=1, success_expected=True):
     """Tests that publishing the given target results in the expected output.
@@ -179,12 +178,14 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
       if success_expected:
         self.assert_success(pants_run, "'pants goal publish' expected success, but failed instead.")
       else:
-        self.assert_failure(pants_run, "'pants goal publish' expected failure, but succeeded instead.")
+        self.assert_failure(pants_run,
+                            "'pants goal publish' expected failure, but succeeded instead.")
         return
 
       # New pushdb directory should be created for all artifacts.
       for pushdb_file in pushdb_files:
-        self.assertTrue(os.path.exists(os.path.dirname(os.path.join(self.pushdb_root, pushdb_file))))
+        pushdb_dir = os.path.dirname(os.path.join(self.pushdb_root, pushdb_file))
+        self.assertTrue(os.path.exists(pushdb_dir))
 
       # But because we are doing local publishes, no pushdb files are created
       for pushdb_file in pushdb_files:


### PR DESCRIPTION
Previously, without a TTY, JarPublish would fail to render changelogs
with non-ascii characters.  Explicitly handle this case.

https://rbcommons.com/s/twitter/r/1787/