### PR TITLE
[Trigger CI] propagate keyboard interrupts from worker threads

### DIFF
--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -9,6 +9,7 @@ import multiprocessing
 import os
 import signal
 import sys
+import thread
 import threading
 from multiprocessing.pool import ThreadPool
 
@@ -140,6 +141,11 @@ class WorkerPool(object):
           return func(*args_tuple)
       else:
         return func(*args_tuple)
+    except KeyboardInterrupt:
+      # If a worker thread intercepts a KeyboardInterrupt, we want to propagate it to the main
+      # thread.
+      thread.interrupt_main()
+      raise
     except Exception as e:
       if on_failure:
         # Note that here the work's workunit is closed. So, e.g., it's OK to use on_failure()

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -53,6 +53,7 @@ target(
     ':run_info',
     ':source_root',
     ':target',
+    ':worker_pool',
   ]
 )
 
@@ -329,5 +330,14 @@ python_tests(
   sources = [ 'test_spec_exclude_integration.py' ],
   dependencies = [
     'tests/python/pants_test:int-test',
+  ]
+)
+
+python_tests(
+  name = 'worker_pool',
+  sources = ['test_worker_pool.py'],
+  dependencies = [
+    'src/python/pants/base:worker_pool',
+    'src/python/pants/util:contextutil',
   ]
 )

--- a/tests/python/pants_test/base/test_worker_pool.py
+++ b/tests/python/pants_test/base/test_worker_pool.py
@@ -25,6 +25,7 @@ def keyboard_interrupt_raiser():
 class WorkerPoolTest(unittest.TestCase):
   def test_keyboard_interrupts_propagated(self):
     condition = threading.Condition()
+    condition.acquire()
     with self.assertRaises(KeyboardInterrupt):
       with temporary_dir() as rundir:
         pool = WorkerPool(WorkUnit(rundir, None, "work"), FakeRunTracker(), 1)

--- a/tests/python/pants_test/base/test_worker_pool.py
+++ b/tests/python/pants_test/base/test_worker_pool.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import threading
+import time
+import unittest
+
+from pants.base.worker_pool import Work, WorkerPool
+from pants.base.workunit import WorkUnit
+from pants.util.contextutil import temporary_dir
+
+
+class FakeRunTracker(object):
+  def register_thread(self, one):
+    pass
+
+
+def keyboard_interrupt_raiser():
+  raise KeyboardInterrupt()
+
+class WorkerPoolTest(unittest.TestCase):
+  def test_keyboard_interrupts_propagated(self):
+    condition = threading.Condition()
+    with self.assertRaises(KeyboardInterrupt):
+      with temporary_dir() as rundir:
+        pool = WorkerPool(WorkUnit(rundir, None, "work"), FakeRunTracker(), 1)
+        try:
+          pool.submit_async_work(Work(keyboard_interrupt_raiser, [()]))
+          condition.wait(2)
+        finally:
+          pool.abort()


### PR DESCRIPTION
If a worker thread happens to be the active thread, Ctrl-C will kill it, but not the pants process because the interrupt isn't propagated to the main thread. This changes the WorkerPool s.t. it's work definition will intercept a keyboard interrupt and interrupt main