### PR TITLE
Fixup Context to return all synthetic targets in-play.

### DIFF
--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -266,20 +266,24 @@ class Context(object):
   def targets(self, predicate=None, postorder=False):
     """Selects targets in-play in this run from the target roots and their transitive dependencies.
 
-    If specified, the predicate will be used to narrow the scope of targets returned.
+    Also includes any new synthetic targets created from the target roots or their transitive
+    dependencies during the course of the run.
 
-    :return: a list of targets evaluated by the predicate in preorder (or postorder, if the
-    postorder parameter is True) traversal order.
+    :param predicate: If specified, the predicate will be used to narrow the scope of targets
+                      returned.
+    :param bool postorder: `True` to gather transitive dependencies with a postorder traversal;
+                          `False` or preorder by default.
+    :returns: A list of matching targets.
     """
 
-    targets = list(self.target_roots)
-    for target in self.target_roots:
-      targets.extend(self._synthetic_targets.get(target, []))
-
-    target_root_addresses = [target.address for target in targets]
-
+    target_root_addresses = [target.address for target in self.target_roots]
     target_set = self.build_graph.transitive_subgraph_of_addresses(target_root_addresses,
                                                                    postorder=postorder)
+
+    for derived_from, synthetic_targets in self._synthetic_targets.items():
+      if derived_from in target_set:
+        target_set.update(synthetic_targets)
+
     return filter(predicate, target_set)
 
   def dependents(self, on_predicate=None, from_predicate=None):

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -6,6 +6,8 @@ python_tests(
   sources=globs('*.py'),
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/base:address',
+    'src/python/pants/base:target',
     'src/python/pants/goal:products',
     'tests/python/pants_test:base_test',
   ]

--- a/tests/python/pants_test/goal/test_context.py
+++ b/tests/python/pants_test/goal/test_context.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.base.address import SyntheticAddress
+from pants.base.target import Target
 from pants_test.base_test import BaseTest
 
 
@@ -21,8 +23,8 @@ class ContextTest(BaseTest):
     d = self.make_target('d', dependencies=[c, a])
     e = self.make_target('e', dependencies=[d])
     context = self.context(target_roots=[a, b, c, d, e])
-    dependees = context.dependents(lambda t: t in set([e, c]))
-    self.assertEquals(set([c]), dependees.pop(d))
+    dependees = context.dependents(lambda t: t in {e, c})
+    self.assertEquals({c}, dependees.pop(d))
     self.assertEquals(0, len(dependees))
 
   def test_targets_order(self):
@@ -53,3 +55,21 @@ class ContextTest(BaseTest):
     self.assertEquals([a], context.targets())
     context._replace_targets([c])
     self.assertEquals([c, b, a], context.targets())
+
+  def test_targets_synthetic(self):
+    a = self.make_target('a')
+    b = self.make_target('b', dependencies=[a])
+    c = self.make_target('c', dependencies=[b])
+    d = self.make_target('d', dependencies=[c, a])
+    context = self.context(target_roots=[c])
+    self.assertEquals([c, b, a], context.targets())
+
+    syn_b = context.add_new_target(SyntheticAddress.parse('syn_b'), Target, derived_from=b)
+    context.add_new_target(SyntheticAddress.parse('syn_d'), Target, derived_from=d)
+    # We expect syn_b to be included now since it has been synthesized during this run from an
+    # in-play target.
+    self.assertEquals([c, b, a, syn_b], context.targets())
+
+    # And verify the predicate operates over both normal and synthetic targets.
+    self.assertEquals([syn_b], context.targets(lambda t: t.derived_from != t))
+    self.assertEquals([c, b, a], context.targets(lambda t: t.derived_from == t))

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -26,7 +26,6 @@ target(
     ':check_published_deps',
     ':config',
     ':console_task',
-    ':context',
     ':dependees',
     ':dependencies',
     ':depmap',
@@ -201,17 +200,6 @@ python_tests(
   dependencies = [
     ':base',
     'src/python/pants/backend/core/tasks:console_task',
-  ]
-)
-
-# XXX this should be in goal
-python_tests(
-  name = 'context',
-  sources = ['test_context.py'],
-  dependencies = [
-    ':base',
-    'src/python/pants/base:config',
-    'src/python/pants/goal:context',
   ]
 )
 


### PR DESCRIPTION
Previously just synthetic targets related directly to the target
roots were returned and this relied on synthetic targets derived from
interior nodes being discovered in some other way.

This also moves test_context.py to its proper home in pants_test/goal.

https://rbcommons.com/s/twitter/r/1863/