### PR TITLE
Kill pantsbuild dependence on maven.twttr.com.

### DIFF
--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -18,12 +18,12 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
                usepoms="true"
                root="https://repo1.maven.org/maven2/"/>
 
-      <!-- This is just for twitter-hosted jvm tools - kill once they are published to maven
-           central. -->
-      <ibiblio name="maven.twttr.com-maven"
+      <!-- This is just for jvm tools used by Pants and not yet published to maven central.
+           Kill once they are published to maven central. -->
+      <ibiblio name="pantsbuild-maven-repo"
                m2compatible="true"
                usepoms="true"
-               root="http://maven.twttr.com/"/>
+               root="https://dl.bintray.com/pantsbuild/maven/"/>
     </chain>
   </macrodef>
 

--- a/pants-plugins/src/python/internal_backend/repositories/register.py
+++ b/pants-plugins/src/python/internal_backend/repositories/register.py
@@ -13,11 +13,11 @@ from pants.base.build_manual import manual
 
 
 public_repo = Repository(name = 'public',
-                         url = 'http://maven.twttr.com',
+                         url = 'https://dl.bintray.com/pantsbuild/maven',
                          push_db_basedir = os.path.join('build-support', 'ivy', 'pushdb'))
 
 testing_repo = Repository(name = 'testing',
-                          url = 'http://maven.twttr.com',
+                          url = 'https://dl.bintray.com/pantsbuild/maven',
                           push_db_basedir = os.path.join('testprojects', 'ivy', 'pushdb'))
 
 

--- a/src/docs/setup_repo.md
+++ b/src/docs/setup_repo.md
@@ -174,11 +174,11 @@ simple example to get you started:
                    usepoms="true"
                    root="https://repo1.maven.org/maven2/"/>
 
-          <!-- This is just for twitter-hosted jvm tools used by Pants -->
-          <ibiblio name="maven.twttr.com-maven"
+          <!-- This is just for jvm tools used by Pants and not yet published to maven central. -->
+          <ibiblio name="pantsbuild-maven-repo"
                    m2compatible="true"
                    usepoms="true"
-                   root="http://maven.twttr.com/"/>
+                   root="https://dl.bintray.com/pantsbuild/maven/"/>
 
         </chain>
       </resolvers>
@@ -513,7 +513,7 @@ If your site uses Sonotype Nexus or another reverse proxy for
 artifacts, you do not need to use a separate HTTP proxy.  Contact the
 reverse proxy administrator to setup a proxy for the sites listed in
 `build-support/ivy/settings.xml` and `pants.ini`.  Currently, these
-sites are `repo1.maven.org` and `maven.twttr.com`:
+sites are `https://repo1.maven.org/maven2/` and `https://dl.bintray.com/pantsbuild/maven/`:
 
 Here is an excerpt of a modified ivysettings.xml with some possible configurations:
 

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -342,7 +342,7 @@ class JarPublish(ScmPublishMixin, JarTask):
        # repository target name is paired with this key
        'myrepo': {
          # ivysettings.xml resolver to use for publishing
-         'resolver': 'maven.twttr.com',
+         'resolver': 'maven.example.com',
          # ivy configurations to publish
          'confs': ['default', 'sources', 'javadoc'],
          # address of a Credentials target to use when publishing

--- a/tests/python/pants_test/base/test_build_file_parser.py
+++ b/tests/python/pants_test/base/test_build_file_parser.py
@@ -196,7 +196,7 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
           return None
         jvm_repo = Repository(
           name = 'maven-central',
-          url = 'http://maven.twttr.com',
+          url = 'http://maven.example.com',
           push_db_basedir = os.path.join('build-support', 'ivy', 'pushdb'),
         )
         return parse_context.create_object('artifact',

--- a/tests/python/pants_test/tasks/test_listtargets.py
+++ b/tests/python/pants_test/tasks/test_listtargets.py
@@ -42,7 +42,7 @@ class ListTargetsTest(BaseListTargetsTest):
         'pants': lambda x: x,
         'artifact': Artifact,
         'public': Repository(name='public',
-                             url='http://maven.twttr.com',
+                             url='http://maven.example.com',
                              push_db_basedir='/tmp'),
       }
     )
@@ -56,7 +56,7 @@ class ListTargetsTest(BaseListTargetsTest):
         self.name = name
         self.provides = dedent('''
             artifact(
-              org='com.twitter',
+              org='com.example',
               name='%s',
               repo=public
             )
@@ -156,14 +156,14 @@ class ListTargetsTest(BaseListTargetsTest):
 
   def test_list_provides(self):
     self.assert_console_output(
-        'a/b:b com.twitter#b',
-        'a/b/c:c2 com.twitter#c2',
+        'a/b:b com.example#b',
+        'a/b/c:c2 com.example#c2',
         args=['--test-provides'])
 
   def test_list_provides_customcols(self):
     self.assert_console_output(
-        '/tmp a/b:b http://maven.twttr.com public com.twitter#b',
-        '/tmp a/b/c:c2 http://maven.twttr.com public com.twitter#c2',
+        '/tmp a/b:b http://maven.example.com public com.example#b',
+        '/tmp a/b/c:c2 http://maven.example.com public com.example#c2',
         args=[
             '--test-provides',
             '--test-provides-columns=push_db_basedir,address,repo_url,repo_name,artifact_id'


### PR DESCRIPTION
The maven artifacts pants needs that are not hosted on maven central are
now hosted on bintray at https://dl.bintray.com/pantsbuild/maven.

The https://github.com/pantsbuild/maven-repo repo contains the script to
sync new artifacts to bintray as well as a script that makes it easy to
grab a graph of targets from maven.twttr.com.

https://rbcommons.com/s/twitter/r/2019/