### PR TITLE
resultlog argument might be given as either in "--resultlog=filename" or

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -410,7 +410,7 @@ class PytestRun(PythonTask):
       resultlogs = [arg[arg.find('=') + 1:] for arg in args if arg.startswith('--resultlog=')]
       if resultlogs:
         return resultlogs[0]
-      if not resultlogs:
+      else:
         try:
           return args[args.index('--resultlog') + 1]
         except ValueError:

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -405,6 +405,17 @@ class PytestRun(PythonTask):
     return list(failed_targets)
 
   def _do_run_tests(self, targets, workunit):
+
+    def _extract_resultlog_filename(args):
+      resultlogs = [arg.split('=', 1)[-1] for arg in args if arg.startswith('--resultlog=')]
+      if resultlogs:
+        return resultlogs[0]
+      if not resultlogs:
+        try:
+          return args[args.index('--resultlog') + 1]
+        except ValueError:
+          return None
+
     if not targets:
       return PythonTestResult.rc(0)
 
@@ -430,13 +441,13 @@ class PytestRun(PythonTask):
       args.extend(sources)
 
       # The user might have already specified the resultlog option. In such case, reuse it.
-      resultlogs = [arg.split('=', 1)[-1] for arg in args if arg.startswith('--resultlog=')]
+      resultlog_arg = _extract_resultlog_filename(args)
 
-      if resultlogs:
-        return run_and_analyze(resultlogs[-1])
+      if resultlog_arg:
+        return run_and_analyze(resultlog_arg)
       else:
         with temporary_file_path() as resultlog_path:
-          args.append('--resultlog={0}'.format(resultlog_path))
+          args.insert(0, '--resultlog={0}'.format(resultlog_path))
           return run_and_analyze(resultlog_path)
 
   def _pex_run(self, pex, workunit, args, setsid=False):

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -413,6 +413,9 @@ class PytestRun(PythonTask):
       else:
         try:
           return args[args.index('--resultlog') + 1]
+        except IndexError:
+          self.context.log.error('--resultlog specified without an argument')
+          return None
         except ValueError:
           return None
 

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -407,7 +407,7 @@ class PytestRun(PythonTask):
   def _do_run_tests(self, targets, workunit):
 
     def _extract_resultlog_filename(args):
-      resultlogs = [arg.split('=', 1)[-1] for arg in args if arg.startswith('--resultlog=')]
+      resultlogs = [arg[arg.find('=') + 1:] for arg in args if arg.startswith('--resultlog=')]
       if resultlogs:
         return resultlogs[0]
       if not resultlogs:


### PR DESCRIPTION
"--resultlog filename" format.
always put the result log at the beginning in order not to potentially
interfere with other arguments.