### PR TITLE
Trigger CI: allow exit handlers in subprocs to run in sigint

### DIFF
--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -181,7 +181,7 @@ class SubprocPool(object):
   @staticmethod
   def worker_init():
     # Exit quietly on sigint, otherwise we get {num_procs} keyboardinterrupt stacktraces spewn
-    signal.signal(signal.SIGINT, lambda *args: os._exit(0))
+    signal.signal(signal.SIGINT, lambda *args: sys.exit())
 
   @classmethod
   def foreground(cls):


### PR DESCRIPTION
otherwise the stdlib multiproc glue code that shuttles results between processes can deadlock