### PR TITLE
[Trigger CI] Restore Config caching in tests.

### DIFF
--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -41,6 +41,15 @@ from pants_test.base.context_utils import create_context
 class BaseTest(unittest.TestCase):
   """A baseclass useful for tests requiring a temporary buildroot."""
 
+  @classmethod
+  def setUpClass(cls):
+    """Ensure that all code has a config to read from the cache.
+
+    TODO: Yuck. Get rid of this after plumbing options through in the right places.
+    """
+    super(BaseTest, cls).setUpClass()
+    Config.cache(Config.load())
+
   def build_path(self, relpath):
     """Returns the canonical BUILD file path for the given relative build path."""
     if os.path.basename(relpath).startswith('BUILD'):


### PR DESCRIPTION
It turns out that some tests still use it, subtly.
Things were working before because of the order in which
some tests happened to be run :(

TODO: Figure out that test interdependency issue.