### PR TITLE
[Trigger CI] A new rebasing API.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -18,4 +18,4 @@ setuptools==5.4.1
 six==1.8.0
 thrift==0.9.1
 wheel==0.23.0
-zincutils==0.2.1
+zincutils==0.3

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis.py
@@ -26,14 +26,10 @@ class Analysis(object):
     """
     raise NotImplementedError()
 
-  def write_to_path(self, outfile_path, rebasings=None):
+  def write_to_path(self, outfile_path):
     with open(outfile_path, 'w') as outfile:
-      self.write(outfile, rebasings)
+      self.write(outfile)
 
-  def write(self, outfile, rebasings=None):
-    """Write this Analysis to outfile.
-
-    rebasings: A list of path prefix pairs [from_prefix, to_prefix] to rewrite.
-               to_prefix may be None, in which case matching paths are removed entirely.
-    """
+  def write(self, outfile):
+    """Write this Analysis to outfile."""
     raise NotImplementedError()

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_parser.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_parser.py
@@ -51,7 +51,7 @@ class AnalysisParser(object):
     """
     if not os.path.exists(path):
       return
-    with open(path, 'r') as infile:
+    with open(path, 'rb') as infile:
       with raise_on_eof(infile):
         # The first line of the file should contain the expected header.
         firstline = infile.next()
@@ -65,10 +65,10 @@ class AnalysisParser(object):
     """Does the specified analysis file contain information for at least one source file."""
     if not os.path.exists(path):
       return False
-    with open(path, 'r') as infile:
+    with open(path, 'rb') as infile:
       with raise_on_eof(infile):
         # Skip until we get to the section that will be nonempty iff the analysis is nonempty.
-        expected_header = '{0}:\n'.format(self.empty_test_header)
+        expected_header = b'{0}:\n'.format(self.empty_test_header)
         while infile.next() != expected_header:
           pass
         # Now see if this section is empty or not.
@@ -76,7 +76,7 @@ class AnalysisParser(object):
 
   def parse_from_path(self, infile_path):
     """Parse an analysis instance from a text file."""
-    with open(infile_path, 'r') as infile:
+    with open(infile_path, 'rb') as infile:
       return self.parse(infile)
 
   def parse(self, infile):
@@ -88,7 +88,7 @@ class AnalysisParser(object):
 
     Returns a map of src -> list of classfiles. All paths are absolute.
     """
-    with open(infile_path, 'r') as infile:
+    with open(infile_path, 'rb') as infile:
       return self.parse_products(infile, classes_dir)
 
   def parse_products(self, infile, classes_dir):
@@ -105,7 +105,7 @@ class AnalysisParser(object):
                         of class->element on the classpath that provides that class.
                         We use this indirection to avoid unnecessary precomputation.
     """
-    with open(infile_path, 'r') as infile:
+    with open(infile_path, 'rb') as infile:
       return self.parse_deps(infile, classpath_indexer, classes_dir)
 
   def parse_deps(self, infile, classpath_indexer, classes_dir):
@@ -130,3 +130,23 @@ class AnalysisParser(object):
     if not matchobj:
       raise ParseError('Expected: "<num> items". Found: "{0}"'.format(line))
     return int(matchobj.group(1))
+
+  def rebase_from_path(self, infile_path, outfile_path, pants_home_from, pants_home_to,
+                       java_home=None):
+    """Rebase an analysis at infile_path, writing the result to outfile_path.
+
+    See rebase() below for an explanation of rebasing.
+    """
+    with open(infile_path, 'rb') as infile:
+      with open(outfile_path, 'wb') as outfile:
+        self.rebase(infile, outfile, pants_home_from, pants_home_to, java_home)
+
+  def rebase(self, infile, outfile, pants_home_from, pants_home_to, java_home=None):
+    """Rebase an analysis read from infile and write the result to outfile.
+
+    Rebasing means replacing references to paths under pants_home_from with references to
+    equivalent paths under pants_home_to.
+
+    If java_home is specified then any references to paths under it are scrubbed entirely.
+    """
+    raise NotImplementedError()

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis.py
@@ -58,41 +58,26 @@ class JMakeAnalysis(Analysis):
 
     return [JMakeAnalysis(x, y) for x, y in zip(split_pcd_entries, split_src_to_deps)]
 
-  def write(self, outfile, rebasings=None):
-    # Note that the only paths in a jmake analysis are source files.
-    def rebase_path(path):
-      if rebasings:
-        for rebase_from, rebase_to in rebasings:
-          if rebase_to is None:
-            if path.startswith(rebase_from):
-              return None
-          else:
-            path = path.replace(rebase_from, rebase_to)
-      return path
-
-    outfile.write('pcd entries:\n')
-    outfile.write('{} items\n'.format(len(self.pcd_entries)))
+  def write(self, outfile):
+    # TODO: Profile and optimize this. For example, it can be faster to write in large chunks, even
+    # at the cost of a large string join.
+    outfile.write(b'pcd entries:\n')
+    outfile.write(b'{} items\n'.format(len(self.pcd_entries)))
     for pcd_entry in self.pcd_entries:
-      rebased_src = rebase_path(pcd_entry[1])
-      if rebased_src:
-        outfile.write(pcd_entry[0])
-        outfile.write('\t')
-        outfile.write(rebased_src)
-        for x in pcd_entry[2:]:
-          outfile.write('\t')
-          outfile.write(x)
-          # Note that last element already includes \n.
+      # Note that last element in pcd_entry already ends with a \n, so we don't write one.
+      outfile.write(b'\t'.join(pcd_entry))
 
-    outfile.write('dependencies:\n')
-    outfile.write('{} items\n'.format(len(self.src_to_deps)))
-    for src, deps in self.src_to_deps.items():
-      rebased_src = rebase_path(src)
-      if rebased_src:
-        outfile.write(rebased_src)
-        for dep in deps:
-          outfile.write('\t')
-          outfile.write(dep)
-        outfile.write('\n')
+    outfile.write(b'dependencies:\n')
+    outfile.write(b'{} items\n'.format(len(self.src_to_deps)))
+    if os.environ.get('JMAKE_SORTED_ANALYSIS'):  # Useful in tests.
+      lines = []
+      for src, deps in self.src_to_deps.items():
+        lines.append(b'{src}\t{deps}\n'.format(src=src, deps=b'\t'.join(deps)))
+      for line in sorted(lines):
+        outfile.write(line)
+    else:
+      for src, deps in self.src_to_deps.items():
+        outfile.write(b'{src}\t{deps}\n'.format(src=src, deps=b'\t'.join(deps)))
 
   def compute_products(self):
     """Returns the products in this analysis.
@@ -107,5 +92,8 @@ class JMakeAnalysis(Analysis):
     for pcd_entry in self.pcd_entries:
       srcfile = pcd_entry[1]
       # In the file classes are represented with slashes, not dots. E.g., com/foo/bar/Baz.
-      src_to_classfiles[srcfile].append(pcd_entry[0] + '.class')
+      src_to_classfiles[srcfile].append(pcd_entry[0] + b'.class')
     return src_to_classfiles
+
+  def is_equal_to(self, other):
+    return (self.pcd_entries, self.src_to_deps) == (other.pcd_entries, other.src_to_deps)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis_parser.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/jmake_analysis_parser.py
@@ -18,49 +18,49 @@ from pants.base.build_environment import get_buildroot
 class JMakeAnalysisParser(AnalysisParser):
   """Parse a file containing representation of an analysis for some JVM language."""
 
-  empty_test_header = 'pcd entries'
-  current_test_header = 'pcd entries:\n'
+  empty_test_header = b'pcd entries'
+  current_test_header = b'pcd entries:\n'
 
-  def parse(self, infile):
-    self._expect_header(infile.readline(), 'pcd entries')
-    num_pcd_entries = self.parse_num_items(infile.readline())
+  def parse(self, lines_iter):
+    self._expect_header(lines_iter.next(), 'pcd entries')
+    num_pcd_entries = self.parse_num_items(lines_iter.next())
     pcd_entries = []
     for i in range(0, num_pcd_entries):
-      line = infile.readline()
-      tpl = line.split('\t')
+      line = lines_iter.next()
+      tpl = line.split(b'\t')
       if len(tpl) != 5:
         raise ParseError('Line must contain 5 tab-separated fields: {}'.format(line))
       pcd_entries.append(tpl)  # Note: we preserve the \n on the last entry.
-    src_to_deps = self._parse_deps_at_position(infile)
+    src_to_deps = self._parse_deps_at_position(lines_iter)
     return JMakeAnalysis(pcd_entries, src_to_deps)
 
-  def parse_products(self, infile, classes_dir):
-    self._expect_header(infile.readline(), 'pcd entries')
-    num_pcd_entries = self.parse_num_items(infile.readline())
+  def parse_products(self, lines_iter, classes_dir):
+    self._expect_header(lines_iter.next(), b'pcd entries')
+    num_pcd_entries = self.parse_num_items(lines_iter.next())
     ret = defaultdict(list)
     # Parse more efficiently than above, since we only care about
     # the first two elements in the line.
     for _ in range(0, num_pcd_entries):
-      line = infile.readline()
-      p1 = line.find('\t')
-      clsfile = os.path.join(classes_dir, line[0:p1] + '.class')
-      p2 = line.find('\t', p1 + 1)
+      line = lines_iter.next()
+      p1 = line.find(b'\t')
+      clsfile = os.path.join(classes_dir, line[0:p1] + b'.class')
+      p2 = line.find(b'\t', p1 + 1)
       src = line[p1+1:p2]
       ret[src].append(clsfile)
     return ret
 
-  def parse_deps(self, infile, classpath_indexer, classes_dir):
+  def parse_deps(self, lines_iter, classpath_indexer, classes_dir):
     buildroot = get_buildroot()
     classpath_elements_by_class = classpath_indexer()
-    self._expect_header(infile.readline(), 'pcd entries')
-    num_pcd_entries = self.parse_num_items(infile.readline())
+    self._expect_header(lines_iter.next(), b'pcd entries')
+    num_pcd_entries = self.parse_num_items(lines_iter.next())
     for _ in range(0, num_pcd_entries):
-      infile.readline()  # Skip these lines.
-    src_to_deps = self._parse_deps_at_position(infile)
+      lines_iter.next()  # Skip these lines.
+    src_to_deps = self._parse_deps_at_position(lines_iter)
     ret = defaultdict(set)
     for src, deps in src_to_deps.items():
       for dep in deps:
-        rel_classfile = dep + '.class'
+        rel_classfile = dep + b'.class'
         # Check if we have an internal class first.
         internal_classfile = os.path.join(buildroot, classes_dir, rel_classfile)
         if os.path.exists(internal_classfile):
@@ -72,12 +72,38 @@ class JMakeAnalysisParser(AnalysisParser):
 
     return ret
 
-  def _parse_deps_at_position(self, infile):
-    self._expect_header(infile.readline(), 'dependencies')
-    num_deps = self.parse_num_items(infile.readline())
+  def rebase(self, lines_iter, outfile, pants_home_from, pants_home_to, java_home=None):
+    # Note that jmake analysis contains no references to jars under java_home,
+    # so we don't use that arg.
+    # TODO: Profile and optimize this. For example, it can be faster to write in large chunks, even
+    # at the cost of a large string join.
+    self._expect_header(lines_iter.next(), b'pcd entries')
+    num_pcd_entries = self.parse_num_items(lines_iter.next())
+    outfile.write(b'pcd entries:\n')
+    outfile.write(b'{} items\n'.format(num_pcd_entries))
+    for i in range(num_pcd_entries):
+      line = lines_iter.next()
+      tpl = line.split(b'\t', 2)
+      if tpl[1].startswith(pants_home_from):
+        tpl[1] = pants_home_to + tpl[1][len(pants_home_from):]
+      outfile.write(b'\t'.join(tpl))
+
+    self._expect_header(lines_iter.next(), b'dependencies')
+    num_deps = self.parse_num_items(lines_iter.next())
+    outfile.write(b'dependencies:\n')
+    outfile.write(b'{} items\n'.format(num_deps))
+    for i in range(num_deps):
+      line = lines_iter.next()
+      if line.startswith(pants_home_from):
+        line = pants_home_to + line[len(pants_home_from):]
+      outfile.write(line)
+
+  def _parse_deps_at_position(self, lines_iter):
+    self._expect_header(lines_iter.next(), b'dependencies')
+    num_deps = self.parse_num_items(lines_iter.next())
     src_to_deps = {}
     for i in range(0, num_deps):
-      tpl = infile.readline().split('\t')
+      tpl = lines_iter.next().split(b'\t')
       src = tpl[0]
       deps = tpl[1:]
       deps[-1] = deps[-1][0:-1]  # Trim off the \n.
@@ -85,6 +111,6 @@ class JMakeAnalysisParser(AnalysisParser):
     return src_to_deps
 
   def _expect_header(self, line, header):
-    expected = header + ':\n'
+    expected = header + b':\n'
     if line != expected:
       raise ParseError('Expected: {}. Found: {}'.format(expected, line))

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis.py
@@ -32,7 +32,7 @@ class ZincAnalysis(Analysis):
     ./pants test tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala:zinc_analysis
   """
 
-  FORMAT_VERSION_LINE = 'format version: 5\n'
+  FORMAT_VERSION_LINE = UnderlyingAnalysis.FORMAT_VERSION_LINE
 
   @classmethod
   def merge(cls, analyses):
@@ -54,8 +54,8 @@ class ZincAnalysis(Analysis):
                   for x in splits]
     return [ZincAnalysis(s) for s in self.underlying_analysis.split(abs_splits, catchall)]
 
-  def write(self, outfile, rebasings=None):
-    self.underlying_analysis.write(outfile, rebasings)
+  def write(self, outfile):
+    self.underlying_analysis.write(outfile)
 
   def diff(self, other):
     return self.underlying_analysis.diff(other.underlying_analysis)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_parser.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis_parser.py
@@ -19,7 +19,7 @@ class ZincAnalysisParser(AnalysisParser):
   """
 
   # Implement AnalysisParser properties.
-  empty_test_header = 'products'
+  empty_test_header = b'products'
   current_test_header = ZincAnalysis.FORMAT_VERSION_LINE
 
   def __init__(self):
@@ -47,5 +47,12 @@ class ZincAnalysisParser(AnalysisParser):
     with raise_on_eof(infile):
       try:
         return self._underlying_parser.parse_deps(infile, classes_dir)
+      except UnderlyingParser.ParseError as e:
+        raise ParseError(e)
+
+  def rebase(self, infile, outfile, pants_home_from, pants_home_to, java_home=None):
+    with raise_on_eof(infile):
+      try:
+        self._underlying_parser.rebase(infile, outfile, pants_home_from, pants_home_to, java_home)
       except UnderlyingParser.ParseError as e:
         raise ParseError(e)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -4,8 +4,19 @@
 target(
   name='java',
   dependencies=[
+    ':jmake_analysis'
   ],
 )
+
+python_tests(
+  name='jmake_analysis',
+  sources=['test_jmake_analysis.py'],
+  dependencies=[
+    'src/python/pants/backend/jvm/tasks/jvm_compile:java',
+    'src/python/pants/util:contextutil',
+  ]
+)
+
 
 python_tests(
   name='apt_compile_integration',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_jmake_analysis.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_jmake_analysis.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import StringIO
+import unittest
+
+from pants.backend.jvm.tasks.jvm_compile.java.jmake_analysis import JMakeAnalysis
+from pants.backend.jvm.tasks.jvm_compile.java.jmake_analysis_parser import JMakeAnalysisParser
+from pants.util.contextutil import environment_as
+
+
+class TestJmakeAnalysis(unittest.TestCase):
+  def setUp(self):
+    self.maxDiff = None
+
+  def test_simple(self):
+    def get_test_analysis_path(name):
+      return os.path.join(os.path.dirname(__file__), 'testdata', 'simple', name)
+
+    def get_analysis_text(name):
+      with open(get_test_analysis_path(name), 'r') as fp:
+        return fp.read()
+
+    def parse_analyis(name):
+      return JMakeAnalysisParser().parse_from_path(get_test_analysis_path(name))
+
+    def analysis_to_string(analysis):
+      buf = StringIO.StringIO()
+      analysis.write(buf)
+      return buf.getvalue()
+
+    with environment_as(JMAKE_SORTED_ANALYSIS='1'):
+      full_analysis = parse_analyis('simple.analysis')
+
+      analysis_splits = full_analysis.split([
+        [b'/src/pants/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java'],
+        [b'/src/pants/examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java'],
+      ])
+      self.assertEquals(len(analysis_splits), 2)
+
+      def compare_split(i):
+        expected_filename = 'simple_split{0}.analysis'.format(i)
+
+        # First compare as objects.
+        expected_analyis = parse_analyis(expected_filename)
+        self.assertTrue(expected_analyis.is_equal_to(analysis_splits[i]))
+
+        # Then compare as text.
+        expected = get_analysis_text(expected_filename)
+        actual = analysis_to_string(analysis_splits[i])
+        self.assertMultiLineEqual(expected, actual)
+
+      compare_split(0)
+      compare_split(1)
+
+      # Now merge and check that we get what we started with.
+      merged_analysis = JMakeAnalysis.merge(analysis_splits)
+      # Check that they compare as objects.
+      self.assertTrue(full_analysis.is_equal_to(merged_analysis))
+      # Check that they compare as text.
+      expected = get_analysis_text('simple.analysis')
+      actual = analysis_to_string(merged_analysis)
+      self.assertMultiLineEqual(expected, actual)
+
+      # Now check rebasing.
+      orig = iter(get_analysis_text('simple.analysis').splitlines(True))
+      expected_rebased = get_analysis_text('simple.rebased.analysis')
+      buf = StringIO.StringIO()
+      JMakeAnalysisParser().rebase(orig, buf, b'/src/pants', b'$PANTS_HOME')
+      rebased = buf.getvalue()
+      self.assertMultiLineEqual(expected_rebased, rebased)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple.analysis
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple.analysis
@@ -1,0 +1,8 @@
+pcd entries:
+2 items
+org/pantsbuild/example/hello/greet/Greeting	/src/pants/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java	1430672789000	3705639092	DummyBlob0
+org/pantsbuild/example/hello/main/HelloMain	/src/pants/examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java	1430672789000	2925777736	DummyBlob1
+dependencies:
+2 items
+/src/pants/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java	java/io/FileInputStream	org/pantsbuild/example/hello/greet/Greeting	java/util/Scanner	java/lang/StringBuilder	java/lang/Object	java/lang/String	java/lang/Throwable	java/io/IOException	java/io/InputStream	java/lang/Class	java/lang/ClassLoader
+/src/pants/examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java	org/pantsbuild/example/hello/main/HelloMain	java/lang/Object	java/io/IOException	java/lang/System	org/pantsbuild/example/hello/greet/Greeting	java/io/PrintStream

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple.rebased.analysis
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple.rebased.analysis
@@ -1,0 +1,8 @@
+pcd entries:
+2 items
+org/pantsbuild/example/hello/greet/Greeting	$PANTS_HOME/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java	1430672789000	3705639092	DummyBlob0
+org/pantsbuild/example/hello/main/HelloMain	$PANTS_HOME/examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java	1430672789000	2925777736	DummyBlob1
+dependencies:
+2 items
+$PANTS_HOME/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java	java/io/FileInputStream	org/pantsbuild/example/hello/greet/Greeting	java/util/Scanner	java/lang/StringBuilder	java/lang/Object	java/lang/String	java/lang/Throwable	java/io/IOException	java/io/InputStream	java/lang/Class	java/lang/ClassLoader
+$PANTS_HOME/examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java	org/pantsbuild/example/hello/main/HelloMain	java/lang/Object	java/io/IOException	java/lang/System	org/pantsbuild/example/hello/greet/Greeting	java/io/PrintStream

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple_split0.analysis
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple_split0.analysis
@@ -1,0 +1,6 @@
+pcd entries:
+1 items
+org/pantsbuild/example/hello/greet/Greeting	/src/pants/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java	1430672789000	3705639092	DummyBlob0
+dependencies:
+1 items
+/src/pants/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java	java/io/FileInputStream	org/pantsbuild/example/hello/greet/Greeting	java/util/Scanner	java/lang/StringBuilder	java/lang/Object	java/lang/String	java/lang/Throwable	java/io/IOException	java/io/InputStream	java/lang/Class	java/lang/ClassLoader

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple_split1.analysis
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/testdata/simple/simple_split1.analysis
@@ -1,0 +1,6 @@
+pcd entries:
+1 items
+org/pantsbuild/example/hello/main/HelloMain	/src/pants/examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java	1430672789000	2925777736	DummyBlob1
+dependencies:
+1 items
+/src/pants/examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java	org/pantsbuild/example/hello/main/HelloMain	java/lang/Object	java/io/IOException	java/lang/System	org/pantsbuild/example/hello/greet/Greeting	java/io/PrintStream


### PR DESCRIPTION
- Matches the new (and more efficient) rebasing functionality in zincutils.
- Makes JMake analysis rebasing fit this new model.
- Adds a basic unittest for JMake analysis manipulation, finally.
- Gets rid of __eq__ and __hash__, which were both broken.
- Replaced with an is_equal_to method for use in tests.
- Introduces optional sorting of items, for ease of testing.