### PR TITLE
Re-establish no nailguns under TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 env:
   global:
     - CXX=g++
+    - PANTS_CONFIG_OVERRIDE=pants.travis-ci.ini
     # Credentials for OSX syncing: GH_USER, GH_EMAIL, GH_TOKEN
     # These are encrypted with a public key for our repo that only
     # Travis-CI has the private key for.  We are trusting Travis-CI

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -1,0 +1,5 @@
+# Overrides for TravisCI runs.
+[DEFAULT]
+
+# Turn off all nailgun use.
+use_nailgun: False


### PR DESCRIPTION
We used to have a switch for this in the ci.sh script that .travis.yml
passed but that went away here: https://rbcommons.com/s/twitter/r/1852/

This just adds a config override file dedicated to TravisCI runs.