### PR TITLE
[Trigger CI] Add Executable in between Executor and Runner

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/scala_compile.py
@@ -93,6 +93,9 @@ class ScalaCompile(JvmCompile):
       ret.append((root, [plugin_info_file]))
     return ret
 
+  def create_compiler_executable(self):
+    return self._zinc_utils.executable(self.create_java_executor())
+
   def compile(self, args, classpath, sources, classes_output_dir, upstream_analysis, analysis_file):
-    return self._zinc_utils.compile(args, classpath, sources,
+    return self._zinc_utils.compile(self.get_compiler_executable(), args, classpath, sources,
                                     classes_output_dir, analysis_file, upstream_analysis)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
@@ -125,7 +125,7 @@ class ZincUtils(object):
   def relativize_classpath(classpath):
     return relativize_paths(classpath, get_buildroot())
 
-  def compile(self, extra_args, classpath, sources, output_dir,
+  def compile(self, executable, extra_args, classpath, sources, output_dir,
               analysis_file, upstream_analysis_files):
 
     # We add compiler_classpath to ensure the scala-library jar is on the classpath.
@@ -157,13 +157,16 @@ class ZincUtils(object):
     args.extend(sources)
 
     self.log_zinc_file(analysis_file)
-    if self._nailgun_task.runjava(classpath=self._zinc_classpath,
-                                  main=self._ZINC_MAIN,
-                                  jvm_options=self._jvm_options,
-                                  args=args,
-                                  workunit_name='zinc',
-                                  workunit_labels=[WorkUnit.COMPILER]):
+    if self._nailgun_task.run_java_executable(executable,
+                                              args=args,
+                                              cwd=None,
+                                              workunit_name='zinc',
+                                              workunit_labels=[WorkUnit.COMPILER]):
       raise TaskError('Zinc compile failed.')
+
+  def executable(self, executor):
+    """Creates a zinc executable from the passed executor."""
+    return executor.executable(self._zinc_classpath, self._ZINC_MAIN, self._jvm_options)
 
   @staticmethod
   def write_plugin_info(resources_dir, target):

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -90,6 +90,17 @@ class NailgunTaskBase(TaskBase, JvmToolTaskMixin):
     except executor.Error as e:
       raise TaskError(e)
 
+  def run_java_executable(self, executable, args, cwd, workunit_name, workunit_labels):
+    """Runs the executable with the given arguments.
+    """
+    try:
+      return util.execute_runner(executable.runner(args, cwd),
+                                 workunit_factory=self.context.new_workunit,
+                                 workunit_name=workunit_name,
+                                 workunit_labels=workunit_labels)
+    except executable.executor.Error as e:
+      raise TaskError(e)
+
 
 class NailgunTask(NailgunTaskBase, Task):
   # TODO(John Sirois): This just prevents ripple - maybe inline

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -79,22 +79,15 @@ class Executor(AbstractClass):
   class Executable(object):
     """A re-usable executable tha can run a java tool."""
 
-    def __init__(self, classpath, main, jvm_options):
+    def __init__(self, executor, classpath, main, jvm_options):
+      self.executor = executor
       self.jvm_options = jvm_options
       self.main = main
       self.classpath = classpath
 
-    @abstractproperty
-    def executor(self):
-      """Returns the executor this runner uses to run itself."""
-
     def runner(self, args=None, cwd=None):
       """Returns a Runner for the passed args / cwd """
-      return self._runner(*Executor._scrub_runner_args(args, cwd))
-
-    @abstractmethod
-    def _runner(self, args, cwd=None):
-      """Subclasses should return a `Runner` that can execute the given java main."""
+      return self.executor._runner(self, *Executor._scrub_runner_args(args, cwd))
 
   def __init__(self, distribution=None):
     """Constructs an Executor that can be used to launch java programs.
@@ -120,12 +113,17 @@ class Executor(AbstractClass):
     """Returns an `Executor.Executable` for a given java classpath / main"""
     return self._executable(*self._scrub_executable_args(classpath, main, jvm_options))
 
-  @abstractmethod
   def _executable(self, classpath, main, jvm_options):
     """Returns an `Executor.Executable` for a given java classpath / main
 
     Subclasses override this to provide specialized executables
     """
+    return self.Executable(self, classpath, main, jvm_options)
+
+  @abstractmethod
+  def _runner(self, executable, args, cwd=None):
+    """Subclasses should return a `Runner` that can execute the given java executable with the
+    passed arguments."""
 
   def runner(self, classpath, main, jvm_options=None, args=None, cwd=None):
     """Returns an `Executor.Runner` for the given java command."""
@@ -164,27 +162,20 @@ class CommandLineGrabber(Executor):
     super(CommandLineGrabber, self).__init__(distribution=distribution)
     self._command = None  # Initialized when we run something.
 
-  def _executable(self, classpath, main, jvm_options):
-    class Executable(self.Executable):
+  def _runner(self, executable, args, cwd=None):
+    self._command = self._create_command(executable.classpath, executable.main, executable.jvm_options, args, cwd=cwd)
+    class Runner(self.Runner):
       @property
       def executor(_):
         return self
 
-      def _runner(_, args, cwd=None):
-        self._command = self._create_command(classpath, main, jvm_options, args, cwd=cwd)
-        class Runner(self.Runner):
-          @property
-          def executor(_):
-            return self
+      @property
+      def command(_):
+        return list(self._command)
 
-          @property
-          def command(_):
-            return list(self._command)
-
-          def run(_, stdout=None, stderr=None, cwd=None):
-            return 0
-        return Runner()
-    return Executable(classpath, main, jvm_options)
+      def run(_, stdout=None, stderr=None, cwd=None):
+        return 0
+    return Runner()
 
   @property
   def cmd(self):
@@ -226,28 +217,21 @@ class SubprocessExecutor(Executor):
     return super(SubprocessExecutor, self)._create_command(classpath, main, jvm_options,
                                                            args, cwd=cwd)
 
-  def _executable(self, classpath, main, jvm_options):
-    class Executable(self.Executable):
+  def _runner(self, executor, args, cwd=None):
+    command = self._create_command(executor.classpath, executor.main, executor.jvm_options, args, cwd=cwd)
+    class Runner(self.Runner):
+      @property
       def executor(_):
         return self
 
-      def _runner(_, args, cwd=None):
-        command = self._create_command(classpath, main, jvm_options, args, cwd=cwd)
+      @property
+      def command(_):
+        return list(command)
 
-        class Runner(self.Runner):
-          @property
-          def executor(_):
-            return self
+      def run(_, stdout=None, stderr=None, cwd=None):
+        return self._spawn(command, stdout=stdout, stderr=stderr, cwd=cwd).wait()
 
-          @property
-          def command(_):
-            return list(command)
-
-          def run(_, stdout=None, stderr=None, cwd=None):
-            return self._spawn(command, stdout=stdout, stderr=stderr, cwd=cwd).wait()
-
-        return Runner()
-    return Executable(classpath, main, jvm_options)
+    return Runner()
 
   def spawn(self, classpath, main, jvm_options=None, args=None, cwd=None, **subprocess_args):
     """Spawns the java program passing any extra subprocess kwargs on to subprocess.Popen.

--- a/tests/python/pants_test/java/test_executor.py
+++ b/tests/python/pants_test/java/test_executor.py
@@ -56,10 +56,10 @@ class SubprocessExecutorTest(unittest.TestCase):
   def test_scrubbed_java_tool_options(self):
     self.do_test_jre_env_var('JAVA_TOOL_OPTIONS', '-Xmx1g')
 
-  def do_test_executor_classpath_relativize(self, executor):
+  def do_test_executor_runners_classpath_relativize(self, executor):
     """Test that 'executor' relativizes the classpath."""
     here = os.path.abspath(".")
-    runner = executor.runner([here], "bogus")
+    runner = executor.executable([here], "bogus").runner()
     self.assertFalse(here in runner.cmd)
     parts = runner.cmd.split(" ")
     found = False
@@ -71,4 +71,5 @@ class SubprocessExecutorTest(unittest.TestCase):
 
   def test_subprocess_classpath_relativize(self):
     with self.jre("FOO") as jre:
-      self.do_test_executor_classpath_relativize(SubprocessExecutor(Distribution(bin_path=jre)))
+      self.do_test_executor_runners_classpath_relativize(
+        SubprocessExecutor(Distribution(bin_path=jre)))


### PR DESCRIPTION
I'm working on adding parallelization to jvm isolated compile, and I ran into an issue where if two backgrounded threads try to run `runjava` they hit a race condition for starting the nailgun server.
This is because each java execution instantiates a new nailgun client, and a new session.

What I'd like to do is create a single nailgun client for each kind of java tool used, and reuse them to create new sessions within the worker threads. That way I can be sure only one server is started.

The least bad way I came up with for doing this involves adding a new abstraction between Executor, which has the java dist to use, and Runner which has everything else. Then I can put the nailgun client initialization there and reuse the same client throughout a given task execution.

