### PR TITLE
Support local pre-commit checks.

### DIFF
--- a/build-support/bin/check_header.sh
+++ b/build-support/bin/check_header.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 expected_header=$(cat <<EOF

--- a/build-support/bin/check_packages.sh
+++ b/build-support/bin/check_packages.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 DIRS_TO_CHECK=(

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd ${REPO_ROOT}
 
 source build-support/common.sh

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# NB: pre-commit runs in the context of GIT_WORK_TREE, ie: pwd == REPO_ROOT
+
+source build-support/common.sh
+
+echo "Checking packages" && ./build-support/bin/check_packages.sh || exit 1
+echo "Checking imports" && ./build-support/bin/isort.sh || \
+  die "To fix import sort order, run \`build-support/bin/isort.sh -f\`"
+echo "Checking headers" && ./build-support/bin/check_header.sh || exit 1
+echo "Success"

--- a/build-support/bin/setup.sh
+++ b/build-support/bin/setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+source "${REPO_ROOT}/build-support/common.sh"
+
+PRE_COMMIT_DEST="${GIT_DIR:-${REPO_ROOT}/.git}/hooks/pre-commit"
+PRE_COMMIT_SRC="${REPO_ROOT}/build-support/bin/pre-commit.sh"
+
+function install_pre_commit_hook() {
+  rm -f "${PRE_COMMIT_DEST}" && \
+  ln "${PRE_COMMIT_SRC}" "${PRE_COMMIT_DEST}" && \
+  echo "Pre-commit checks installed from ${PRE_COMMIT_SRC} to ${PRE_COMMIT_DEST}";
+  cd - &> /dev/null
+}
+
+if [[ ! -e "${PRE_COMMIT_DEST}" ]]
+then
+  install_pre_commit_hook
+else
+  existing_hook_sig="$(cat "${PRE_COMMIT_DEST}" | fingerprint_data)"
+  canonical_hook_sig="$(cat "${PRE_COMMIT_SRC}" | fingerprint_data)"
+  if [[ "${existing_hook_sig}" != "${canonical_hook_sig}" ]]
+  then
+    read -p "A pre-commit script already exists, replace with ${PRE_COMMIT_SRC}? [Yn]" ok
+    if [[ "${ok:-Y}" =~ ^[yY]([eE][sS])?$ ]]
+    then
+      install_pre_commit_hook
+    else
+      echo "Pre-commit checks not installed"
+      exit 1
+    fi
+  else
+    echo "Pre-commit checks up to date."
+  fi
+fi
+exit 0

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -37,3 +37,7 @@ function banner() {
   echo "[== $(elapsed) $@ ==]"
   echo
 }
+
+function fingerprint_data() {
+  openssl md5 | cut -d' ' -f2
+}

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -22,10 +22,6 @@ function venv_dir() {
   fi
 }
 
-function fingerprint_data() {
-  openssl md5 | cut -d' ' -f2
-}
-
 function activate_venv() {
   source "$(venv_dir)/bin/activate"
 }

--- a/src/python/pants/docs/howto_contribute.md
+++ b/src/python/pants/docs/howto_contribute.md
@@ -98,6 +98,18 @@ branch using the [syncing a
 fork](https://help.github.com/articles/syncing-a-fork/) instructions on
 github.
 
+Whether you've cloned the repo or your fork of the repo, you should setup the
+local pre-commit hooks to ensure your commits meet minimum compliance checks
+before pushing branches to ci:
+
+    :::bash
+    $ ./build-support/bin/setup.sh
+
+You can always run the pre-commit checks manually via:
+
+    :::bash
+    $ ./build-support/bin/pre-commit.sh
+
 **Pro tip:** If you want your local master branch to be an exact copy of
 the `pantsbuild/pants` repo's master branch, use these commands:
 


### PR DESCRIPTION
This change adds a setup script that will install or re-install a
pre-commit hook to run pants lints.  The pre-commit script is also
runnable directly to support a centralized stable script developers can
run to execute all lints independent of performing a commit.