### PR TITLE
Copy junit-runner in from twitter/commons.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -27,10 +27,10 @@ env:
     # No need to run the self-checks on OSX where vms are at a premium since these are file-level,
     # non-platform fragile lints.
     # - CI_FLAGS="-clpnet 'Various pants self checks'"  # (fkmsr)
-    - CI_FLAGS="-fkmsrclpn 'Test examples and testprojects'"  # (et)
-    - CI_FLAGS="-fkmsrcnet 'Python unit tests for pants and pants-plugins'"  # (lp)
-    - CI_FLAGS="-fkmsrclpet 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrlpnet 'Python integration tests for pants'"  # (c)
+    - CI_FLAGS="-fkmsrcjlpn 'Test examples and testprojects'"  # (et)
+    - CI_FLAGS="-fkmsrcnet 'Unit tests for pants and pants-plugins'"  # (jlp)
+    - CI_FLAGS="-fkmsrcjlpet 'Python contrib tests'"  # (n)
+    - CI_FLAGS="-fkmsrjlpnet 'Python integration tests for pants'"  # (c)
 
 before_install:
   # We need a sane python and as of 3/5/2015 on OSX 10.9 the provided python 2.7.5 encounters

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,16 @@ env:
     # See: http://docs.travis-ci.com/user/encryption-keys/
     - secure: VvwbndU++a2/iNAjk9cd67ATiipDwqcKnxDR4/J2Ik3GH10wHEDUhJ1+MK4WLhedfaOakDOEmarZQS3GwtgvCHO3knpTJuJc8d/bCfZovYuSqdi//BEv4dS7hDt6tQeJfkbBjG0T4yNjPJ3W9R9KDWCy/vj2CUm90BGg2CmxUbg=
   matrix:
-    - CI_FLAGS="-clpnet 'Various pants self checks'"  # (fkmsr)
-    - CI_FLAGS="-fkmsrclpn 'Test examples and testprojects'"  # (et)
-    - CI_FLAGS="-fkmsrcnet 'Python unit tests for pants and pants-plugins'"  # (lp)
-    - CI_FLAGS="-fkmsrclpet 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrlpnet -i 6:0 'Python integration tests for pants - shard 1'"  # (c)
-    - CI_FLAGS="-fkmsrlpnet -i 6:1 'Python integration tests for pants - shard 2'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:2 'Python integration tests for pants - shard 3'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:3 'Python integration tests for pants - shard 4'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:4 'Python integration tests for pants - shard 5'"
-    - CI_FLAGS="-fkmsrlpnet -i 6:5 'Python integration tests for pants - shard 6'"
+    - CI_FLAGS="-cjlpnet 'Various pants self checks'"  # (fkmsr)
+    - CI_FLAGS="-fkmsrcjlpn 'Test examples and testprojects'"  # (et)
+    - CI_FLAGS="-fkmsrcnet 'Unit tests for pants and pants-plugins'"  # (jlp)
+    - CI_FLAGS="-fkmsrcjlpet 'Python contrib tests'"  # (n)
+    - CI_FLAGS="-fkmsrjlpnet -i 6:0 'Python integration tests for pants - shard 1'"  # (c)
+    - CI_FLAGS="-fkmsrjlpnet -i 6:1 'Python integration tests for pants - shard 2'"
+    - CI_FLAGS="-fkmsrjlpnet -i 6:2 'Python integration tests for pants - shard 3'"
+    - CI_FLAGS="-fkmsrjlpnet -i 6:3 'Python integration tests for pants - shard 4'"
+    - CI_FLAGS="-fkmsrjlpnet -i 6:4 'Python integration tests for pants - shard 5'"
+    - CI_FLAGS="-fkmsrjlpnet -i 6:5 'Python integration tests for pants - shard 6'"
 
 before_script: |
   ./build-support/bin/ci-sync.sh

--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -20,6 +20,11 @@ def add_log4j_excludes(jar):
             .exclude(org='com.sun.jdmk', name='jmxtools')
             .exclude(org='com.sun.jmx', name='jmxri'))
 
+jar_library(name='args4j',
+            jars=[
+              jar(org='args4j', name='args4j', rev='2.32')
+            ])
+
 jar_library(name='checkstyle',
             jars = [
               jar(org='com.puppycrawl.tools', name='checkstyle', rev='5.5')

--- a/BUILD
+++ b/BUILD
@@ -3,9 +3,11 @@
 
 # Pants source code
 source_root('src/python', page, python_binary, python_library, resources)
+source_root('src/java', page, java_library, jvm_binary)
 
 # Pants test code
 source_root('tests/python', page, python_library, python_tests, python_test_suite, python_binary, resources)
+source_root('tests/java', page, java_library, junit_tests, jvm_binary)
 
 # Pants own plugins for this repo's exclusive use
 source_root('pants-plugins/src/python', page, python_binary, python_library, resources)
@@ -43,5 +45,4 @@ source_root('examples/tests/resources', page, resources)
 source_root('examples/tests/scala', page, junit_tests, scala_library, scala_specs)
 
 
-page(name="readme",
-  source="README.md")
+page(name="readme", source="README.md")

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -8,7 +8,7 @@ source build-support/common.sh
 function usage() {
   echo "Runs commons tests for local or hosted CI."
   echo
-  echo "Usage: $0 (-h|-fxbkmsrlpncieat)"
+  echo "Usage: $0 (-h|-fxbkmsrjlpncieat)"
   echo " -h           print out this help message"
   echo " -f           skip python code formatting checks"
   echo " -x           skip bootstrap clean-all (assume bootstrapping from a"
@@ -19,6 +19,7 @@ function usage() {
   echo "              files"
   echo " -s           skip self-distribution tests"
   echo " -r           skip doc generation tests"
+  echo " -j           skip core jvm tests"
   echo " -l           skip internal backends python tests"
   echo " -p           skip core python tests"
   echo " -n           skip contrib python tests"
@@ -43,7 +44,7 @@ bootstrap_compile_args=(
   --fail-slow
 )
 
-while getopts "hfxbkmsrlpnci:eat" opt; do
+while getopts "hfxbkmsrjlpnci:eat" opt; do
   case ${opt} in
     h) usage ;;
     f) skip_pre_commit_checks="true" ;;
@@ -53,6 +54,7 @@ while getopts "hfxbkmsrlpnci:eat" opt; do
     m) skip_sanity_checks="true" ;;
     s) skip_distribution="true" ;;
     r) skip_docs="true" ;;
+    j) skip_jvm="true" ;;
     l) skip_internal_backends="true" ;;
     p) skip_python="true" ;;
     n) skip_contrib="true" ;;
@@ -156,6 +158,13 @@ fi
 if [[ "${skip_docs:-false}" == "false" ]]; then
   banner "Running site doc generation test"
   ./build-support/bin/publish_docs.sh || die "Failed to generate site docs."
+fi
+
+if [[ "${skip_jvm:-false}" == "false" ]]; then
+  banner "Running core jvm tests"
+  (
+    ./pants.pex ${PANTS_ARGS[@]} test tests/java::
+  ) || die "Core jvm test failure"
 fi
 
 if [[ "${skip_internal_backends:-false}" == "false" ]]; then

--- a/src/java/org/pantsbuild/args4j/BUILD
+++ b/src/java/org/pantsbuild/args4j/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(
+  name='args4j',
+  sources=globs('*.java'),
+  dependencies=[
+    '3rdparty:args4j',
+    '3rdparty:jsr305',
+  ],
+  provides=artifact(
+    org='org.pantsbuild',
+    name='args4j',
+    repo=public,
+  ),
+)

--- a/src/java/org/pantsbuild/args4j/InvalidCmdLineArgumentException.java
+++ b/src/java/org/pantsbuild/args4j/InvalidCmdLineArgumentException.java
@@ -37,9 +37,9 @@ public class InvalidCmdLineArgumentException extends RuntimeException {
    * @param message A message describing how the {@code optionValue} is invalid.
    */
   public InvalidCmdLineArgumentException(
-        String optionName,
-        @Nullable Object optionValue,
-        String message) {
+      String optionName,
+      @Nullable Object optionValue,
+      String message) {
 
     super(String.format("Invalid option value '%s' for option '%s': %s",
         optionName, optionValue, message));

--- a/src/java/org/pantsbuild/args4j/InvalidCmdLineArgumentException.java
+++ b/src/java/org/pantsbuild/args4j/InvalidCmdLineArgumentException.java
@@ -1,0 +1,47 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.args4j;
+
+import javax.annotation.Nullable;
+
+import org.kohsuke.args4j.OptionDef;
+
+/**
+ * Indicates a problem parsing a command line argument.
+ * <p/>
+ * Although args4j provides {@link org.kohsuke.args4j.CmdLineException} it is difficult to
+ * construct one.  As such, this exception is useful for implementing
+ * {@link org.kohsuke.args4j.spi.OptionHandler OptionHandlers} that detect and reject malformed
+ * values.
+ */
+public class InvalidCmdLineArgumentException extends RuntimeException {
+
+  /**
+   * @param optionDef The {@code OptionDef} describing the option being parsed.
+   * @param optionValue The raw value of the option being parsed.
+   * @param message A message describing how the {@code optionValue} is invalid.
+   */
+  public InvalidCmdLineArgumentException(
+      OptionDef optionDef,
+      @Nullable Object optionValue,
+      String message) {
+
+    super(String.format("Invalid option value '%s' for the option with usage '%s': %s",
+        optionValue, optionDef.usage(), message));
+  }
+
+  /**
+   * @param optionName The name of the option being parsed.
+   * @param optionValue The raw value of the option being parsed.
+   * @param message A message describing how the {@code optionValue} is invalid.
+   */
+  public InvalidCmdLineArgumentException(
+        String optionName,
+        @Nullable Object optionValue,
+        String message) {
+
+    super(String.format("Invalid option value '%s' for option '%s': %s",
+        optionName, optionValue, message));
+  }
+}

--- a/src/java/org/pantsbuild/junit/annotations/BUILD
+++ b/src/java/org/pantsbuild/junit/annotations/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(
+  name='annotations',
+  provides=artifact(
+    org='org.pantsbuild',
+    name='junit-runner-annotations',
+    repo=public,
+  ),
+  sources=globs('*.java')
+)

--- a/src/java/org/pantsbuild/junit/annotations/TestParallel.java
+++ b/src/java/org/pantsbuild/junit/annotations/TestParallel.java
@@ -1,0 +1,21 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.junit.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate that a test class can be run in parallel. See usage note in
+ * {@link org.pantsbuild.tools.junit.ConsoleRunner}. The {@link TestSerial} annotation
+ * takes precedence over this annotation if a class has both (including via inheritance).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Target(ElementType.TYPE)
+public @interface TestParallel {
+}

--- a/src/java/org/pantsbuild/junit/annotations/TestSerial.java
+++ b/src/java/org/pantsbuild/junit/annotations/TestSerial.java
@@ -1,0 +1,21 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.junit.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate that a test class must be run in serial. See usage note in
+ * {@link org.pantsbuild.tools.junit.ConsoleRunner}. This annotation takes precedence
+ * over a {@link TestParallel} annotation if a class has both (including via inheritance).
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Target(ElementType.TYPE)
+public @interface TestSerial {
+}

--- a/src/java/org/pantsbuild/tools/junit/AbortableListener.java
+++ b/src/java/org/pantsbuild/tools/junit/AbortableListener.java
@@ -1,0 +1,75 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+/**
+ * A listener that can be manually aborted while still retaining normal test suite finishing
+ * behavior for its underlying listeners.
+ */
+abstract class AbortableListener extends ForwardingListener {
+  private final Result result = new Result();
+  private final boolean failFast;
+  private Description started;
+
+  /**
+   * Creates a new abortable listener that optionally fails a test run on its first failure.
+   *
+   * @param failFast Pass {@code true} to {@link #abort(Result)} a test suite on its first failure.
+   */
+  AbortableListener(boolean failFast) {
+    this.failFast = failFast;
+    addListener(result.createListener());
+  }
+
+  @Override
+  public void testStarted(Description description) throws Exception {
+    this.started = description;
+    super.testStarted(description);
+  }
+
+  @Override
+  public void testFailure(Failure failure) throws Exception {
+    // Allow any listeners to handle the failure in the normal way first.
+    super.testFailure(failure);
+
+    if (failFast) {
+      finish();
+
+      // Allow the subclass to actually stop the test run.
+      abort(result);
+    }
+  }
+
+  /**
+   * Signals a test run is aborting and and passes this signal to underlying listeners with a
+   * simulated test suite finishing cycle.
+   *
+   * @param reason The reason the test run is being stopped.
+   * @throws Exception If the underlying listener throws.
+   */
+  void abort(Throwable reason) throws Exception {
+    if (started != null) {
+      super.testFailure(new Failure(started, reason));
+    }
+    finish();
+  }
+
+  private void finish() throws Exception {
+    // Simulate the junit test run lifecycle end.
+    testRunFinished(result);
+  }
+
+  /**
+   * Called on the first test failure.  Its expected that subclasses will halt the test run in some
+   * way.
+   *
+   * @param failureResult The test result for the failing suite up to and including the first
+   *     failure
+   */
+  protected abstract void abort(Result failureResult);
+}

--- a/src/java/org/pantsbuild/tools/junit/AnnotatedClassRequest.java
+++ b/src/java/org/pantsbuild/tools/junit/AnnotatedClassRequest.java
@@ -1,0 +1,45 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.io.PrintStream;
+
+import org.junit.internal.requests.ClassRequest;
+import org.junit.runner.Runner;
+
+import org.pantsbuild.tools.junit.withretry.AllDefaultPossibilitiesBuilderWithRetry;
+
+/**
+ * A ClassRequest that exposes the wrapped class. Also used to support retrying
+ * flaky tests via AllDefaultPossibilitiesBuilderWithRetry, that in turn gives us
+ * access to other code inside JUnit4, that cannot be customized in a simpler way.
+ */
+public class AnnotatedClassRequest extends ClassRequest {
+
+  private final Class<?> testClass;
+  private final int numRetries;
+  private final PrintStream err;
+
+  /**
+   * Constructs an instance for the given test class, number of retries for failing tests
+   * (0 means no retries) and a stream to print the information about flaky tests (those
+   * that first fail but then pass after retrying).
+   */
+  public AnnotatedClassRequest(Class<?> testClass, int numRetries, PrintStream err) {
+    super(testClass);
+    this.testClass = testClass;
+    this.numRetries = numRetries;
+    this.err = err;
+  }
+
+  public Class<?> getClazz() {
+    return testClass;
+  }
+
+  @Override
+  public Runner getRunner() {
+    return new
+        AllDefaultPossibilitiesBuilderWithRetry(numRetries, err).safeRunnerForClass(testClass);
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/AntJunitXmlReportListener.java
@@ -1,0 +1,445 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.FilterWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+import javax.xml.bind.JAXB;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlValue;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * A run listener that creates ant junit xml report compatible output describing a junit run.
+ */
+class AntJunitXmlReportListener extends RunListener {
+
+  /**
+   * A JAXB bean describing a test case exception.  These may indicate either an assertion failure
+   * or an uncaught test exception.
+   */
+  @XmlRootElement
+  static class Exception {
+    private final String message;
+    private final String type;
+    private final String stacktrace;
+
+    Exception() {
+      // for JAXB
+      message = null;
+      type = null;
+      stacktrace = null;
+    }
+
+    Exception(Failure failure) {
+      message = failure.getMessage();
+      type = failure.getException().getClass().getName();
+      stacktrace = failure.getTrace();
+    }
+
+    @XmlAttribute
+    public String getMessage() {
+      return message;
+    }
+
+    @XmlAttribute
+    public String getType() {
+      return type;
+    }
+
+    @XmlValue
+    public String getStacktrace() {
+      return stacktrace;
+    }
+  }
+
+  /**
+   * A JAXB bean describing an individual test method.
+   */
+  @XmlRootElement(name = "testcase")
+  static class TestCase {
+    private final String classname;
+    private final String name;
+    private String time;
+    private Exception failure;
+    private Exception error;
+    private long startNs;
+
+    TestCase() {
+      // for JAXB
+      classname = null;
+      name = null;
+    }
+
+    TestCase(Description test) {
+      classname = test.getClassName();
+      name = test.getMethodName();
+    }
+
+    @XmlAttribute
+    public String getClassname() {
+      return classname;
+    }
+
+    @XmlAttribute
+    public String getName() {
+      return name;
+    }
+
+    @XmlAttribute
+    public String getTime() {
+      return time;
+    }
+
+    @XmlElement
+    public Exception getFailure() {
+      return failure;
+    }
+
+    public void setFailure(Exception failure) {
+      this.failure = failure;
+    }
+
+    @XmlElement
+    public Exception getError() {
+      return error;
+    }
+
+    public void setError(Exception error) {
+      this.error = error;
+    }
+
+    public void started() {
+      startNs = System.nanoTime();
+    }
+
+    public void finished() {
+      time = convertTimeSpanNs(System.nanoTime() - startNs);
+    }
+  }
+
+  /**
+   * A JAXB bean describing an individual system property.
+   */
+  @XmlRootElement(name = "property")
+  static class Property {
+    private final String name;
+    private final String value;
+
+    Property() {
+      // for JAXB
+      name = null;
+      value = null;
+    }
+
+    Property(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    @XmlAttribute
+    public String getName() {
+      return name;
+    }
+
+    @XmlAttribute
+    public String getValue() {
+      return value;
+    }
+  }
+
+  /**
+   * A JAXB bean describing a test class.
+   */
+  @XmlRootElement(name = "testsuite")
+  static class TestSuite {
+    private final String name;
+
+    private int errors;
+    private int failures;
+    private String hostname;
+    private int tests;
+    private String time;
+    private String timestamp;
+    private final List<Property> properties = ImmutableList.copyOf(
+        Iterables.transform(System.getProperties().entrySet(),
+            new Function<Entry<Object, Object>, Property>() {
+              @Override public Property apply(Entry<Object, Object> entry) {
+                return new Property(entry.getKey().toString(), entry.getValue().toString());
+              }
+            }));
+    private final List<TestCase> testCases = Lists.newArrayList();
+    private String out;
+    private String err;
+
+    private long startNs;
+
+    TestSuite() {
+      // for JAXB
+      name = null;
+    }
+
+    TestSuite(Description test) {
+      name = test.getClassName();
+      try {
+        hostname = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        hostname = "localhost";
+      }
+    }
+
+    @XmlAttribute
+    public int getErrors() {
+      return errors;
+    }
+
+    @XmlAttribute
+    public int getFailures() {
+      return failures;
+    }
+
+    @XmlAttribute
+    public String getHostname() {
+      return hostname;
+    }
+
+    @XmlAttribute
+    public String getName() {
+      return name;
+    }
+
+    @XmlAttribute
+    public int getTests() {
+      return tests;
+    }
+
+    @XmlAttribute
+    public String getTime() {
+      return time;
+    }
+
+    @XmlAttribute
+    public String getTimestamp() {
+      return timestamp;
+    }
+
+    @XmlElementRef
+    @XmlElementWrapper(name = "properties")
+    public List<Property> getProperties() {
+      return properties;
+    }
+
+    @XmlElementRef
+    public List<TestCase> getTestCases() {
+      return testCases;
+    }
+
+    @XmlElement(name = "system-out")
+    public String getOut() {
+      return out;
+    }
+
+    public void setOut(String out) {
+      this.out = out;
+    }
+
+    @XmlElement(name = "system-err")
+    public String getErr() {
+      return err;
+    }
+
+    public void setErr(String err) {
+      this.err = err;
+    }
+
+    public void started() {
+      if (startNs == 0) {
+        timestamp = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").format(new Date());
+        startNs = System.nanoTime();
+      }
+    }
+
+    public void finished() {
+      if (++tests == testCases.size()) {
+        time = convertTimeSpanNs(System.nanoTime() - startNs);
+      }
+    }
+
+    public void incrementFailures() {
+      failures++;
+    }
+
+    public void incrementErrors() {
+      errors++;
+    }
+
+    public boolean wasStarted() {
+      return startNs > 0;
+    }
+  }
+
+  private final Map<Class<?>, TestSuite> suites = Maps.newHashMap();
+  private final Map<Description, TestCase> cases = Maps.newHashMap();
+
+  private final File outdir;
+  private final StreamSource streamSource;
+
+  AntJunitXmlReportListener(File outdir, StreamSource streamSource) {
+    this.outdir = outdir;
+    this.streamSource = streamSource;
+  }
+
+  @Override
+  public void testRunStarted(Description description) throws java.lang.Exception {
+    createSuites(description.getChildren());
+  }
+
+  private void createSuites(Iterable<Description> tests) {
+    for (Description test : tests) {
+      createSuites(test.getChildren());
+      if (Util.isRunnable(test)) {
+        Class<?> testClass = test.getTestClass();
+        TestSuite suite = suites.get(testClass);
+        if (suite == null) {
+          suite = new TestSuite(test);
+          suites.put(testClass, suite);
+        }
+        TestCase testCase = new TestCase(test);
+        suite.testCases.add(testCase);
+        cases.put(test, testCase);
+      }
+    }
+  }
+
+  @Override
+  public void testStarted(Description description) throws java.lang.Exception {
+    suites.get(description.getTestClass()).started();
+    cases.get(description).started();
+  }
+
+  @Override
+  public void testFailure(Failure failure) throws java.lang.Exception {
+    Exception exception = new Exception(failure);
+
+    Description description = failure.getDescription();
+    TestSuite suite = suites.get(description.getTestClass());
+    TestCase testCase = cases.get(description);
+    if (Util.isAssertionFailure(failure)) {
+      testCase.setFailure(exception);
+      suite.incrementFailures();
+    } else {
+      testCase.setError(exception);
+      suite.incrementErrors();
+    }
+  }
+
+  @Override
+  public void testFinished(Description description) throws java.lang.Exception {
+    cases.get(description).finished();
+    suites.get(description.getTestClass()).finished();
+  }
+
+  @Override
+  public void testRunFinished(Result result) throws java.lang.Exception {
+    for (Entry<Class<?>, TestSuite> entry : suites.entrySet()) {
+      Class<?> testClass = entry.getKey();
+      TestSuite suite = entry.getValue();
+
+      if (suite.wasStarted()) {
+        suite.setOut(new String(streamSource.readOut(testClass), Charsets.UTF_8));
+        suite.setErr(new String(streamSource.readErr(testClass), Charsets.UTF_8));
+
+        Writer xmlOut = new FileWriter(new File(outdir, String.format("TEST-%s.xml", suite.name)));
+
+        // Only output valid XML1.0 characters - JAXB does not handle this.
+        JAXB.marshal(suite, new XmlWriter(xmlOut) {
+          @Override protected void handleInvalid(int c) throws IOException {
+            out.write(' ');
+          }
+        });
+      }
+    }
+  }
+
+  private abstract static class XmlWriter extends FilterWriter {
+    protected XmlWriter(Writer out) {
+      super(out);
+    }
+
+    @Override
+    public void write(char[] cbuf, int off, int len) throws IOException {
+      for (int i = off; i < len; i++) {
+        write(cbuf[i]);
+      }
+    }
+
+    @Override
+    public void write(String str, int off, int len) throws IOException {
+      for (int i = off; i < len; i++) {
+        write(str.charAt(i));
+      }
+    }
+
+    @Override
+    public void write(int c) throws IOException {
+      // Only output valid XML1.0 characters by default.
+      // See the spec here: http://www.w3.org/TR/2000/REC-xml-20001006#NT-Char
+
+      // This is a complex boolean expression but it follows the spec referenced above exactly and
+      // so it seems to provide clarity.
+      // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+      if (c == 0x9
+          || c == 0xA
+          || c == 0xD
+          || ((0x20 <= c) && (c <= 0xD7FF))
+          || ((0xE000 <= c) && (c <= 0xFFFD))
+          || ((0x10000 <= c) && (c <= 0x10FFFF))) {
+
+        out.write(c);
+      } else {
+        handleInvalid(c);
+      }
+    }
+
+    /**
+     * Subclasses can handle invalid XML 1.0 characters as appropriate.
+     *
+     * @param c The invalid character.
+     * @throws IOException If there is a problem using this stream while handling the invalid
+     *     character.
+     */
+    protected abstract void handleInvalid(int c) throws IOException;
+  }
+
+  private static String convertTimeSpanNs(long timespanNs) {
+    return String.format("%f", timespanNs / (double) TimeUnit.SECONDS.toNanos(1));
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/BUILD
+++ b/src/java/org/pantsbuild/tools/junit/BUILD
@@ -12,6 +12,7 @@ java_library(
     '3rdparty:args4j',
     '3rdparty:guava',
     '3rdparty:junit',
+    'src/java/org/pantsbuild/args4j',
     'src/java/org/pantsbuild/junit/annotations',
     'src/java/org/pantsbuild/tools/junit/withretry',
   ],

--- a/src/java/org/pantsbuild/tools/junit/BUILD
+++ b/src/java/org/pantsbuild/tools/junit/BUILD
@@ -1,0 +1,36 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(
+  name='junit',
+  provides=artifact(
+    org='org.pantsbuild',
+    name='junit-runner',
+    repo=public,
+  ),
+  dependencies=[
+    '3rdparty:args4j',
+    '3rdparty:guava',
+    '3rdparty:junit',
+    'src/java/org/pantsbuild/junit/annotations',
+    'src/java/org/pantsbuild/tools/junit/withretry',
+  ],
+  sources=globs('*.java')
+)
+
+jvm_binary(
+  name='main',
+  basename='junit-runner',
+  main='org.pantsbuild.tools.junit.ConsoleRunner',
+  dependencies=[
+    ':junit',
+  ],
+  description="""
+A replacement for org.junit.runner.JUnitCore.main that adds:
+  + support for running individual test methods using [classname]#[methodname]
+  + support for stderr and stdout redirection for tests
+  + support for ant style junit-report xml output
+  + support for per test class timer
+  + support for running test classes in parallel
+"""
+)

--- a/src/java/org/pantsbuild/tools/junit/CompositeRequest.java
+++ b/src/java/org/pantsbuild/tools/junit/CompositeRequest.java
@@ -1,0 +1,79 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.util.List;
+
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.internal.runners.ErrorReportingRunner;
+import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.runner.Description;
+import org.junit.runner.Request;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runner.notification.StoppedByUserException;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+
+/**
+ * A JUnit {@link Request} that is composed of a list of {@link Request}s.
+ */
+public class CompositeRequest extends ParentRunner<Request> {
+
+  private final List<Request> requests;
+
+  /**
+   * Constructor
+   * @param requests List of requests to be composed of.
+   * @throws InitializationError
+   */
+  public CompositeRequest(List<Request> requests) throws InitializationError {
+    // Note: this works for now, Suite constructor also calls super(null), but it may break some
+    // point in future, in which case fall back to implementing Runner may be necessary.
+    super(null);
+    this.requests = requests;
+  }
+
+  @Override
+  protected List<Request> getChildren() {
+    return requests;
+  }
+
+  @Override
+  protected Description describeChild(Request child) {
+    return child.getRunner().getDescription();
+  }
+
+  @Override
+  protected void runChild(Request child, RunNotifier notifier) {
+    // This mirrors the implementation of ParentRunner.run
+    EachTestNotifier eachNotifier = new EachTestNotifier(notifier, describeChild(child));
+    try {
+      Runner runner = child.getRunner();
+      boolean exemptThisRunner = false;
+      if (runner instanceof ErrorReportingRunner) {
+        // Test sharding may result in no tests running within this request. In that case,
+        // FilterRequest.getRunner() returns an instance of ErrorReportingRunner with the
+        // Exception instance with known message.
+        ErrorReportingRunner erRunner = (ErrorReportingRunner) runner;
+        Description desc = erRunner.getDescription();
+        if ("org.junit.runner.manipulation.Filter".equals(desc.getDisplayName())) {
+          exemptThisRunner = true;
+        }
+      }
+      if (!exemptThisRunner) {
+        runner.run(notifier);
+      }
+    } catch (AssumptionViolatedException e) {
+      eachNotifier.fireTestIgnored();
+    } catch (StoppedByUserException e) {
+      throw e;
+    // We wan't to fail the test no matter what here for an intelligible user message.
+    // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+    } catch (Throwable e) {
+      eachNotifier.addFailure(e);
+    }
+  }
+
+}

--- a/src/java/org/pantsbuild/tools/junit/ConcurrentCompositeRequest.java
+++ b/src/java/org/pantsbuild/tools/junit/ConcurrentCompositeRequest.java
@@ -1,0 +1,49 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.util.List;
+
+import org.junit.runner.Request;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+/**
+ * A Runner for running composite requests in a concurrent fashion.
+ */
+public class ConcurrentCompositeRequest extends CompositeRequest {
+
+  private final ConcurrentRunnerScheduler runnerScheduler;
+
+  public ConcurrentCompositeRequest(List<Request> requests, boolean defaultParallel, int numThreads)
+      throws InitializationError {
+    super(requests);
+    this.runnerScheduler = new ConcurrentRunnerScheduler(defaultParallel, numThreads);
+    setScheduler(runnerScheduler);
+  }
+
+  @Override
+  protected Statement childrenInvoker(final RunNotifier notifier) {
+    return new Statement() {
+      @Override
+      public void evaluate() {
+        for (final Request child : getChildren()) {
+          Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+              runChild(child, notifier);
+            }
+          };
+          if (child instanceof AnnotatedClassRequest) {
+            runnerScheduler.schedule(runnable, ((AnnotatedClassRequest) child).getClazz());
+          } else {
+            runnerScheduler.schedule(runnable);
+          }
+        }
+        runnerScheduler.finished();
+      }
+    };
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/ConcurrentRunnerScheduler.java
+++ b/src/java/org/pantsbuild/tools/junit/ConcurrentRunnerScheduler.java
@@ -1,0 +1,99 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+
+import com.google.common.base.Throwables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.junit.runners.model.RunnerScheduler;
+
+import org.pantsbuild.junit.annotations.TestParallel;
+import org.pantsbuild.junit.annotations.TestSerial;
+
+public class ConcurrentRunnerScheduler implements RunnerScheduler {
+  private final CompletionService<Void> completionService;
+  private final Queue<Future<Void>> concurrentTasks;
+  private final Queue<Runnable> serialTasks;
+  private final boolean defaultParallel;
+
+  /**
+   * A concurrent scheduler to run junit tests in parallel if possible, followed by tests that can
+   * only be run in serial.
+   *
+   * Test classes annotated with {@link TestSerial} will be run in serial.
+   * Test classes annotated with {@link TestParallel} will be run in parallel.
+   * Test classes without neither annotation will be run in parallel if defaultParallel is set.
+   *
+   * Call {@link org.junit.runners.ParentRunner#setScheduler} to use this scheduler.
+   *
+   * @param defaultParallel  whether to unannotated classes in parallel
+   * @param numThreads       number of parallel threads to use, must be positive.
+   */
+  public ConcurrentRunnerScheduler(boolean defaultParallel, int numThreads) {
+    this.defaultParallel = defaultParallel;
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setDaemon(true)
+        .setNameFormat("concurrent-junit-runner-%d")
+        .build();
+    completionService = new ExecutorCompletionService<Void>(
+        Executors.newFixedThreadPool(numThreads, threadFactory));
+    concurrentTasks = new LinkedList<Future<Void>>();
+    serialTasks = new LinkedList<Runnable>();
+  }
+
+  @Override
+  public void schedule(Runnable childStatement) {
+    serialTasks.offer(childStatement);
+  }
+
+  /**
+   * Schedule a test childStatement associated with clazz, using clazz's policy to decide running
+   * in serial or parallel.
+   */
+  public void schedule(Runnable childStatement, Class<?> clazz) {
+    if (shouldRunParallel(clazz)) {
+      concurrentTasks.offer(completionService.submit(childStatement, null));
+    } else {
+      serialTasks.offer(childStatement);
+    }
+  }
+
+  private boolean shouldRunParallel(Class<?> clazz) {
+    return !clazz.isAnnotationPresent(TestSerial.class)
+        && (clazz.isAnnotationPresent(TestParallel.class) || this.defaultParallel);
+  }
+
+  @Override
+  public void finished() {
+    try {
+      // Wait for all concurrent tasks to finish.
+      while (!concurrentTasks.isEmpty()) {
+        concurrentTasks.poll().get();
+      }
+      // Then run all serial tasks in serial.
+      for (Runnable task : serialTasks) {
+        task.run();
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      // This should not normally happen since junit statements trap and record errors and failures.
+      throw Throwables.propagate(e.getCause());
+    } finally {
+      // In case of error, cancel all in-flight concurrent tasks
+      while (!concurrentTasks.isEmpty()) {
+        concurrentTasks.poll().cancel(true);
+      }
+    }
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/ConsoleListener.java
+++ b/src/java/org/pantsbuild/tools/junit/ConsoleListener.java
@@ -1,0 +1,26 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.io.PrintStream;
+
+import org.junit.internal.TextListener;
+import org.junit.runner.notification.Failure;
+
+/**
+ * A run listener that logs test events with single characters.
+ */
+class ConsoleListener extends TextListener {
+  private final PrintStream out;
+
+  ConsoleListener(PrintStream out) {
+    super(out);
+    this.out = out;
+  }
+
+  @Override
+  public void testFailure(Failure failure) {
+    out.append(Util.isAssertionFailure(failure) ? 'F' : 'E');
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
+++ b/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
@@ -588,7 +588,7 @@ public class ConsoleRunner {
     } catch (CmdLineException e) {
       parser.printUsage(System.out);
       exit(1);
-    } catch(InvalidCmdLineArgumentException e) {
+    } catch (InvalidCmdLineArgumentException e) {
       parser.printUsage(System.out);
       exit(1);
     }

--- a/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
+++ b/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
@@ -532,7 +532,10 @@ public class ConsoleRunner {
         }
         this.parallelThreads = parallelThreads;
         if (parallelThreads == 0) {
-          this.parallelThreads = Runtime.getRuntime().availableProcessors();
+          int availableProcessors = Runtime.getRuntime().availableProcessors();
+          this.parallelThreads = availableProcessors;
+          System.err.printf("Auto-detected %d processors, using -parallel-threads=%d\n",
+              availableProcessors, this.parallelThreads);
         }
       }
 
@@ -586,10 +589,10 @@ public class ConsoleRunner {
     try {
       parser.parseArgument(args);
     } catch (CmdLineException e) {
-      parser.printUsage(System.out);
+      parser.printUsage(System.err);
       exit(1);
     } catch (InvalidCmdLineArgumentException e) {
-      parser.printUsage(System.out);
+      parser.printUsage(System.err);
       exit(1);
     }
 

--- a/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
+++ b/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
@@ -1,0 +1,712 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.io.Closeables;
+import com.google.common.io.Files;
+
+import org.junit.runner.Computer;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runners.model.InitializationError;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+
+import org.pantsbuild.tools.junit.withretry.AllDefaultPossibilitiesBuilderWithRetry;
+
+/**
+ * An alternative to {@link JUnitCore} with stream capture and junit-report xml output capabilities.
+ */
+public class ConsoleRunner {
+
+  private static final SwappableStream<PrintStream> SWAPPABLE_OUT =
+      new SwappableStream<PrintStream>(System.out);
+
+  private static final SwappableStream<PrintStream> SWAPPABLE_ERR =
+      new SwappableStream<PrintStream>(System.err);
+
+  /** Should be set to false for unit testing via {@link #setCallSystemExitOnFinish} */
+  private static boolean callSystemExitOnFinish = true;
+  /** Intended to be used in unit testing this class */
+  private static int exitStatus;
+
+  /**
+   * A stream that allows its underlying output to be swapped.
+   */
+  static class SwappableStream<T extends OutputStream> extends FilterOutputStream {
+    private final T original;
+
+    SwappableStream(T out) {
+      super(out);
+      this.original = out;
+    }
+
+    OutputStream swap(OutputStream out) {
+      OutputStream old = this.out;
+      this.out = out;
+      return old;
+    }
+
+    /**
+     * Returns the original stream this swappable stream was created with.
+     */
+    public T getOriginal() {
+      return original;
+    }
+  }
+
+  /**
+   * Captures a tests stderr and stdout streams, restoring the previous streams on {@link #close()}.
+   */
+  static class StreamCapture {
+    private final File out;
+    private OutputStream outstream;
+
+    private final File err;
+    private OutputStream errstream;
+
+    private int useCount;
+    private boolean closed;
+
+    StreamCapture(File out, File err) throws IOException {
+      this.out = out;
+      this.err = err;
+    }
+
+    void incrementUseCount() {
+      this.useCount++;
+    }
+
+    void open() throws FileNotFoundException {
+      if (outstream == null) {
+        outstream = new FileOutputStream(out);
+      }
+      if (errstream == null) {
+        errstream = new FileOutputStream(err);
+      }
+      SWAPPABLE_OUT.swap(outstream);
+      SWAPPABLE_ERR.swap(errstream);
+    }
+
+    void close() throws IOException {
+      if (--useCount <= 0 && !closed) {
+        if (outstream != null) {
+          Closeables.close(outstream, /* swallowIOException */ true);
+        }
+        if (errstream != null) {
+          Closeables.close(errstream, /* swallowIOException */ true);
+        }
+        closed = true;
+      }
+    }
+
+    void dispose() throws IOException {
+      useCount = 0;
+      close();
+    }
+
+    byte[] readOut() throws IOException {
+      return read(out);
+    }
+
+    byte[] readErr() throws IOException {
+      return read(err);
+    }
+
+    private byte[] read(File file) throws IOException {
+      Preconditions.checkState(closed, "Capture must be closed by all users before it can be read");
+      return Files.toByteArray(file);
+    }
+  }
+
+  /**
+   * A run listener that captures the output and error streams for each test class and makes the
+   * content of these available.
+   */
+  static class StreamCapturingListener extends ForwardingListener implements StreamSource {
+    private final Map<Class<?>, StreamCapture> captures = Maps.newHashMap();
+
+    private final File outdir;
+
+    StreamCapturingListener(File outdir) {
+      this.outdir = outdir;
+    }
+
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+      registerTests(description.getChildren());
+      super.testRunStarted(description);
+    }
+
+    private void registerTests(Iterable<Description> tests) throws IOException {
+      for (Description test : tests) {
+        registerTests(test.getChildren());
+        if (Util.isRunnable(test)) {
+          StreamCapture capture = captures.get(test.getTestClass());
+          if (capture == null) {
+            String prefix = test.getClassName();
+
+            File out = new File(outdir, prefix + ".out.txt");
+            Files.createParentDirs(out);
+
+            File err = new File(outdir, prefix + ".err.txt");
+            Files.createParentDirs(err);
+            capture = new StreamCapture(out, err);
+            captures.put(test.getTestClass(), capture);
+          }
+          capture.incrementUseCount();
+        }
+      }
+    }
+
+    @Override
+    public void testRunFinished(Result result) throws Exception {
+      for (StreamCapture capture : captures.values()) {
+        capture.dispose();
+      }
+      super.testRunFinished(result);
+    }
+
+    @Override
+    public void testStarted(Description description) throws Exception {
+      captures.get(description.getTestClass()).open();
+      super.testStarted(description);
+    }
+
+    @Override
+    public void testFinished(Description description) throws Exception {
+      captures.get(description.getTestClass()).close();
+      super.testFinished(description);
+    }
+
+    @Override
+    public byte[] readOut(Class<?> testClass) throws IOException {
+      return captures.get(testClass).readOut();
+    }
+
+    @Override
+    public byte[] readErr(Class<?> testClass) throws IOException {
+      return captures.get(testClass).readErr();
+    }
+  }
+
+  private static final Pattern METHOD_PARSER = Pattern.compile("^([^#]+)#([^#]+)$");
+
+  private final boolean failFast;
+  private final boolean suppressOutput;
+  private final boolean xmlReport;
+  private final File outdir;
+  private final boolean perTestTimer;
+  private final boolean defaultParallel;
+  private final int parallelThreads;
+  private final int testShard;
+  private final int numTestShards;
+  private final int numRetries;
+
+  ConsoleRunner(
+      boolean failFast,
+      boolean suppressOutput,
+      boolean xmlReport,
+      boolean perTestTimer,
+      File outdir,
+      boolean defaultParallel,
+      int parallelThreads,
+      int testShard,
+      int numTestShards,
+      int numRetries) {
+
+    this.failFast = failFast;
+    this.suppressOutput = suppressOutput;
+    this.xmlReport = xmlReport;
+    this.perTestTimer = perTestTimer;
+    this.outdir = outdir;
+    this.defaultParallel = defaultParallel;
+    this.parallelThreads = parallelThreads;
+    this.testShard = testShard;
+    this.numTestShards = numTestShards;
+    this.numRetries = numRetries;
+  }
+
+  void run(Iterable<String> tests) {
+    final PrintStream out = System.out;
+    final PrintStream err = System.err;
+    System.setOut(new PrintStream(SWAPPABLE_OUT));
+    System.setErr(new PrintStream(SWAPPABLE_ERR));
+
+    List<Request> requests = parseRequests(out, err, tests);
+
+    if (numTestShards > 0) {
+      requests = setFilterForTestShard(requests);
+    }
+
+    JUnitCore core = new JUnitCore();
+    final AbortableListener abortableListener = new AbortableListener(failFast) {
+      @Override protected void abort(Result failureResult) {
+        exit(failureResult.getFailureCount());
+      }
+    };
+    core.addListener(abortableListener);
+
+    if (xmlReport || suppressOutput) {
+      if (!outdir.exists()) {
+        if (!outdir.mkdirs()) {
+          throw new IllegalStateException("Failed to create output directory: " + outdir);
+        }
+      }
+      StreamCapturingListener streamCapturingListener = new StreamCapturingListener(outdir);
+      abortableListener.addListener(streamCapturingListener);
+
+      if (xmlReport) {
+        AntJunitXmlReportListener xmlReportListener =
+            new AntJunitXmlReportListener(outdir, streamCapturingListener);
+        abortableListener.addListener(xmlReportListener);
+      }
+    }
+
+    if (perTestTimer) {
+      abortableListener.addListener(new PerClassConsoleListener(out));
+    } else {
+      abortableListener.addListener(new ConsoleListener(out));
+    }
+
+    Thread abnormalExitHook = new Thread() {
+      @Override public void run() {
+        try {
+          abortableListener.abort(new UnknownError("Abnormal VM exit - test crashed."));
+        // We want to trap and log no matter why abort failed for a better end user message.
+        // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+        } catch (Exception e) {
+          out.println(e);
+          e.printStackTrace(out);
+        }
+      }
+    };
+    abnormalExitHook.setDaemon(true);
+    Runtime.getRuntime().addShutdownHook(abnormalExitHook);
+
+    int failures = 0;
+    try {
+      if (this.parallelThreads > 1) {
+        ConcurrentCompositeRequest request = new ConcurrentCompositeRequest(
+            requests, this.defaultParallel, this.parallelThreads);
+        failures = core.run(request).getFailureCount();
+      } else {
+        for (Request request : requests) {
+          Result result = core.run(request);
+          failures += result.getFailureCount();
+        }
+      }
+    } catch (InitializationError initializationError) {
+      failures = 1;
+    }
+
+    Runtime.getRuntime().removeShutdownHook(abnormalExitHook);
+    exit(failures);
+  }
+
+  private List<Request> parseRequests(PrintStream out, PrintStream err, Iterable<String> specs) {
+    /**
+     * Datatype representing an individual test method.
+     */
+    class TestMethod {
+      private final Class<?> clazz;
+      private final String name;
+      TestMethod(Class<?> clazz, String name) {
+        this.clazz = clazz;
+        this.name = name;
+      }
+    }
+    Set<TestMethod> testMethods = Sets.newLinkedHashSet();
+    Set<Class<?>> classes = Sets.newLinkedHashSet();
+    for (String spec : specs) {
+      Matcher matcher = METHOD_PARSER.matcher(spec);
+      try {
+        if (matcher.matches()) {
+          Class<?> testClass = loadClass(matcher.group(1));
+          if (isTest(testClass)) {
+            String method = matcher.group(2);
+            testMethods.add(new TestMethod(testClass, method));
+          }
+        } else {
+          Class<?> testClass = loadClass(spec);
+          if (isTest(testClass)) {
+            classes.add(testClass);
+          }
+        }
+      } catch (NoClassDefFoundError e) {
+        notFoundError(spec, out, e);
+      } catch (ClassNotFoundException e) {
+        notFoundError(spec, out, e);
+      } catch (LinkageError e) {
+        // Any of a number of runtime linking errors can occur when trying to load a class,
+        // fail with the test spec so the class failing to link is known.
+        notFoundError(spec, out, e);
+      // See the comment below for justification.
+      // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+      } catch (RuntimeException e) {
+        // The class may fail with some variant of RTE in its static initializers, trap these
+        // and dump the bad spec in question to help narrow down issue.
+        notFoundError(spec, out, e);
+      }
+    }
+    List<Request> requests = Lists.newArrayList();
+
+    if (!classes.isEmpty()) {
+      if (this.perTestTimer || this.parallelThreads > 1) {
+        for (Class<?> clazz : classes) {
+          requests.add(new AnnotatedClassRequest(clazz, numRetries, err));
+        }
+      } else {
+        // The code below does what the original call
+        // requests.add(Request.classes(classes.toArray(new Class<?>[classes.size()])));
+        // does, except that it instantiates our own builder, needed to support retries
+        try {
+          AllDefaultPossibilitiesBuilderWithRetry builder =
+              new AllDefaultPossibilitiesBuilderWithRetry(numRetries, err);
+          Runner suite = new Computer().getSuite(
+              builder, classes.toArray(new Class<?>[classes.size()]));
+          requests.add(Request.runner(suite));
+        } catch (InitializationError e) {
+          throw new RuntimeException(
+              "Internal error: Suite constructor, called as above, should always complete");
+        }
+      }
+    }
+    for (TestMethod testMethod : testMethods) {
+      requests.add(new AnnotatedClassRequest(testMethod.clazz, numRetries, err)
+          .filterWith(Description.createTestDescription(testMethod.clazz, testMethod.name)));
+    }
+    return requests;
+  }
+
+  // Loads classes without initializing them.  We just need the type, annotations and method
+  // signatures, none of which requires initialization.
+  private Class<?> loadClass(String name) throws ClassNotFoundException {
+    return Class.forName(name, /* initialize = */ false, getClass().getClassLoader());
+  }
+
+  /**
+   * Using JUnit4 test filtering mechanism, replaces the provided list of requests with
+   * the one where each request has a filter attached. The filters are used to run only
+   * one test shard, i.e. every Mth test out of N (testShard and numTestShards fields).
+   */
+  private List<Request> setFilterForTestShard(List<Request> requests) {
+    // The filter below can be called multiple times for the same test, at least
+    // when parallelThreads is true. To maintain the stable "run - not run" test status,
+    // we determine it once, when the test is seen for the first time (always in serial
+    // order), and save it in testToRunStatus table.
+    class TestFilter extends Filter {
+      private int testIdx;
+      private HashMap<String, Boolean> testToRunStatus = new HashMap<String, Boolean>();
+
+      @Override
+      public boolean shouldRun(Description desc) {
+        if (desc.isSuite()) {
+          return true;
+        }
+        String descString = desc.getDisplayName();
+        // Note that currently even when parallelThreads is true, the first time this
+        // is called in serial order, by our own iterator below.
+        synchronized (this) {
+          Boolean shouldRun = testToRunStatus.get(descString);
+          if (shouldRun != null) {
+            return shouldRun;
+          } else {
+            shouldRun = testIdx % numTestShards == testShard;
+            testIdx++;
+            testToRunStatus.put(descString, shouldRun);
+            return shouldRun;
+          }
+        }
+      }
+
+      @Override
+      public String describe() {
+        return "Filters a static subset of test methods";
+      }
+    }
+
+    class AlphabeticComparator implements Comparator<Description> {
+      @Override
+      public int compare(Description o1, Description o2) {
+        return o1.getDisplayName().compareTo(o2.getDisplayName());
+      }
+    }
+
+    TestFilter testFilter = new TestFilter();
+    AlphabeticComparator alphaComp = new AlphabeticComparator();
+    ArrayList<Request> filteredRequests = new ArrayList<Request>(requests.size());
+    for (Request request: requests) {
+      filteredRequests.add(request.sortWith(alphaComp).filterWith(testFilter));
+    }
+    // This will iterate over all of the test serially, calling shouldRun() above.
+    // It's needed to guarantee stable sharding in all situations.
+    for (Request request: filteredRequests) {
+      request.getRunner().getDescription();
+    }
+    return filteredRequests;
+  }
+
+  private void notFoundError(String spec, PrintStream out, Throwable t) {
+    out.printf("FATAL: Error during test discovery for %s: %s\n", spec, t);
+    throw new RuntimeException("Classloading error during test discovery for " + spec, t);
+  }
+
+  /**
+   * Launcher for JUnitConsoleRunner.
+   */
+  public static void main(String[] args) {
+    /**
+     * Command line option bean.
+     */
+    class Options {
+      private boolean failFast = false;
+      private boolean suppressOutput = false;
+      private boolean xmlReport = false;
+      private boolean perTestTimer = false;
+      private boolean defaultParallel = false;
+      private int parallelThreads = 0;
+      private int testShard = 0;
+      private int numTestShards = 0;
+      private int numRetries = 0;
+      private File outdir = new File(System.getProperty("java.io.tmpdir"));
+      private List<String> tests = Lists.newArrayList();
+
+      private CmdLineParser parser;
+
+      void setParser(CmdLineParser parser) {
+        this.parser = parser;
+      }
+
+      @Option(name = "-fail-fast", usage = "Causes the test suite run to fail fast.")
+      public void setFailFast(boolean failFast) {
+        this.failFast = failFast;
+      }
+
+      @Option(name = "-suppress-output", usage = "Suppresses test output.")
+      public void setSuppressOutput(boolean suppressOutput) {
+        this.suppressOutput = suppressOutput;
+      }
+
+      @Option(name = "-xmlreport",
+              usage = "Create ant compatible junit xml report files in -outdir.")
+      public void setXmlReport(boolean xmlReport) {
+        this.xmlReport = xmlReport;
+      }
+
+      @Option(name = "-outdir",
+              usage = "Directory to output test captures too.  Only used if -suppress-output or "
+                      + "-xmlreport is set.")
+      public void setOutdir(File outdir) {
+        this.outdir = outdir;
+      }
+
+      @Option(name = "-per-test-timer",
+          usage = "Show progress and timer for each test class.")
+      public void setPerTestTimer(boolean perTestTimer) {
+        this.perTestTimer = perTestTimer;
+      }
+
+      @Option(name = "-default-parallel",
+          usage = "Whether to run test classes without @TestParallel or @TestSerial in parallel.")
+      public void setDefaultParallel(boolean defaultParallel) {
+        this.defaultParallel = defaultParallel;
+      }
+
+      @Option(name = "-parallel-threads",
+          usage = "Number of threads to execute tests in parallel. Must be positive, "
+              + "or 0 to set automatically.")
+      public void setParallelThreads(int parallelThreads) throws CmdLineException {
+        if (parallelThreads < 0) {
+          throw new CmdLineException(parser, "-parallel-threads cannot be negative");
+        }
+        this.parallelThreads = parallelThreads;
+        if (parallelThreads == 0) {
+          this.parallelThreads = Runtime.getRuntime().availableProcessors();
+        }
+      }
+
+      @Option(name = "-test-shard",
+          usage = "Subset of tests to run, in the form M/N, 0 <= M < N. For example, 1/3 means "
+                  + "run tests number 2, 5, 8, 11, ...")
+      public void setTestShard(String shard) throws CmdLineException {
+        String errorMsg = "-test-shard should be in the form M/N";
+        int slashIdx = shard.indexOf('/');
+        if (slashIdx < 0) {
+          throw new CmdLineException(parser, errorMsg);
+        }
+        try {
+          this.testShard = Integer.parseInt(shard.substring(0, slashIdx));
+          this.numTestShards = Integer.parseInt(shard.substring(slashIdx + 1));
+        } catch (NumberFormatException ex) {
+          throw new CmdLineException(parser, errorMsg);
+        }
+        if (testShard < 0 || numTestShards <= 0 || testShard >= numTestShards) {
+          throw new CmdLineException(parser, "0 <= M < N is required in -test-shard M/N");
+        }
+      }
+
+      @Option(name = "-num-retries",
+          usage = "Number of attempts to retry each failing test, 0 by default")
+      public void setNumRetries(int numRetries) throws CmdLineException {
+        if (numRetries < 0) {
+          throw new CmdLineException(parser, "-num-retries cannot be negative");
+        }
+        this.numRetries = numRetries;
+      }
+
+      @Argument(usage = "Names of junit test classes or test methods to run.  Names prefixed "
+                        + "with @ are considered arg file paths and these will be loaded and the "
+                        + "whitespace delimited arguments found inside added to the list",
+                required = true,
+                metaVar = "TESTS",
+                handler = StringArrayOptionHandler.class)
+      public void setTests(String[] tests) {
+        this.tests = Arrays.asList(tests);
+      }
+    }
+
+    Options options = new Options();
+    CmdLineParser parser = new CmdLineParser(options);
+    options.setParser(parser);
+    try {
+      parser.parseArgument(args);
+    } catch (CmdLineException e) {
+      e.getParser().printUsage(System.out);
+      exit(1);
+    }
+
+    ConsoleRunner runner =
+        new ConsoleRunner(options.failFast,
+            options.suppressOutput,
+            options.xmlReport,
+            options.perTestTimer,
+            options.outdir,
+            options.defaultParallel,
+            options.parallelThreads,
+            options.testShard,
+            options.numTestShards,
+            options.numRetries);
+
+    List<String> tests = Lists.newArrayList();
+    for (String test : options.tests) {
+      if (test.startsWith("@")) {
+        try {
+          String argFileContents = Files.toString(new File(test.substring(1)), Charsets.UTF_8);
+          tests.addAll(Arrays.asList(argFileContents.split("\\s+")));
+        } catch (IOException e) {
+          System.err.printf("Failed to load args from arg file %s: %s\n", test, e.getMessage());
+          exit(1);
+        }
+      } else {
+        tests.add(test);
+      }
+    }
+
+    runner.run(tests);
+  }
+
+  public static final Predicate<Constructor<?>> IS_PUBLIC_CONSTRUCTOR =
+      new Predicate<Constructor<?>>() {
+        @Override public boolean apply(Constructor<?> constructor) {
+          return Modifier.isPublic(constructor.getModifiers());
+        }
+      };
+
+  private static final Predicate<Method> IS_ANNOTATED_TEST_METHOD = new Predicate<Method>() {
+    @Override public boolean apply(Method method) {
+      return Modifier.isPublic(method.getModifiers())
+          && method.isAnnotationPresent(org.junit.Test.class);
+    }
+  };
+
+  private static boolean isTest(final Class<?> clazz) {
+    // Must be a public concrete class to be a runnable junit Test.
+    if (clazz.isInterface()
+        || Modifier.isAbstract(clazz.getModifiers())
+        || !Modifier.isPublic(clazz.getModifiers())) {
+      return false;
+    }
+
+    // The class must have some public constructor to be instantiated by the runner being used
+    if (!Iterables.any(Arrays.asList(clazz.getConstructors()), IS_PUBLIC_CONSTRUCTOR)) {
+      return false;
+    }
+
+    // Support junit 3.x Test hierarchy.
+    if (junit.framework.Test.class.isAssignableFrom(clazz)) {
+      return true;
+    }
+
+    // Support classes using junit 4.x custom runners.
+    if (clazz.isAnnotationPresent(RunWith.class)) {
+      return true;
+    }
+
+    // Support junit 4.x @Test annotated methods.
+    return Iterables.any(Arrays.asList(clazz.getMethods()), IS_ANNOTATED_TEST_METHOD);
+  }
+
+  private static void exit(int code) {
+    exitStatus = code;
+    if (callSystemExitOnFinish) {
+      // We're a main - its fine to exit.
+      // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+      System.exit(code);
+    } else {
+      if (code != 0) {
+        throw new RuntimeException("ConsoleRunner exited with status " + code);
+      }
+    }
+  }
+
+  // ---------------------------- For testing only ---------------------------------
+
+  static void setCallSystemExitOnFinish(boolean v) {
+    callSystemExitOnFinish = v;
+  }
+
+  static int getExitStatus() {
+    return exitStatus;
+  }
+
+  static void setExitStatus(int v) {
+    exitStatus = v;
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/ForwardingListener.java
+++ b/src/java/org/pantsbuild/tools/junit/ForwardingListener.java
@@ -1,0 +1,103 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * A run listener that forwards all events to a sequence of registered listeners.
+ */
+class ForwardingListener extends RunListener implements ListenerRegistry {
+  /**
+   * Fires an event to a listener.
+   *
+   * @param <E> The type of exception thrown when firing this event.
+   */
+  private interface Event<E extends Exception> {
+    void fire(RunListener listener) throws E;
+  }
+
+  private final List<RunListener> listeners = Lists.newArrayList();
+
+  @Override
+  public void addListener(RunListener listener) {
+    listeners.add(listener);
+  }
+
+  private <E extends Exception> void fire(Event<E> dispatcher) throws E {
+    for (RunListener listener : listeners) {
+      dispatcher.fire(listener);
+    }
+  }
+
+  @Override
+  public void testRunStarted(final Description description) throws Exception {
+    fire(new Event<Exception>() {
+      @Override public void fire(RunListener listener) throws Exception {
+        listener.testRunStarted(description);
+      }
+    });
+  }
+
+  @Override
+  public void testRunFinished(final Result result) throws Exception {
+    fire(new Event<Exception>() {
+      @Override public void fire(RunListener listener) throws Exception {
+        listener.testRunFinished(result);
+      }
+    });
+  }
+
+  @Override
+  public void testStarted(final Description description) throws Exception {
+    fire(new Event<Exception>() {
+      @Override public void fire(RunListener listener) throws Exception {
+        listener.testStarted(description);
+      }
+    });
+  }
+
+  @Override
+  public void testIgnored(final Description description) throws Exception {
+    fire(new Event<Exception>() {
+      @Override public void fire(RunListener listener) throws Exception {
+        listener.testIgnored(description);
+      }
+    });
+  }
+
+  @Override
+  public void testFailure(final Failure failure) throws Exception {
+    fire(new Event<Exception>() {
+      @Override public void fire(RunListener listener) throws Exception {
+        listener.testFailure(failure);
+      }
+    });
+  }
+
+  @Override
+  public void testFinished(final Description description) throws Exception {
+    fire(new Event<Exception>() {
+      @Override public void fire(RunListener listener) throws Exception {
+        listener.testFinished(description);
+      }
+    });
+  }
+
+  @Override
+  public void testAssumptionFailure(final Failure failure) {
+    fire(new Event<RuntimeException>() {
+      @Override public void fire(RunListener listener) {
+        listener.testAssumptionFailure(failure);
+      }
+    });
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/ListenerRegistry.java
+++ b/src/java/org/pantsbuild/tools/junit/ListenerRegistry.java
@@ -1,0 +1,19 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.runner.notification.RunListener;
+
+/**
+ * Registers {@link RunListener RunListeners} for callbacks during a a test run session.
+ */
+interface ListenerRegistry {
+
+  /**
+   * Registers the {@code listener} for callbacks.
+   *
+   * @param listener The listener to register.
+   */
+  void addListener(RunListener listener);
+}

--- a/src/java/org/pantsbuild/tools/junit/PerClassConsoleListener.java
+++ b/src/java/org/pantsbuild/tools/junit/PerClassConsoleListener.java
@@ -1,0 +1,33 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.io.PrintStream;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+
+/**
+ * A run listener that shows progress and timing for each test class.
+ */
+class PerClassConsoleListener extends ConsoleListener {
+  private final PrintStream out;
+
+  PerClassConsoleListener(PrintStream out) {
+    super(out);
+    this.out = out;
+  }
+
+  @Override
+  public void testRunStarted(Description description) throws Exception {
+    out.print(description.getDisplayName() + ":");
+  }
+
+  @Override
+  public void testRunFinished(Result result) {
+    out.println(" [" + result.getRunTime() + " ms]");
+    super.printFailures(result);
+  }
+
+}

--- a/src/java/org/pantsbuild/tools/junit/StreamSource.java
+++ b/src/java/org/pantsbuild/tools/junit/StreamSource.java
@@ -1,0 +1,30 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.io.IOException;
+
+/**
+ * Provides contents of the output streams captured from a test class run.
+ */
+interface StreamSource {
+
+  /**
+   * Returns the contents of STDOUT from a test class run.
+   *
+   * @param testClass The test class to retrieve captured output for.
+   * @return The captured STDOUT stream.
+   * @throws IOException If there is a problem retrieving the output.
+   */
+  byte[] readOut(Class<?> testClass) throws IOException;
+
+  /**
+   * Returns the contents of STDERR from a test class run.
+   *
+   * @param testClass The test class to retrieve captured output for.
+   * @return The captured STDERR stream.
+   * @throws IOException If there is a problem retrieving the output.
+   */
+  byte[] readErr(Class<?> testClass) throws IOException;
+}

--- a/src/java/org/pantsbuild/tools/junit/Util.java
+++ b/src/java/org/pantsbuild/tools/junit/Util.java
@@ -1,0 +1,50 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.Ignore;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+
+/**
+ * Utilities for working with junit test runs.
+ */
+final class Util {
+
+  private Util() {
+    // utility
+  }
+
+  /**
+   * Returns {@code true} if the given {@code test} is {@literal @Ignore}d.
+   *
+   * @param test The test description to evaluate.
+   * @return {@code true} if the described test is marked as ignored.
+   */
+  static boolean isIgnored(Description test) {
+    return test.getAnnotation(Ignore.class) != null;
+  }
+
+  /**
+   * Returns {@code true} if the given {@code test} is eligible for running.  Runnable tests are
+   * those that are not {@literal @Ignore}d and have direct executable content (i.e.: not a test
+   * suite or other executable test aggregator).
+   *
+   * @param test The test description to evaluate.
+   * @return {@code true} if the described test will be run by a standard junit runner.
+   */
+  static boolean isRunnable(Description test) {
+    return test.isTest() && !isIgnored(test);
+  }
+
+  /**
+   * Returns {@code true} if the test failure represents an assertion failure.
+   *
+   * @param failure The failure to test.
+   * @return {@code true} if the failure was from an incorrect assertion, {@code false} otherwise.
+   */
+  static boolean isAssertionFailure(Failure failure) {
+    return failure.getException() instanceof AssertionError;
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/withretry/AllDefaultPossibilitiesBuilderWithRetry.java
+++ b/src/java/org/pantsbuild/tools/junit/withretry/AllDefaultPossibilitiesBuilderWithRetry.java
@@ -1,0 +1,30 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.withretry;
+
+import java.io.PrintStream;
+
+import org.junit.internal.builders.AllDefaultPossibilitiesBuilder;
+import org.junit.internal.builders.JUnit4Builder;
+
+/**
+ * Needed to support retrying flaky tests. Using method overriding, gives us access to code
+ * in JUnit4 that cannot be customized in a simpler way.
+ */
+public class AllDefaultPossibilitiesBuilderWithRetry extends AllDefaultPossibilitiesBuilder {
+
+  private final int numRetries;
+  private final PrintStream err;
+
+  public AllDefaultPossibilitiesBuilderWithRetry(int numRetries, PrintStream err) {
+    super(true);
+    this.numRetries = numRetries;
+    this.err = err;
+  }
+
+  @Override
+  public JUnit4Builder junit4Builder() {
+    return new JUnit4BuilderWithRetry(numRetries, err);
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/withretry/BUILD
+++ b/src/java/org/pantsbuild/tools/junit/withretry/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(
+  name='withretry',
+  provides=artifact(
+    org='org.pantsbuild',
+    name='junit-runner-withretry',
+    repo=public,
+  ),
+  dependencies=[
+    '3rdparty:junit',
+  ],
+  sources=globs('*.java')
+)

--- a/src/java/org/pantsbuild/tools/junit/withretry/BlockJUnit4ClassRunnerWithRetry.java
+++ b/src/java/org/pantsbuild/tools/junit/withretry/BlockJUnit4ClassRunnerWithRetry.java
@@ -1,0 +1,84 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.withretry;
+
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+/**
+ * A subclass of BlockJUnit4ClassRunner that supports retrying failing tests, up to the
+ * specified number of attempts. This is useful if some tests are known or suspected
+ * to be flaky.
+ */
+public class BlockJUnit4ClassRunnerWithRetry extends BlockJUnit4ClassRunner {
+
+  private final int numRetries;
+  private final PrintStream err;
+
+  public BlockJUnit4ClassRunnerWithRetry(Class<?> klass, int numRetries, PrintStream err)
+      throws InitializationError {
+    super(klass);
+    this.numRetries = numRetries;
+    this.err = err;
+  }
+
+  protected Statement createStatement(FrameworkMethod method) {
+    return super.methodBlock(method);
+  }
+
+  @Override
+  protected Statement methodBlock(FrameworkMethod method) {
+    return new InvokeWithRetry(method);
+  }
+
+  private class InvokeWithRetry extends Statement {
+
+    private final FrameworkMethod method;
+
+    public InvokeWithRetry(FrameworkMethod method) {
+      this.method = method;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+      Throwable error = null;
+      for (int i = 0; i <= numRetries; i++) {
+        try {
+          // This re-creates the Test object every time (including retries), to make everything
+          // as close as possible to clean manual re-invocation of the failed test. It also
+          // ensures that all the things encapsulated by the top-level Statement, e.g. setup/
+          // teardown, checking for expected exceptions, etc., are redone every time.
+          createStatement(method).evaluate();
+          // The test succeeded. However, if it has been retried, it's flaky.
+          if (i > 0) {
+            Method m = method.getMethod();
+            String testName = m.getName() + '(' + m.getDeclaringClass().getName() + ')';
+            err.println("Test " + testName + " is FLAKY; passed after " + (i + 1) + " attempts");
+          }
+          return;
+        // We want implement generic retry logic here with exception capturing as a key part.
+        // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+        } catch (Throwable t) {
+          // Test failed - save the very first thrown exception. However, if we caught an
+          // Error other than AssertionError, exit immediately. It probably doesn't make
+          // sense to retry a test after an OOM or LinkageError.
+          if (t instanceof Exception || t instanceof AssertionError) {
+            if (error == null) {
+              error = t;
+            }
+          } else {
+            throw t;
+          }
+        }
+      }
+      throw error;
+    }
+  }
+
+}

--- a/src/java/org/pantsbuild/tools/junit/withretry/JUnit4BuilderWithRetry.java
+++ b/src/java/org/pantsbuild/tools/junit/withretry/JUnit4BuilderWithRetry.java
@@ -1,0 +1,30 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.withretry;
+
+import java.io.PrintStream;
+
+import org.junit.internal.builders.JUnit4Builder;
+import org.junit.runner.Runner;
+
+/**
+ * Needed to support retrying flaky tests. Using method overriding, gives us access to code
+ * in JUnit4 that cannot be customized in a simpler way.
+ */
+public class JUnit4BuilderWithRetry extends JUnit4Builder {
+
+  private final int numRetries;
+  private final PrintStream err;
+
+  public JUnit4BuilderWithRetry(int numRetries, PrintStream err) {
+    this.numRetries = numRetries;
+    this.err = err;
+  }
+
+  @Override
+  public Runner runnerForClass(Class<?> testClass) throws Throwable {
+    return new BlockJUnit4ClassRunnerWithRetry(testClass, numRetries, err);
+  }
+
+}

--- a/tests/java/org/pantsbuild/tools/junit/BUILD
+++ b/tests/java/org/pantsbuild/tools/junit/BUILD
@@ -4,6 +4,7 @@
 java_tests(
   name='junit',
   dependencies=[
+    '3rdparty:junit',
     'src/java/org/pantsbuild/junit/annotations',
     'src/java/org/pantsbuild/tools/junit',
   ],

--- a/tests/java/org/pantsbuild/tools/junit/BUILD
+++ b/tests/java/org/pantsbuild/tools/junit/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_tests(
+  name='junit',
+  dependencies=[
+    'src/java/org/pantsbuild/junit/annotations',
+    'src/java/org/pantsbuild/tools/junit',
+  ],
+  sources=globs('*.java')
+)

--- a/tests/java/org/pantsbuild/tools/junit/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/ConsoleRunnerTest.java
@@ -1,0 +1,111 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.pantsbuild.junit.annotations.TestSerial;
+
+/**
+ * Tests several recently added features in ConsoleRunner.
+ * TODO: cover the rest of ConsoleRunner functionality.
+ */
+@TestSerial
+public class ConsoleRunnerTest {
+
+  @Before
+  public void setUp() {
+    ConsoleRunner.setCallSystemExitOnFinish(false);
+    ConsoleRunner.setExitStatus(0);
+    TestRegistry.reset();
+  }
+
+  @After
+  public void tearDown() {
+    ConsoleRunner.setCallSystemExitOnFinish(true);
+    ConsoleRunner.setExitStatus(0);
+  }
+
+  @Test
+  public void testNormalTesting() throws Exception {
+    ConsoleRunner.main(asArgsArray("MockTest1 MockTest2 MockTest3"));
+    Assert.assertEquals("test11 test12 test13 test21 test22 test31 test32",
+        TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting02() throws Exception {
+    ConsoleRunner.main(asArgsArray("MockTest1 MockTest2 MockTest3 -test-shard 0/2"));
+    Assert.assertEquals("test11 test13 test22 test32", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting13() throws Exception {
+    ConsoleRunner.main(asArgsArray("MockTest1 MockTest2 MockTest3 -test-shard 1/3"));
+    Assert.assertEquals("test12 test22", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting23() throws Exception {
+    // This tests a corner case when no tests from MockTest2 are going to run.
+    ConsoleRunner.main(asArgsArray(
+        "MockTest1 MockTest2 MockTest3 -test-shard 2/3"));
+    Assert.assertEquals("test13 test31", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting12WithParallelThreads() throws Exception {
+    ConsoleRunner.main(asArgsArray(
+        "MockTest1 MockTest2 MockTest3 -test-shard 1/2 -parallel-threads 4 -default-parallel"));
+    Assert.assertEquals("test12 test21 test31", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testShardedTesting23WithParallelThreads() throws Exception {
+    // This tests a corner case when no tests from MockTest2 are going to run.
+    ConsoleRunner.main(asArgsArray(
+        "MockTest1 MockTest2 MockTest3 -test-shard 2/3 -parallel-threads 3 -default-parallel"));
+    Assert.assertEquals("test13 test31", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testFlakyTests() throws Exception {
+    TestRegistry.consoleRunnerTestRunsFlakyTests = true;
+    try {
+      ConsoleRunner.main(asArgsArray("FlakyTest -num-retries 2"));
+      Assert.fail("Should have failed with RuntimeException due to FlakyTest.methodAlwaysFails");
+      // FlakyTest.methodAlwaysFails fails this way - though perhaps that should be fixed to be an
+      // RTE subclass.
+      // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+    } catch (RuntimeException ex) {
+      // Expected due to FlakyTest.methodAlwaysFails()
+    } finally {
+      TestRegistry.consoleRunnerTestRunsFlakyTests = false;
+    }
+
+    Assert.assertEquals("expected_ex flaky1 flaky1 flaky2 flaky2 flaky2 flaky3 flaky3 flaky3 "
+        + "notflaky", TestRegistry.getCalledTests());
+
+    // Verify that FlakyTest class has been instantiated once per test method invocation,
+    // including flaky test method invocations.
+    Assert.assertEquals(10, FlakyTest.numFlakyTestInstantiations);
+
+    // Verify that a method with expected exception is not treated
+    // as flaky - that is, it should be invoked only once.
+    Assert.assertEquals(1, FlakyTest.numExpectedExceptionMethodInvocations);
+  }
+
+  private String[] asArgsArray(String cmdLine) {
+    String[] args = cmdLine.split(" ");
+    for (int i = 0; i < args.length; i++) {
+      if (args[i].contains("Test")) {
+        args[i] = getClass().getPackage().getName() + '.' + args[i];
+      }
+    }
+    return args;
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/FlakyTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/FlakyTest.java
@@ -1,0 +1,99 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import junit.framework.Assert;
+
+/**
+ * Contains tests that pass only after some number of retries. Used in
+ * ConsoleRunnerTest.testFlakyTests(). Since this test class can also be picked
+ * up on its own, independently of testFlakyTests, the flaky tests are disabled
+ * by default via the TestRegistry.consoleRunnerTestRunsFlakyTests flag.
+ */
+public class FlakyTest {
+
+  public static int numFlaky1Invocations = 0;
+  public static int numFlaky2Invocations = 0;
+  public static int numFlaky3Invocations = 0;
+  public static int numExpectedExceptionMethodInvocations = 0;
+
+  public static int numFlakyTestInstantiations = 0;
+
+  public int numTestMethodInvocationsPerTestInstance;
+
+  public FlakyTest() {
+    numFlakyTestInstantiations++;
+  }
+
+  // Checks in Before/After methods ensure that when a flaky test is retried,
+  // a test object (an instance of FlakyTest class) is re-instantiated. If that
+  // didn't happen, we could have seen numTestMethodInvocationsPerTestInstance
+  // greater than 1 in after/tearDown.
+  @Before
+  public void before() {
+    Assert.assertEquals(0, numTestMethodInvocationsPerTestInstance);
+  }
+
+  @After
+  public void after() {
+    Assert.assertEquals(1, numTestMethodInvocationsPerTestInstance);
+  }
+
+  @Test
+  public void flakyMethodSucceedsAfter1Retry() throws Exception {
+    numTestMethodInvocationsPerTestInstance++;
+    Assume.assumeTrue(TestRegistry.consoleRunnerTestRunsFlakyTests);
+    TestRegistry.registerTestCall("flaky1");
+    numFlaky1Invocations++;
+    if (numFlaky1Invocations < 2) {
+      throw new Exception("flaky1 failed on invocation number " + numFlaky1Invocations);
+    }
+  }
+
+  @Test
+  public void flakyMethodSucceedsAfter2Retries() throws Exception {
+    numTestMethodInvocationsPerTestInstance++;
+    Assume.assumeTrue(TestRegistry.consoleRunnerTestRunsFlakyTests);
+    TestRegistry.registerTestCall("flaky2");
+    numFlaky2Invocations++;
+    if (numFlaky2Invocations < 3) {
+      throw new Exception("flaky2 failed on invocation number " + numFlaky2Invocations);
+    }
+  }
+
+  @Test
+  public void methodAlwaysFails() throws Exception {
+    numTestMethodInvocationsPerTestInstance++;
+    Assume.assumeTrue(TestRegistry.consoleRunnerTestRunsFlakyTests);
+    TestRegistry.registerTestCall("flaky3");
+    numFlaky3Invocations++;
+    throw new Exception("flaky3 failed on invocation number " + numFlaky3Invocations);
+  }
+
+  @Test
+  public void notFlakyMethod() {
+    numTestMethodInvocationsPerTestInstance++;
+    TestRegistry.registerTestCall("notflaky");
+  }
+
+  @Test(expected = CustomException.class)
+  public void methodWithExpectedException() throws Exception {
+    numTestMethodInvocationsPerTestInstance++;
+    numExpectedExceptionMethodInvocations++;
+    TestRegistry.registerTestCall("expected_ex");
+    throw new CustomException("This is expected");
+  }
+
+  public static class CustomException extends Exception {
+
+    CustomException(String message) {
+      super(message);
+    }
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/FlakyTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/FlakyTest.java
@@ -4,11 +4,10 @@
 package org.pantsbuild.tools.junit;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
-
-import junit.framework.Assert;
 
 /**
  * Contains tests that pass only after some number of retries. Used in

--- a/tests/java/org/pantsbuild/tools/junit/MockTest1.java
+++ b/tests/java/org/pantsbuild/tools/junit/MockTest1.java
@@ -1,0 +1,24 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.Test;
+
+public class MockTest1 {
+
+  @Test
+  public void testMethod11() {
+    TestRegistry.registerTestCall("test11");
+  }
+
+  @Test
+  public void testMethod12() {
+    TestRegistry.registerTestCall("test12");
+  }
+
+  @Test
+  public void testMethod13() {
+    TestRegistry.registerTestCall("test13");
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/MockTest2.java
+++ b/tests/java/org/pantsbuild/tools/junit/MockTest2.java
@@ -1,0 +1,19 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.Test;
+
+public class MockTest2 {
+
+  @Test
+  public void testMethod21() {
+    TestRegistry.registerTestCall("test21");
+  }
+
+  @Test
+  public void testMethod22() {
+    TestRegistry.registerTestCall("test22");
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/MockTest3.java
+++ b/tests/java/org/pantsbuild/tools/junit/MockTest3.java
@@ -1,0 +1,19 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import org.junit.Test;
+
+public class MockTest3 {
+
+  @Test
+  public void testMethod31() {
+    TestRegistry.registerTestCall("test31");
+  }
+
+  @Test
+  public void testMethod32() {
+    TestRegistry.registerTestCall("test32");
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/README
+++ b/tests/java/org/pantsbuild/tools/junit/README
@@ -4,43 +4,33 @@ in the future, but in the mean time, here are the steps one needs to perform
 if they change anything under src/java/org/pantsbuild/junit:
 
 I.) On the dev branch:
-1) Publish to the local maven cache
-$ yes | ./pants clean-all publish --no-publish-dryrun src/java/org/pantsbuild/junit --publish-local=~/.m2/repository
+1) Create a self-contained binary
+$ PANTS_DEV=1 ./pants binary src/java/org/pantsbuild/tools/junit:main
 
-< lots of output... >
+2) Edit BUILD.tools to pick up the self-contained binary you created in 1,
+so that the end result looks like (modulo the exact path to the binary jar you created in 1):
 
-published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT.jar
-published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT.pom
-published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT-sources.jar
-published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT-javadoc.jar
-published ivy to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/ivy-0.0.32-SNAPSHOT.xml
+$$ git diff
+ diff --git a/BUILD.tools b/BUILD.tools
+ index fc53e75..da0a936 100644
+ --- a/BUILD.tools
+ +++ b/BUILD.tools
+ @@ -123,7 +123,8 @@ jar_library(name = 'junit',
+              jars = [
+                jar(org = 'junit', name = 'junit-dep', rev = '4.10'),
+                jar(org = 'org.hamcrest', name = 'hamcrest-core', rev = '1.2'),
+ -              jar(org = 'com.twitter.common', name = 'junit-runner', rev = '0.0.41'),
+ +              jar(org = 'org.pantsbuild', name = 'junit-runner', rev = 'none', mutable = True,
+ +                  url = 'file:///home/jsirois/dev/3rdparty/jsirois-pants4/dist/junit-runner.jar'),
 
-2) Edit the profile ivy.xml to pick up the local SNAPSHOT you created in 1,
-so that the end result looks like (modulo concrete rev numbers):
-
-$ git diff
-diff --git a/build-support/profiles/junit.ivy.xml b/build-support/profiles/junit.ivy.xml
-index c33ab3e..86f4197 100644
---- a/build-support/profiles/junit.ivy.xml
-+++ b/build-support/profiles/junit.ivy.xml
-@@ -27,6 +27,6 @@ limitations under the License.
-   <dependencies>
-     <dependency org="junit" name="junit-dep" rev="4.10"/>
-     <dependency org="org.hamcrest" name="hamcrest-core" rev="1.2"/>
--    <dependency org="com.twitter.common" name="junit-runner" rev="0.0.31"/>
-+    <dependency org="com.twitter.common" name="junit-runner" rev="0.0.32-SNAPSHOT" changing="true"/>
-   </dependencies>
- </ivy-module>
-
-3) Kill the profile cache so this get picked up
-$ rm -rf build-support/profiles/junit.libs*
-
-As you edit the source files, you repeat steps 1 and 3 to re-publish and pick up the change.
+As you edit the source files, just repeat step 1 and the change will be picked up.
 
 II.) Revert the change made in I-2 above, mark with @Ignore the tests that rely on
 code changes in the runner (or the entire test class), and submit changes from I
 to master
 
+# TODO(John Sirois): Fix the publishing advice once publishing is sussed.
+# See: https://github.com/pantsbuild/pants/issues/1361
 III.) The operation below should be done on MASTER. Publish a jar with:
 
 1) git checkout master; git pull
@@ -51,5 +41,5 @@ III.) The operation below should be done on MASTER. Publish a jar with:
 3) looks ok? do it:
 yes | ./pants publish --no-publish-dryrun src/java/org/pantsbuild/junit
 
-IV.) Switch back to a dev branch. Make a change that bumps the revision number in
-build-support/profiles/junit.ivy.xml and un-@Ignores any tests temporarily ignored in step I.
+IV.) Switch back to a dev branch. Make a change that bumps the revision number in BUILD.tools and
+un-@Ignores any tests temporarily ignored in step I.

--- a/tests/java/org/pantsbuild/tools/junit/README
+++ b/tests/java/org/pantsbuild/tools/junit/README
@@ -1,0 +1,55 @@
+Testing ConsoleRunner and other classes in src/java/org/pantsbuild/junit
+is non-trivial because of bootstrapping issues. It should become somewhat easier
+in the future, but in the mean time, here are the steps one needs to perform
+if they change anything under src/java/org/pantsbuild/junit:
+
+I.) On the dev branch:
+1) Publish to the local maven cache
+$ yes | ./pants clean-all publish --no-publish-dryrun src/java/org/pantsbuild/junit --publish-local=~/.m2/repository
+
+< lots of output... >
+
+published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT.jar
+published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT.pom
+published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT-sources.jar
+published junit-runner to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/junit-runner-0.0.32-SNAPSHOT-javadoc.jar
+published ivy to /home/jsirois/.m2/repository/org/pantsbuild/junit-runner/0.0.32-SNAPSHOT/ivy-0.0.32-SNAPSHOT.xml
+
+2) Edit the profile ivy.xml to pick up the local SNAPSHOT you created in 1,
+so that the end result looks like (modulo concrete rev numbers):
+
+$ git diff
+diff --git a/build-support/profiles/junit.ivy.xml b/build-support/profiles/junit.ivy.xml
+index c33ab3e..86f4197 100644
+--- a/build-support/profiles/junit.ivy.xml
++++ b/build-support/profiles/junit.ivy.xml
+@@ -27,6 +27,6 @@ limitations under the License.
+   <dependencies>
+     <dependency org="junit" name="junit-dep" rev="4.10"/>
+     <dependency org="org.hamcrest" name="hamcrest-core" rev="1.2"/>
+-    <dependency org="com.twitter.common" name="junit-runner" rev="0.0.31"/>
++    <dependency org="com.twitter.common" name="junit-runner" rev="0.0.32-SNAPSHOT" changing="true"/>
+   </dependencies>
+ </ivy-module>
+
+3) Kill the profile cache so this get picked up
+$ rm -rf build-support/profiles/junit.libs*
+
+As you edit the source files, you repeat steps 1 and 3 to re-publish and pick up the change.
+
+II.) Revert the change made in I-2 above, mark with @Ignore the tests that rely on
+code changes in the runner (or the entire test class), and submit changes from I
+to master
+
+III.) The operation below should be done on MASTER. Publish a jar with:
+
+1) git checkout master; git pull
+
+2) dry run:
+./pants clean-all publish src/java/org/pantsbuild/junit
+
+3) looks ok? do it:
+yes | ./pants publish --no-publish-dryrun src/java/org/pantsbuild/junit
+
+IV.) Switch back to a dev branch. Make a change that bumps the revision number in
+build-support/profiles/junit.ivy.xml and un-@Ignores any tests temporarily ignored in step I.

--- a/tests/java/org/pantsbuild/tools/junit/TestRegistry.java
+++ b/tests/java/org/pantsbuild/tools/junit/TestRegistry.java
@@ -1,0 +1,55 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This is used by each of our mock tests to register the fact that it was called.
+ * Unfortunately, we have to use a static API, and explicit reset() call is needed
+ * every time before running a new real test. Trying to use a singleton object seems
+ * to cause more problems than it fixes, since our MockTestX are called independently
+ * by pants, and they may catch TestRegistry singleton in uninitialized state.
+ */
+final class TestRegistry {
+
+  /** Should be set to true only while tests from FlakyTest is executed from ConsoleRunnerTest */
+  public static boolean consoleRunnerTestRunsFlakyTests = false;
+  private static List<String> testsCalled = new ArrayList<String>();
+
+  // No instances of this classes can be constructed
+  private TestRegistry() { }
+
+  static synchronized void registerTestCall(String testId) {
+    testsCalled.add(testId);
+  }
+
+  static synchronized void reset() {
+    testsCalled.clear();
+  }
+
+  /** Returns the called tests in sorted order as a single string */
+  static String getCalledTests() {
+    return getCalledTests(true);
+  }
+
+  static synchronized String getCalledTests(boolean sort) {
+    if (testsCalled.isEmpty()) {
+      return "";
+    }
+
+    String[] tests = testsCalled.toArray(new String[testsCalled.size()]);
+    if (sort) {
+      Arrays.sort(tests);
+    }
+    StringBuilder sb = new StringBuilder(50);
+    sb.append(tests[0]);
+    for (int i = 1; i < tests.length; i++) {
+      sb.append(' ').append(tests[i]);
+    }
+    return sb.toString();
+  }
+}

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -69,27 +69,33 @@ class JarCreateExecuteTest(JarCreateTestBase):
   def setUp(self):
     super(JarCreateExecuteTest, self).setUp()
 
+    def test_path(path):
+      return os.path.join(self.__class__.__name__, path)
+
     def get_source_root_fs_path(path):
-      return os.path.realpath(os.path.join(self.build_root, path))
+      return os.path.realpath(os.path.join(self.build_root, test_path(path)))
 
     SourceRoot.register(get_source_root_fs_path('src/resources'), Resources)
     SourceRoot.register(get_source_root_fs_path('src/java'), JavaLibrary, JvmBinary)
     SourceRoot.register(get_source_root_fs_path('src/scala'), ScalaLibrary)
     SourceRoot.register(get_source_root_fs_path('src/thrift'), JavaThriftLibrary)
 
-    self.res = self.create_resources('src/resources/com/twitter', 'spam', 'r.txt')
-    self.jl = self.java_library('src/java/com/twitter', 'foo', ['a.java'],
-                                resources='src/resources/com/twitter:spam')
-    self.sl = self.scala_library('src/scala/com/twitter', 'bar', ['c.scala'])
-    self.jtl = self.java_thrift_library('src/thrift/com/twitter', 'baz', 'd.thrift')
-    self.java_lib_foo = self.java_library('src/java/com/twitter/foo', 'java_foo', ['java_foo.java'])
-    self.scala_lib = self.scala_library('src/scala/com/twitter/foo',
+    self.res = self.create_resources(test_path('src/resources/com/twitter'), 'spam', 'r.txt')
+    self.jl = self.java_library(test_path('src/java/com/twitter'), 'foo', ['a.java'],
+                                resources=test_path('src/resources/com/twitter:spam'))
+    self.sl = self.scala_library(test_path('src/scala/com/twitter'), 'bar', ['c.scala'])
+    self.jtl = self.java_thrift_library(test_path('src/thrift/com/twitter'), 'baz', 'd.thrift')
+    self.java_lib_foo = self.java_library(test_path('src/java/com/twitter/foo'),
+                                          'java_foo',
+                                          ['java_foo.java'])
+    self.scala_lib = self.scala_library(test_path('src/scala/com/twitter/foo'),
                                         'scala_foo',
                                         ['scala_foo.scala'],
-                                        java_sources=['src/java/com/twitter/foo:java_foo'])
-    self.binary = self.jvm_binary('src/java/com/twitter/baz', 'baz', source='b.java',
-                                  resources='src/resources/com/twitter:spam')
-    self.empty_sl = self.scala_library('src/scala/com/foo', 'foo', ['dupe.scala'])
+                                        java_sources=[
+                                          test_path('src/java/com/twitter/foo:java_foo')])
+    self.binary = self.jvm_binary(test_path('src/java/com/twitter/baz'), 'baz', source='b.java',
+                                  resources=test_path('src/resources/com/twitter:spam'))
+    self.empty_sl = self.scala_library(test_path('src/scala/com/foo'), 'foo', ['dupe.scala'])
 
   def context(self, **kwargs):
     return super(JarCreateExecuteTest, self).context(
@@ -114,9 +120,12 @@ class JarCreateExecuteTest(JarCreateTestBase):
     with self.add_data(context.products, 'classes_by_target', self.jl, 'a.class', 'b.class'):
       with self.add_data(context.products, 'classes_by_target', self.sl, 'c.class'):
         with self.add_data(context.products, 'classes_by_target', self.binary, 'b.class'):
-          with self.add_data(context.products, 'resources_by_target', self.res, 'r.txt.transformed'):
-            with self.add_data(context.products, 'classes_by_target', self.scala_lib, 'scala_foo.class',
-                               'java_foo.class'):
+          with self.add_data(context.products,
+                             'resources_by_target',
+                             self.res,
+                             'r.txt.transformed'):
+            with self.add_data(context.products, 'classes_by_target', self.scala_lib,
+                               'scala_foo.class', 'java_foo.class'):
               self.execute(context)
 
               self.assert_jar_contents(context, 'jars', self.jl,


### PR DESCRIPTION
This ports the junit-runner used by pants but does not actually
configure pants to use the ported runner.  That will come later after
the tool is published: https://github.com/pantsbuild/pants/issues/1361

The junit-runner in twitter/commons will be deleted after this tool is
published and consumed by pants HEAD.

https://rbcommons.com/s/twitter/r/2043/