### PR TITLE
Upgrade to self-hosted jvm tools.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -73,9 +73,7 @@ jar_library(name = 'benchmark-java-allocation-instrumenter-2.1',
 
 jar_library(name = 'zinc',
             jars = [
-              jar(org = 'com.typesafe.zinc', name = 'zinc', rev = '0.3.7')
-                .exclude(org = 'com.martiansoftware', name = 'nailgun-server')
-                .exclude(org = 'org.ensime', name = 'ensime-sbt-cmd')
+              jar(org = 'org.pantsbuild', name = 'zinc', rev = '1.0.0')
             ])
 
 # common rev for all org.scala-lang%* artifacts
@@ -121,18 +119,8 @@ jar_library(name = 'checkstyle',
 
 jar_library(name = 'junit',
             jars = [
-              jar(org = 'junit', name = 'junit-dep', rev = '4.10'),
-              jar(org = 'org.hamcrest', name = 'hamcrest-core', rev = '1.2'),
-              jar(org = 'com.twitter.common', name = 'junit-runner', rev = '0.0.41'),
-
-              # TODO(Eric Ayers) We need to rename/shade the dependencies of junit-runner
-              #      or use a custom classloader for junit runner to permanently
-              #      address guava version conflicts in guava
-              #
-              # junit-runner version 0.0.41 uses guava 16.0 by default
-              # If your user code needs to use a more recent version of guava, you can force
-              # the version in the next line.
-              jar(org = 'com.google.guava', name = 'guava', rev = '16.0', force = True),
+              jar(org = 'junit', name = 'junit', rev = '4.12'),
+              jar(org = 'org.pantsbuild', name = 'junit-runner', rev = '0.0.2'),
             ])
 
 jar_library(name = 'scrooge-gen',
@@ -152,7 +140,7 @@ jar_library(name = 'spindle-codegen',
 
 jar_library(name = 'jar-tool',
             jars = [
-              jar(org = 'com.twitter.common', name = 'jar-tool', rev = '0.1.9')
+              jar(org = 'org.pantsbuild', name = 'jar-tool', rev = '0.0.1')
             ])
 
 jar_library(name = 'jarjar',

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -27,7 +27,7 @@ class JarTool(JvmToolMixin, Subsystem):
   def run(self, context, runjava, args):
     return runjava(self.tool_classpath_from_products(context.products, 'jar-tool',
                                                      scope=self.options_scope),
-                   'com.twitter.common.jar.tool.Main',
+                   'org.pantsbuild.tools.jar.Main',
                    jvm_options=self.get_options().jvm_options,
                    args=args,
                    workunit_name='jar-tool',

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -714,7 +714,7 @@ class Cobertura(_Coverage):
 
 
 class JUnitRun(JvmTask, JvmToolTaskMixin):
-  _MAIN = 'com.twitter.common.junit.runner.ConsoleRunner'
+  _MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_utils.py
@@ -26,7 +26,7 @@ class ZincUtils(object):
   Instances are immutable, and all methods are reentrant (assuming that the java_runner is).
   """
 
-  _ZINC_MAIN = 'com.typesafe.zinc.Main'
+  _ZINC_MAIN = 'org.pantsbuild.zinc.Main'
 
   def __init__(self, context, nailgun_task, jvm_options, color=True, log_level='info'):
     self.context = context

--- a/tests/python/pants_test/tasks/test_jar_task.py
+++ b/tests/python/pants_test/tasks/test_jar_task.py
@@ -155,7 +155,7 @@ class JarTaskTest(BaseJarTaskTest):
     def manifest_content(classpath):
       return (b'Manifest-Version: 1.0\r\n' +
               b'Class-Path: {}\r\n' +
-              b'Created-By: com.twitter.common.jar.tool.JarBuilder\r\n\r\n').format(
+              b'Created-By: org.pantsbuild.tools.jar.JarBuilder\r\n\r\n').format(
                 ' '.join(maybe_list(classpath)))
 
     def assert_classpath(classpath):


### PR DESCRIPTION
This upgrades jar-tool, junit-runner and zinc to the versions hosted in
this repository and published to maven central using pants itself.