### PR TITLE
Further cleanup of test context setup.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/python_task_test.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test.py
@@ -74,9 +74,11 @@ class PythonTaskTest(TaskTestBase):
     """).format(name=name, requirements=','.join(map(make_requirement, requirements))))
     return self.target(SyntheticAddress(relpath, name).spec)
 
-  def context(self, options=None, target_roots=None, **kwargs):
+  def context(self, for_task_types=None, options=None, target_roots=None,
+              console_outstream=None, workspace=None):
     # Our python tests don't pass on Python 3 yet.
     # TODO: Clean up this hard-coded interpreter constraint once we have subsystems
     # and can simplify InterpreterCache and PythonSetup.
     self.set_options(interpreter=['CPython>=2.7,<3'])
-    return super(PythonTaskTest, self).context(options=options, target_roots=target_roots, **kwargs)
+    return super(PythonTaskTest, self).context(for_task_types=for_task_types, options=options,
+        target_roots=target_roots, console_outstream=console_outstream, workspace=workspace)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -141,7 +141,8 @@ class BaseTest(unittest.TestCase):
   def set_options_for_scope(self, scope, **kwargs):
     self.options[scope].update(kwargs)
 
-  def context(self, for_task_types=None, options=None, target_roots=None, **kwargs):
+  def context(self, for_task_types=None, options=None, target_roots=None,
+              console_outstream=None, workspace=None):
     for_task_types = for_task_types or []
     options = options or {}
 
@@ -194,7 +195,8 @@ class BaseTest(unittest.TestCase):
                           build_graph=self.build_graph,
                           build_file_parser=self.build_file_parser,
                           address_mapper=self.address_mapper,
-                          **kwargs)
+                          console_outstream=console_outstream,
+                          workspace=workspace)
 
   def tearDown(self):
     BuildRoot().reset()

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -62,13 +62,15 @@ class TaskTestBase(BaseTest):
   def set_options(self, **kwargs):
     self.set_options_for_scope(self.options_scope, **kwargs)
 
-  def context(self, config='', options=None, target_roots=None, **kwargs):
+  def context(self, for_task_types=None, options=None, target_roots=None,
+              console_outstream=None, workspace=None):
     # Add in our task type.
-    return super(TaskTestBase, self).context(for_task_types=[self._testing_task_type],
-                                             config=config,
+    for_task_types = [self._testing_task_type] + (for_task_types or [])
+    return super(TaskTestBase, self).context(for_task_types=for_task_types,
                                              options=options,
                                              target_roots=target_roots,
-                                             **kwargs)
+                                             console_outstream=console_outstream,
+                                             workspace=workspace)
 
   def create_task(self, context, workdir=None):
     return self._testing_task_type(context, workdir or self._test_workdir)

--- a/tests/python/pants_test/tasks/test_jar_task.py
+++ b/tests/python/pants_test/tasks/test_jar_task.py
@@ -215,7 +215,7 @@ class JarBuilderTest(BaseJarTaskTest):
         )''').strip())
     java_agent = self.target('src/java/pants/agents:fake_agent')
 
-    context = self.context(target_roots=java_agent)
+    context = self.context(target_roots=[java_agent])
     jar_task = self.prepare_jar_task(context)
 
     class_products = context.products.get_data('classes_by_target',


### PR DESCRIPTION
- Make the context creation arguments explicit, so that more deps
  don't creep back in via **kwargs.
- Make the signature of context() the same in subclasses of
  BaseTest as in the base class, for hygiene.
- Emphasize that in tests context.config is now an empty config.