### PR TITLE
Upgrade jar-tool to pickup a fix for skip rules.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -142,7 +142,7 @@ jar_library(name = 'spindle-codegen',
 
 jar_library(name = 'jar-tool',
             jars = [
-              jar(org = 'org.pantsbuild', name = 'jar-tool', rev = '0.0.2')
+              jar(org = 'org.pantsbuild', name = 'jar-tool', rev = '0.0.3')
             ])
 
 jar_library(name = 'jarjar',


### PR DESCRIPTION
See:
https://repo1.maven.org/maven2/org/pantsbuild/jar-tool/0.0.3/jar-tool-0.0.3-CHANGELOG.txt

https://rbcommons.com/s/twitter/r/2207/