### PR TITLE
[Trigger CI] Handle --print-exception-stacktrace and --version more elegantly.

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -106,10 +106,10 @@ class GoalRunner(object):
         # project plugins, or specialized configuration files.
         self.build_file_parser.parse_build_file_family(build_file)
 
+    self._expand_goals_and_specs()
+
     # Now that we've parsed the bootstrap BUILD files, and know about the SCM system.
     self.run_tracker.run_info.add_scm_info()
-
-    self._expand_goals_and_specs()
 
   @property
   def spec_excludes(self):

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import copy
 import sys
 
-from pants.base.build_environment import pants_release
+from pants.base.build_environment import pants_release, pants_version
 from pants.goal.goal import Goal
 from pants.option import custom_types
 from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
@@ -196,7 +196,10 @@ class Options(object):
     Otherwise return False.
     """
     if self._help_request:
-      self._print_help()
+      if self._help_request.version:
+        print(pants_version())
+      else:
+        self._print_help()
       return True
     else:
       return False

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -27,7 +27,8 @@ class CustomArgumentParser(ArgumentParser):
     self._scope = scope
 
   def error(self, message):
-    raise ParseError('{0} in scope {1}'.format(message, self._scope))
+    scope = 'global' if self._scope == GLOBAL_SCOPE else self._scope
+    raise ParseError('{0} in {1} scope'.format(message, scope))
 
   def walk_actions(self):
     """Iterates over the argparse.Action objects for options registered on this parser."""

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -31,6 +31,7 @@ class ArgSplitterTest(unittest.TestCase):
                       splitter.help_request is not None and splitter.help_request.advanced)
     self.assertEquals(expected_help_all,
                       splitter.help_request is not None and splitter.help_request.all_scopes)
+    self.assertFalse(splitter.help_request is not None and splitter.help_request.version)
 
   def _split_help(self, args_str, expected_goals, expected_scope_to_flags, expected_target_specs,
                   expected_help_advanced=False, expected_help_all=False):
@@ -39,6 +40,12 @@ class ArgSplitterTest(unittest.TestCase):
                 expected_is_help=True,
                 expected_help_advanced=expected_help_advanced,
                 expected_help_all=expected_help_all)
+
+  def _split_version(self, args_str):
+    splitter = ArgSplitter(ArgSplitterTest._known_scopes)
+    args = shlex.split(str(args_str))
+    splitter.split_args(args)
+    self.assertTrue(splitter.help_request is not None and splitter.help_request.version)
 
   def test_arg_splitting(self):
     # Various flag combos.
@@ -143,3 +150,13 @@ class ArgSplitterTest(unittest.TestCase):
                      {'': [], 'compile': []}, [], True, False)
     self._split_help('./pants compile help-all test --help', ['compile', 'test'],
                      {'': [], 'compile': [], 'test': []}, [], False, True)
+
+  def test_version_request_detection(self):
+    self._split_version('./pants -V')
+    self._split_version('./pants --version')
+
+    # --version in a non-global scope is OK, and not a version request.
+    self._split('./pants compile --version src/java/com/pants/foo',
+                ['compile'],
+                { '': [], 'compile': ['--version'], },
+                ['src/java/com/pants/foo'])


### PR DESCRIPTION
- --print-exception-stacktrace is now a regular global option.
  Previously it was registered as one, but not actually used.
  Instead, pants_exe.py special-cased it by looking for it on the
  cmd line. This meant that it couldn't be set in config, for example.

- --version is now special-cased in the options parser, using the same
  mechanism as --help. This makes sense as --version is very similar
  to --help in spirit, and isn't really an option (you'd never want
  to set it in config, for example).

- --log-exit support was removed, since it doesn't currently work, and
  is completely unnecessary anyway.