### PR TITLE
[Trigger CI] Remove superfluous 'self.conf' argument to self.classpath.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -63,7 +63,7 @@ class BenchmarkRun(JvmTask, JvmToolTaskMixin):
 
     benchmark_tools_classpath = self.tool_classpath('benchmark-tool')
 
-    classpath = self.classpath(self.context.targets(), benchmark_tools_classpath, confs=self.confs)
+    classpath = self.classpath(self.context.targets(), benchmark_tools_classpath)
 
     caliper_main = 'com.google.caliper.Runner'
     exit_code = execute_java(classpath=classpath,

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -139,7 +139,7 @@ class _JUnitRunner(object):
                  else self._calculate_tests_from_targets(java_tests_targets))
     if tests:
       bootstrapped_cp = self._task_exports.tool_classpath('junit')
-      junit_classpath = self._task_exports.classpath(targets, cp=bootstrapped_cp, confs=self._task_exports.confs)
+      junit_classpath = self._task_exports.classpath(targets, cp=bootstrapped_cp)
 
       self._context.release_lock()
       self.instrument(targets, tests, junit_classpath)

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -92,7 +92,7 @@ class JvmRun(JvmTask):
       executor = CommandLineGrabber() if self.only_write_cmd_line else None
       self.context.release_lock()
       result = execute_java(
-        classpath=(self.classpath([target], confs=self.confs)),
+        classpath=(self.classpath([target])),
         main=binary.main,
         executor=executor,
         jvm_options=self.jvm_options,

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -48,9 +48,13 @@ class JvmTask(Task):
 
     self.confs = self.get_options().confs
 
-  def classpath(self, targets, cp=None, confs=None):
+  def classpath(self, targets, cp=None):
     classpath = list(cp) if cp else []
     compile_classpaths = self.context.products.get_data('compile_classpath')
     compile_classpath = compile_classpaths.get_for_targets(targets)
-    classpath.extend(path for conf, path in compile_classpath if not confs or conf in confs)
+
+    def conf_needed(conf):
+      return not self.confs or conf in self.confs
+
+    classpath.extend(path for conf, path in compile_classpath if conf_needed(conf))
     return classpath

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -108,7 +108,7 @@ class JvmdocGen(JvmTask):
     targets = self.context.targets()
     with self.invalidated(filter(docable, targets)) as invalidation_check:
       safe_mkdir(self.workdir)
-      classpath = self.classpath(targets, confs=self.confs)
+      classpath = self.classpath(targets)
 
       def find_jvmdoc_targets():
         invalid_targets = set()

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -38,7 +38,7 @@ class ScalaRepl(JvmTask, JvmToolTaskMixin):
       tools_classpath = self.tool_classpath('scala-repl')
       self.context.release_lock()
       with preserve_stty_settings():
-        classpath = self.classpath(targets, cp=tools_classpath, confs=self.confs)
+        classpath = self.classpath(targets, cp=tools_classpath)
 
         print('')  # Start REPL output on a new line.
         try:

--- a/src/python/pants/backend/jvm/tasks/specs_run.py
+++ b/src/python/pants/backend/jvm/tasks/specs_run.py
@@ -64,7 +64,7 @@ class SpecsRun(JvmTask, JvmToolTaskMixin):
         specs_runner_main = 'com.twitter.common.testing.ExplicitSpecsRunnerMain'
 
         bootstrapped_cp = self.tool_classpath('specs')
-        classpath = self.classpath(targets, cp=bootstrapped_cp, confs=self.confs)
+        classpath = self.classpath(targets, cp=bootstrapped_cp)
 
         result = execute_java(
           classpath=classpath,


### PR DESCRIPTION
The base class can access self.conf directly.