### PR TITLE
[Trigger CI] always use relpath on --test file args, refactor execute in junit_run, a...

### DIFF
--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -128,8 +128,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       self.assertTrue(os.path.exists(
         os.path.join(workdir, 'test', 'junit', 'coverage', 'xml', 'coverage.xml')))
 
-  def test_junit_test_with_cwd(self):
-    # Make sure the test fails if you don't specify cwd
+  def test_junit_test_requiring_cwd_fails_without_option_specified(self):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/com/pants/testproject/cwdexample',
@@ -138,7 +137,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         '--test-junit-jvm-options=-Dcwd.test.enabled=true'])
     self.assert_failure(pants_run)
 
-    # Expicit cwd specified
+  def test_junit_test_requiring_cwd_passes_with_option_with_value_specified(self):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/com/pants/testproject/cwdexample',
@@ -148,7 +147,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         '--test-junit-cwd=testprojects/src/java/com/pants/testproject/cwdexample/subdir'])
     self.assert_success(pants_run)
 
-    # Implicit cwd specified based on path to target
+  def test_junit_test_requiring_cwd_passes_with_option_with_no_value_specified(self):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/com/pants/testproject/cwdexample',
@@ -157,3 +156,14 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         '--test-junit-jvm-options=-Dcwd.test.enabled=true',
         '--test-junit-cwd',])
     self.assert_success(pants_run)
+
+  def test_junit_test_requiring_cwd_fails_when_target_not_first(self):
+    pants_run = self.run_pants([
+        'test',
+        'examples/tests/scala/com/pants/example/hello/welcome',
+        'testprojects/tests/java/com/pants/testproject/cwdexample',
+        '--interpreter=CPython>=2.6,<3',
+        '--interpreter=CPython>=3.3',
+        '--test-junit-jvm-options=-Dcwd.test.enabled=true',
+        '--test-junit-cwd',])
+    self.assert_failure(pants_run)

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -13,19 +13,15 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class JunitTestsIntegrationTest(PantsRunIntegrationTest):
 
+  def _assert_junit_output_exists_for_class(self, workdir, classname):
+    self.assertTrue(os.path.exists(
+      os.path.join(workdir, 'test', 'junit', '{}.out.txt'.format(classname))))
+    self.assertTrue(os.path.exists(
+      os.path.join(workdir, 'test', 'junit', '{}.err.txt'.format(classname))))
+
   def _assert_junit_output(self, workdir):
-    self.assertTrue(os.path.exists(
-      os.path.join(workdir, 'test', 'junit',
-                   'com.pants.examples.hello.greet.GreetingTest.out.txt')))
-    self.assertTrue(os.path.exists(
-      os.path.join(workdir, 'test', 'junit',
-                   'com.pants.examples.hello.greet.GreetingTest.err.txt')))
-    self.assertTrue(os.path.exists(
-      os.path.join(workdir, 'test', 'junit',
-                   'com.pants.example.hello.welcome.WelSpec.out.txt')))
-    self.assertTrue(os.path.exists(
-      os.path.join(workdir, 'test', 'junit',
-                   'com.pants.example.hello.welcome.WelSpec.err.txt')))
+    self._assert_junit_output_exists_for_class(workdir, 'com.pants.examples.hello.greet.GreetingTest')
+    self._assert_junit_output_exists_for_class(workdir, 'com.pants.example.hello.welcome.WelSpec')
 
   def test_junit_test(self):
     with temporary_dir(root_dir=self.workdir_root()) as workdir:
@@ -38,6 +34,39 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           workdir)
       self.assert_success(pants_run)
       self._assert_junit_output(workdir)
+
+  def test_junit_test_with_test_option_with_relpath(self):
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      pants_run = self.run_pants_with_workdir([
+          'test',
+          '--test-junit-test=examples/tests/java/com/pants/examples/hello/greet/GreetingTest.java',
+          'examples/tests/java/com/pants/examples/hello/greet',
+          'examples/tests/scala/com/pants/example/hello/welcome'],
+          workdir)
+      self.assert_success(pants_run)
+      self._assert_junit_output_exists_for_class(workdir, 'com.pants.examples.hello.greet.GreetingTest')
+
+  def test_junit_test_with_test_option_with_dot_slash_relpath(self):
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      pants_run = self.run_pants_with_workdir([
+          'test',
+          '--test-junit-test=./examples/tests/java/com/pants/examples/hello/greet/GreetingTest.java',
+          'examples/tests/java/com/pants/examples/hello/greet',
+          'examples/tests/scala/com/pants/example/hello/welcome'],
+          workdir)
+      self.assert_success(pants_run)
+      self._assert_junit_output_exists_for_class(workdir, 'com.pants.examples.hello.greet.GreetingTest')
+
+  def test_junit_test_with_test_option_with_classname(self):
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      pants_run = self.run_pants_with_workdir([
+          'test',
+          '--test-junit-test=com.pants.examples.hello.greet.GreetingTest',
+          'examples/tests/java/com/pants/examples/hello/greet',
+          'examples/tests/scala/com/pants/example/hello/welcome'],
+          workdir)
+      self.assert_success(pants_run)
+      self._assert_junit_output_exists_for_class(workdir, 'com.pants.examples.hello.greet.GreetingTest')
 
   def test_junit_test_with_emma(self):
     with temporary_dir(root_dir=self.workdir_root()) as workdir:


### PR DESCRIPTION
...dd more integration tests

Specifying the test to run prefixed with ./ fails because the ./ causes the src path to not match the paths in the classes_by_source product. This changes that so it will always create the relpath when trying to derive the classes.

It also refactors execute to reduce nesting and clarify some of the flag / config interactions.