### PR TITLE
Rename Address.path_spec_path to fully_qualifed_spec_path

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -276,6 +276,7 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':address',
     ':build_environment',
+    ':build_manual',
     ':fingerprint_strategy',
     ':hash_utils',
     ':lazy_source_mapper',

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -276,7 +276,6 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':address',
     ':build_environment',
-    ':build_manual',
     ':fingerprint_strategy',
     ':hash_utils',
     ':lazy_source_mapper',

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -273,10 +273,9 @@ python_library(
   sources = ['target.py'],
   dependencies = [
     '3rdparty/python:six',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     ':address',
     ':build_environment',
-    ':build_manual',
+    ':exceptions',
     ':fingerprint_strategy',
     ':hash_utils',
     ':lazy_source_mapper',
@@ -284,6 +283,7 @@ python_library(
     ':payload_field',
     ':source_root',
     ':target_addressable',
+    ':validation',
   ],
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -278,7 +278,6 @@ python_library(
     ':exceptions',
     ':fingerprint_strategy',
     ':hash_utils',
-    ':lazy_source_mapper',
     ':payload',
     ':payload_field',
     ':source_root',

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -140,6 +140,7 @@ class Address(AbstractClass):
 
   @property
   def path_safe_spec(self):
+    """Return the path to the target from the build root and the target name, joined by periods."""
     return ('{safe_spec_path}.{target_name}'
             .format(safe_spec_path=self._spec_path.replace(os.sep, '.'),
                     target_name=self._target_name))

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -139,7 +139,7 @@ class Address(AbstractClass):
                                               target_name=self._target_name)
 
   @property
-  def path_safe_spec(self):
+  def fully_qualified_spec_path(self):
     return ('{safe_spec_path}.{target_name}'
             .format(safe_spec_path=self._spec_path.replace(os.sep, '.'),
                     target_name=self._target_name))

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -140,7 +140,10 @@ class Address(AbstractClass):
 
   @property
   def path_safe_spec(self):
-    """Return the path to the target from the build root and the target name, joined by periods."""
+    """Return spec address in a form safe for use as a filename on unix systems.
+
+    This is exactly as unique as the spec itself when compared with other path_spec_names.
+    """
     return ('{safe_spec_path}.{target_name}'
             .format(safe_spec_path=self._spec_path.replace(os.sep, '.'),
                     target_name=self._target_name))

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -139,7 +139,7 @@ class Address(AbstractClass):
                                               target_name=self._target_name)
 
   @property
-  def fully_qualified_spec_path(self):
+  def path_safe_spec(self):
     return ('{safe_spec_path}.{target_name}'
             .format(safe_spec_path=self._spec_path.replace(os.sep, '.'),
                     target_name=self._target_name))

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import functools
 import os
 from hashlib import sha1
 
@@ -13,7 +12,6 @@ from six import string_types
 
 from pants.base.address import Addresses, SyntheticAddress
 from pants.base.build_environment import get_buildroot
-from pants.base.build_manual import manual
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import hash_all
@@ -381,7 +379,7 @@ class Target(AbstractTarget):
   def id(self):
     """A unique identifier for the Target.
 
-    The generated id is safe for use as a path name on unix systems.
+    The generated id is safe for use as a filename on unix systems.
     """
     return self.address.path_safe_spec
 
@@ -389,7 +387,7 @@ class Target(AbstractTarget):
   def identifier(self):
     """A unique identifier for the Target.
 
-    The generated id is safe for use as a path name on unix systems.
+    The generated id is safe for use as a filename on unix systems.
     """
     return self.id
 

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import functools
 import os
 from hashlib import sha1
 
@@ -13,7 +12,6 @@ from six import string_types
 
 from pants.base.address import Addresses, SyntheticAddress
 from pants.base.build_environment import get_buildroot
-from pants.base.build_manual import manual
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import hash_all
@@ -381,15 +379,17 @@ class Target(AbstractTarget):
   def id(self):
     """A unique identifier for the Target.
 
-    The generated id is safe for use as a path name on unix systems.
+    The generated id is the target's spec_path and name joined by periods,
+    similar to a fully-qualified package name. e.g. 3rdparty.commons-lang
     """
-    return self.address.path_safe_spec
+    return self.address.fully_qualified_spec_path
 
   @property
   def identifier(self):
     """A unique identifier for the Target.
 
-    The generated id is safe for use as a path name on unix systems.
+    The identifier is the target's spec_path and name joined by periods,
+    similar to a fully-qualified package name. e.g. 3rdparty.commons-lang
     """
     return self.id
 

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import functools
 import os
 from hashlib import sha1
 
@@ -12,6 +13,7 @@ from six import string_types
 
 from pants.base.address import Addresses, SyntheticAddress
 from pants.base.build_environment import get_buildroot
+from pants.base.build_manual import manual
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import hash_all
@@ -379,17 +381,15 @@ class Target(AbstractTarget):
   def id(self):
     """A unique identifier for the Target.
 
-    The generated id is the target's spec_path and name joined by periods,
-    similar to a fully-qualified package name. e.g. 3rdparty.commons-lang
+    The generated id is safe for use as a path name on unix systems.
     """
-    return self.address.fully_qualified_spec_path
+    return self.address.path_safe_spec
 
   @property
   def identifier(self):
     """A unique identifier for the Target.
 
-    The identifier is the target's spec_path and name joined by periods,
-    similar to a fully-qualified package name. e.g. 3rdparty.commons-lang
+    The generated id is safe for use as a path name on unix systems.
     """
     return self.id
 


### PR DESCRIPTION
The impetus for this was the stale comment on target.id
and target.identifier. The docstring read that the
target.id is safe for use as a unix path name, which is
not currently true.

The id is set using address.path_spec_path which processes
the spec_path kwarg in the Address ctor. It joins the
path and the name and converts the os.seps to periods. I
renamed the path_spec_path to fully_qualified_spec_path
since it looks like a package name to me.

I also removed a couple unused imports. I could be convinced
to put that in a separate CR if you'd like.