### PR TITLE
[Trigger CI ]walk synthetic targets dependencies when constructing context.target()

### DIFF
--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -10,6 +10,8 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 
+from twitter.common.collections import OrderedSet
+
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.build_graph import BuildGraph
@@ -275,16 +277,29 @@ class Context(object):
                           `False` or preorder by default.
     :returns: A list of matching targets.
     """
-
     target_root_addresses = [target.address for target in self.target_roots]
-    target_set = self.build_graph.transitive_subgraph_of_addresses(target_root_addresses,
-                                                                   postorder=postorder)
+    target_set = self._collect_targets(self.target_roots, postorder=postorder)
 
+    synthetics = OrderedSet()
     for derived_from, synthetic_targets in self._synthetic_targets.items():
-      if derived_from in target_set:
-        target_set.update(synthetic_targets)
+      if derived_from in target_set or derived_from in synthetics:
+        synthetics.update(synthetic_targets)
+      else:
+        self.log.debug(
+          "Found synthetic targets derived from {}, which is outside the expected graph.".format(
+            derived_from.address))
+
+    synthetic_set = self._collect_targets(synthetics, postorder=postorder)
+
+    target_set.update(synthetic_set)
 
     return filter(predicate, target_set)
+
+  def _collect_targets(self, root_targets, postorder=False):
+    addresses = [target.address for target in root_targets]
+    target_set = self.build_graph.transitive_subgraph_of_addresses(addresses,
+                                                                   postorder=postorder)
+    return target_set
 
   def dependents(self, on_predicate=None, from_predicate=None):
     """Returns  a map from targets that satisfy the from_predicate to targets they depend on that

--- a/tests/python/pants_test/goal/test_context.py
+++ b/tests/python/pants_test/goal/test_context.py
@@ -73,3 +73,17 @@ class ContextTest(BaseTest):
     # And verify the predicate operates over both normal and synthetic targets.
     self.assertEquals([syn_b], context.targets(lambda t: t.derived_from != t))
     self.assertEquals([c, b, a], context.targets(lambda t: t.derived_from == t))
+
+  def test_targets_includes_synthetic_dependencies(self):
+    a = self.make_target('a')
+    b = self.make_target('b')
+    context = self.context(target_roots=[b])
+    self.assertEquals([b], context.targets())
+
+    syn_with_deps = context.add_new_target(
+                                           SyntheticAddress.parse('syn_with_deps'),
+                                           Target,
+                                           derived_from=b,
+                                           dependencies=[a])
+
+    self.assertEquals([b, syn_with_deps, a], context.targets())


### PR DESCRIPTION
A recent change made it so that synthetic targets dependencies aren't traversed which caused their 3rdparty deps to be not added to the classpath in certain cases. This caused compilation errors. This patch retains the derivation checks from the previous one, but expands the synthetic targets after determining which ones are needed.

https://rbcommons.com/s/twitter/r/1914/