### PR TITLE
Fixup contrib tests on osx CI.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -10,6 +10,10 @@
 #   http://blog.travis-ci.com/2014-05-13-multi-os-feature-available/
 language: objective-c
 
+env:
+  global:
+    - CXX=g++
+
 script: |
   sw_vers
   python --version


### PR DESCRIPTION
The contrib/cpp integration tests unconditionally expect a
cpp compiler to be defined.

https://rbcommons.com/s/twitter/r/1867/