### PR TITLE
part two of two in separating out a separate goal from depmap for use by...

### DIFF
--- a/src/python/pants/backend/project_info/register.py
+++ b/src/python/pants/backend/project_info/register.py
@@ -9,6 +9,7 @@ from pants.backend.project_info.tasks.dependencies import Dependencies
 from pants.backend.project_info.tasks.depmap import Depmap
 from pants.backend.project_info.tasks.eclipse_gen import EclipseGen
 from pants.backend.project_info.tasks.ensime_gen import EnsimeGen
+from pants.backend.project_info.tasks.export import Export
 from pants.backend.project_info.tasks.filedeps import FileDeps
 from pants.backend.project_info.tasks.idea_gen import IdeaGen
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -28,6 +29,8 @@ def register_goals():
 
   task(name='ensime', action=EnsimeGen).install().with_description(
       'Create an Ensime project from the given targets.')
+
+  task(name='export', action=Export).install().with_description("Export project information for targets in JSON format.")
 
   task(name='depmap', action=Depmap).install().with_description("Depict the target's dependencies.")
 

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -8,6 +8,7 @@ python_library(
     ':depmap',
     ':eclipse_gen',
     ':ensime_gen',
+    ':export',
     ':filedeps',
     ':ide_gen',
     ':idea_gen',
@@ -36,6 +37,7 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
   ],
 )
@@ -63,6 +65,20 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:generator',
     'src/python/pants/util:dirutil',
+  ],
+)
+
+python_library(
+  name = 'export',
+  sources = ['export.py'],
+  dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/core/targets:all',
+    'src/python/pants/backend/core/tasks:console_task',
+    'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/backend/jvm/targets:scala',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/base:exceptions',
   ],
 )
 

--- a/src/python/pants/backend/project_info/tasks/depmap.py
+++ b/src/python/pants/backend/project_info/tasks/depmap.py
@@ -18,11 +18,10 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_binary import JvmApp
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated
 from pants.base.exceptions import TaskError
 
 
-# Changing the behavior of this task may affect the IntelliJ Pants plugin
-# Please add fkorotkov, tdesai to reviews for this file
 class Depmap(ConsoleTask):
   """Generates either a textual dependency tree or a graphviz digraph dot file for the dependency
   set of a target.
@@ -70,9 +69,13 @@ class Depmap(ConsoleTask):
              help='Specifies the internal dependency graph should be output in the dot digraph '
                   'format.')
     register('--project-info', default=False, action='store_true',
+             deprecated_version='0.0.31',
+             deprecated_hint='Use the export goal instead of depmap to get info for the IDE.',
              help='Produces a json object with info about the target, including source roots, '
                   'dependencies, and paths to libraries for their targets and dependencies.')
     register('--project-info-formatted', default=True, action='store_false',
+             deprecated_version='0.0.31',
+             deprecated_hint='Use the export goal instead of depmap to get info for the IDE.',
              help='Causes project-info output to be a single line of JSON.')
     register('--separator', default='-',
              help='Specifies the separator to use between the org/name/rev components of a '
@@ -237,6 +240,8 @@ class Depmap(ConsoleTask):
     graph_attr = ['  node [shape=rectangle, colorscheme=set312;];', '  rankdir=LR;']
     return header + graph_attr + output_deps(set(), target) + ['}']
 
+  @deprecated(removal_version='0.0.31',
+      hint_message='Information from "depmap --project-info" should now be accessed through the "export" goal')
   def project_info_output(self, targets):
     targets_map = {}
     resource_target_map = {}

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -1,0 +1,205 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import json
+import os
+from collections import defaultdict
+
+from twitter.common.collections import OrderedSet
+
+from pants.backend.core.targets.resources import Resources
+from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.backend.jvm.targets.jvm_binary import JvmApp
+from pants.backend.jvm.targets.scala_library import ScalaLibrary
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
+
+
+# Changing the behavior of this task may affect the IntelliJ Pants plugin
+# Please add fkorotkov, tdesai to reviews for this file
+class Export(ConsoleTask):
+  """Generates a JSON description of the targets as configured in pants.
+
+  Intended for exporting project information for IDE, such as the IntelliJ Pants plugin.
+  """
+  class SourceRootTypes(object):
+    """Defines SourceRoot Types Constants"""
+    SOURCE = 'SOURCE'  # Source Target
+    TEST = 'TEST'  # Test Target
+    SOURCE_GENERATED = 'SOURCE_GENERATED'  # Code Gen Source Targets
+    EXCLUDED = 'EXCLUDED'  # Excluded Target
+    RESOURCE = 'RESOURCE'  # Resource belonging to Source Target
+    TEST_RESOURCE = 'TEST_RESOURCE'  # Resource belonging to Test Target
+
+  @staticmethod
+  def _is_jvm(dep):
+    return dep.is_jvm or isinstance(dep, JvmApp)
+
+  @staticmethod
+  def _jar_id(jar):
+    if jar.rev:
+      return '{0}:{1}:{2}'.format(jar.org, jar.name, jar.rev)
+    else:
+      return '{0}:{1}'.format(jar.org, jar.name)
+
+  @staticmethod
+  def _address(address):
+    """
+    :type address: pants.base.address.SyntheticAddress
+    """
+    return '{0}:{1}'.format(address.spec_path, address.target_name)
+
+  @classmethod
+  def register_options(cls, register):
+    super(Export, cls).register_options(register)
+    register('--project-info', default=True, action='store_true',
+             deprecated_version='0.0.31',
+             deprecated_hint='This option is a no-op. Project info format is always enabled for '
+                             'the export goal.',
+             help='Produces a json object with info about the target, including source roots, '
+                  'dependencies, and paths to libraries for their targets and dependencies.')
+    register('--formatted', default=True, action='store_false',
+             help='Causes output to be a single line of JSON.')
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(Export, cls).prepare(options, round_manager)
+    round_manager.require_data('ivy_jar_products')
+
+  def __init__(self, *args, **kwargs):
+    super(Export, self).__init__(*args, **kwargs)
+    self.format = self.get_options().formatted
+    self.target_aliases_map = None
+
+  def console_output(self, targets):
+    if len(self.context.target_roots) == 0:
+      raise TaskError("One or more target addresses are required.")
+    output = self.project_info_output(targets)
+    for line in output:
+      yield line
+
+  def project_info_output(self, targets):
+    targets_map = {}
+    resource_target_map = {}
+    ivy_jar_products = self.context.products.get_data('ivy_jar_products') or {}
+    # This product is a list for historical reasons (exclusives groups) but in practice should
+    # have either 0 or 1 entries.
+    ivy_info_list = ivy_jar_products.get('default')
+    if ivy_info_list:
+      assert len(ivy_info_list) == 1, (
+        'The values in ivy_jar_products should always be length 1,'
+        ' since we no longer have exclusives groups.'
+      )
+      ivy_info = ivy_info_list[0]
+    else:
+      ivy_info = None
+
+    ivy_jar_memo = {}
+    def process_target(current_target):
+      """
+      :type current_target:pants.base.target.Target
+      """
+      def get_target_type(target):
+        if target.is_test:
+          return Export.SourceRootTypes.TEST
+        else:
+          if (isinstance(target, Resources) and
+              target in resource_target_map and
+              resource_target_map[target].is_test):
+            return Export.SourceRootTypes.TEST_RESOURCE
+          elif isinstance(target, Resources):
+            return Export.SourceRootTypes.RESOURCE
+          else:
+            return Export.SourceRootTypes.SOURCE
+
+      def get_transitive_jars(jar_lib):
+        if not ivy_info:
+          return OrderedSet()
+        transitive_jars = OrderedSet()
+        for jar in jar_lib.jar_dependencies:
+          transitive_jars.update(ivy_info.get_jars_for_ivy_module(jar, memo=ivy_jar_memo))
+        return transitive_jars
+
+      info = {
+        'targets': [],
+        'libraries': [],
+        'roots': [],
+        'target_type': get_target_type(current_target),
+        'is_code_gen': current_target.is_codegen,
+        'pants_target_type': self._get_pants_target_alias(type(current_target))
+      }
+
+      target_libraries = set()
+      if isinstance(current_target, JarLibrary):
+        target_libraries = get_transitive_jars(current_target)
+      for dep in current_target.dependencies:
+        info['targets'].append(self._address(dep.address))
+        if isinstance(dep, JarLibrary):
+          for jar in dep.jar_dependencies:
+            target_libraries.add(jar)
+          # Add all the jars pulled in by this jar_library
+          target_libraries.update(get_transitive_jars(dep))
+        if isinstance(dep, Resources):
+          resource_target_map[dep] = current_target
+
+      if isinstance(current_target, ScalaLibrary):
+        for dep in current_target.java_sources:
+          info['targets'].append(self._address(dep.address))
+          process_target(dep)
+
+      info['roots'] = map(lambda (source_root, package_prefix): {
+        'source_root': source_root,
+        'package_prefix': package_prefix
+      }, self._source_roots_for_target(current_target))
+
+      info['libraries'] = [self._jar_id(lib) for lib in target_libraries]
+      targets_map[self._address(current_target.address)] = info
+
+    for target in targets:
+      process_target(target)
+
+    graph_info = {
+      'targets': targets_map,
+      'libraries': self._resolve_jars_info()
+    }
+    if self.format:
+      return json.dumps(graph_info, indent=4, separators=(',', ': ')).splitlines()
+    else:
+      return [json.dumps(graph_info)]
+
+  def _resolve_jars_info(self):
+    mapping = defaultdict(list)
+    jar_data = self.context.products.get_data('ivy_jar_products')
+    if not jar_data:
+      return mapping
+    for dep in jar_data['default']:
+      for module in dep.modules_by_ref.values():
+        mapping[self._jar_id(module.ref)] = [artifact.path for artifact in module.artifacts]
+    return mapping
+
+  def _get_pants_target_alias(self, pants_target_type):
+    """Returns the pants target alias for the given target"""
+    if not self.target_aliases_map:
+      target_aliases = self.context.build_file_parser.registered_aliases().targets
+      # If a target class is registered under multiple aliases returns the last one.
+      self.target_aliases_map = {classname: alias for alias, classname in target_aliases.items()}
+    if pants_target_type in self.target_aliases_map:
+      return self.target_aliases_map.get(pants_target_type)
+    else:
+      raise TaskError('Unregistered target type {target_type}'.format(target_type=pants_target_type))
+
+  @staticmethod
+  def _source_roots_for_target(target):
+    """
+    :type target:pants.base.target.Target
+    """
+    def root_package_prefix(source_file):
+      source = os.path.dirname(source_file)
+      return os.path.join(get_buildroot(), target.target_base, source), source.replace(os.sep, '.')
+    return set(map(root_package_prefix, target.sources_relative_to_source_root()))

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -6,6 +6,7 @@ python_library(
   dependencies = [
     ':dependencies',
     ':depmap',
+    ':export',
     ':filedeps',
     ':ide_gen',
     ':idea_gen',
@@ -40,6 +41,23 @@ python_tests(
     'src/python/pants/backend/project_info/tasks:depmap',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:exceptions',
+    'tests/python/pants_test/tasks:base',
+  ]
+)
+
+python_tests(
+  name = 'export',
+  sources = ['test_export.py'],
+  dependencies = [
+    'src/python/pants/backend/core:plugin',
+    'src/python/pants/backend/core/targets:common',
+    'src/python/pants/backend/jvm:plugin',
+    'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/backend/jvm/targets:scala',
+    'src/python/pants/backend/project_info/tasks:export',
+    'src/python/pants/backend/python:plugin',
     'src/python/pants/base:exceptions',
     'tests/python/pants_test/tasks:base',
   ]

--- a/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
@@ -390,7 +390,12 @@ class ProjectInfoTest(ConsoleTaskTest):
       resources=[],
     )
 
+
   def test_without_dependencies(self):
+    # Are these tests failing?  --project-info is to be removed
+    # from the depmap target in 0.0.31.  The ProjectInfoTest suite
+    # has already been moved to test_export.py so you can remove
+    # this class from test_depmap.py when it goes away.
     result = get_json(self.execute_console_task(
       args=['--test-project-info'],
       targets=[self.target('project_info:first')]

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -1,0 +1,237 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import json
+import os
+
+from pants.backend.core.register import build_file_aliases as register_core
+from pants.backend.core.targets.dependencies import Dependencies
+from pants.backend.core.targets.resources import Resources
+from pants.backend.jvm.register import build_file_aliases as register_jvm
+from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.targets.java_tests import JavaTests
+from pants.backend.jvm.targets.jvm_binary import JvmApp, JvmBinary
+from pants.backend.jvm.targets.jvm_target import JvmTarget
+from pants.backend.jvm.targets.scala_library import ScalaLibrary
+from pants.backend.project_info.tasks.export import Export
+from pants.base.exceptions import TaskError
+from pants_test.tasks.test_base import ConsoleTaskTest
+
+
+class ProjectInfoTest(ConsoleTaskTest):
+  @classmethod
+  def task_type(cls):
+    return Export
+
+  @property
+  def alias_groups(self):
+    return register_core().merge(register_jvm())
+
+  def setUp(self):
+    super(ProjectInfoTest, self).setUp()
+
+    self.make_target(
+      'project_info:first',
+      target_type=JarLibrary,
+    )
+
+    jar_lib = self.make_target(
+      'project_info:jar_lib',
+      target_type=JarLibrary,
+      jars=[JarDependency('org.apache', 'apache-jar', '12.12.2012')],
+    )
+
+    self.make_target(
+      'java/project_info:java_lib',
+      target_type=JavaLibrary,
+      sources=['com/foo/Bar.java', 'com/foo/Baz.java'],
+    )
+
+    self.make_target(
+      'project_info:third',
+      target_type=ScalaLibrary,
+      dependencies=[jar_lib],
+      java_sources=['java/project_info:java_lib'],
+      sources=['com/foo/Bar.scala', 'com/foo/Baz.scala'],
+    )
+
+    self.make_target(
+      'project_info:jvm_app',
+      target_type=JvmApp,
+      dependencies=[jar_lib],
+    )
+
+    self.make_target(
+      'project_info:jvm_target',
+      target_type=ScalaLibrary,
+      dependencies=[jar_lib],
+      sources=['this/is/a/source/Foo.scala', 'this/is/a/source/Bar.scala'],
+    )
+
+    test_resource = self.make_target(
+      'project_info:test_resource',
+      target_type=Resources,
+      sources=['y_resource', 'z_resource'],
+    )
+
+    self.make_target(
+      'project_info:java_test',
+      target_type=JavaTests,
+      dependencies=[jar_lib],
+      sources=['this/is/a/test/source/FooTest.scala'],
+      resources=[test_resource],
+    )
+
+    jvm_binary = self.make_target(
+      'project_info:jvm_binary',
+      target_type=JvmBinary,
+      dependencies=[jar_lib],
+    )
+
+    self.make_target(
+      'project_info:top_dependency',
+      target_type=Dependencies,
+      dependencies=[jvm_binary],
+    )
+
+    src_resource = self.make_target(
+      'project_info:resource',
+      target_type=Resources,
+      sources=['a_resource', 'b_resource'],
+    )
+
+    self.make_target(
+        'project_info:target_type',
+        target_type=ScalaLibrary,
+        dependencies=[jvm_binary],
+        resources=[src_resource],
+    )
+
+    self.make_target(
+      'project_info:unrecognized_target_type',
+      target_type=JvmTarget,
+      dependencies=[],
+      resources=[],
+    )
+
+  def test_without_dependencies(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:first')]
+    ))
+    self.assertEqual({}, result['libraries'])
+
+  def test_with_dependencies(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:third')]
+    ))
+
+    self.assertEqual(
+      [
+        'java/project_info:java_lib',
+        'project_info:jar_lib'
+      ],
+      sorted(result['targets']['project_info:third']['targets'])
+    )
+    self.assertEqual(['org.apache:apache-jar:12.12.2012'],
+                     result['targets']['project_info:third']['libraries'])
+
+    self.assertEqual(1, len(result['targets']['project_info:third']['roots']))
+    source_root = result['targets']['project_info:third']['roots'][0]
+    self.assertEqual('com.foo', source_root['package_prefix'])
+    self.assertEqual(
+      '%s/project_info/com/foo' % self.build_root,
+      source_root['source_root']
+    )
+
+  def test_jvm_app(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:jvm_app')]
+    ))
+    self.assertEqual(['org.apache:apache-jar:12.12.2012'],
+                     result['targets']['project_info:jvm_app']['libraries'])
+
+  def test_jvm_target(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:jvm_target')]
+    ))
+    jvm_target = result['targets']['project_info:jvm_target']
+    expected_jmv_target = {
+      'libraries': ['org.apache:apache-jar:12.12.2012'],
+      'is_code_gen': False,
+      'targets': ['project_info:jar_lib'],
+      'roots': [
+         {
+           'source_root': '{root}/project_info/this/is/a/source'.format(root=self.build_root),
+           'package_prefix': 'this.is.a.source'
+         },
+      ],
+      'target_type': 'SOURCE',
+      'pants_target_type': 'scala_library'
+    }
+    self.assertEqual(jvm_target, expected_jmv_target)
+
+  def test_java_test(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:java_test')]
+    ))
+    self.assertEqual('TEST', result['targets']['project_info:java_test']['target_type'])
+    self.assertEqual(['org.apache:apache-jar:12.12.2012'],
+                     result['targets']['project_info:java_test']['libraries'])
+    self.assertEqual('TEST_RESOURCE',
+                     result['targets']['project_info:test_resource']['target_type'])
+
+  def test_jvm_binary(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:jvm_binary')]
+    ))
+    self.assertEqual(['org.apache:apache-jar:12.12.2012'],
+                     result['targets']['project_info:jvm_binary']['libraries'])
+
+  def test_top_dependency(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:top_dependency')]
+    ))
+    self.assertEqual([], result['targets']['project_info:top_dependency']['libraries'])
+    self.assertEqual(['project_info:jvm_binary'],
+                     result['targets']['project_info:top_dependency']['targets'])
+
+  def test_format_flag(self):
+    result = self.execute_console_task(
+      args=['--test-formatted'],
+      targets=[self.target('project_info:third')]
+    )
+    # confirms only one line of output, which is what -format should produce
+    self.assertEqual(1, len(result))
+
+  def test_target_types(self):
+    result = get_json(self.execute_console_task(
+      targets=[self.target('project_info:target_type')]
+    ))
+    self.assertEqual('SOURCE',
+                     result['targets']['project_info:target_type']['target_type'])
+    self.assertEqual('RESOURCE', result['targets']['project_info:resource']['target_type'])
+
+  def test_output_file(self):
+    outfile = os.path.join(self.build_root, '.pants.d', 'test')
+    self.execute_console_task(args=['--test-output-file={}'.format(outfile)],
+                              targets=[self.target('project_info:target_type')])
+    self.assertTrue(os.path.exists(outfile))
+
+  def test_output_file_error(self):
+    with self.assertRaises(TaskError):
+      self.execute_console_task(args=['--test-output-file={}'.format(self.build_root)],
+                                targets=[self.target('project_info:target_type')])
+
+  def test_unrecognized_target_type(self):
+    with self.assertRaises(TaskError):
+      self.execute_console_task(targets=[self.target('project_info:unrecognized_target_type')])
+
+
+def get_json(lines):
+  return json.loads(''.join(lines))

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -56,6 +56,7 @@ target(
     ':depmap_integration',
     ':eclipse_integration',
     ':ensime_integration',
+    ':export_integration',
     ':idea_integration',
     ':ivy_resolve_integration',
     ':jar_publish_integration',
@@ -228,6 +229,17 @@ python_tests(
   ],
 )
 
+python_tests(
+  name = 'export_integration',
+  sources = ['test_export_integration.py'],
+  dependencies = [
+    'src/python/pants/base:build_environment',
+    'src/python/pants/base:config',
+    'src/python/pants/ivy:ivy',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ],
+)
 python_tests(
   name = 'filemap',
   sources = ['test_filemap.py'],

--- a/tests/python/pants_test/tasks/test_export_integration.py
+++ b/tests/python/pants_test/tasks/test_export_integration.py
@@ -15,47 +15,43 @@ from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
-class DepmapIntegrationTest(PantsRunIntegrationTest):
+class ExportIntegrationTest(PantsRunIntegrationTest):
 
-  def run_depmap_project_info(self, test_target, workdir):
-    depmap_out_file = os.path.join(workdir, 'depmap_out.txt')
+  def run_export(self, test_target, workdir):
+    export_out_file = os.path.join(workdir, 'export_out.txt')
     pants_run = self.run_pants_with_workdir([
-        'depmap',
-        '--project-info',
-        '--output-file={out_file}'.format(out_file=depmap_out_file),
+        'export',
+        '--output-file={out_file}'.format(out_file=export_out_file),
         test_target],
         workdir)
-    # Is the above call failing? The --project-info flag is scheduled to be removed
-    # after 0.0.31. These tests have already been duplicated to test_export_integration.py
-    # so you can just remove this file completely.
     self.assert_success(pants_run)
-    self.assertTrue(os.path.exists(depmap_out_file),
-                    msg='Could not find depmap output file in {out_file}'
-                        .format(out_file=depmap_out_file))
-    with open(depmap_out_file) as json_file:
+    self.assertTrue(os.path.exists(export_out_file),
+                    msg='Could not find export output file in {out_file}'
+                        .format(out_file=export_out_file))
+    with open(export_out_file) as json_file:
       json_data = json.load(json_file)
       return json_data
 
-  def test_depmap_code_gen(self):
+  def test_export_code_gen(self):
     with temporary_dir(root_dir=self.workdir_root()) as workdir:
       test_target = 'examples/tests/java/com/pants/examples/usethrift:usethrift'
-      json_data = self.run_depmap_project_info(test_target, workdir)
+      json_data = self.run_export(test_target, workdir)
       thrift_target_name = 'examples.src.thrift.com.pants.examples.precipitation.precipitation-java'
       codegen_target = os.path.join(os.path.relpath(workdir, get_buildroot()),
                                     'gen/thrift/combined/gen-java:%s' % thrift_target_name)
       self.assertIn(codegen_target, json_data.get('targets'))
 
-  def test_depmap_json_transitive_jar(self):
+  def test_export_json_transitive_jar(self):
     with temporary_dir(root_dir=self.workdir_root()) as workdir:
       test_target = 'examples/tests/java/com/pants/examples/usethrift:usethrift'
-      json_data = self.run_depmap_project_info(test_target, workdir)
+      json_data = self.run_export(test_target, workdir)
       targets = json_data.get('targets')
       self.assertIn('org.hamcrest:hamcrest-core:1.3', targets[test_target]['libraries'])
 
-  def test_depmap_jar_path(self):
+  def test_export_jar_path(self):
     with temporary_dir(root_dir=self.workdir_root()) as workdir:
       test_target = 'examples/tests/java/com/pants/examples/usethrift:usethrift'
-      json_data = self.run_depmap_project_info(test_target, workdir)
+      json_data = self.run_export(test_target, workdir)
       # Hack because Bootstrapper.instance() reads config from cache. Will go away after we plumb
       # options into IvyUtil properly.
       Config.cache(Config.load())
@@ -67,6 +63,6 @@ class DepmapIntegrationTest(PantsRunIntegrationTest):
   def test_dep_map_for_java_sources(self):
     with temporary_dir(root_dir=self.workdir_root()) as workdir:
       test_target = 'examples/src/scala/com/pants/example/scala_with_java_sources'
-      json_data = self.run_depmap_project_info(test_target, workdir)
+      json_data = self.run_export(test_target, workdir)
       targets = json_data.get('targets')
       self.assertIn('examples/src/java/com/pants/examples/java_sources:java_sources', targets)


### PR DESCRIPTION
... an IDE

Copied 'depmap' to 'export' and trimmed out the unecessary stuff for running
 --project-info
Marked --project-info flag as deprecated in depmap.