### PR TITLE
Cap BootstrapJvmTools mem in JvmToolTaskTestBase.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -190,8 +190,8 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
                                        workunit_name='shade-{}'.format(key))
           if result != 0:
             raise TaskError("Shading of tool '{key}' with main class {main} for {scope} failed "
-                            "with exit code {result}".format(key=key, main=main, scope=scope,
-                                                             result=result))
+                            "with exit code {result}, command run was:\n\t{cmd}"
+                            .format(key=key, main=main, scope=scope, result=result, cmd=shader.cmd))
         except Executor.Error as e:
           raise TaskError("Shading of tool '{key}' with main class {main} for {scope} failed "
                           "with: {exception}".format(key=key, main=main, scope=scope, exception=e))

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -52,6 +52,11 @@ class JvmToolTaskTestBase(TaskTestBase):
 
     self.bootstrap_task_type.register_options(register)
 
+    # Cap BootstrapJvmTools memory usage in tests.  The Xmx was empirically arrived upon using
+    # -Xloggc and verifying no full gcs for a test using the full gamut of resolving a multi-jar
+    # tool, constructing a fat jar and then shading that fat jar.
+    self.set_options_for_scope(bootstrap_scope, jvm_options=['-Xmx128m'])
+
     def link_or_copy(src, dest):
       try:
         os.link(src, dest)


### PR DESCRIPTION
The option in the pantsbuild/pants pants.ini used to be plumbed but no
longer is.  This change explicitly set -Xmx for BootstrapJvmTools to a
reasonable value for test runs.

https://rbcommons.com/s/twitter/r/2077/