### PR TITLE
Fixup Config to find DEFAULT values for missing sections.

### DIFF
--- a/src/python/pants/base/config.py
+++ b/src/python/pants/base/config.py
@@ -19,8 +19,6 @@ except ImportError:
   import configparser as ConfigParser
 
 
-
-
 def reset_default_bootstrap_option_values(defaults, values=None, buildroot=None):
   """Reset the bootstrap options' default values.
 
@@ -136,6 +134,8 @@ class Config(object):
     """
     return ConfigParser.SafeConfigParser(cls._defaults)
 
+  # TODO(John Sirois): s/type/type_/
+
   def getbool(self, section, option, default=None):
     """Equivalent to calling get with expected type bool."""
     return self.get(section, option, type=bool, default=default)
@@ -157,23 +157,24 @@ class Config(object):
     return self.get(section, option, type=dict, default=default)
 
   def getdefault(self, option, type=str, default=None):
-    """
-      Retrieves option from the DEFAULT section if it exists and attempts to parse it as type.
-      If there is no definition found, the default value supplied is returned.
+    """Retrieves option from the DEFAULT section if it exists and attempts to parse it as type.
+
+    If there is no definition found, the default value supplied is returned.
     """
     return self.get(Config.DEFAULT_SECTION, option, type, default=default)
 
   def get(self, section, option, type=str, default=None):
-    """
-      Retrieves option from the specified section if it exists and attempts to parse it as type.
-      If the specified section is missing a definition for the option, the value is looked up in the
-      DEFAULT section.  If there is still no definition found, the default value supplied is
-      returned.
+    """Retrieves option from the specified section (or 'DEFAULT') and attempts to parse it as type.
+
+    If the specified section does not exist or is missing a definition for the option, the value is
+    looked up in the DEFAULT section.  If there is still no definition found, the default value
+    supplied is returned.
     """
     return self._getinstance(section, option, type, default=default)
 
   def get_required(self, section, option, type=str):
     """Retrieves option from the specified section and attempts to parse it as type.
+
     If the specified section is missing a definition for the option, the value is
     looked up in the DEFAULT section. If there is still no definition found,
     a `ConfigError` is raised.
@@ -258,10 +259,14 @@ class SingleFileConfig(Config):
     return self.configparser.has_section(section)
 
   def has_option(self, section, option):
-    return self.configparser.has_option(section, option)
+    return (self.configparser.has_option(section, option) or
+            self.configparser.has_option(self.DEFAULT_SECTION, option))
 
   def get_value(self, section, option):
-    return self.configparser.get(section, option)
+    if self.configparser.has_option(section, option):
+      return self.configparser.get(section, option)
+    else:
+      return self.configparser.get(self.DEFAULT_SECTION, option)
 
 
 class ChainedConfig(Config):

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -45,6 +45,7 @@ target(
     ':build_invalidator',
     ':build_root',
     ':cmd_line_spec_parser',
+    ':config',
     ':deprecated',
     ':extension_loader',
     ':fingerprint_strategy',
@@ -202,6 +203,15 @@ python_tests(
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:cmd_line_spec_parser',
     'tests/python/pants_test:base_test',
+  ]
+)
+
+python_tests(
+  name = 'config',
+  sources = ['test_config.py'],
+  dependencies = [
+    'src/python/pants/base:config',
+    'src/python/pants/util:contextutil',
   ]
 )
 

--- a/tests/python/pants_test/base/test_config.py
+++ b/tests/python/pants_test/base/test_config.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -50,6 +50,8 @@ class ConfigTest(unittest.TestCase):
 
           [b]
           preempt: False
+
+          [defined_section]
           """))
         ini2.close()
         self.config = Config.load(configpaths=[ini1.name, ini2.name])
@@ -85,7 +87,7 @@ that.""",
     self._check_defaults(self.config.get, [])
     self._check_defaults(self.config.get, [42])
 
-  def test_getmap(self):
+  def test_getdict(self):
     self.assertEquals(dict(a=1, b=42, c=['42', 42]), self.config.getdict('b', 'dict'))
     self._check_defaults(self.config.get, {})
     self._check_defaults(self.config.get, dict(a=42))
@@ -107,8 +109,14 @@ that.""",
     self.assertEquals('foo', self.config.getdefault('name', type=str))
 
   def test_getdefault_not_found(self):
+    # TODO(John Sirois): This is an odd test that highlights odd eval behavior buried in Config.
+    # Switch to ast.literal_eval, trap ValueError, and raise ConfigErrors.
     with self.assertRaises(NameError):
-      self.assertEquals('foo', self.config.getdefault('name', type=int))
+      self.config.getdefault('name', type=int)
+
+  def test_default_section_fallback(self):
+    self.assertEquals('foo', self.config.get('defined_section', 'name'))
+    self.assertEquals('foo', self.config.get('not_a_defined_section', 'name'))
 
   def _check_defaults(self, accessor, default):
     self.assertEquals(None, accessor('c', 'fast'))

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -24,7 +24,6 @@ target(
     ':builddict',
     ':cache_manager',
     ':check_published_deps',
-    ':config',
     ':console_task',
     ':context',
     ':dependees',
@@ -181,17 +180,6 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:check_published_deps',
     'src/python/pants/base:build_file_aliases',
-  ]
-)
-
-# XXX Uh shouldn't this be in base?
-python_tests(
-  name = 'config',
-  sources = ['test_config.py'],
-  dependencies = [
-    ':base',
-    'src/python/pants/base:config',
-    'src/python/pants/util:contextutil',
   ]
 )
 


### PR DESCRIPTION
This supports the spirit of the `Config.get` and `Options` docs.
Previously the DEFAULT section was only consulted when the section
being queried existed but had no option defined.  Now the DEFAULT
section is also consulted when the section being queried is not
defined at all.  This should support more less brittle configs that
can have global defaults defined for all current and future scopes.

https://rbcommons.com/s/twitter/r/1851/