### PR TITLE
[Trigger CI] Remove the reference to config in Context.

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -224,7 +224,6 @@ class GoalRunner(object):
     update_reporting(self.global_options, is_quiet_task() or is_explain, self.run_tracker)
 
     context = Context(
-      config=self.config,
       options=self.options,
       run_tracker=self.run_tracker,
       target_roots=self.targets,

--- a/src/python/pants/docs/dev_tasks.md
+++ b/src/python/pants/docs/dev_tasks.md
@@ -102,20 +102,9 @@ file paths.
 Task Configuration
 ------------------
 
-Tasks may be configured in two ways:
+Tasks may be configured via options.
 
--   a configuration file
--   command-line flags
-
-The configuration file is normally called `pants.ini` and is a standard
-`ini` file loaded with `ConfigParser`. During instantiation, tasks have
-access to a `pants.base.config.Config` to read these settings.
-
-    :::python
-    # Let's read mykey from the mytask pants.ini section.
-    self.context.config.get('mytask', 'mykey')
-
-To define a command-line flag, handle your Task's `register_options`
+To define an option, handle your Task's `register_options`
 class method and call the passed-in `register` function:
 
 !inc[start-after=ListGoals&end-before=console_output](../backend/core/tasks/list_goals.py)
@@ -123,8 +112,24 @@ class method and call the passed-in `register` function:
 Option values are available via `self.get_options()`:
 
     :::python
-    # Did user pass in the --all CLI flag (or set it in .ini)?
-    if self.get_options().all:
+    # Did user pass in the --my-option CLI flag (or set it in .ini)?
+    if self.get_options().my_option:
+
+Every task has an options scope: If the task is registered as `task` in goal `goal`, then its
+scope is `goal.task`, unless goal and task are the same string, in which case the scope is simply
+that string. For example, the `JavaCompile` task has scope `compile.java`, and the `filemap`
+task has the scope `filemap`.
+
+The scope is used to set options values. E.g., the value of `self.get_options().my_option` for a
+task with scope `scope` is set by, in this order:
+  - The value of the cmd-line flag `--scope-my-option`.
+  - The value of the environment variable `PANTS_SCOPE_MY_OPTION`.
+  - The value of the config var `my_option` in section `scope`.
+
+Note that if the task being run is specified explicitly on the command line, you can omit the
+scope from the cmd-line flag name. For example, instead of
+`./pants compile --compile-java-foo-bar` you can do `./pants compile.java --foo-bar`.
+
 
 GroupTask
 ---------

--- a/src/python/pants/docs/taskdev/taskdev.asc
+++ b/src/python/pants/docs/taskdev/taskdev.asc
@@ -122,8 +122,7 @@ Constructor is called "on the way in." What typically happens?
 
 What's in +context+?
 
-* +self.context.config+ - access the configuration file
-* +self.context.options+ - access command-line flags
+* +self.context.options+ - access option values
 * +self.context.log+ - access the logger
 * +self.context.products+ - access the product mapping
 
@@ -144,33 +143,10 @@ Execute is called "on the way out." Its where your task instance does its thing.
 * Do whatever needs to happen to the target.
 
 
-== Task Configuration
-
-Pants is configured in two ways:
-
-* command-line flags - for per-invocation options
-* repo configuration file - configure optional behavior for the whole repo
-
-Read +mykey+ from the +mytask+ configuration file section.
-
-----
-
-self.context.config.get('mytask', 'mykey')
-----
-
-Access a command-line flag the task defined.
-
-----
-self.context.options.myflag
-----
+== Task O
 
 ////
-* Command-line flags
-* Repo Configuration file
-* User Configuration file
-* Does something really need to be configurable?
-* Give it a sensible default.
-* Read & validate configuration as early as possible and give good error messages.
+* TODO: Discuss options system as it relates to tasks.
 ////
 
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -58,11 +58,10 @@ class Context(object):
 
   # TODO: Figure out a more structured way to construct and use context than this big flat
   # repository of attributes?
-  def __init__(self, config, options, run_tracker, target_roots,
+  def __init__(self, options, run_tracker, target_roots,
                requested_goals=None, target_base=None, build_graph=None,
                build_file_parser=None, address_mapper=None, console_outstream=None, scm=None,
                workspace=None, spec_excludes=None):
-    self._config = config
     self._options = options
     self.build_graph = build_graph
     self.build_file_parser = build_file_parser
@@ -81,11 +80,6 @@ class Context(object):
     self._spec_excludes = spec_excludes
     self._replace_targets(target_roots)
     self._synthetic_targets = defaultdict(list)
-
-  @property
-  def config(self):
-    """Returns a Config object containing the configuration data found in pants.ini."""
-    return self._config
 
   @property
   def options(self):

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -35,7 +35,6 @@ python_library(
     'src/python/pants/base:build_graph',
     'src/python/pants/base:build_root',
     'src/python/pants/base:cmd_line_spec_parser',
-    'src/python/pants/base:config',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:target',
     'src/python/pants/goal:goal',

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -7,7 +7,6 @@ python_library(
   dependencies = [
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/base:config',
     'src/python/pants/base:target',
     'src/python/pants/goal:context',
   ]

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -41,15 +41,6 @@ from pants_test.base.context_utils import create_context
 class BaseTest(unittest.TestCase):
   """A baseclass useful for tests requiring a temporary buildroot."""
 
-  @classmethod
-  def setUpClass(cls):
-    """Ensure that all code has a config to read from the cache.
-
-    TODO: Yuck. Get rid of this after plumbing options through in the right places.
-    """
-    super(BaseTest, cls).setUpClass()
-    Config.cache(Config.load())
-
   def build_path(self, relpath):
     """Returns the canonical BUILD file path for the given relative build path."""
     if os.path.basename(relpath).startswith('BUILD'):

--- a/tests/python/pants_test/python/BUILD
+++ b/tests/python/pants_test/python/BUILD
@@ -53,9 +53,7 @@ python_tests(name = 'test_resolver',
   sources = ['test_resolver.py'],
   dependencies = [
     '3rdparty/python:pex',
-    'src/python/pants/base:config',
     'src/python/pants/backend/python:resolver',
-    'src/python/pants/util:contextutil',
   ],
 )
 

--- a/tests/python/pants_test/python/test_resolver.py
+++ b/tests/python/pants_test/python/test_resolver.py
@@ -10,24 +10,10 @@ import unittest
 from pex.platforms import Platform
 
 from pants.backend.python.resolver import get_platforms
-from pants.base.config import Config
-from pants.util.contextutil import temporary_file
 
 
 class ResolverTest(unittest.TestCase):
-  def setUp(self):
-    with temporary_file() as ini:
-      ini.write(
-'''
-[python-setup]
-platforms: [
-  'current',
-  'linux-x86_64']
-''')
-      ini.close()
-      self.config = Config.load(configpaths=[ini.name])
-
   def test_get_current_platform(self):
     expected_platforms = [Platform.current(), 'linux-x86_64']
     self.assertEqual(set(expected_platforms),
-                     set(get_platforms(self.config.getlist('python-setup', 'platforms'))))
+                     set(get_platforms(['current', 'linux-x86_64'])))


### PR DESCRIPTION
No tasks use it any more, and this will help prevent
future code from accessing config directly, instead
of through the options system.