### PR TITLE
Use 2 IT shards to avoid OSX CI timeouts.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -30,7 +30,8 @@ env:
     - CI_FLAGS="-fkmsrcjlpn 'Test examples and testprojects'"  # (et)
     - CI_FLAGS="-fkmsrcnet 'Unit tests for pants and pants-plugins'"  # (jlp)
     - CI_FLAGS="-fkmsrcjlpet 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrjlpnet 'Python integration tests for pants'"  # (c)
+    - CI_FLAGS="-fkmsrjlpnet -i 2:0 'Python integration tests for pants - shard 1'"  # (c)
+    - CI_FLAGS="-fkmsrjlpnet -i 2:1 'Python integration tests for pants - shard 2'"
 
 before_install:
   # We need a sane python and as of 3/5/2015 on OSX 10.9 the provided python 2.7.5 encounters


### PR DESCRIPTION
Right now the single IT shard runs up against the 50 minute timeout
where the other 3 shards finish in ~20 minutes.  This should yield a
pair of ~30 minute shards and get more OSX CI runs passing.