### PR TITLE
Convert ragel-gen.py to use new options and expunge config from BinaryUtil

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -18,10 +18,6 @@ pythonpath: [
     "%(buildroot)s/contrib/cpp/src/python",
   ]
 
-pants_support_baseurls = [
-    "https://dl.bintray.com/pantsbuild/bin/build-support"
-  ]
-
 outdir: %(pants_distdir)s
 
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
@@ -65,9 +61,7 @@ structs_deps: {
 
 
 [gen.thrift]
-supportdir: bin/thrift
 strict: False
-version: 0.5.0-finagle
 java: {
     "gen": "java:hashcode",
     "deps": {
@@ -82,11 +76,6 @@ python: {
       "structs": ["3rdparty/python:thrift"]
     }
   }
-
-
-[ragel-gen]
-supportdir: bin/ragel
-version: 6.8
 
 
 [compile.checkstyle]

--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -62,8 +62,12 @@ class ApacheThriftGen(CodeGen):
              help='Force generation of thrift code for these languages.')
     register('--strict', action='store_true',
              help='Run thrift compiler with strict warnings.')
-    register('--supportdir', advanced=True, help='Find thrift binaries under this dir.')
-    register('--version', advanced=True, help='Thrift compiler version.')
+    register('--supportdir', advanced=True, default='bin/thrift',
+             help='Find thrift binaries under this dir.   Used as part of the path to lookup the'
+                  'tool with --pants-support-baseurls and --pants-bootstrapdir')
+    register('--version', advanced=True, default='0.5.0-finagle',
+             help='Thrift compiler version.   Used as part of the path to lookup the'
+                  'tool with --pants-support-baseurls and --pants-bootstrapdir')
     register('--java', advanced=True, type=Options.dict, help='GenInfo for Java.')
     register('--python', advanced=True, type=Options.dict, help='GenInfo for Python.')
 
@@ -86,7 +90,7 @@ class ApacheThriftGen(CodeGen):
   @property
   def thrift_binary(self):
     if self._thrift_binary is None:
-      self._thrift_binary = select_thrift_binary(self.context.options)
+      self._thrift_binary = select_thrift_binary(self.get_options())
     return self._thrift_binary
 
   def create_geninfo(self, key):

--- a/src/python/pants/backend/codegen/tasks/ragel_gen.py
+++ b/src/python/pants/backend/codegen/tasks/ragel_gen.py
@@ -23,20 +23,23 @@ from pants.binary_util import BinaryUtil
 class RagelGen(CodeGen):
   def __init__(self, *args, **kwargs):
     super(RagelGen, self).__init__(*args, **kwargs)
-
-    self._ragel_supportdir = self.context.config.get('ragel-gen', 'supportdir')
-    self._ragel_version = self.context.config.get('ragel-gen', 'version', default='6.8')
     self._java_out = os.path.join(self.workdir, 'gen-java')
     self._ragel_binary = None
+
+  @classmethod
+  def register_options(cls, register):
+    super(RagelGen, cls).register_options(register)
+    register('--supportdir', default='bin/ragel', advanced=True,
+             help='The path to find the ragel binary.  Used as part of the path to lookup the'
+                  'tool with --pants-support-baseurls and --pants_bootstrapdir.')
+    register('--version', default='6.8', advanced=True,
+             help='The version of ragel to use.  Used as part of the path to lookup the'
+                  'tool with --pants-support-baseurls and --pants-bootstrapdir')
 
   @property
   def ragel_binary(self):
     if self._ragel_binary is None:
-      self._ragel_binary = BinaryUtil(config=self.context.config).select_binary(
-        self._ragel_supportdir,
-        self._ragel_version,
-        'ragel'
-        )
+      self._ragel_binary = BinaryUtil.from_options(self.get_options()).select_binary('ragel')
     return self._ragel_binary
 
   @property

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -86,7 +86,6 @@ python_library(
     'src/python/pants/backend/core/targets:common',
     'src/python/pants:binary_util',
     'src/python/pants/util:dirutil',
-
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -158,7 +158,11 @@ class Jar(object):
     self._jars.append(jar)
 
   @contextmanager
-  def _render_jar_tool_args(self):
+  def _render_jar_tool_args(self, options):
+    """Format the arguments to jar-tool.
+
+    :param Options options:
+    """
     args = []
 
     with temporary_dir() as manifest_stage_dir:
@@ -171,9 +175,9 @@ class Jar(object):
 
       jars = self._jars or []
 
-      with safe_args(classpath, delimiter=',') as classpath_args:
-        with safe_args(files, delimiter=',') as files_args:
-          with safe_args(jars, delimiter=',') as jars_args:
+      with safe_args(classpath, options, delimiter=',') as classpath_args:
+        with safe_args(files, options, delimiter=',') as files_args:
+          with safe_args(jars, options, delimiter=',') as jars_args:
 
             if self._main:
               args.append('-main={}'.format(self._main))
@@ -191,7 +195,6 @@ class Jar(object):
               args.append('-jars={}'.format(','.join(jars_args)))
 
             yield args
-
 
 class JarTask(NailgunTask):
   """A baseclass for tasks that need to create or update jars.
@@ -257,7 +260,7 @@ class JarTask(NailgunTask):
     except jar.Error as e:
       raise TaskError('Failed to write to jar at {}: {}'.format(path, e))
 
-    with jar._render_jar_tool_args() as args:
+    with jar._render_jar_tool_args(self.get_options()) as args:
       if args:  # Don't build an empty jar
         args.append('-update={}'.format(self._flag(not overwrite)))
         args.append('-compress={}'.format(self._flag(compressed)))

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -201,7 +201,7 @@ class _JUnitRunner(object):
     result = 0
     cwd = cwd or get_buildroot()
     for batch in self._partition(tests):
-      with binary_util.safe_args(batch) as batch_tests:
+      with binary_util.safe_args(batch, self._task_exports.task_options) as batch_tests:
         result += abs(execute_java(
           classpath=classpath,
           main=main,
@@ -360,7 +360,8 @@ class Emma(_Coverage):
   def instrument(self, targets, tests, junit_classpath):
     safe_mkdir(self._coverage_instrument_dir, clean=True)
     self._emma_classpath = self._task_exports.tool_classpath('emma')
-    with binary_util.safe_args(self.get_coverage_patterns(targets)) as patterns:
+    with binary_util.safe_args(self.get_coverage_patterns(targets),
+                               self._task_exports.task_options) as patterns:
       args = [
         'instr',
         '-out', self._coverage_metadata_file,

--- a/src/python/pants/backend/jvm/tasks/specs_run.py
+++ b/src/python/pants/backend/jvm/tasks/specs_run.py
@@ -70,7 +70,7 @@ class SpecsRun(JvmTask, JvmToolTaskMixin):
       if self.tests:
         run_tests(self.tests)
       else:
-        with safe_args(self.calculate_tests(targets)) as tests:
+        with safe_args(self.calculate_tests(targets), self.get_options()) as tests:
           if tests:
             run_tests(tests)
 

--- a/src/python/pants/backend/python/thrift_builder.py
+++ b/src/python/pants/backend/python/thrift_builder.py
@@ -22,11 +22,20 @@ class PythonThriftBuilder(CodeGenerator):
   class UnknownPlatformException(CodeGenerator.Error):
     def __init__(self, platform):
       super(PythonThriftBuilder.UnknownPlatformException, self).__init__(
-          'Unknown platform: %s!' % str(platform))
+          'Unknown platform: {}!'.format(str(platform)))
 
   def __init__(self, target, root_dir, options, target_suffix=None):
     super(PythonThriftBuilder, self).__init__(target, root_dir, options, target_suffix)
     self._workdir = os.path.join(options.for_global_scope().pants_workdir, 'thrift', 'py-thrift')
+
+  @classmethod
+  def register_options(cls, register):
+    """Register options for this task.
+
+    Note that this task uses options from scope 'gen.thrift' to determine the settings for
+    finding the thrift binary.
+    """
+    super(PythonThriftBuilder, cls).register_options(register)
 
   @property
   def install_requires(self):
@@ -68,7 +77,7 @@ class PythonThriftBuilder(CodeGenerator):
 
   def _run_thrift(self, source):
     args = [
-        select_thrift_binary(self.options),
+        select_thrift_binary(self.options.for_scope('gen.thrift')),
         '--gen',
         'py:new_style',
         '-o', self.codegen_root,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -74,6 +74,16 @@ def register_global_options(register):
            default=10 * 365 * 86400,  # 10 years.
            help='the time in seconds before we consider re-resolving an open-ended '
                 'requirement, e.g. "flask>=0.2" if a matching distribution is available on disk.')
+  register('--pants-support-baseurls', type=Options.list, advanced=True, recursive=True,
+           default = [ 'https://dl.bintray.com/pantsbuild/bin/build-support' ],
+           help='List of urls from which binary tools are downloaded.  Urls are searched in order'
+           'until the requested path is found.')
+  register('--max-subprocess-args', type=int, default=100,  advanced=True, recursive=True,
+           help='Used to limit the number of arguments passed to some subprocesses by breaking'
+           'the command up into multiple invocations')
+  register('--pants-support-fetch-timeout-secs', type=int, default=30, advanced=True, recursive=True,
+           help='Timeout in seconds for url reads when fetching binary tools from the '
+                'repos specified by --pants-support-baseurls')
 
   # The following options are specific to java_thrift_library targets.
   register('--thrift-default-compiler', type=str, advanced=True, default='thrift',

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -211,6 +211,9 @@ migrations = {
   # usage has led to the former being used primarily for mathematical indices and the latter
   # for book indexes, database indexes and the like.
   ('python-repos', 'indices'): ('python-repos', 'indexes'),
+
+  {'ragel-gen', 'supportdir'}: ('gen.ragel', 'supportdir'),
+  {'ragel-gen', 'version'}: ('gen.ragel', 'version'),
 }
 
 ng_daemons_note = ('The global "ng_daemons" option has been replaced by a "use_nailgun" option '

--- a/src/python/pants/thrift_util.py
+++ b/src/python/pants/thrift_util.py
@@ -97,7 +97,7 @@ def calculate_compile_roots(targets, is_thrift_target):
 def select_thrift_binary(options):
   """Selects a thrift compiler binary matching the current os and architecture.
 
+  :param Options options: options for the current task
   Defaults to the thrift compiler version specified in the gen.thrift options scope.
   """
-  thrift_options = options.for_scope('gen.thrift')
-  return BinaryUtil().select_binary(thrift_options.supportdir, thrift_options.version, 'thrift')
+  return BinaryUtil.from_options(options).select_binary('thrift')

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -52,7 +52,7 @@ python_tests(
   dependencies = [
     ':base_test',
     'src/python/pants:binary_util',
-    'src/python/pants/base:exceptions'
+    'tests/python/pants_test/base:context_utils',
   ]
 )
 

--- a/tests/python/pants_test/backend/codegen/tasks/test_protobuf_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_protobuf_gen.py
@@ -24,6 +24,14 @@ from pants_test.task_test_base import TaskTestBase
 
 
 class ProtobufGenTest(TaskTestBase):
+
+  def setUp(self):
+    super(ProtobufGenTest, self).setUp()
+    self.set_options(pants_bootstrapdir='~/.cache/pants',
+                     max_subprocess_args=100,
+                     pants_support_fetch_timeout_secs=1,
+                     pants_support_baseurls=['http://example.com/dummy_base_url'])
+
   @classmethod
   def task_type(cls):
     return ProtobufGen

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -23,6 +23,10 @@ from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 class JUnitRunnerTest(JvmToolTaskTestBase):
   """Tests for junit_run._JUnitRunner class"""
 
+  def setUp(self):
+    super(JUnitRunnerTest, self).setUp()
+    self.set_options(pants_bootstrapdir='~/.cache/pants', max_subprocess_args=100)
+
   @classmethod
   def task_type(cls):
     return JUnitRun

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -116,7 +116,7 @@ class BaseTest(unittest.TestCase):
       'pants_workdir': os.path.join(self.build_root, '.pants.d'),
       'pants_supportdir': os.path.join(self.build_root, 'build-support'),
       'pants_distdir': os.path.join(self.build_root, 'dist'),
-      'cache_key_gen_version': '0-test'
+      'cache_key_gen_version': '0-test',
     }
     BuildRoot().path = self.build_root
 

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -27,8 +27,7 @@ class JarCreateTestBase(JarTaskTestBase):
 
   def setUp(self):
     super(JarCreateTestBase, self).setUp()
-    self.set_options(compressed=False)
-
+    self.set_options(compressed=False, pants_bootstrapdir='~/.cache/pants', max_subprocess_args=100)
 
 class JarCreateMiscTest(JarCreateTestBase):
   def test_jar_create_init(self):

--- a/tests/python/pants_test/tasks/test_jar_task.py
+++ b/tests/python/pants_test/tasks/test_jar_task.py
@@ -61,12 +61,8 @@ class JarTaskTest(BaseJarTaskTest):
 
   def setUp(self):
     super(JarTaskTest, self).setUp()
-
-    self.jar_task = self.prepare_jar_task(
-      self.context(config=dedent('''
-        [DEFAULT]
-        max_subprocess_args: {}
-        '''.format(self.MAX_SUBPROC_ARGS))))
+    self.set_options(max_subprocess_args=self.MAX_SUBPROC_ARGS)
+    self.jar_task = self.prepare_jar_task(self.context())
 
   def test_update_write(self):
     with temporary_dir() as chroot:
@@ -202,6 +198,11 @@ class JarTaskTest(BaseJarTaskTest):
 
 
 class JarBuilderTest(BaseJarTaskTest):
+
+  def setUp(self):
+    super(JarBuilderTest, self).setUp()
+    self.set_options(max_subprocess_args=100)
+
   def test_agent_manifest(self):
     self.add_to_build_file('src/java/pants/agents', dedent('''
         java_agent(

--- a/tests/python/pants_test/test_binary_util.py
+++ b/tests/python/pants_test/test_binary_util.py
@@ -6,11 +6,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.binary_util import BinaryUtil
+from pants_test.base.context_utils import create_options
 from pants_test.base_test import BaseTest
 
 
 class BinaryUtilTest(BaseTest):
   """Tests binary_util's pants_support_baseurls handling."""
+
 
   class LambdaReader(object):
     """Class which pretends to be an input stream, but is actually a lambda function."""
@@ -52,81 +54,50 @@ class BinaryUtilTest(BaseTest):
   def setUp(self):
     super(BinaryUtilTest, self).setUp()
 
-  def config_urls(self, urls=None, legacy=None):
-    """Generates the contents of a configuration file."""
-    def clean_config(txt):
-      return '\n'.join((line.strip() for line in txt.split('\n')))
-
-    if legacy:
-      legacy = '\npants_support_baseurl: {url}'.format(url=legacy)
-    else:
-      legacy = ''
-
-    if urls:
-      urls = '\npants_support_baseurls = {urls}'.format(urls=urls)
-    else:
-      urls = ''
-
-    return self.config(overrides=clean_config('[DEFAULT]{urls}{legacy}'.format(urls=urls,
-                                                                               legacy=legacy)))
-
   @classmethod
   def _fake_base(cls, name):
     return 'fake-url-{name}'.format(name=name)
 
   @classmethod
   def _fake_url(cls, binaries, base, binary_key):
-    base_path, version, name = binaries[binary_key]
+    supportdir, version, name = binaries[binary_key]
     return '{base}/{binary}'.format(base=base,
-                                    binary=BinaryUtil().select_binary_base_path(
-                                        base_path, version, name))
-
-  def _seens_test(self, binaries, bases, reader, config=None):
-    unseen = [item for item in reader.values() if item.startswith('SEEN ')]
-    if not config:
-      config = self.config_urls(bases)
-    util = BinaryUtil(config=config)
-    for key in binaries:
-      base_path, version, name = binaries[key]
-      with util.select_binary_stream(base_path,
-                                     version,
-                                     name,
-                                     url_opener=reader) as stream:
-        self.assertEqual(stream(), 'SEEN ' + key.upper())
-        unseen.remove(stream())
-    self.assertEqual(0, len(unseen)) # Make sure we've seen all the SEENs.
+                                    binary=BinaryUtil.select_binary_base_path(
+                                      supportdir, version, binary_key))
 
   def test_nobases(self):
     """Tests exception handling if build support urls are improperly specified."""
     try:
-      util = BinaryUtil(config=self.config_urls())
-      with util.select_binary_stream('bin/foo', '4.4.3', 'foo') as stream:
+      with BinaryUtil('bin/protobuf', '2.4.1', [], 30, '/tmp').select_binary_stream('protoc') as stream:
         self.fail('We should have gotten a "NoBaseUrlsError".')
     except BinaryUtil.NoBaseUrlsError as e:
       pass # expected
 
   def test_support_url_multi(self):
     """Tests to make sure existing base urls function as expected."""
-    config = self.config_urls([
+    count = 0
+    with BinaryUtil(
+      supportdir='bin/protobuf',
+      version='2.4.1',
+      baseurls=[
       'BLATANTLY INVALID URL',
-      'https://pantsbuild.github.io/binaries/reasonably-invalid-url',
-      'https://pantsbuild.github.io/binaries/build-support',
-      'https://pantsbuild.github.io/binaries/build-support', # Test duplicate entry handling.
-      'https://pantsbuild.github.io/binaries/another-invalid-url',
-    ])
-    binaries = [
-      ('bin/protobuf', '2.4.1', 'protoc',),
-    ]
-    util = BinaryUtil(config=config)
-    for base_path, version, name in binaries:
-      one = 0
-      with util.select_binary_stream(base_path, version, name) as stream:
-        stream()
-        one += 1
-      self.assertEqual(one, 1)
+      'https://dl.bintray.com/pantsbuild/bin/reasonably-invalid-url',
+      'https://dl.bintray.com/pantsbuild/bin/build-support',
+      'https://dl.bintray.com/pantsbuild/bin/build-support', # Test duplicate entry handling.
+      'https://dl.bintray.com/pantsbuild/bin/another-invalid-url',
+    ],
+      timeout_secs=30,
+      bootstrapdir='/tmp').select_binary_stream('protoc') as stream:
+      stream()
+      count += 1
+    self.assertEqual(count, 1)
 
   def test_support_url_fallback(self):
-    """Tests fallback behavior with multiple support baseurls."""
+    """Tests fallback behavior with multiple support baseurls.
+
+    Mocks up some dummy baseurls and then swaps out the URL reader to make sure urls are accessed
+    and others are not.
+    """
     fake_base, fake_url = self._fake_base, self._fake_url
     binaries = {
       'protoc': ('bin/protobuf', '2.4.1', 'protoc',),
@@ -142,4 +113,13 @@ class BinaryUtilTest(BaseTest):
       fake_url(binaries, bases[2], 'protoc'): 'UNSEEN PROTOC 2',
       fake_url(binaries, bases[2], 'ivy'): 'UNSEEN IVY 2',
     })
-    self._seens_test(binaries, bases, reader)
+
+    unseen = [item for item in reader.values() if item.startswith('SEEN ')]
+    for key in binaries:
+      supportdir, version, name = binaries[key]
+      with BinaryUtil(supportdir, version, bases, 30, '/tmp').select_binary_stream(
+          key,
+          url_opener=reader) as stream:
+        self.assertEqual(stream(), 'SEEN ' + key.upper())
+        unseen.remove(stream())
+    self.assertEqual(0, len(unseen)) # Make sure we've seen all the SEENs.


### PR DESCRIPTION


- Register global options --pants-support-baseurls, --max-subprocess-args,
  and --pants-support-fetch-timeout-secs.
- Remove 'config' parameter and other referecnes from BinaryUtil.
- Remove pants.ini values that have good compiled in defaults.
- Updated help for the common --support and --version flags by making BinaryUtil a mixin