### PR TITLE
Remove plumbing for custom test config.

### DIFF
--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -29,7 +29,6 @@ python_library(
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/base:address',
     'src/python/pants/base:build_configuration',
-    'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_address_mapper',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:build_file_parser',

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -51,12 +51,12 @@ class ScalastyleTest(NailgunTaskTestBase):
       relpath='scalastyle_excludes.txt',
       contents='\n'.join(exclude_patterns) if exclude_patterns else '')
 
-  def _create_context(self, config=None, excludes=None, skip=False, target_roots=None):
+  def _create_context(self, scalastyle_config=None, excludes=None, skip=False, target_roots=None):
     # If config is not specified, then we override pants.ini scalastyle such that
     # we have a default scalastyle config xml but with empty excludes.
     # Also by default, the task shouldn't be skipped, so use no skip option.
     options={
-      'config': config,
+      'config': scalastyle_config,
       'skip': skip,
     }
     if excludes:
@@ -68,8 +68,9 @@ class ScalastyleTest(NailgunTaskTestBase):
       },
       target_roots=target_roots)
 
-  def _create_scalastyle_task(self, config=None, excludes=None, skip=False):
-    return self.create_task(self._create_context(config, excludes, skip), self.build_root)
+  def _create_scalastyle_task(self, scalastyle_config=None, excludes=None, skip=False):
+    return self.create_task(self._create_context(scalastyle_config, excludes, skip),
+                            self.build_root)
 
   def _create_scalastyle_task_from_context(self, context=None):
     if context:
@@ -83,11 +84,12 @@ class ScalastyleTest(NailgunTaskTestBase):
 
   def test_initialize_config_no_config_settings(self):
     with self.assertRaises(Scalastyle.UnspecifiedConfig):
-      self._create_scalastyle_task(config='').validate_scalastyle_config()
+      self._create_scalastyle_task(scalastyle_config='').validate_scalastyle_config()
 
   def test_initialize_config_config_setting_exist_but_invalid(self):
     with self.assertRaises(Scalastyle.MissingConfig):
-      self._create_scalastyle_task(config='file_does_not_exist.xml').validate_scalastyle_config()
+      self._create_scalastyle_task(
+        scalastyle_config='file_does_not_exist.xml').validate_scalastyle_config()
 
   def test_excludes_setting_exists_but_invalid(self):
     with self.assertRaises(TaskError):
@@ -180,7 +182,7 @@ class ScalastyleTest(NailgunTaskTestBase):
     # Create a custom context so we can manually inject scala targets
     # with mixed sources in them to test the source filtering logic.
     context = self._create_context(
-      config=self._create_scalastyle_config_file(),
+      scalastyle_config=self._create_scalastyle_config_file(),
       excludes=self._create_scalastyle_excludes_file(['a/scala_2/Source2.scala']),
       target_roots=[
         scala_target_1,
@@ -223,7 +225,7 @@ class ScalastyleTest(NailgunTaskTestBase):
     self.build_graph.inject_address_closure(scala_target_address)
     scala_target = self.build_graph.get_target(scala_target_address)
 
-    context = self._create_context(config=self._create_scalastyle_config_file(),
+    context = self._create_context(scalastyle_config=self._create_scalastyle_config_file(),
                                    target_roots=[scala_target])
 
     self.execute(context)

--- a/tests/python/pants_test/backend/python/tasks/python_task_test.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test.py
@@ -74,10 +74,9 @@ class PythonTaskTest(TaskTestBase):
     """).format(name=name, requirements=','.join(map(make_requirement, requirements))))
     return self.target(SyntheticAddress(relpath, name).spec)
 
-  def context(self, config='', options=None, target_roots=None, **kwargs):
+  def context(self, options=None, target_roots=None, **kwargs):
     # Our python tests don't pass on Python 3 yet.
     # TODO: Clean up this hard-coded interpreter constraint once we have subsystems
     # and can simplify InterpreterCache and PythonSetup.
     self.set_options(interpreter=['CPython>=2.7,<3'])
-    return super(PythonTaskTest, self).context(config=config, options=options,
-                                               target_roots=target_roots, **kwargs)
+    return super(PythonTaskTest, self).context(options=options, target_roots=target_roots, **kwargs)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -15,7 +15,6 @@ from textwrap import dedent
 from pants.backend.core.targets.dependencies import Dependencies
 from pants.base.address import SyntheticAddress
 from pants.base.build_configuration import BuildConfiguration
-from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.base.build_file_address_mapper import BuildFileAddressMapper
 from pants.base.build_file_aliases import BuildFileAliases
@@ -30,7 +29,7 @@ from pants.base.target import Target
 from pants.goal.goal import Goal
 from pants.goal.products import MultipleRootedProducts, UnionProducts
 from pants.option.options import Options
-from pants.util.contextutil import pushd, temporary_dir, temporary_file
+from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree, touch
 from pants_test.base.context_utils import create_context
 
@@ -139,21 +138,10 @@ class BaseTest(unittest.TestCase):
     self.address_mapper = BuildFileAddressMapper(self.build_file_parser)
     self.build_graph = BuildGraph(address_mapper=self.address_mapper)
 
-  def config(self, overrides=''):
-    """Returns a config valid for the test build root."""
-    ini_file = os.path.join(get_buildroot(), 'pants.ini')
-    if overrides:
-      with temporary_file(cleanup=False) as fp:
-        fp.write(overrides)
-        fp.close()
-        return Config.load([ini_file, fp.name])
-    else:
-      return Config.load([ini_file])
-
   def set_options_for_scope(self, scope, **kwargs):
     self.options[scope].update(kwargs)
 
-  def context(self, for_task_types=None, config='', options=None, target_roots=None, **kwargs):
+  def context(self, for_task_types=None, options=None, target_roots=None, **kwargs):
     for_task_types = for_task_types or []
     options = options or {}
 
@@ -201,8 +189,7 @@ class BaseTest(unittest.TestCase):
           if key not in opts:  # Inner scope values override the inherited ones.
             opts[key] = val
 
-    return create_context(config=self.config(overrides=config),
-                          options=option_values,
+    return create_context(options=option_values,
                           target_roots=target_roots,
                           build_graph=self.build_graph,
                           build_file_parser=self.build_file_parser,

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -27,7 +27,7 @@ class JvmToolTaskTestBase(TaskTestBase):
   def setUp(self):
     # Ensure we get a read of the real pants.ini config
     Config.reset_default_bootstrap_option_values()
-    real_config = self.config()
+    real_config = Config.from_cache()
 
     super(JvmToolTaskTestBase, self).setUp()
 

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -31,12 +31,7 @@ class JarCreateTestBase(JarTaskTestBase):
 
 class JarCreateMiscTest(JarCreateTestBase):
   def test_jar_create_init(self):
-    ini = dedent("""
-          [DEFAULT]
-          pants_supportdir: /tmp/build-support
-          """).strip()
-
-    self.create_task(self.context(config=ini), '/tmp/workdir')
+    self.create_task(self.context(), '/tmp/workdir')
 
   def test_resources_with_scala_java_files(self):
     for ftype in ('java', 'scala'):


### PR DESCRIPTION
All tests now specify option values directly. There is no longer any
way for them to do so via pants.ini mechanisms.

Note that we still load the real config file into the cache, until
such times as no code at all reads pants.ini directly.

Also renamed config->scalastyle_config in a test, to avoid git grep confusion.