### PR TITLE
Replace all t.c.lang.Compatibility uses with six.

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -82,8 +82,7 @@ python_library(
   sources = ['binary_util.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    '3rdparty/python/twitter/commons:twitter.common.log',
+    '3rdparty/python:six',
     'src/python/pants/base:config',
     'src/python/pants/base:exceptions',
     'src/python/pants/util:contextutil',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -114,7 +114,7 @@ python_library(
     ':analysis_tools',
     ':jvm_compile',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    '3rdparty/python:six',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:hash_utils',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_diff.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_diff.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from collections import OrderedDict
 
-from twitter.common.lang import Compatibility
+import six
 
 
 # TODO(benjy): Move to a util package?
@@ -46,7 +46,7 @@ class DictDiff(object):
     return '\n'.join(parts)
 
   def __str__(self):
-    if Compatibility.PY3:
+    if six.PY3:
       return self.__unicode__()
     else:
       return self.__unicode__().encode('utf-8')
@@ -76,7 +76,7 @@ class ZincAnalysisElementDiff(object):
     return ''.join(parts)  # '' is a unicode, so the entire result will be.
 
   def __str__(self):
-    if Compatibility.PY3:
+    if six.PY3:
       return self.__unicode__()
     else:
       return self.__unicode__().encode('utf-8')

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -167,7 +167,7 @@ python_library(
     '3rdparty/python:pex',
     '3rdparty/python:pytest',
     '3rdparty/python:pytest-cov',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    '3rdparty/python:six',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:config',
     'src/python/pants/base:target',

--- a/src/python/pants/backend/python/test_builder.py
+++ b/src/python/pants/backend/python/test_builder.py
@@ -16,7 +16,8 @@ from textwrap import dedent
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
-from twitter.common.lang import Compatibility
+from six import StringIO
+from six.moves import configparser
 
 from pants.backend.python.python_chroot import PythonChroot
 from pants.backend.python.python_requirement import PythonRequirement
@@ -25,15 +26,6 @@ from pants.base.config import Config
 from pants.base.target import Target
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir, safe_open
-
-
-try:
-  import configparser
-except ImportError:
-  import ConfigParser as configparser
-
-
-
 
 
 # Initialize logging, since tests do not run via pants_exe (where it is usually done)
@@ -145,7 +137,7 @@ class PythonTestBuilder(object):
         realpaths.add(realpath)
 
     cp = configparser.SafeConfigParser()
-    cp.readfp(Compatibility.StringIO(self.DEFAULT_COVERAGE_CONFIG))
+    cp.readfp(StringIO(self.DEFAULT_COVERAGE_CONFIG))
 
     # We use the source_mappings to setup the `combine` coverage command to transform paths in
     # coverage data files into canonical form.

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -188,7 +188,7 @@ python_library(
   sources = ['generator.py'],
   dependencies = [
     ':mustache',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    '3rdparty/python:six',
   ]
 )
 

--- a/src/python/pants/base/generator.py
+++ b/src/python/pants/base/generator.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import pprint
 
 import pystache
-from twitter.common.lang import Compatibility
+import six
 
 from pants.base.mustache import MustacheRenderer
 
@@ -47,7 +47,7 @@ class Generator(object):
   def __init__(self, template_text, **template_data):
     # pystache does a typecheck for unicode in python 2.x but rewrites its sources to deal unicode
     # via str in python 3.x.
-    if Compatibility.PY2:
+    if six.PY2:
       template_text = unicode(template_text)
     self._template = pystache.parse(template_text)
     self.template_data = template_data

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -5,7 +5,6 @@ python_library(
   name = 'bin',
   sources = ['goal_runner.py', 'pants_exe.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     '3rdparty/python/twitter/commons:twitter.common.log',
     '3rdparty/python:setuptools',
 

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -11,7 +11,6 @@ import sys
 
 import pkg_resources
 from twitter.common import log
-from twitter.common.lang import Compatibility
 from twitter.common.log.options import LogOptions
 
 from pants.backend.core.tasks.task import QuietTaskMixin
@@ -34,9 +33,6 @@ from pants.option.global_options import register_global_options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.report import Report
 from pants.util.dirutil import safe_mkdir
-
-
-StringIO = Compatibility.StringIO
 
 
 class GoalRunner(object):

--- a/src/python/pants/binary_util.py
+++ b/src/python/pants/binary_util.py
@@ -5,27 +5,20 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 import posixpath
 import subprocess
 from contextlib import closing, contextmanager
 
-from twitter.common import log
+import six.moves.urllib.error as urllib_error
+import six.moves.urllib.request as urllib_request
 from twitter.common.collections import OrderedSet
-from twitter.common.lang import Compatibility
 
 from pants.base.config import Config
 from pants.base.exceptions import TaskError
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_delete, safe_open
-
-
-if Compatibility.PY3:
-  import urllib.request as urllib_request
-  import urllib.error as urllib_error
-else:
-  import urllib2 as urllib_request
-  import urllib2 as urllib_error
 
 
 _ID_BY_OS = {
@@ -45,6 +38,9 @@ _PATH_BY_ID = {
   ('darwin', '13'):     ['mac', '10.9'],
   ('darwin', '14'):     ['mac', '10.10'],
 }
+
+
+logger = logging.getLogger(__name__)
 
 
 class BinaryUtil(object):
@@ -135,10 +131,10 @@ class BinaryUtil(object):
     accumulated_errors = []
     for baseurl in OrderedSet(baseurls): # Wrap in OrderedSet because duplicates are wasteful.
       url = posixpath.join(baseurl, binary_path)
-      log.info('Attempting to fetch {name} binary from: {url} ...'.format(name=name, url=url))
+      logger.info('Attempting to fetch {name} binary from: {url} ...'.format(name=name, url=url))
       try:
         with url_opener(url) as binary:
-          log.info('Fetched {name} binary from: {url} .'.format(name=name, url=url))
+          logger.info('Fetched {name} binary from: {url} .'.format(name=name, url=url))
           downloaded_successfully = True
           yield lambda: binary.read()
           break
@@ -169,8 +165,8 @@ class BinaryUtil(object):
       finally:
         safe_delete(downloadpath)
 
-    log.debug('Selected {binary} binary bootstrapped to: {path}'
-              .format(binary=name, path=bootstrapped_binary_path))
+    logger.debug('Selected {binary} binary bootstrapped to: {path}'
+                 .format(binary=name, path=bootstrapped_binary_path))
     return bootstrapped_binary_path
 
 

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -56,7 +56,7 @@ python_library(
   name = 'initialize_reporting',  # XXX shouldn't this be in reporting?!
   sources = ['initialize_reporting.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    '3rdparty/python:six',
     'src/python/pants/reporting',
     'src/python/pants/reporting:report',
     'src/python/pants/util:dirutil',

--- a/src/python/pants/goal/initialize_reporting.py
+++ b/src/python/pants/goal/initialize_reporting.py
@@ -9,7 +9,7 @@ import errno
 import os
 import sys
 
-from twitter.common.lang import Compatibility
+from six import StringIO
 
 from pants.reporting.html_reporter import HtmlReporter
 from pants.reporting.plaintext_reporter import PlainTextReporter
@@ -17,9 +17,6 @@ from pants.reporting.quiet_reporter import QuietReporter
 from pants.reporting.report import Report, ReportingError
 from pants.reporting.reporting_server import ReportingServerManager
 from pants.util.dirutil import safe_mkdir, safe_rmtree
-
-
-StringIO = Compatibility.StringIO
 
 
 def initial_reporting(config, run_tracker):

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -32,7 +32,7 @@ python_library(
   name = 'jar',
   sources = globs('jar/manifest.py'),
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    '3rdparty/python:six',
   ]
 )
 

--- a/src/python/pants/java/jar/manifest.py
+++ b/src/python/pants/java/jar/manifest.py
@@ -7,10 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from contextlib import closing
 
-from twitter.common.lang import Compatibility
-
-
-StringIO = Compatibility.StringIO
+from six import StringIO
 
 
 class Manifest(object):

--- a/src/python/pants/rwbuf/BUILD
+++ b/src/python/pants/rwbuf/BUILD
@@ -5,6 +5,6 @@ python_library(
   name = 'rwbuf',
   sources = globs('*.py'),
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    '3rdparty/python:six',
   ]
 )

--- a/src/python/pants/rwbuf/read_write_buffer.py
+++ b/src/python/pants/rwbuf/read_write_buffer.py
@@ -7,10 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import threading
 
-from twitter.common.lang import Compatibility
-
-
-StringIO = Compatibility.StringIO
+from six import StringIO
 
 
 class _RWBuf(object):

--- a/tests/python/pants_test/net/http/BUILD
+++ b/tests/python/pants_test/net/http/BUILD
@@ -7,7 +7,7 @@ python_tests(
   dependencies = [
     '3rdparty/python:mox',
     '3rdparty/python:requests',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    '3rdparty/python:six',
     'src/python/pants/net',
     'src/python/pants/util:contextutil',
   ]

--- a/tests/python/pants_test/net/http/test_fetcher.py
+++ b/tests/python/pants_test/net/http/test_fetcher.py
@@ -11,7 +11,7 @@ from contextlib import closing
 import mox
 import pytest
 import requests
-from twitter.common.lang import Compatibility
+from six import StringIO
 
 from pants.net.http.fetcher import Fetcher
 from pants.util.contextutil import temporary_file
@@ -81,7 +81,7 @@ class FetcherTest(mox.MoxTestBase):
 
     self.mox.ReplayAll()
 
-    with closing(Compatibility.StringIO()) as fp:
+    with closing(StringIO()) as fp:
       self.fetcher.fetch('http://foo',
                          Fetcher.DownloadListener(fp).wrap(self.listener),
                          chunk_size_bytes=1024 * 1024,


### PR DESCRIPTION
Unfortunately the t.c.lang requirement is not dropped globally since
both AbstractClass and Singleton are used in several files.