### PR TITLE
Add a dummy workunit to the end of the run 

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -288,6 +288,10 @@ class RunTracker(object):
 
     SubprocPool.shutdown(self._aborted)
 
+    # Run a dummy work unit to rite out one last timestamp
+    with self.new_workunit("complete"):
+      pass
+    
     self.end_workunit(self._main_root_workunit)
 
     outcome = self._main_root_workunit.outcome()


### PR DESCRIPTION
To print out a timestamp that includes the time spent in the last task.