### PR TITLE
[Trigger CI] Refactor ZincUtils.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -144,6 +144,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:hash_utils',
     'src/python/pants/base:workunit',
+    'src/python/pants/option',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ],


### PR DESCRIPTION
Much of its structure was due to it previously being used not just
for compilation but also for split/merge/rebase. But now that we do those
directly in Pants code, we can simplify and streamline ZincUtils.

- Concentrates zinc argument construction in one place. Previously
  args got added to piecemeal.
- Ensures that we invalidate on changes in scalac options (including
  plugins).
- Removes a superfluous sorting of invalidation arguments (the JvmFingerprintStrategy
  sorts them anyway).
- Simplifies a test and adds a new test.
- Replaces a direct config access with an option.