### PR TITLE
Example of issue with annotation processors that have 3rdparty deps

### DIFF
--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker/BUILD
@@ -1,0 +1,8 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(
+  name = 'hellomaker',
+  sources = globs('*.java'),
+  dependencies = [],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker/HelloMaker.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker/HelloMaker.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.annotation.processorwithdep.hellomaker;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HelloMaker {}

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+jvm_binary(name='main',
+  source = 'Main.java',
+  main = 'org.pantsbuild.testproject.annotation.processorwithdep.Main',
+  basename = 'processorwithdep-main',
+  dependencies = [
+    'testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker',
+    'testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor',
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/Main.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/Main.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.annotation.processorwithdep.main;
+
+import org.pantsbuild.testproject.annotation.processorwithdep.hellomaker.HelloMaker;
+
+@HelloMaker
+public class Main {
+  public static void main() {
+    System.out.println("Hello World!");
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/BUILD
@@ -1,0 +1,20 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+#
+#  annotation_processor() target to test generating java code
+
+annotation_processor(name = 'processor',
+  sources = globs('*.java'),
+  processors = ['org.pantsbuild.testproject.annotation.processorwithdep.processor.ProcessorWithDep'],
+  dependencies = [
+    'testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker',
+    ':javapoet',
+  ],
+)
+
+jar_library(
+  name = 'javapoet',
+  jars = [
+    jar(org='com.squareup', name='javapoet', rev='1.2.0'),
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/ProcessorWithDep.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/ProcessorWithDep.java
@@ -1,0 +1,116 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.annotation.processorwithdep.processor;
+
+import org.pantsbuild.testproject.annotation.processorwithdep.hellomaker.HelloMaker;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.JavaFileObject;
+
+/**
+ * A sample implementation of an annotation processor which creates a "HEllo WOrld
+ *
+ */
+public class ProcessorWithDep extends AbstractProcessor {
+  TypeSpec unused = TypeSpec.enumBuilder("PantsProblemCauser")
+      .addEnumConstant("BAR")
+      .build();
+  private ProcessingEnvironment processingEnvironment = null;
+  private Elements elementUtils;
+
+  private void writeHelloWorld(String packageName, String classPrefix) throws IOException{
+    MethodSpec main = MethodSpec.methodBuilder("main")
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .returns(void.class)
+        .addParameter(String[].class, "args")
+        .addStatement("$T.out.println($S)", System.class, "Hello, JavaPoet!")
+        .build();
+
+    String className = classPrefix + "_HelloWorld";
+    TypeSpec helloWorld = TypeSpec.classBuilder(className)
+        .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+        .addMethod(main)
+        .build();
+
+    JavaFile javaFile = JavaFile.builder(packageName, helloWorld)
+        .build();
+
+    JavaFileObject f = processingEnvironment.getFiler().createSourceFile(
+        String.format("%s.%s", packageName, className));
+    Writer w = f.openWriter();
+    javaFile.writeTo(w);
+    w.close();
+  }
+
+  @Override public void init(ProcessingEnvironment processingEnvironment) {
+    this.processingEnvironment = processingEnvironment;
+    this.elementUtils = processingEnvironment.getElementUtils();
+    // Make a reference to the 3rdparty library in the initialization of the annotation processor
+    // to tickle a bug in pants
+    TypeSpec.enumBuilder("PantsProblemCauser")
+        .addEnumConstant("BAR")
+        .build();
+  }
+
+  @Override public Set<String> getSupportedAnnotationTypes() {
+    return Collections.singleton(HelloMaker.class.getCanonicalName());
+  }
+
+  @Override public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latest();
+  }
+
+  @Override public boolean process(Set<? extends TypeElement> annotations,
+      RoundEnvironment roundEnv) {
+    if (roundEnv.processingOver()) {
+      return false;
+    }
+
+    PrintWriter writer = null;
+
+    try {
+      for (TypeElement appAnnotation : annotations) {
+        Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(appAnnotation);
+        Set<TypeElement> elements = ElementFilter.typesIn(annotatedElements);
+        for (Element elem : elements) {
+          if (!(elem instanceof TypeElement))
+            continue;
+          TypeElement typeElem = (TypeElement) elem;
+          String packageName = elementUtils.getPackageOf(typeElem).getQualifiedName().toString();
+          String typeName = typeElem.getSimpleName().toString();
+          writeHelloWorld(packageName, typeName);
+        }
+      }
+    } catch (IOException ex) {
+      log(Kind.ERROR, "Problem writing source file.", ex);
+      throw new RuntimeException(ex);
+    } finally {
+      if (writer != null) {
+        writer.close();
+      }
+    }
+    return true;
+  }
+
+  private void log(Diagnostic.Kind category, String message, Object... args) {
+    processingEnvironment.getMessager().printMessage(category, String.format(message, args));
+  }
+}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
@@ -33,16 +33,19 @@ class BaseCompileIT(PantsRunIntegrationTest):
           else:
             self.assert_success(pants_run)
         found = defaultdict(set)
+        workdir_files = []
         if expected_files:
           to_find = set(expected_files)
           for root, _, files in os.walk(workdir):
             for file in files:
+              workdir_files.append(os.path.join(root, file))
               if file in to_find:
                 found[file].add(os.path.join(root, file))
           to_find.difference_update(found)
           if not expect_failure:
             self.assertEqual(set(), to_find,
-                            'Failed to find the following compiled files: {}'.format(to_find))
+                             'Failed to find the following compiled files: {} in {}'.format(
+                               to_find, '\n'.join(sorted(workdir_files))))
         yield found
 
   def run_test_compile(self, workdir, cachedir, target, strategy, clean_all=False, extra_args=None):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -22,6 +22,7 @@ python_tests(
   name='apt_compile_integration',
   sources=['test_apt_compile_integration.py'],
   dependencies=[
+    'src/python/pants/util:contextutil',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_apt_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_apt_compile_integration.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.util.contextutil import temporary_dir
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
 
@@ -48,3 +49,42 @@ class AptCompileIntegrationTest(BaseCompileIT):
       # service info file from on its compile classpath.
       with open(self.get_only(found, 'deprecation_report.txt')) as fp:
         self.assertIn('org.pantsbuild.testproject.annotation.main.Main', fp.read().splitlines())
+
+  @provide_compile_strategies
+  def test_stale_apt_with_deps(self, strategy):
+    """An annotation processor with a dependency doesn't pollute other annotation processors.
+
+    At one point, when you added an annotation processor, it stayed configured for all subsequent
+    compiles.  Meaning that if that annotation processor had a dep that wasn't on the classpath,
+    subsequent compiles would fail with missing symbols required by the stale annotation processor.
+    """
+
+    # Demonstrate that the annotation processor is working
+    with self.do_test_compile(
+        'testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main',
+        strategy,
+        expected_files=['Main.class', 'Main_HelloWorld.class', 'Main_HelloWorld.java']) as found:
+      gen_file = self.get_only(found, 'Main_HelloWorld.java')
+      self.assertTrue(gen_file.endswith(
+        'org/pantsbuild/testproject/annotation/processorwithdep/main/Main_HelloWorld.java'),
+        msg='{} does not match'.format(gen_file))
+
+
+    # Try to reproduce second compile that fails with missing symbol
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with temporary_dir(root_dir=self.workdir_root()) as cachedir:
+        # This annotation processor has a unique external dependency
+        self.assert_success(self.run_test_compile(
+          workdir,
+          cachedir,
+          'testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep::',
+          strategy))
+
+        # When we run a second compile with annotation processors, make sure the previous annotation
+        # processor doesn't stick around to spoil the compile
+        self.assert_success(self.run_test_compile(
+          workdir,
+          cachedir,
+          'testprojects/src/java/org/pantsbuild/testproject/annotation/processor::',
+          strategy,
+          clean_all=False))


### PR DESCRIPTION
This PR demonstrates an issue that we are seeing in our repo with annotation processors in pants.  To reproduce, patch this in and run:

```
$  ./pants clean-all
$  ./pants compile testprojects/src/java/com/pants/testproject/annotation/processorwithdep::
...
SUCCESS
```

Now, compile some code that depends on an unrelated annotation processor:

```
$  ./pants compile ./examples/src/java/org/pantsbuild/example/annotation::
...
16:04:43 00:01           [jmake]
                         error: Bad service configuration file, or exception thrown while constructing Processor object: javax.annotation.processing.Processor: Provider com.pants.testproject.annotation.processorwithdep.processor.ProcessorWithDep could not be instantiated: java.lang.NoClassDefFoundError: com/squareup/javapoet/TypeSpec

```

The issue is that we are leaving all annotation processors ever encountered configured in Pants to be run with all subsequent runs. 

```
$ cat .pants.d/compile/jvm/apt/apt-processor-info-global/META-INF/services/javax.annotation.processing.Processor
com.pants.testproject.annotation.processor.ResourceMappingProcessor
com.pants.testproject.annotation.processorwithdep.processor.ProcessorWithDep
com.pants.examples.annotation.processor.ExampleProcessor
```

First of all, For that to work properly, the 3rdparty deps for the annotation processors must be on the classpath for the apt run of the compiler.  Second, I'm not sure that is what the caller intended - maybe we should configure the annotation processors fresh for each time the annotation processors run with only the processors in the transitive closure of dependencies.

The example isn't strictly necessary.  The testprojects annotation processor example already has  a guava dep in it,  so if you run that one first, then the one under `examples/src/java/com/pants/examples/annotation/` that will suffice to reproduce the issue.  However, this sample annotation processor has a 3rdparty dep that is unlikely to be on the classpath and also creates source code so it might be good at exercising other things for pants.

