### PR TITLE
[Trigger CI] Streamline some test setup.

### DIFF
--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -13,7 +13,7 @@ from pants.util.meta import Singleton
 
 # TODO: Even this should probably just be a new-style option?
 class BuildRoot(Singleton):
-  """Represents the global workspace build root
+  """Represents the global workspace build root.
 
   By default a pants workspace is defined by a root directory where the workspace configuration
   file - 'pants.ini' - lives.  This can be overridden by exporting 'PANTS_BUILD_ROOT' in the
@@ -59,8 +59,7 @@ class BuildRoot(Singleton):
 
   @contextmanager
   def temporary(self, path):
-    """A contextmanager that establishes a temporary build root, restoring the prior build root on
-    exit."""
+    """Establishes a temporary build root, restoring the prior build root on exit."""
     if path is None:
       raise ValueError('Can only temporarily establish a build root given a path.')
     prior = self._root_dir

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -46,9 +46,6 @@ class Bootstrapper(object):
 
   _INSTANCE = None
 
-  def global_subsystems(cls):
-    return super(Bootstrapper, cls).global_subsystems() + (IvySubsystem, )
-
   @classmethod
   def default_ivy(cls, bootstrap_workunit_factory=None):
     """Returns an Ivy instance using the default global bootstrapper.
@@ -64,7 +61,6 @@ class Bootstrapper(object):
 
   def __init__(self, *args, **kwargs):
     """Creates an ivy bootstrapper."""
-    super(Bootstrapper, self).__init__(*args, **kwargs)
     self._ivy_subsystem = IvySubsystem.global_instance()
     self._version_or_ivyxml = self._ivy_subsystem.get_options().ivy_profile
     self._classpath = None

--- a/tests/python/pants_test/backend/codegen/tasks/BUILD
+++ b/tests/python/pants_test/backend/codegen/tasks/BUILD
@@ -20,6 +20,8 @@ python_tests(
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/codegen/tasks:antlr_gen',
+    'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:source_root',
     'tests/python/pants_test/jvm:nailgun_task_test_base',
   ],
 )

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -35,8 +35,10 @@ python_tests(
   name = 'checkstyle',
   sources = ['test_checkstyle.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:checkstyle',
     'src/python/pants/base:address',
+    'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
     'tests/python/pants_test/jvm:nailgun_task_test_base',
   ]
@@ -87,7 +89,10 @@ python_tests(
   sources = ['test_junit_run.py'],
   dependencies = [
     'src/python/pants/backend/core/targets:common',
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:junit_run',
+    'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:exceptions',
     'src/python/pants/goal:products',
     'src/python/pants/ivy',
     'src/python/pants/java/distribution:distribution',
@@ -109,9 +114,11 @@ python_tests(
   name = 'scalastyle',
   sources = ['test_scalastyle.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/tasks:scalastyle',
     'src/python/pants/base:address',
+    'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
     'tests/python/pants_test/jvm:nailgun_task_test_base',
   ]

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -11,7 +11,9 @@ from collections import defaultdict
 from textwrap import dedent
 
 from pants.backend.core.targets.resources import Resources
+from pants.backend.jvm.targets.java_tests import JavaTests
 from pants.backend.jvm.tasks.junit_run import JUnitRun
+from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants.goal.products import MultipleRootedProducts
 from pants.ivy.bootstrapper import Bootstrapper
@@ -36,9 +38,17 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
   def task_type(cls):
     return JUnitRun
 
+  @property
+  def alias_groups(self):
+    return super(JUnitRunnerTest, self).alias_groups.merge(BuildFileAliases.create(
+      targets={
+        'java_tests': JavaTests,
+      },
+    ))
+
   def test_junit_runner_success(self):
     self.execute_junit_runner(
-      dedent('''
+      dedent("""
         import org.junit.Test;
         import static org.junit.Assert.assertTrue;
         public class FooTest {
@@ -47,13 +57,13 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
             assertTrue(5 > 3);
           }
         }
-      ''')
+      """)
     )
 
   def test_junit_runner_failure(self):
     with self.assertRaises(TaskError) as cm:
       self.execute_junit_runner(
-        dedent('''
+        dedent("""
           import org.junit.Test;
           import static org.junit.Assert.assertTrue;
           public class FooTest {
@@ -62,7 +72,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
               assertTrue(5 < 3);
             }
           }
-        ''')
+        """)
       )
 
     self.assertEqual([t.name for t in cm.exception.failed_targets], ['foo_test'])

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -8,9 +8,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 from textwrap import dedent
 
+from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.scalastyle import FileExcluder, Scalastyle
 from pants.base.address import BuildFileAddress
+from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
@@ -25,6 +27,14 @@ class ScalastyleTest(NailgunTaskTestBase):
   def task_type(cls):
     return Scalastyle
 
+  @property
+  def alias_groups(self):
+    return super(ScalastyleTest, self).alias_groups.merge(BuildFileAliases.create(
+      targets={
+        'java_library': JavaLibrary,
+        'scala_library': ScalaLibrary,
+      },
+    ))
   #
   # Internal test helper section
   #

--- a/tests/python/pants_test/ivy/BUILD
+++ b/tests/python/pants_test/ivy/BUILD
@@ -15,7 +15,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/jvm/tasks:ivy_resolve',
     'src/python/pants/ivy',
-    'src/python/pants/util:contextutil',
+    'src/python/pants/option',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
   ]
 )

--- a/tests/python/pants_test/ivy/test_bootstrapper.py
+++ b/tests/python/pants_test/ivy/test_bootstrapper.py
@@ -43,19 +43,19 @@ class BootstrapperTest(JvmToolTaskTestBase):
     self.assertIsNotNone(ivy.ivy_cache_dir)
     self.assertIsNotNone(ivy.ivy_settings)
 
-  # def test_reset(self):
-  #   bootstrapper1 = Bootstrapper.instance()
-  #   Bootstrapper.reset_instance()
-  #   bootstrapper2 = Bootstrapper.instance()
-  #   self.assertNotEqual(bootstrapper1, bootstrapper2)
+  def test_reset(self):
+    bootstrapper1 = Bootstrapper.instance()
+    Bootstrapper.reset_instance()
+    bootstrapper2 = Bootstrapper.instance()
+    self.assertNotEqual(bootstrapper1, bootstrapper2)
 
   def test_default_ivy(self):
     ivy = Bootstrapper.default_ivy()
     self.assertIsNotNone(ivy.ivy_cache_dir)
     self.assertIsNotNone(ivy.ivy_settings)
 
-  # def test_fresh_bootstrap(self):
-  #   Bootstrapper.default_ivy()
-  #   bootstrap_jar_path = os.path.join(self.test_workdir,
-  #                                     'tools', 'jvm', 'ivy', 'bootstrap.jar')
-  #   self.assertTrue(os.path.exists(bootstrap_jar_path))
+  def test_fresh_bootstrap(self):
+    Bootstrapper.default_ivy()
+    bootstrap_jar_path = os.path.join(self.test_workdir,
+                                      'tools', 'jvm', 'ivy', 'bootstrap.jar')
+    self.assertTrue(os.path.exists(bootstrap_jar_path))

--- a/tests/python/pants_test/ivy/test_bootstrapper.py
+++ b/tests/python/pants_test/ivy/test_bootstrapper.py
@@ -10,7 +10,7 @@ import os
 from pants.backend.core.tasks.task import Task
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.util.contextutil import temporary_dir
+from pants.option.options import Options
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 
 
@@ -32,8 +32,10 @@ class BootstrapperTest(JvmToolTaskTestBase):
 
   def setUp(self):
     super(BootstrapperTest, self).setUp()
-    # Calling self.context() is a hack to make sure subsystems are initialized.
-    self.context()
+    # Make sure subsystems are initialized with the given options.
+    self.context(options={
+      Options.GLOBAL_SCOPE: { 'pants_bootstrapdir': self.test_workdir }
+    })
 
   def test_simple(self):
     bootstrapper = Bootstrapper.instance()
@@ -41,23 +43,19 @@ class BootstrapperTest(JvmToolTaskTestBase):
     self.assertIsNotNone(ivy.ivy_cache_dir)
     self.assertIsNotNone(ivy.ivy_settings)
 
-  def test_reset(self):
-    bootstrapper1 = Bootstrapper.instance()
-    Bootstrapper.reset_instance()
-    bootstrapper2 = Bootstrapper.instance()
-    self.assertNotEqual(bootstrapper1, bootstrapper2)
+  # def test_reset(self):
+  #   bootstrapper1 = Bootstrapper.instance()
+  #   Bootstrapper.reset_instance()
+  #   bootstrapper2 = Bootstrapper.instance()
+  #   self.assertNotEqual(bootstrapper1, bootstrapper2)
 
   def test_default_ivy(self):
     ivy = Bootstrapper.default_ivy()
     self.assertIsNotNone(ivy.ivy_cache_dir)
     self.assertIsNotNone(ivy.ivy_settings)
 
-  def test_fresh_bootstrap(self):
-    with temporary_dir() as fresh_bootstrap_dir:
-      self.set_bootstrap_options(pants_bootstrapdir=fresh_bootstrap_dir)
-      # Initialize the Ivy subsystem
-      self.context()
-      Bootstrapper.default_ivy()
-      bootstrap_jar_path = os.path.join(fresh_bootstrap_dir,
-                                        'tools', 'jvm', 'ivy', 'bootstrap.jar')
-      self.assertTrue(os.path.exists(bootstrap_jar_path))
+  # def test_fresh_bootstrap(self):
+  #   Bootstrapper.default_ivy()
+  #   bootstrap_jar_path = os.path.join(self.test_workdir,
+  #                                     'tools', 'jvm', 'ivy', 'bootstrap.jar')
+  #   self.assertTrue(os.path.exists(bootstrap_jar_path))

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -16,9 +16,10 @@ python_library(
   sources = ['jvm_tool_task_test_base.py'],
   dependencies = [
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
+    'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
     'src/python/pants/base:config',
-    'src/python/pants/base:extension_loader',
+    'src/python/pants/base:build_file_aliases',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/tasks:task_test_base',
   ]

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -495,6 +495,7 @@ python_tests(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:six',
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_task',
     'src/python/pants/base:build_file_aliases',

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -35,8 +35,8 @@ class TaskTestBase(BaseTest):
   def setUp(self):
     super(TaskTestBase, self).setUp()
     self._testing_task_type, self.options_scope = self.synthesize_task_subtype(self.task_type())
-    # We locate the workdir below the pants_workdir, which BaseTest locates within
-    # the BuildRoot.
+    # We locate the workdir below the pants_workdir, which BaseTest locates within the BuildRoot.
+    # BaseTest cleans this up, so we don't need to.
     self._tmpdir = tempfile.mkdtemp(dir=self.pants_workdir)
     self._test_workdir = os.path.join(self._tmpdir, 'workdir')
     os.mkdir(self._test_workdir)

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -15,6 +15,7 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.jar_create import JarCreate, is_jvm_library
+from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.source_root import SourceRoot
 from pants.util.contextutil import open_zip
 from pants_test.jvm.jar_task_test_base import JarTaskTestBase
@@ -24,6 +25,18 @@ class JarCreateTestBase(JarTaskTestBase):
   @classmethod
   def task_type(cls):
     return JarCreate
+
+  @property
+  def alias_groups(self):
+    return super(JarCreateTestBase, self).alias_groups.merge(BuildFileAliases.create(
+      targets={
+        'java_library': JavaLibrary,
+        'java_thrift_library': JavaThriftLibrary,
+        'jvm_binary': JvmBinary,
+        'resources': Resources,
+        'scala_library': ScalaLibrary,
+      },
+    ))
 
   def setUp(self):
     super(JarCreateTestBase, self).setUp()
@@ -50,12 +63,12 @@ class JarCreateExecuteTest(JarCreateTestBase):
 
   def jvm_binary(self, path, name, source=None, resources=None):
     self.create_files(path, [source])
-    self.add_to_build_file(path, dedent('''
+    self.add_to_build_file(path, dedent("""
           jvm_binary(name=%(name)r,
             source=%(source)r,
             resources=[%(resources)r],
           )
-        ''' % dict(name=name, source=source, resources=resources)))
+        """ % dict(name=name, source=source, resources=resources)))
     return self.target('%s:%s' % (path, name))
 
   def java_thrift_library(self, path, name, *sources):


### PR DESCRIPTION
- Handle bootstrap options properly: Previously we were using
  the 'real' bootstrap option values, as set in pants.ini or whatever.
  Now we set the bootstrap option values the same as any other option -
  by capturing the default values, and then overriding those with any options
  specified in the test being run. This improves test isolation, as tests
  will no longer have access to real values by default.

- Get rid of some weird logic around linking ivy support files.
  It's not necessary, since we link the entire ivy support directory anyway.

- Don't bring in every registered BUILD file symbol and every source_root in every
  JvmToolTask test. Each test now brings in just what it needs.