### PR TITLE
Fixup OSX CI breaks.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -27,7 +27,7 @@ env:
     # No need to run the self-checks on OSX where vms are at a premium since these are file-level,
     # non-platform fragile lints.
     # - CI_FLAGS="-clpnet 'Various pants self checks'"  # (fkmsr)
-    - CI_FLAGS="-fkmsrcnet 'Unit tests for pants and pants-plugins'"  # (jlp)
+    - CI_FLAGS="-fkmsrcn 'Unit tests for pants and pants-plugins'"  # (jlp)
     - CI_FLAGS="-fkmsrcjlp 'Python contrib tests'"  # (n)
     - CI_FLAGS="-fkmsrjlpn -i 2:0 'Python integration tests for pants - shard 1'"  # (c)
     - CI_FLAGS="-fkmsrjlpn -i 2:1 'Python integration tests for pants - shard 2'"

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -126,7 +126,7 @@ class Distribution(object):
 
     self._jdk = jdk
 
-    self._home_path = None
+    self._home = None
     self._is_jdk = False
     self._system_properties = None
     self._version = None
@@ -181,7 +181,7 @@ class Distribution(object):
   @property
   def home(self):
     """Returns the distribution JAVA_HOME."""
-    if not self._home_path:
+    if not self._home:
       home = self._get_system_properties(self.java)['java.home']
       # The `jre/bin/java` executable in a JDK distribution will report `java.home` as the jre dir,
       # so we check for this and re-locate to the containing jdk dir when present.
@@ -189,8 +189,8 @@ class Distribution(object):
         jdk_dir = os.path.dirname(home)
         if self._is_executable(os.path.join(jdk_dir, 'bin', 'javac')):
           home = jdk_dir
-      self._home_path = home
-    return self._home_path
+      self._home = home
+    return self._home
 
   @property
   def java(self):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -12,7 +12,6 @@ import unittest
 from collections import namedtuple
 from contextlib import contextmanager
 
-import pytest
 from twitter.common.collections import maybe_list
 
 from pants.base.revision import Revision
@@ -22,21 +21,21 @@ from pants.util.dirutil import chmod_plus_x, safe_open, touch
 
 
 class MockDistributionTest(unittest.TestCase):
-  EXE = namedtuple('Exe', ['name', 'contents'])
-
+  EXE = namedtuple('Exe', ['relpath', 'contents'])
 
   @classmethod
-  def exe(cls, name, version=None):
-    contents = None if not version else textwrap.dedent('''
+  def exe(cls, relpath, version=None):
+    contents = textwrap.dedent("""
         #!/bin/sh
         if [ $# -ne 3 ]; then
           # Sanity check a classpath switch with a value plus the classname for main
           echo "Expected 3 arguments, got $#: $@" >&2
           exit 1
         fi
-        echo "java.version=%s"
-      ''' % version).strip()
-    return cls.EXE(name, contents=contents)
+        echo "java.home=${{DIST_ROOT}}"
+        {}
+      """.format('echo "java.version={}"'.format(version) if version else '')).strip()
+    return cls.EXE(relpath, contents=contents)
 
   @contextmanager
   def env(self, **kwargs):
@@ -46,24 +45,17 @@ class MockDistributionTest(unittest.TestCase):
       yield
 
   @contextmanager
-  def distribution(self, files=None, executables=None, libs=None):
-    with temporary_dir() as jdk_root:
-      jdk_bin_dir = os.path.join(jdk_root, 'bin')
-      os.mkdir(jdk_bin_dir)
-      for f in maybe_list(files or ()):
-        touch(os.path.join(jdk_bin_dir, f))
-      for exe in maybe_list(executables or (), expected_type=self.EXE):
-        path = os.path.join(jdk_bin_dir, exe.name)
-        with safe_open(path, 'w') as fp:
-          fp.write(exe.contents or '')
-        chmod_plus_x(path)
-
-      jdk_lib_dir = os.path.join(jdk_root, 'lib')
-      os.mkdir(jdk_lib_dir)
-      for f in maybe_list(libs or ()):
-        touch(os.path.join(jdk_lib_dir, f))
-
-      yield jdk_bin_dir
+  def distribution(self, files=None, executables=None, java_home=None):
+    with temporary_dir() as dist_root:
+      with environment_as(DIST_ROOT=os.path.join(dist_root, java_home) if java_home else dist_root):
+        for f in maybe_list(files or ()):
+          touch(os.path.join(dist_root, f))
+        for exe in maybe_list(executables or (), expected_type=self.EXE):
+          path = os.path.join(dist_root, exe.relpath)
+          with safe_open(path, 'w') as fp:
+            fp.write(exe.contents or '')
+          chmod_plus_x(path)
+        yield dist_root
 
   def setUp(self):
     super(MockDistributionTest, self).setUp()
@@ -76,164 +68,210 @@ class MockDistributionTest(unittest.TestCase):
     Distribution._CACHE = self._local_cache
 
   def test_validate_basic(self):
-    with pytest.raises(Distribution.Error):
-      with self.distribution() as jdk:
-        Distribution(bin_path=jdk).validate()
+    with self.assertRaises(ValueError):
+      with self.distribution() as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'bin')).validate()
 
-    with pytest.raises(Distribution.Error):
-      with self.distribution(files='java') as jdk:
-        Distribution(bin_path=jdk).validate()
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(files='bin/java') as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'bin')).validate()
 
-    with self.distribution(executables=self.exe('java')) as jdk:
-      Distribution(bin_path=jdk).validate()
+    with self.distribution(executables=self.exe('bin/java')) as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'bin')).validate()
+
+  def test_validate_jre(self):
+    with self.distribution(executables=self.exe('bin/java')) as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'bin'), jdk=False).validate()
 
   def test_validate_jdk(self):
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java')) as jdk:
-        Distribution(bin_path=jdk, jdk=True).validate()
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('bin/java')) as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'bin'), jdk=True).validate()
 
-    with self.distribution(executables=[self.exe('java'), self.exe('javac')]) as jdk:
-      Distribution(bin_path=jdk, jdk=True).validate()
+    with self.distribution(executables=[self.exe('bin/java'), self.exe('bin/javac')]) as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'bin'), jdk=True).validate()
+
+    with self.distribution(executables=[self.exe('jre/bin/java'),
+                                        self.exe('bin/javac')],
+                           java_home='jre') as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'jre/bin'), jdk=True).validate()
 
   def test_validate_version(self):
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
-        Distribution(bin_path=jdk, minimum_version='1.7.0_45').validate()
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.8.0_1')) as jdk:
-        Distribution(bin_path=jdk, maximum_version='1.7.9999').validate()
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('bin/java', '1.7.0_25')) as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'bin'), minimum_version='1.7.0_45').validate()
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('bin/java', '1.8.0_1')) as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'bin'), maximum_version='1.7.9999').validate()
 
-    with self.distribution(executables=self.exe('java', '1.7.0_25')) as jdk:
-      Distribution(bin_path=jdk, minimum_version='1.7.0_25').validate()
-      Distribution(bin_path=jdk, minimum_version=Revision.semver('1.6.0')).validate()
-      Distribution(bin_path=jdk, minimum_version='1.7.0_25', maximum_version='1.7.999').validate()
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_25')) as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'bin'), minimum_version='1.7.0_25').validate()
+      Distribution(bin_path=os.path.join(dist_root, 'bin'),
+                   minimum_version=Revision.semver('1.6.0')).validate()
+      Distribution(bin_path=os.path.join(dist_root, 'bin'),
+                   minimum_version='1.7.0_25',
+                   maximum_version='1.7.999').validate()
 
   def test_validated_binary(self):
-    with pytest.raises(Distribution.Error):
-      with self.distribution(files='jar', executables=self.exe('java')) as jdk:
-        Distribution(bin_path=jdk).binary('jar')
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(files='bin/jar', executables=self.exe('bin/java')) as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'bin')).binary('jar')
 
-    with self.distribution(executables=[self.exe('java'), self.exe('jar')]) as jdk:
-      Distribution(bin_path=jdk).binary('jar')
+    with self.distribution(executables=[self.exe('bin/java'), self.exe('bin/jar')]) as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'bin')).binary('jar')
+
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=[self.exe('jre/bin/java'),
+                                          self.exe('bin/jar')],
+                             java_home='jre') as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'jre', 'bin')).binary('jar')
+
+    with self.distribution(executables=[self.exe('jre/bin/java'),
+                                        self.exe('bin/jar'),
+                                        self.exe('bin/javac')],
+                           java_home='jre') as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'jre', 'bin')).binary('jar')
+
+    with self.distribution(executables=[self.exe('jre/bin/java'),
+                                        self.exe('jre/bin/java_vm'),
+                                        self.exe('bin/javac')],
+                           java_home='jre') as dist_root:
+      Distribution(bin_path=os.path.join(dist_root, 'jre', 'bin')).binary('java_vm')
 
   def test_validated_library(self):
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java')) as jdk:
-        Distribution(bin_path=jdk).find_libs(['tools.jar'])
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('bin/java')) as dist_root:
+        Distribution(bin_path=os.path.join(dist_root, 'bin')).find_libs(['tools.jar'])
 
-    with self.distribution(executables=self.exe('java'), libs='tools.jar') as jdk:
-      Distribution(bin_path=jdk).find_libs(['tools.jar'])
+    with self.distribution(executables=self.exe('bin/java'), files='lib/tools.jar') as dist_root:
+      distribution = Distribution(bin_path=os.path.join(dist_root, 'bin'))
+      self.assertEqual([os.path.join(dist_root, 'lib', 'tools.jar')],
+                       distribution.find_libs(['tools.jar']))
+
+    with self.distribution(executables=[self.exe('jre/bin/java'), self.exe('bin/javac')],
+                           files=['lib/tools.jar', 'jre/lib/rt.jar'],
+                           java_home='jre') as dist_root:
+      distribution = Distribution(bin_path=os.path.join(dist_root, 'jre/bin'))
+      self.assertEqual([os.path.join(dist_root, 'lib', 'tools.jar'),
+                        os.path.join(dist_root, 'jre', 'lib', 'rt.jar')],
+                       distribution.find_libs(['tools.jar', 'rt.jar']))
 
   def test_locate(self):
-
-    with pytest.raises(Distribution.Error):
+    with self.assertRaises(Distribution.Error):
       with self.env():
         Distribution.locate()
 
-    with pytest.raises(Distribution.Error):
-      with self.distribution(files='java') as jdk:
-        with self.env(PATH=jdk):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(files='bin/java') as dist_root:
+        with self.env(PATH=os.path.join(dist_root, 'bin')):
           Distribution.locate()
 
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java')) as jdk:
-        with self.env(PATH=jdk):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('bin/java')) as dist_root:
+        with self.env(PATH=os.path.join(dist_root, 'bin')):
           Distribution.locate(jdk=True)
 
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.6.0')) as jdk:
-        with self.env(PATH=jdk):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('bin/java', '1.6.0')) as dist_root:
+        with self.env(PATH=os.path.join(dist_root, 'bin')):
           Distribution.locate(minimum_version='1.7.0')
 
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java', '1.8.0')) as jdk:
-        with self.env(PATH=jdk):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('bin/java', '1.8.0')) as dist_root:
+        with self.env(PATH=os.path.join(dist_root, 'bin')):
           Distribution.locate(maximum_version='1.7.999')
 
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java')) as jdk:
-        with self.env(JDK_HOME=jdk):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('java')) as dist_root:
+        with self.env(JDK_HOME=dist_root):
           Distribution.locate()
 
-    with pytest.raises(Distribution.Error):
-      with self.distribution(executables=self.exe('java')) as jdk:
-        with self.env(JAVA_HOME=jdk):
+    with self.assertRaises(Distribution.Error):
+      with self.distribution(executables=self.exe('java')) as dist_root:
+        with self.env(JAVA_HOME=dist_root):
           Distribution.locate()
 
-    with self.distribution(executables=self.exe('java')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate()
 
-    with self.distribution(executables=[self.exe('java'), self.exe('javac')]) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=[self.exe('bin/java'), self.exe('bin/javac')]) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(jdk=True)
 
-    with self.distribution(executables=self.exe('java', '1.7.0')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=[self.exe('jre/bin/java'),
+                                        self.exe('bin/javac')],
+                           java_home='jre') as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'jre', 'bin')):
+        Distribution.locate(jdk=True)
+
+    with self.distribution(executables=self.exe('bin/java', '1.7.0')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(minimum_version='1.6.0')
-      with self.env(PATH=jdk):
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(maximum_version='1.7.999')
-      with self.env(PATH=jdk):
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(minimum_version='1.6.0', maximum_version='1.7.999')
 
-    with self.distribution(executables=self.exe('bin/java')) as jdk:
-      with self.env(JDK_HOME=jdk):
+    with self.distribution(executables=self.exe('bin/java')) as dist_root:
+      with self.env(JDK_HOME=dist_root):
         Distribution.locate()
 
-    with self.distribution(executables=self.exe('bin/java')) as jdk:
-      with self.env(JAVA_HOME=jdk):
+    with self.distribution(executables=self.exe('bin/java')) as dist_root:
+      with self.env(JAVA_HOME=dist_root):
         Distribution.locate()
 
   def test_cached_good_min(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.cached(minimum_version='1.7.0_25')
 
   def test_cached_good_max(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.cached(maximum_version='1.7.0_50')
 
   def test_cached_good_bounds(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.cached(minimum_version='1.6.0_35', maximum_version='1.7.0_55')
 
   def test_cached_too_low(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.7.0_40')
 
   def test_cached_too_high(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_83')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_83')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(maximum_version='1.7.0_55')
 
   def test_cached_low_fault(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.7.0_35', maximum_version='1.7.0_55')
 
   def test_cached_high_fault(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.6.0_00', maximum_version='1.6.0_50')
 
   def test_cached_conflicting(self):
-    with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-      with self.env(PATH=jdk):
+    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+      with self.env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.7.0_00', maximum_version='1.6.0_50')
 
   def test_cached_bad_input(self):
     with self.assertRaises(ValueError):
-      with self.distribution(executables=self.exe('java', '1.7.0_33')) as jdk:
-        with self.env(PATH=jdk):
+      with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
+        with self.env(PATH=os.path.join(dist_root, 'bin')):
           Distribution.cached(minimum_version=1.7, maximum_version=1.8)
+
 
 def exe_path(name):
   process = subprocess.Popen(['which', name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -248,11 +286,11 @@ class LiveDistributionTest(unittest.TestCase):
   JAVA = exe_path('java')
   JAVAC = exe_path('javac')
 
-  @pytest.mark.skipif('not LiveDistributionTest.JAVA', reason='No java executable on the PATH.')
+  @unittest.skipIf(not JAVA, reason='No java executable on the PATH.')
   def test_validate_live(self):
-    with pytest.raises(Distribution.Error):
+    with self.assertRaises(Distribution.Error):
       Distribution(bin_path=os.path.dirname(self.JAVA), minimum_version='999.9.9').validate()
-    with pytest.raises(Distribution.Error):
+    with self.assertRaises(Distribution.Error):
       Distribution(bin_path=os.path.dirname(self.JAVA), maximum_version='0.0.1').validate()
 
     Distribution(bin_path=os.path.dirname(self.JAVA)).validate()
@@ -262,7 +300,7 @@ class LiveDistributionTest(unittest.TestCase):
                  maximum_version='999.999.999').validate()
     Distribution.locate(jdk=False)
 
-  @pytest.mark.skipif('not LiveDistributionTest.JAVAC', reason='No javac executable on the PATH.')
+  @unittest.skipIf(not JAVAC, reason='No javac executable on the PATH.')
   def test_validate_live_jdk(self):
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).validate()
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).binary('javap')

--- a/tests/python/pants_test/java/test_executor.py
+++ b/tests/python/pants_test/java/test_executor.py
@@ -25,8 +25,9 @@ class SubprocessExecutorTest(unittest.TestCase):
       with safe_open(path, 'w') as fp:
         fp.write(textwrap.dedent("""
             #!/bin/sh
-            echo ${env_var}
-          """.format(env_var=env_var)).strip())
+            echo ${env_var} >&2
+            echo "java.home={java_home}"
+          """.format(env_var=env_var, java_home=jre)).strip())
       chmod_plus_x(path)
       yield jre
 
@@ -39,9 +40,9 @@ class SubprocessExecutorTest(unittest.TestCase):
                                  main='dummy.main',
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
-        stdout, _ = process.communicate()
+        _, stderr = process.communicate()
         self.assertEqual(0, process.returncode)
-        self.assertEqual('' if scrubbed else env_value, stdout.strip())
+        self.assertEqual('' if scrubbed else env_value, stderr.strip())
 
   def test_not_scrubbed(self):
     self.do_test_jre_env_var('FRED', 'frog', scrubbed=False)


### PR DESCRIPTION
Kill now-dead `-e` and `-t` flags in one of the OSX CI shards.

Fixup Distribution to discover its true home dir even if initial
discovery is via the jre `java` executable and add unit tests to
exercise this.  Also fixup both binary and lib_path discovery to
check both JDK and JRE bin and lib paths when the distribution is a JDK.

https://rbcommons.com/s/twitter/r/2241/