### PR TITLE
I'm pretty sure this has to be dead code

### DIFF
--- a/src/python/pants/goal/task_registrar.py
+++ b/src/python/pants/goal/task_registrar.py
@@ -28,32 +28,7 @@ class TaskRegistrar(object):
     """
     self.serialize = serialize
     self.name = name
-
-    if isinstance(type(action), type) and issubclass(action, Task):
-      self._task = action
-    else:
-      args, varargs, keywords, defaults = inspect.getargspec(action)
-      if varargs or keywords or defaults:
-        raise GoalError('Invalid action supplied, cannot accept varargs, keywords or defaults')
-      if len(args) > 1:
-        raise GoalError('Invalid action supplied, must accept either no args or else a single '
-                        'Context object')
-
-      class FuncTask(Task):
-        def __init__(self, *args, **kwargs):
-          super(FuncTask, self).__init__(*args, **kwargs)
-
-          if not args:
-            self.action = action
-          elif len(args) == 1:
-            self.action = functools.partial(action, self.context)
-          else:
-            raise AssertionError('Unexpected fallthrough')
-
-        def execute(self):
-          self.action()
-
-      self._task = FuncTask
+    self._task = action
 
     if dependencies:
       # TODO(John Sirois): kill this warning and the kwarg after a deprecation cycle.

--- a/tests/python/pants_test/base/test_extension_loader.py
+++ b/tests/python/pants_test/base/test_extension_loader.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 from pkg_resources import (Distribution, EmptyProvider, VersionConflict, WorkingSet, working_set,
                            yield_lines)
 
+from pants.backend.core.tasks.task import Task
 from pants.base.build_configuration import BuildConfiguration
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import BuildConfigurationError
@@ -36,6 +37,13 @@ class MockMetadata(EmptyProvider):
 
   def get_metadata_lines(self, name):
     return yield_lines(self.get_metadata(name))
+
+
+class DummyTask(Task):
+  def __init__(self, *args, **kwargs):
+    super(DummyTask, self).__init__(*args, **kwargs)
+
+  def execute(self): return 42
 
 
 class LoaderTest(unittest.TestCase):
@@ -95,7 +103,7 @@ class LoaderTest(unittest.TestCase):
 
   def test_load_valid_partial_goals(self):
     def register_goals():
-      Goal.by_name('jack').install(TaskRegistrar('jill', lambda: 42))
+      Goal.by_name('jack').install(TaskRegistrar('jill', DummyTask))
 
     with self.create_register(register_goals=register_goals) as backend_package:
       Goal.clear()
@@ -202,7 +210,7 @@ class LoaderTest(unittest.TestCase):
 
   def test_plugin_installs_goal(self):
     def reg_goal():
-      Goal.by_name('plugindemo').install(TaskRegistrar('foo', lambda: 1))
+      Goal.by_name('plugindemo').install(TaskRegistrar('foo', DummyTask))
     self.working_set.add(self.get_mock_plugin('regdemo', '0.0.1', reg=reg_goal))
 
     # Start without the custom goal.

--- a/tests/python/pants_test/tasks/test_reflect.py
+++ b/tests/python/pants_test/tasks/test_reflect.py
@@ -7,11 +7,19 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.core.register import build_file_aliases as register_core
 from pants.backend.core.tasks import reflect
+from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar
 from pants_test.tasks.test_base import BaseTest
+
+
+class DummyTask(Task):
+  def __init__(self, *args, **kwargs):
+    super(DummyTask, self).__init__(*args, **kwargs)
+
+  def execute(self): return 42
 
 
 class BuildsymsSanityTests(BaseTest):
@@ -39,7 +47,7 @@ class BuildsymsSanityTests(BaseTest):
 class GoalDataTest(BaseTest):
   def test_gen_tasks_options_reference_data(self):
     # can we run our reflection-y goal code without crashing? would be nice
-    Goal.by_name('jack').install(TaskRegistrar('jill', lambda: 42))
+    Goal.by_name('jack').install(TaskRegistrar('jill', DummyTask))
     oref_data = reflect.gen_tasks_options_reference_data()
     self.assertTrue(len(oref_data) > 0,
                     'Tried to generate data for options reference, got emptiness')


### PR DESCRIPTION
Note first, in passing, that `isinstance(type(action), type)` is a tautology. But, that aside, what this code seems to be trying to do is check whether the `action` is either a class representing a subclass of Task  or a function of either zero or one arguments. In the latter case it wants to make a new subclass of Task that invokes the function when executed. However, the function wrapping code can't possibly work unless I'm deeply missing something: In the `__init__` method of `FuncTask` the args parameter containing the positional arguments to `__init__` has to be either empty or contain one argument. However TaskBase in task.py defines an `__init__` that takes two positional arguments. So any attempt to construct an instance of `FuncTask` would fail: if passed zero or one arguments, the call to `super(FuncTask, self).__init__(...)` will fail because the super constructer needs two positional arguments and if called with more than one arguments it will raise an `AssertionError` itself.

It's possible that the code was meant to refer to the args in the enclosing scope but, unless I'm very confused about Python, it does not so this code must never be used so might as well be deleted.