### PR TITLE
To add android.jar to the classpath, create a hard link under workdir.

### DIFF
--- a/src/python/pants/backend/android/BUILD
+++ b/src/python/pants/backend/android/BUILD
@@ -24,6 +24,9 @@ python_library(
 python_library(
   name = 'android_distribution',
   sources = ['distribution/android_distribution.py'],
+  dependencies = [
+    'src/python/pants/util:dirutil',
+  ]
 )
 
 python_library(

--- a/src/python/pants/backend/android/distribution/android_distribution.py
+++ b/src/python/pants/backend/android/distribution/android_distribution.py
@@ -78,15 +78,15 @@ class AndroidDistribution(object):
     :raises: ``DistributionError`` if tool cannot be found.
     """
     if tool_path not in self._validated_tools:
-      tool_dir = self._get_tool_path(tool_path)
-      android_tool = os.path.join(workdir, os.path.basename(tool_path))
-      if not os.path.isfile(android_tool):
+      android_tool = self._get_tool_path(tool_path)
+      link_path = os.path.join(workdir, os.path.basename(tool_path))
+      if not os.path.isfile(link_path):
         safe_mkdir(workdir)
         try:
-          os.link(tool_dir, android_tool)
+          os.link(android_tool, link_path)
         except OSError as e:
           raise self.DistributionError('Problem creating a link to the android tool: ', e)
-      self._validated_tools[tool_path] = android_tool
+      self._validated_tools[tool_path] = link_path
     return self._validated_tools[tool_path]
 
   def register_android_tool(self, tool_path):

--- a/src/python/pants/backend/android/distribution/android_distribution.py
+++ b/src/python/pants/backend/android/distribution/android_distribution.py
@@ -87,7 +87,7 @@ class AndroidDistribution(object):
             safe_mkdir(os.path.dirname(link_path))
             os.link(android_tool, link_path)
           except OSError as e:
-            raise self.DistributionError('Problem creating a link to the android tool: '.format(e))
+            raise self.DistributionError('Problem creating a link to the android tool: {}'.format(e))
         self._validated_tools[tool_path] = link_path
       else:
         self._validated_tools[tool_path] = android_tool

--- a/src/python/pants/backend/android/distribution/android_distribution.py
+++ b/src/python/pants/backend/android/distribution/android_distribution.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import shutil
 
 from pants.util.dirutil import safe_mkdir
 
@@ -66,12 +67,12 @@ class AndroidDistribution(object):
     self._validated_tools = {}
 
   def register_android_tool(self, tool_path, workdir=None):
-    """Return a handle for the android tool at SDK location tool_path.
+    """Return the full path for the tool at SDK location tool_path or of a copy under workdir.
 
     All android tasks should request their tools using this method.
     :param string tool_path: Path to tool, relative to the Android SDK root, e.g
       'platforms/android-19/android.jar'.
-    :param string workdir: Path to the calling Task's workdir. Pants will create a link to the
+    :param string workdir: Location for the copied file. Pants will put a copy of the
       android file under workdir.
     :return: Full path to either the tool or hard link to that tool.
     :rtype: string
@@ -79,16 +80,16 @@ class AndroidDistribution(object):
     """
     if tool_path not in self._validated_tools:
       android_tool = self._get_tool_path(tool_path)
-      # If an android file is bound for the classpath it must be under buildroot, so create a link.
+      # If an android file is bound for the classpath it must be under buildroot, so create a copy.
       if workdir:
-        link_path = os.path.join(workdir, tool_path)
-        if not os.path.isfile(link_path):
+        copy_path = os.path.join(workdir, tool_path)
+        if not os.path.isfile(copy_path):
           try:
-            safe_mkdir(os.path.dirname(link_path))
-            os.link(android_tool, link_path)
+            safe_mkdir(os.path.dirname(copy_path))
+            shutil.copy(android_tool, copy_path)
           except OSError as e:
-            raise self.DistributionError('Problem creating a link to the android tool: {}'.format(e))
-        self._validated_tools[tool_path] = link_path
+            raise self.DistributionError('Problem creating copy of the android tool: {}'.format(e))
+        self._validated_tools[tool_path] = copy_path
       else:
         self._validated_tools[tool_path] = android_tool
     return self._validated_tools[tool_path]

--- a/src/python/pants/backend/android/tasks/aapt_task.py
+++ b/src/python/pants/backend/android/tasks/aapt_task.py
@@ -56,4 +56,4 @@ class AaptTask(AndroidTask):
       target_sdk = self._forced_target_sdk
     android_jar = os.path.join('platforms', 'android-' + target_sdk, 'android.jar')
     # The android.jar is bound for the classpath and so must be under the buildroot.
-    return self.android_sdk.register_tool_link(android_jar, self.workdir)
+    return self.android_sdk.register_android_tool(android_jar, workdir=self.workdir)

--- a/src/python/pants/backend/android/tasks/aapt_task.py
+++ b/src/python/pants/backend/android/tasks/aapt_task.py
@@ -55,4 +55,5 @@ class AaptTask(AndroidTask):
     if self._forced_target_sdk:
       target_sdk = self._forced_target_sdk
     android_jar = os.path.join('platforms', 'android-' + target_sdk, 'android.jar')
-    return self.android_sdk.register_android_tool(android_jar)
+    # The android.jar is bound for the classpath and so must be under the buildroot.
+    return self.android_sdk.register_tool_link(android_jar, self.workdir)

--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -76,6 +76,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/android:android_distribution',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
     'tests/python/pants_test/android:android_base',
   ]
 )

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -133,7 +133,7 @@ class TestAndroidDistribution(TestAndroidBase):
     with self.distribution() as sdk:
       with temporary_dir() as workdir:
         android_sdk = AndroidDistribution.cached(sdk)
-        android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+        android_jar = os.path.join('platforms', 'android-19', 'android.jar')
         android_sdk.register_tool_link(android_jar, workdir)
         self.assertEquals(android_sdk._validated_tools[android_jar],
                           os.path.join(workdir, 'android.jar'))
@@ -142,7 +142,7 @@ class TestAndroidDistribution(TestAndroidBase):
     with self.distribution() as sdk:
       with temporary_dir() as workdir:
         android_sdk = AndroidDistribution.cached(sdk)
-        android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+        android_jar = os.path.join('platforms', 'android-19', 'android.jar')
         android_sdk.register_tool_link(android_jar, workdir)
         self.assertIn(android_jar, android_sdk._validated_tools)
 
@@ -151,7 +151,7 @@ class TestAndroidDistribution(TestAndroidBase):
       with self.distribution() as sdk:
         with temporary_dir() as workdir:
           android_sdk = AndroidDistribution.cached(sdk)
-          android_jar = os.path.join('platforms', 'android-19',  'no.jar')
+          android_jar = os.path.join('platforms', 'android-19', 'no.jar')
           android_sdk.register_tool_link(android_jar, workdir)
           self.assertEquals(android_sdk._validated_tools[android_jar],
                             os.path.join(workdir, 'android.jar'))
@@ -162,13 +162,13 @@ class TestAndroidDistribution(TestAndroidBase):
         with temporary_dir() as workdir:
           os.chmod(workdir, 0o400)
           android_sdk = AndroidDistribution.cached(sdk)
-          android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+          android_jar = os.path.join('platforms', 'android-19', 'android.jar')
           android_sdk.register_tool_link(android_jar, workdir)
 
   def test_get_tool_path(self):
     with self.distribution() as sdk:
       android_sdk = AndroidDistribution.cached(sdk)
-      android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+      android_jar = os.path.join('platforms', 'android-19', 'android.jar')
       tool_path = android_sdk._get_tool_path(android_jar)
       self.assertEquals(tool_path, os.path.join(sdk, android_jar))
 
@@ -176,6 +176,6 @@ class TestAndroidDistribution(TestAndroidBase):
     with self.assertRaises(AndroidDistribution.DistributionError):
       with self.distribution() as sdk:
         android_sdk = AndroidDistribution.cached(sdk)
-        android_jar = os.path.join('platforms', 'android-19',  'no.jar')
+        android_jar = os.path.join('platforms', 'android-19', 'no.jar')
         tool_path = android_sdk._get_tool_path(android_jar)
         self.assertEquals(tool_path, os.path.join(sdk, android_jar))

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -128,3 +128,54 @@ class TestAndroidDistribution(TestAndroidBase):
       aapt = os.path.join('build-tools', '19.1.0', 'aapt')
       android_sdk.register_android_tool(aapt)
       self.assertIn(aapt, android_sdk._validated_tools)
+
+  def test_register_tool_link(self):
+    with self.distribution() as sdk:
+      with temporary_dir() as workdir:
+        android_sdk = AndroidDistribution.cached(sdk)
+        android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+        android_sdk.register_tool_link(android_jar, workdir)
+        self.assertEquals(android_sdk._validated_tools[android_jar],
+                          os.path.join(workdir, 'android.jar'))
+
+  def test_register_link_is_validated(self):
+    with self.distribution() as sdk:
+      with temporary_dir() as workdir:
+        android_sdk = AndroidDistribution.cached(sdk)
+        android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+        android_sdk.register_tool_link(android_jar, workdir)
+        self.assertIn(android_jar, android_sdk._validated_tools)
+
+  def test_register_link_but_no_tool(self):
+    with self.assertRaises(AndroidDistribution.DistributionError):
+      with self.distribution() as sdk:
+        with temporary_dir() as workdir:
+          android_sdk = AndroidDistribution.cached(sdk)
+          android_jar = os.path.join('platforms', 'android-19',  'no.jar')
+          android_sdk.register_tool_link(android_jar, workdir)
+          self.assertEquals(android_sdk._validated_tools[android_jar],
+                            os.path.join(workdir, 'android.jar'))
+
+  def test_register_link_no_permission(self):
+    with self.assertRaises(AndroidDistribution.DistributionError):
+      with self.distribution() as sdk:
+        with temporary_dir() as workdir:
+          os.chmod(workdir, 0o400)
+          android_sdk = AndroidDistribution.cached(sdk)
+          android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+          android_sdk.register_tool_link(android_jar, workdir)
+
+  def test_get_tool_path(self):
+    with self.distribution() as sdk:
+      android_sdk = AndroidDistribution.cached(sdk)
+      android_jar = os.path.join('platforms', 'android-19',  'android.jar')
+      tool_path = android_sdk._get_tool_path(android_jar)
+      self.assertEquals(tool_path, os.path.join(sdk, android_jar))
+
+  def test_get_bad_tool_path(self):
+    with self.assertRaises(AndroidDistribution.DistributionError):
+      with self.distribution() as sdk:
+        android_sdk = AndroidDistribution.cached(sdk)
+        android_jar = os.path.join('platforms', 'android-19',  'no.jar')
+        tool_path = android_sdk._get_tool_path(android_jar)
+        self.assertEquals(tool_path, os.path.join(sdk, android_jar))

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from pants.backend.android.distribution.android_distribution import AndroidDistribution
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import touch
-
 from pants_test.android.test_android_base import TestAndroidBase
 
 

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -10,6 +10,8 @@ from contextlib import contextmanager
 
 from pants.backend.android.distribution.android_distribution import AndroidDistribution
 from pants.util.contextutil import environment_as, temporary_dir
+from pants.util.dirutil import touch
+
 from pants_test.android.test_android_base import TestAndroidBase
 
 
@@ -129,7 +131,7 @@ class TestAndroidDistribution(TestAndroidBase):
       android_sdk.register_android_tool(aapt)
       self.assertIn(aapt, android_sdk._validated_tools)
 
-  def test_register_tool_link(self):
+  def test_register_tool_copy(self):
     with self.distribution() as sdk:
       with temporary_dir() as workdir:
         android_sdk = AndroidDistribution.cached(sdk)
@@ -138,7 +140,7 @@ class TestAndroidDistribution(TestAndroidBase):
         self.assertEquals(android_sdk._validated_tools[android_jar],
                           os.path.join(workdir, android_jar))
 
-  def test_register_tool_returns_link(self):
+  def test_register_tool_returns_file(self):
     with self.distribution() as sdk:
       with temporary_dir() as workdir:
         android_sdk = AndroidDistribution.cached(sdk)
@@ -146,7 +148,7 @@ class TestAndroidDistribution(TestAndroidBase):
         android_sdk.register_android_tool(android_jar, workdir=workdir)
         self.assertEquals(os.path.isfile(android_sdk._validated_tools[android_jar]), True)
 
-  def test_register_link_is_validated(self):
+  def test_register_copy_is_validated(self):
     with self.distribution() as sdk:
       with temporary_dir() as workdir:
         android_sdk = AndroidDistribution.cached(sdk)
@@ -154,7 +156,7 @@ class TestAndroidDistribution(TestAndroidBase):
         android_sdk.register_android_tool(android_jar, workdir=workdir)
         self.assertIn(android_jar, android_sdk._validated_tools)
 
-  def test_register_link_but_no_tool(self):
+  def test_register_copy_but_no_tool(self):
     with self.assertRaises(AndroidDistribution.DistributionError):
       with self.distribution() as sdk:
         with temporary_dir() as workdir:
@@ -164,7 +166,17 @@ class TestAndroidDistribution(TestAndroidBase):
           self.assertEquals(android_sdk._validated_tools[android_jar],
                             os.path.join(workdir, 'android.jar'))
 
-  def test_register_link_no_permission(self):
+  def test_register_copy_file_exists(self):
+    with self.distribution() as sdk:
+      with temporary_dir() as workdir:
+        android_sdk = AndroidDistribution.cached(sdk)
+        android_jar = os.path.join('platforms', 'android-19', 'android.jar')
+        existing_file = os.path.join(workdir, android_jar)
+        touch(existing_file)
+        android_sdk.register_android_tool(android_jar, workdir=workdir)
+        self.assertIn(android_jar, android_sdk._validated_tools)
+
+  def test_register_tool_no_permission(self):
     with self.assertRaises(AndroidDistribution.DistributionError):
       with self.distribution() as sdk:
         with temporary_dir() as workdir:

--- a/tests/python/pants_test/android/test_android_distribution.py
+++ b/tests/python/pants_test/android/test_android_distribution.py
@@ -134,16 +134,24 @@ class TestAndroidDistribution(TestAndroidBase):
       with temporary_dir() as workdir:
         android_sdk = AndroidDistribution.cached(sdk)
         android_jar = os.path.join('platforms', 'android-19', 'android.jar')
-        android_sdk.register_tool_link(android_jar, workdir)
+        android_sdk.register_android_tool(android_jar, workdir=workdir)
         self.assertEquals(android_sdk._validated_tools[android_jar],
-                          os.path.join(workdir, 'android.jar'))
+                          os.path.join(workdir, android_jar))
+
+  def test_register_tool_returns_link(self):
+    with self.distribution() as sdk:
+      with temporary_dir() as workdir:
+        android_sdk = AndroidDistribution.cached(sdk)
+        android_jar = os.path.join('platforms', 'android-19', 'android.jar')
+        android_sdk.register_android_tool(android_jar, workdir=workdir)
+        self.assertEquals(os.path.isfile(android_sdk._validated_tools[android_jar]), True)
 
   def test_register_link_is_validated(self):
     with self.distribution() as sdk:
       with temporary_dir() as workdir:
         android_sdk = AndroidDistribution.cached(sdk)
         android_jar = os.path.join('platforms', 'android-19', 'android.jar')
-        android_sdk.register_tool_link(android_jar, workdir)
+        android_sdk.register_android_tool(android_jar, workdir=workdir)
         self.assertIn(android_jar, android_sdk._validated_tools)
 
   def test_register_link_but_no_tool(self):
@@ -152,7 +160,7 @@ class TestAndroidDistribution(TestAndroidBase):
         with temporary_dir() as workdir:
           android_sdk = AndroidDistribution.cached(sdk)
           android_jar = os.path.join('platforms', 'android-19', 'no.jar')
-          android_sdk.register_tool_link(android_jar, workdir)
+          android_sdk.register_android_tool(android_jar, workdir=workdir)
           self.assertEquals(android_sdk._validated_tools[android_jar],
                             os.path.join(workdir, 'android.jar'))
 
@@ -163,7 +171,7 @@ class TestAndroidDistribution(TestAndroidBase):
           os.chmod(workdir, 0o400)
           android_sdk = AndroidDistribution.cached(sdk)
           android_jar = os.path.join('platforms', 'android-19', 'android.jar')
-          android_sdk.register_tool_link(android_jar, workdir)
+          android_sdk.register_android_tool(android_jar, workdir=workdir)
 
   def test_get_tool_path(self):
     with self.distribution() as sdk:


### PR DESCRIPTION

The classpath refactor requires that all classpath entries be under the
buildroot. The aapt_gen task was creating a synthetic target that added
android.jar from the local Android SDK. That failed with the new rule.

This adds the register_tool_link method, which creates a hard link
under the task workdir. I could not use a symlink (as suggested by Stu)
because it crashes during the creation of the symlink farm.

I am throwing this up for feedback. Maybe people would prefer I fetch
the jar through ivy or something.