### PR TITLE
[Trigger CI] Remove an unused config reference.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/wire_gen.py
+++ b/src/python/pants/backend/codegen/tasks/wire_gen.py
@@ -39,7 +39,6 @@ class WireGen(CodeGen, JvmToolTaskMixin):
   def __init__(self, *args, **kwargs):
     """Generates Java files from .proto files using the Wire protobuf compiler."""
     super(WireGen, self).__init__(*args, **kwargs)
-    self.wire_version = self.context.config.get('wire-gen', 'version', default='1.6.0')
     self.java_out = os.path.join(self.workdir, 'gen-java')
 
   def resolve_deps(self, key, default=None):


### PR DESCRIPTION
If needed in the future, it can be added back as an option.