### PR TITLE
Setup publishing to maven-central.

### DIFF
--- a/build-support/ivy/BUILD.netrc
+++ b/build-support/ivy/BUILD.netrc
@@ -1,5 +1,10 @@
 # Enable ~/.netrc for credentials management of jvm publishing.
 
+# These credentials are used by our 'public' publish repo defined in [publish]repos in `pants.ini`
+# and the username and password here are templated in to a credentials configuration for
+# oss.sonatype.org in `build-support/ivy/publish.ivysettings.xml`.  This setup is complex, but
+# documented well here: http://pantsbuild.github.io/setup_repo.html#enabling-pants-publish
+
 netrc = netrc()
 
 credentials(

--- a/build-support/ivy/BUILD.netrc
+++ b/build-support/ivy/BUILD.netrc
@@ -1,0 +1,8 @@
+# Enable ~/.netrc for credentials management of jvm publishing.
+
+netrc = netrc()
+
+credentials(
+  name = 'netrc',
+  username=netrc.getusername,
+  password=netrc.getpassword)

--- a/build-support/ivy/ivy.xml
+++ b/build-support/ivy/ivy.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+-->
+
+<ivy-module version="2.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
+
+  <info organisation="pants" module="ivy"/>
+
+  <dependencies defaultconf="default">
+    <dependency org="org.apache.ivy" name="ivy" rev="2.4.0"/>
+
+    <!-- support for the pgp signer -->
+    <dependency org="org.bouncycastle" name="bcpg-jdk14" rev="1.45"/>
+    <dependency org="org.bouncycastle" name="bcprov-jdk14" rev="1.45"/>
+  </dependencies>
+</ivy-module>

--- a/build-support/ivy/ivy.xml
+++ b/build-support/ivy/ivy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 Licensed under the Apache License, Version 2.0 (see LICENSE).
 -->
 
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:noNamespaceSchemaLocation="http://ant.apache.org/ivy/schemas/ivy.xsd">
 
-  <info organisation="pants" module="ivy"/>
+  <info organisation="org.pantsbuild" module="ivy"/>
 
   <dependencies defaultconf="default">
     <dependency org="org.apache.ivy" name="ivy" rev="2.4.0"/>

--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -5,9 +5,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 -->
 
 <ivysettings>
-  <property name="root.dir" value="${ivy.settings.dir}/../.." override="false"/>
   <property name="ivy.cache.dir" value="${user.home}/.ivy2/pants" override="false"/>
-  <properties file="${root.dir}/build.properties" override="false"/>
 
   <settings defaultResolver="chain-repos"/>
 

--- a/build-support/ivy/publish.ivysettings.xml
+++ b/build-support/ivy/publish.ivysettings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 Licensed under the Apache License, Version 2.0 (see LICENSE).
 -->
 
@@ -17,24 +17,24 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
   <!-- The ${login} and ${password} values below come from a credentials() object,
        which is fed by '~/.netrc'.  There must be a '~/.netrc' machine entry which
-       matches a resolver in the "[publish]repos" object in 'pants.ini', which also 
+       matches a resolver in the "[publish]repos" object in 'pants.ini', which also
        matches the 'host' in this XML block. -->
   <credentials host="oss.sonatype.org"
                realm="Sonatype Nexus Repository Manager"
                username="${login}"
                passwd="${password}"/>
- 
+
   <resolvers>
     <!-- For resolving foreign deps only (to create a poms for publishing). -->
     <_remote_resolvers name="remote-repos"/>
-    
+
     <!-- For publishing to maven central only. -->
     <ibiblio name="oss.sonatype.org"
              m2compatible="true"
              root="https://oss.sonatype.org/service/local/staging/deploy/maven2/"
              signer="pgp"/>
   </resolvers>
-  
+
   <signers>
     <pgp name="pgp"
          secring="${pgp.secring}"

--- a/build-support/ivy/publish.ivysettings.xml
+++ b/build-support/ivy/publish.ivysettings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+-->
+
+<ivysettings>
+  <include file="${ivy.settings.dir}/ivysettings.xml"/>
+
+  <!-- TODO(John Sirois): Find a better way to get the pgp passphrase than this
+       by-convention-only, chmod 400 file.  This may require writing an ivy signer
+       plugin that shells out to pgp and invokes it password dialog. Tracked by:
+       https://github.com/pantsbuild/pants/issues/1407 -->
+  <properties file="${user.home}/.pantsbuild.pants.pgp.properties"/>
+  <property name="pgp.secring" value="${user.home}/.gnupg/secring.gpg" override="false"/>
+  <property name="pgp.keyid" value="auto" override="false"/>
+
+  <!-- The ${login} and ${password} values below come from a credentials() object,
+       which is fed by '~/.netrc'.  There must be a '~/.netrc' machine entry which
+       matches a resolver in the "[publish]repos" object in 'pants.ini', which also 
+       matches the 'host' in this XML block. -->
+  <credentials host="oss.sonatype.org"
+               realm="Sonatype Nexus Repository Manager"
+               username="${login}"
+               passwd="${password}"/>
+ 
+  <resolvers>
+    <!-- For resolving foreign deps only (to create a poms for publishing). -->
+    <_remote_resolvers name="remote-repos"/>
+    
+    <!-- For publishing to maven central only. -->
+    <ibiblio name="oss.sonatype.org"
+             m2compatible="true"
+             root="https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+             signer="pgp"/>
+  </resolvers>
+  
+  <signers>
+    <pgp name="pgp"
+         secring="${pgp.secring}"
+         keyId="${pgp.keyid}"
+         password="${pgp.password}"/>
+  </signers>
+</ivysettings>

--- a/pants-plugins/src/python/internal_backend/repositories/register.py
+++ b/pants-plugins/src/python/internal_backend/repositories/register.py
@@ -12,13 +12,13 @@ from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.build_manual import manual
 
 
-public_repo = Repository(name = 'public',
-                         url = 'https://dl.bintray.com/pantsbuild/maven',
-                         push_db_basedir = os.path.join('build-support', 'ivy', 'pushdb'))
+public_repo = Repository(name='public',
+                         url='https://oss.sonatype.org/#stagingRepositories',
+                         push_db_basedir=os.path.join('build-support', 'ivy', 'pushdb'))
 
-testing_repo = Repository(name = 'testing',
-                          url = 'https://dl.bintray.com/pantsbuild/maven',
-                          push_db_basedir = os.path.join('testprojects', 'ivy', 'pushdb'))
+testing_repo = Repository(name='testing',
+                          url='https://dl.bintray.com/pantsbuild/maven',
+                          push_db_basedir=os.path.join('testprojects', 'ivy', 'pushdb'))
 
 
 # Your repositories don't need this manual.builddict magic.

--- a/pants.ini
+++ b/pants.ini
@@ -148,7 +148,10 @@ repos: {
     'public': {  # must match the name of the `Repository` object that you defined in your plugin.
       'resolver': 'oss.sonatype.org', # must match hostname in ~/.netrc and the <url> parameter
                                       # in your custom ivysettings.xml.
-      'confs': ['default', 'sources', 'docs', 'changelog'],
+      # NB: default, sources, and javadoc are added automatically - they are listed here for sanity
+      # sake but only 'changelog' is needed.  Fixing confs configuration to be needed or trimmed is
+      # tracked here: https://github.com/pantsbuild/pants/issues/1410
+      'confs': ['default', 'sources', 'javadoc', 'changelog'],
       'auth': 'build-support/ivy:netrc',  # Pants spec to a 'credentials()' object.
       'help': 'Configure your ~/.netrc for oss.sonatype.org access.'
     }

--- a/pants.ini
+++ b/pants.ini
@@ -32,6 +32,10 @@ bootstrap_buildfiles: [
 [ivy]
 ivy_settings: %(pants_supportdir)s/ivy/ivysettings.xml
 
+# We need a custom ivy profile to grab the optional pgp libs for
+# signing artifacts we publish to maven central.
+ivy_profile: %(pants_supportdir)s/ivy/ivy.xml
+
 
 [gen.scrooge]
 strict: False
@@ -136,6 +140,20 @@ python_test_paths: ["tests/python"]
 python_lib_paths: ["3rdparty/python"]
 scala_maximum_heap_size_mb: 1024
 java_maximum_heap_size_mb: 1024
+
+
+[publish]
+ivy_settings: %(pants_supportdir)s/ivy/publish.ivysettings.xml
+repos: {
+    'public': {  # must match the name of the `Repository` object that you defined in your plugin.
+      'resolver': 'oss.sonatype.org', # must match hostname in ~/.netrc and the <url> parameter
+                                      # in your custom ivysettings.xml.
+      'confs': ['default', 'sources', 'docs', 'changelog'],
+      'auth': 'build-support/ivy:netrc',  # Pants spec to a 'credentials()' object.
+      'help': 'Configure your ~/.netrc for oss.sonatype.org access.'
+    }
+  }
+restrict_push_branches: ['master']
 
 
 [python-setup]


### PR DESCRIPTION
This gets all the pieces in-place to publish pants jvm artifacts to
maven central.  There are currently 2 warts:

 1. The pgp signing requires a passphrase for your key and this is read
    from a properties file in your home dir.  Although this can be setup
    as securely as the ~/.netrc we rely on for maven-central credentials,
    its another file permission someone can get wrong.  I've filed
    tracking issue: https://github.com/pantsbuild/pants/issues/1407
 2. The pre-commit hook gets confused by the automated commits of pushdb
    files and isort checks erroneously fail.  I've not figured the cause
    of the failure yet and have just un-installed my hook for now.
    I've filed tracking issue:
      https://github.com/pantsbuild/pants/issues/1408