### PR TITLE
Instead of invoking 'test examples/::' and 'test testprojects/::' in ci.sh created Python integration tests for them.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -27,11 +27,10 @@ env:
     # No need to run the self-checks on OSX where vms are at a premium since these are file-level,
     # non-platform fragile lints.
     # - CI_FLAGS="-clpnet 'Various pants self checks'"  # (fkmsr)
-    - CI_FLAGS="-fkmsrcjlpn 'Test examples and testprojects'"  # (et)
     - CI_FLAGS="-fkmsrcnet 'Unit tests for pants and pants-plugins'"  # (jlp)
-    - CI_FLAGS="-fkmsrcjlpet 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrjlpnet -i 2:0 'Python integration tests for pants - shard 1'"  # (c)
-    - CI_FLAGS="-fkmsrjlpnet -i 2:1 'Python integration tests for pants - shard 2'"
+    - CI_FLAGS="-fkmsrcjlp 'Python contrib tests'"  # (n)
+    - CI_FLAGS="-fkmsrjlpn -i 2:0 'Python integration tests for pants - shard 1'"  # (c)
+    - CI_FLAGS="-fkmsrjlpn -i 2:1 'Python integration tests for pants - shard 2'"
 
 before_install:
   # We need a sane python and as of 3/5/2015 on OSX 10.9 the provided python 2.7.5 encounters

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,16 +32,15 @@ env:
     # See: http://docs.travis-ci.com/user/encryption-keys/
     - secure: VvwbndU++a2/iNAjk9cd67ATiipDwqcKnxDR4/J2Ik3GH10wHEDUhJ1+MK4WLhedfaOakDOEmarZQS3GwtgvCHO3knpTJuJc8d/bCfZovYuSqdi//BEv4dS7hDt6tQeJfkbBjG0T4yNjPJ3W9R9KDWCy/vj2CUm90BGg2CmxUbg=
   matrix:
-    - CI_FLAGS="-cjlpnet 'Various pants self checks'"  # (fkmsr)
-    - CI_FLAGS="-fkmsrcjlpn 'Test examples and testprojects'"  # (et)
-    - CI_FLAGS="-fkmsrcnet 'Unit tests for pants and pants-plugins'"  # (jlp)
-    - CI_FLAGS="-fkmsrcjlpet 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrjlpnet -i 6:0 'Python integration tests for pants - shard 1'"  # (c)
-    - CI_FLAGS="-fkmsrjlpnet -i 6:1 'Python integration tests for pants - shard 2'"
-    - CI_FLAGS="-fkmsrjlpnet -i 6:2 'Python integration tests for pants - shard 3'"
-    - CI_FLAGS="-fkmsrjlpnet -i 6:3 'Python integration tests for pants - shard 4'"
-    - CI_FLAGS="-fkmsrjlpnet -i 6:4 'Python integration tests for pants - shard 5'"
-    - CI_FLAGS="-fkmsrjlpnet -i 6:5 'Python integration tests for pants - shard 6'"
+    - CI_FLAGS="-cjlpn 'Various pants self checks'"  # (fkmsr)
+    - CI_FLAGS="-fkmsrcn 'Unit tests for pants and pants-plugins'"  # (jlp)
+    - CI_FLAGS="-fkmsrcjlp 'Python contrib tests'"  # (n)
+    - CI_FLAGS="-fkmsrjlpn -i 6:0 'Python integration tests for pants - shard 1'"  # (c)
+    - CI_FLAGS="-fkmsrjlpn -i 6:1 'Python integration tests for pants - shard 2'"
+    - CI_FLAGS="-fkmsrjlpn -i 6:2 'Python integration tests for pants - shard 3'"
+    - CI_FLAGS="-fkmsrjlpn -i 6:3 'Python integration tests for pants - shard 4'"
+    - CI_FLAGS="-fkmsrjlpn -i 6:4 'Python integration tests for pants - shard 5'"
+    - CI_FLAGS="-fkmsrjlpn -i 6:5 'Python integration tests for pants - shard 6'"
 
 before_script: |
   ./build-support/bin/ci-sync.sh

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -120,6 +120,7 @@ target(
     'tests/python/pants_test/net',
     'tests/python/pants_test/option',
     'tests/python/pants_test/process',
+    'tests/python/pants_test/projects',
     'tests/python/pants_test/python',
     'tests/python/pants_test/reporting',
     'tests/python/pants_test/scm',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -41,14 +41,6 @@ python_tests(
 )
 
 python_library(
-  name = 'utils',
-  sources = ['utils.py'],
-  dependencies = [
-    '3rdparty/python:pytest',
-  ]
-)
-
-python_library(
   name='base_compile_integration_test',
   sources=['base_compile_integration_test.py'],
   dependencies=[

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_apt_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_apt_compile_integration.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
-from pants_test.backend.jvm.tasks.jvm_compile.utils import provide_compile_strategies
+from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
 
 
 class AptCompileIntegrationTest(BaseCompileIT):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -11,8 +11,8 @@ from pants.backend.jvm.tasks.jvm_compile.java.jmake_analysis_parser import JMake
 from pants.fs.archive import TarArchiver
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_walk
-from pants_test.backend.jvm.tasks.jvm_compile.utils import provide_compile_strategies
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
 
 
 class JavaCompileIntegrationTest(PantsRunIntegrationTest):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_zinc_compile_integration.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.util.contextutil import temporary_dir
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
-from pants_test.backend.jvm.tasks.jvm_compile.utils import provide_compile_strategies
+from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
 
 
 class JvmExamplesCompileIntegrationTest(BaseCompileIT):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scala_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scala_compile_integration.py
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET
 from contextlib import contextmanager
 
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
-from pants_test.backend.jvm.tasks.jvm_compile.utils import provide_compile_strategies
+from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
 
 
 class ScalaCompileIntegrationTest(BaseCompileIT):

--- a/tests/python/pants_test/projects/BUILD
+++ b/tests/python/pants_test/projects/BUILD
@@ -1,0 +1,36 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name='projects',
+  dependencies=[
+    ':examples_integration',
+    ':testprojects_integration',
+  ]
+)
+
+python_tests(
+  name='examples_integration',
+  sources=['test_examples_integration.py'],
+  dependencies=[
+    ':base',
+    'tests/python/pants_test/testutils',
+  ]
+)
+
+python_tests(
+  name='testprojects_integration',
+  sources=['test_testprojects_integration.py'],
+  dependencies=[
+    ':base',
+    'tests/python/pants_test/testutils',
+  ]
+)
+
+python_tests(
+  name='base',
+  sources=['base_project_integration_test.py'],
+  dependencies=[
+    'tests/python/pants_test:int-test',
+  ]
+)

--- a/tests/python/pants_test/projects/base_project_integration_test.py
+++ b/tests/python/pants_test/projects/base_project_integration_test.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class ProjectIntegrationTest(PantsRunIntegrationTest):
+  @staticmethod
+  def _android_flags():
+    exclude_android = os.environ.get('SKIP_ANDROID') == "true" or not os.environ.get('ANDROID_HOME')
+    return ['--exclude-target-regexp=.*android.*'] if exclude_android else []
+
+  def pants_test(self, strategy, command):
+    return self.run_pants([
+      'test'
+      '--compile-apt-strategy={}'.format(strategy),
+      '--compile-java-strategy={}'.format(strategy),
+      '--compile-scala-strategy={}'.format(strategy),
+    ] + command + self._android_flags())

--- a/tests/python/pants_test/projects/test_examples_integration.py
+++ b/tests/python/pants_test/projects/test_examples_integration.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.projects.base_project_integration_test import ProjectIntegrationTest
+from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
+
+
+class ExamplesIntegrationTest(ProjectIntegrationTest):
+  @provide_compile_strategies
+  def tests_examples(self, strategy):
+    pants_run = self.pants_test(strategy, ['examples::'])
+    self.assert_success(pants_run)

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.projects.base_project_integration_test import ProjectIntegrationTest
+from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
+
+
+class TestProjectsIntegrationTest(ProjectIntegrationTest):
+  @provide_compile_strategies
+  def tests_testprojects(self, strategy):
+    # TODO(Eric Ayers) find a better way to deal with tests that are known to fail.
+    # right now, just split them into two categories and ignore them.
+
+    # Targets that fail but shouldn't
+    known_failing_targets = [
+      # The following two targets lose out due to a resource collision, because `example_b` happens
+      # to be first in the context, and test.junit mixes all classpaths.
+      'testprojects/maven_layout/resource_collision/example_b/src/test/java/org/pantsbuild/duplicateres/exampleb:exampleb',
+      'testprojects/maven_layout/resource_collision/example_c/src/test/java/org/pantsbuild/duplicateres/examplec:examplec',
+    ]
+
+    # Targets that are intended to fail
+    negative_test_targets = [
+      'testprojects/src/antlr/pants/backend/python/test:antlr_failure',
+      'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-files',
+      'testprojects/src/java/org/pantsbuild/testproject/cycle1',
+      'testprojects/src/java/org/pantsbuild/testproject/cycle2',
+      'testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist.*',
+      'testprojects/src/python/antlr:test_antlr_failure',
+      'testprojects/src/scala/org/pantsbuild/testproject/compilation_failure',
+      'testprojects/src/thrift/org/pantsbuild/thrift_linter:',
+      'testprojects/tests/java/org/pantsbuild/testproject/empty:',
+      'testprojects/tests/java/org/pantsbuild/testproject/dummies:failing_target',
+      'testprojects/tests/python/pants/dummies:failing_target',
+    ]
+
+    targets_to_exclude = known_failing_targets + negative_test_targets
+    exclude_opts = map(lambda target: '--exclude-target-regexp={}'.format(target), targets_to_exclude)
+    pants_run = self.pants_test(strategy, ['testprojects::'] + exclude_opts)
+    self.assert_success(pants_run)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -334,7 +334,7 @@ python_tests(
     'src/python/pants/scm:scm',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test/backend/jvm/tasks/jvm_compile:utils',
+    'tests/python/pants_test/testutils',
   ],
 )
 

--- a/tests/python/pants_test/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/tasks/test_jar_publish.py
@@ -24,8 +24,8 @@ from pants.base.generator import TemplateData
 from pants.scm.scm import Scm
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_walk
-from pants_test.backend.jvm.tasks.jvm_compile.utils import set_compile_strategies
 from pants_test.tasks.task_test_base import TaskTestBase
+from pants_test.testutils.compile_strategy_utils import set_compile_strategies
 
 
 class JarPublishTest(TaskTestBase):

--- a/tests/python/pants_test/testutils/compile_strategy_utils.py
+++ b/tests/python/pants_test/testutils/compile_strategy_utils.py
@@ -29,7 +29,10 @@ def _wrap(testmethod, setupfun):
   return wrapped
 
 def provide_compile_strategies(testmethod):
-  """A decorator for test methods that provides the compilation strategy as a parameter."""
+  """ A decorator for test methods that provides the compilation strategy as a parameter.
+
+  Invokes the test multiple times, once for each built-in strategy in _STRATEGIES.
+  """
   return _wrap(testmethod, lambda self, testmethod, strategy: testmethod(self, strategy))
 
 def set_compile_strategies(testmethod):


### PR DESCRIPTION
Instead of invoking 'test examples/::' and 'test testprojects/::' in ci.sh created Python integration tests for them.

Moved compile_strategy_utils.py to testutils.

Moved test_binary_util, test_maven_layout and test_thrift_util to util folder.