### PR TITLE
Reduce number of shards from 8 to 6 on Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,14 +34,12 @@ env:
     - CI_FLAGS="-fkmsrclpn 'Test examples and testprojects'"  # (et)
     - CI_FLAGS="-fkmsrcnet 'Python unit tests for pants and pants-plugins'"  # (lp)
     - CI_FLAGS="-fkmsrclpet 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrlpnet -i 8:0 'Python integration tests for pants - shard 1'"  # (c)
-    - CI_FLAGS="-fkmsrlpnet -i 8:1 'Python integration tests for pants - shard 2'"
-    - CI_FLAGS="-fkmsrlpnet -i 8:2 'Python integration tests for pants - shard 3'"
-    - CI_FLAGS="-fkmsrlpnet -i 8:3 'Python integration tests for pants - shard 4'"
-    - CI_FLAGS="-fkmsrlpnet -i 8:4 'Python integration tests for pants - shard 5'"
-    - CI_FLAGS="-fkmsrlpnet -i 8:5 'Python integration tests for pants - shard 6'"
-    - CI_FLAGS="-fkmsrlpnet -i 8:6 'Python integration tests for pants - shard 7'"
-    - CI_FLAGS="-fkmsrlpnet -i 8:7 'Python integration tests for pants - shard 8'"
+    - CI_FLAGS="-fkmsrlpnet -i 6:0 'Python integration tests for pants - shard 1'"  # (c)
+    - CI_FLAGS="-fkmsrlpnet -i 6:1 'Python integration tests for pants - shard 2'"
+    - CI_FLAGS="-fkmsrlpnet -i 6:2 'Python integration tests for pants - shard 3'"
+    - CI_FLAGS="-fkmsrlpnet -i 6:3 'Python integration tests for pants - shard 4'"
+    - CI_FLAGS="-fkmsrlpnet -i 6:4 'Python integration tests for pants - shard 5'"
+    - CI_FLAGS="-fkmsrlpnet -i 6:5 'Python integration tests for pants - shard 6'"
 
 before_script: |
   ./build-support/bin/ci-sync.sh


### PR DESCRIPTION
Watching the builds late at night, our project never gets more than 5 shards.  This means that there is some
tradeoff where fewer longer running shards will actually outperform more shorter ones.

We were up to 12 shards and the timeline went like this:

```
*--------->
  ... first 5 shards ...
*---------->
           *-------->
              ... next 5 shards ...
            *-------->
                     *------->
                       ... last 2 shards ...
                      *------->
```