### PR TITLE
Use a fake context when testing.

### DIFF
--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -157,11 +157,6 @@ class Context(object):
     ident = Target.identify(self.targets())
     return 'Context(id:%s, targets:%s)' % (ident, self.targets())
 
-  def submit_foreground_work_and_wait(self, work, workunit_parent=None):
-    """Returns the pool to which tasks can submit foreground (blocking) work."""
-    return self.run_tracker.foreground_worker_pool().submit_work_and_wait(
-      work, workunit_parent=workunit_parent)
-
   def submit_background_work_chain(self, work_chain, parent_workunit_name=None):
     background_root_workunit = self.run_tracker.get_background_root_workunit()
     if parent_workunit_name:

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -10,10 +10,7 @@ python_library(
     'src/python/pants/base:config',
     'src/python/pants/base:target',
     'src/python/pants/goal:context',
-    'src/python/pants/goal:run_tracker',
     'src/python/pants/option',
-    'src/python/pants/reporting',
-    'src/python/pants/util:dirutil',
   ]
 )
 


### PR DESCRIPTION
Allows us to not have a RunTracker and other heavy machinery in
task code under test.