### PR TITLE
Copy java-compiler in from twitter/commons.

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -25,6 +25,11 @@ jar_library(name='guava',
                   apidocs='http://docs.guava-libraries.googlecode.com/git-history/v18.0/javadoc/'),
             ])
 
+jar_library(name='jansi',
+            jars=[
+              jar('org.fusesource.jansi', 'jansi', '1.11'),
+            ])
+
 jar_library(name='jsr305',
             jars=[
               jar('com.google.code.findbugs', 'jsr305', '3.0.0'),

--- a/src/java/org/pantsbuild/testing/BUILD
+++ b/src/java/org/pantsbuild/testing/BUILD
@@ -1,18 +1,13 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(
-  name='jar',
+java_library(
+  name='testing',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:easymock',
     '3rdparty:guava',
     '3rdparty:guava-testlib',
-    '3rdparty:junit',
-    'src/java/org/pantsbuild/testing',
-    'src/java/org/pantsbuild/tools/jar',
-  ],
-  resources=[
-    'tests/resources/org/pantsbuild/tools/jar',
-  ],
+    '3rdparty:junit'
+  ]
 )

--- a/src/java/org/pantsbuild/testing/EasyMockTest.java
+++ b/src/java/org/pantsbuild/testing/EasyMockTest.java
@@ -1,0 +1,63 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testing;
+
+import com.google.common.reflect.TypeToken;
+import com.google.common.testing.TearDown;
+
+import org.easymock.IMocksControl;
+import org.junit.Before;
+
+import static org.easymock.EasyMock.createControl;
+
+/**
+ * A baseclass for tests that use EasyMock.
+ *
+ * A new {@link IMocksControl control} is set up before each test and the mocks created and
+ * replayed with it are verified during tear down.
+ */
+public class EasyMockTest extends TearDownTestCase {
+  protected IMocksControl control;
+
+  /**
+   * Creates an EasyMock {@link #control} for tests to use that will be automatically
+   * {@link IMocksControl#verify() verified} on tear down.
+   *
+   * This {@code @Before} will be invoked by the junit runner test infrastructure and is not
+   * intended to be called by test subclasses.
+   */
+  @Before
+  public final void setupControl() {
+    control = createControl();
+    addTearDown(new TearDown() {
+      @Override
+      public void tearDown() {
+        control.verify();
+      }
+    });
+  }
+
+  /**
+   * Creates an EasyMock mock with this test's control.
+   *
+   * Will be {@link IMocksControl#verify() verified} in a tear down.
+   */
+  protected <T> T createMock(Class<T> token) {
+    return createMock(TypeToken.of(token));
+  }
+
+  /**
+   * Creates an EasyMock mock with this test's control.
+   *
+   * Allows for mocking of parameterized types without all the unchecked conversion warnings in a
+   * safe way.
+   *
+   * Will be {@link IMocksControl#verify() verified} in a tear down.
+   */
+  protected <T> T createMock(TypeToken<T> token) {
+    @SuppressWarnings("unchecked")
+    Class<T> rawType = (Class<T>) token.getRawType();
+    return control.createMock(rawType);
+  }
+}

--- a/src/java/org/pantsbuild/testing/TearDownTestCase.java
+++ b/src/java/org/pantsbuild/testing/TearDownTestCase.java
@@ -1,0 +1,40 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testing;
+
+import com.google.common.testing.TearDown;
+import com.google.common.testing.TearDownStack;
+
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * A baseclass for tests that allows use of inline {@link TearDown TearDowns} as an alternative to
+ * {@code @Before} and {@code @After} resource management.
+ */
+public class TearDownTestCase {
+
+  private TearDownStack tearDowns;
+
+  @Before
+  public final void setUpTearDowns() {
+    tearDowns = new TearDownStack();
+  }
+
+  @After
+  public final void runTearDowns() {
+    tearDowns.runTearDown();
+  }
+
+  /**
+   * Adds {@code tearDown} to the list of tear downs to ensure are executed.
+   *
+   * The tear downs registered via this method will be execute in LIFO order.
+   *
+   * @param tearDown The {@code tearDown} to ensure is run.
+   */
+  protected final void addTearDown(TearDown tearDown) {
+    tearDowns.addTearDown(tearDown);
+  }
+}

--- a/src/java/org/pantsbuild/tools/compiler/AnsiColorDiagnosticListener.java
+++ b/src/java/org/pantsbuild/tools/compiler/AnsiColorDiagnosticListener.java
@@ -1,0 +1,182 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.compiler;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.Ansi.Color;
+import org.fusesource.jansi.AnsiConsole;
+
+/**
+ * A DiagnosticListener that supports colorized console output and warning filters.
+ *
+ * <p>Users should make sure to call {@link #prepareConsole(boolean)} prior to reporting on any
+ * diagnostics.
+ *
+ * @param <T> The type of FileObject this listener can handle.
+ */
+class AnsiColorDiagnosticListener<T extends FileObject> extends FilteredDiagnosticListener<T> {
+  private static final Pattern EOL = Pattern.compile("$", Pattern.MULTILINE);
+
+  private final PrintWriter outWriter;
+  private final PrintWriter errWriter;
+  private boolean colorOutput;
+  private boolean includeSourceInfo;
+
+  /**
+   * Creates a diagnostic listener that outputs notes to {@link System#out} and warnings and errors
+   * to {@link System#err}.
+   */
+  AnsiColorDiagnosticListener() {
+    this(new PrintWriter(System.out), new PrintWriter(System.err));
+  }
+
+  /**
+   * Creates a diagnostic listener that outputs notes to the given {@code outWriter} and warnings
+   * and errors to the given {@code errWriter}.
+   */
+  AnsiColorDiagnosticListener(PrintWriter outWriter, PrintWriter errWriter) {
+    this.outWriter = outWriter;
+    this.errWriter = errWriter;
+  }
+
+  private static String getMessage(Diagnostic<? extends FileObject> diagnostic) {
+    return diagnostic.getMessage(Locale.getDefault());
+  }
+
+  /**
+   * When set to {@code true} this listener will output source and line information in addition to
+   * the underlying diagnostic message.
+   *
+   * @param includeSourceInfo {@code true} to include source and line info.
+   */
+  void setIncludeSourceInfo(boolean includeSourceInfo) {
+    this.includeSourceInfo = includeSourceInfo;
+  }
+
+  /**
+   * Prepares the console for either plain or color output.  Caller's should make sure to call
+   * {@link #releaseConsole()} when they are done reporting diagnostics.
+   *
+   * @param color {@code true} to output diagnostics in color.
+   */
+  void prepareConsole(boolean color) {
+    colorOutput = color;
+    if (color) {
+      AnsiConsole.systemInstall();
+    } else {
+      System.setProperty(Ansi.DISABLE, "true");
+    }
+  }
+
+  /**
+   * Returns the console to its state prior to the last call of {@link #prepareConsole(boolean)}.
+   */
+  void releaseConsole() {
+    if (colorOutput) {
+      AnsiConsole.systemUninstall();
+    } else {
+      System.setProperty(Ansi.DISABLE, "false");
+    }
+  }
+
+  @Override
+  protected void reportOn(Diagnostic<? extends T> diagnostic) {
+    switch (diagnostic.getKind()) {
+      case NOTE:
+        logDiagnostic(outWriter, Ansi.ansi().fg(Color.GREEN), diagnostic);
+        break;
+      case WARNING:
+      case MANDATORY_WARNING:
+        logDiagnostic(errWriter, Ansi.ansi().fg(Color.YELLOW), diagnostic);
+        break;
+      case ERROR:
+        logDiagnostic(errWriter, Ansi.ansi().fg(Color.RED), diagnostic);
+        break;
+      case OTHER:
+      default:
+        outWriter.println(getMessage(diagnostic));
+    }
+  }
+
+  private void logDiagnostic(PrintWriter out, Ansi ansi,
+      Diagnostic<? extends FileObject> diagnostic) {
+
+    String message = getMessage(diagnostic);
+    CharSequence sourceCode = extractSource(diagnostic);
+    if (sourceCode == null) {
+      out.println(ansi.format("%s%s", includeSourceInfo ? kindMessage(diagnostic) : "", message));
+    } else {
+      out.println(ansi.format(
+          "%s%s\n%s\n%s^",
+          includeSourceInfo
+              ? String.format("%s:%d: %s",
+                              diagnostic.getSource().toUri().getPath(),
+                              diagnostic.getLineNumber(),
+                              kindMessage(diagnostic))
+              : "",
+          message,
+          sourceCode,
+          spaces((int) diagnostic.getColumnNumber() - 1)));
+    }
+    out.print(Ansi.ansi().reset());
+    out.flush();
+  }
+
+  private String kindMessage(Diagnostic<? extends FileObject> diagnostic) {
+    return String.format("%s: ", diagnostic.getKind().name().toLowerCase());
+  }
+
+  private CharSequence extractSource(Diagnostic<? extends FileObject> diagnostic) {
+    FileObject source = diagnostic.getSource();
+    int startPosition = (int) diagnostic.getStartPosition();
+    if ((source == null) || (Diagnostic.NOPOS == startPosition) || (startPosition < 1)) {
+      return null;
+    }
+    try {
+      CharSequence content = source.getCharContent(true);
+      // Start and end positions can both be in the middle of a line, here we expand out and grab
+      // The whole line for useful error context.
+      Matcher matcher = EOL.matcher(content);
+      int endPosition =  (int) diagnostic.getEndPosition();
+      if (matcher.find(startPosition)) {
+        endPosition = matcher.end();
+      }
+
+      // Handle the error being at eol - back up a step so we can scan back to the prior eol and
+      // capture the line of program text preceding the error point at eol.
+      if (startPosition == endPosition && startPosition > 0) {
+        startPosition--;
+      }
+
+      for (; startPosition > 0; startPosition--) {
+        if (content.charAt(startPosition) == '\n' || content.charAt(startPosition) == '\r') {
+          // Start just after the beginning newline
+          startPosition++;
+          break;
+        }
+      }
+      return content.subSequence(startPosition, endPosition);
+    } catch (IOException e) {
+      return null;
+    } catch (IndexOutOfBoundsException e) {
+      return null;
+    }
+  }
+
+  private String spaces(int count) {
+    char[] spaces = new char[count];
+    Arrays.fill(spaces, ' ');
+    return new String(spaces);
+  }
+}

--- a/src/java/org/pantsbuild/tools/compiler/BUILD
+++ b/src/java/org/pantsbuild/tools/compiler/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='compiler',
+  provides=artifact(
+    org='org.pantsbuild.tools.compiler',
+    name='java-compiler',
+    repo=public,
+    publication_metadata=pants_library("""
+      A thin wrapper around the system java compiler that adds support for:
+      + dependency tracking
+      + warning suppression based on regex matches of paths and messages
+      + colorized console output
+    """)
+  ),
+  sources=globs('*.java'),
+  dependencies=[
+    '3rdparty:jansi'
+  ]
+)
+
+jvm_binary(name='compiler-main',
+  main='org.pantsbuild.tools.compiler.Compiler',
+  dependencies=[
+    ':compiler'
+  ]
+)

--- a/src/java/org/pantsbuild/tools/compiler/Compiler.java
+++ b/src/java/org/pantsbuild/tools/compiler/Compiler.java
@@ -1,0 +1,281 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.compiler;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.FileObject;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileManager;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import org.pantsbuild.tools.compiler.DiagnosticFilters.DiagnosticFilter;
+import org.pantsbuild.tools.compiler.DiagnosticFilters.Guard;
+
+/**
+ * A simple dependency tracking compiler that maps generated classes to the owning sources.
+ *
+ * Supports a <pre>-Tdependencyfile</pre> option to output dependency information to in the form:
+ * <pre>
+ * [source file path] -&gt; [class file path]
+ * </pre>
+ *
+ * There may be multiple lines per source file if the file contains multiple top level classes or
+ * inner classes.  All paths are normalized to be relative to the classfile output directory.
+ *
+ * Also supports warning customizations including:
+ * <ul>
+ *   <li><pre>-Tcolor</pre> To turn on colorized console output.
+ *   <li><pre>-Tnowarnprefixes</pre> Path prefixes to skip warnings for, multiple can be separated
+ *   with the system path separator and the flag itself can be passed multiple times.
+ *   <li><pre>-Tnowarnregex</pre> Regex to apply to warning messages.  Matches are not warned and
+ *   the flag can be massed multiple times to specify several regexs.
+ * </ul>
+ */
+// SUPPRESS CHECKSTYLE HideUtilityClassConstructor
+public final class Compiler {
+
+  public static final String DEPENDENCYFILE_FLAG = "-Tdependencyfile";
+  public static final String COLOR_FLAG = "-Tcolor";
+  public static final String WARN_IGNORE_PATH_PREFIXES = "-Tnowarnprefixes";
+  public static final String WARN_IGNORE_MESSAGE_REGEX = "-Tnowarnregex";
+
+  /**
+   * Should not be used; instead invoke {@link #main} directly.  Only present to conform to
+   * a common compiler interface idiom expected by jmake.
+   */
+  public Compiler() {
+  }
+
+  /**
+   * Handles parsing args for the compiler.
+   */
+  static class ArgParser {
+    private static final Set<Kind> WARNING_KINDS = EnumSet.of(Kind.WARNING, Kind.MANDATORY_WARNING);
+    private static final Guard<Diagnostic<? extends FileObject>> IS_WARNING =
+        new Guard<Diagnostic<? extends FileObject>>() {
+          @Override public boolean permit(Diagnostic<? extends FileObject> diagnostic) {
+            return WARNING_KINDS.contains(diagnostic.getKind());
+          }
+        };
+
+    private final JavaCompiler compiler;
+    private final FilteredDiagnosticListener<? extends FileObject> diagnosticListener;
+    private final StandardJavaFileManager standardFileManager;
+
+    private final List<String> options = new ArrayList<String>();
+    private final List<String> compilationUnits = new ArrayList<String>();
+    private File dependencyFile;
+    private boolean color;
+
+    ArgParser(JavaCompiler compiler,
+        FilteredDiagnosticListener<? extends FileObject> diagnosticListener,
+        StandardJavaFileManager standardFileManager) {
+
+      this.compiler = compiler;
+      this.diagnosticListener = diagnosticListener;
+      this.standardFileManager = standardFileManager;
+    }
+
+    void parse(String[] args) {
+      List<DiagnosticFilter<? super FileObject>> filters =
+          new ArrayList<DiagnosticFilter<? super FileObject>>();
+
+      List<String> pathPrefixes = new ArrayList<String>();
+      List<Pattern> messageRegexes = new ArrayList<Pattern>();
+
+      for (Iterator<String> iter = Arrays.asList(args).iterator(); iter.hasNext();) {
+        String arg = iter.next();
+        if (DEPENDENCYFILE_FLAG.equals(arg)) {
+          parseDependencyFile(iter);
+        } else if (COLOR_FLAG.equals(arg)) {
+          color = true;
+        } else if (WARN_IGNORE_PATH_PREFIXES.equals(arg)) {
+          pathPrefixes.addAll(parsePrefixes(iter));
+        } else if (WARN_IGNORE_MESSAGE_REGEX.equals(arg)) {
+          messageRegexes.add(parseRegex(iter));
+        } else if (arg.startsWith("-")) {
+          parsePassThroughOption(arg, iter);
+        } else {
+          compilationUnits.add(arg);
+        }
+      }
+
+      if (!pathPrefixes.isEmpty()) {
+        filters.add(DiagnosticFilters.guarded(
+            DiagnosticFilters.ignorePathPrefixes(pathPrefixes), IS_WARNING));
+      }
+      if (!messageRegexes.isEmpty()) {
+        filters.add(DiagnosticFilters.guarded(
+            DiagnosticFilters.ignoreMessagesMatching(messageRegexes), IS_WARNING));
+      }
+
+      if (!filters.isEmpty()) {
+        diagnosticListener.setFilter(DiagnosticFilters.combine(filters));
+      }
+    }
+
+    private void parseDependencyFile(Iterator<String> iter) {
+      if (!iter.hasNext()) {
+        throw new IllegalArgumentException(
+            String.format("%s requires an argument specifying the output path",
+                DEPENDENCYFILE_FLAG));
+      }
+      dependencyFile = new File(iter.next());
+    }
+
+    private Collection<String> parsePrefixes(Iterator<String> iter) {
+      if (!iter.hasNext()) {
+        throw new IllegalArgumentException(
+            String.format("%s requires an argument specifying path prefixes to ignore",
+                WARN_IGNORE_PATH_PREFIXES));
+      }
+      return Arrays.asList(iter.next().split(File.pathSeparator));
+    }
+
+    private Pattern parseRegex(Iterator<String> iter) {
+      if (!iter.hasNext()) {
+        throw new IllegalArgumentException(
+            String.format("%s requires an argument specifying a warning message regex",
+                WARN_IGNORE_MESSAGE_REGEX));
+      }
+      return Pattern.compile(iter.next());
+    }
+
+    private void parsePassThroughOption(String arg, Iterator<String> iter) {
+      int argCount = compiler.isSupportedOption(arg);
+      if (argCount == -1) {
+        argCount = standardFileManager.isSupportedOption(arg);
+      }
+      if (argCount == -1) {
+        System.err.println("WARNING: Skipping unsupported option " + arg);
+      } else {
+        options.add(arg);
+        while (argCount-- > 0) {
+          if (iter.hasNext()) {
+            options.add(iter.next());
+          }
+        }
+      }
+    }
+
+    List<String> getOptions() {
+      return options;
+    }
+
+    List<String> getCompilationUnits() {
+      return compilationUnits;
+    }
+
+    File getDependencyFile() {
+      return dependencyFile;
+    }
+
+    boolean isColor() {
+      return color;
+    }
+  }
+
+  /**
+   * Passes through all args to the system java compiler and tracks classes generated for each
+   * source file.
+   *
+   * @param args The command line arguments.
+   * @return An exit code where 0 indicates successful compilation.
+   */
+  public static int compile(String[] args) {
+    try {
+      return doCompile(args);
+    // We want a controlled exit.
+    // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+    } catch (Throwable t) {
+      System.err.println("Unexpected compilation error:");
+      t.printStackTrace(System.err);
+      return 1;
+    }
+  }
+
+  private static int doCompile(String[] args) throws IOException {
+    AnsiColorDiagnosticListener<FileObject> diagnosticListener =
+        new AnsiColorDiagnosticListener<FileObject>();
+
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    StandardJavaFileManager standardFileManager =
+        compiler.getStandardFileManager(
+            diagnosticListener,
+            null /* default locale */,
+            null /* default charset */);
+
+    ArgParser argParser = new ArgParser(compiler, diagnosticListener, standardFileManager);
+    try {
+      argParser.parse(args);
+    } catch (IllegalArgumentException e) {
+      System.err.println(e.getMessage());
+      return 1;
+    }
+
+    diagnosticListener.setIncludeSourceInfo(getJavaVersion() >= 7);
+    diagnosticListener.prepareConsole(argParser.isColor());
+    try {
+      JavaFileManager fileManager = standardFileManager;
+      File dependencyFile = argParser.getDependencyFile();
+      if (dependencyFile != null) {
+        fileManager = new DependencyTrackingFileManager(standardFileManager, dependencyFile);
+      }
+
+      try {
+        CompilationTask compilationTask =
+            compiler.getTask(
+                null, // default output stream
+                fileManager,
+                diagnosticListener,
+                argParser.getOptions(),
+                null, // we specify no custom annotation processors manually here
+                standardFileManager.getJavaFileObjectsFromStrings(argParser.getCompilationUnits()));
+
+        boolean success = compilationTask.call();
+        return success ? 0 : 1;
+      } finally {
+        fileManager.close();
+      }
+    } finally {
+      diagnosticListener.releaseConsole();
+    }
+  }
+
+  private static int getJavaVersion() {
+    String version = System.getProperty("java.version");
+    String[] components = version.split("\\.", 3);
+    return Integer.parseInt(components[1]);
+  }
+
+  /**
+   * Passes through all args to the system java compiler and tracks classes generated for each
+   * source file.
+   *
+   * @param args The command line arguments.
+   */
+  public static void main(String[] args) {
+    exit(compile(args));
+  }
+
+  private static void exit(int code) {
+    // We're a main - its fine to exit.
+    // SUPPRESS CHECKSTYLE RegexpSinglelineJava
+    System.exit(code);
+  }
+}

--- a/src/java/org/pantsbuild/tools/compiler/DependencyTrackingFileManager.java
+++ b/src/java/org/pantsbuild/tools/compiler/DependencyTrackingFileManager.java
@@ -1,0 +1,197 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.compiler;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+
+/**
+ * A file manager that intercepts requests for class output files to track dependencies.
+ *
+ * Stores dependencies from source file to class file in a line oriented plain text format where
+ * each line has the following format:
+ * <pre>
+ * [source file path] -&gt; [class file path]
+ * </pre>
+ *
+ * There may be multiple lines per source file if the file contains multiple top level classes or
+ * inner classes.  All paths are normalized to be relative to the classfile output directory.
+ */
+final class DependencyTrackingFileManager
+    extends ForwardingJavaFileManager<StandardJavaFileManager> {
+
+  private final LinkedHashMap<String, List<String>> sourceToClasses =
+      new LinkedHashMap<String, List<String>>();
+  private final Set<String> priorSources = new HashSet<String>();
+  private final File dependencyFile;
+
+  private List<String> outputPath;
+  private File outputDir;
+
+  DependencyTrackingFileManager(StandardJavaFileManager fileManager, File dependencies)
+      throws IOException {
+
+    super(fileManager);
+    this.dependencyFile = dependencies;
+
+    if (dependencyFile.exists()) {
+      System.out.println("Reading existing dependency file at " + dependencies);
+      BufferedReader dependencyReader = new BufferedReader(new FileReader(dependencies));
+      try {
+        int line = 0;
+        while (true) {
+          String mapping = dependencyReader.readLine();
+          if (mapping == null) {
+            break;
+          }
+
+          line++;
+          String[] components = mapping.split(" -> ");
+          if (components.length != 2) {
+            System.err.printf("Ignoring malformed dependency in %s[%d]: %s\n",
+                dependencies, line, mapping);
+          } else {
+            String sourceRelpath = components[0];
+            String classRelpath = components[1];
+            addMapping(sourceRelpath, classRelpath);
+          }
+        }
+      } finally {
+        dependencyReader.close();
+      }
+    }
+    priorSources.addAll(sourceToClasses.keySet());
+  }
+
+  @Override
+  public JavaFileObject getJavaFileForOutput(Location location, String className, Kind kind,
+      FileObject sibling) throws IOException {
+
+    JavaFileObject file = super.getJavaFileForOutput(location, className, kind, sibling);
+    // We only map loose source files to class file output.
+    if (Kind.CLASS == kind && sibling != null && sibling.toUri().getPath() != null) {
+      addMapping(toOutputRelpath(sibling), toOutputRelpath(file));
+    }
+    return file;
+  }
+
+  private void addMapping(String sourceFile, String classFile) {
+    List<String> classFiles = sourceToClasses.get(sourceFile);
+    if (classFiles == null || priorSources.remove(sourceFile)) {
+      classFiles = new ArrayList<String>();
+      sourceToClasses.put(sourceFile, classFiles);
+    }
+    classFiles.add(classFile);
+  }
+
+  private String toOutputRelpath(FileObject file) {
+    List<String> base = new ArrayList<String>(getOutputPath());
+    List<String> path = toList(file);
+    for (Iterator<String> baseIter = base.iterator(), pathIter = path.iterator();
+         baseIter.hasNext() && pathIter.hasNext();) {
+      if (!baseIter.next().equals(pathIter.next())) {
+        break;
+      } else {
+        baseIter.remove();
+        pathIter.remove();
+      }
+    }
+
+    if (!base.isEmpty()) {
+      path.addAll(0, Collections.nCopies(base.size(), ".."));
+    }
+    return join(path);
+  }
+
+  private String join(List<String> components) {
+    StringBuilder path = new StringBuilder();
+    for (int i = 0, max = components.size(); i < max; i++) {
+      if (i > 0) {
+        path.append(File.separatorChar);
+      }
+      path.append(components.get(i));
+    }
+    return path.toString();
+  }
+
+  private List<String> toList(FileObject path) {
+    return new ArrayList<String>(Arrays.asList(path.toUri().normalize().getPath().split("/")));
+  }
+
+  private synchronized List<String> getOutputPath() {
+    if (outputPath == null) {
+      List<String> components = new ArrayList<String>();
+      File f = getOutputDir();
+      while (f != null) {
+        components.add(f.getName());
+        f = f.getParentFile();
+      }
+      Collections.reverse(components);
+      outputPath = components;
+    }
+    return outputPath;
+  }
+
+  private synchronized File getOutputDir() {
+    if (outputDir == null) {
+      Iterable<? extends File> location = fileManager.getLocation(StandardLocation.CLASS_OUTPUT);
+      if (location == null || !location.iterator().hasNext()) {
+        throw new IllegalStateException("Expected to be called after compilation started - found "
+            + "no class output dir.");
+      }
+      for (File path : location) {
+        if (outputDir != null) {
+          throw new IllegalStateException("Expected exactly 1 output path");
+        }
+        outputDir = path;
+      }
+    }
+    return outputDir;
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+
+    System.out.println("Writing class dependency file to " + dependencyFile);
+    PrintWriter dependencyWriter = new PrintWriter(new FileWriter(dependencyFile, false));
+    try {
+      for (Entry<String, List<String>> entry : sourceToClasses.entrySet()) {
+        String sourceFile = entry.getKey();
+        for (String classFile : entry.getValue()) {
+          if (!priorSources.contains(sourceFile) || doesMappingExist(sourceFile, classFile)) {
+            dependencyWriter.printf("%s -> %s\n", sourceFile, classFile);
+          }
+        }
+      }
+    } finally {
+      dependencyWriter.close();
+    }
+  }
+
+  private boolean doesMappingExist(String sourceFile, String classFile) {
+    return new File(getOutputDir(), sourceFile).exists()
+        && new File(getOutputDir(), classFile).exists();
+  }
+}

--- a/src/java/org/pantsbuild/tools/compiler/DiagnosticFilters.java
+++ b/src/java/org/pantsbuild/tools/compiler/DiagnosticFilters.java
@@ -1,0 +1,177 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.compiler;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+
+/**
+ * A utility for constructing {@link DiagnosticFilter DiagnosticFilters}.
+ */
+final class DiagnosticFilters {
+
+  /**
+   * Indicates the treatment that should be applied to a diagnostic.
+   * <ul>
+   *   <li>{@link #IGNORE} indicates the diagnostic should be ignored.
+   *   <li>{@link #PASS} ndicates a filter passes on categorizing a diagnostic.
+   * </ul>
+   *
+   * All other treatments map to a {@link Diagnostic.Kind} of the same name.
+   */
+  public enum Treatment {
+    // Diagnostic.Kind equivalents
+    NOTE,
+    WARNING,
+    MANDATORY_WARNING,
+    ERROR,
+    OTHER,
+
+    /**
+     * Indicates a diagnostic should be dropped.
+     */
+    IGNORE,
+
+    /**
+     * Indicates a {@link DiagnosticFilter} passes on treatment assignment to the next filter.
+     */
+    PASS
+  }
+
+  /**
+   * A filter for diagnostics that can signal a diagnostic be skipped or alter its treatment by
+   * a downstream {@link javax.tools.DiagnosticListener}.
+   *
+   * @param <T>
+   */
+  interface DiagnosticFilter<T> {
+
+    /**
+     * Reports the appropriate treatment for the given diagnostic.
+     *
+     * @param diagnostic The diagnostic to categorize.
+     * @return A suggested treatment for the diagnostic or {@link Treatment#PASS} to pass the
+     *     categorization to the next filter.
+     */
+    Treatment categorize(Diagnostic<? extends T> diagnostic);
+  }
+
+  /**
+   * A predicate that tests if values of type {@code T} are permitted to pass through to the guarded
+   * code.
+   *
+   * @param <T> The type of values the guard tests.
+   */
+  interface Guard<T> {
+
+    /**
+     * Tests if the given item is permitted to pass through to some guarded code.
+     *
+     * @param item the item to test.
+     * @return {@code true} if the item is permitted to pass through to the guarded code.
+     */
+    boolean permit(T item);
+  }
+
+  /**
+   * A filter that maps each {@link Diagnostic.Kind} straight to its obvious {@link Treatment}
+   * counterpart and never returns {@link Treatment#IGNORE} or {@link Treatment#PASS}.
+   */
+  static final DiagnosticFilter<Object> STRAIGHT_MAPPING = new DiagnosticFilter<Object>() {
+    @Override public Treatment categorize(Diagnostic<?> diagnostic) {
+      Treatment treatment;
+      switch (diagnostic.getKind()) {
+        case NOTE:
+          treatment = Treatment.NOTE;
+          break;
+        case WARNING:
+          treatment = Treatment.WARNING;
+          break;
+        case MANDATORY_WARNING:
+          treatment = Treatment.MANDATORY_WARNING;
+          break;
+        case ERROR:
+          treatment = Treatment.ERROR;
+          break;
+        case OTHER:
+        default:
+          treatment = Treatment.OTHER;
+      }
+      return treatment;
+    }
+  };
+
+  private DiagnosticFilters() {
+    // utility
+  }
+
+  static <S> DiagnosticFilter<S> combine(
+      final Iterable<? extends DiagnosticFilter<? super S>> filters) {
+
+    return new DiagnosticFilter<S>() {
+      @Override public Treatment categorize(Diagnostic<? extends S> diagnostic) {
+        for (DiagnosticFilter<? super S> filter : filters) {
+          Treatment treatment = filter.categorize(diagnostic);
+          if (Treatment.PASS != treatment) {
+            return treatment;
+          }
+        }
+        return STRAIGHT_MAPPING.categorize(diagnostic);
+      }
+    };
+  }
+
+  static <T extends FileObject> DiagnosticFilter<T> guarded(final DiagnosticFilter<T> guarded,
+      final Guard<Diagnostic<? extends T>> guard) {
+
+    return new DiagnosticFilter<T>() {
+      @Override public Treatment categorize(Diagnostic<? extends T> diagnostic) {
+        return guard.permit(diagnostic) ? guarded.categorize(diagnostic) : Treatment.PASS;
+      }
+    };
+  }
+
+  static <T extends FileObject> DiagnosticFilter<T> ignorePathPrefixes(
+      final Iterable<String> pathPrefixes) {
+
+    return new DiagnosticFilter<T>() {
+      @Override public Treatment categorize(Diagnostic<? extends T> diagnostic) {
+        FileObject source = diagnostic.getSource();
+        if (source != null) {
+          // URI's need not have a path in general and in practice diagnostics get emitted for
+          // jar:// sources that in fact do not have a path - guard against these cases since we
+          // only need to match against file:// to satisfy this filter.
+          String path = source.toUri().getPath();
+          if (path != null) {
+            for (String pathPrefix : pathPrefixes) {
+              if (path.startsWith(pathPrefix)) {
+                return Treatment.IGNORE;
+              }
+            }
+          }
+        }
+        return Treatment.PASS;
+      }
+    };
+  }
+
+  static <T extends FileObject> DiagnosticFilter<T> ignoreMessagesMatching(
+      final Iterable<Pattern> regexes) {
+
+    return new DiagnosticFilter<T>() {
+      @Override public Treatment categorize(Diagnostic<? extends T> diagnostic) {
+        String message = diagnostic.getMessage(Locale.getDefault());
+        for (Pattern regex : regexes) {
+          if (regex.matcher(message).matches()) {
+            return Treatment.IGNORE;
+          }
+        }
+        return Treatment.PASS;
+      }
+    };
+  }
+}

--- a/src/java/org/pantsbuild/tools/compiler/FilteredDiagnosticListener.java
+++ b/src/java/org/pantsbuild/tools/compiler/FilteredDiagnosticListener.java
@@ -1,0 +1,137 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.compiler;
+
+import java.util.Locale;
+
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.DiagnosticListener;
+
+import org.pantsbuild.tools.compiler.DiagnosticFilters.DiagnosticFilter;
+import org.pantsbuild.tools.compiler.DiagnosticFilters.Treatment;
+
+/**
+ * A DiagnosticListener that supports filtering and promotion or demotion of diagnostics.
+ *
+ * <p>By default no diagnostics are filtered or otherwise rank-adjusted, use
+ * {@link #setFilter(DiagnosticFilter)} to change this.
+ *
+ * @param <T> The type of diagnostic this listener can handle.
+ */
+abstract class FilteredDiagnosticListener<T> implements DiagnosticListener<T> {
+
+  /**
+   * A diagnostic wrapper that replaces the wrapped diagnostic's {@link Diagnostic#getKind() kind}.
+   */
+  class FilteredDiagnostic implements Diagnostic<T> {
+    private final Kind filteredKind;
+    private final Diagnostic<? extends T> delegate;
+
+    FilteredDiagnostic(Kind filteredKind, Diagnostic<? extends T> delegate) {
+      this.filteredKind = filteredKind;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Kind getKind() {
+      return filteredKind;
+    }
+
+    @Override
+    public T getSource() {
+      return delegate.getSource();
+    }
+
+    @Override
+    public long getPosition() {
+      return delegate.getPosition();
+    }
+
+    @Override
+    public long getStartPosition() {
+      return delegate.getStartPosition();
+    }
+
+    @Override
+    public long getEndPosition() {
+      return delegate.getEndPosition();
+    }
+
+    @Override
+    public long getLineNumber() {
+      return delegate.getLineNumber();
+    }
+
+    @Override
+    public long getColumnNumber() {
+      return delegate.getColumnNumber();
+    }
+
+    @Override
+    public String getCode() {
+      return delegate.getCode();
+    }
+
+    @Override
+    public String getMessage(Locale locale) {
+      return delegate.getMessage(locale);
+    }
+  }
+
+  private volatile DiagnosticFilter<? super T> filter = DiagnosticFilters.STRAIGHT_MAPPING;
+
+  /**
+   * Set the filter to use for all subsequent reporting.
+   *
+   * @param filter The filter to use for all subsequent reporting.
+   */
+  void setFilter(final DiagnosticFilter<? super T> filter) {
+    if (filter == null) {
+      throw new NullPointerException("The filter cannot be null.");
+    }
+
+    this.filter = new DiagnosticFilter<T>() {
+      @Override public Treatment categorize(Diagnostic<? extends T> diagnostic) {
+        Treatment treatment = filter.categorize(diagnostic);
+        if (Treatment.PASS != treatment) {
+          return treatment;
+        }
+        // Backstop with a mapping guaranteed not to ignore or pass
+        return DiagnosticFilters.STRAIGHT_MAPPING.categorize(diagnostic);
+      }
+    };
+  }
+
+  @Override
+  public final void report(Diagnostic<? extends T> diagnostic) {
+    Treatment treatment = filter.categorize(diagnostic);
+    switch (treatment) {
+      case IGNORE:
+        break;
+      case NOTE:
+        reportOn(new FilteredDiagnostic(Kind.NOTE, diagnostic));
+        break;
+      case WARNING:
+        reportOn(new FilteredDiagnostic(Kind.WARNING, diagnostic));
+        break;
+      case MANDATORY_WARNING:
+        reportOn(new FilteredDiagnostic(Kind.MANDATORY_WARNING, diagnostic));
+        break;
+      case ERROR:
+        reportOn(new FilteredDiagnostic(Kind.ERROR, diagnostic));
+        break;
+      case OTHER:
+      default:
+        reportOn(new FilteredDiagnostic(Kind.OTHER, diagnostic));
+    }
+  }
+
+  /**
+   * Subclasses should override and handle reporting of the given diagnostic.
+   *
+   *  @param diagnostic The diagnostic to report.
+   */
+  protected abstract void reportOn(Diagnostic<? extends T> diagnostic);
+}

--- a/tests/java/org/pantsbuild/testing/BUILD
+++ b/tests/java/org/pantsbuild/testing/BUILD
@@ -2,17 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name='jar',
+  name='testing',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:easymock',
     '3rdparty:guava',
     '3rdparty:guava-testlib',
     '3rdparty:junit',
-    'src/java/org/pantsbuild/testing',
-    'src/java/org/pantsbuild/tools/jar',
-  ],
-  resources=[
-    'tests/resources/org/pantsbuild/tools/jar',
-  ],
+    'src/java/org/pantsbuild/testing'
+  ]
 )

--- a/tests/java/org/pantsbuild/testing/EasyMockTestTest.java
+++ b/tests/java/org/pantsbuild/testing/EasyMockTestTest.java
@@ -1,0 +1,56 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testing;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.expectLastCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EasyMockTestTest extends EasyMockTest {
+
+  private void assertSimplyParametrizedMockWorks(Runnable mockRunnable) {
+    final AtomicBoolean ran = new AtomicBoolean(false);
+
+    mockRunnable.run();
+    expectLastCall().andAnswer(new IAnswer<Void>() {
+      @Override public Void answer() {
+        ran.set(true);
+        return null;
+      }
+    });
+    control.replay();
+
+    mockRunnable.run();
+    assertTrue(ran.get());
+  }
+
+  @Test
+  public void testSimplyParametrizedMockViaOverload() {
+    assertSimplyParametrizedMockWorks(createMock(Runnable.class));
+  }
+
+  @Test
+  public void testSimplyParametrizedMock() {
+    assertSimplyParametrizedMockWorks(createMock(new TypeToken<Runnable>() { }));
+  }
+
+  @Test
+  public void testNestedParametrizedMock() {
+    List<List<String>> list = createMock(new TypeToken<List<List<String>>>() { });
+    EasyMock.expect(list.get(0)).andReturn(ImmutableList.of("jake"));
+    control.replay();
+
+    assertEquals(ImmutableList.of("jake"), list.get(0));
+  }
+}

--- a/tests/java/org/pantsbuild/tools/compiler/AnsiColorDiagnosticListenerTest.java
+++ b/tests/java/org/pantsbuild/tools/compiler/AnsiColorDiagnosticListenerTest.java
@@ -1,0 +1,173 @@
+package org.pantsbuild.tools.compiler;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.FileObject;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+import com.google.common.testing.TearDown;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.pantsbuild.testing.EasyMockTest;
+
+import static org.easymock.EasyMock.anyBoolean;
+import static org.easymock.EasyMock.expect;
+
+import static org.junit.Assert.assertEquals;
+
+public class AnsiColorDiagnosticListenerTest extends EasyMockTest {
+  private static final Pattern NEWLINE = Pattern.compile("\r?\n", Pattern.MULTILINE);
+
+  private AnsiColorDiagnosticListener<FileObject> listener;
+  private Diagnostic<FileObject> diagnostic;
+  private FileObject file;
+  private StringWriter out;
+  private StringWriter err;
+
+  @Before
+  public void setUp() {
+    out = new StringWriter();
+    err = new StringWriter();
+
+    listener = new AnsiColorDiagnosticListener<FileObject>(
+        new PrintWriter(out), new PrintWriter(err));
+    listener.prepareConsole(false);
+    addTearDown(new TearDown() {
+      @Override public void tearDown() {
+        listener.releaseConsole();
+      }
+    });
+
+    diagnostic = createMock(new TypeToken<Diagnostic<FileObject>>() { });
+    file = createMock(FileObject.class);
+  }
+
+  @Test
+  public void testNote() throws IOException {
+    expectDiagnostic(Kind.NOTE, "aside", null, Diagnostic.NOPOS, Diagnostic.NOPOS,
+        Diagnostic.NOPOS);
+
+    control.replay();
+    listener.reportOn(diagnostic);
+
+    assertOut("aside");
+    assertNoErr();
+  }
+
+  @Test
+  public void testOther() throws IOException {
+    expectDiagnostic(Kind.OTHER, "unknown", null, Diagnostic.NOPOS, Diagnostic.NOPOS,
+        Diagnostic.NOPOS);
+
+    control.replay();
+    listener.reportOn(diagnostic);
+
+    assertOut("unknown");
+    assertNoErr();
+  }
+
+  @Test
+  public void testWarning() throws IOException {
+    expectDiagnostic(Kind.WARNING, "warning", "abcdefg", 1L, 3L, 2L);
+
+    control.replay();
+    listener.reportOn(diagnostic);
+
+    assertErr(
+        "warning",
+        "abcdefg",
+        " ^");
+    assertNoOut();
+  }
+
+  @Test
+  public void testMandatoryWarning() throws IOException {
+    expectDiagnostic(Kind.MANDATORY_WARNING, "mandatory warning", "abcdefg", 1L, 5L, 1L);
+
+    control.replay();
+    listener.reportOn(diagnostic);
+
+    assertErr(
+        "mandatory warning",
+        "abcdefg",
+        "^");
+    assertNoOut();
+  }
+
+  @Test
+  public void testError() throws IOException {
+    expectDiagnostic(Kind.ERROR, "error", "a\nbcd\nefg", 3L, 5L, 2L);
+
+    control.replay();
+    listener.reportOn(diagnostic);
+
+    assertErr(
+        "error",
+        "bcd",
+        " ^");
+    assertNoOut();
+  }
+
+  @Test
+  public void testErrorEol() throws IOException {
+    expectDiagnostic(Kind.ERROR, "error", "a\nbcd\n", 5L, 6L, 4L);
+
+    control.replay();
+    listener.reportOn(diagnostic);
+
+    assertErr(
+        "error",
+        "bcd",
+        "   ^");
+    assertNoOut();
+  }
+
+  private void assertOut(String... lines) {
+    assertOutput(out, Arrays.asList(lines));
+  }
+
+  private void assertErr(String... lines) {
+    assertOutput(err, Arrays.asList(lines));
+  }
+
+  private void assertOutput(StringWriter writer, Iterable<String> lines) {
+    assertEquals(ImmutableList.builder().addAll(lines).add("").build(),
+        ImmutableList.copyOf(Splitter.on(NEWLINE).split(writer.toString())));
+  }
+
+  private void assertNoOut() {
+    assertNoOutput(out);
+  }
+
+  private void assertNoErr() {
+    assertNoOutput(err);
+  }
+
+  private void assertNoOutput(StringWriter writer) {
+    assertEquals("", writer.toString());
+  }
+
+  private void expectDiagnostic(Kind kind, String message, @Nullable String source, long start,
+      long end, long col) throws IOException {
+
+    expect(diagnostic.getKind()).andReturn(kind);
+    expect(diagnostic.getMessage(EasyMock.<Locale>notNull())).andReturn(message);
+    expect(diagnostic.getSource()).andReturn(file).anyTimes();
+    expect(diagnostic.getStartPosition()).andReturn(start).anyTimes();
+    expect(diagnostic.getEndPosition()).andReturn(end).anyTimes();
+    expect(diagnostic.getColumnNumber()).andReturn(col).anyTimes();
+    expect(file.getCharContent(anyBoolean())).andReturn(source).anyTimes();
+  }
+}

--- a/tests/java/org/pantsbuild/tools/compiler/BUILD
+++ b/tests/java/org/pantsbuild/tools/compiler/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_tests(name='compiler',
+  sources=globs('*.java'),
+  dependencies=[
+    '3rdparty:easymock',
+    '3rdparty:guava',
+    '3rdparty:junit',
+    'src/java/org/pantsbuild/testing',
+    'src/java/org/pantsbuild/tools/compiler:compiler'
+  ]
+)

--- a/tests/java/org/pantsbuild/tools/compiler/DiagnosticFiltersTest.java
+++ b/tests/java/org/pantsbuild/tools/compiler/DiagnosticFiltersTest.java
@@ -1,0 +1,127 @@
+package org.pantsbuild.tools.compiler;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.FileObject;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import org.pantsbuild.testing.EasyMockTest;
+import org.pantsbuild.tools.compiler.DiagnosticFilters.DiagnosticFilter;
+import org.pantsbuild.tools.compiler.DiagnosticFilters.Guard;
+import org.pantsbuild.tools.compiler.DiagnosticFilters.Treatment;
+
+import static org.easymock.EasyMock.expect;
+
+import static org.junit.Assert.assertEquals;
+
+public class DiagnosticFiltersTest extends EasyMockTest {
+
+  @Test
+  public void testIgnorePathPrefixes() throws URISyntaxException {
+    Diagnostic<FileObject> a = expectDiagnosticUri("file:///a");
+    Diagnostic<FileObject> b = expectDiagnosticUri("file:///b");
+    Diagnostic<FileObject> c = expectDiagnosticUri("file:///c");
+    control.replay();
+
+    DiagnosticFilter<FileObject> filter =
+        DiagnosticFilters.ignorePathPrefixes(ImmutableList.of("/a", "/b"));
+
+    assertEquals(Treatment.IGNORE, filter.categorize(a));
+    assertEquals(Treatment.IGNORE, filter.categorize(b));
+    assertEquals(Treatment.PASS, filter.categorize(c));
+  }
+
+  private Diagnostic<FileObject> expectDiagnosticUri(String uri) throws URISyntaxException {
+    return expectDiagnostic(Kind.WARNING, new URI(uri), null);
+  }
+
+  @Test
+  public void testIgnoreMessagesMatching() throws URISyntaxException {
+    Diagnostic<FileObject> a = expectDiagnosticMessage("fred jake*");
+    Diagnostic<FileObject> b = expectDiagnosticMessage("*fred jake");
+    Diagnostic<FileObject> c = expectDiagnosticMessage("*fred jake*");
+    control.replay();
+
+    DiagnosticFilter<FileObject> filter =
+        DiagnosticFilters.ignoreMessagesMatching(
+            ImmutableList.of(Pattern.compile("^fred.*"), Pattern.compile(".*jake$")));
+
+    assertEquals(Treatment.IGNORE, filter.categorize(a));
+    assertEquals(Treatment.IGNORE, filter.categorize(b));
+    assertEquals(Treatment.PASS, filter.categorize(c));
+  }
+
+  private Diagnostic<FileObject> expectDiagnosticMessage(String message) throws URISyntaxException {
+    return expectDiagnostic(Kind.WARNING, null, message);
+  }
+
+  @Test
+  public void testCombine() throws URISyntaxException {
+    Diagnostic<FileObject> a = expectDiagnostic(Kind.WARNING, new URI("file:///a"), null);
+    Diagnostic<FileObject> b = expectDiagnostic(Kind.ERROR, new URI("file:///b"), "fred*");
+    Diagnostic<FileObject> c = expectDiagnostic(Kind.WARNING, new URI("file:///c"), "*fred");
+    control.replay();
+
+    DiagnosticFilter<FileObject> filter =
+        DiagnosticFilters.combine(
+            ImmutableList.of(
+                DiagnosticFilters.ignorePathPrefixes(ImmutableList.of("/a")),
+                DiagnosticFilters.ignoreMessagesMatching(
+                    ImmutableList.of(Pattern.compile("^fred.*")))));
+
+
+    assertEquals(Treatment.IGNORE, filter.categorize(a));
+    assertEquals(Treatment.IGNORE, filter.categorize(b));
+    assertEquals(Treatment.WARNING, filter.categorize(c));
+  }
+
+  @Test
+  public void testGuarded() throws URISyntaxException {
+    Diagnostic<FileObject> a = expectDiagnostic(Kind.NOTE, new URI("file:///a"), null);
+
+    // URI testing should short-circuit on the kind test
+    Diagnostic<FileObject> b = expectDiagnostic(Kind.WARNING, null, null);
+
+    Diagnostic<FileObject> c = expectDiagnostic(Kind.NOTE, new URI("file:///c"), null);
+
+    control.replay();
+
+    DiagnosticFilter<FileObject> filter =
+        DiagnosticFilters.guarded(DiagnosticFilters.ignorePathPrefixes(ImmutableList.of("/a")),
+            new Guard<Diagnostic<? extends FileObject>>() {
+              @Override public boolean permit(Diagnostic<? extends FileObject> diagnostic) {
+                return diagnostic.getKind() == Kind.NOTE;
+              }
+            });
+
+    assertEquals(Treatment.IGNORE, filter.categorize(a));
+    assertEquals(Treatment.PASS, filter.categorize(b));
+    assertEquals(Treatment.PASS, filter.categorize(c));
+  }
+
+  private Diagnostic<FileObject> expectDiagnostic(Kind kind, @Nullable URI uri,
+      @Nullable String message) throws URISyntaxException {
+    Diagnostic<FileObject> diagnostic = createMock(new TypeToken<Diagnostic<FileObject>>() { });
+    expect(diagnostic.getKind()).andReturn(kind).anyTimes();
+    if (uri != null) {
+      FileObject fileObject = createMock(FileObject.class);
+      expect(fileObject.toUri()).andReturn(uri).atLeastOnce();
+      expect(diagnostic.getSource()).andReturn(fileObject);
+    }
+    if (message != null) {
+      expect(diagnostic.getMessage(EasyMock.<Locale>notNull())).andReturn(message).atLeastOnce();
+    }
+    return diagnostic;
+  }
+}

--- a/tests/java/org/pantsbuild/tools/jar/JarBuilderTest.java
+++ b/tests/java/org/pantsbuild/tools/jar/JarBuilderTest.java
@@ -18,7 +18,6 @@ import java.util.regex.Pattern;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
@@ -29,11 +28,8 @@ import com.google.common.io.Closer;
 import com.google.common.io.Files;
 import com.google.common.reflect.TypeToken;
 import com.google.common.testing.TearDown;
-import com.google.common.testing.TearDownStack;
 
 import org.easymock.Capture;
-import org.easymock.IMocksControl;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,7 +37,8 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
+import org.pantsbuild.testing.EasyMockTest;
+import org.pantsbuild.testing.TearDownTestCase;
 import org.pantsbuild.tools.jar.JarBuilder.DuplicateAction;
 import org.pantsbuild.tools.jar.JarBuilder.DuplicateEntryException;
 import org.pantsbuild.tools.jar.JarBuilder.DuplicateHandler;
@@ -50,7 +47,6 @@ import org.pantsbuild.tools.jar.JarBuilder.Entry;
 import org.pantsbuild.tools.jar.JarBuilder.Listener;
 
 import static org.easymock.EasyMock.capture;
-import static org.easymock.EasyMock.createControl;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
@@ -68,47 +64,6 @@ public class JarBuilderTest {
 
   interface ExceptionalFunction<S, T, E extends Exception> {
     T apply(S input) throws E;
-  }
-
-  public static class TearDownTestCase {
-
-    private TearDownStack tearDowns;
-
-    @Before
-    public final void setUpTearDowns() {
-      tearDowns = new TearDownStack();
-    }
-
-    @After
-    public final void runTearDowns() {
-      tearDowns.runTearDown();
-    }
-
-    protected final void addTearDown(TearDown tearDown) {
-      Preconditions.checkState(tearDowns != null);
-      tearDowns.addTearDown(tearDown);
-    }
-  }
-
-  public static class EasyMockTest extends TearDownTestCase {
-    protected IMocksControl control;
-
-    @Before
-    public final void setupControl() {
-      control = createControl();
-      addTearDown(new TearDown() {
-        @Override
-        public void tearDown() {
-          control.verify();
-        }
-      });
-    }
-
-    protected <T> T createMock(TypeToken<T> token) {
-      @SuppressWarnings("unchecked")
-      Class<T> rawType = (Class<T>) token.getRawType();
-      return control.createMock(rawType);
-    }
   }
 
   public static class DuplicatePolicyTests {

--- a/tests/java/org/pantsbuild/tools/junit/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/ConsoleRunnerTest.java
@@ -75,6 +75,9 @@ public class ConsoleRunnerTest {
   @Test
   public void testFlakyTests() throws Exception {
     TestRegistry.consoleRunnerTestRunsFlakyTests = true;
+    FlakyTest.numFlakyTestInstantiations = 0;
+    FlakyTest.numExpectedExceptionMethodInvocations = 0;
+
     try {
       ConsoleRunner.main(asArgsArray("FlakyTest -num-retries 2"));
       Assert.fail("Should have failed with RuntimeException due to FlakyTest.methodAlwaysFails");


### PR DESCRIPTION
This ports the java-compiler used by pants but does not actually
configure pants to use the ported Compiler.  That will come later
after the tool is published:
https://github.com/pantsbuild/pants/issues/1361

The java-compiler in twitter/commons will be deleted after this tool
is published and consumed by pants HEAD.