### PR TITLE
[Trigger CI] memoize linkify to reduce reporting file stat calls

### DIFF
--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -52,6 +52,7 @@ class HtmlReporter(Reporter):
 
     # We redirect stdout, stderr etc. of tool invocations to these files.
     self._output_files = defaultdict(dict)  # workunit_id -> {path -> fileobj}.
+    self._linkify_memo = {}
 
   def report_path(self):
     """The path to the main report file."""
@@ -81,7 +82,8 @@ class HtmlReporter(Reporter):
     # Get useful properties from the workunit.
     workunit_dict = workunit.to_dict()
     if workunit_dict['cmd']:
-      workunit_dict['cmd'] = linkify(self._buildroot, workunit_dict['cmd'].replace('$', '\\\\$'))
+      workunit_dict['cmd'] = linkify(self._buildroot, workunit_dict['cmd'].replace('$', '\\\\$'),
+                                     self._linkify_memo)
 
     # Create the template arguments.
     args = { 'indent': len(workunit.ancestors()) * 10,
@@ -264,7 +266,7 @@ class HtmlReporter(Reporter):
   def _htmlify_text(self, s):
     """Make text HTML-friendly."""
     colored = self._handle_ansi_color_codes(cgi.escape(s.decode('utf-8')))
-    return linkify(self._buildroot, colored).replace('\n', '</br>')
+    return linkify(self._buildroot, colored, self._linkify_memo).replace('\n', '</br>')
 
   _ANSI_COLOR_CODE_RE = re.compile(r'\033\[((?:\d|;)*)m')
 

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -20,7 +20,7 @@ _ABS_PATH_COMPONENTS = r'({})+'.format(_ABS_PATH_COMPONENT)
 _OPTIONAL_TARGET_SUFFIX = r'(:{})?'.format(_REL_PATH_COMPONENT)  # For /foo/bar:target.
 
 # Note that we require at least two path components.
-# We require the last characgter to be alphanumeric or underscore, because some tools print an
+# We require the last character to be alphanumeric or underscore, because some tools print an
 # ellipsis after file names (I'm looking at you, zinc). None of our files end in a dot in practice,
 # so this is fine.
 _PATH = _PREFIX + _REL_PATH_COMPONENT + _OPTIONAL_PORT + _ABS_PATH_COMPONENTS + \
@@ -29,10 +29,14 @@ _PATH_RE = re.compile(_PATH)
 
 _NO_URL = "no url" # Sentinel value for non-existent files in linkify's memo
 
-def linkify(buildroot, s, memoized_urls=None):
-  """Augment text by heuristically finding URL and file references and turning them into links."""
-  if memoized_urls is None:
-    memoized_urls = {}
+def linkify(buildroot, s, memoized_urls):
+  """Augment text by heuristically finding URL and file references and turning them into links.
+
+  :param string buildroot: The base directory of the project.
+  :param string s: The text to insert links into.
+  :param dict memoized_urls: A cache of text to links so repeated substitutions don't require
+                             additional file stats calls.
+  """
   def memoized_to_url(m):
     # to_url uses None to signal not to replace the text,
     # so we use a different sentinel value.

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -34,6 +34,8 @@ def linkify(buildroot, s, memoized_urls=None):
   if memoized_urls is None:
     memoized_urls = {}
   def memoized_to_url(m):
+    # to_url uses None to signal not to replace the text,
+    # so we use a different sentinel value.
     value = memoized_urls.get(m.group(0), _NO_URL)
     if value is _NO_URL:
       value = to_url(m)

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -27,10 +27,10 @@ _PATH = _PREFIX + _REL_PATH_COMPONENT + _OPTIONAL_PORT + _ABS_PATH_COMPONENTS + 
         _OPTIONAL_TARGET_SUFFIX + '\w'
 _PATH_RE = re.compile(_PATH)
 
-_NO_URL = "no url"
+_NO_URL = "no url" # Sentinel value for non-existent files in linkify's memo
 
 def linkify(buildroot, s, memoized_urls=None):
-  """Augment text by heuristically finding URL and file references and turning them into links/"""
+  """Augment text by heuristically finding URL and file references and turning them into links."""
   if memoized_urls is None:
     memoized_urls = {}
   def memoized_to_url(m):

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -27,8 +27,19 @@ _PATH = _PREFIX + _REL_PATH_COMPONENT + _OPTIONAL_PORT + _ABS_PATH_COMPONENTS + 
         _OPTIONAL_TARGET_SUFFIX + '\w'
 _PATH_RE = re.compile(_PATH)
 
-def linkify(buildroot, s):
+_NO_URL = "no url"
+
+def linkify(buildroot, s, memoized_urls=None):
   """Augment text by heuristically finding URL and file references and turning them into links/"""
+  if memoized_urls is None:
+    memoized_urls = {}
+  def memoized_to_url(m):
+    value = memoized_urls.get(m.group(0), _NO_URL)
+    if value is _NO_URL:
+      value = to_url(m)
+      memoized_urls[m.group(0)] = value
+    return value
+
   def to_url(m):
     if m.group(1):
       return m.group(0)  # It's an http(s) url.
@@ -44,7 +55,7 @@ def linkify(buildroot, s):
       else:
         putative_dir = path
       if os.path.isdir(os.path.join(buildroot, putative_dir)):
-        build_file = FilesystemBuildFile(buildroot, putative_dir, must_exist=False)
+        build_file = FilesystemBuildFile.from_cache(buildroot, putative_dir, must_exist=False)
         path = build_file.relpath
     if os.path.exists(os.path.join(buildroot, path)):
       # The reporting server serves file content at /browse/<path_from_buildroot>.
@@ -54,4 +65,5 @@ def linkify(buildroot, s):
 
   def maybe_add_link(url, text):
     return '<a target="_blank" href="{}">{}</a>'.format(url, text) if url else text
-  return _PATH_RE.sub(lambda m: maybe_add_link(to_url(m), m.group(0)), s)
+
+  return _PATH_RE.sub(lambda m: maybe_add_link(memoized_to_url(m), m.group(0)), s)

--- a/tests/python/pants_test/reporting/test_linkify.py
+++ b/tests/python/pants_test/reporting/test_linkify.py
@@ -31,22 +31,34 @@ class RunInfoTest(unittest.TestCase):
       shutil.rmtree(self._buildroot, ignore_errors=True)
 
   def _do_test_linkify(self, expected_link, url, memo=None):
-    s = 'foo %s bar' % url
-    expected = 'foo <a target="_blank" href="%s">%s</a> bar' % (expected_link, url)
+    memo = {} if memo is None else memo
+    s = 'foo {} bar'.format(url)
+    expected = 'foo <a target="_blank" href="{}">{}</a> bar'.format(expected_link, url)
     linkified = linkify(self._buildroot, s, memo)
     self.assertEqual(expected, linkified)
+
+  def _do_test_not_linkified(self, url, memo=None):
+    memo = {} if memo is None else memo
+    s = 'foo {} bar'.format(url)
+    linkified = linkify(self._buildroot, s, memo)
+    self.assertEqual(s, linkified)
 
   def test_linkify_absolute_paths(self):
     relpath = 'underscore_and.dot/and-dash/baz'
     path = os.path.join(self._buildroot, relpath)
     ensure_file_exists(path)
-    self._do_test_linkify('/browse/%s' % relpath, path)
+    self._do_test_linkify('/browse/{}'.format(relpath), path)
 
   def test_linkify_relative_paths(self):
     relpath = 'underscore_and.dot/and-dash/baz'
     path = os.path.join(self._buildroot, relpath)
     ensure_file_exists(path)
-    self._do_test_linkify('/browse/%s' % relpath, relpath)
+    self._do_test_linkify('/browse/{}'.format(relpath), relpath)
+
+  def test_linkify_non_existent_relative_paths(self):
+    relpath = 'underscore_and.dot/and-dash/baz'
+
+    self._do_test_not_linkified(relpath)
 
   def test_linkify_http(self):
     url = 'http://foobar.com/baz/qux'
@@ -58,6 +70,10 @@ class RunInfoTest(unittest.TestCase):
   def test_linkify_https(self):
     url = 'https://foobar.com/baz/qux'
     self._do_test_linkify(url, url)
+
+  def test_linkify_ftps(self):
+    url = 'ftps://foobar.com/baz/qux'
+    self._do_test_not_linkified(url)
 
   def test_linkify_target(self):
     ensure_file_exists(os.path.join(self._buildroot, 'foo/bar/BUILD'))

--- a/tests/python/pants_test/reporting/test_linkify.py
+++ b/tests/python/pants_test/reporting/test_linkify.py
@@ -71,8 +71,8 @@ class RunInfoTest(unittest.TestCase):
     url = 'https://foobar.com/baz/qux'
     self._do_test_linkify(url, url)
 
-  def test_linkify_ftps(self):
-    url = 'ftps://foobar.com/baz/qux'
+  def test_linkify_sftp(self):
+    url = 'sftp://foobar.com/baz/qux'
     self._do_test_not_linkified(url)
 
   def test_linkify_target(self):

--- a/tests/python/pants_test/reporting/test_linkify.py
+++ b/tests/python/pants_test/reporting/test_linkify.py
@@ -30,10 +30,10 @@ class RunInfoTest(unittest.TestCase):
     if os.path.exists(self._buildroot):
       shutil.rmtree(self._buildroot, ignore_errors=True)
 
-  def _do_test_linkify(self, expected_link, url):
+  def _do_test_linkify(self, expected_link, url, memo=None):
     s = 'foo %s bar' % url
     expected = 'foo <a target="_blank" href="%s">%s</a> bar' % (expected_link, url)
-    linkified = linkify(self._buildroot, s)
+    linkified = linkify(self._buildroot, s, memo)
     self.assertEqual(expected, linkified)
 
   def test_linkify_absolute_paths(self):
@@ -67,3 +67,9 @@ class RunInfoTest(unittest.TestCase):
   def test_linkify_suffix(self):
     ensure_file_exists(os.path.join(self._buildroot, 'foo/bar/BUILD.suffix'))
     self._do_test_linkify('/browse/foo/bar/BUILD.suffix', 'foo/bar')
+
+  def test_linkify_stores_values_in_memo(self):
+    url = 'https://foobar.com/baz/qux'
+    memo = {}
+    self._do_test_linkify(url, url, memo)
+    self.assertEqual(url, memo[url])


### PR DESCRIPTION
- adds memo to linkify
- use from_cache on build file usage in linkify
- store memo in html reporter

when doing an incremental compile, for some targets, stating files for doing link substitution was taking 50% or more of the total time. memoizing the results of substitutions bought some of that back