### PR TITLE
[Trigger CI] Convert two existing concepts (RunTracker and the jar tool) to subsystem...

### DIFF
--- a/src/python/pants/backend/core/tasks/reflect.py
+++ b/src/python/pants/backend/core/tasks/reflect.py
@@ -438,6 +438,7 @@ def gen_glopts_reference_data():
   def register(*args, **kwargs):
     option_parser.register(*args, **kwargs)
   register.bootstrap = bootstrap_option_values()
+  register.scope = ''
   register_bootstrap_options(register, buildroot='<buildroot>')
   register_global_options(register)
   argparser = option_parser._help_argparser

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -1,0 +1,22 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name = 'jvm_tool_mixin',
+  sources = ['jvm_tool_mixin.py'],
+  dependencies = [
+    'src/python/pants/base:exceptions',
+    'src/python/pants/option',
+    ],
+  )
+
+python_library(
+  name = 'jar_tool',
+  sources = ['jar_tool.py'],
+  dependencies = [
+    ':jvm_tool_mixin',
+    'src/python/pants/base:workunit',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
+    ],
+  )

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
+from pants.base.workunit import WorkUnit
+from pants.option.options import Options
+from pants.subsystem.subsystem import Subsystem
+
+
+class JarTool(JvmToolMixin, Subsystem):
+  scope_qualifier = 'jar-tool'
+
+  @classmethod
+  def register_options(cls, register):
+    super(JarTool, cls).register_options(register)
+    # TODO: All jvm tools will need this option, so might as well have register_jvm_tool add it?
+    register('--jvm-options', advanced=True, type=Options.list, default=['-Xmx64M'],
+             help='Run the jar tool with these JVM options.')
+    cls.register_jvm_tool(register, 'jar-tool')
+
+  def run(self, context, runjava, args):
+    return runjava(self.tool_classpath_from_products(context.products, 'jar-tool',
+                                                     scope=self.options_scope),
+                   'com.twitter.common.jar.tool.Main',
+                   jvm_options=self.get_options().jvm_options,
+                   args=args,
+                   workunit_name='jar-tool',
+                   workunit_labels=[WorkUnit.TOOL, WorkUnit.JVM, WorkUnit.NAILGUN])

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -12,7 +12,9 @@ from pants.subsystem.subsystem import Subsystem
 
 
 class JarTool(JvmToolMixin, Subsystem):
-  scope_qualifier = 'jar-tool'
+  @classmethod
+  def scope_qualifier(cls):
+    return 'jar-tool'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.base.exceptions import TaskError
+from pants.option.options import Options
+
+
+class JvmToolMixin(object):
+  """A mixin for registering and accessing JVM-based tools."""
+
+  _tool_keys = []  # List of (scope, key, main, custom_rule) tuples.
+
+  @classmethod
+  def register_jvm_tool(cls, register, key, default=None, main=None, custom_rules=None):
+    """Registers a jvm tool under `key` for lazy classpath resolution.
+
+    Classpaths can be retrieved in `execute` scope via `tool_classpath`.
+
+    NB: If the tool's `main` class name is supplied the tool classpath will be shaded.
+
+    :param register: A function that can register options with the option system.
+    :param unicode key: The key the tool configuration should be registered under.
+    :param list default: The default tool classpath target address specs to use.
+    :param unicode main: The fully qualified class name of the tool's main class if shading of the
+                         tool classpath is desired.
+    :param list custom_rules: An optional list of `Shader.Rule`s to apply before the automatically
+                              generated binary jar shading rules.  This is useful for excluding
+                              classes shared between the tool and the code it runs over.  The
+                              canonical example is the `org.junit.Test` annotation read by junit
+                              runner tools from user code. In this sort of case the shared code must
+                              have a uniform name between the tool and the user code and so the
+                              shared code must be excluded from shading.
+    """
+    register('--{0}'.format(key),
+             advanced=True,
+             type=Options.list,
+             default=default or ['//:{0}'.format(key)],
+             help='Target specs for bootstrapping the {0} tool.'.format(key))
+
+    # TODO(John Sirois): Move towards requiring tool specs point to jvm_binary targets.
+    # These already have a main and are a natural place to house any custom shading rules.  That
+    # would eliminate the need to pass main and custom_rules here.
+    # It is awkward that jars can no longer be inlined as dependencies - this will require 2 targets
+    # for every tool - the jvm_binary, and a jar_library for its dependencies to point to.  It may
+    # be worth creating a JarLibrary subclass - say JarBinary, or else mixing in a Binary interface
+    # to JarLibrary to endow it with main and shade_rules attributes to allow for single-target
+    # definition of resolvable jvm binaries.
+    JvmToolMixin._tool_keys.append((register.scope, key, main, custom_rules))
+
+  @staticmethod
+  def get_registered_tools():
+    return JvmToolMixin._tool_keys
+
+  @staticmethod
+  def reset_registered_tools():
+    """Needed only for test isolation."""
+    JvmToolMixin._tool_keys = []
+
+  def tool_classpath_from_products(self, products, key, scope):
+    """Get a classpath for the tool previously registered under key in the given scope.
+
+    Returns a list of paths.
+    """
+    return self.lazy_tool_classpath_from_products(products, key, scope)()
+
+  def lazy_tool_classpath_from_products(self, products, key, scope):
+    """Get a lazy classpath for the tool previously registered under the key in the given scope.
+
+    Returns a no-arg callable. Invoking it returns a list of paths.
+    """
+    callback_product_map = products.get_data('jvm_build_tools_classpath_callbacks') or {}
+    callback = callback_product_map.get(scope, {}).get(key)
+    if not callback:
+      raise TaskError('No bootstrap callback registered for {key} in {scope}'.format(
+        key=key, scope=scope))
+    return callback

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -68,12 +68,12 @@ python_library(
   dependencies = [
     ':ivy_task_mixin',
     ':jar_task',
-    ':jvm_tool_task_mixin',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/java:executor',
     'src/python/pants/java:util',
     'src/python/pants/java/jar:shader',
+    'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
   ],
 )
@@ -222,9 +222,9 @@ python_library(
     ':nailgun_task',
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/jvm/subsystems:jar_tool',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:exceptions',
-    'src/python/pants/base:workunit',
     'src/python/pants/java/jar:manifest',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:meta',
@@ -300,8 +300,7 @@ python_library(
   name = 'jvm_tool_task_mixin',
   sources = ['jvm_tool_task_mixin.py'],
   dependencies = [
-    'src/python/pants/base:exceptions',
-    'src/python/pants/option',
+    'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -11,9 +11,9 @@ import shutil
 import threading
 from collections import defaultdict
 
+from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyResolveFingerprintStrategy, IvyTaskMixin
 from pants.backend.jvm.tasks.jar_task import JarTask
-from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.exceptions import TaskError
 from pants.java import util
@@ -90,7 +90,7 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
 
   def execute(self):
     context = self.context
-    if JvmToolTaskMixin.get_registered_tools():
+    if JvmToolMixin.get_registered_tools():
       # Map of scope -> (map of key -> callback).
       callback_product_map = (context.products.get_data('jvm_build_tools_classpath_callbacks') or
                               defaultdict(dict))
@@ -101,7 +101,7 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
       # the bootstrap tools.  It would be awkward and possibly incorrect to call
       # self.invalidated twice on a Task that does meaningful invalidation on its
       # targets. -pl
-      for scope, key, main, custom_rules in JvmToolTaskMixin.get_registered_tools():
+      for scope, key, main, custom_rules in JvmToolMixin.get_registered_tools():
         option = key.replace('-', '_')
         deplist = self.context.options.for_scope(scope)[option]
         callback_product_map[scope][key] = self.cached_bootstrap_classpath_callback(

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -5,69 +5,23 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.exceptions import TaskError
-from pants.option.options import Options
+from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 
 
-class JvmToolTaskMixin(object):
-
-  _tool_keys = []  # List of (scope, key) pairs.
-
-  @classmethod
-  def register_jvm_tool(cls, register, key, default=None, main=None, custom_rules=None):
-    """Registers a jvm tool under `key` for lazy classpath resolution.
-
-    Classpaths can be retrieved in `execute` scope via `tool_classpath`.
-
-    NB: If the tool's `main` class name is supplied the tool classpath will be shaded.
-
-    :param register: A function that can register options with the option system.
-    :param unicode key: The key the tool configuration should be registered under.
-    :param list default: The default tool classpath target address specs to use.
-    :param unicode main: The fully qualified class name of the tool's main class if shading of the
-                         tool classpath is desired.
-    :param list custom_rules: An optional list of `Shader.Rule`s to apply before the automatically
-                              generated binary jar shading rules.  This is useful for excluding
-                              classes shared between the tool and the code it runs over.  The
-                              canonical example is the `org.junit.Test` annotation read by junit
-                              runner tools from user code. In this sort of case the shared code must
-                              have a uniform name between the tool and the user code and so the
-                              shared code must be excluded from shading.
-    """
-    register('--{0}'.format(key),
-             type=Options.list,
-             default=default or ['//:{0}'.format(key)],
-             help='Target specs for bootstrapping the {0} tool.'.format(key))
-
-    # TODO(John Sirois): Move towards requiring tool specs point to jvm_binary targets.
-    # These already have a main and are a natural place to house any custom shading rules.  That
-    # would eliminate the need to pass main and custom_rules here.
-    # It is awkward that jars can no longer be inlined as dependencies - this will require 2 targets
-    # for every tool - the jvm_binary, and a jar_library for its dependencies to point to.  It may
-    # be worth creating a JarLibrary subclass - say JarBinary, or else mixing in a Binary interface
-    # to JarLibrary to endow it with main and shade_rules attributes to allow for single-target
-    # definition of resolvable jvm binaries.
-    JvmToolTaskMixin._tool_keys.append((cls.options_scope, key, main, custom_rules))
-
-  @staticmethod
-  def get_registered_tools():
-    return JvmToolTaskMixin._tool_keys
-
-  @staticmethod
-  def reset_registered_tools():
-    """Needed only for test isolation."""
-    JvmToolTaskMixin._tool_keys = []
+class JvmToolTaskMixin(JvmToolMixin):
+  """A JvmToolMixin specialized for mixing in to Tasks."""
 
   def tool_classpath(self, key, scope=None):
     """Get a classpath for the tool previously registered under key in the given scope.
 
     Returns a list of paths.
     """
-    scope = scope or self.options_scope
-    callback_product_map = (self.context.products.get_data('jvm_build_tools_classpath_callbacks')
-                            or {})
-    callback = callback_product_map.get(scope, {}).get(key)
-    if not callback:
-      raise TaskError('No bootstrap callback registered for {key} in {scope}'.format(
-          key=key, scope=scope))
-    return callback()
+    return self.lazy_tool_classpath(key, scope=scope)()
+
+  def lazy_tool_classpath(self, key, scope=None):
+    """Get a lazy classpath for the tool previously registered under the key in the given scope.
+
+    Returns a no-arg callable. Invoking it returns a list of paths.
+    """
+    return self.lazy_tool_classpath_from_products(self.context.products, key,
+                                                  scope=scope or self.options_scope)

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -43,7 +43,9 @@ class RunTracker(Subsystem):
   Can track execution against multiple 'roots', e.g., one for the main thread and another for
   background threads.
   """
-  scope_qualifier = 'run-tracker'
+  @classmethod
+  def scope_qualifier(cls):
+    return 'run-tracker'
 
   # The name of the tracking root for the main thread (and the foreground worker threads).
   DEFAULT_ROOT_NAME = 'main'

--- a/src/python/pants/option/migrate_config.py
+++ b/src/python/pants/option/migrate_config.py
@@ -207,6 +207,10 @@ migrations = {
   ('scrooge-gen', 'scala'): ('gen.scrooge', 'service_deps'),
   ('scrooge-gen', 'java'): ('gen.scrooge', 'service_deps'),
 
+  # jar-tool subsystem.
+  ('jar-tool', 'bootstrap-tools'): ('jar-tool', 'jar-tool'),
+  ('jar-tool', 'jvm_args'): ('jar-tool', 'jvm_options'),
+
   # Technically 'indices' and 'indexes' are both acceptable plural forms of 'index'. However
   # usage has led to the former being used primarily for mathematical indices and the latter
   # for book indexes, database indexes and the like.

--- a/src/python/pants/subsystem/BUILD
+++ b/src/python/pants/subsystem/BUILD
@@ -6,6 +6,5 @@ python_library(
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/option',
-    'src/python/pants/util:meta',
   ],
 )

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -5,17 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from abc import abstractproperty
-
 from pants.option.options import Options
-from pants.util.meta import AbstractClass
 
 
 class SubsystemError(Exception):
   """An error in a subsystem."""
 
 
-class Subsystem(AbstractClass):
+class Subsystem(object):
   """A separable piece of functionality that may be reused across multiple tasks or other code.
 
   Subsystems encapsulate the configuration and initialization of things like JVMs,
@@ -32,12 +29,13 @@ class Subsystem(AbstractClass):
 
   TODO(benjy): Model dependencies between subsystems? Registration of subsystems?
   """
-  @abstractproperty
-  def scope_qualifier(self):
+  @classmethod
+  def scope_qualifier(cls):
     """Qualifies the options scope of this Subsystem type.
 
     E.g., for SubsystemFoo this should return 'foo'.
     """
+    raise NotImplementedError()
 
   @classmethod
   def register_options(cls, register):
@@ -53,7 +51,7 @@ class Subsystem(AbstractClass):
 
   @classmethod
   def qualify_scope(cls, scope):
-    return '{0}.{1}'.format(scope, cls.scope_qualifier) if scope else cls.scope_qualifier
+    return '{0}.{1}'.format(scope, cls.scope_qualifier()) if scope else cls.scope_qualifier()
 
   # The full Options object for this pants run.  Will be set after options are parsed.
   # TODO: A less clunky way to make option values available?

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -36,7 +36,7 @@ class Subsystem(AbstractClass):
   def scope_qualifier(self):
     """Qualifies the options scope of this Subsystem type.
 
-    E.g., for SubsystemFoo this might return 'foo'.
+    E.g., for SubsystemFoo this should return 'foo'.
     """
 
   @classmethod
@@ -48,7 +48,7 @@ class Subsystem(AbstractClass):
 
   @classmethod
   def register_options_on_scope(cls, options, scope):
-    """Trigger registration of this subsystem's options, qualified under the given scope."""
+    """Trigger registration of this subsystem's options under a given scope."""
     cls.register_options(options.registration_function_for_scope(cls.qualify_scope(scope)))
 
   @classmethod

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -170,6 +170,7 @@ class BaseTest(unittest.TestCase):
           for flag_name in rargs:
             option_name = flag_name.lstrip('-').replace('-', '_')
             scoped_options[option_name] = default
+        # TODO: Set register.bootstrap here, for good measure?
         register.scope = on_scope
         return register
 

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -15,7 +15,7 @@ python_library(
   name = 'jvm_tool_task_test_base',
   sources = ['jvm_tool_task_test_base.py'],
   dependencies = [
-    'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
+    'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
     'src/python/pants/base:config',
     'src/python/pants/base:extension_loader',

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -11,7 +11,9 @@ from pants.subsystem.subsystem import Subsystem
 
 
 class DummySubsystem(Subsystem):
-  scope_qualifier = 'dummy'
+  @classmethod
+  def scope_qualifier(cls):
+    return 'dummy'
 
 
 class DummyOptions(object):

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -16,7 +16,7 @@ from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.jar_create import JarCreate, is_jvm_library
 from pants.base.source_root import SourceRoot
-from pants.util.contextutil import open_zip, temporary_dir
+from pants.util.contextutil import open_zip
 from pants_test.jvm.jar_task_test_base import JarTaskTestBase
 
 


### PR DESCRIPTION
...s.

- The RunTracker change is straightforward.

- There is now a JarTool subsystem.  But implementing this neatly
  required some changes to the JVM tool machinery:

  + The old JvmToolTaskMixin is now JvmToolMixin. I.e., you don't have
    to be a task to use JVM tools. Indeed, subsystems can mix this in
    in order to register and bootstrap JVM tools.

  + JvmToolTaskMixin is now a thin subclass of JvmToolMixin, adapting
    it for ease of use by tasks. In the future we might make all
    JVM tools (compilers etc.) into subsystems and then not need
    JvmToolTaskMixin at all.

  + The new JarTool subsystem does two things:
      1) Bootstraps the jar tool and handles its options.
      2) Actually runs the jar tool with given args in a given runner.
         This interface is slightly awkward perhaps, but very reusable.
         And we already pass runners around as arguments elsewhere anyway.

- Removed some clunky code in JvmToolTaskTestBase that registers options
  for BootstrapJvmTools, which is not the task under test but needed
  to bootstrap tools for the task under test.  Instead overrides context() to
  add BootstrapJvmTools to the list of tasks the base class already clunkily
  registers options for (in addition to the task under test)...

- TODO: JarTool is now tested indirectly in test_jar_task.py,
  but we might want to also test the now-standalone subsystem directly.