### PR TITLE
[Trigger CI] Rename the PythonSetup task to SetupPy.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -17,7 +17,7 @@ from pants.backend.python.tasks.pytest_run import PytestRun
 from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
 from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
-from pants.backend.python.tasks.python_setup import PythonSetup
+from pants.backend.python.tasks.setup_py import SetupPy
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.goal.task_registrar import TaskRegistrar as task
 
@@ -47,5 +47,5 @@ def register_goals():
   task(name='pytest', action=PytestRun).install('test')
   task(name='py', action=PythonRun).install('run')
   task(name='py', action=PythonRepl).install('repl')
-  task(name='setup-py', action=PythonSetup).install().with_description(
+  task(name='setup-py', action=SetupPy).install().with_description(
     'Build setup.py-based Python projects from python_library targets.')

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -51,7 +51,7 @@ class SetupPyRunner(InstallerBase):
     return self.__setup_command
 
 
-class PythonSetup(PythonTask):
+class SetupPy(PythonTask):
   """Generate setup.py-based Python projects from python_library targets."""
 
   GENERATED_TARGETS = {
@@ -62,7 +62,7 @@ class PythonSetup(PythonTask):
 
   @classmethod
   def register_options(cls, register):
-    super(PythonSetup, cls).register_options(register)
+    super(SetupPy, cls).register_options(register)
     register('--run',
              help="The command to run against setup.py.  Don't forget to quote any additional "
                   "parameters.  If no run command is specified, pants will by default generate "
@@ -247,7 +247,7 @@ class PythonSetup(PythonTask):
     return isinstance(tgt, PythonTarget) and tgt.provides
 
   def __init__(self, *args, **kwargs):
-    super(PythonSetup, self).__init__(*args, **kwargs)
+    super(SetupPy, self).__init__(*args, **kwargs)
     self._root = get_buildroot()
     self._run = self.get_options().run
     self._recursive = self.get_options().recursive
@@ -398,14 +398,14 @@ class PythonSetup(PythonTask):
       setup_runner.run()
 
   def execute(self):
-    targets = filter(PythonSetup.has_provides, self.context.target_roots)
+    targets = filter(SetupPy.has_provides, self.context.target_roots)
     if not targets:
       raise TaskError('setup-py target(s) must provide an artifact.')
 
     setup_targets = OrderedSet()
     if self._recursive:
       def add_providing_target(target):
-        if PythonSetup.has_provides(target):
+        if SetupPy.has_provides(target):
           setup_targets.add(target)
           return OrderedSet(target.provided_binaries.values())
       for target in targets:

--- a/tests/python/pants_test/python/BUILD
+++ b/tests/python/pants_test/python/BUILD
@@ -103,8 +103,8 @@ python_tests(
 )
 
 python_tests(
-  name = 'test_python_setup',
-  sources = ['test_python_setup.py'],
+  name = 'test_setup_py',
+  sources = ['test_setup_py.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',

--- a/tests/python/pants_test/python/test_setup_py.py
+++ b/tests/python/pants_test/python/test_setup_py.py
@@ -16,7 +16,7 @@ from twitter.common.dirutil.chroot import Chroot
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
-from pants.backend.python.tasks.python_setup import PythonSetup
+from pants.backend.python.tasks.setup_py import SetupPy
 from pants.base.exceptions import TargetDefinitionException
 from pants.util.contextutil import temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir, safe_mkdtemp
@@ -26,7 +26,7 @@ from pants_test.task_test_base import TaskTestBase
 class TestPythonSetup(TaskTestBase):
   @classmethod
   def task_type(cls):
-    return PythonSetup
+    return SetupPy
 
   def create_dependencies(self, depmap):
     target_map = {}
@@ -47,14 +47,14 @@ class TestPythonSetup(TaskTestBase):
     # foo -> bar -> baz
     dep_map = OrderedDict(foo=['bar'], bar=['baz'], baz=[])
     target_map = self.create_dependencies(dep_map)
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['foo']),
+    self.assertEqual(SetupPy.minified_dependencies(target_map['foo']),
                      OrderedSet([target_map['bar']]))
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['bar']),
+    self.assertEqual(SetupPy.minified_dependencies(target_map['bar']),
                      OrderedSet([target_map['baz']]))
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['baz']), OrderedSet())
-    self.assertEqual(PythonSetup.install_requires(target_map['foo']), set(['bar==0.0.0']))
-    self.assertEqual(PythonSetup.install_requires(target_map['bar']), set(['baz==0.0.0']))
-    self.assertEqual(PythonSetup.install_requires(target_map['baz']), set([]))
+    self.assertEqual(SetupPy.minified_dependencies(target_map['baz']), OrderedSet())
+    self.assertEqual(SetupPy.install_requires(target_map['foo']), set(['bar==0.0.0']))
+    self.assertEqual(SetupPy.install_requires(target_map['bar']), set(['baz==0.0.0']))
+    self.assertEqual(SetupPy.install_requires(target_map['baz']), set([]))
 
   @contextmanager
   def run_execute(self, target, recursive=False):
@@ -86,11 +86,11 @@ class TestPythonSetup(TaskTestBase):
     # bar ----'
     dep_map = OrderedDict(foo=['bar', 'baz'], bar=['baz'], baz=[])
     target_map = self.create_dependencies(dep_map)
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['foo']),
+    self.assertEqual(SetupPy.minified_dependencies(target_map['foo']),
                      OrderedSet([target_map['bar']]))
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['bar']),
+    self.assertEqual(SetupPy.minified_dependencies(target_map['bar']),
                      OrderedSet([target_map['baz']]))
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['baz']), OrderedSet())
+    self.assertEqual(SetupPy.minified_dependencies(target_map['baz']), OrderedSet())
 
   def test_minified_dependencies_diamond(self):
     #   bar <-- foo --> baz
@@ -98,15 +98,15 @@ class TestPythonSetup(TaskTestBase):
     #    `----> bak <----'
     dep_map = OrderedDict(foo=['bar', 'baz'], bar=['bak'], baz=['bak'], bak=[])
     target_map = self.create_dependencies(dep_map)
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['foo']),
+    self.assertEqual(SetupPy.minified_dependencies(target_map['foo']),
                      OrderedSet([target_map['bar'], target_map['baz']]))
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['bar']),
+    self.assertEqual(SetupPy.minified_dependencies(target_map['bar']),
                      OrderedSet([target_map['bak']]))
-    self.assertEqual(PythonSetup.minified_dependencies(target_map['baz']),
+    self.assertEqual(SetupPy.minified_dependencies(target_map['baz']),
                      OrderedSet([target_map['bak']]))
-    self.assertEqual(PythonSetup.install_requires(target_map['foo']), set(['bar==0.0.0', 'baz==0.0.0']))
-    self.assertEqual(PythonSetup.install_requires(target_map['bar']), set(['bak==0.0.0']))
-    self.assertEqual(PythonSetup.install_requires(target_map['baz']), set(['bak==0.0.0']))
+    self.assertEqual(SetupPy.install_requires(target_map['foo']), set(['bar==0.0.0', 'baz==0.0.0']))
+    self.assertEqual(SetupPy.install_requires(target_map['bar']), set(['bak==0.0.0']))
+    self.assertEqual(SetupPy.install_requires(target_map['baz']), set(['bak==0.0.0']))
 
   def test_binary_target_injected_into_minified_dependencies(self):
     foo_bin_dep = self.make_target(
@@ -134,8 +134,8 @@ class TestPythonSetup(TaskTestBase):
       )
     )
 
-    self.assertEqual(PythonSetup.minified_dependencies(foo), OrderedSet([foo_bin, foo_bin_dep]))
-    entry_points = dict(PythonSetup.iter_entry_points(foo))
+    self.assertEqual(SetupPy.minified_dependencies(foo), OrderedSet([foo_bin, foo_bin_dep]))
+    entry_points = dict(SetupPy.iter_entry_points(foo))
     self.assertEqual(entry_points, {'foo_binary': 'foo.bin.foo'})
 
     with self.run_execute(foo, recursive=False) as setup_py_command:
@@ -175,9 +175,9 @@ class TestPythonSetup(TaskTestBase):
     )
 
     # TODO(pl): Why is this set ordered?  Does the order actually matter?
-    assert PythonSetup.minified_dependencies(bar) == OrderedSet([bar_bin, bar_bin_dep])
-    assert PythonSetup.install_requires(bar) == set(['bar_bin_dep==0.0.0'])
-    entry_points = dict(PythonSetup.iter_entry_points(bar))
+    assert SetupPy.minified_dependencies(bar) == OrderedSet([bar_bin, bar_bin_dep])
+    assert SetupPy.install_requires(bar) == set(['bar_bin_dep==0.0.0'])
+    entry_points = dict(SetupPy.iter_entry_points(bar))
     assert entry_points == {'bar_binary': 'bar.bin.bar'}
 
     with self.run_execute(bar, recursive=False) as setup_py_command:
@@ -211,7 +211,7 @@ class TestPythonSetup(TaskTestBase):
     )
 
     with self.assertRaises(TargetDefinitionException):
-      PythonSetup.minified_dependencies(foo)
+      SetupPy.minified_dependencies(foo)
 
 
 def test_detect_namespace_packages():
@@ -219,7 +219,7 @@ def test_detect_namespace_packages():
     with temporary_file() as fp:
       fp.write(stmt)
       fp.flush()
-      return PythonSetup.declares_namespace_package(fp.name)
+      return SetupPy.declares_namespace_package(fp.name)
 
   assert not has_ns('')
   assert not has_ns('add(1, 2); foo(__name__); self.shoot(__name__)')
@@ -236,7 +236,7 @@ def yield_chroot(packages, namespace_packages, resources):
 
   with temporary_dir() as td:
     def write(package, name, content):
-      package_path = os.path.join(td, PythonSetup.SOURCE_ROOT, to_path(package))
+      package_path = os.path.join(td, SetupPy.SOURCE_ROOT, to_path(package))
       safe_mkdir(os.path.dirname(os.path.join(package_path, name)))
       with open(os.path.join(package_path, name), 'w') as fp:
         fp.write(content)
@@ -256,7 +256,7 @@ def yield_chroot(packages, namespace_packages, resources):
 def test_find_packages():
   def assert_single_chroot(packages, namespace_packages, resources):
     with yield_chroot(packages, namespace_packages, resources) as chroot:
-      p, n_p, r = PythonSetup.find_packages(chroot)
+      p, n_p, r = SetupPy.find_packages(chroot)
       assert p == set(packages + namespace_packages)
       assert n_p == set(namespace_packages)
       assert r == dict((k, set(v)) for (k, v) in resources.items())
@@ -279,7 +279,7 @@ def test_find_packages():
 
   # assert that nearest-submodule is honored
   with yield_chroot(['foo', 'foo.bar'], [], resources) as chroot:
-    _, _, r = PythonSetup.find_packages(chroot)
+    _, _, r = SetupPy.find_packages(chroot)
     assert r == {
       'foo': set(['f0']),
       'foo.bar': set([
@@ -294,21 +294,21 @@ def test_find_packages():
       [],
       {'foo.bar1': ['f0']}) as chroot:
 
-    _, _, r = PythonSetup.find_packages(chroot)
+    _, _, r = SetupPy.find_packages(chroot)
     assert r == {'foo': set(['bar1/f0'])}
 
 
 def test_nearest_subpackage():
   # degenerate
-  assert PythonSetup.nearest_subpackage('foo', []) == 'foo'
-  assert PythonSetup.nearest_subpackage('foo', ['foo']) == 'foo'
-  assert PythonSetup.nearest_subpackage('foo', ['bar']) == 'foo'
+  assert SetupPy.nearest_subpackage('foo', []) == 'foo'
+  assert SetupPy.nearest_subpackage('foo', ['foo']) == 'foo'
+  assert SetupPy.nearest_subpackage('foo', ['bar']) == 'foo'
 
   # common prefix
-  assert 'foo' == PythonSetup.nearest_subpackage('foo.bar', ['foo'])
-  assert 'foo.bar' == PythonSetup.nearest_subpackage(
+  assert 'foo' == SetupPy.nearest_subpackage('foo.bar', ['foo'])
+  assert 'foo.bar' == SetupPy.nearest_subpackage(
       'foo.bar', ['foo', 'foo.bar'])
-  assert 'foo.bar' == PythonSetup.nearest_subpackage(
+  assert 'foo.bar' == SetupPy.nearest_subpackage(
       'foo.bar.topo', ['foo', 'foo.bar'])
-  assert 'foo' == PythonSetup.nearest_subpackage(
+  assert 'foo' == SetupPy.nearest_subpackage(
       'foo.barization', ['foo', 'foo.bar'])


### PR DESCRIPTION
This is both more in line with its registered scope name (setup-py), and
prevents confusion with the unrelated backend.python.PythonSetup utility class.