### PR TITLE
Fixup DxCompile jvm_options to be a list.

### DIFF
--- a/src/python/pants/backend/android/tasks/dx_compile.py
+++ b/src/python/pants/backend/android/tasks/dx_compile.py
@@ -33,7 +33,7 @@ class DxCompile(AndroidTask, NailgunTask):
     super(DxCompile, cls).register_options(register)
     register('--build-tools-version',
              help='Create the dex file using this version of the Android build tools.')
-    register('--jvm-options',
+    register('--jvm-options', action='append', metavar='<option>...',
              help='Run dx with these JVM options.')
 
   @classmethod


### PR DESCRIPTION
The underlying runjava call expects a list so this was always broken.
The issue surfaces because pants.ini defines a global jvm_options list
that is now seen as the default value for the option since a Config
DEFAULT section inheritance fix went in.

https://rbcommons.com/s/twitter/r/1878/