### PR TITLE
Modernize the protobuf and wire task tests

### DIFF
--- a/tests/python/pants_test/backend/codegen/tasks/BUILD
+++ b/tests/python/pants_test/backend/codegen/tasks/BUILD
@@ -41,9 +41,10 @@ python_tests(
   sources = ['test_protobuf_gen.py'],
   dependencies = [
     'src/python/pants/backend/codegen/tasks:protobuf_gen',
-    'src/python/pants/backend/core/targets:common',
+    'src/python/pants/backend/codegen:plugin',
+    'src/python/pants/backend/core:plugin',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/tasks:base',
+    'tests/python/pants_test:task_test_base',
   ],
 )
 
@@ -77,9 +78,13 @@ python_tests(
   name = 'wire_gen',
   sources = ['test_wire_gen.py'],
   dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/codegen/tasks:wire_gen',
+    'src/python/pants/backend/codegen:plugin',
+    'src/python/pants/backend/core:plugin',
+    'src/python/pants/base:source_root',
+    'src/python/pants/base:validation',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/tasks:base',
-    'tests/python/pants_test/jvm:jar_task_test_base',
+    'tests/python/pants_test:task_test_base',
   ],
 )

--- a/tests/python/pants_test/backend/codegen/tasks/test_wire_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_wire_gen.py
@@ -5,16 +5,27 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from textwrap import dedent
+
+from twitter.common.collections import OrderedSet
+
+from pants.backend.codegen.register import build_file_aliases as register_codegen
 from pants.backend.codegen.tasks.wire_gen import WireGen, calculate_genfiles
+from pants.backend.core.register import build_file_aliases as register_core
+from pants.base.source_root import SourceRoot
 from pants.base.validation import assert_list
 from pants.util.contextutil import temporary_file
-from pants_test.tasks.test_base import TaskTest
+from pants_test.task_test_base import TaskTestBase
 
 
-class WireGenCalculateGenfilesTestBase(TaskTest):
+class WireGenTest(TaskTestBase):
   @classmethod
   def task_type(cls):
     return WireGen
+
+  @property
+  def alias_groups(self):
+    return register_core().merge(register_codegen())
 
   def assert_files(self, lang, rel_path, contents, service_writer, expected_files):
     assert_list(expected_files)
@@ -23,9 +34,6 @@ class WireGenCalculateGenfilesTestBase(TaskTest):
       fp.write(contents)
       fp.close()
       self.assertEqual(set(expected_files), calculate_genfiles(fp.name, rel_path, service_writer)[lang])
-
-
-class WireGenCalculateJavaTest(WireGenCalculateGenfilesTestBase):
 
   def assert_java_files(self, rel_path, contents, service_writer, expected_files):
     self.assert_files('java', rel_path, contents, service_writer, expected_files)
@@ -112,3 +120,30 @@ class WireGenCalculateJavaTest(WireGenCalculateGenfilesTestBase):
       ''',
       'com.squareup.wire.SimpleServiceWriter',
       ['com/pants/protos/preferences/SomeService.java'])
+
+  def test_calculate_sources(self):
+    self.add_to_build_file('wire-lib', dedent('''
+      java_wire_library(name='wire-target',
+        sources=['foo.proto'],
+      )
+      '''))
+    target = self.target('wire-lib:wire-target')
+    context = self.context(target_roots=[target])
+    task = self.create_task(context)
+    result = task._calculate_sources([target])
+    self.assertEquals(1, len(result.keys()))
+    self.assertEquals(OrderedSet(['wire-lib/foo.proto']), result['wire-lib'])
+
+  def test_calculate_sources_with_source_root(self):
+    SourceRoot.register('project/src/main/wire')
+    self.add_to_build_file('project/src/main/wire/wire-lib', dedent('''
+      java_wire_library(name='wire-target',
+        sources=['foo.proto'],
+      )
+      '''))
+    target = self.target('project/src/main/wire/wire-lib:wire-target')
+    context = self.context(target_roots=[target])
+    task = self.create_task(context)
+    result = task._calculate_sources([target])
+    self.assertEquals(1, len(result.keys()))
+    self.assertEquals(OrderedSet(['project/src/main/wire/wire-lib/foo.proto']), result['project/src/main/wire'])


### PR DESCRIPTION
- Get rid of odd inheritance in WireGen test
- Cleanup BUILD deps
- Inherit from TaskTestBase instead of TaskTest
- Add test of _calculate_sources that uses the instantiated task
- Refactor alias_groups() to use shortcuts directly from register.py