### PR TITLE
Remove integration tests from default targets in test BUILD files

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -4,8 +4,6 @@
 target(
   name='java',
   dependencies=[
-    ':apt_compile_integration',
-    ':java_compile_integration',
   ],
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/BUILD
@@ -4,7 +4,6 @@
 target(
   name='scala',
   dependencies=[
-    ':scala_compile_integration',
     ':zinc_analysis',
   ],
 )


### PR DESCRIPTION
These integration test targets made it into the default targets, but
they shouldn't be there so they won't get run in `./pants test tests/python/pants_test:all`
Integration tests are run by looking for targets with the name
'integration' in build-support/bin/ci.sh