### PR TITLE
[Trigger CI] ensure source_roots always loaded; validate source_roots dir is subdir

### DIFF
--- a/src/python/pants/backend/core/BUILD
+++ b/src/python/pants/backend/core/BUILD
@@ -29,6 +29,7 @@ python_library(
     'src/python/pants/backend/core/tasks:all',
     'src/python/pants/base:address',
     'src/python/pants/base:build_environment',
+    'src/python/pants/fs',
     'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/backend/core/wrapped_globs.py
+++ b/src/python/pants/backend/core/wrapped_globs.py
@@ -10,7 +10,9 @@ import os
 from six import string_types
 from twitter.common.dirutil.fileset import Fileset
 
+
 from pants.base.build_environment import get_buildroot
+from pants.fs.fs import is_dir_outside_root
 
 
 class FilesetRelPathWrapper(object):
@@ -30,7 +32,7 @@ class FilesetRelPathWrapper(object):
         excludes[i] = [exclude]
 
     for glob in args:
-      if(self._is_glob_dir_outside_root(glob, root)):
+      if is_dir_outside_root(glob, root):
         raise ValueError('Invalid glob {}, points outside BUILD file root dir {}'.format(glob, root))
 
     result = self.wrapped_fn(root=root, *args, **kwargs)

--- a/src/python/pants/base/build_configuration.py
+++ b/src/python/pants/base/build_configuration.py
@@ -142,6 +142,9 @@ class BuildConfiguration(object):
 
     parse_globals = type_aliases.copy()
     for alias, object_factory in self._exposed_context_aware_object_factories.items():
-      parse_globals[alias] = object_factory(parse_context)
+      factory = object_factory(parse_context)
+      if not callable(factory):
+        raise TypeError('The factory for the {} returned None for {}'.format(alias, parse_context))
+      parse_globals[alias] = factory
 
     return self.ParseState(registered_addressable_instances, parse_globals)

--- a/src/python/pants/base/build_file_parser.py
+++ b/src/python/pants/base/build_file_parser.py
@@ -66,6 +66,13 @@ class BuildFileParser(object):
     """Returns a copy of the registered build file aliases this build file parser uses."""
     return self._build_configuration.registered_aliases()
 
+  def address_map_from_build_file(self, build_file):
+    family_address_map_by_build_file = self.parse_build_file_family(build_file)
+    address_map = {}
+    for build_file, sibling_address_map in family_address_map_by_build_file.items():
+      address_map.update(sibling_address_map)
+    return address_map
+
   def address_map_from_spec_path(self, spec_path):
     try:
       build_file = BuildFile.from_cache(self._root_dir, spec_path)
@@ -73,11 +80,7 @@ class BuildFileParser(object):
       raise self.BuildFileScanError("{message}\n searching {spec_path}"
                                     .format(message=e,
                                             spec_path=spec_path))
-    family_address_map_by_build_file = self.parse_build_file_family(build_file)
-    address_map = {}
-    for build_file, sibling_address_map in family_address_map_by_build_file.items():
-      address_map.update(sibling_address_map)
-    return address_map
+    return self.address_map_from_build_file(build_file)
 
   def parse_build_file_family(self, build_file):
     family_address_map_by_build_file = {}  # {build_file: {address: addressable}}

--- a/src/python/pants/base/source_root.py
+++ b/src/python/pants/base/source_root.py
@@ -12,6 +12,7 @@ from twitter.common.collections import OrderedSet
 from pants.base.build_environment import get_buildroot
 from pants.base.build_manual import manual
 from pants.base.exceptions import TargetDefinitionException
+from pants.fs.fs import is_dir_outside_root
 
 
 class SourceRootTree(object):
@@ -186,6 +187,9 @@ class SourceRoot(object):
   def __call__(self, basedir, *allowed_target_types):
     allowed_target_types = [proxy._addressable_type.get_target_type()
                             for proxy in allowed_target_types]
+    if is_dir_outside_root(dir=basedir, root=self.rel_path):
+      raise ValueError("Invalid source root: {} is not a subdirectory of {}".format(basedir, self.rel_path))
+
     SourceRoot.register(os.path.join(self.rel_path, basedir), *allowed_target_types)
 
   def here(self, *allowed_target_types):

--- a/src/python/pants/fs/fs.py
+++ b/src/python/pants/fs/fs.py
@@ -52,3 +52,11 @@ def safe_filename(name, extension=None, digest=None, max_length=_MAX_FILENAME_LE
 def expand_path(path):
   """Returns ``path`` as an absolute path with ~user and env var expansion applied."""
   return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
+
+def is_dir_outside_root(dir, root):
+  # The assumption is that a correct subdir starts with the root,
+  # even after normalizing.
+  dir_path = os.path.normpath(os.path.join(root, dir))
+
+  # Check if the dir path has the correct root.
+  return os.path.commonprefix([root, dir_path]) != root

--- a/tests/python/pants_test/base/test_build_configuration.py
+++ b/tests/python/pants_test/base/test_build_configuration.py
@@ -100,6 +100,14 @@ class BuildConfigurationTest(unittest.TestCase):
     with self.do_test_exposed_context_aware_object(func) as context_aware_object:
       self.assertEqual('george', context_aware_object(*args, **kwargs))
 
+  @staticmethod
+  def not_georgemethod(parse_context):
+    pass
+
+  def test_register_exposed_context_aware_staticmethod_returning_none(self):
+    with self.assertRaises(TypeError):
+      self.do_test_exposed_context_aware_object(self.not_georgemethod)
+
   def test_register_exposed_context_aware_class(self):
     class George(object):
       def __init__(self, parse_context):

--- a/tests/python/pants_test/base/test_source_root.py
+++ b/tests/python/pants_test/base/test_source_root.py
@@ -86,6 +86,10 @@ class SourceRootTest(unittest.TestCase):
     SourceRoot("mock/foo").here(proxy)
     self.assertEqual("mock/foo", SourceRoot.find(target))
 
+  def test_call_source_root_with_directory_outside_current_path(self):
+    with self.assertRaises(ValueError):
+      SourceRoot("mock/foo")("../other/directory")
+
   def test_find(self):
     # When no source_root is registered, it should just return the path from the address
     self.assertEqual("tests/foo/bar", SourceRoot.find(TestTarget("//tests/foo/bar:baz")))

--- a/tests/python/pants_test/test_maven_layout.py
+++ b/tests/python/pants_test/test_maven_layout.py
@@ -21,7 +21,7 @@ class MavenLayoutTest(BaseTest):
         'junit_tests': JavaTests,
       },
       context_aware_object_factories={
-        'maven_layout': maven_layout,
+        'maven_layout': BuildFileAliases.curry_context(maven_layout),
       }
     )
 
@@ -30,15 +30,22 @@ class MavenLayoutTest(BaseTest):
 
     self.add_to_build_file('projectB/src/test/scala',
                            'junit_tests(name="test", sources=["a/source"])')
+    self.add_to_build_file('projectB/src/main/java/com/example',
+                           'java_library(name="example", sources=["a/source"])')
+
     self.create_file('projectB/BUILD', 'maven_layout()')
 
     self.add_to_build_file('projectA/subproject/src/main/java',
                            'java_library(name="test", sources=[])')
     self.create_file('BUILD', 'maven_layout("projectA/subproject")')
 
-  def test_layout_here(self):
+  def test_target_at_root_of_maven_layout_source_root(self):
     self.assertEqual('projectB/src/test/scala',
                      self.target('projectB/src/test/scala:test').target_base)
+
+  def test_target_at_subdir_of_maven_layout_source_root(self):
+    self.assertEqual('projectB/src/main/java',
+                     self.target('projectB/src/main/java/com/example').target_base)
 
   def test_subproject_layout(self):
     self.assertEqual('projectA/subproject/src/main/java',


### PR DESCRIPTION
This changes address mapping so that when an address is mapped, and the BUILD file for it is parsed, it ensures all its parent BUILD files have also been parsed. I put it in the address mapper because it already caches the results of parses, which'll reduce re-excution of build files. Also source_root primarily affects addressable entities.

What I'd really like to do is to remove all side effecting things from build files, and have a cache of all the interesting things from them. Instead of only retaining addressables from build parses, we'd collect source_roots etc. Then that service would be passed into others like the address mapper which could perform tasks and build derivative data structures based on the contents.

- fix maven_layout tests so they exercise the maven_layout function
- raise errors when source roots are outside the BUILD dir they are defined in
- raise errors if a context aware factory fails to create a callable
- add method to BuildFile to get direct parent without finding all ancestors