### PR TITLE
[Trigger CI] Ensure that every test begins with a properly reset build root.

### DIFF
--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -50,6 +50,9 @@ class BuildRoot(Singleton):
       raise ValueError('Build root does not exist: {}'.format(root_dir))
     self._root_dir = path
 
+  def is_set(self):
+    return self._root_dir is not None
+
   def reset(self):
     """Clears the last calculated build root for the current workspace."""
     self._root_dir = None

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -17,6 +17,7 @@ python_library(
   dependencies = [
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
+    'src/python/pants/base:build_root',
     'src/python/pants/base:config',
     'src/python/pants/base:extension_loader',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -11,6 +11,7 @@ import shutil
 
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.tasks.bootstrap_jvm_tools import BootstrapJvmTools
+from pants.base.build_root import BuildRoot
 from pants.base.config import Config
 from pants.base.extension_loader import load_plugins_and_backends
 from pants.ivy.bootstrapper import Bootstrapper
@@ -30,6 +31,10 @@ class JvmToolTaskTestBase(TaskTestBase):
     # Ensure we get a read of the real pants.ini config
     Config.reset_default_bootstrap_option_values()
     real_config = Config.from_cache()
+    # Loading the config sets BuildRoot, but our superclass setUp() relies on it being unset.
+    # Fortunately we plan to get rid of this direct config read soon, and then we can get rid of
+    # this hack too.
+    BuildRoot().reset()
 
     super(JvmToolTaskTestBase, self).setUp()
 

--- a/tests/python/pants_test/tasks/test_detect_duplicates.py
+++ b/tests/python/pants_test/tasks/test_detect_duplicates.py
@@ -70,6 +70,7 @@ class DuplicateDetectorTest(TaskTestBase):
       }
 
   def tearDown(self):
+    super(DuplicateDetectorTest, self).tearDown()
     safe_rmtree(self.base_dir)
 
   def test_duplicate_found(self):


### PR DESCRIPTION
This is very important: A failure in any test subclass's setUp()
method would cause the unittest framework not to run tearDown().
And BaseTest strongly assumes that tearDown() always runs in order
to clean up state that must not persist across tests.

Chief among this state is the buildroot. If setUp() crashes after
setting the buildroot to the tmpdir, then tearDown() won't run,
and the next test will see the previous test's tmpdir as its
real buildroot. And because we compute relative paths against that
buildroot, we can in some cases end up with a path relative to the
bad buildroot pointing into the real buildroot! If you've ever seen
files mysteriously deleted after a test failure, and had to re-check
 them out of git, this is why.

Because this is so dangerous, we aggressively crash the entire test
run if we detect this state.

Note that we use the build root setting as a proxy for all the state
that's set up in setUp() and reset in tearDown(), because it's by far
the most important such state.

In the future we hope to get rid of the need to know the real buildroot,
but for now it's vital not to misdetect it.