### PR TITLE
[CI] Put all extra classpath elements (e.g., plugins) at the end.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -155,6 +155,10 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     """Extra classpath elements common to all compiler invocations.
 
     E.g., jars for compiler plugins.
+
+    These are added at the end of the classpath, after any dependencies, so that if they
+    overlap with any explicit dependencies, the compiler sees those first.  This makes
+    missing dependency accounting much simpler.
     """
     return []
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
@@ -227,8 +227,9 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
     # chunk, which avoids needing to introduce compile-time dependencies between annotation
     # processors and the classes they annotate.
     compile_classpath = compile_classpaths.get_for_targets(all_targets)
-    compile_classpath = OrderedSet(
-      self._compute_extra_classpath(extra_compile_time_classpath_elements) + list(compile_classpath))
+
+    compile_classpath = OrderedSet(list(compile_classpath) +
+                          self._compute_extra_classpath(extra_compile_time_classpath_elements))
 
     # Validate that all classpath entries are located within the working copy, which
     # simplifies relativizing the analysis files.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
@@ -117,7 +117,7 @@ class JvmCompileIsolatedStrategy(JvmCompileStrategy):
     # Generate a classpath specific to this compile and target, and include analysis
     # for upstream targets.
     raw_compile_classpath = compile_classpaths.get_for_target(compile_context.target)
-    compile_classpath = extra_compile_time_classpath + list(raw_compile_classpath)
+    compile_classpath = list(raw_compile_classpath) + extra_compile_time_classpath
     # Validate that the classpath is located within the working copy, which simplifies
     # relativizing the analysis files.
     self._validate_classpath(compile_classpath)


### PR DESCRIPTION
See comment in the diff for why.  This caused a real problem - zinc
was registering a dependency on a plugin jar in the analysis file,
which pants then saw as a missing dependency, even though the same
jar (at a different path) was in fact a dependency.