### PR TITLE
[Trigger CI] cache parsed mustache templates as they are requested

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -194,7 +194,6 @@ python_library(
   dependencies = [
     ':mustache',
     '3rdparty/python:pystache',
-    '3rdparty/python:six',
   ]
 )
 
@@ -217,6 +216,7 @@ python_library(
   sources = ['mustache.py'],
   dependencies = [
     '3rdparty/python:pystache',
+    '3rdparty/python:six',
   ]
 )
 

--- a/src/python/pants/base/generator.py
+++ b/src/python/pants/base/generator.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import pprint
 
 import pystache
-import six
 
 from pants.base.mustache import MustacheRenderer
 
@@ -45,11 +44,7 @@ class Generator(object):
   """Generates pants intermediary output files using a configured mustache template."""
 
   def __init__(self, template_text, **template_data):
-    # pystache does a typecheck for unicode in python 2.x but rewrites its sources to deal unicode
-    # via str in python 3.x.
-    if six.PY2:
-      template_text = unicode(template_text)
-    self._template = pystache.parse(template_text)
+    self._template = MustacheRenderer.parse_template(template_text)
     self.template_data = template_data
 
   def write(self, stream):

--- a/src/python/pants/base/mustache.py
+++ b/src/python/pants/base/mustache.py
@@ -10,6 +10,7 @@ import pkgutil
 import urlparse
 
 import pystache
+import six
 
 
 class MustacheRenderer(object):
@@ -39,6 +40,15 @@ class MustacheRenderer(object):
     ret.update(dict(items))
     return ret
 
+  @staticmethod
+  def parse_template(template_text):
+    if six.PY2:
+      # pystache does a typecheck for unicode in python 2.x but rewrites its sources to deal
+      # unicode via str in python 3.x.
+      template_text = unicode(template_text)
+    template = pystache.parse(template_text)
+    return template
+
   def __init__(self, template_dir=None, package_name=None):
     """Create a renderer that finds templates by name in one of two ways.
 
@@ -51,22 +61,11 @@ class MustacheRenderer(object):
     self._template_dir = template_dir
     self._package_name = package_name
     self._pystache_renderer = pystache.Renderer(search_dirs=template_dir)
+    self._templates = {}
 
   def render_name(self, template_name, args):
-    # TODO: Precompile and cache the templates?
-    if self._template_dir:
-      # Let pystache find the template by name.
-      return self._pystache_renderer.render_name(template_name, MustacheRenderer.expand(args))
-    else:
-      # Load the named template embedded in our package.
-      path = os.path.join('templates', template_name + '.mustache')
-      template = pkgutil.get_data(self._package_name, path)
-
-      if template == None:
-        raise self.MustacheError(
-          "could not find template {} in package {}".format(path, self._package_name))
-
-      return self.render(template, args)
+    parsed_template = self._load_template(template_name)
+    return self.render(parsed_template, args)
 
   def render(self, template, args):
     return self._pystache_renderer.render(template, MustacheRenderer.expand(args))
@@ -97,3 +96,20 @@ class MustacheRenderer(object):
     args = dict(outer_args.items() + inner_args.items())
     # Render.
     return self.render_name(inner_template_name, args)
+
+  def _load_template(self, template_name):
+    template = self._templates.get(template_name)
+    if not template:
+      if self._template_dir:
+        # Let pystache find the template by name.
+        template = self._pystache_renderer.load_template(template_name)
+      else:
+        # Load the named template embedded in our package.
+        path = os.path.join('templates', template_name + '.mustache')
+        template_text = pkgutil.get_data(self._package_name, path)
+        if template_text is None:
+          raise self.MustacheError(
+            "could not find template {} in package {}".format(path, self._package_name))
+        template = MustacheRenderer.parse_template(template_text)
+      self._templates[template_name] = template
+    return template


### PR DESCRIPTION
While looking at profiles, this popped up. I saw the todo and decided to add a cache.

Since the lookup lives under the report lock, its cost is magnified because it causes threads to wait for it.