### PR TITLE
Shard out OSX CI.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -12,13 +12,21 @@ language: objective-c
 
 env:
   global:
-    - CXX=g++
+    - CXX=clang++
+  matrix:
+    # No need to run the self-checks on OSX where vms are at a premium since these are file-level,
+    # non-platform fragile lints.
+    # - CI_FLAGS="-clpnet 'Various pants self checks'"  # (fkmsr)
+    - CI_FLAGS="-fkmsrclpn 'Test examples and testprojects'"  # (et)
+    - CI_FLAGS="-fkmsrcnet 'Python unit tests for pants and pants-plugins'"  # (lp)
+    - CI_FLAGS="-fkmsrclpet 'Python contrib tests'"  # (n)
+    - CI_FLAGS="-fkmsrlpnet 'Python integration tests for pants'"  # (c)
 
 script: |
   sw_vers
   python --version
   java -version
-  ./build-support/bin/ci.sh -x
+  ./build-support/bin/ci.sh -x ${CI_FLAGS}
 
 # The `notifications:` configuration will be programatically copied over from `.travis.yml` for
 # central maintenance of distribution lists, see: `build-support/bin/ci-sync.sh`.

--- a/tests/python/pants_test/backend/python/test_test_builder.py
+++ b/tests/python/pants_test/backend/python/test_test_builder.py
@@ -33,11 +33,9 @@ class PythonTestBuilderTestBase(BaseTest):
     # We only need to cache the current interpreter, avoid caching for every interpreter on the
     # PATH.
     current_interpreter = PythonInterpreter.get()
-    current_id = (current_interpreter.binary, current_interpreter.identity)
-    for cached_interpreter in cache.setup(filters=[current_interpreter.identity.requirement]):
-      # TODO(John Sirois): Revert to directly comparing interpreters when
-      # https://github.com/pantsbuild/pex/pull/31 is in, released and consumed by pants.
-      if (cached_interpreter.binary, cached_interpreter.identity) == current_id:
+    for cached_interpreter in cache.setup(paths=[current_interpreter.binary],
+                                          filters=[current_interpreter.identity.requirement]):
+      if cached_interpreter == current_interpreter:
         return cached_interpreter
     raise RuntimeError('Could not find suitable interpreter to run tests.')
 


### PR DESCRIPTION
This manually mirrors most of the sharding in the main .travis.yml but
keeps ITs all in one shard to start.  If 5 shards proves stably
schedulable the next step will be just programatically mirroring the
matrix env from the main .travis.yml build.

Also fix further issues this re-sharding exposed in
test_test_builder.py.  Force caching of just the current python
interpreter by restricting paths and simplify current interpreter
check.

https://rbcommons.com/s/twitter/r/1869/