### PR TITLE
Check import sorting before checking headers.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -93,9 +93,9 @@ if [[ "${skip_formatting_checks:-false}" == "false" ]]; then
   banner "Checking python code formatting"
 
   ./build-support/bin/check_packages.sh || exit 1
-  ./build-support/bin/check_header.sh || exit 1
   ./build-support/bin/isort.sh || \
     die "To fix import sort order, run \`build-support/bin/isort.sh -f\`"
+  ./build-support/bin/check_header.sh || exit 1
 fi
 
 # TODO(John sirois): Re-plumb build such that it grabs constraints from the built python_binary


### PR DESCRIPTION
The header check includes an import check for `__future__` imports.  Its
easier to understand / correct issues with headers that have
non-compliant import sorting for the `__future__` imports if the isort
check runs first, fails, and suggests running
`./build-support/bin/isort -f`.

https://rbcommons.com/s/twitter/r/1812/