### PR TITLE
Android backend now exclusively uses the new option system.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -195,7 +195,7 @@ packages: [
   ]
 
 
-[android-keystore-location]
+[sign]
 # Default to debug keystore installed with SDK.
 # You can change this to point to a config.ini holding the definition of your keys.
 keystore_config_location: %(pants_bootstrapdir)s/android/keystore/default_config.ini

--- a/src/python/pants/backend/android/keystore/keystore_resolver.py
+++ b/src/python/pants/backend/android/keystore/keystore_resolver.py
@@ -35,7 +35,7 @@ class KeystoreResolver(object):
         config.readfp(keystore_config)
     except IOError as e:
       raise KeystoreResolver.Error('Problem parsing config at {}: {}'.format(config_file, e))
-    
+
     parser = SingleFileConfig(config_file, config)
     key_names = config.sections()
     keys = {}

--- a/src/python/pants/backend/android/keystore/keystore_resolver.py
+++ b/src/python/pants/backend/android/keystore/keystore_resolver.py
@@ -24,8 +24,6 @@ class KeystoreResolver(object):
   class Error(Exception):
     """Indicates an invalid android distribution."""
 
-  _CONFIG_SECTION = 'android-keystore-location'
-
   @classmethod
   def resolve(cls, config_file):
     """Parse a keystore config file and return a list of Keystore objects."""
@@ -34,9 +32,8 @@ class KeystoreResolver(object):
     try:
       with open(config_file, 'rb') as keystore_config:
         config.readfp(keystore_config)
-    except IOError:
-      raise KeystoreResolver.Error('The \'--{0}\' option must point at a valid .ini file holding '
-                                   'keystore definitions.'.format(cls._CONFIG_SECTION))
+    except IOError as e:
+      raise KeystoreResolver.Error('Problem parsing the keystore config: {}'.format(e))
     parser = SingleFileConfig(config_file, config)
     key_names = config.sections()
     keys = {}
@@ -97,8 +94,8 @@ class Keystore(object):
     if self._type is None:
       keystore_type = self._build_type.lower()
       if keystore_type not in ('release', 'debug'):
-        raise ValueError(self, 'The build_type must be one of (debug, release) '
-                               'instead of: {0}.'.format(self._build_type))
+        raise ValueError('The build_type of Android keystores must be one of (debug, release) '
+                         'instead of: {0}.'.format(self._build_type))
       else:
         self._type = keystore_type
     return self._type

--- a/src/python/pants/backend/android/keystore/keystore_resolver.py
+++ b/src/python/pants/backend/android/keystore/keystore_resolver.py
@@ -33,7 +33,7 @@ class KeystoreResolver(object):
       with open(config_file, 'rb') as keystore_config:
         config.readfp(keystore_config)
     except IOError as e:
-      raise KeystoreResolver.Error('Problem parsing the keystore config: {}'.format(e))
+      raise KeystoreResolver.Error('Problem parsing config at {}: {}'.format(config_file, e))
     parser = SingleFileConfig(config_file, config)
     key_names = config.sections()
     keys = {}

--- a/src/python/pants/backend/android/tasks/BUILD
+++ b/src/python/pants/backend/android/tasks/BUILD
@@ -85,6 +85,7 @@ python_library(
     'src/python/pants/backend/android:keystore_resolver',
     'src/python/pants/backend/android/targets:android',
     'src/python/pants/backend/core/tasks:common',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/java:distribution',

--- a/src/python/pants/backend/android/tasks/BUILD
+++ b/src/python/pants/backend/android/tasks/BUILD
@@ -85,7 +85,6 @@ python_library(
     'src/python/pants/backend/android:keystore_resolver',
     'src/python/pants/backend/android/targets:android',
     'src/python/pants/backend/core/tasks:common',
-    'src/python/pants/base:config',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/java:distribution',

--- a/src/python/pants/backend/android/tasks/dx_compile.py
+++ b/src/python/pants/backend/android/tasks/dx_compile.py
@@ -22,7 +22,6 @@ class DxCompile(AndroidTask, NailgunTask):
 
   # name of output file. "Output name must end with one of: .dex .jar .zip .apk or be a directory."
   DEX_NAME = 'classes.dex'
-  _CONFIG_SECTION = 'dx-tool'
 
   @staticmethod
   def is_dextarget(target):
@@ -53,10 +52,6 @@ class DxCompile(AndroidTask, NailgunTask):
     self._forced_jvm_options = self.get_options().jvm_options
 
     self.setup_artifact_cache()
-
-  @property
-  def config_section(self):
-    return self._CONFIG_SECTION
 
   def _render_args(self, outdir, classes):
     dex_file = os.path.join(outdir, self.DEX_NAME)

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -25,6 +25,8 @@ logger = logging.getLogger(__name__)
 class SignApkTask(Task):
   """Sign Android packages with keystores using the jarsigner tool."""
 
+  _DEFAULT_KEYSTORE_CONFIG = 'android/keystore/default_config.ini'
+
   @classmethod
   def register_options(cls, register):
     super(SignApkTask, cls).register_options(register)
@@ -44,12 +46,29 @@ class SignApkTask(Task):
   def product_types(cls):
     return ['release_apk']
 
+  @classmethod
+  def setup_default_config(cls, path):
+    """Create the default keystore config file for Android targets.
+
+    :param string path: Full path for the created default config file.
+    """
+    # TODO(mateor): Hook into pants global setup instead of relying on building an Android target.
+    try:
+      AndroidConfigUtil.setup_keystore_config(path)
+    except AndroidConfigUtil.AndroidConfigError as e:
+      raise TaskError('Failed to setup default keystore config: {0}'.format(e))
+
+  @classmethod
+  def signed_package_name(cls, target, build_type):
+    """Get package name with 'build_type', a string KeyResolver mandates is in (debug, release)."""
+    return '{0}.{1}.signed.apk'.format(target.app_name, build_type)
+
   def __init__(self, *args, **kwargs):
     super(SignApkTask, self).__init__(*args, **kwargs)
     self._config_file = self.get_options().keystore_config_location
-    self._dist = None
     self._distdir = self.get_options().pants_distdir
-    self._configdir = self.context.config.getdefault('pants_bootstrapdir')
+    self._configdir = self.get_options().pants_bootstrapdir
+    self._dist = None
 
   @property
   def config_file(self):
@@ -62,14 +81,14 @@ class SignApkTask(Task):
   def default_config_location(self):
     """Return the path where pants creates the default keystore config file.
 
-    This file holds the well-known definition of the debug keystore installed along the Android SDK.
+    This location will hold the well-known definition of the debug keystore installed with the SDK.
     """
-    return os.path.join(self._configdir, 'android/keystore/default_config.ini')
+    return os.path.join(self._configdir, self._DEFAULT_KEYSTORE_CONFIG)
 
   @property
   def distribution(self):
     if self._dist is None:
-      # Currently no Java 8 for Android. I considered max=1.7.0_50. See comment in render_args().
+      # Currently no Java 8 for Android. I considered max=1.7.0_50. See comment in _render_args().
       self._dist = Distribution.cached(minimum_version='1.6.0_00',
                                        maximum_version='1.7.0_99',
                                        jdk=True)
@@ -96,19 +115,18 @@ class SignApkTask(Task):
     args.extend(['-keystore', key.keystore_location])
     args.extend(['-storepass', key.keystore_password])
     args.extend(['-keypass', key.key_password])
-    args.extend(['-signedjar', os.path.join(outdir, self.package_name(target, key.build_type))])
+    args.extend(['-signedjar', os.path.join(outdir, self.signed_package_name(target, key.build_type))])
     args.append(unsigned_apk)
     args.append(key.keystore_alias)
     logger.debug('Executing: {0}'.format(' '.join(args)))
     return args
 
   def execute(self):
-    targets = self.context.targets(self.is_signtarget)
-
-    # One time set-up of the default keystore config.
+    # One time setup of the default keystore config file.
     if not os.path.isfile(self.default_config_location):
-      self.setup_default(self.default_config_location)
+      self.setup_default_config(self.default_config_location)
 
+    targets = self.context.targets(self.is_signtarget)
     with self.invalidated(targets) as invalidation_check:
       invalid_targets = []
       for vt in invalidation_check.invalid_vts:
@@ -142,22 +160,10 @@ class SignApkTask(Task):
 
     for target in targets:
       release_path = self.sign_apk_out(target, 'release')
-      release_apk = self.package_name(target, 'release')
+      release_apk = self.signed_package_name(target, 'release')
 
       if os.path.isfile(os.path.join(release_path, release_apk)):
         self.context.products.get('release_apk').add(target, release_path).append(release_apk)
-
-
-  def setup_default(self, path):
-    """One time setup for the default keystore config file."""
-    try:
-      AndroidConfigUtil.setup_keystore_config(path)
-    except AndroidConfigUtil.AndroidConfigError as e:
-      raise TaskError('Failed to setup default keystore config: {0}'.format(e))
-
-  def package_name(self, target, build_type):
-    """Get package name with 'build_type', a string KeyResolver mandates is in (debug, release)."""
-    return '{0}.{1}.signed.apk'.format(target.app_name, build_type)
 
   def sign_apk_out(self, target, build_type):
     """Compute the outdir for a target."""

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -115,7 +115,8 @@ class SignApkTask(Task):
     args.extend(['-keystore', key.keystore_location])
     args.extend(['-storepass', key.keystore_password])
     args.extend(['-keypass', key.key_password])
-    args.extend(['-signedjar', os.path.join(outdir, self.signed_package_name(target, key.build_type))])
+    args.extend(['-signedjar',
+                 os.path.join(outdir, self.signed_package_name(target, key.build_type))])
     args.append(unsigned_apk)
     args.append(key.keystore_alias)
     logger.debug('Executing: {0}'.format(' '.join(args)))

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -62,10 +62,9 @@ class SignApkTask(Task):
   def default_config_location(self):
     """Return the path where pants creates the default keystore config file.
 
-    This file will hold the example keystore definition, the debug key installed along the SDK.
+    This file holds the well-known definition of the debug keystore installed along the Android SDK.
     """
-    return os.path.join(self._configdir,
-                        'andrrrrrgggggrroid/keystore/default_config.ini')
+    return os.path.join(self._configdir, 'android/keystore/default_config.ini')
 
   @property
   def distribution(self):
@@ -105,8 +104,8 @@ class SignApkTask(Task):
 
   def execute(self):
     targets = self.context.targets(self.is_signtarget)
+
     # One time set-up of the default keystore config.
-    print("DEEEEFAAAUSKSKKD", self.default_config_location)
     if not os.path.isfile(self.default_config_location):
       self.setup_default(self.default_config_location)
 

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -13,6 +13,7 @@ from pants.backend.android.android_config_util import AndroidConfigUtil
 from pants.backend.android.keystore.keystore_resolver import KeystoreResolver
 from pants.backend.android.targets.android_binary import AndroidBinary
 from pants.backend.core.tasks.task import Task
+from pants.base.build_environment import get_pants_configdir
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 from pants.java.distribution.distribution import Distribution
@@ -67,7 +68,7 @@ class SignApkTask(Task):
     super(SignApkTask, self).__init__(*args, **kwargs)
     self._config_file = self.get_options().keystore_config_location
     self._distdir = self.get_options().pants_distdir
-    self._configdir = self.get_options().pants_bootstrapdir
+    self._configdir = get_pants_configdir()
     self._dist = None
 
   @property

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -29,6 +29,8 @@ def register_bootstrap_options(register, buildroot=None):
   status as "bootstrap options" is only pertinent during option registration.
   """
   buildroot = buildroot or get_buildroot()
+  register('--pants-bootstrapdir', metavar='<dir>', default=os.path.expanduser('~/.pants.d'),
+           help='Write global pants cache files to this dir.')
   register('--pants-workdir', metavar='<dir>', default=os.path.join(buildroot, '.pants.d'),
            help='Write intermediate output files to this dir.')
   register('--pants-supportdir', metavar='<dir>', default=os.path.join(buildroot, 'build-support'),

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -29,8 +29,6 @@ def register_bootstrap_options(register, buildroot=None):
   status as "bootstrap options" is only pertinent during option registration.
   """
   buildroot = buildroot or get_buildroot()
-  register('--pants-bootstrapdir', metavar='<dir>', default=os.path.expanduser('~/.pants.d'),
-           help='Write global cache files to this dir.')
   register('--pants-workdir', metavar='<dir>', default=os.path.join(buildroot, '.pants.d'),
            help='Write intermediate output files to this dir.')
   register('--pants-supportdir', metavar='<dir>', default=os.path.join(buildroot, 'build-support'),

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -30,7 +30,7 @@ def register_bootstrap_options(register, buildroot=None):
   """
   buildroot = buildroot or get_buildroot()
   register('--pants-bootstrapdir', metavar='<dir>', default=os.path.expanduser('~/.pants.d'),
-           help='Write global pants cache files to this dir.')
+           help='Write global cache files to this dir.')
   register('--pants-workdir', metavar='<dir>', default=os.path.join(buildroot, '.pants.d'),
            help='Write intermediate output files to this dir.')
   register('--pants-supportdir', metavar='<dir>', default=os.path.join(buildroot, 'build-support'),

--- a/tests/python/pants_test/android/tasks/test_sign_apk.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk.py
@@ -24,7 +24,7 @@ class SignApkTest(TestAndroidBase):
 
   @classmethod
   def _get_config(cls,
-                  section=SignApkTask._CONFIG_SECTION,
+                  section='test',
                   option='keystore_config_location',
                   location=_TEST_KEYSTORE):
     ini = textwrap.dedent("""
@@ -64,7 +64,7 @@ class SignApkTest(TestAndroidBase):
 
   def test_no_config_file_defined(self):
     with self.assertRaises(TaskError):
-      task = self.prepare_task(config=self._get_config(location=""),
+      task = self.prepare_task(config=self._get_config(location=''),
                                build_graph=self.build_graph,
                                build_file_parser=self.build_file_parser)
       task.config_file
@@ -79,14 +79,14 @@ class SignApkTest(TestAndroidBase):
 
   def test_no_section_in_pantsini(self):
     with self.assertRaises(TaskError):
-      task = self.prepare_task(config=self._get_config(location=""),
+      task = self.prepare_task(config=self._get_config(location=''),
                                build_graph=self.build_graph,
                                build_file_parser=self.build_file_parser)
       task.config_file
 
   def test_overriding_config_with_cli(self):
     with temporary_dir() as temp:
-      task = self.prepare_task(config=self._get_config(section="bad-section-header"),
+      task = self.prepare_task(config=self._get_config(section='bad-section-header'),
                                args=['--test-keystore-config-location={0}'.format(temp)],
                                build_graph=self.build_graph,
                                build_file_parser=self.build_file_parser)
@@ -103,8 +103,8 @@ class SignApkTest(TestAndroidBase):
     with temporary_dir() as temp:
       with self.android_binary() as android_binary:
         task = self.prepare_task(config=self._get_config(),
-                                   build_graph=self.build_graph,
-                                   build_file_parser=self.build_file_parser)
+                                 build_graph=self.build_graph,
+                                 build_file_parser=self.build_file_parser)
         target = android_binary
         fake_key = self.FakeKeystore()
         task._dist = self.FakeDistribution()

--- a/tests/python/pants_test/android/tasks/test_sign_apk.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk.py
@@ -108,8 +108,10 @@ class SignApkTest(TestAndroidBase):
                         'binary.debug.signed.apk')
 
   def test_setup_default_config(self):
-    with temporary_file() as temp:
-      SignApkTask.setup_default_config(temp.name)
+    with temporary_dir() as temp:
+      default_config = os.path.join(temp, 'default_config.ini')
+      SignApkTask.setup_default_config(default_config)
+      self.assertTrue(os.path.isfile(default_config))
 
   def test_setup_default_config_no_permission(self):
     with self.assertRaises(TaskError):


### PR DESCRIPTION
No arbitrary config access, no CONFIG_SECTION etc.

I do not define a default for the keystore_config_location in the
task because we actually produce a default file. If the keystore_location
is changed, I don't want to fallback to a default silently or
else the user may not know that their config wasn't used.