### PR TITLE
sort classifiers

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -241,7 +241,7 @@ class PomWriter(DependencyWriter):
     if classifier:
       s.add(classifier)
     s.update([i.classifier for i in artifacts if i.classifier])
-    return map(lambda x: TemplateData(classifier=x), s)
+    return map(lambda x: TemplateData(classifier=x), sorted(s))
 
   def internaldep(self, jar_dependency, target, configurations=None, classifier=None):
     template_data = self.jardep(jar_dependency, classifier=classifier)


### PR DESCRIPTION
    This bug sneaked by because scaladoc isn't enabled in Travis and consequently
    the test that would have caught it wasn't run.
    
    See https://github.com/pantsbuild/pants/issues/1545