### PR TITLE
sort classifiers

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -241,7 +241,7 @@ class PomWriter(DependencyWriter):
     if classifier:
       s.add(classifier)
     s.update([i.classifier for i in artifacts if i.classifier])
-    return map(lambda x: TemplateData(classifier=x), s)
+    return map(lambda x: TemplateData(classifier=x), sorted(s))
 
   def internaldep(self, jar_dependency, target, configurations=None, classifier=None):
     template_data = self.jardep(jar_dependency, classifier=classifier)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -331,6 +331,7 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_publish',
     'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:generator',
     'src/python/pants/base:source_root',
     'src/python/pants/scm:scm',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/tasks/test_jar_publish.py
@@ -14,11 +14,13 @@ from mock import Mock
 from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
+from pants.backend.jvm.targets.jar_dependency import IvyArtifact
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.backend.jvm.tasks.jar_publish import JarPublish
+from pants.backend.jvm.tasks.jar_publish import JarPublish, PomWriter
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
+from pants.base.generator import TemplateData
 from pants.scm.scm import Scm
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_walk
@@ -247,6 +249,13 @@ class JarPublishTest(TaskTestBase):
   def test_publish_local_only(self):
     with pytest.raises(TaskError):
       self.create_task(self.context())
+
+  def test_publish_classifiers(self):
+    artifacts = map(lambda x: IvyArtifact(x, classifier=x), ['a', 'c', 'b'])
+    p = PomWriter(None, None)
+    c = p.classifiers('a', artifacts)
+    r = map(lambda x: TemplateData(classifier=x), ['a', 'b', 'c'])
+    self.assertEquals(r, c)
 
 class FailNTimes:
   def __init__(self, tries, exc_type, success=None):


### PR DESCRIPTION
    This bug sneaked by because scaladoc isn't enabled in Travis and consequently
    the test that would have caught it wasn't run.
    
    See https://github.com/pantsbuild/pants/issues/1545