### PR TITLE
Adding lazyness to a single line

### DIFF
--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -32,7 +32,7 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(),
         'Expected an object of acceptable type {}, received None and can_be_none is False'
         .format(allowable))
 
-  if [typ for typ in allowable if isinstance(val, typ)]:
+  if any(isinstance(val, typ) for typ in allowable):
     lst = list(val)
     for e in lst:
       if not isinstance(e, expected_type):

--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -32,7 +32,7 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(),
         'Expected an object of acceptable type {}, received None and can_be_none is False'
         .format(allowable))
 
-  if any(isinstance(val, typ) for typ in allowable):
+  if isinstance(val, allowable):
     lst = list(val)
     for e in lst:
       if not isinstance(e, expected_type):

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -52,6 +52,7 @@ target(
     ':run_info',
     ':source_root',
     ':target',
+    ':validation',
     ':worker_pool',
   ]
 )
@@ -361,5 +362,13 @@ python_tests(
   dependencies = [
     'src/python/pants/base:worker_pool',
     'src/python/pants/util:contextutil',
+  ]
+)
+
+python_tests(
+  name = 'validation',
+  sources = ['test_validation.py'],
+  dependencies = [
+    'src/python/pants/base:validation',
   ]
 )

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -5,15 +5,12 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-import unittest
-from contextlib import contextmanager
-
 import pytest
 
 from pants.base import validation
 
 assert_list = validation.assert_list
+
 
 class FunctionCounter(object):
   def __init__(self, func):
@@ -23,18 +20,20 @@ class FunctionCounter(object):
   def __call__(self, *args, **kwargs):
     self.counter += 1
     return self.func(*args, **kwargs)
-    
+
 
 def test_valid_inputs():
   # list of strings gives list of strings
   assert assert_list(["file1.txt", "file2.txt"]) == ["file1.txt", "file2.txt"]
   assert assert_list(None) == []  # None is ok by default
 
+
 def test_invalid_inputs():
   with pytest.raises(ValueError):
-    assert_list({"file2.txt": True}) # Can't pass a dict by default
+    assert_list({"file2.txt": True})  # Can't pass a dict by default
   with pytest.raises(ValueError):
-     assert_list([["file2.txt"], "file2.txt"]) # Can't a list of non-string values
+    assert_list([["file2.txt"], "file2.txt"])  # Can't a list of non-string values
+
 
 def test_lazyness(monkeypatch):
   mock = FunctionCounter(isinstance)
@@ -44,5 +43,3 @@ def test_lazyness(monkeypatch):
   mock.counter = 0
   assert_list(set(), allowable=(list, set))
   assert mock.counter == 2  # isinstance was called twice
-  
-  

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -9,6 +9,7 @@ import pytest
 
 from pants.base import validation
 
+
 assert_list = validation.assert_list
 
 

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -7,20 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import pytest
 
-from pants.base import validation
-
-
-assert_list = validation.assert_list
-
-
-class FunctionCounter(object):
-  def __init__(self, func):
-    self.func = func
-    self.counter = 0
-
-  def __call__(self, *args, **kwargs):
-    self.counter += 1
-    return self.func(*args, **kwargs)
+from pants.base.validation import assert_list
 
 
 def test_valid_inputs():
@@ -33,14 +20,4 @@ def test_invalid_inputs():
   with pytest.raises(ValueError):
     assert_list({"file2.txt": True})  # Can't pass a dict by default
   with pytest.raises(ValueError):
-    assert_list([["file2.txt"], "file2.txt"])  # Can't a list of non-string values
-
-
-def test_lazyness(monkeypatch):
-  mock = FunctionCounter(isinstance)
-  monkeypatch.setattr(validation, 'isinstance', mock, raising=False)  # Create new module level var
-  assert_list([], allowable=(list, set))
-  assert mock.counter == 1  # isinstance was only called once despite allowable having two types
-  mock.counter = 0
-  assert_list(set(), allowable=(list, set))
-  assert mock.counter == 2  # isinstance was called twice
+    assert_list([["file2.txt"], "file2.txt"])  # All values in list must be stringy values

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import unittest
+from contextlib import contextmanager
+
+import pytest
+
+from pants.base import validation
+
+assert_list = validation.assert_list
+
+class FunctionCounter(object):
+  def __init__(self, func):
+    self.func = func
+    self.counter = 0
+
+  def __call__(self, *args, **kwargs):
+    self.counter += 1
+    return self.func(*args, **kwargs)
+    
+
+def test_valid_inputs():
+  # list of strings gives list of strings
+  assert assert_list(["file1.txt", "file2.txt"]) == ["file1.txt", "file2.txt"]
+  assert assert_list(None) == []  # None is ok by default
+
+def test_invalid_inputs():
+  with pytest.raises(ValueError):
+    assert_list({"file2.txt": True}) # Can't pass a dict by default
+  with pytest.raises(ValueError):
+     assert_list([["file2.txt"], "file2.txt"]) # Can't a list of non-string values
+
+def test_lazyness(monkeypatch):
+  mock = FunctionCounter(isinstance)
+  monkeypatch.setattr(validation, 'isinstance', mock, raising=False)  # Create new module level var
+  assert_list([], allowable=(list, set))
+  assert mock.counter == 1  # isinstance was only called once despite allowable having two types
+  mock.counter = 0
+  assert_list(set(), allowable=(list, set))
+  assert mock.counter == 2  # isinstance was called twice
+  
+  


### PR DESCRIPTION
This is not a big performance win but assert_list is used on many things (dependencies, resources) and adding lazyness can omit multiple calls to isinstance in the common case of checking a list.

I also added a few unit tests specifically for this validation utility.