### PR TITLE
[Trigger CI] Upgrade the python task tests to use TaskTestBase.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -1,6 +1,7 @@
 target(
   name='tasks',
   dependencies=[
+    ':pytest_run',
     ':python_eval',
     ':python_repl',
     ':setup_py',
@@ -11,11 +12,11 @@ python_library(
   name='python_task_test',
   sources=['python_task_test.py'],
   dependencies=[
-    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python:plugin',
     'src/python/pants/base:address',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test/tasks:base'
+    'tests/python/pants_test:task_test_base'
   ]
 )
 
@@ -23,14 +24,12 @@ python_tests(
   name='pytest_run',
   sources=['test_pytest_run.py'],
   dependencies=[
+    ':python_task_test',
     '3rdparty/python:coverage',
     '3rdparty/python:pex',
     'src/python/pants/backend/python:python_setup',
-    'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
-    'src/python/pants/base:build_file_aliases',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test:task_test_base'
   ]
 )
 
@@ -68,14 +67,12 @@ python_tests(
   name='setup_py',
   sources=['test_setup_py.py'],
   dependencies=[
+    ':python_task_test',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:mock',
-    'src/python/pants/backend/python:plugin',
     'src/python/pants/backend/python/tasks:python',
-    'src/python/pants/base:address',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test:task_test_base',
   ],
 )

--- a/tests/python/pants_test/backend/python/tasks/python_task_test.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test.py
@@ -6,58 +6,78 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import shutil
 from textwrap import dedent
 
-from pants.backend.python.targets.python_binary import PythonBinary
-from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.register import build_file_aliases as register_python
 from pants.base.address import SyntheticAddress
-from pants.base.build_file_aliases import BuildFileAliases
-from pants.util.dirutil import safe_mkdir
-from pants_test.tasks.test_base import TaskTest
+from pants_test.task_test_base import TaskTestBase
 
 
-# TODO(John Sirois): Convert to TaskTestBase - note this will require a good bit of option plumbing
-# to get the main pants cache re-use for speed-ups bit in setUp below.
-class PythonTaskTest(TaskTest):
+class PythonTaskTest(TaskTestBase):
   def setUp(self):
     super(PythonTaskTest, self).setUp()
-
-    # Re-use the main pants python cache to speed up interpreter selection and artifact resolution.
-    safe_mkdir(os.path.join(self.build_root, '.pants.d'))
-    shutil.copytree(os.path.join(self.real_build_root, '.pants.d', 'python'),
-                    os.path.join(self.build_root, '.pants.d', 'python'),
-                    symlinks=True)
+    self.set_options_for_scope('', python_chroot_requirements_ttl=1000000000)
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'python_library': PythonLibrary,
-                                            'python_binary': PythonBinary})
+    return register_python()
 
-  def create_python_library(self, relpath, name, source, contents, dependencies=()):
+  def create_python_library(self, relpath, name, source_contents_map=None,
+                            dependencies=(), provides=None):
+    sources = ['__init__.py'] + source_contents_map.keys() if source_contents_map else None
+    sources_strs = ["'{0}'".format(s) for s in sources] if sources else None
     self.create_file(relpath=self.build_path(relpath), contents=dedent("""
     python_library(
       name='{name}',
-      sources=['__init__.py', '{source}'],
+      {sources_clause}
       dependencies=[
         {dependencies}
-      ]
+      ],
+      {provides_clause}
     )
-    """).format(name=name, source=source, dependencies=','.join(map(repr, dependencies))))
-
-    self.create_file(relpath=os.path.join(relpath, '__init__.py'))
-    self.create_file(relpath=os.path.join(relpath, source), contents=contents)
+    """).format(
+      name=name,
+      sources_clause='sources=[{0}],'.format(','.join(sources_strs)) if sources_strs else '',
+      dependencies=','.join(map(repr, dependencies)),
+      provides_clause='provides={0},'.format(provides) if provides else ''))
+    if source_contents_map:
+      self.create_file(relpath=os.path.join(relpath, '__init__.py'))
+      for source, contents in source_contents_map.items():
+        self.create_file(relpath=os.path.join(relpath, source), contents=contents)
     return self.target(SyntheticAddress(relpath, name).spec)
 
-  def create_python_binary(self, relpath, name, entry_point, dependencies=()):
+  def create_python_binary(self, relpath, name, entry_point, dependencies=(), provides=None):
     self.create_file(relpath=self.build_path(relpath), contents=dedent("""
     python_binary(
       name='{name}',
       entry_point='{entry_point}',
       dependencies=[
         {dependencies}
+      ],
+      {provides_clause}
+    )
+    """).format(name=name, entry_point=entry_point, dependencies=','.join(map(repr, dependencies)),
+                provides_clause='provides={0},'.format(provides) if provides else ''))
+    return self.target(SyntheticAddress(relpath, name).spec)
+
+  def create_python_requirement_library(self, relpath, name, requirements):
+    def make_requirement(req):
+      return 'python_requirement("{}")'.format(req)
+
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    python_requirement_library(
+      name='{name}',
+      requirements=[
+        {requirements}
       ]
     )
-    """).format(name=name, entry_point=entry_point, dependencies=','.join(map(repr, dependencies))))
-
+    """).format(name=name, requirements=','.join(map(make_requirement, requirements))))
     return self.target(SyntheticAddress(relpath, name).spec)
+
+  def context(self, config='', options=None, target_roots=None, **kwargs):
+    # Our python tests don't pass on Python 3 yet.
+    # TODO: Clean up this hard-coded interpreter constraint once we have subsystems
+    # and can simplify InterpreterCache and PythonSetup.
+    self.set_options(interpreter=['CPython>=2.7,<3'])
+    return super(PythonTaskTest, self).context(config=config, options=options,
+                                               target_roots=target_roots, **kwargs)

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -12,28 +12,18 @@ from textwrap import dedent
 
 import coverage
 
-from pants.backend.python.targets.python_library import PythonLibrary
-from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.pytest_run import PytestRun, PythonTestFailure
-from pants.base.build_file_aliases import BuildFileAliases
 from pants.util.contextutil import environment_as, pushd
-from pants_test.task_test_base import TaskTestBase
+from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
 
 
-class PythonTestBuilderTestBase(TaskTestBase):
+class PythonTestBuilderTestBase(PythonTaskTest):
   @classmethod
   def task_type(cls):
     return PytestRun
 
-  def setUp(self):
-    super(PythonTestBuilderTestBase, self).setUp()
-    self.set_options_for_scope('', python_chroot_requirements_ttl=1000000000)
-
   def run_tests(self, targets):
     options = {
-      # TODO: Clean up this hard-coded interpreter constraint once we have subsystems
-      # and can simplify InterpreterCache and PythonSetup.
-      'interpreter': ['CPython>=2.7,<3'],  # These tests don't pass on Python 3 yet.
       'colors': False,
       'level': 'info'  # When debugging a test failure it may be helpful to set this to 'debug'.
     }
@@ -47,20 +37,15 @@ class PythonTestBuilderTestBase(TaskTestBase):
     with self.assertRaises(PythonTestFailure):
       self.run_tests(targets=targets)
 
+
 class PythonTestBuilderTestEmpty(PythonTestBuilderTestBase):
   def test_empty(self):
     self.run_tests(targets=[])
 
 
 class PythonTestBuilderTest(PythonTestBuilderTestBase):
-  @property
-  def alias_groups(self):
-    return BuildFileAliases.create(targets={
-      'python_tests': PythonTests, 'python_library': PythonLibrary})
-
   def setUp(self):
     super(PythonTestBuilderTest, self).setUp()
-
     self.create_file(
         'lib/core.py',
         dedent("""

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -14,66 +14,17 @@ from mock import Mock
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.chroot import Chroot
 
-from pants.backend.python.register import build_file_aliases as register_python
 from pants.backend.python.tasks.setup_py import SetupPy
-from pants.base.address import SyntheticAddress
 from pants.base.exceptions import TaskError
 from pants.util.contextutil import temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir
-from pants_test.task_test_base import TaskTestBase
+from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
 
 
-class TestSetupPy(TaskTestBase):
+class TestSetupPy(PythonTaskTest):
   @classmethod
   def task_type(cls):
     return SetupPy
-
-  @property
-  def alias_groups(self):
-    return register_python()
-
-  def create_target(self, relpath, name, contents):
-    self.create_file(relpath=self.build_path(relpath), contents=contents)
-    return self.target(SyntheticAddress(relpath, name).spec)
-
-  def create_python_requirement_library(self, relpath, name, requirements):
-    def make_requirement(req):
-      return 'python_requirement("{}")'.format(req)
-
-    return self.create_target(relpath=relpath, name=name, contents=dedent("""
-    python_requirement_library(
-      name='{name}',
-      requirements=[
-        {requirements}
-      ]
-    )
-    """).format(name=name, requirements=','.join(map(make_requirement, requirements))))
-
-  def create_python_library(self, relpath, name, dependencies=(), provides=None):
-    return self.create_target(relpath=relpath, name=name, contents=dedent("""
-    python_library(
-      name='{name}',
-      dependencies=[
-        {dependencies}
-      ],
-      provides={provides}
-    )
-    """).format(name=name, dependencies=','.join(map(repr, dependencies)), provides=provides))
-
-  def create_python_binary(self, relpath, name, entry_point, dependencies=(), provides=None):
-    return self.create_target(relpath=relpath, name=name, contents=dedent("""
-    python_binary(
-      name='{name}',
-      entry_point='{entry_point}',
-      dependencies=[
-        {dependencies}
-      ],
-      provides={provides}
-    )
-    """).format(name=name,
-                entry_point=entry_point,
-                dependencies=','.join(map(repr, dependencies)),
-                provides=provides))
 
   def setUp(self):
     super(TestSetupPy, self).setUp()


### PR DESCRIPTION
1) Upgrades the PythonTaskTest to extend TaskTestBase instead of TaskTest.
2) Make all relevant tests subclass PythonTaskTest.
3) Move a bunch of common code into that base class.

I removed some rather hacky code whose ostensible purpose was to
make the code under test use the test-invoking code's InterpreterCache.
It would have been hard to make this code work under the new scheme,
but in any case, no benchmarks I ran could detect any performance
difference before and after. Even if I kept the old code but just
commented out that hack I could see no performance difference.

Let's revisit this performance issue if it crops up, or feel free
to show me that this is necessary and I'll figure something out.