### PR TITLE
[Trigger CI] Set print_exception_stacktrace in pants.ini.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -108,7 +108,6 @@ for constraint in ${INTERPRETER_CONSTRAINTS[@]}; do
 done
 
 PANTS_ARGS=(
-  "--print-exception-stacktrace"
   "${INTERPRETER_ARGS[@]}"
 )
 

--- a/build-support/bin/publish_docs.sh
+++ b/build-support/bin/publish_docs.sh
@@ -36,8 +36,7 @@ while getopts "hopd:" opt; do
   esac
 done
 
-${PANTS_EXE} --print-exception-stacktrace builddict \
-             --omit-impl-re='internal_backend.*' || \
+${PANTS_EXE} builddict --omit-impl-re='internal_backend.*' || \
   die "Failed to generate the 'BUILD Dictionary' and/or 'Options Reference'."
 
 function do_open() {
@@ -53,13 +52,13 @@ function do_open() {
 }
 
 # generate html from markdown pages.
-${PANTS_EXE} --print-exception-stacktrace markdown \
+${PANTS_EXE} markdown \
   --markdown-fragment src:: examples:: src/docs:: //:readme \
   testprojects/src/java/com/pants/testproject/page:readme || \
   die "Failed to generate HTML from markdown'."
 
 # invoke doc site generator.
-${PANTS_EXE} --print-exception-stacktrace sitegen \
+${PANTS_EXE} sitegen \
   --sitegen-config-path=src/python/pants/docs/docsite.json || \
   die "Failed to generate doc site'."
 

--- a/pants.ini
+++ b/pants.ini
@@ -7,10 +7,10 @@
 #   pants_supportdir: pants support files for this repo go here; for example: ivysettings.xml
 #   pants_distdir: user visible artifacts for this repo go here
 #   pants_workdir: the scratch space used to for live builds in this repo
-#
-# NOTE: Values of list and dict type must be valid JSON.
 
 [DEFAULT]
+print_exception_stacktrace: True
+
 # Enable our own custom loose-source plugins as well as contribs.
 pythonpath: [
     "%(buildroot)s/pants-plugins/src/python",

--- a/tests/python/pants_test/tasks/test_protobuf_integration.py
+++ b/tests/python/pants_test/tasks/test_protobuf_integration.py
@@ -47,7 +47,7 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
   def test_bundle_protobuf_unpacked_jars(self):
     pants_run = self.run_pants(
       [ 'bundle', 'examples/src/java/com/pants/examples/protobuf/unpacked_jars',
-       '--bundle-deployjar', '--print-exception-stacktrace',])
+        '--bundle-deployjar',])
     self.assertEquals(pants_run.returncode, self.PANTS_SUCCESS_CODE,
                       "goal bundle run expected success, got {0}\n"
                       "got stderr:\n{1}\n"


### PR DESCRIPTION
Allows us to remove invocations of it on the cmd-line.

Also removes a cmd-line specification of that flag in test_protobuf_integration
that was superfluous for a different reason (run_pants always sets it anyway).