### PR TITLE
Fixup CppToolchain to be lazy and actually cache.

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/toolchain/cpp_toolchain.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/toolchain/cpp_toolchain.py
@@ -9,29 +9,40 @@ import os
 
 
 class CppToolchain(object):
-  """
-  Represents the cpp toolchain on the local system.
-  """
+  """Represents the cpp toolchain on the local system."""
 
   class Error(Exception):
     """Indicates an invalid cpp toolchain."""
 
   def __init__(self, compiler=None):
     """Create a cpp toolchain and cache tools for quick retrieval."""
-    self._validated_tools = set()
-    _compiler = compiler or os.environ.get('CXX')
+    self._validated_tools = {}
+    self._compiler = compiler
+
+  @property
+  def compiler(self):
+    if 'compiler' in self._validated_tools:
+      return self._validated_tools['compiler']
+
+    _compiler = self._compiler or os.environ.get('CXX')
     if _compiler is None:
       raise self.Error('Please set the CXX environment variable or the "compiler" option.')
-    self.compiler = self.register_tool(_compiler)
+    return self.register_tool(name='compiler', tool=_compiler)
 
-  def register_tool(self, tool):
+  def register_tool(self, tool, name=None):
     """Check tool and see if it is installed in the local cpp toolchain.
 
     All cpp tasks should request their tools using this method. Tools are validated
     and cached for quick lookup.
 
-    :param string tool: Name of tool, eg 'g++'
+    :param string tool: Name or path of program tool, eg 'g++'
+    :param string name: Logical name of tool, eg 'compiler'. If not supplied defaults to basename
+                        of `tool`
     """
+    name = name or os.path.basename(tool)
+    if name in self._validated_tools:
+      return self._validated_tools[name]
+
     def which(program):
       def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
@@ -49,14 +60,8 @@ class CppToolchain(object):
 
       return None
 
-    cpp_tool = which(tool)
-    if cpp_tool is None:
+    tool_path = which(tool)
+    if tool_path is None:
       raise self.Error('Failed to locate {0}. Please install.'.format(tool))
-
-    self._register_file(cpp_tool)
-    return cpp_tool
-
-  def _register_file(self, tool):
-    if tool not in self._validated_tools:
-      self._validated_tools.add(tool)
-    return tool
+    self._validated_tools[name] = tool_path
+    return tool_path

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
@@ -22,10 +22,10 @@ class CppIntegrationTest(PantsRunIntegrationTest):
   @classmethod
   def has_compiler(cls):
     try:
-      compiler = CppToolchain().compiler
-    except Exception:
+      CppToolchain().compiler
+      return True
+    except CppToolchain.Error:
       return False
-    return True
 
   @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
                       reason='cpp integration tests require compiler')

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_toolchain.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_toolchain.py
@@ -15,7 +15,7 @@ from pants.util.dirutil import chmod_plus_x, touch
 from pants.contrib.cpp.toolchain.cpp_toolchain import CppToolchain
 
 
-class TestCppToolchainTest(unittest.TestCase):
+class CppToolchainTest(unittest.TestCase):
   @contextmanager
   def tool(self, name):
     with temporary_dir() as tool_root:
@@ -40,8 +40,7 @@ class TestCppToolchainTest(unittest.TestCase):
 
   def test_tool_registration(self):
     with self.tool('good-tool') as tool_path:
-      self.assertEqual(tool_path, CppToolchain().register_tool(name='foo',
-                                                               tool=os.path.basename(tool_path)))
+      self.assertEqual(tool_path, CppToolchain().register_tool(name='foo', tool='good-tool'))
 
   def test_invalid_tool_registration(self):
     with self.assertRaises(CppToolchain.Error):

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_toolchain.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_toolchain.py
@@ -7,36 +7,42 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import unittest
+from contextlib import contextmanager
 
-import pytest
-from pants.util.contextutil import environment_as, temporary_dir
+from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import chmod_plus_x, touch
 
 from pants.contrib.cpp.toolchain.cpp_toolchain import CppToolchain
 
 
 class TestCppToolchainTest(unittest.TestCase):
-  def setUp(self):
-    super(TestCppToolchainTest, self).setUp()
+  @contextmanager
+  def tool(self, name):
+    with temporary_dir() as tool_root:
+      tool_path = os.path.join(tool_root, name)
+      touch(tool_path)
+      chmod_plus_x(tool_path)
+      new_path = os.pathsep.join([tool_root] + os.environ.get('PATH', '').split(os.pathsep))
+      with environment_as(PATH=new_path):
+        yield tool_path
 
   def test_default_compiler_from_environ(self):
-    with environment_as(CXX='g++'):
-      assert(CppToolchain().compiler == CppToolchain().register_tool('g++'))
+    with self.tool('g++') as tool_path:
+      with environment_as(CXX='g++'):
+        self.assertEqual(CppToolchain().compiler, tool_path)
+        self.assertEqual(CppToolchain().compiler,
+                         CppToolchain().register_tool(name='compiler', tool=tool_path))
 
   def test_invalid_compiler(self):
-    with pytest.raises(CppToolchain.Error):
-      CppToolchain('not-a-command')
+    cpp_toolchain = CppToolchain(compiler='not-a-command')
+    with self.assertRaises(CppToolchain.Error):
+      cpp_toolchain.compiler
 
   def test_tool_registration(self):
-    with temporary_dir() as tool_root:
-      newpath = os.pathsep.join((os.environ['PATH'], tool_root))
-      with environment_as(PATH=newpath):
-        GOODTOOL = 'good-tool'
-        goodtool_path = os.path.join(tool_root, GOODTOOL)
-        touch(goodtool_path)
-        chmod_plus_x(goodtool_path)
-        CppToolchain().register_tool(GOODTOOL)
+    with self.tool('good-tool') as tool_path:
+      self.assertEqual(tool_path, CppToolchain().register_tool(name='foo',
+                                                               tool=os.path.basename(tool_path)))
 
   def test_invalid_tool_registration(self):
-    with pytest.raises(CppToolchain.Error):
+    with self.assertRaises(CppToolchain.Error):
       CppToolchain().register_tool('not-a-command')


### PR DESCRIPTION
Previously the c++ compiler was resolved in the constructor.  Doing this
work in the constructor made every indirect user pay the price with the
concrete example being the test_cpp_toolchain.py unit tests which would
fail if run without CXX exported.

Also, only the compiler tool was cached, other tool lookups via
register_tool populated but did not use the cache.  Fixup register_tool
to fully self-contain its caching behavior.

Finally, fixup test_cpp_toolchain.py to be unit-friendly and run in the
absence of CXX being exported and also tighten up
test_cpp_integration.py exception trapping.

https://rbcommons.com/s/twitter/r/1850/