### PR TITLE
Fix regexp in test_setup.py test.

### DIFF
--- a/tests/python/pants_test/logging/test_setup.py
+++ b/tests/python/pants_test/logging/test_setup.py
@@ -56,6 +56,6 @@ class SetupTest(unittest.TestCase):
       with open(log_file) as fp:
         loglines = fp.read().splitlines()
         self.assertEqual(2, len(loglines))
-        glog_format = r'\d{4} \d{2}:\d{2}:\d{2}.\d{6} \d+ \w+\.py:\d+] '
+        glog_format = r'\d{4} \d{2}:\d{2}:\d{2}.\d+ \d+ \w+\.py:\d+] '
         self.assertRegexpMatches(loglines[0], r'^W{}warn$'.format(glog_format))
         self.assertRegexpMatches(loglines[1], r'^I{}info$'.format(glog_format))


### PR DESCRIPTION
test_setup.py flaked out on the string 'W0302 16:52:41.90029 4057 test_setup.py:48] warn'
See: https://travis-ci.org/pantsbuild/pants/builds/52767020