### PR TITLE
[CI] Make the version of specs in BUILD.tools match the one in 3rdparty/BU…

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -93,7 +93,7 @@ jar_library(name = 'scala-library',
 
 jar_library(name = 'scala-specs',
             jars = [
-              jar(org = 'org.scala-tools.testing', name = 'specs_2.10.3', rev = '1.6.9'),
+              jar(org = 'org.scala-tools.testing', name = 'specs_2.10', rev = '1.6.9'),
               jar(org = 'com.twitter.common', name = 'specs-testing', rev = '0.0.6')
             ],
             dependencies = [


### PR DESCRIPTION
…ILD.

This was causing some resolution errors under some conditions, for reasons
I'm not entirely clear on.  The specs running is going away soon anyway,
so I didn't feel the need to dig too deeply.