### PR TITLE
[Trigger CI] Make rglobs follow symlinked directories by default.

### DIFF
--- a/src/python/pants/backend/core/wrapped_globs.py
+++ b/src/python/pants/backend/core/wrapped_globs.py
@@ -89,7 +89,13 @@ class RGlobs(FilesetRelPathWrapper):
   :returns Fileset matching files in this directory and its descendents.
   :rtype Fileset
   """
-  wrapped_fn = Fileset.rglobs
+  @staticmethod
+  def rglobs_following_symlinked_dirs_by_default(*globspecs, **kw):
+    if 'follow_links' not in kw:
+      kw['follow_links'] = True
+    return Fileset.rglobs(*globspecs, **kw)
+
+  wrapped_fn = rglobs_following_symlinked_dirs_by_default
 
 
 class ZGlobs(FilesetRelPathWrapper):


### PR DESCRIPTION
It seems unintuitive that it doesn't, and this has in fact led
to problems in Foursquare's codebase.