### PR TITLE
[Trigger CI] Make option registration recursion optional.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -128,10 +128,10 @@ fi
 
 if [[ "${skip_sanity_checks:-false}" == "false" ]]; then
   banner "Sanity checking bootrapped pants and repo BUILD files"
-  ./pants.pex clean-all ${PANTS_ARGS[@]} || die "Failed to clean-all."
-  ./pants.pex goals ${PANTS_ARGS[@]} || die "Failed to list goals."
-  ./pants.pex list :: ${PANTS_ARGS[@]} || die "Failed to list all targets."
-  ./pants.pex targets ${PANTS_ARGS[@]} || die "Failed to show target help."
+  ./pants.pex ${PANTS_ARGS[@]} clean-all || die "Failed to clean-all."
+  ./pants.pex ${PANTS_ARGS[@]} goals || die "Failed to list goals."
+  ./pants.pex ${PANTS_ARGS[@]} list :: || die "Failed to list all targets."
+  ./pants.pex ${PANTS_ARGS[@]} targets || die "Failed to show target help."
 fi
 
 if [[ "${skip_distribution:-false}" == "false" ]]; then
@@ -150,10 +150,10 @@ packages: [
   ]
 EOF
     ) && \
-    ./pants.pex binary ${INTERPRETER_ARGS[@]} --config-override=${config} \
+    ./pants.pex ${INTERPRETER_ARGS[@]} --config-override=${config} binary \
         src/python/pants:_pants_transitional_publishable_binary_ && \
     mv dist/_pants_transitional_publishable_binary_.pex dist/self.pex && \
-    ./dist/self.pex binary --config-override=${config} ${INTERPRETER_ARGS[@]} \
+    ./dist/self.pex ${INTERPRETER_ARGS[@]} --config-override=${config} binary \
       src/python/pants:_pants_transitional_publishable_binary_ && \
     ./dist/self.pex --config-override=${config} setup-py --recursive \
       src/python/pants:pants-packaged
@@ -169,7 +169,7 @@ if [[ "${skip_internal_backends:-false}" == "false" ]]; then
   banner "Running internal backend python tests"
   (
     PANTS_PYTHON_TEST_FAILSOFT=1 \
-      ./pants.pex test ${PANTS_ARGS[@]} \
+      ./pants.pex ${PANTS_ARGS[@]} test \
         $(./pants.pex list pants-plugins/tests/python:: | \
             xargs ./pants.pex filter --filter-type=python_tests | \
             grep -v integration)
@@ -181,7 +181,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
   (
     PANTS_PY_COVERAGE=paths:pants/ \
       PANTS_PYTHON_TEST_FAILSOFT=1 \
-      ./pants.pex test ${PANTS_ARGS[@]} \
+      ./pants.pex ${PANTS_ARGS[@]} test \
         $(./pants.pex list tests/python:: | \
             xargs ./pants.pex filter --filter-type=python_tests | \
             grep -v integration)
@@ -195,7 +195,7 @@ if [[ "${skip_contrib:-false}" == "false" ]]; then
     # test (ie: pants_test.contrib) namespace packages.
     # TODO(John Sirois): Get to the bottom of the issue and kill --no-fast, see:
     #  https://github.com/pantsbuild/pants/issues/1149
-    PANTS_PYTHON_TEST_FAILSOFT=1 ./pants.pex test.pytest --no-fast ${PANTS_ARGS[@]} contrib::
+    PANTS_PYTHON_TEST_FAILSOFT=1 ./pants.pex ${PANTS_ARGS[@]} test.pytest --no-fast contrib::
   ) || die "Contrib python test failure"
 fi
 
@@ -228,15 +228,15 @@ if [[ "${skip_testprojects:-false}" == "false" ]]; then
 
   banner "Running tests in testprojects/ "
   (
-    ./pants.pex test testprojects:: $android_test_opts $exclude_opts ${PANTS_ARGS[@]}
+    ./pants.pex ${PANTS_ARGS[@]} test testprojects:: $android_test_opts $exclude_opts
   ) || die "test failure in testprojects/"
 fi
 
 if [[ "${skip_examples:-false}" == "false" ]]; then
   banner "Running example tests"
   (
-    ./pants.pex compile.python-eval --closure --fail-slow test examples:: \
-      $android_test_opts ${PANTS_ARGS[@]}
+    ./pants.pex ${PANTS_ARGS[@]} compile.python-eval --closure --fail-slow test examples:: \
+      $android_test_opts
   ) || die "Examples test failure"
 fi
 
@@ -248,7 +248,7 @@ if [[ "${skip_integration:-false}" == "false" ]]; then
   banner "Running Pants Integration tests${shard_desc}"
   (
     PANTS_PYTHON_TEST_FAILSOFT=1 \
-      ./pants.pex test ${PANTS_ARGS[@]} \
+      ./pants.pex ${PANTS_ARGS[@]} test \
         $(./pants.pex list tests/python:: | \
             xargs ./pants.pex filter --filter-type=python_tests | \
             grep integration | \

--- a/build-support/bin/publish_docs.sh
+++ b/build-support/bin/publish_docs.sh
@@ -36,8 +36,8 @@ while getopts "hopd:" opt; do
   esac
 done
 
-${PANTS_EXE} builddict --print-exception-stacktrace \
-                       --omit-impl-re='internal_backend.*' || \
+${PANTS_EXE} --print-exception-stacktrace builddict \
+             --omit-impl-re='internal_backend.*' || \
   die "Failed to generate the 'BUILD Dictionary' and/or 'Options Reference'."
 
 function do_open() {
@@ -53,13 +53,13 @@ function do_open() {
 }
 
 # generate html from markdown pages.
-${PANTS_EXE} markdown --print-exception-stacktrace \
+${PANTS_EXE} --print-exception-stacktrace markdown \
   --markdown-fragment src:: examples:: src/docs:: //:readme \
   testprojects/src/java/com/pants/testproject/page:readme || \
   die "Failed to generate HTML from markdown'."
 
 # invoke doc site generator.
-${PANTS_EXE} sitegen --print-exception-stacktrace \
+${PANTS_EXE} --print-exception-stacktrace sitegen \
   --sitegen-config-path=src/python/pants/docs/docsite.json || \
   die "Failed to generate doc site'."
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -33,12 +33,11 @@ def register_global_options(register):
   # TODO: After moving to the new options system these abstraction leaks can go away.
   register('-k', '--kill-nailguns', action='store_true',
            help='Kill nailguns before exiting')
-
   register('-i', '--interpreter', default=[], action='append', metavar='<requirement>',
            help="Constrain what Python interpreters to use.  Uses Requirement format from "
                 "pkg_resources, e.g. 'CPython>=2.6,<3' or 'PyPy'. By default, no constraints "
                 "are used.  Multiple constraints may be added.  They will be ORed together.")
-  register('--colors', action='store_true', default=True,
+  register('--colors', action='store_true', default=True, recursive=True,
            help='Set whether log messages are displayed in color.')
   register('--spec-excludes', action='append', default=[register.bootstrap.pants_workdir],
            help='Exclude these paths when computing the command-line target specs.')
@@ -48,23 +47,23 @@ def register_global_options(register):
   # TODO: When we have a model for 'subsystems', create one for artifact caching and move these
   # options to there. When we do that, also drop the cumbersome word 'artifact' from these
   # option names. There's only one cache concept that users care about.
-  register('--read-from-artifact-cache', action='store_true', default=True,
+  register('--read-from-artifact-cache', action='store_true', default=True, recursive=True,
            help='Read build artifacts from cache, if available.')
-  register('--read-artifact-caches', type=Options.list,
+  register('--read-artifact-caches', type=Options.list, recursive=True,
            help='The URIs of artifact caches to read from. Each entry is a URL of a RESTful cache, '
                 'a path of a filesystem cache, or a pipe-separated list of alternate caches to '
                 'choose from.')
-  register('--write-to-artifact-cache', action='store_true', default=True,
+  register('--write-to-artifact-cache', action='store_true', default=True, recursive=True,
            help='Write build artifacts to cache, if possible.')
-  register('--write-artifact-caches', type=Options.list,
+  register('--write-artifact-caches', type=Options.list, recursive=True,
            help='The URIs of artifact caches to write to. Each entry is a URL of a RESTful cache, '
                 'a path of a filesystem cache, or a pipe-separated list of alternate caches to '
                 'choose from.')
-  register('--overwrite-cache-artifacts', action='store_true',
+  register('--overwrite-cache-artifacts', action='store_true', recursive=True,
            help='If writing to build artifacts to cache, overwrite (instead of skip) existing.')
-  register('--cache-key-gen-version', advanced=True, default='200',
-           help='The cache key generation. Bump this to invalidate every artifact.')
-  register('--cache-compression', advanced=True, type=int, default=5,
+  register('--cache-key-gen-version', advanced=True, default='200', recursive=True,
+           help='The cache key generation. Bump this to invalidate every artifact for a scope.')
+  register('--cache-compression', advanced=True, type=int, default=5, recursive=True,
            help='The gzip compression level for created artifacts.')
   register('--print-exception-stacktrace', action='store_true',
            help='Print to console the full exception stack trace if encountered.')

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -61,10 +61,10 @@ def register_bootstrap_options(register, buildroot=None):
   # Since pants has supported 'warn' since inception, leave the 'warn' choice as-is but explicitly
   # setup a 'WARN' logging level name that maps to 'WARNING'.
   logging.addLevelName(logging.WARNING, 'WARN')
-  register('-l', '--level', choices=['debug', 'info', 'warn'], default='info',
+  register('-l', '--level', choices=['debug', 'info', 'warn'], default='info', recursive=True,
            help='Set the logging level.')
 
-  register('-q', '--quiet', action='store_true',
+  register('-q', '--quiet', action='store_true', 
            help='Squelches all console output apart from errors.')
 
 

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -22,8 +22,12 @@ from pants.option.ranked_value import RankedValue
 # Standard ArgumentParser prints usage and exits on error. We subclass so we can raise instead.
 # Note that subclassing ArgumentParser for this purpose is allowed by the argparse API.
 class CustomArgumentParser(ArgumentParser):
+  def __init__(self, scope, *args, **kwargs):
+    super(CustomArgumentParser, self).__init__(*args, **kwargs)
+    self._scope = scope
+
   def error(self, message):
-    raise ParseError(message)
+    raise ParseError('{0} in scope {1}'.format(message, self._scope))
 
   def walk_actions(self):
     """Iterates over the argparse.Action objects for options registered on this parser."""
@@ -105,14 +109,14 @@ class Parser(object):
     self._frozen = False
 
     # The argparser we use for actually parsing args.
-    self._argparser = CustomArgumentParser(conflict_handler='resolve')
+    self._argparser = CustomArgumentParser(scope=self._scope, conflict_handler='resolve')
 
     # The argparser we use for formatting help messages.
     # We don't use self._argparser for this as it will have all options from enclosing scopes
     # registered on it too, which would create unnecessarily repetitive help messages.
     formatter_class = (PantsAdvancedHelpFormatter if help_request and help_request.advanced
                        else PantsBasicHelpFormatter)
-    self._help_argparser = CustomArgumentParser(conflict_handler='resolve',
+    self._help_argparser = CustomArgumentParser(scope=self._scope, conflict_handler='resolve',
                                                 formatter_class=formatter_class)
 
     # Options are registered in two groups.  The first group will always be displayed in the help
@@ -189,6 +193,7 @@ class Parser(object):
       ancestor = ancestor._parent_parser
 
     # Pull out our custom arguments, they aren't valid for argparse.
+    recursive = kwargs.pop('recursive', False)
     advanced = kwargs.pop('advanced', False)
 
     self._validate(args, kwargs)
@@ -231,9 +236,9 @@ class Parser(object):
     # Register the option for the purpose of parsing, on this and all enclosed scopes.
     if is_invertible:
       inverse_kwargs = self._create_inverse_kwargs(kwargs)
-      self._register_boolean(dest, args, kwargs, inverse_args, inverse_kwargs)
+      self._register_boolean(dest, args, kwargs, inverse_args, inverse_kwargs, recursive)
     else:
-      self._register(dest, args, kwargs)
+      self._register(dest, args, kwargs, recursive)
 
   def is_deprecated(self, flag):
     """Returns True if the flag has been marked as deprecated with 'deprecated_version'.
@@ -275,17 +280,18 @@ class Parser(object):
         warnings.warn('*** {}'.format(self.deprecated_message(flag)), DeprecationWarning,
                       stacklevel=9999) # out of range stacklevel to suppress printing source line.
 
-  def _register(self, dest, args, kwargs):
+  def _register(self, dest, args, kwargs, recursive):
     """Recursively register the option for parsing."""
     ranked_default = self._compute_default(dest, is_invertible=False, kwargs=kwargs)
     kwargs_with_default = dict(kwargs, default=ranked_default)
     self._argparser.add_argument(*args, **kwargs_with_default)
 
-    # Propagate registration down to inner scopes.
-    for child_parser in self._child_parsers:
-      child_parser._register(dest, args, kwargs)
+    if recursive:
+      # Propagate registration down to inner scopes.
+      for child_parser in self._child_parsers:
+        child_parser._register(dest, args, kwargs, recursive)
 
-  def _register_boolean(self, dest, args, kwargs, inverse_args, inverse_kwargs):
+  def _register_boolean(self, dest, args, kwargs, inverse_args, inverse_kwargs, recursive):
     """Recursively register the boolean option, and its inverse, for parsing."""
     group = self._argparser.add_mutually_exclusive_group()
     ranked_default = self._compute_default(dest, is_invertible=True, kwargs=kwargs)
@@ -293,9 +299,10 @@ class Parser(object):
     group.add_argument(*args, **kwargs_with_default)
     group.add_argument(*inverse_args, **inverse_kwargs)
 
-    # Propagate registration down to inner scopes.
-    for child_parser in self._child_parsers:
-      child_parser._register_boolean(dest, args, kwargs, inverse_args, inverse_kwargs)
+    if recursive:
+      # Propagate registration down to inner scopes.
+      for child_parser in self._child_parsers:
+        child_parser._register_boolean(dest, args, kwargs, inverse_args, inverse_kwargs, recursive)
 
   def _validate(self, args, kwargs):
     """Ensure that the caller isn't trying to use unsupported argparse features."""
@@ -310,8 +317,8 @@ class Parser(object):
       raise RegistrationError('nargs={0} unsupported in registration of option {1} in '
                               'scope {2}.'.format(kwargs['nargs'], args, self._scope))
     if 'required' in kwargs:
-      raise RegistrationError('{0} unsupported in registration of option {1} in '
-                              'scope {2}.'.format(k, args, self._scope))
+      raise RegistrationError('required unsupported in registration of option {0} in '
+                              'scope {1}.'.format(args, self._scope))
 
   def _set_dest(self, args, kwargs):
     """Maps the externally-used dest to a scoped one only seen internally.

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -12,7 +12,10 @@ import warnings
 from contextlib import contextmanager
 from textwrap import dedent
 
+import pytest
+
 from pants.base.deprecated import PastRemovalVersionError
+from pants.option.errors import ParseError
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.parser import Parser
@@ -23,9 +26,10 @@ class OptionsTest(unittest.TestCase):
   _known_scopes = ['compile', 'compile.java', 'compile.scala', 'stale', 'test', 'test.junit']
 
   def _register(self, options):
-    options.register_global('-v', '--verbose', action='store_true', help='Verbose output.')
-    options.register_global('-n', '--num', type=int, default=99)
-    options.register_global('-x', '--xlong', action='store_true')
+    options.register_global('-v', '--verbose', action='store_true', help='Verbose output.',
+                            recursive=True)
+    options.register_global('-n', '--num', type=int, default=99, recursive=True)
+    options.register_global('-x', '--xlong', action='store_true', recursive=True)
     options.register_global('--y', action='append', type=int)
     options.register_global('--pants-foo')
     options.register_global('--bar-baz')
@@ -41,8 +45,8 @@ class OptionsTest(unittest.TestCase):
     options.register_global('--listy', type=Options.list, default='[1, 2, 3]')
 
     # For the design doc example test.
-    options.register_global('--a', type=int)
-    options.register_global('--b', type=int)
+    options.register_global('--a', type=int, recursive=True)
+    options.register_global('--b', type=int, recursive=True)
 
     # Deprecated global options
     options.register_global('--global-crufty',
@@ -55,7 +59,7 @@ class OptionsTest(unittest.TestCase):
     options.register('test', '--xlong', type=int)
 
     # For the design doc example test.
-    options.register('compile', '--c', type=int)
+    options.register('compile', '--c', type=int, recursive=True)
     options.register('compile.java', '--b', type=str, default='foo')
 
     # Test deprecated options with a scope
@@ -230,6 +234,13 @@ class OptionsTest(unittest.TestCase):
     self.assertEqual(88, options.for_global_scope().num)
     self.assertEqual(55, options.for_scope('compile').num)
     self.assertEqual(44, options.for_scope('compile.java').num)
+
+  def test_recursion(self):
+    options = self._parse('./pants --bar-baz=foo')
+    self.assertEqual('foo', options.for_global_scope().bar_baz)
+    options = self._parse('./pants compile --bar-baz=foo')
+    with pytest.raises(ParseError):
+      options.for_scope('compile').bar_baz
 
   def test_is_known_scope(self):
     options = self._parse('./pants')

--- a/tests/python/pants_test/tasks/test_what_changed.py
+++ b/tests/python/pants_test/tasks/test_what_changed.py
@@ -295,7 +295,7 @@ class WhatChangedTest(BaseWhatChangedTest):
       'root/src/py/dependency_tree/c:c',
       args=[
         '--test-include-dependees=transitive',
-        '--test-exclude-target-regexp=:b',
+        '--exclude-target-regexp=:b',
       ],
       workspace=self.workspace(files=['root/src/py/dependency_tree/a/a.py'])
     )


### PR DESCRIPTION
Previously every option registered on a scope was also implicitly
registered on all enclosed scopes, and those scopes could have
their own value for that option. Sometimes this makes sense,
e.g., --level, but often it doesn't.

This change adds a recursive= registration option, which is
False by default.

It also sets recursive=True on some global options where that
makes sense.