### PR TITLE
[Trigger CI ]Fix regression in synthetic target context handling.

### DIFF
--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -262,7 +262,10 @@ class Context(object):
                                              derived_from=derived_from,
                                              **kwargs)
     new_target = self.build_graph.get_target(address)
-    self._synthetic_targets[derived_from].append(new_target)
+
+    if derived_from:
+      self._synthetic_targets[derived_from].append(new_target)
+
     return new_target
 
   def targets(self, predicate=None, postorder=False):
@@ -284,10 +287,6 @@ class Context(object):
     for derived_from, synthetic_targets in self._synthetic_targets.items():
       if derived_from in target_set or derived_from in synthetics:
         synthetics.update(synthetic_targets)
-      else:
-        self.log.debug(
-          "Found synthetic targets derived from {}, which is outside the expected graph.".format(
-            derived_from.address))
 
     synthetic_set = self._collect_targets(synthetics, postorder=postorder)
 

--- a/tests/python/pants_test/goal/test_context.py
+++ b/tests/python/pants_test/goal/test_context.py
@@ -87,3 +87,30 @@ class ContextTest(BaseTest):
                                            dependencies=[a])
 
     self.assertEquals([b, syn_with_deps, a], context.targets())
+
+  def test_targets_ignore_synthetics_with_no_derived_from_not_injected_into_graph(self):
+    a = self.make_target('a')
+    b = self.make_target('b')
+    context = self.context(target_roots=[b])
+    self.assertEquals([b], context.targets())
+
+    syn_with_deps = context.add_new_target(
+                                           SyntheticAddress.parse('syn_with_deps'),
+                                           Target,
+                                           dependencies=[a])
+
+    self.assertEquals([b], context.targets())
+
+  def test_targets_include_synthetics_with_no_derived_from_injected_into_graph(self):
+    a = self.make_target('a')
+    b = self.make_target('b')
+    context = self.context(target_roots=[b])
+    self.assertEquals([b], context.targets())
+
+    syn_with_deps = context.add_new_target(
+                                           SyntheticAddress.parse('syn_with_deps'),
+                                           Target,
+                                           dependencies=[a])
+    b.inject_dependency(syn_with_deps.address)
+
+    self.assertEquals([b, syn_with_deps, a], context.targets())


### PR DESCRIPTION
This fixes an issue I ran into testing the changes I introduced on friday. The problem was that if you set derived_from to None, when applying the synthetic targets by their derived targets, the derived target would be None, so it would raise an error on the logging line I added. I removed the log line, since after thinking about it, I don't think it's necessary. Also I guarded adding targets to the synthetic target dict because if derived_from _is_ None, then it won't be used, so there's no point in adding it.