### PR TITLE
Fixup the scrooge release.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -119,7 +119,7 @@ function publish_packages() {
 
     # TODO(Jin Feng) Note --recursive option would cause some of the packages being
     # uploaded multiple times because of dependencies. No harms, but not efficient.
-    run_local_pants setup-py --run="sdist upload" --recursive ${BUILD_TARGET} || \
+    run_local_pants setup-py --run="register sdist upload" --recursive ${BUILD_TARGET} || \
     die "Failed to publish package ${NAME}-$(local_version) with target '${BUILD_TARGET}'!"
   done
 }

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -136,7 +136,7 @@ function post_install() {
 }
 
 function install_and_test_packages() {
-  PIP_ARGS="$@"
+  PIP_ARGS="$@ --quiet"
 
   for PACKAGE in "${RELEASE_PACKAGES[@]}"
   do

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -21,8 +21,14 @@ PKG_SCROOGE=(
 )
 function pkg_scrooge_install_test() {
   PIP_ARGS="$@"
-  pip install ${PIP_ARGS} pantsbuild.pants.contrib.scrooge==$(local_version) && \
-  execute_packaged_pants_with_internal_backends goals | grep "scrooge" &> /dev/null && \
+  # TODO(John Sirois): The generated pantsbuild.pants.contrib.scrooge should have a requirement on
+  # pantsbuild.pants but it currently does not so we must manually install it here.  Investigate
+  # this and when fixed, drop the pantsbuild.pants install requirement here.
+  # See: https://github.com/pantsbuild/pants/issues/1126
+  pip install ${PIP_ARGS} \
+    pantsbuild.pants==$(local_version) \
+    pantsbuild.pants.contrib.scrooge==$(local_version) && \
+  execute_packaged_pants_with_internal_backends --explain gen | grep "scrooge" &> /dev/null && \
   execute_packaged_pants_with_internal_backends goals | grep "thrift-linter" &> /dev/null
 }
 


### PR DESCRIPTION
This patches up the scrooge release script to work and adds a TODO to
investigate simplification of contrib plugin installation / testing.

https://rbcommons.com/s/twitter/r/1793/