### PR TITLE
Create a directory with no write perms for TestAndroidConfigUtil.

### DIFF
--- a/src/python/pants/backend/android/android_config_util.py
+++ b/src/python/pants/backend/android/android_config_util.py
@@ -21,7 +21,7 @@ class AndroidConfigUtil(object):
   def setup_keystore_config(cls, config):
     """Create a config file for Android keystores and seed with the default keystore.
 
-    :param string config: Desired location for the new .ini config file.
+    :param string config: File name and location for the new .ini config file.
     """
 
     # Unless the config file in ~/.pants.d/android is deleted, this method should only run once,
@@ -54,5 +54,6 @@ class AndroidConfigUtil(object):
     try:
       with safe_open(config, 'w') as config_file:
         config_file.write(ini)
-    except OSError as e:
-      raise cls.AndroidConfigError("Problem creating Android keystore config file: {0}".format(e))
+    # OSError if no permission to make directories, IOError if there are no write perms for file.
+    except (IOError, OSError) as e:
+      raise cls.AndroidConfigError("Problem creating Android keystore config file: {}".format(e))

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -112,7 +112,7 @@ class SignApkTask(Task):
     if not os.path.isfile(config_file):
       try:
         AndroidConfigUtil.setup_keystore_config(config_file)
-      except OSError as e:
+      except AndroidConfigUtil.AndroidConfigError as e:
         raise TaskError('Failed to setup keystore config: {0}'.format(e))
 
     with self.invalidated(targets) as invalidation_check:

--- a/tests/python/pants_test/android/test_android_config_util.py
+++ b/tests/python/pants_test/android/test_android_config_util.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import textwrap
 import unittest
 
@@ -45,4 +46,6 @@ class TestAndroidConfigUtil(unittest.TestCase):
 
   def test_no_permission_keystore_config(self):
     with self.assertRaises(AndroidConfigUtil.AndroidConfigError):
-      AndroidConfigUtil.setup_keystore_config('/outside/home/directory')
+      with temporary_file() as temp:
+        os.chmod(temp.name, 0o400)
+        AndroidConfigUtil.setup_keystore_config(temp.name)


### PR DESCRIPTION
The original test assumed we would have no write permissions outside
of home, which turned out not to be a safe assumption.

I added the IOError to the exception catch in AndroidConfigUtil.
The OSError is raised from the safe_open, if there is no
permission to make dirs. The IOError is for cases where the
directories exist but pants does not have permission to write there.