### PR TITLE
Get rid of almost all direct config access in python-building code.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -161,7 +161,7 @@ repos: [
     "https://pantsbuild.github.io/cheeseshop/third_party/python/index.html"
   ]
 
-indices: ["https://pypi.python.org/simple/"]
+indexes: ["https://pypi.python.org/simple/"]
 
 
 [backends]

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -46,6 +46,8 @@ python_library(
   name = 'python_setup',
   sources = ['python_setup.py'],
   dependencies = [
+    '3rdparty/python:pex',
+    '3rdparty/python:setuptools',
     'src/python/pants/base:config',
   ]
 )
@@ -89,8 +91,6 @@ python_library(
   name = 'interpreter_cache',
   sources = ['interpreter_cache.py'],
   dependencies = [
-    ':python_setup',
-    ':resolver',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
     'src/python/pants/util:dirutil',
@@ -138,7 +138,6 @@ python_library(
   name = 'resolver',
   sources = ['resolver.py'],
   dependencies = [
-    ':python_setup',
     '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python/targets:python',

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -23,7 +23,7 @@ from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.prep_command import PrepCommand
 from pants.backend.python.antlr_builder import PythonAntlrBuilder
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.backend.python.python_setup import PythonSetup
+from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.backend.python.resolver import resolve_multi
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -62,6 +62,10 @@ class PythonChroot(object):
                platforms=None,
                interpreter=None):
     self.context = context
+    # TODO: These should come from the caller, and we should not know about config.
+    self._python_setup = PythonSetup(self.context.config)
+    self._python_repos = PythonRepos(self.context.config)
+    
     self._targets = targets
     self._extra_requirements = list(extra_requirements) if extra_requirements else []
     self._platforms = platforms
@@ -71,8 +75,7 @@ class PythonChroot(object):
 
     # Note: unrelated to the general pants artifact cache.
     self._egg_cache_root = os.path.join(
-        PythonSetup(self.context.config).scratch_dir('artifact_cache', default_name='artifacts'),
-        str(self._interpreter.identity))
+      self._python_setup.scratch_dir, 'artifacts', str(self._interpreter.identity))
 
     self._key_generator = CacheKeyGenerator()
     self._build_invalidator = BuildInvalidator( self._egg_cache_root)
@@ -204,7 +207,8 @@ class PythonChroot(object):
         find_links.append(req.repository)
 
     distributions = resolve_multi(
-         self.context.config,
+         self._python_setup,
+         self._python_repos,
          reqs_to_build,
          interpreter=self._interpreter,
          platforms=self._platforms,

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python:python_chroot',
     'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python:python_setup',
     'src/python/pants/backend/python:test_builder',
     'src/python/pants/backend/python:thrift_builder',
     'src/python/pants/backend/python/targets:python',

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -13,6 +13,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.backend.core.tasks.task import Task
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
+from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.base.exceptions import TaskError
 
 
@@ -26,7 +27,8 @@ class PythonTask(Task):
   @property
   def interpreter_cache(self):
     if self._interpreter_cache is None:
-      self._interpreter_cache = PythonInterpreterCache(self.context.config,
+      self._interpreter_cache = PythonInterpreterCache(PythonSetup(self.context.config),
+                                                       PythonRepos(self.context.config),
                                                        logger=self.context.log.debug)
 
       # Cache setup's requirement fetching can hang if run concurrently by another pants proc.

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -206,6 +206,11 @@ migrations = {
   # NB: For the following two options, see the notes below.
   ('scrooge-gen', 'scala'): ('gen.scrooge', 'service_deps'),
   ('scrooge-gen', 'java'): ('gen.scrooge', 'service_deps'),
+
+  # Technically 'indices' and 'indexes' are both acceptable plural forms of 'index'. However
+  # usage has led to the former being used primarily for mathematical indices and the latter
+  # for book indexes, database indexes and the like.
+  ('python-repos', 'indices'): ('python-repos', 'indexes'),
 }
 
 ng_daemons_note = ('The global "ng_daemons" option has been replaced by a "use_nailgun" option '

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -17,6 +17,7 @@ python_tests(
     '3rdparty/python:coverage',
     '3rdparty/python:pex',
     'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python:python_setup',
     'src/python/pants/backend/python:test_builder',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/python/test_test_builder.py
+++ b/tests/python/pants_test/backend/python/test_test_builder.py
@@ -14,6 +14,7 @@ import coverage
 from pex.interpreter import PythonInterpreter
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
+from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.test_builder import PythonTestBuilder
@@ -28,7 +29,7 @@ class PythonTestBuilderTestBase(BaseTest):
     self.set_options_for_scope('', python_chroot_requirements_ttl=1000000000)
 
   def _cache_current_interpreter(self):
-    cache = PythonInterpreterCache(self.config())
+    cache = PythonInterpreterCache(PythonSetup(self.config()), PythonRepos(self.config()))
 
     # We only need to cache the current interpreter, avoid caching for every interpreter on the
     # PATH.


### PR DESCRIPTION
- Instead, relies more heavily on the existing PythonSetup class,
  and a new sibling called PythonRepos.
- These are basically proto-subsystems, and we'll retrofit them
  to be part of the subsystem mechanism once we invent that.
- Cleans up and streamlines significant parts of the code.
- Moves some standalone functions into classes, for a more natural design.
- Refactors a test for better code reuse.