### PR TITLE
Add pants_bootstradir and pants_configdir to options bootstrapper.

### DIFF
--- a/src/python/pants/backend/android/tasks/BUILD
+++ b/src/python/pants/backend/android/tasks/BUILD
@@ -85,7 +85,6 @@ python_library(
     'src/python/pants/backend/android:keystore_resolver',
     'src/python/pants/backend/android/targets:android',
     'src/python/pants/backend/core/tasks:common',
-    'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/java:distribution',

--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -13,7 +13,6 @@ from pants.backend.android.android_config_util import AndroidConfigUtil
 from pants.backend.android.keystore.keystore_resolver import KeystoreResolver
 from pants.backend.android.targets.android_binary import AndroidBinary
 from pants.backend.core.tasks.task import Task
-from pants.base.build_environment import get_pants_configdir
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 from pants.java.distribution.distribution import Distribution
@@ -68,7 +67,7 @@ class SignApkTask(Task):
     super(SignApkTask, self).__init__(*args, **kwargs)
     self._config_file = self.get_options().keystore_config_location
     self._distdir = self.get_options().pants_distdir
-    self._configdir = get_pants_configdir()
+    self._configdir = self.get_options().pants_configdir
     self._dist = None
 
   @property

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -132,7 +132,6 @@ class Bootstrapper(object):
     # https://jira.twitter.biz/browse/DPB-283
     ivy_bootstrap_dir = \
       os.path.join(self._config.getdefault('pants_bootstrapdir'), 'tools', 'jvm', 'ivy')
-    ivy_bootstrap_dir = os.path.expanduser(ivy_bootstrap_dir) # Support ~ in pants_bootstrapdir.
 
     digest = hashlib.sha1()
     if os.path.isfile(self._version_or_ivyxml):

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import sys
 
-from pants.base.build_environment import get_buildroot
+from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
 from pants.base.config import Config
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.options import Options
@@ -29,6 +29,10 @@ def register_bootstrap_options(register, buildroot=None):
   status as "bootstrap options" is only pertinent during option registration.
   """
   buildroot = buildroot or get_buildroot()
+  register('--pants-bootstrapdir', metavar='<dir>', default=get_pants_cachedir(),
+           help='Use this dir for global cache.')
+  register('--pants-configdir', metavar='<dir>', default=get_pants_configdir(),
+         help='Use this dir for global config files.')
   register('--pants-workdir', metavar='<dir>', default=os.path.join(buildroot, '.pants.d'),
            help='Write intermediate output files to this dir.')
   register('--pants-supportdir', metavar='<dir>', default=os.path.join(buildroot, 'build-support'),


### PR DESCRIPTION
This makes these values available to all classes plumbed with
the options system. The only places I see the boostrapdir used
are in binary_utils and in the ivy boostrapper. So as they config
access is removed from those classes, then they can convert
to getting the pants_bootstrapdir form the options.

Removed the expanduser call from the ivy class as it is now
redundant. The expanduser happens in the get_cachedir() call
that sets pants_bootstrapdir.