### PR TITLE
Adding a --test-junit-coverage-jvm-options flag that allows specifying J...

### DIFF
--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -79,7 +79,9 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           '--test-junit-coverage-processor=emma',
           '--test-junit-coverage',
           '--test-junit-coverage-xml',
-          '--test-junit-coverage-html'],
+          '--test-junit-coverage-html',
+          '--test-junit-coverage-jvm-options=-Xmx1g',
+          '--test-junit-coverage-jvm-options=-XX:MaxPermSize=256m'],
           workdir)
       self.assert_success(pants_run)
       self._assert_junit_output(workdir)
@@ -117,7 +119,9 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           '--test-junit-coverage-processor=cobertura',
           '--test-junit-coverage',
           '--test-junit-coverage-xml',
-          '--test-junit-coverage-html'],
+          '--test-junit-coverage-html',
+          '--test-junit-coverage-jvm-options=-Xmx1g',
+          '--test-junit-coverage-jvm-options=-XX:MaxPermSize=256m'],
           workdir)
       self.assert_success(pants_run)
       self._assert_junit_output(workdir)


### PR DESCRIPTION
...VM options for the processes that run the test coverage tools.

Cobertura's "instrument" target runs out of PermGen space when it needs to process a target with a larger number of files, and currently there's no way to increase the default (512M).

Not sure who the right reviewers are, so adding some people that I've talked to in the hipchat room.

Testing Done:
Tested the change on a Twitter target that failed with the default options, and passed with --test-junit-coverage-jvm-options=-Xmx4g --test-junit-coverage-jvm-options=-XX:MaxPermSize=1g

build-support/bin/ci.sh passed.

Reviewed at https://rbcommons.com/s/twitter/r/1968/