### PR TITLE
Introduce pants_setup_py and contrib_setup_py helpers.

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -55,8 +55,20 @@ Contrib plugins should generally follow 3 basic setup steps:
      ]
    ```
 
-3. When you're ready for your plugin to be distributed, add a `provides` `setup_py` descriptor to
-   your main plugin BUILD target and register the plugin with the release script.
+3. When you're ready for your plugin to be distributed, add a `provides` `contrib_setup_py`
+   descriptor to your main plugin BUILD target and register the plugin with the release script.
+   The `provides` descriptor just requires a name and decription for your plugin suitable for
+   [pypi](https://pypi.python.org/pypi):
+   ```python
+   python_library(
+      name='plugin',
+      sources=['register.py'],
+      provides=contrib_setup_py(
+        name='pantsbuild.pants.contrib.example',
+        description='An example pants contrib plugin.'
+      )
+   )
+   ```
    To register with the release script, add an entry to `contrib/release_packages.sh`:
    ```bash
    PKG_EXAMPLE=(

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -89,10 +89,10 @@ Contrib plugins should generally follow 3 basic setup steps:
    )
    ```
    NB: The act of releasing your contrib distribution is part of of the normal `pantsbuild.pants`
-   [[release process|pants('src/python/pants/docs:release')]].  You may need request a release from
-   the owners if you have a change that should be fast-tracked before the next `pantsbuild.pants`
-   release.  You can always test that your contrib distribution works though by doing a release dry
-   run:
+   [release process](https://pantsbuild.github.io/howto_contribute.html).  You may need request a
+   release from the owners if you have a change that should be fast-tracked before the next
+   `pantsbuild.pants` release.  You can always test that your contrib distribution works though by
+   doing a release dry run:
    ```bash
-   ./build-support/bin/release.sh -n`
+   ./build-support/bin/release.sh -n
    ```

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -89,8 +89,8 @@ Contrib plugins should generally follow 3 basic setup steps:
    )
    ```
    NB: The act of releasing your contrib distribution is part of of the normal `pantsbuild.pants`
-   [release process](https://pantsbuild.github.io/howto_contribute.html).  You may need request a
-   release from the owners if you have a change that should be fast-tracked before the next
+   [release process](https://pantsbuild.github.io/howto_contribute.html).  You may need to request
+   a release from the owners if you have a change that should be fast-tracked before the next
    `pantsbuild.pants` release.  You can always test that your contrib distribution works though by
    doing a release dry run:
    ```bash

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -9,7 +9,7 @@ plugin APIs are used.
 
 Most new plugins should get their own top-level `contrib/` subdirectory although it may make sense
 to house the source code for related plugins under one top-level `contrib/` subdirectory.  The
-`contrib/scrooge` directory is an example of this and houses 2 plugin tasks that both use the same
+`contrib/scrooge` directory is an example of this and houses two plugin tasks that both use the same
 underlying [Scrooge](https://github.com/twitter/scrooge) tool.
 
 Contrib plugins should generally follow 3 basic setup steps:
@@ -57,7 +57,7 @@ Contrib plugins should generally follow 3 basic setup steps:
 
 3. When you're ready for your plugin to be distributed, add a `provides` `contrib_setup_py`
    descriptor to your main plugin BUILD target and register the plugin with the release script.
-   The `provides` descriptor just requires a name and decription for your plugin suitable for
+   The `provides` descriptor just requires a name and description for your plugin suitable for
    [pypi](https://pypi.python.org/pypi):
    ```python
    python_library(
@@ -87,4 +87,12 @@ Contrib plugins should generally follow 3 basic setup steps:
      PKG_SCROOGE
      PKG_EXAMPLE
    )
+   ```
+   NB: The act of releasing your contrib distribution is part of of the normal `pantsbuild.pants`
+   [[release process|pants('src/python/pants/docs:release')]].  You may need request a release from
+   the owners if you have a change that should be fast-tracked before the next `pantsbuild.pants`
+   release.  You can always test that your contrib distribution works though by doing a release dry
+   run:
+   ```bash
+   ./build-support/bin/release.sh -n`
    ```

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
@@ -2,33 +2,17 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'plugin',
-  sources = ['register.py'],
-  dependencies = [
+  name='plugin',
+  sources=['register.py'],
+  dependencies=[
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks',
     'src/python/pants/goal:task_registrar',
   ],
-  provides=setup_py(
+  provides=contrib_setup_py(
     name='pantsbuild.pants.contrib.scrooge',
-    version=pants_version(),
     description='Scrooge thrift generator pants plugins.',
-    long_description=(
-      read_contents('src/python/pants/ABOUT.rst', relative_to_buildroot=True) +
-      read_contents('src/python/pants/CHANGELOG.rst', relative_to_buildroot=True)),
-    url='https://github.com/pantsbuild/pants',
-    license='Apache License, Version 2.0',
-    zip_safe=True,
-    namespace_packages=['pants'],
-    classifiers=[
-      'Intended Audience :: Developers',
-      'License :: OSI Approved :: Apache Software License',
-      # We know for a fact these OSs work but, for example, know Windows
-      # does not work yet.  Take the conservative approach and only list OSs
-      # we know pants works with for now.
-      'Operating System :: MacOS :: MacOS X',
-      'Operating System :: POSIX :: Linux',
-      'Programming Language :: Python',
-      'Topic :: Software Development :: Build Tools',
+    additional_classifiers=[
+      'Topic :: Software Development :: Code Generators'
     ]
   )
 )

--- a/pants-plugins/src/python/internal_backend/utilities/BUILD
+++ b/pants-plugins/src/python/internal_backend/utilities/BUILD
@@ -2,9 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'plugin',
-  sources = ['register.py'],
-  dependencies = [
+  name='plugin',
+  sources=['register.py'],
+  dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/python:python_artifact',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_aliases',
   ]

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -36,7 +36,7 @@ def pants_setup_py(name, description, namespace_packages=None, additional_classi
   classifiers = OrderedSet(standard_classifiers + (additional_classifiers or []))
 
   def _read_contents(path):
-    with open(os.path.join(get_buildroot(), path)) as fp:
+    with open(os.path.join(get_buildroot(), path), 'rb') as fp:
       return fp.read()
 
   return PythonArtifact(

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -7,21 +7,74 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pants.base.build_environment import get_buildroot
+from twitter.common.collections import OrderedSet
+
+from pants.backend.python.python_artifact import PythonArtifact
+from pants.base.build_environment import get_buildroot, pants_version
 from pants.base.build_file_aliases import BuildFileAliases
 
 
-def read_contents_factory(parse_context):
-  def read_contents(path, relative_to_buildroot=False):
-    base_dir = get_buildroot() if relative_to_buildroot else parse_context.rel_path
-    with open(os.path.join(base_dir, path)) as fp:
+def pants_setup_py(name, description, namespace_packages=None, additional_classifiers=None):
+  """Creates the setup_py for a pants artifact.
+
+  :param str name: The name of the package.
+  :param str description: A brief description of what the package provides.
+  :param list additional_classifiers: Any additional trove classifiers that apply to the package,
+                                      see: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+  :returns: A setup_py suitable for building and publishing pants components.
+  """
+  standard_classifiers = [
+      'Intended Audience :: Developers',
+      'License :: OSI Approved :: Apache Software License',
+      # We know for a fact these OSs work but, for example, know Windows
+      # does not work yet.  Take the conservative approach and only list OSs
+      # we know pants works with for now.
+      'Operating System :: MacOS :: MacOS X',
+      'Operating System :: POSIX :: Linux',
+      'Programming Language :: Python',
+      'Topic :: Software Development :: Build Tools']
+  classifiers = OrderedSet(standard_classifiers + (additional_classifiers or []))
+
+  def _read_contents(path):
+    with open(os.path.join(get_buildroot(), path)) as fp:
       return fp.read()
-  return read_contents
+
+  return PythonArtifact(
+      name=name,
+      version=pants_version(),
+      description=description,
+      long_description=(_read_contents('src/python/pants/ABOUT.rst') +
+                        _read_contents('src/python/pants/CHANGELOG.rst')),
+      url='https://github.com/pantsbuild/pants',
+      license='Apache License, Version 2.0',
+      zip_safe=True,
+      namespace_packages=namespace_packages,
+      classifiers=list(classifiers))
+
+
+def contrib_setup_py(name, description, additional_classifiers=None):
+  """Creates the setup_py for a pants contrib plugin artifact.
+
+  :param str name: The name of the package; must start with 'pantsbuild.pants.contrib.'.
+  :param str description: A brief description of what the plugin provides.
+  :param list additional_classifiers: Any additional trove classifiers that apply to the plugin,
+                                      see: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+  :returns: A setup_py suitable for building and publishing pants components.
+  """
+  if not name.startswith('pantsbuild.pants.contrib.'):
+    raise ValueError("Contrib plugin package names must start with 'pantsbuild.pants.contrib.', "
+                     "given {}".format(name))
+
+  return pants_setup_py(name,
+                        description,
+                        namespace_packages=['pants', 'pants.contrib'],
+                        additional_classifiers=additional_classifiers)
 
 
 def build_file_aliases():
   return BuildFileAliases.create(
-    context_aware_object_factories={
-      'read_contents': read_contents_factory
+    objects={
+      'pants_setup_py': pants_setup_py,
+      'contrib_setup_py': contrib_setup_py
     }
   )

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -2,35 +2,19 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name = 'pants',
-  dependencies = [
+  name='pants',
+  dependencies=[
     'src/python/pants/bin:pants',
   ],
-  description = 'An alias for the pants binary target.',
+  description='An alias for the pants binary target.',
 )
 
 python_library(
-  name = 'pants-packaged',
-  provides=setup_py(
+  name='pants-packaged',
+  provides=pants_setup_py(
     name='pantsbuild.pants',
-    version=pants_version(),
     description='A bottom-up build tool.',
-    long_description=read_contents('ABOUT.rst') + read_contents('CHANGELOG.rst'),
-    url='https://github.com/pantsbuild/pants',
-    license='Apache License, Version 2.0',
-    zip_safe=True,
     namespace_packages=['pants'],
-    classifiers=[
-      'Intended Audience :: Developers',
-      'License :: OSI Approved :: Apache Software License',
-      # We know for a fact these OSs work but, for example, know Windows
-      # does not work yet.  Take the conservative approach and only list OSs
-      # we know pants works with for now.
-      'Operating System :: MacOS :: MacOS X',
-      'Operating System :: POSIX :: Linux',
-      'Programming Language :: Python',
-      'Topic :: Software Development :: Build Tools',
-    ]
   ).with_binaries(
     # TODO(John Sirois): Switch back when target cycles have been sorted out.
     # pants='src/python/pants/bin:pants',
@@ -48,25 +32,11 @@ python_library(
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
     'tests/python/pants_test/engine:engine_test_base',
   ],
-  provides=setup_py(
+  provides=pants_setup_py(
     name='pantsbuild.pants.testinfra',
-    version=pants_version(),
     description='Test support for writing pants plugins.',
-    long_description=read_contents('ABOUT.rst') + read_contents('CHANGELOG.rst'),
-    url='https://github.com/pantsbuild/pants',
-    license='Apache License, Version 2.0',
-    zip_safe=True,
     namespace_packages=['pants_test'],
-    classifiers=[
-      'Intended Audience :: Developers',
-      'License :: OSI Approved :: Apache Software License',
-      # We know for a fact these OSs work but, for example, know Windows
-      # does not work yet.  Take the conservative approach and only list OSs
-      # we know pants works with for now.
-      'Operating System :: MacOS :: MacOS X',
-      'Operating System :: POSIX :: Linux',
-      'Programming Language :: Python',
-      'Topic :: Software Development :: Build Tools',
+    additional_classifiers=[
       'Topic :: Software Development :: Testing',
     ]
   )
@@ -78,9 +48,9 @@ page(name='readme',
 
 # XXX move into base or thrift
 python_library(
-  name = 'binary_util',
-  sources = ['binary_util.py'],
-  dependencies = [
+  name='binary_util',
+  sources=['binary_util.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:six',
     'src/python/pants/base:config',
@@ -91,16 +61,16 @@ python_library(
 )
 
 python_library(
-  name = 'thrift_util',
-  sources = ['thrift_util.py'],
-  dependencies = [
+  name='thrift_util',
+  sources=['thrift_util.py'],
+  dependencies=[
     ':binary_util',
   ],
 )
 
 python_library(
-  name = 'version',
-  sources = ['version.py'],
+  name='version',
+  sources=['version.py'],
 )
 
 page(


### PR DESCRIPTION
A bit of DRY help for creating a provides setup_py artifact descriptor
for pants artifacts and, in particular, contrib plugin artifacts.

https://rbcommons.com/s/twitter/r/1822/