### PR TITLE
Add a test for the Git changelog.

### DIFF
--- a/src/python/pants/scm/BUILD
+++ b/src/python/pants/scm/BUILD
@@ -22,6 +22,5 @@ python_library(
   sources = ['git.py'],
   dependencies = [
     ':scm',
-    '3rdparty/python/twitter/commons:twitter.common.log',
   ],
 )

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -35,7 +35,7 @@ class Git(Scm):
     """
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     out, _ = process.communicate()
-    return (process, out)
+    return process, out
 
   @classmethod
   def _cleanse(cls, output):
@@ -44,7 +44,7 @@ class Git(Scm):
   @classmethod
   def _check_result(cls, cmd, result, failure_msg=None, raise_type=Scm.ScmException):
     if result != 0:
-      raise raise_type(failure_msg or '%s failed with exit code %d' % (' '.join(cmd), result))
+      raise raise_type(failure_msg or '{} failed with exit code {}'.format(' '.join(cmd), result))
 
   def __init__(self, binary='git', gitdir=None, worktree=None, remote=None, branch=None, log=None):
     """Creates a git scm proxy that assumes the git repository is in the cwd by default.
@@ -67,8 +67,8 @@ class Git(Scm):
     if log:
       self._log = log
     else:
-      from twitter.common import log as c_log
-      self._log = c_log
+      import logging
+      self._log = logging.getLogger(__name__)
 
   def current_rev_identifier(self):
     return 'HEAD'
@@ -110,7 +110,7 @@ class Git(Scm):
     if from_commit:
       # Grab the diff from the merge-base to HEAD using ... syntax.  This ensures we have just
       # the changes that have occurred on the current branch.
-      committed_cmd = ['diff', '--name-only', '%s...HEAD' % from_commit] + rel_suffix
+      committed_cmd = ['diff', '--name-only', from_commit + '...HEAD'] + rel_suffix
       committed_changes = self._check_output(committed_cmd,
                                              raise_type=Scm.LocalException)
       files.update(committed_changes.split())
@@ -129,9 +129,9 @@ class Git(Scm):
     return set(self.fix_git_relative_path(f.strip(), relative_to) for f in files)
 
   def changelog(self, from_commit=None, files=None):
-    args = ['whatchanged', '--stat', '--find-renames', '--find-copies']
+    args = ['log', '--no-merges', '--stat', '--find-renames', '--find-copies']
     if from_commit:
-      args.append('%s..HEAD' % from_commit)
+      args.append(from_commit + '..HEAD')
     if files:
       args.append('--')
       args.extend(files)
@@ -167,12 +167,12 @@ class Git(Scm):
     # We use -a here instead of --annotate to maintain maximum git compatibility.
     # --annotate was only introduced in 1.7.8 via:
     #   https://github.com/git/git/commit/c97eff5a95d57a9561b7c7429e7fcc5d0e3a7f5d
-    self._check_call(['tag', '-a', '--message=%s' % (message or ''), name],
+    self._check_call(['tag', '-a', '--message=' + (message or ''), name],
                      raise_type=Scm.LocalException)
-    self.push('refs/tags/%s' % name)
+    self.push('refs/tags/' + name)
 
   def commit(self, message):
-    self._check_call(['commit', '--all', '--message=%s' % message], raise_type=Scm.LocalException)
+    self._check_call(['commit', '--all', '--message=' + message], raise_type=Scm.LocalException)
 
   def commit_date(self, commit_reference):
     return self._check_output(['log', '-1', '--pretty=tformat:%ci', commit_reference],
@@ -194,8 +194,8 @@ class Git(Scm):
                                    raise_type=Scm.LocalException)
         return value.strip()
 
-      self._remote = self._remote or get_local_config('branch.%s.remote' % branch)
-      self._branch = self._branch or get_local_config('branch.%s.merge' % branch)
+      self._remote = self._remote or get_local_config('branch.{}.remote'.format(branch))
+      self._branch = self._branch or get_local_config('branch.{}.merge'.format(branch))
     return self._remote, self._branch
 
   def _check_call(self, args, failure_msg=None, raise_type=None):
@@ -214,7 +214,7 @@ class Git(Scm):
     return self._cleanse(out)
 
   def _create_git_cmdline(self, args):
-    return [self._gitcmd, '--git-dir=%s' % self._gitdir, '--work-tree=%s' % self._worktree] + args
+    return [self._gitcmd, '--git-dir=' + self._gitdir, '--work-tree=' + self._worktree] + args
 
   def _log_call(self, cmd):
-    self._log.debug('Executing: %s' % ' '.join(cmd))
+    self._log.debug('Executing: ' + ' '.join(cmd))

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -53,7 +53,7 @@ class VersionTest(unittest.TestCase):
 
 
 def git_version():
-  '''Get a Version() based on installed command-line git's version'''
+  """Get a Version() based on installed command-line git's version"""
   process = subprocess.Popen(['git', '--version'], stdout=subprocess.PIPE)
   (stdout, stderr) = process.communicate()
   assert process.returncode == 0, "Failed to determine git version."
@@ -71,7 +71,6 @@ class GitTest(unittest.TestCase):
     subprocess.check_call(['git', 'config', 'user.name', 'Your Name'])
     subprocess.check_call(['git', 'remote', 'add', remote_name, remote])
 
-  @classmethod
   def setUp(self):
     self.origin = safe_mkdtemp()
     with pushd(self.origin):
@@ -108,9 +107,8 @@ class GitTest(unittest.TestCase):
 
     self.git = Git(gitdir=self.gitdir, worktree=self.worktree)
 
-  @staticmethod
   @contextmanager
-  def mkremote(remote_name):
+  def mkremote(self, remote_name):
     with temporary_dir() as remote_uri:
       subprocess.check_call(['git', 'remote', 'add', remote_name, remote_uri])
       try:
@@ -118,7 +116,6 @@ class GitTest(unittest.TestCase):
       finally:
         subprocess.check_call(['git', 'remote', 'remove', remote_name])
 
-  @classmethod
   def tearDown(self):
     safe_rmtree(self.origin)
     safe_rmtree(self.gitdir)
@@ -127,7 +124,7 @@ class GitTest(unittest.TestCase):
 
   def test_integration(self):
     self.assertEqual(set(), self.git.changed_files())
-    self.assertEqual(set(['README']), self.git.changed_files(from_commit='HEAD^'))
+    self.assertEqual({'README'}, self.git.changed_files(from_commit='HEAD^'))
 
     tip_sha = self.git.commit_id
     self.assertTrue(tip_sha)
@@ -139,7 +136,7 @@ class GitTest(unittest.TestCase):
 
     self.assertTrue(merge_base in self.git.changelog())
 
-    with pytest.raises(Scm.LocalException):
+    with self.assertRaises(Scm.LocalException):
       self.git.server_url
 
     with environment_as(GIT_DIR=self.gitdir, GIT_WORK_TREE=self.worktree):
@@ -151,14 +148,14 @@ class GitTest(unittest.TestCase):
     self.assertEqual('master', self.git.branch_name)
 
     def edit_readme():
-      with open(self.readme_file, 'a') as readme:
-        readme.write('More data.')
+      with open(self.readme_file, 'a') as fp:
+        fp.write('More data.')
 
     edit_readme()
     with open(os.path.join(self.worktree, 'INSTALL'), 'w') as untracked:
       untracked.write('make install')
-    self.assertEqual(set(['README']), self.git.changed_files())
-    self.assertEqual(set(['README', 'INSTALL']), self.git.changed_files(include_untracked=True))
+    self.assertEqual({'README'}, self.git.changed_files())
+    self.assertEqual({'README', 'INSTALL'}, self.git.changed_files(include_untracked=True))
 
     # confirm that files outside of a given relative_to path are ignored
     self.assertEqual(set(), self.git.changed_files(relative_to='non-existent'))
@@ -195,7 +192,7 @@ class GitTest(unittest.TestCase):
         with safe_open(os.path.realpath('CHANGES'), 'w') as changes:
           changes.write('none')
         subprocess.check_call(['git', 'add', 'CHANGES'])
-        self.assertEqual(set(['README', 'CHANGES']), git.changed_files(from_commit='first'))
+        self.assertEqual({'README', 'CHANGES'}, git.changed_files(from_commit='first'))
 
         self.assertEqual('master', git.branch_name)
         self.assertEqual('second', git.tag_name, msg='annotated tags should be found')
@@ -209,7 +206,7 @@ class GitTest(unittest.TestCase):
         subprocess.check_call(['git', 'pull', '--tags', 'origin', 'master:master'])
 
         def worktree_relative_to(cwd, expected):
-          """Given a cwd relative to the worktree, tests that the worktree is detected as 'expected'."""
+          # Given a cwd relative to the worktree, tests that the worktree is detected as 'expected'.
           orig_cwd = os.getcwd()
           try:
             abs_cwd = os.path.join(clone, cwd)
@@ -227,7 +224,8 @@ class GitTest(unittest.TestCase):
         worktree_relative_to('is/a', clone)
         worktree_relative_to('is/a/dir', clone)
 
-  def test_diffspec(self):
+  @property
+  def test_changes_in(self):
     """Test finding changes in a diffspecs
 
     To some extent this is just testing functionality of git not pants, since all pants says
@@ -240,52 +238,85 @@ class GitTest(unittest.TestCase):
           with safe_open(os.path.join(self.worktree, path), 'w') as fp:
             fp.write(content)
         subprocess.check_call(['git', 'add', '.'])
-        subprocess.check_call(['git', 'commit', '-m', 'change '+path])
+        subprocess.check_call(['git', 'commit', '-m', 'change {}'.format(files)])
         return subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip()
 
       # We can get changes in HEAD or by SHA
       c1 = commit_contents_to_files('1', 'foo')
-      self.assertEqual(set(['foo']), self.git.changes_in('HEAD'))
-      self.assertEqual(set(['foo']), self.git.changes_in(c1))
+      self.assertEqual({'foo'}, self.git.changes_in('HEAD'))
+      self.assertEqual({'foo'}, self.git.changes_in(c1))
 
       # Changes in new HEAD, from old-to-new HEAD, in old HEAD, or from old-old-head to new.
-      c2 = commit_contents_to_files('2', 'bar')
-      self.assertEqual(set(['bar']), self.git.changes_in('HEAD'))
-      self.assertEqual(set(['bar']), self.git.changes_in('HEAD^..HEAD'))
-      self.assertEqual(set(['foo']), self.git.changes_in('HEAD^'))
-      self.assertEqual(set(['foo']), self.git.changes_in('HEAD~1'))
-      self.assertEqual(set(['foo', 'bar']), self.git.changes_in('HEAD^^..HEAD'))
+      commit_contents_to_files('2', 'bar')
+      self.assertEqual({'bar'}, self.git.changes_in('HEAD'))
+      self.assertEqual({'bar'}, self.git.changes_in('HEAD^..HEAD'))
+      self.assertEqual({'foo'}, self.git.changes_in('HEAD^'))
+      self.assertEqual({'foo'}, self.git.changes_in('HEAD~1'))
+      self.assertEqual({'foo', 'bar'}, self.git.changes_in('HEAD^^..HEAD'))
 
       # New commit doesn't change results-by-sha
-      self.assertEqual(set(['foo']), self.git.changes_in(c1))
+      self.assertEqual({'foo'}, self.git.changes_in(c1))
 
       # Files changed in multiple diffs within a range
       c3 = commit_contents_to_files('3', 'foo')
-      self.assertEqual(set(['foo', 'bar']), self.git.changes_in('{}..{}'.format(c1, c3)))
+      self.assertEqual({'foo', 'bar'}, self.git.changes_in('{}..{}'.format(c1, c3)))
 
       # Changes in a tag
       subprocess.check_call(['git', 'tag', 'v1'])
-      self.assertEqual(set(['foo']), self.git.changes_in('v1'))
+      self.assertEqual({'foo'}, self.git.changes_in('v1'))
 
       # Introduce a new filename
       c4 = commit_contents_to_files('4', 'baz')
-      self.assertEqual(set(['baz']), self.git.changes_in('HEAD'))
+      self.assertEqual({'baz'}, self.git.changes_in('HEAD'))
 
       # Tag-to-sha
-      self.assertEqual(set(['baz']), self.git.changes_in('{}..{}'.format('v1', c4)))
+      self.assertEqual({'baz'}, self.git.changes_in('{}..{}'.format('v1', c4)))
 
       # We can get multiple changes from one ref
-      c5 = commit_contents_to_files('5', 'foo', 'bar')
-      self.assertEqual(set(['foo', 'bar']), self.git.changes_in('HEAD'))
-      self.assertEqual(set(['foo', 'bar', 'baz']), self.git.changes_in('HEAD~4..HEAD'))
-      self.assertEqual(set(['foo', 'bar', 'baz']), self.git.changes_in('{}..HEAD'.format(c1)))
-      self.assertEqual(set(['foo', 'bar', 'baz']), self.git.changes_in('{}..{}'.format(c1, c4)))
+      commit_contents_to_files('5', 'foo', 'bar')
+      self.assertEqual({'foo', 'bar'}, self.git.changes_in('HEAD'))
+      self.assertEqual({'foo', 'bar', 'baz'}, self.git.changes_in('HEAD~4..HEAD'))
+      self.assertEqual({'foo', 'bar', 'baz'}, self.git.changes_in('{}..HEAD'.format(c1)))
+      self.assertEqual({'foo', 'bar', 'baz'}, self.git.changes_in('{}..{}'.format(c1, c4)))
+
+  def test_changelog_utf8(self):
+    with environment_as(GIT_DIR=self.gitdir, GIT_WORK_TREE=self.worktree):
+      def commit_contents_to_files(message, encoding, content, *files):
+        for path in files:
+          with safe_open(os.path.join(self.worktree, path), 'w') as fp:
+            fp.write(content)
+        subprocess.check_call(['git', 'add', '.'])
+
+        subprocess.check_call(['git', 'config', '--local', '--add', 'i18n.commitencoding',
+                               encoding])
+        try:
+          subprocess.check_call(['git', 'commit', '-m', message.encode(encoding)])
+        finally:
+          subprocess.check_call(['git', 'config', '--local', '--unset-all', 'i18n.commitencoding'])
+
+        return subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip()
+
+      commit_contents_to_files('START1 © END', 'iso-8859-1', '1', 'foo')
+      commit_contents_to_files('START2 © END', 'latin1', '1', 'bar')
+      commit_contents_to_files('START3 © END', 'utf-8', '1', 'baz')
+      commit_contents_to_files('START4 ~ END', 'us-ascii', '1', 'bip')
+
+      # Prove our non-utf-8 encodings were stored in the commit metadata.
+      log = subprocess.check_output(['git', 'log', '--format=%e'])
+      self.assertEqual(['us-ascii', 'latin1', 'iso-8859-1'], filter(None, log.strip().splitlines()))
+
+      # And show that the git log successfully transcodes all the commits none-the-less to utf-8
+      changelog = self.git.changelog()
+      self.assertIn('START1 © END', changelog)
+      self.assertIn('START2 © END', changelog)
+      self.assertIn('START3 © END', changelog)
+      self.assertIn('START4 ~ END', changelog)
 
   def test_refresh_with_conflict(self):
     with environment_as(GIT_DIR=self.gitdir, GIT_WORK_TREE=self.worktree):
       self.assertEqual(set(), self.git.changed_files())
-      self.assertEqual(set(['README']), self.git.changed_files(from_commit='HEAD^'))
-      self.assertEqual(set(['README']), self.git.changes_in('HEAD'))
+      self.assertEqual({'README'}, self.git.changed_files(from_commit='HEAD^'))
+      self.assertEqual({'README'}, self.git.changes_in('HEAD'))
 
       # Create a change on this branch that is incompatible with the change to master
       with open(self.readme_file, 'w') as readme:
@@ -297,7 +328,8 @@ class GitTest(unittest.TestCase):
       with self.assertRaises(Scm.LocalException):
         self.git.refresh(leave_clean=False)
       # The repo is dirty
-      self.assertEquals(set(['README']), self.git.changed_files(include_untracked=True, from_commit='HEAD'))
+      self.assertEquals({'README'},
+                        self.git.changed_files(include_untracked=True, from_commit='HEAD'))
 
       with environment_as(GIT_DIR=self.gitdir, GIT_WORK_TREE=self.worktree):
         subprocess.check_call(['git', 'reset', '--hard', 'HEAD'])


### PR DESCRIPTION
This test confirms that a log with commits of mixed encodings with
non-ascii, non-utf-8 characters is properly decoded.

https://rbcommons.com/s/twitter/r/1792/