### PR TITLE
Refactor AndroidDistribution and increase coverage for that class.

### DIFF
--- a/src/python/pants/backend/android/distribution/android_distribution.py
+++ b/src/python/pants/backend/android/distribution/android_distribution.py
@@ -9,8 +9,7 @@ import os
 
 
 class AndroidDistribution(object):
-  """
-  Represents the Android SDK on the local system.
+  """Represents a Android SDK distribution.
   """
 
   class Error(Exception):
@@ -39,8 +38,8 @@ class AndroidDistribution(object):
     Locate an Android SDK by checking for traditional environmental aliases.
 
     This method returns an AndroidDistribution even if there is no valid SDK on the user's path.
-    There is no verification of valid SDK until an actual tool is requested by a task using
-    AndroidDistribution.register_android_tool()
+    The SDK is not validated until an actual tool or the sdk_path is requested by a task using
+    AndroidDistribution.register_android_tool() or AndroidDistribution.sdk_path.
 
     :param string path: Optional local address of a SDK, set by user in CLI invocation.
     """
@@ -49,7 +48,7 @@ class AndroidDistribution(object):
       return os.path.abspath(sdk) if sdk else None
 
     def search_path(path):
-      # Check path if one is passed at instantiation, then check environmental variables
+      # Check path if one is passed at instantiation, then check environmental variables.
       if path:
         yield os.path.abspath(path)
       yield sdk_path('ANDROID_HOME')
@@ -65,32 +64,36 @@ class AndroidDistribution(object):
   def __init__(self, sdk_path=None):
     """Create an Android distribution and cache tools for quick retrieval."""
     self._sdk_path = sdk_path
+    self._sdk = None
     self._validated_tools = set()
 
+
+  @property
+  def sdk_path(self):
+    """Return the full path of the validated Android sdk."""
+    if not self._sdk:
+      if os.path.isdir(self._sdk_path):
+        self._sdk = self._sdk_path
+      else:
+        raise AndroidDistribution.Error('Failed to locate Android SDK. Please install SDK and '
+                                        'set ANDROID_HOME in your path')
+    return self._sdk
+
   def register_android_tool(self, tool_path):
-    """Check tool_path and see if it is installed in the local Android SDK.
+    """Check tool located at tool_path and see if it is installed in the local Android SDK.
 
-    All android tasks should request their tools using this method. Tools are validated
-    and cached for quick lookup. This is where the _sdk_path is validated.
-
+    All android tasks should request their tools using this method.
     :param string tool_path: Path to tool, relative to the Android SDK root, e.g
       'platforms/android-19/android.jar'.
     """
-    try:
-      android_tool = os.path.join(self._sdk_path, tool_path)
-    except:
-      raise AndroidDistribution.Error('Failed to locate Android SDK. Please install SDK and '
-                                      'set ANDROID_HOME in your path')
-    self._register_file(android_tool)
+    android_tool = os.path.join(self.sdk_path, tool_path)
+    if android_tool not in self._validated_tools:
+        if os.path.isfile(android_tool):
+          self._validated_tools.add(android_tool)
+        else:
+          raise self.Error('There is no {} installed.The Android SDK may need to be updated'
+                           .format(android_tool))
     return android_tool
 
-  def _register_file(self, tool):
-    if tool not in self._validated_tools:
-      if not os.path.isfile(tool):
-        raise self.Error('There is no {0!r} installed.The Android SDK may need to be updated'
-                         .format(tool))
-      self._validated_tools.add(tool)
-    return tool
-
   def __repr__(self):
-    return ('AndroidDistribution({0!r})'.format(self._sdk_path))
+    return 'AndroidDistribution({})'.format(self._sdk_path)

--- a/src/python/pants/backend/android/distribution/android_distribution.py
+++ b/src/python/pants/backend/android/distribution/android_distribution.py
@@ -9,7 +9,7 @@ import os
 
 
 class AndroidDistribution(object):
-  """Represents a Android SDK distribution.
+  """Represents an Android SDK distribution.
   """
 
   class DistributionError(Exception):
@@ -18,7 +18,7 @@ class AndroidDistribution(object):
   class MissingToolError(Exception):
     """Indicates a missing tool at SDK location.
 
-    The sdk_path has been either passed at invocation or as environmental variable. But the needed
+    The sdk_path has been either passed at invocation or as environmental variable but the needed
     tool cannot be found.
     """
 
@@ -29,7 +29,7 @@ class AndroidDistribution(object):
     """
     Check for cached SDK. If not found, instantiate class and search for local SDK.
 
-    :param string path: Optional local address of an SDK, set by user in CLI invocation.
+    :param string path: Optional local address of an SDK, set by user as an option.
     :returns: a new :class:``pants.backend.android.distribution.AndroidDistribution``.
     """
     dist = cls._CACHED_SDK.get(path)
@@ -47,7 +47,7 @@ class AndroidDistribution(object):
     The SDK is not validated until an actual tool or the sdk_path is requested by a task using
     AndroidDistribution.register_android_tool() or AndroidDistribution.sdk_path.
 
-    :param string path: Optional local address of a SDK, set by user in CLI invocation.
+    :param string path: Optional local address of a SDK, set by user as an option.
     """
     def sdk_path(sdk_env_var):
       sdk = os.environ.get(sdk_env_var)
@@ -82,13 +82,13 @@ class AndroidDistribution(object):
         self._sdk = self._sdk_path
       else:
         raise self.DistributionError('Failed to locate Android SDK. Please install '
-                                     'SDK and set ANDROID_HOME in your path')
+                                     'SDK and set ANDROID_HOME in your path.')
     return self._sdk
 
   def register_android_tool(self, tool_path):
     """Check tool located at tool_path and see if it is installed in the local Android SDK.
 
-    All android tasks should request their tools using this method. Tools are verified and then
+    All android tasks should request their tools using this method. Tools are validated and then
     cached for quick lookup.
     :param string tool_path: Path to tool, relative to the Android SDK root, e.g
       'platforms/android-19/android.jar'.
@@ -100,7 +100,7 @@ class AndroidDistribution(object):
         self._validated_tools[tool_path] = android_tool
       else:
         raise self.MissingToolError('There is no {} installed.The Android SDK may need to be '
-                                    'updated'.format(android_tool))
+                                    'updated.'.format(android_tool))
     return self._validated_tools[tool_path]
 
   def __repr__(self):

--- a/src/python/pants/backend/android/distribution/android_distribution.py
+++ b/src/python/pants/backend/android/distribution/android_distribution.py
@@ -17,11 +17,11 @@ class AndroidDistribution(object):
 
   class MissingToolError(Exception):
     """Indicates a missing tool at SDK location.
-    
+
     The sdk_path has been either passed at invocation or as environmental variable. But the needed
     tool cannot be found.
     """
-    
+
   _CACHED_SDK = {}
 
   @classmethod
@@ -99,8 +99,8 @@ class AndroidDistribution(object):
         # Use entire relative path as a key since the SDK usually has multiple copies of each tool.
         self._validated_tools[tool_path] = android_tool
       else:
-        raise self.MissingToolError('There is no {} installed.The Android SDK may need to be updated'
-                               .format(android_tool))
+        raise self.MissingToolError('There is no {} installed.The Android SDK may need to be '
+                                    'updated'.format(android_tool))
     return self._validated_tools[tool_path]
 
   def __repr__(self):

--- a/src/python/pants/backend/android/tasks/android_task.py
+++ b/src/python/pants/backend/android/tasks/android_task.py
@@ -19,11 +19,12 @@ class AndroidTask(Task):
 
   def __init__(self, *args, **kwargs):
     super(AndroidTask, self).__init__(*args, **kwargs)
-    self.forced_sdk = self.get_options().sdk_path or None
+    self._sdk_path = self.get_options().sdk_path or None
     self._android_sdk = None
 
   @property
   def android_sdk(self):
+    """Instantiate an Android SDK distribution that provides tools to android tasks."""
     if self._android_sdk is None:
-      self._android_sdk = AndroidDistribution.cached(self.forced_sdk)
+      self._android_sdk = AndroidDistribution.cached(self._sdk_path)
     return self._android_sdk

--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -32,9 +32,9 @@ python_tests(
 )
 
 python_library(
-  name = 'android_base',
+  name = 'android_mixin',
   sources = [
-    'test_android_base.py',
+    'test_android_mixin.py',
   ],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
@@ -75,7 +75,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/android:android_distribution',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/android:android_base',
+    'tests/python/pants_test/android:android_mixin',
   ]
 )
 

--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -42,7 +42,6 @@ python_library(
     'src/python/pants/backend/android/tasks:all',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test/tasks:base'
   ]
 )
 

--- a/tests/python/pants_test/android/tasks/BUILD
+++ b/tests/python/pants_test/android/tasks/BUILD
@@ -59,7 +59,8 @@ python_tests(
     'src/python/pants/backend/android/tasks:sign_apk',
     'src/python/pants/base:exceptions',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/android:android_base'
+    'tests/python/pants_test/android:android_base',
+    'tests/python/pants_test/tasks:base'
   ],
 )
 
@@ -82,6 +83,7 @@ python_tests(
     'src/python/pants/backend/android/tasks:zipalign',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/android:android_base',
+    'tests/python/pants_test/tasks:base'
   ],
 )
 

--- a/tests/python/pants_test/android/tasks/BUILD
+++ b/tests/python/pants_test/android/tasks/BUILD
@@ -59,7 +59,7 @@ python_tests(
     'src/python/pants/backend/android/tasks:sign_apk',
     'src/python/pants/base:exceptions',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/android:android_base',
+    'tests/python/pants_test/android:android_mixin',
     'tests/python/pants_test/tasks:base'
   ],
 )
@@ -82,7 +82,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/android/tasks:zipalign',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/android:android_base',
+    'tests/python/pants_test/android:android_mixin',
     'tests/python/pants_test/tasks:base'
   ],
 )

--- a/tests/python/pants_test/android/tasks/test_sign_apk.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk.py
@@ -11,11 +11,11 @@ import textwrap
 from pants.backend.android.tasks.sign_apk import SignApkTask
 from pants.base.exceptions import TaskError
 from pants.util.contextutil import temporary_dir, temporary_file
-from pants_test.android.test_android_base import TestAndroidBase
+from pants_test.android.test_android_mixin import TestAndroidMixin
 from pants_test.tasks.test_base import TaskTest
 
 
-class SignApkTest(TaskTest, TestAndroidBase):
+class SignApkTest(TestAndroidMixin, TaskTest):
   """Test the package signing methods in pants.backend.android.tasks.SignApk"""
 
   _TEST_KEYSTORE = '%(homedir)s/.doesnt/matter/keystore_config.ini'

--- a/tests/python/pants_test/android/tasks/test_sign_apk.py
+++ b/tests/python/pants_test/android/tasks/test_sign_apk.py
@@ -12,9 +12,10 @@ from pants.backend.android.tasks.sign_apk import SignApkTask
 from pants.base.exceptions import TaskError
 from pants.util.contextutil import temporary_dir, temporary_file
 from pants_test.android.test_android_base import TestAndroidBase
+from pants_test.tasks.test_base import TaskTest
 
 
-class SignApkTest(TestAndroidBase):
+class SignApkTest(TaskTest, TestAndroidBase):
   """Test the package signing methods in pants.backend.android.tasks.SignApk"""
 
   _TEST_KEYSTORE = '%(homedir)s/.doesnt/matter/keystore_config.ini'

--- a/tests/python/pants_test/android/tasks/test_zipalign.py
+++ b/tests/python/pants_test/android/tasks/test_zipalign.py
@@ -9,9 +9,10 @@ import os
 
 from pants.backend.android.tasks.zipalign import Zipalign
 from pants_test.android.test_android_base import TestAndroidBase
+from pants_test.tasks.test_base import TaskTest
 
 
-class TestZipalign(TestAndroidBase):
+class TestZipalign(TaskTest, TestAndroidBase):
   """Test class for the Zipalign task."""
 
   @classmethod

--- a/tests/python/pants_test/android/tasks/test_zipalign.py
+++ b/tests/python/pants_test/android/tasks/test_zipalign.py
@@ -8,11 +8,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.android.tasks.zipalign import Zipalign
-from pants_test.android.test_android_base import TestAndroidBase
+from pants_test.android.test_android_mixin import TestAndroidMixin
 from pants_test.tasks.test_base import TaskTest
 
 
-class TestZipalign(TaskTest, TestAndroidBase):
+class TestZipalign(TestAndroidMixin, TaskTest):
   """Test class for the Zipalign task."""
 
   @classmethod
@@ -29,8 +29,8 @@ class TestZipalign(TaskTest, TestAndroidBase):
     with self.distribution() as dist:
       with self.android_binary() as android_binary:
         task = self.prepare_task(args=['--test-sdk-path={0}'.format(dist)],
-                                   build_graph=self.build_graph,
-                                   build_file_parser=self.build_file_parser)
+                                 build_graph=self.build_graph,
+                                 build_file_parser=self.build_file_parser)
         target = android_binary
         self.assertEqual(task.zipalign_binary(target),
                          os.path.join(dist, 'build-tools', target.build_tools_version, 'zipalign'))
@@ -52,7 +52,7 @@ class TestZipalign(TaskTest, TestAndroidBase):
                                  build_file_parser=self.build_file_parser)
         target = android_binary
         expected_args = [os.path.join(dist, 'build-tools', target.build_tools_version, 'zipalign'),
-                          '-f', '4', 'package/path',
-                          os.path.join(task._distdir, target.name,
-                                       '{0}.signed.apk'.format(target.name))]
+                         '-f', '4', 'package/path',
+                         os.path.join(task._distdir, target.name,
+                                      '{0}.signed.apk'.format(target.name))]
         self.assertEqual(task._render_args('package/path', target), expected_args)

--- a/tests/python/pants_test/android/test_android_base.py
+++ b/tests/python/pants_test/android/test_android_base.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import textwrap
+import unittest
 from contextlib import contextmanager
 
 from twitter.common.collections import maybe_list
@@ -14,10 +15,9 @@ from twitter.common.collections import maybe_list
 from pants.backend.android.targets.android_binary import AndroidBinary
 from pants.util.contextutil import temporary_dir, temporary_file
 from pants.util.dirutil import chmod_plus_x, touch
-from pants_test.tasks.test_base import TaskTest
 
 
-class TestAndroidBase(TaskTest):
+class TestAndroidBase(unittest.TestCase):
   """Base class for Android tests that provides some mock structures useful for testing."""
 
   @contextmanager

--- a/tests/python/pants_test/android/test_android_mixin.py
+++ b/tests/python/pants_test/android/test_android_mixin.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import textwrap
-import unittest
 from contextlib import contextmanager
 
 from twitter.common.collections import maybe_list
@@ -17,7 +16,7 @@ from pants.util.contextutil import temporary_dir, temporary_file
 from pants.util.dirutil import chmod_plus_x, touch
 
 
-class TestAndroidBase(unittest.TestCase):
+class TestAndroidMixin(object):
   """Base class for Android tests that provides some mock structures useful for testing."""
 
   @contextmanager
@@ -52,8 +51,8 @@ class TestAndroidBase(unittest.TestCase):
     :param tuple[strings] installed_build_tools: Build tools version of any tools.
     :param tuple[strings] files: The files are to mock non-executables and one will be created for
       each installed_sdks version.
-    :param tuple[strings] executables: Executables are any required tools and one is created for each
-      installed_build_tools version.
+    :param tuple[strings] executables: Executables are any required tools and one is created for
+      each installed_build_tools version.
     """
     with temporary_dir() as sdk:
       for sdk_version in installed_sdks:


### PR DESCRIPTION
Inspired by CR 1850, this improves the AndroidDistribution
class. All tools and path validation is cached so that calls
to the os module only happen once.

This includes some updating of comment strings and
a good increase of test coverage.