### PR TITLE
Copy t.c.lang.{AbstractClass,Singleton} to pants.

### DIFF
--- a/3rdparty/python/twitter/commons/requirements.txt
+++ b/3rdparty/python/twitter/commons/requirements.txt
@@ -9,7 +9,6 @@ twitter.common.config>=0.3.1,<0.4
 twitter.common.confluence>=0.3.1,<0.4
 twitter.common.decorators>=0.3.1,<0.4
 twitter.common.dirutil>=0.3.1,<0.4
-twitter.common.lang>=0.3.1,<0.4
 twitter.common.log>=0.3.1,<0.4
 twitter.common.options>=0.3.1,<0.4
 twitter.common.process>=0.3.1,<0.4

--- a/src/python/pants/BUILD.transitional
+++ b/src/python/pants/BUILD.transitional
@@ -41,7 +41,6 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.config',
     '3rdparty/python/twitter/commons:twitter.common.confluence',
     '3rdparty/python/twitter/commons:twitter.common.decorators',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     '3rdparty/python/twitter/commons:twitter.common.log',
     '3rdparty/python/twitter/commons:twitter.common.process',
     '3rdparty/python/twitter/commons:twitter.common.threading',

--- a/src/python/pants/backend/codegen/targets/BUILD
+++ b/src/python/pants/backend/codegen/targets/BUILD
@@ -13,13 +13,13 @@ python_library(
   ],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    '3rdparty/python:six',
     'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/base:build_manual',
     'src/python/pants/base:config',
+    'src/python/pants/base:exceptions',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
-    'src/python/pants/base:target',
   ],
 )
 

--- a/src/python/pants/backend/core/targets/BUILD
+++ b/src/python/pants/backend/core/targets/BUILD
@@ -17,9 +17,6 @@ python_library(
     'resources.py',
   ],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    '3rdparty/python/twitter/commons:twitter.common.log',
     'src/python/pants/base:address',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:payload',

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -330,6 +330,7 @@ python_library(
     'src/python/pants/ivy',
     'src/python/pants/java:executor',
     'src/python/pants/reporting',
+    'src/python/pants/util:meta',
   ],
 )
 

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -146,8 +146,6 @@ python_library(
   name = 'group_task',
   sources = ['group_task.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     ':task',
     'src/python/pants/base:build_graph',
     'src/python/pants/base:workunit',
@@ -220,12 +218,8 @@ python_library(
   name = 'paths',
   sources = ['paths.py'],
   dependencies = [
-    ':common',
     ':console_task',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/base:address',
-    'src/python/pants/base:target',
+    'src/python/pants/base:exceptions',
   ],
 )
 

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -13,7 +13,6 @@ from abc import abstractmethod
 from contextlib import contextmanager
 
 from twitter.common.collections.orderedset import OrderedSet
-from twitter.common.lang import AbstractClass
 
 from pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
 from pants.base.cache_manager import InvalidationCacheManager, InvalidationCheck
@@ -23,6 +22,7 @@ from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use
 from pants.cache.cache_setup import create_artifact_cache
 from pants.cache.read_write_artifact_cache import ReadWriteArtifactCache
 from pants.reporting.reporting_utils import items_to_report_element
+from pants.util.meta import AbstractClass
 
 
 class TaskBase(AbstractClass):

--- a/src/python/pants/backend/jvm/scala/BUILD
+++ b/src/python/pants/backend/jvm/scala/BUILD
@@ -4,7 +4,6 @@ python_library(
     'target_platform.py',
   ],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/base:config',
   ],
 )

--- a/src/python/pants/backend/jvm/targets/BUILD
+++ b/src/python/pants/backend/jvm/targets/BUILD
@@ -27,7 +27,6 @@ python_library(
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_manual',
@@ -37,6 +36,7 @@ python_library(
     'src/python/pants/base:payload_field',
     'src/python/pants/base:target',
     'src/python/pants/base:validation',
+    'src/python/pants/util:meta',
   ],
 )
 

--- a/src/python/pants/backend/jvm/targets/BUILD
+++ b/src/python/pants/backend/jvm/targets/BUILD
@@ -50,10 +50,8 @@ python_library(
   ],
   dependencies = [
     ':jvm',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    'src/python/pants/base:config',
-    'src/python/pants/base:target',
+    '3rdparty/python:six',
+    'src/python/pants/base:exceptions',
   ],
 )
 

--- a/src/python/pants/backend/jvm/targets/jarable.py
+++ b/src/python/pants/backend/jvm/targets/jarable.py
@@ -7,9 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from abc import abstractproperty
 
-from twitter.common.lang import AbstractClass
-
 from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.util.meta import AbstractClass
 
 
 class Jarable(AbstractClass):

--- a/src/python/pants/backend/jvm/targets/java_agent.py
+++ b/src/python/pants/backend/jvm/targets/java_agent.py
@@ -9,7 +9,6 @@ from six import string_types
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.exceptions import TargetDefinitionException
-from pants.base.validation import assert_list
 
 
 class JavaAgent(JavaLibrary):

--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -5,11 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from twitter.common.collections import maybe_list
-
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TargetDefinitionException
-from pants.base.validation import assert_list
 
 
 class JavaTests(JvmTarget):

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -7,11 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import re
-from hashlib import sha1
 
 from six import string_types
 from twitter.common.dirutil import Fileset
-from twitter.common.lang import AbstractClass
 
 from pants.backend.jvm.targets.exclude import Exclude
 from pants.backend.jvm.targets.jvm_target import JvmTarget
@@ -22,6 +20,7 @@ from pants.base.payload import Payload
 from pants.base.payload_field import BundleField
 from pants.base.target import Target
 from pants.base.validation import assert_list
+from pants.util.meta import AbstractClass
 
 
 class JarRule(AbstractClass):

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -331,12 +331,12 @@ python_library(
     ':nailgun_task',
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/java:jar',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:meta',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 
 from six import binary_type, string_types
 from twitter.common.collections import maybe_list
-from twitter.common.lang import AbstractClass
 
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, Skip
@@ -21,6 +20,7 @@ from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 from pants.java.jar.manifest import Manifest
 from pants.util.contextutil import temporary_dir
+from pants.util.meta import AbstractClass
 
 
 class Jar(object):

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -222,12 +222,6 @@ python_library(
 python_library(
   name = 'payload',
   sources = ['payload.py'],
-  dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    ':build_environment',
-    ':validation',
-  ]
 )
 
 python_library(

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -10,8 +10,8 @@ python_library(
   name = 'address',
   sources = ['address.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     ':build_file',
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -24,8 +24,8 @@ python_library(
   name = 'addressable',
   sources = ['addressable.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     ':address',
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -120,7 +120,7 @@ python_library(
   name = 'build_root',
   sources = ['build_root.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    'src/python/pants/util:meta',
   ],
 )
 
@@ -179,7 +179,7 @@ python_library(
   name = 'fingerprint_strategy',
   sources = ['fingerprint_strategy.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -235,10 +235,9 @@ python_library(
   sources = ['payload_field.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
-    '3rdparty/python:six',
     ':build_environment',
     ':validation',
+    'src/python/pants/util:meta',
   ]
 )
 

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from collections import namedtuple
 
-from twitter.common.lang import AbstractClass
+from pants.util.meta import AbstractClass
 
 
 def parse_spec(spec, relative_to=None):

--- a/src/python/pants/base/addressable.py
+++ b/src/python/pants/base/addressable.py
@@ -5,9 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from twitter.common.lang import AbstractClass
-
 from pants.base.address import BuildFileAddress
+from pants.util.meta import AbstractClass
 
 
 class AddressableCallProxy(object):

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from contextlib import contextmanager
 
-from twitter.common.lang import Singleton
+from pants.util.meta import Singleton
 
 
 # TODO: Even this should probably just be a new-style option?

--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from abc import abstractmethod
 
-from twitter.common.lang import AbstractClass
+from pants.util.meta import AbstractClass
 
 
 class DefaultFingerprintHashingMixin(object):

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -10,12 +10,11 @@ import os
 from abc import abstractmethod
 from hashlib import sha1
 
-import six
 from twitter.common.collections import OrderedSet
-from twitter.common.lang import AbstractClass
 
 from pants.base.build_environment import get_buildroot
 from pants.base.validation import assert_list
+from pants.util.meta import AbstractClass
 
 
 def stable_json_dumps(obj):

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -6,9 +6,9 @@ python_library(
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/goal',
+    'src/python/pants/util:meta',
   ],
 )

--- a/src/python/pants/engine/engine.py
+++ b/src/python/pants/engine/engine.py
@@ -7,9 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from abc import abstractmethod
 
-from twitter.common.lang import AbstractClass
-
 from pants.base.exceptions import TaskError
+from pants.util.meta import AbstractClass
 
 
 class Engine(AbstractClass):

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -5,7 +5,7 @@ python_library(
   name = 'fs',
   sources = globs('*.py'),
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:meta',
   ]
 )

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -10,17 +10,13 @@ from abc import abstractmethod
 from collections import OrderedDict
 from zipfile import ZIP_DEFLATED
 
-from twitter.common.lang import AbstractClass
-
 from pants.util.contextutil import open_tar, open_zip64
 from pants.util.dirutil import safe_walk
+from pants.util.meta import AbstractClass
 from pants.util.strutil import ensure_text
 
 
 """Support for wholesale archive creation and extraction in a uniform API across archive types."""
-
-
-
 
 
 class Archiver(AbstractClass):

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -101,8 +101,8 @@ python_library(
   name = 'workspace',
   sources = ['workspace.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants/base:build_environment',
     'src/python/pants/scm',
+    'src/python/pants/util:meta',
   ],
 )

--- a/src/python/pants/goal/workspace.py
+++ b/src/python/pants/goal/workspace.py
@@ -7,10 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from abc import abstractmethod
 
-from twitter.common.lang import AbstractClass
-
 from pants.base.build_environment import get_buildroot
 from pants.scm.scm import Scm
+from pants.util.meta import AbstractClass
 
 
 class Workspace(AbstractClass):

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -20,11 +20,11 @@ python_library(
     ':distribution',
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     '3rdparty/python/twitter/commons:twitter.common.log',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:meta',
   ]
 )
 

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -5,20 +5,23 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 import subprocess
 from abc import abstractmethod, abstractproperty
 from contextlib import contextmanager
 
 from six import string_types
-from twitter.common import log
 from twitter.common.collections import maybe_list
-from twitter.common.lang import AbstractClass
 
 from pants.base.build_environment import get_buildroot
 from pants.java.distribution.distribution import Distribution
 from pants.util.contextutil import environment_as
 from pants.util.dirutil import relativize_paths
+from pants.util.meta import AbstractClass
+
+
+logger = logging.getLogger(__name__)
 
 
 class Executor(AbstractClass):
@@ -157,7 +160,7 @@ class SubprocessExecutor(Executor):
     for env_var in cls._SCRUBBED_ENV:
       value = os.getenv(env_var)
       if value:
-        log.warn('Scrubbing {env_var}={value}'.format(env_var=env_var, value=value))
+        logger.warn('Scrubbing {env_var}={value}'.format(env_var=env_var, value=value))
     with environment_as(**cls._SCRUBBED_ENV):
       yield
 
@@ -198,8 +201,8 @@ class SubprocessExecutor(Executor):
   def _spawn(self, cmd, cwd=None, **subprocess_args):
     with self._maybe_scrubbed_env():
       cwd = cwd or self._buildroot
-      log.debug('Executing: {cmd} args={args} at cwd={cwd}'
-               .format(cmd=' '.join(cmd), args=subprocess_args, cwd=cwd))
+      logger.debug('Executing: {cmd} args={args} at cwd={cwd}'
+                   .format(cmd=' '.join(cmd), args=subprocess_args, cwd=cwd))
       try:
         return subprocess.Popen(cmd, cwd=cwd, **subprocess_args)
       except OSError as e:

--- a/src/python/pants/scm/BUILD
+++ b/src/python/pants/scm/BUILD
@@ -13,7 +13,7 @@ python_library(
   name = 'scm',
   sources = ['scm.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.lang',
+    'src/python/pants/util:meta',
   ],
 )
 

--- a/src/python/pants/scm/scm.py
+++ b/src/python/pants/scm/scm.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from abc import abstractmethod, abstractproperty
 
-from twitter.common.lang import AbstractClass
+from pants.util.meta import AbstractClass
 
 
 class Scm(AbstractClass):

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -19,18 +19,23 @@ python_library(
 )
 
 python_library(
-  name = 'strutil',
-  sources = ['strutil.py'],
-  dependencies = [
-    '3rdparty/python:six',
-  ],
-)
-
-python_library(
   name = 'fileutil',
   sources = ['fileutil.py'],
   dependencies = [
     ':contextutil',
+  ],
+)
+
+python_library(
+  name = 'meta',
+  sources = ['meta.py'],
+)
+
+python_library(
+  name = 'strutil',
+  sources = ['strutil.py'],
+  dependencies = [
+    '3rdparty/python:six',
   ],
 )
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -17,8 +17,8 @@ class SingletonMetaclass(type):
 
 
 # Extend Singleton and your class becomes a singleton, each construction returns the same instance.
-Singleton = SingletonMetaclass('Singleton', (object,), {})
+Singleton = SingletonMetaclass(str('Singleton'), (object,), {})
 
 
 # Abstract base classes w/o __metaclass__ or meta =, just extend AbstractClass.
-AbstractClass = ABCMeta('AbstractClass', (object,), {})
+AbstractClass = ABCMeta(str('AbstractClass'), (object,), {})

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from abc import ABCMeta
+
+
+class SingletonMetaclass(type):
+  """Singleton metaclass."""
+  def __call__(cls, *args, **kwargs):
+    if not hasattr(cls, 'instance'):
+      cls.instance = super(SingletonMetaclass, cls).__call__(*args, **kwargs)
+    return cls.instance
+
+
+# Extend Singleton and your class becomes a singleton, each construction returns the same instance.
+Singleton = SingletonMetaclass('Singleton', (object,), {})
+
+
+# Abstract base classes w/o __metaclass__ or meta =, just extend AbstractClass.
+AbstractClass = ABCMeta('AbstractClass', (object,), {})

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -70,7 +70,6 @@ python_tests(
   sources = ['test_thrift_util.py'],
   dependencies = [
     ':base_test',
-    '3rdparty/python/twitter/commons:twitter.common.lang',
     'src/python/pants:thrift_util',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',


### PR DESCRIPTION
Replace uses of t.c.lang.{AbstractClass,Singleton} with pants.util.meta
copies and kill pants deps globally on t.c.lang.

https://rbcommons.com/s/twitter/r/1802/