### PR TITLE
Removed parallel_test_paths setting from pants.ini.  

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -127,12 +127,6 @@ runtime-deps: ["//:scala-library"]
 jvm_options: ["-Xmx2g", "-XX:MaxPermSize=256m", "-Dzinc.analysis.cache.limit=0"]
 
 
-[jvm]
-# TODO(John Sirois): Kill this when commons tests are converted to use explicit test target
-# (default is False).
-parallel_test_paths: True
-
-
 [run.jvm]
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 


### PR DESCRIPTION
It isn't needed in the pants repo any more and we'd like to remove support for it entirely.