### PR TITLE
Fixup minified_dependencies.

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/BUILD
@@ -10,6 +10,9 @@ python_library(
     'contrib/cpp/src/python/pants/contrib/cpp/toolchain:toolchain',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/goal:task_registrar',
+
+    # TODO(John Sirois): Remove this once setup-py learns to index providers that are out of scope.
+    'src/python/pants:pants-packaged',
   ],
   provides=contrib_setup_py(
     name='pantsbuild.pants.contrib.cpp',

--- a/contrib/cpp/src/python/pants/contrib/cpp/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/BUILD
@@ -12,6 +12,7 @@ python_library(
     'src/python/pants/goal:task_registrar',
 
     # TODO(John Sirois): Remove this once setup-py learns to index providers that are out of scope.
+    # see: https://github.com/pantsbuild/pants/issues/1329
     'src/python/pants:pants-packaged',
   ],
   provides=contrib_setup_py(

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -21,13 +21,7 @@ PKG_SCROOGE=(
 )
 function pkg_scrooge_install_test() {
   PIP_ARGS="$@"
-  # TODO(John Sirois): The generated pantsbuild.pants.contrib.scrooge should have a requirement on
-  # pantsbuild.pants but it currently does not so we must manually install it here.  Investigate
-  # this and when fixed, drop the pantsbuild.pants install requirement here.
-  # See: https://github.com/pantsbuild/pants/issues/1126
-  pip install ${PIP_ARGS} \
-    pantsbuild.pants==$(local_version) \
-    pantsbuild.pants.contrib.scrooge==$(local_version) && \
+  pip install ${PIP_ARGS} pantsbuild.pants.contrib.scrooge==$(local_version) && \
   execute_packaged_pants_with_internal_backends --explain gen | grep "scrooge" &> /dev/null && \
   execute_packaged_pants_with_internal_backends goals | grep "thrift-linter" &> /dev/null
 }

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
@@ -9,6 +9,7 @@ python_library(
     'src/python/pants/goal:task_registrar',
 
     # TODO(John Sirois): Remove this once setup-py learns to index providers that are out of scope.
+    # see: https://github.com/pantsbuild/pants/issues/1329
     'src/python/pants:pants-packaged',
   ],
   provides=contrib_setup_py(

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
@@ -7,6 +7,9 @@ python_library(
   dependencies=[
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks',
     'src/python/pants/goal:task_registrar',
+
+    # TODO(John Sirois): Remove this once setup-py learns to index providers that are out of scope.
+    'src/python/pants:pants-packaged',
   ],
   provides=contrib_setup_py(
     name='pantsbuild.pants.contrib.scrooge',

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -31,6 +31,7 @@ python_library(
     'tests/python/pants_test/engine:engine_test_base',
 
     # TODO(John Sirois): Remove this once setup-py learns to index providers that are out of scope.
+    # see: https://github.com/pantsbuild/pants/issues/1329
     'src/python/pants:pants-packaged',
   ],
   provides=pants_setup_py(

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -29,6 +29,9 @@ python_library(
     'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
     'tests/python/pants_test/engine:engine_test_base',
+
+    # TODO(John Sirois): Remove this once setup-py learns to index providers that are out of scope.
+    'src/python/pants:pants-packaged',
   ],
   provides=pants_setup_py(
     name='pantsbuild.pants.testinfra',

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -2,11 +2,12 @@ target(
   name='tasks',
   dependencies=[
     ':python_eval',
-    ':python_repl'
+    ':python_repl',
+    ':setup_py',
   ]
 )
 
-python_tests(
+python_library(
   name='python_task_test',
   sources=['python_task_test.py'],
   dependencies=[
@@ -45,4 +46,23 @@ python_tests(
     'src/python/pants/base:target',
     'src/python/pants/util:contextutil',
   ]
+)
+
+python_tests(
+  name='setup_py',
+  sources=['test_setup_py.py'],
+  dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python/twitter/commons:twitter.common.dirutil',
+    '3rdparty/python:mock',
+    'src/python/pants/backend/core/targets:common',
+    'src/python/pants/backend/python:python_artifact',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:target',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:task_test_base',
+  ],
 )

--- a/tests/python/pants_test/python/BUILD
+++ b/tests/python/pants_test/python/BUILD
@@ -102,25 +102,6 @@ python_tests(
   ],
 )
 
-python_tests(
-  name = 'test_setup_py',
-  sources = ['test_setup_py.py'],
-  dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python/twitter/commons:twitter.common.dirutil',
-    '3rdparty/python:mock',
-    'src/python/pants/backend/core/targets:common',
-    'src/python/pants/backend/python:python_artifact',
-    'src/python/pants/backend/python/targets:python',
-    'src/python/pants/backend/python/tasks:python',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:target',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
-    'tests/python/pants_test:task_test_base',
-    ],
-  )
-
 # Used by interpreter_selection_integration.
 python_binary(
   name = 'echo_interpreter_version_2.6',


### PR DESCRIPTION
This change fixes the core of the SetupPy minified_dependencies and adds
a hack dependency to each of pants 3 auxiliary sdist targets to produce
correct sdists with no repeated code and an exact set of setup_requires.

The SetupPy test is moved to its proper parallel test tree home and a test
added for the pantsbuild.pants contrib sdist case is added that fails
before the fix.

A follow-on change will remove the need for the 3 hack deps by imposing
a well defined global ownership model for python targets that don't provide.

https://rbcommons.com/s/twitter/r/1986/