### PR TITLE
Move count variable outside loop.

### DIFF
--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -93,8 +93,8 @@ class CmdLineSpecParser(object):
                    .format(excludes='\n  '.join(self._exclude_target_regexps)))
       targets = ', '.join(self._excluded_target_map[CmdLineSpecParser._UNMATCHED_KEY])
       logger.debug('Targets after excludes: {targets}'.format(targets=targets))
+      excluded_count = 0
       for pattern, targets in self._excluded_target_map.iteritems():
-        excluded_count = 0
         if pattern != CmdLineSpecParser._UNMATCHED_KEY:
           logger.debug('Targets excluded by pattern {pattern}\n  {targets}'
                        .format(pattern=pattern,


### PR DESCRIPTION
I'm pretty sure this is just a bug, right? Before this change the debugging output would only include the count of the last pattern if there was more than one.