### PR TITLE
Add a controlled repro case for a Twitter-like pants.pex.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,9 @@
-# Enables support for a docker container-based build
-# which should provide faster startup times and beefier
-# "machines". This is also required in order to use the
-# cache configured below.
-sudo: false
+language: objective-c
 
-cache:
-  directories:
-    - $HOME/.cache/pants
-    - $HOME/.ivy2
-    - build-support/isort.venv
-    - build-support/pants_dev_deps.venv
-    - build-support/virtualenv.dist
-
-language: python
-
-python:
-  - "2.7"
-
-install:
-  - pip --quiet install coveralls
-
-env:
-  global:
-    - CXX=g++
-    # Credentials for OSX syncing: GH_USER, GH_EMAIL, GH_TOKEN
-    # These are encrypted with a public key for our repo that only
-    # Travis-CI has the private key for.  We are trusting Travis-CI
-    # here but no-one else.
-    #
-    # See: http://docs.travis-ci.com/user/encryption-keys/
-    - secure: VvwbndU++a2/iNAjk9cd67ATiipDwqcKnxDR4/J2Ik3GH10wHEDUhJ1+MK4WLhedfaOakDOEmarZQS3GwtgvCHO3knpTJuJc8d/bCfZovYuSqdi//BEv4dS7hDt6tQeJfkbBjG0T4yNjPJ3W9R9KDWCy/vj2CUm90BGg2CmxUbg=
-  matrix:
-    - CI_FLAGS="-clpnet 'Various pants self checks'"  # (fkmsr)
-    - CI_FLAGS="-fkmsrclpn 'Test examples and testprojects'"  # (et)
-    - CI_FLAGS="-fkmsrcnet 'Python unit tests for pants and pants-plugins'"  # (lp)
-    - CI_FLAGS="-fkmsrclpet 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrlpnet -i 6:0 'Python integration tests for pants - shard 1'"  # (c)
-    - CI_FLAGS="-fkmsrlpnet -i 6:1 'Python integration tests for pants - shard 2'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:2 'Python integration tests for pants - shard 3'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:3 'Python integration tests for pants - shard 4'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:4 'Python integration tests for pants - shard 5'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:5 'Python integration tests for pants - shard 6'"
-
-before_script: |
-  ./build-support/bin/ci-sync.sh
+before_install:
+  - brew update
+  - brew install python
 
 script: |
-  uname -a
-  java -version
-  ./build-support/bin/ci.sh -x ${CI_FLAGS}
-
-# We accept the default travis-ci email author+comitter notification
-# for now which is enabled even with no `notifications` config.
-# notifications:
-#   email: ...
-
-after_success:
-  coveralls
-
+  ./test-pants-pex.sh
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-language: python
+language: objective-c
+
+before_install:
+  - brew update
+  - brew install python
 
 script: |
   ./test-pants-pex.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
-language: objective-c
-
-before_install:
-  - brew update
-  - brew install python
+language: python
 
 script: |
   ./test-pants-pex.sh

--- a/contrib/cpp/src/python/pants/contrib/cpp/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/BUILD
@@ -8,8 +8,7 @@ python_library(
     'contrib/cpp/src/python/pants/contrib/cpp/targets:targets',
     'contrib/cpp/src/python/pants/contrib/cpp/tasks:tasks',
     'contrib/cpp/src/python/pants/contrib/cpp/toolchain:toolchain',
-    'src/python/pants/base:build_file_aliases',
-    'src/python/pants/goal:task_registrar',
+    'src/python/pants:pants-packaged',
   ],
   provides=contrib_setup_py(
     name='pantsbuild.pants.contrib.cpp',

--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/BUILD
@@ -10,10 +10,6 @@ python_library(
     'cpp_target.py',
   ],
   dependencies=[
-    'src/python/pants/base:build_environment',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:payload_field',
-    'src/python/pants/base:target',
-    'src/python/pants/backend/core/targets:common'
+    'src/python/pants:pants-packaged',
   ],
 )

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/BUILD
@@ -14,9 +14,6 @@ python_library(
   dependencies=[
     'contrib/cpp/src/python/pants/contrib/cpp/toolchain:toolchain',
     'contrib/cpp/src/python/pants/contrib/cpp/targets:targets',
-    'src/python/pants/backend/core/tasks:common',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:workunit',
-    'src/python/pants/util:dirutil',
+    'src/python/pants:pants-packaged',
   ],
 )

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
@@ -6,7 +6,7 @@ python_library(
   sources=['register.py'],
   dependencies=[
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks',
-    'src/python/pants/goal:task_registrar',
+    'src/python/pants:pants-packaged',
   ],
   provides=contrib_setup_py(
     name='pantsbuild.pants.contrib.scrooge',

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -14,18 +14,7 @@ python_library(
   sources = ['scrooge_gen.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/backend/codegen/targets:java',
-    'src/python/pants/backend/jvm/targets:java',
-    'src/python/pants/backend/jvm/targets:scala',
-    'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
-    'src/python/pants/backend/jvm/tasks:nailgun_task',
-    'src/python/pants/base:address',
-    'src/python/pants/base:address_lookup_error',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/option',
-    'src/python/pants/util:dirutil',
-    'src/python/pants:thrift_util',
+    'src/python/pants:pants-packaged',
   ],
 )
 
@@ -33,10 +22,6 @@ python_library(
   name = 'thrift_linter',
   sources = ['thrift_linter.py'],
   dependencies = [
-    'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
-    'src/python/pants/backend/jvm/tasks:nailgun_task',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:workunit',
-    'src/python/pants/option',
+    'src/python/pants:pants-packaged',
   ],
 )

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -25,6 +25,7 @@ python_library(
 python_library(
   name='test_infra',
   dependencies=[
+    'src/python/pants:pants-packaged',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test/jvm:jar_task_test_base',

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -136,9 +136,13 @@ class SetupPy(PythonTask):
     root_deps = depmap.pop(root_target, OrderedSet())
 
     def elide(target):
-      if any(target in depset for depset in depmap.values()):
-        root_deps.discard(target)
-
+      for provider, depset in depmap.items():
+        if target in depset:
+          root_deps.discard(target)
+        elif target == provider:
+          for dep in depset:
+            if isinstance(dep, PythonTarget):
+              root_deps.discard(dep)
     root_target.walk(elide)
     return root_deps
 

--- a/test-pants-pex.sh
+++ b/test-pants-pex.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+PANTS_DEV=1 ./pants setup-py --recursive contrib/scrooge/src/python/pants/contrib/scrooge:plugin && \
 curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-12.0.7.tar.gz && \
 tar -xzf virtualenv-12.0.7.tar.gz && \
 cd virtualenv-12.0.7 && \
@@ -10,6 +11,7 @@ pip install pex && \
 pex \
   --no-wheel \
   --python=python2.7 \
+  --repo=./dist/ \
   -r pantsbuild.pants==0.0.31 \
   -r pantsbuild.pants.contrib.scrooge==0.0.31 \
   -r twitter.common.pants==0.8.2 \

--- a/test-pants-pex.sh
+++ b/test-pants-pex.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+curl -O https://pypi.python.org/packages/source/v/virtualenv/virtualenv-12.0.7.tar.gz && \
+tar -xzf virtualenv-12.0.7.tar.gz && \
+cd virtualenv-12.0.7 && \
+python2.7 virtualenv.py ../pex && \
+cd .. && \
+source ./pex/bin/activate && \
+pip install pex && \
+pex \
+  --no-wheel \
+  --python=python2.7 \
+  -r pantsbuild.pants==0.0.31 \
+  -r pantsbuild.pants.contrib.scrooge==0.0.31 \
+  -r twitter.common.pants==0.8.2 \
+  -r "beautifulsoup4>=4.3.2,<4.4" \
+  -e pants.bin.pants_exe:main \
+  -o pants.pex && \
+./pants.pex && \
+./pants.pex goals && \
+./pants.pex list && \
+./pants.pex compile compile testprojects/src/thrift/com/pants/::
+

--- a/test-pants-pex.sh
+++ b/test-pants-pex.sh
@@ -16,6 +16,7 @@ pex \
   -r "beautifulsoup4>=4.3.2,<4.4" \
   -e pants.bin.pants_exe:main \
   -o pants.pex && \
+zipinfo -1 pants.pex && \
 ./pants.pex && \
 ./pants.pex goals && \
 ./pants.pex list && \

--- a/tests/python/pants_test/python/test_setup_py.py
+++ b/tests/python/pants_test/python/test_setup_py.py
@@ -52,8 +52,8 @@ class TestSetupPy(TaskTestBase):
     self.assertEqual(SetupPy.minified_dependencies(target_map['bar']),
                      OrderedSet([target_map['baz']]))
     self.assertEqual(SetupPy.minified_dependencies(target_map['baz']), OrderedSet())
-    self.assertEqual(SetupPy.install_requires(target_map['foo']), set(['bar==0.0.0']))
-    self.assertEqual(SetupPy.install_requires(target_map['bar']), set(['baz==0.0.0']))
+    self.assertEqual(SetupPy.install_requires(target_map['foo']), {'bar==0.0.0'})
+    self.assertEqual(SetupPy.install_requires(target_map['bar']), {'baz==0.0.0'})
     self.assertEqual(SetupPy.install_requires(target_map['baz']), set())
 
   @contextmanager
@@ -104,9 +104,9 @@ class TestSetupPy(TaskTestBase):
                      OrderedSet([target_map['bak']]))
     self.assertEqual(SetupPy.minified_dependencies(target_map['baz']),
                      OrderedSet([target_map['bak']]))
-    self.assertEqual(SetupPy.install_requires(target_map['foo']), set(['bar==0.0.0', 'baz==0.0.0']))
-    self.assertEqual(SetupPy.install_requires(target_map['bar']), set(['bak==0.0.0']))
-    self.assertEqual(SetupPy.install_requires(target_map['baz']), set(['bak==0.0.0']))
+    self.assertEqual(SetupPy.install_requires(target_map['foo']), {'bar==0.0.0', 'baz==0.0.0'})
+    self.assertEqual(SetupPy.install_requires(target_map['bar']), {'bak==0.0.0'})
+    self.assertEqual(SetupPy.install_requires(target_map['baz']), {'bak==0.0.0'})
 
   def test_binary_target_injected_into_minified_dependencies(self):
     foo_bin_dep = self.make_target(
@@ -176,7 +176,7 @@ class TestSetupPy(TaskTestBase):
 
     # TODO(pl): Why is this set ordered?  Does the order actually matter?
     assert SetupPy.minified_dependencies(bar) == OrderedSet([bar_bin, bar_bin_dep])
-    assert SetupPy.install_requires(bar) == set(['bar_bin_dep==0.0.0'])
+    assert SetupPy.install_requires(bar) == {'bar_bin_dep==0.0.0'}
     entry_points = dict(SetupPy.iter_entry_points(bar))
     assert entry_points == {'bar_binary': 'bar.bin.bar'}
 
@@ -281,11 +281,8 @@ def test_find_packages():
   with yield_chroot(['foo', 'foo.bar'], [], resources) as chroot:
     _, _, r = SetupPy.find_packages(chroot)
     assert r == {
-      'foo': set(['f0']),
-      'foo.bar': set([
-        os.path.join('baz', 'f1'),
-        os.path.join('baz', 'f2'),
-      ])
+      'foo': {'f0'},
+      'foo.bar': {os.path.join('baz', 'f1'), os.path.join('baz', 'f2')}
     }
 
   # assert that nearest submodule splits on module prefixes
@@ -295,7 +292,7 @@ def test_find_packages():
       {'foo.bar1': ['f0']}) as chroot:
 
     _, _, r = SetupPy.find_packages(chroot)
-    assert r == {'foo': set(['bar1/f0'])}
+    assert r == {'foo': {'bar1/f0'}}
 
 
 def test_nearest_subpackage():


### PR DESCRIPTION
This fails under OSX ci - see 1st commit's .travis.yml.
It works on my linux box - and we'll see on linux CI in the 2nd commit.