### PR TITLE
Rid pantsbuild.pants of an un-needed antlr dep.

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -4,4 +4,11 @@
 # see/edit requirements.txt in this directory to change deps.
 python_requirements()
 
-target(name='antlr-3.1.3', dependencies=[':antlr-python-runtime'])
+# Only used by tests so we lift this library out of the requirements.txt
+# file used to bootstrap pants itself.
+python_requirement_library(
+  name='antlr-3.1.3',
+  requirements=[
+    python_requirement('antlr_python_runtime==3.1.3')
+  ]
+)

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,9 +1,4 @@
 ansicolors==1.0.2
-
-antlr_python_runtime==3.1.3
---allow-external antlr-python-runtime
---allow-unverified antlr-python-runtime
-
 coverage>=3.7,<3.8
 docutils>=0.12,<0.13
 Markdown==2.1.1

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -39,8 +39,7 @@ PKG_PANTS_TESTINFRA=(
 )
 function pkg_pants_testinfra_install_test() {
   PIP_ARGS="$@"
-  pip install ${PIP_ARGS} pantsbuild.pants.testinfra==$(local_version) \
-    --allow-external antlr-python-runtime --allow-unverified antlr-python-runtime && \
+  pip install ${PIP_ARGS} pantsbuild.pants.testinfra==$(local_version) && \
   python -c "import pants_test"
 }
 
@@ -139,9 +138,6 @@ function install_and_test_packages() {
   PIP_ARGS=(
     "$@"
     --quiet
-
-    # Needed for now by pantsbuild.pants which any install requires.
-    --allow-external antlr-python-runtime --allow-unverified antlr-python-runtime
   )
 
   for PACKAGE in "${RELEASE_PACKAGES[@]}"

--- a/examples/src/python/example/3rdparty_py.md
+++ b/examples/src/python/example/3rdparty_py.md
@@ -29,7 +29,7 @@ file and make a pip `requirements.txt` file in the same directory.
 
 E.g, your `3rdparty/python/BUILD` file might look like:
 
-!inc[start-at=python_requirement&end-before=target](../../../../3rdparty/python/BUILD)
+!inc[start-at=python_requirement&end-before=#](../../../../3rdparty/python/BUILD)
 
 ...with `3rdparty/python/requirements.txt` like:
 

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -326,7 +326,7 @@ API Changes
   - Deprecate target.with_description in favor of target(description=)
     `RB #1790 <https://rbcommons.com/s/twitter/r/1790>`_
   - Allow exclude in globs
-    `RB #1790 <https://rbcommons.com/s/twitter/r/1762>`_
+    `RB #1762 <https://rbcommons.com/s/twitter/r/1762>`_
   - Move with_artifacts to an artifacts argument
     `RB #1672 <https://rbcommons.com/s/twitter/r/1672>`_
 
@@ -504,7 +504,7 @@ Bugfixes and features
 * Add util.XmlParser and AndroidManifestParser
   `RB #1757 <https://rbcommons.com/s/twitter/r/1757>`_
 
-* Replace Compatibility.exec_function with six.exec_
+* Replace Compatibility.exec_function with `six.exec_`
   `RB #1742 <https://rbcommons.com/s/twitter/r/1742>`_
   `RB #1794 <https://rbcommons.com/s/twitter/r/1794>`_
 
@@ -518,7 +518,7 @@ Bugfixes and features
   `RB #1780 <https://rbcommons.com/s/twitter/r/1780>`_
 
 * Fixup JarPublish changelog rendering
-  `RB #1780 <https://rbcommons.com/s/twitter/r/1787>`_
+  `RB #1787 <https://rbcommons.com/s/twitter/r/1787>`_
 
 * Preserve dictionary order in the anonymizer
   `RB #1779 <https://rbcommons.com/s/twitter/r/1779>`_

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -56,7 +56,6 @@ python_library(
   sources = ['antlr_builder.py'],
   dependencies = [
     ':code_generator',
-    '3rdparty/python:antlr-3.1.3',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/ivy',

--- a/testprojects/src/python/antlr/BUILD
+++ b/testprojects/src/python/antlr/BUILD
@@ -2,7 +2,6 @@ python_tests(
   name = 'test_antlr_failure',
   sources = ['donothing.py'],
   dependencies = [
-    '3rdparty/python:antlr-3.1.3',
     'testprojects/src/antlr/pants/backend/python/test:antlr_failure',
   ],
 )


### PR DESCRIPTION
The dep is only needed by 1 test that attempts to use the generated code
to parse via the antlr runtime.  This change lifts the dep from the
requirements.txt file used to bootstrap pants into a stand-alone
python_requirement_library that the test can depend on without forcing
each pants bootstrap to fetch this dep.

Since 3rdparty/python/BUILD was used for an include in the docs, doc gen
broke leading to fixes for CI doc gen errors.

https://rbcommons.com/s/twitter/r/1989/