### PR TITLE
[Trigger CI] Support subsystem registration in targets.

### DIFF
--- a/src/python/pants/base/build_configuration.py
+++ b/src/python/pants/base/build_configuration.py
@@ -34,6 +34,10 @@ class BuildConfiguration(object):
     self._addressable_alias_map = {}
     self._exposed_objects = {}
     self._exposed_context_aware_object_factories = {}
+    self._subsystems = set()
+
+  def subsystem_types(self):
+    return self._subsystems
 
   def registered_aliases(self):
     """Return the registered aliases exposed in BUILD files.
@@ -70,6 +74,7 @@ class BuildConfiguration(object):
                   .format(alias=alias))
     self._target_aliases[alias] = target
     self.register_addressable_alias(alias, target.get_addressable_type())
+    self._subsystems.update(target.subsystems())
 
   def register_exposed_object(self, alias, obj):
     """Registers the given object under the given alias.
@@ -85,6 +90,9 @@ class BuildConfiguration(object):
       logger.debug('Object alias {alias} has already been registered. Overwriting!'
                   .format(alias=alias))
     self._exposed_objects[alias] = obj
+    # obj doesn't implement any common base class, so we have to test for this attr.
+    if hasattr(obj, 'subsystems'):
+      self._subsystems.update(obj.subsystems())
 
   def register_addressable_alias(self, alias, addressable_type):
     """Registers a general Addressable type under the given alias.

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -27,6 +27,16 @@ from pants.base.validation import assert_list
 
 class AbstractTarget(object):
 
+  @classmethod
+  def subsystems(cls):
+    """The subsystems this target uses.
+
+    Targets always use the global subsystem instance. They have no notion of any other scope.
+
+    :return: A tuple of subsystem types.
+    """
+    return tuple()
+
   @property
   def has_resources(self):
     """Returns True if the target has an associated set of Resources."""

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -78,7 +78,9 @@ class GoalRunner(object):
     known_scopes = ['']
 
     # Add scopes for global subsystem instances.
-    for subsystem_type in set(self.subsystems) | Goal.global_subsystem_types():
+    for subsystem_type in (set(self.subsystems) |
+                           Goal.global_subsystem_types() |
+                           build_configuration.subsystem_types()):
       known_scopes.append(subsystem_type.qualify_scope(Options.GLOBAL_SCOPE))
 
     # Add scopes for all tasks in all goals.

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -78,9 +78,10 @@ class GoalRunner(object):
     known_scopes = ['']
 
     # Add scopes for global subsystem instances.
-    for subsystem_type in (set(self.subsystems) |
-                           Goal.global_subsystem_types() |
-                           build_configuration.subsystem_types()):
+    global_subsystems = (set(self.subsystems) |
+                         Goal.global_subsystem_types() |
+                         build_configuration.subsystem_types())
+    for subsystem_type in global_subsystems:
       known_scopes.append(subsystem_type.qualify_scope(Options.GLOBAL_SCOPE))
 
     # Add scopes for all tasks in all goals.
@@ -90,7 +91,7 @@ class GoalRunner(object):
 
     # Now that we have the known scopes we can get the full options.
     self.options = options_bootstrapper.get_full_options(known_scopes=known_scopes)
-    self.register_options()
+    self.register_options(global_subsystems)
 
     # Make the options values available to all subsystems.
     Subsystem._options = self.options
@@ -145,12 +146,12 @@ class GoalRunner(object):
   def global_options(self):
     return self.options.for_global_scope()
 
-  def register_options(self):
+  def register_options(self, global_subsystems):
     # Standalone global options.
     register_global_options(self.options.registration_function_for_global_scope())
 
     # Options for global-level subsystems.
-    for subsystem_type in set(self.subsystems) | Goal.global_subsystem_types():
+    for subsystem_type in global_subsystems:
       subsystem_type.register_options_on_scope(self.options, Options.GLOBAL_SCOPE)
 
     # TODO(benjy): Should Goals be subsystems? Or should the entire goal-running mechanism

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -235,6 +235,7 @@ python_tests(
     'src/python/pants/base:target',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
+    'src/python/pants/subsystem',
   ]
 )
 


### PR DESCRIPTION
This will be used in a future change to allow ScalaLibrary to use a
ScalaPlatform subsystem, instead of reaching into config directly.

This change also allows registered "build file objects" to declare
subsystems, for completeness.