### PR TITLE
Fix `Git.detect_worktree` to fail gracefully.

### DIFF
--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -21,6 +21,8 @@ class Git(Scm):
 
     binary: The path to the git binary to use, 'git' by default.
     """
+    # TODO(John Sirois): This is only used as a factory for a Git instance in
+    # pants.base.build_environment.get_scm, encapsulate in a true factory method.
     cmd = [binary, 'rev-parse', '--show-toplevel']
     try:
       process, out = cls._invoke(cmd)

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import errno
 import os
 import subprocess
 import traceback
@@ -227,8 +226,7 @@ class Git(Scm):
     cmd = self._create_git_cmdline(args)
     self._log_call(cmd)
 
-    process, out = self.\
-      _invoke(cmd)
+    process, out = self._invoke(cmd)
 
     self._check_result(cmd, process.returncode, failure_msg, raise_type)
     return self._cleanse(out, errors=errors)


### PR DESCRIPTION
Previously if there was no git executable on the path this method
would fail instead of returning `None`.  The upshot was that pants could
not be used outside a git repository.

This also makes `Git.detect_worktree` symmetric with `Git.__init__`,
allowing the git binary name/path to be passed in directly.

https://rbcommons.com/s/twitter/r/1903/