### PR TITLE
Upgrade virtualenv from 12.0.7 to 12.1.1.

### DIFF
--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Wrapper for self-bootstrapping virtualenv
 set -e
-VIRTUALENV_VERSION=12.0.7
+VIRTUALENV_VERSION=12.1.1
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.python.org/packages/source/v/virtualenv}
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)


### PR DESCRIPTION
This just upgrades pip from 6.0.8 to 6.1.1 and makes virtualenv setup
warnings go away when bootstrapping pants as a pex or in dev mode.

https://rbcommons.com/s/twitter/r/2047/