### PR TITLE
[Trigger CI] Use jvm-compilers as the parent of isolation workunits instead of 'isola...

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -195,6 +195,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
                                           self.get_options(),
                                           self.workdir,
                                           self.create_analysis_tools(),
+                                          self._language,
                                           lambda s: s.endswith(self._file_suffix))
 
   def _jvm_fingerprint_strategy(self):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
@@ -59,8 +59,9 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
     register('--delete-scratch', default=True, action='store_true',
              help='Leave intermediate scratch files around, for debugging build problems.')
 
-  def __init__(self, context, options, workdir, analysis_tools, sources_predicate):
-    super(JvmCompileGlobalStrategy, self).__init__(context, options, workdir, analysis_tools, sources_predicate)
+  def __init__(self, context, options, workdir, analysis_tools, language, sources_predicate):
+    super(JvmCompileGlobalStrategy, self).__init__(context, options, workdir, analysis_tools,
+                                                   language, sources_predicate)
 
     # Various working directories.
     # NB: These are grandfathered in with non-strategy-specific names, but to prevent

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
@@ -79,6 +79,9 @@ class JvmCompileIsolatedStrategy(JvmCompileStrategy):
     # This ensures the workunit for the worker pool is set
     with self.context.new_workunit('isolation-{}-pool-bootstrap'.format(self._language)) \
             as workunit:
+      # This uses workunit.parent as the WorkerPool's parent so that child workunits
+      # of different pools will show up in order in the html output. This way the current running
+      # workunit is on the bottom of the page rather than possibly in the middle.
       self._worker_pool = WorkerPool(workunit.parent,
                                      self.context.run_tracker,
                                      self._worker_count)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_strategy.py
@@ -62,7 +62,8 @@ class JvmCompileStrategy(object):
     """
     pass
 
-  def __init__(self, context, options, workdir, analysis_tools, sources_predicate):
+  def __init__(self, context, options, workdir, analysis_tools, language, sources_predicate):
+    self._language = language
     self.context = context
     self._analysis_tools = analysis_tools
 


### PR DESCRIPTION
...tion', add workunits for analysis

Before the execution graph's time was under isolation for each of the compiler types. This made it harder to see what was going on because the context managed by isolation was only creating the pool of workers. Moving them to have jvm-compilers as a parent means that as each compile runs, it gets appended to the same list even if it is using a different task. This makes it easier to see things over time in the html reporter output