### PR TITLE
Allow the dependees goal and idea to respect the --spec_excludes option.

### DIFF
--- a/src/python/pants/backend/core/tasks/dependees.py
+++ b/src/python/pants/backend/core/tasks/dependees.py
@@ -39,6 +39,8 @@ class ReverseDepmap(ConsoleTask):
     self._transitive = self.get_options().transitive
     self._closed = self.get_options().closed
     self._dependees_type = self.get_options().type
+    self._spec_excludes = self.context.options.for_global_scope().spec_excludes
+
 
   def console_output(self, _):
     buildfiles = OrderedSet()
@@ -62,13 +64,13 @@ class ReverseDepmap(ConsoleTask):
                         '\n\tsource_root(\'<src-folder>\', %s)' % ', '.join(self._dependees_type))
       for base_path in base_paths:
         buildfiles.update(BuildFile.scan_buildfiles(get_buildroot(),
-                                                    os.path.join(get_buildroot(), base_path)))
+                                                    os.path.join(get_buildroot(), base_path),
+                                                    spec_excludes=self._spec_excludes))
     else:
-      buildfiles = BuildFile.scan_buildfiles(get_buildroot())
+      buildfiles = BuildFile.scan_buildfiles(get_buildroot(), spec_excludes=self._spec_excludes)
 
     build_graph = self.context.build_graph
     build_file_parser = self.context.build_file_parser
-    address_mapper = self.context.address_mapper
 
     dependees_by_target = defaultdict(set)
     for build_file in buildfiles:

--- a/src/python/pants/backend/jvm/tasks/ide_gen.py
+++ b/src/python/pants/backend/jvm/tasks/ide_gen.py
@@ -173,7 +173,8 @@ class IdeGen(JvmToolTaskMixin, Task):
                       debug_port,
                       jvm_targets,
                       not self.intransitive,
-                      self.TargetUtil(self.context))
+                      self.TargetUtil(self.context),
+                      self.context.options.for_global_scope().spec_excludes)
 
     if self.python:
       python_source_paths = self.context.config.getlist('ide', 'python_source_paths', default=[])
@@ -424,7 +425,7 @@ class Project(object):
     return collapsed_source_sets
 
   def __init__(self, name, has_python, skip_java, skip_scala, use_source_root, root_dir,
-               debug_port, targets, transitive, target_util):
+               debug_port, targets, transitive, target_util, spec_excludes):
     """Creates a new, unconfigured, Project based at root_dir and comprised of the sources visible
     to the given targets."""
 
@@ -450,6 +451,7 @@ class Project(object):
 
     self.internal_jars = OrderedSet()
     self.external_jars = OrderedSet()
+    self.spec_excludes = spec_excludes
 
   def configure_python(self, source_roots, test_roots, lib_roots):
     self.py_sources.extend(SourceSet(get_buildroot(), root, None, False) for root in source_roots)
@@ -538,7 +540,7 @@ class Project(object):
           candidates.update(self.target_util.get_all_addresses(ancestor))
         for sibling in target.address.build_file.siblings():
           candidates.update(self.target_util.get_all_addresses(sibling))
-        for descendant in target.address.build_file.descendants():
+        for descendant in target.address.build_file.descendants(spec_excludes=self.spec_excludes):
           candidates.update(self.target_util.get_all_addresses(descendant))
         def is_sibling(target):
           return source_target(target) and target_dirset.intersection(find_source_basedirs(target))

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -109,10 +109,10 @@ class GoalRunner(object):
 
     self._expand_goals_and_specs()
 
-  def get_spec_excludes(self):
+  @property
+  def spec_excludes(self):
     # Note: Only call after register_options() has been called.
-    return [os.path.join(self.root_dir, spec_exclude)
-            for spec_exclude in self.options.for_global_scope().spec_excludes]
+    return self.options.for_global_scope().spec_excludes
 
   @property
   def global_options(self):
@@ -147,7 +147,7 @@ class GoalRunner(object):
 
     with self.run_tracker.new_workunit(name='setup', labels=[WorkUnit.SETUP]):
       spec_parser = CmdLineSpecParser(self.root_dir, self.address_mapper,
-                                      spec_excludes=self.get_spec_excludes(),
+                                      spec_excludes=self.spec_excludes,
                                       exclude_target_regexps=self.global_options.exclude_target_regexp)
       with self.run_tracker.new_workunit(name='parse', labels=[WorkUnit.SETUP]):
         for spec in specs:
@@ -232,7 +232,7 @@ class GoalRunner(object):
       build_graph=self.build_graph,
       build_file_parser=self.build_file_parser,
       address_mapper=self.address_mapper,
-      spec_excludes=self.get_spec_excludes()
+      spec_excludes=self.spec_excludes
     )
 
     unknown = []

--- a/tests/python/pants_test/base/test_build_file.py
+++ b/tests/python/pants_test/base/test_build_file.py
@@ -90,6 +90,13 @@ class BuildFileTest(unittest.TestCase):
         self.create_buildfile('grandparent/parent/child5'),
     ]), self.buildfile.descendants())
 
+  def test_descendants_with_spec_excludes(self):
+    self.assertEquals(OrderedSet([
+        self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
+        self.create_buildfile('grandparent/parent/child5'),
+      ]),
+      self.buildfile.descendants(spec_excludes=['grandparent/parent/child1']))
+
   def testMustExistFalse(self):
     buildfile = BuildFile(self.root_dir, "path-that-does-not-exist/BUILD", must_exist=False)
     self.assertEquals(OrderedSet([buildfile]), buildfile.family())
@@ -166,11 +173,26 @@ class BuildFileTest(unittest.TestCase):
 
       ]), buildfiles)
 
-  def test_scan_buildfiles_exclude(self):
+  def test_scan_buildfiles_exclude_abspath(self):
     buildfiles = BuildFile.scan_buildfiles(
       self.root_dir, '', spec_excludes=[
         os.path.join(self.root_dir, 'grandparent/parent/child1'),
         os.path.join(self.root_dir, 'grandparent/parent/child2')
+      ])
+
+    self.assertEquals([self.create_buildfile('BUILD'),
+                       self.create_buildfile('BUILD.twitter'),
+                       self.create_buildfile('grandparent/parent/BUILD'),
+                       self.create_buildfile('grandparent/parent/BUILD.twitter'),
+                       self.create_buildfile('grandparent/parent/child5/BUILD'),
+                       ],
+                      buildfiles)
+
+  def test_scan_buildfiles_exclude_relpath(self):
+    buildfiles = BuildFile.scan_buildfiles(
+      self.root_dir, '', spec_excludes=[
+        'grandparent/parent/child1',
+        'grandparent/parent/child2'
       ])
 
     self.assertEquals([self.create_buildfile('BUILD'),

--- a/tests/python/pants_test/tasks/test_dependees.py
+++ b/tests/python/pants_test/tasks/test_dependees.py
@@ -241,3 +241,21 @@ class ReverseDepmapTest(BaseReverseDepmapTest):
       'src/java/a:a_java',
        targets=[self.target('resources/a:a_resources')]
     )
+
+  def test_with_spec_excludes(self):
+    self.assert_console_output(
+      'overlaps:one',
+      'overlaps:two',
+      'overlaps:three',
+      targets=[self.target('common/a')]
+    )
+
+    self.assert_console_output(
+      targets=[self.target('common/a')],
+      config=dedent('''
+      [DEFAULT]
+      spec_excludes: [
+          "overlaps"
+        ]
+      '''),
+    )


### PR DESCRIPTION
BuildFile.scan_buildfiles() now accept relative paths for spec_excludes.
BuildFile.dependees() now accepts the spec_excludes parameter.
Wire in spec_excludes into the dependees and idea goals.