### PR TITLE
Work around py test_runner issue with ns packages.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -194,14 +194,11 @@ fi
 if [[ "${skip_contrib:-false}" == "false" ]]; then
   banner "Running contrib python tests"
   (
-    # We run using --no-fast - aka test chroot per target - to work around issues with
+    # We run python tests using --no-fast - aka test chroot per target - to work around issues with
     # test (ie: pants_test.contrib) namespace packages.
     # TODO(John Sirois): Get to the bottom of the issue and kill --no-fast, see:
     #  https://github.com/pantsbuild/pants/issues/1149
-    PANTS_PYTHON_TEST_FAILSOFT=1 \
-      ./pants.pex test.pytest --no-fast ${PANTS_ARGS[@]} \
-        $(./pants.pex list contrib:: | \
-            xargs ./pants.pex filter --filter-type=python_tests)
+    PANTS_PYTHON_TEST_FAILSOFT=1 ./pants.pex test.pytest --no-fast ${PANTS_ARGS[@]} contrib::
   ) || die "Contrib python test failure"
 fi
 

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -194,8 +194,12 @@ fi
 if [[ "${skip_contrib:-false}" == "false" ]]; then
   banner "Running contrib python tests"
   (
+    # We run using --no-fast - aka test chroot per target - to work around issues with
+    # test (ie: pants_test.contrib) namespace packages.
+    # TODO(John Sirois): Get to the bottom of the issue and kill --no-fast, see:
+    #  https://github.com/pantsbuild/pants/issues/1149
     PANTS_PYTHON_TEST_FAILSOFT=1 \
-      ./pants.pex test ${PANTS_ARGS[@]} \
+      ./pants.pex test.pytest --no-fast ${PANTS_ARGS[@]} \
         $(./pants.pex list contrib:: | \
             xargs ./pants.pex filter --filter-type=python_tests)
   ) || die "Contrib python test failure"


### PR DESCRIPTION
The python test_runner does not handle running tests from seperate
source trees contributinng to the same _test_ ns package.  We'd like to
run all contrib/ tests together and these all share the
`pants_test/contrib` ns package, so this test_runner bug forces us to
use the runner in `--no-fast` mode, ie: run each test target in its own
chroot / py.test session.'

https://rbcommons.com/s/twitter/r/1813/