### PR TITLE
Upgrade to junit-runner 0.0.4.

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -122,7 +122,7 @@ jar_library(name = 'checkstyle',
 jar_library(name = 'junit',
             jars = [
               jar(org = 'junit', name = 'junit', rev = '4.12'),
-              jar(org = 'org.pantsbuild', name = 'junit-runner', rev = '0.0.3'),
+              jar(org = 'org.pantsbuild', name = 'junit-runner', rev = '0.0.4'),
             ])
 
 jar_library(name = 'scrooge-gen',

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -181,7 +181,6 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         '--test-junit-cwd',])
     self.assert_failure(pants_run)
 
-  @unittest.skip("junit-runner isn't published yet ")
   def test_junit_test_suppress_output_flag(self):
     pants_run = self.run_pants([
         'test.junit',


### PR DESCRIPTION
This picks up an enhancement that allows for forking test output to the
console and files.

https://rbcommons.com/s/twitter/r/2211/