### PR TITLE
[Trigger CI] Replace config use in RunTracker with options.

### DIFF
--- a/src/python/pants/backend/core/tasks/reporting_server.py
+++ b/src/python/pants/backend/core/tasks/reporting_server.py
@@ -15,7 +15,6 @@ import sys
 from pants import binary_util
 from pants.backend.core.tasks.task import QuietTaskMixin, Task
 from pants.base.build_environment import get_buildroot
-from pants.base.run_info import RunInfo
 from pants.reporting.reporting_server import ReportingServer, ReportingServerManager
 
 
@@ -36,6 +35,8 @@ class RunServer(Task, QuietTaskMixin):
                   'your source code is exposed to all allowed clients!')
     register('--open', action='store_true', default=False,
              help='Attempt to open the server web ui in a browser.')
+    register('--template-dir', help='Use templates from this dir instead of the defaults.')
+    register('--assets-dir', help='Use assets from this dir instead of the defaults.')
 
   def execute(self):
     DONE = '__done_reporting'
@@ -66,11 +67,13 @@ class RunServer(Task, QuietTaskMixin):
         # but is allowed to block indefinitely on the server loop.
         if not os.fork():
           # Child process.
-          info_dir = RunInfo.dir(self.context.config)
+          # The server finds run-specific info dirs by looking at the subdirectories of info_dir,
+          # which is conveniently and obviously the parent dir of the current run's info dir.
+          info_dir = os.path.dirname(self.context.run_tracker.run_info_dir)
           # If these are specified explicitly in the config, use those. Otherwise
           # they will be None, and we'll use the ones baked into this package.
-          template_dir = self.context.config.get('reporting', 'reports_template_dir')
-          assets_dir = self.context.config.get('reporting', 'reports_assets_dir')
+          template_dir = self.get_options().template_dir
+          assets_dir = self.get_options().assets_dir
           settings = ReportingServer.Settings(info_dir=info_dir, template_dir=template_dir,
                                               assets_dir=assets_dir, root=get_buildroot(),
                                               allowed_clients=self.get_options().allowed_clients)

--- a/src/python/pants/base/run_info.py
+++ b/src/python/pants/base/run_info.py
@@ -20,16 +20,6 @@ class RunInfo(object):
 
   Can only be appended to, never edited.
   """
-
-  @classmethod
-  def dir(cls, config):
-    """Returns the configured base directory run info files are stored under."""
-    # TODO(John Sirois): This is centralized, but in an awkward location.  Isolate RunInfo reading
-    # and writing in 1 package or class that could naturally know this location and synthesize
-    # info_file names.
-    return config.getdefault('info_dir',
-                             default=os.path.join(config.getdefault('pants_workdir'), 'runs'))
-
   def __init__(self, info_file):
     self._info_file = info_file
     safe_mkdir_for(self._info_file)

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -145,7 +145,7 @@ class WorkUnit(object):
     if not m or m.group(0) != name:
       raise Exception('Invalid output name: %s' % name)
     if name not in self._outputs:
-      path = os.path.join(self.run_tracker.info_dir, 'tool_outputs', '%s.%s' % (self.id, name))
+      path = os.path.join(self.run_tracker.run_info_dir, 'tool_outputs', '%s.%s' % (self.id, name))
       safe_mkdir_for(path)
       self._outputs[name] = FileBackedRWBuf(path)
     return self._outputs[name]

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -66,7 +66,9 @@ class GoalRunner(object):
 
     # Now that plugins and backends are loaded, we can gather the known scopes.
     self.targets = []
-    known_scopes = ['']
+    # TODO: Create a 'Subsystem' abstraction instead of special-casing run-tracker here
+    # and in register_options().
+    known_scopes = ['', 'run-tracker']
     for goal in Goal.all():
       # Note that enclosing scopes will appear before scopes they enclose.
       known_scopes.extend(filter(None, goal.known_scopes()))
@@ -79,7 +81,7 @@ class GoalRunner(object):
     # Enable standard python logging for code with no handle to a context/work-unit.
     self._setup_logging()  # NB: self.options are needed for this call.
 
-    self.run_tracker = RunTracker.from_config(self.config)
+    self.run_tracker = RunTracker.from_options(self.options)
     report = initial_reporting(self.config, self.run_tracker)
     self.run_tracker.start(report)
     url = self.run_tracker.run_info.get_info('report_url')
@@ -127,6 +129,11 @@ class GoalRunner(object):
       return self.options.register_global(*args, **kwargs)
     register_global.bootstrap = self.options.bootstrap_option_values()
     register_global_options(register_global)
+
+    def register_run_tracker(*args, **kwargs):
+      self.options.register('run-tracker', *args, **kwargs)
+    RunTracker.register_options(register_run_tracker)
+
     for goal in Goal.all():
       goal.register_options(self.options)
 

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -93,7 +93,6 @@ python_library(
     'src/python/pants/base:worker_pool',
     'src/python/pants/base:workunit',
     'src/python/pants/reporting', # XXX(fixme)
-    'src/python/pants/base:config',
   ],
 )
 

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -123,6 +123,12 @@ migrations = {
   ('ide', 'extra_jvm_source_paths'): ('idea', 'extra_jvm_source_paths'),
   ('ide', 'extra_jvm_test_paths'): ('idea', 'extra_jvm_test_paths'),
   ('ide', 'debug_port'): ('idea', 'debug_port'),
+
+
+  ('DEFAULT', 'stats_upload_url'): ('run-tracker', 'stats_upload_url'),
+  ('DEFAULT', 'stats_upload_timeout'): ('run-tracker', 'stats_upload_timeout'),
+  ('DEFAULT', 'num_foreground_workers'): ('run-tracker', 'num_foreground_workers'),
+  ('DEFAULT', 'num_background_workers'): ('run-tracker', 'num_background_workers'),
 }
 
 notes = {


### PR DESCRIPTION
- RunTracker now registers its options.
- This is the first case we have of non-task, non-global options.
- The current implementation special-cases RunTracker, and is temporary.
- In the near future it will be replaced with a 'Subsystem' abstraction.
- But for now this is useful for kicking the tires.