### PR TITLE
[CI] Move a comment to work around a pytest bug.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -69,9 +69,11 @@ class PythonTestResult(object):
 
 class PytestRun(PythonTask):
   _TESTING_TARGETS = [
-    PythonRequirement('pytest'),
+    # Note: the requirement restrictions on pytest and pytest-cov match those in requirements.txt,
+    # to avoid confusion.  TODO: Read them from there?
+    PythonRequirement('pytest>=2.6,<2.7'),
     PythonRequirement('pytest-timeout'),
-    PythonRequirement('pytest-cov'),
+    PythonRequirement('pytest-cov>=1.8,<1.9'),
     PythonRequirement('unittest2', version_filter=lambda py, pl: py.startswith('2')),
     PythonRequirement('unittest2py3k', version_filter=lambda py, pl: py.startswith('3'))
   ]

--- a/tests/python/pants_test/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/tasks/test_idea_integration.py
@@ -333,6 +333,6 @@ class IdeaIntegrationTest(PantsRunIntegrationTest):
                     })
 
   def test_all_targets(self):
+    # The android targets won't work if the Android ADK is not installed.
     self._idea_test(['src::', 'tests::', 'examples::', 'testprojects::',
-                     # The android targets won't work if the Android ADK is not installed
                      '--exclude-target-regexp=.*android.*',])


### PR DESCRIPTION
When that test fails, pytest attempts to construct a verbose backtrace.
However that comment in the middle of a multiline list literal tickles
a bug that causes pytest to fail hard with an INTERNALERROR, instead
of showing the details of the underlying bug.

While debugging this, I noticed that we don't constrain the versions of
pytest that we bake into the test chroot, so it will end up being a
different version than the one in 3rdparty/python/requirements.txt.
This is pretty confusing, so I added the relevant constraints.