### PR TITLE
[Trigger CI] Move construction of PythonChroot to PythonTask base class.

### DIFF
--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import time
 
-from pants.backend.python.python_chroot import PythonChroot
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.exceptions import TaskError
@@ -49,14 +48,6 @@ class PythonBinaryCreate(PythonTask):
     pexinfo = binary.pexinfo.copy()
     pexinfo.build_properties = build_properties
 
-    with self.temporary_pex_builder(pex_info=pexinfo, interpreter=interpreter) as builder:
-      chroot = PythonChroot(
-        context=self.context,
-        targets=[binary],
-        builder=builder,
-        platforms=binary.platforms,
-        interpreter=interpreter)
-
+    with self.temporary_chroot(interpreter=interpreter, pex_info=pexinfo, targets=[binary], platforms=binary.platforms) as chroot:
       pex_path = os.path.join(self._distdir, '%s.pex' % binary.name)
-      chroot.dump()
-      builder.build(pex_path)
+      chroot.builder.build(pex_path)

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -13,6 +13,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.backend.core.tasks.task import Task
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
+from pants.backend.python.python_chroot import PythonChroot
 from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.base.exceptions import TaskError
 
@@ -83,9 +84,26 @@ class PythonTask(Task):
     return interpreter
 
   @contextmanager
-  def temporary_pex_builder(self, interpreter=None, pex_info=None, parent_dir=None):
-    """Yields a PEXBuilder and cleans up its chroot when it goes out of context."""
-    path = tempfile.mkdtemp(dir=parent_dir)
+  def temporary_chroot(self, interpreter=None, pex_info=None, targets=None,
+                       extra_requirements=None, platforms=None, pre_freeze=None):
+    """Yields a temporary PythonChroot created with the specified args.
+
+    pre_freeze is an optional function run on the chrooy just before freezing its builder,
+    to allow for any extra modification.
+    """
+    path = tempfile.mkdtemp()
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info)
-    yield builder
-    builder.chroot().delete()
+    with self.context.new_workunit('chroot'):
+      chroot = PythonChroot(
+        context=self.context,
+        targets=targets,
+        extra_requirements=extra_requirements,
+        builder=builder,
+        platforms=platforms,
+        interpreter=interpreter)
+      chroot.dump()
+      if pre_freeze:
+        pre_freeze(chroot)
+      builder.freeze()
+    yield chroot
+    chroot.delete()


### PR DESCRIPTION
Previously each subtask was creating its own.
This commit replaces temporary_pex_builder with temporary_chroot.

Isolating PythonChroot creation in just one place will make it easier
to transition to python-environment-as-a-subsystem.