### PR TITLE
Fix python_repl to work for python_requirement_libraries.

### DIFF
--- a/src/python/pants/backend/python/targets/python_requirement_library.py
+++ b/src/python/pants/backend/python/targets/python_requirement_library.py
@@ -26,3 +26,4 @@ class PythonRequirementLibrary(Target):
       'requirements': PythonRequirementsField(requirements or []),
     })
     super(PythonRequirementLibrary, self).__init__(payload=payload, **kwargs)
+    self.add_labels('python')

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -27,7 +27,8 @@ class PythonRepl(PythonTask):
     register('--ipython-requirements', advanced=True, type=Options.list, default=['ipython==1.0.0'],
              help='The IPython interpreter version to use.')
 
-  def execute(self):
+  # NB: **pex_run_kwargs is used by tests only, execute nominally has (void)void signature.
+  def execute(self, **pex_run_kwargs):
     (accept_predicate, reject_predicate) = Target.lang_discriminator('python')
     targets = self.require_homogeneous_targets(accept_predicate, reject_predicate)
     if targets:
@@ -59,7 +60,7 @@ class PythonRepl(PythonTask):
         self.context.release_lock()
         with stty_utils.preserve_stty_settings():
           with self.context.new_workunit(name='run', labels=[WorkUnit.RUN]):
-            po = pex.run(blocking=False)
+            po = pex.run(blocking=False, **pex_run_kwargs)
             try:
               return po.wait()
             except KeyboardInterrupt:

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -1,7 +1,20 @@
 target(
   name='tasks',
   dependencies=[
-    ':python_eval'
+    ':python_eval',
+    ':python_repl'
+  ]
+)
+
+python_tests(
+  name='python_task_test',
+  sources=['python_task_test.py'],
+  dependencies=[
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/base:address',
+    'src/python/pants/base:build_file_aliases',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/tasks:base'
   ]
 )
 
@@ -9,13 +22,27 @@ python_tests(
   name='python_eval',
   sources=['test_python_eval.py'],
   dependencies=[
+    ':python_task_test',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:source_root',
+  ]
+)
+
+python_tests(
+  name='python_repl',
+  sources=['test_python_repl.py'],
+  dependencies=[
+    ':python_task_test',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/backend/python:all_utils',
     'src/python/pants/base:address',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',
-    'src/python/pants/util:dirutil',
-    'tests/python/pants_test/tasks:base'
+    'src/python/pants/base:target',
+    'src/python/pants/util:contextutil',
   ]
 )

--- a/tests/python/pants_test/backend/python/tasks/python_task_test.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import shutil
+from textwrap import dedent
+
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.base.address import SyntheticAddress
+from pants.base.build_file_aliases import BuildFileAliases
+from pants.util.dirutil import safe_mkdir
+from pants_test.tasks.test_base import TaskTest
+
+
+# TODO(John Sirois): Convert to TaskTestBase - note this will require a good bit of option plumbing
+# to get the main pants cache re-use for speed-ups bit in setUp below.
+class PythonTaskTest(TaskTest):
+  def setUp(self):
+    super(PythonTaskTest, self).setUp()
+
+    # Re-use the main pants python cache to speed up interpreter selection and artifact resolution.
+    safe_mkdir(os.path.join(self.build_root, '.pants.d'))
+    shutil.copytree(os.path.join(self.real_build_root, '.pants.d', 'python'),
+                    os.path.join(self.build_root, '.pants.d', 'python'),
+                    symlinks=True)
+
+  @property
+  def alias_groups(self):
+    return BuildFileAliases.create(targets={'python_library': PythonLibrary,
+                                            'python_binary': PythonBinary})
+
+  def create_python_library(self, relpath, name, source, contents, dependencies=()):
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    python_library(
+      name='{name}',
+      sources=['__init__.py', '{source}'],
+      dependencies=[
+        {dependencies}
+      ]
+    )
+    """).format(name=name, source=source, dependencies=','.join(map(repr, dependencies))))
+
+    self.create_file(relpath=os.path.join(relpath, '__init__.py'))
+    self.create_file(relpath=os.path.join(relpath, source), contents=contents)
+    return self.target(SyntheticAddress(relpath, name).spec)
+
+  def create_python_binary(self, relpath, name, entry_point, dependencies=()):
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    python_binary(
+      name='{name}',
+      entry_point='{entry_point}',
+      dependencies=[
+        {dependencies}
+      ]
+    )
+    """).format(name=name, entry_point=entry_point, dependencies=','.join(map(repr, dependencies))))
+
+    return self.target(SyntheticAddress(relpath, name).spec)

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -1,0 +1,171 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import sys
+from contextlib import contextmanager
+from textwrap import dedent
+
+from pants.backend.python.python_requirement import PythonRequirement
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.tasks.python_repl import PythonRepl
+from pants.base.address import SyntheticAddress
+from pants.base.build_file_aliases import BuildFileAliases
+from pants.base.exceptions import TaskError
+from pants.base.source_root import SourceRoot
+from pants.base.target import Target
+from pants.util.contextutil import temporary_dir
+from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
+
+
+class PythonReplTest(PythonTaskTest):
+  @classmethod
+  def task_type(cls):
+    return PythonRepl
+
+  class JvmTarget(Target):
+    def __init__(self, *args, **kwargs):
+      super(PythonReplTest.JvmTarget, self).__init__(*args, **kwargs)
+      self.add_labels('jvm')
+
+  @property
+  def alias_groups(self):
+    return super(PythonReplTest, self).alias_groups.merge(
+        BuildFileAliases.create(targets={'jvm_target': self.JvmTarget,
+                                         'python_requirement_library': PythonRequirementLibrary},
+                                objects={'python_requirement': PythonRequirement}))
+
+  def create_non_python_target(self, relpath, name):
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    jvm_target(
+      name='{name}',
+    )
+    """).format(name=name))
+
+    return self.target(SyntheticAddress(relpath, name).spec)
+
+  def create_python_requirement_library(self, relpath, name, *requirements):
+    def make_requirement(req):
+      return 'python_requirement("{}")'.format(req)
+
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    python_requirement_library(
+      name='{name}',
+      requirements=[
+        {requirements}
+      ]
+    )
+    """).format(name=name, requirements=','.join(map(make_requirement, requirements))))
+
+    return self.target(SyntheticAddress(relpath, name).spec)
+
+  def setUp(self):
+    super(PythonReplTest, self).setUp()
+
+    SourceRoot.register('3rdparty', PythonRequirementLibrary)
+    SourceRoot.register('src', PythonBinary, PythonLibrary)
+
+    self.six = self.create_python_requirement_library('3rdparty/six', 'six', 'six==1.9.0')
+    self.requests = self.create_python_requirement_library('3rdparty/requests', 'requests',
+                                                           'requests==2.6.0')
+
+    self.library = self.create_python_library('src/lib', 'lib', 'lib.py', dedent("""
+    import six
+
+
+    def go():
+      six.print_('go', 'go', 'go!', sep='')
+    """), dependencies=['//3rdparty/six'])
+
+    self.binary = self.create_python_binary('src/bin', 'bin', 'lib.go', dependencies=['//src/lib'])
+
+    self.non_python_target = self.create_non_python_target('src/java', 'java')
+
+  def tearDown(self):
+    super(PythonReplTest, self).tearDown()
+    SourceRoot.reset()
+
+  @contextmanager
+  def new_io(self, input):
+    orig_stdin, orig_stdout, orig_stderr = sys.stdin, sys.stdout, sys.stderr
+    with temporary_dir() as iodir:
+      stdin = os.path.join(iodir, 'stdin')
+      stdout = os.path.join(iodir, 'stdout')
+      stderr = os.path.join(iodir, 'stderr')
+      with open(stdin, 'w') as fp:
+        fp.write(input)
+      with open(stdin, 'rb') as inp, open(stdout, 'wb') as out, open(stderr, 'wb') as err:
+        sys.stdin, sys.stdout, sys.stderr = inp, out, err
+        try:
+          yield inp, out, err
+        finally:
+          sys.stdin, sys.stdout, sys.stderr = orig_stdin, orig_stdout, orig_stderr
+
+  def do_test_repl(self, code, expected, targets, args=None):
+    python_repl = self.prepare_task(args=args, targets=targets, build_graph=self.build_graph)
+    with self.new_io('\n'.join(code)) as (inp, out, err):
+      python_repl.execute(stdin=inp, stdout=out, stderr=err)
+      with open(out.name) as fp:
+        lines = fp.read()
+        if not expected:
+          self.assertEqual('', lines)
+        else:
+          for expectation in expected:
+            self.assertIn(expectation, lines)
+
+  def do_test_library(self, *targets):
+    self.do_test_repl(code=['from lib.lib import go',
+                            'go()'],
+                      expected=['gogogo!'],
+                      targets=targets)
+
+  def test_library(self):
+    self.do_test_library(self.library)
+
+  def test_binary(self):
+    self.do_test_library(self.binary)
+
+  def test_requirement(self):
+    self.do_test_repl(code=['import six',
+                            'print("python 2?:{}".format(six.PY2))'],
+                      expected=['python 2?:True'],
+                      targets=[self.six])
+
+  def test_mixed_python(self):
+    self.do_test_repl(code=['import requests',
+                            'import six',
+                            'from lib.lib import go',
+                            'print("teapot response code is: {}".format(requests.codes.teapot))',
+                            'go()',
+                            'print("python 2?:{}".format(six.PY2))'],
+                      expected=['teapot response code is: 418',
+                                'gogogo!',
+                                'python 2?:True'],
+                      targets=[self.requests, self.binary])
+
+  def test_disallowed_mix(self):
+    with self.assertRaises(TaskError):
+      self.do_test_repl(code=['print("unreachable")'],
+                        expected=[],
+                        targets=[self.library, self.non_python_target])
+
+  def test_non_python_targets(self):
+    self.do_test_repl(code=['import java.lang.unreachable'],
+                      expected=[''],
+                      targets=[self.non_python_target])
+
+  def test_ipython(self):
+    # IPython supports shelling out with a leading !, so indirectly test its presence by reading
+    # the head of this very file.
+    with open(__file__) as fp:
+      me = fp.readline()
+      self.do_test_repl(code=['!head -1 {}'.format(__file__)],
+                        expected=[me],
+                        targets=[self.six],  # Just to get the repl to pop up.
+                        args=['--test-ipython'])


### PR DESCRIPTION
This also adds a unit test for PythonRepl and knocks off a TODO
lifting up a bit of test infra for PythonTask tests.

https://rbcommons.com/s/twitter/r/1934/