### PR TITLE
Find java distributions in well known locations.

### DIFF
--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -179,7 +179,7 @@ class Distribution(object):
     # We accommodate that difference here using lenient parsing.
     # We also accommodate specification versions, which just have major and minor
     # components; eg: `1.8`.  These are useful when specifying constraints a distribution must
-    # satisfy; eg to pick any 1.8 java distribution: '1.8' <= version <= '1.8.99'
+    # satisfy; eg: to pick any 1.8 java distribution: '1.8' <= version <= '1.8.99'
     if isinstance(version, string_types):
       version = Revision.lenient(version)
     if version and not isinstance(version, Revision):

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -143,8 +143,6 @@ class Distribution(object):
       for location in cls._linux_java_homes():
         yield location
 
-      # OSX has non-standard on-disk layouts for jdks that can lead to trouble unless a special
-      # tool is used to locate the standard-layout dir.
       for location in cls._osx_java_homes():
         yield location
 
@@ -192,7 +190,9 @@ class Distribution(object):
 
   def __init__(self, home_path=None, bin_path=None, minimum_version=None, maximum_version=None,
                jdk=False):
-    """Creates a distribution wrapping the given bin_path.
+    """Creates a distribution wrapping the given `home_path` or `bin_path`.
+
+    Only one of `home_path` or `bin_path` should be supplied.
 
     :param string home_path: the path to the java distribution's home dir
     :param string bin_path: the path to the java distribution's bin dir
@@ -204,9 +204,9 @@ class Distribution(object):
       raise ValueError('The specified java home path is invalid: {}'.format(home_path))
     if bin_path and not os.path.isdir(bin_path):
       raise ValueError('The specified binary path is invalid: {}'.format(bin_path))
-    if home_path and bin_path and not bin_path.startswith(home_path):
-      raise ValueError('The specified binary path {} is not inside java home {}'
-                       .format(bin_path, home_path))
+    if not bool(home_path) ^ bool(bin_path):
+      raise ValueError('Exactly one of home path or bin path should be supplied, given: '
+                       'home_path={} bin_path={}'.format(home_path, bin_path))
 
     self._home = home_path
     self._bin_path = bin_path or (os.path.join(home_path, 'bin') if home_path else '/usr/bin')

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -8,7 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 import pkgutil
+import plistlib
 import subprocess
+from collections import namedtuple
 from contextlib import contextmanager
 
 from six import string_types
@@ -58,6 +60,71 @@ class Distribution(object):
       cls._CACHE[key] = dist
     return dist
 
+  class _Location(namedtuple('Location', ['home_path', 'bin_path'])):
+    """Represents the location of a java distribution."""
+    @classmethod
+    def from_home(cls, home):
+      """Creates a location given the JAVA_HOME directory.
+
+      :param string home: The path of the JAVA_HOME directory.
+      :returns: The java distribution location.
+      """
+      return cls(home_path=home, bin_path=None)
+
+    @classmethod
+    def from_bin(cls, bin_path):
+      """Creates a location given the `java` executable parent directory.
+
+      :param string bin_path: The parent path of the `java` executable.
+      :returns: The java distribution location.
+      """
+      return cls(home_path=None, bin_path=bin_path)
+
+  # The `/usr/lib/jvm` dir is a common target of packages built for redhat and debian as well as
+  # other more exotic distributions.
+  _JAVA_DIST_DIR = '/usr/lib/jvm'
+
+  @classmethod
+  def _linux_java_homes(cls):
+    if os.path.isdir(cls._JAVA_DIST_DIR):
+      for path in os.listdir(cls._JAVA_DIST_DIR):
+        home = os.path.join(cls._JAVA_DIST_DIR, path)
+        if os.path.isdir(home):
+          yield cls._Location.from_home(home)
+
+  _OSX_JAVA_HOME_EXE = '/usr/libexec/java_home'
+
+  @classmethod
+  def _osx_java_homes(cls):
+    # OSX will have a java_home tool that can be used to locate a unix-compatible java home dir.
+    #
+    # See:
+    #   https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/java_home.1.html
+    #
+    # The `--xml` output looks like so:
+    # <?xml version="1.0" encoding="UTF-8"?>
+    # <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    #                        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    # <plist version="1.0">
+    #   <array>
+    #     <dict>
+    #       ...
+    #       <key>JVMHomePath</key>
+    #       <string>/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home</string>
+    #       ...
+    #     </dict>
+    #     ...
+    #   </array>
+    # </plist>
+    if os.path.exists(cls._OSX_JAVA_HOME_EXE):
+      try:
+        plist = subprocess.check_output([cls._OSX_JAVA_HOME_EXE, '--failfast', '--xml'])
+        for distribution in plistlib.readPlistFromString(plist):
+          home = distribution['JVMHomePath']
+          yield cls._Location.from_home(home)
+      except subprocess.CalledProcessError:
+        pass
+
   @classmethod
   def locate(cls, minimum_version=None, maximum_version=None, jdk=False):
     """Finds a java distribution that meets any given constraints and returns it.
@@ -65,22 +132,34 @@ class Distribution(object):
     First looks in JDK_HOME and JAVA_HOME if defined falling back to a search on the PATH.
     Raises Distribution.Error if no suitable java distribution could be found.
     """
-    def home_bin_path(home_env_var):
+    def env_home(home_env_var):
       home = os.environ.get(home_env_var)
-      return os.path.join(home, 'bin') if home else None
+      return cls._Location.from_home(home) if home else None
 
     def search_path():
-      yield home_bin_path('JDK_HOME')
-      yield home_bin_path('JAVA_HOME')
-      path = os.environ.get('PATH')
-      if path:
-        for p in path.strip().split(os.pathsep):
-          yield p
+      yield env_home('JDK_HOME')
+      yield env_home('JAVA_HOME')
 
-    for path in filter(None, search_path()):
+      for location in cls._linux_java_homes():
+        yield location
+
+      # OSX has non-standard on-disk layouts for jdks that can lead to trouble unless a special
+      # tool is used to locate the standard-layout dir.
+      for location in cls._osx_java_homes():
+        yield location
+
+      search_path = os.environ.get('PATH')
+      if search_path:
+        for bin_path in search_path.strip().split(os.pathsep):
+          yield cls._Location.from_bin(bin_path)
+
+    for location in filter(None, search_path()):
       try:
-        dist = cls(bin_path=path, minimum_version=minimum_version,
-                   maximum_version=maximum_version, jdk=jdk)
+        dist = cls(home_path=location.home_path,
+                   bin_path=location.bin_path,
+                   minimum_version=minimum_version,
+                   maximum_version=maximum_version,
+                   jdk=jdk)
         dist.validate()
         logger.debug('Located {} for constraints: minimum_version {}, maximum_version {}, jdk {}'
                      .format(dist, minimum_version, maximum_version, jdk))
@@ -97,9 +176,12 @@ class Distribution(object):
     #  http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
     # These version strings comply with semver except that the traditional pre-release semver
     # slot (the 4th) can be delimited by an _ in the case of update releases of the jdk.
-    # We accommodate that difference here.
+    # We accommodate that difference here using lenient parsing.
+    # We also accommodate specification versions, which just have major and minor
+    # components; eg: `1.8`.  These are useful when specifying constraints a distribution must
+    # satisfy; eg to pick any 1.8 java distribution: '1.8' <= version <= '1.8.99'
     if isinstance(version, string_types):
-      version = Revision.semver(version.replace('_', '-'))
+      version = Revision.lenient(version)
     if version and not isinstance(version, Revision):
       raise ValueError('{} must be a string or a Revision object, given: {}'.format(name, version))
     return version
@@ -108,25 +190,32 @@ class Distribution(object):
   def _is_executable(path):
     return os.path.isfile(path) and os.access(path, os.X_OK)
 
-  def __init__(self, bin_path='/usr/bin', minimum_version=None, maximum_version=None, jdk=False):
+  def __init__(self, home_path=None, bin_path=None, minimum_version=None, maximum_version=None,
+               jdk=False):
     """Creates a distribution wrapping the given bin_path.
 
-    :param string bin_path: the path to the java distributions bin dir
+    :param string home_path: the path to the java distribution's home dir
+    :param string bin_path: the path to the java distribution's bin dir
     :param minimum_version: a modified semantic version string or else a Revision object
     :param maximum_version: a modified semantic version string or else a Revision object
     :param bool jdk: ``True`` to require the distribution be a JDK vs a JRE
     """
+    if home_path and not os.path.isdir(home_path):
+      raise ValueError('The specified java home path is invalid: {}'.format(home_path))
+    if bin_path and not os.path.isdir(bin_path):
+      raise ValueError('The specified binary path is invalid: {}'.format(bin_path))
+    if home_path and bin_path and not bin_path.startswith(home_path):
+      raise ValueError('The specified binary path {} is not inside java home {}'
+                       .format(bin_path, home_path))
 
-    if not os.path.isdir(bin_path):
-      raise ValueError('The specified distribution path is invalid: {}'.format(bin_path))
-    self._bin_path = bin_path
+    self._home = home_path
+    self._bin_path = bin_path or (os.path.join(home_path, 'bin') if home_path else '/usr/bin')
 
     self._minimum_version = self._parse_java_version("minimum_version", minimum_version)
     self._maximum_version = self._parse_java_version("maximum_version", maximum_version)
 
     self._jdk = jdk
 
-    self._home = None
     self._is_jdk = False
     self._system_properties = None
     self._version = None

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -148,10 +148,7 @@ class DistributionValidationTest(unittest.TestCase):
 class BaseDistributionLocationTest(unittest.TestCase):
   def make_tmp_dir(self):
     tmpdir = tempfile.mkdtemp()
-
-    def cleanup_tmpdir():
-      safe_rmtree(tmpdir)
-    self.addCleanup(cleanup_tmpdir)
+    self.addCleanup(safe_rmtree, tmpdir)
     return tmpdir
 
   def set_up_no_linux_discovery(self):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -44,10 +44,10 @@ def distribution(files=None, executables=None, java_home=None):
     with environment_as(DIST_ROOT=os.path.join(dist_root, java_home) if java_home else dist_root):
       for f in maybe_list(files or ()):
         touch(os.path.join(dist_root, f))
-      for exe in maybe_list(executables or (), expected_type=EXE):
-        path = os.path.join(dist_root, exe.relpath)
+      for executable in maybe_list(executables or (), expected_type=EXE):
+        path = os.path.join(dist_root, executable.relpath)
         with safe_open(path, 'w') as fp:
-          fp.write(exe.contents or '')
+          fp.write(executable.contents or '')
         chmod_plus_x(path)
       yield dist_root
 
@@ -227,9 +227,8 @@ class DistributionEnvLocationTest(BaseDistributionLocationEnvOnlyTest):
         Distribution.locate(jdk=True)
 
   def test_locate_jdk_via_jre_path(self):
-    with distribution(executables=[exe('jre/bin/java'),
-                                        exe('bin/javac')],
-                           java_home='jre') as dist_root:
+    with distribution(executables=[exe('jre/bin/java'), exe('bin/javac')],
+                      java_home='jre') as dist_root:
       with env(PATH=os.path.join(dist_root, 'jre', 'bin')):
         Distribution.locate(jdk=True)
 

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import subprocess
+import tempfile
 import textwrap
 import unittest
 from collections import namedtuple
@@ -17,259 +18,457 @@ from twitter.common.collections import maybe_list
 from pants.base.revision import Revision
 from pants.java.distribution.distribution import Distribution
 from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import chmod_plus_x, safe_open, touch
+from pants.util.dirutil import chmod_plus_x, safe_open, safe_rmtree, touch
 
 
-class MockDistributionTest(unittest.TestCase):
-  EXE = namedtuple('Exe', ['relpath', 'contents'])
+EXE = namedtuple('Exe', ['relpath', 'contents'])
 
-  @classmethod
-  def exe(cls, relpath, version=None):
-    contents = textwrap.dedent("""
-        #!/bin/sh
-        if [ $# -ne 3 ]; then
-          # Sanity check a classpath switch with a value plus the classname for main
-          echo "Expected 3 arguments, got $#: $@" >&2
-          exit 1
-        fi
-        echo "java.home=${{DIST_ROOT}}"
-        {}
-      """.format('echo "java.version={}"'.format(version) if version else '')).strip()
-    return cls.EXE(relpath, contents=contents)
 
-  @contextmanager
-  def env(self, **kwargs):
-    environment = dict(JDK_HOME=None, JAVA_HOME=None, PATH=None)
-    environment.update(**kwargs)
-    with environment_as(**environment):
-      yield
+def exe(relpath, version=None):
+  contents = textwrap.dedent("""
+      #!/bin/sh
+      if [ $# -ne 3 ]; then
+        # Sanity check a classpath switch with a value plus the classname for main
+        echo "Expected 3 arguments, got $#: $@" >&2
+        exit 1
+      fi
+      echo "java.home=${{DIST_ROOT}}"
+      {}
+    """.format('echo "java.version={}"'.format(version) if version else '')).strip()
+  return EXE(relpath, contents=contents)
 
-  @contextmanager
-  def distribution(self, files=None, executables=None, java_home=None):
-    with temporary_dir() as dist_root:
-      with environment_as(DIST_ROOT=os.path.join(dist_root, java_home) if java_home else dist_root):
-        for f in maybe_list(files or ()):
-          touch(os.path.join(dist_root, f))
-        for exe in maybe_list(executables or (), expected_type=self.EXE):
-          path = os.path.join(dist_root, exe.relpath)
-          with safe_open(path, 'w') as fp:
-            fp.write(exe.contents or '')
-          chmod_plus_x(path)
-        yield dist_root
 
-  def setUp(self):
-    super(MockDistributionTest, self).setUp()
-    # Save local cache and then flush so tests get a clean environment. _CACHE restored in tearDown.
-    self._local_cache = Distribution._CACHE
-    Distribution._CACHE = {}
+@contextmanager
+def distribution(files=None, executables=None, java_home=None):
+  with temporary_dir() as dist_root:
+    with environment_as(DIST_ROOT=os.path.join(dist_root, java_home) if java_home else dist_root):
+      for f in maybe_list(files or ()):
+        touch(os.path.join(dist_root, f))
+      for exe in maybe_list(executables or (), expected_type=EXE):
+        path = os.path.join(dist_root, exe.relpath)
+        with safe_open(path, 'w') as fp:
+          fp.write(exe.contents or '')
+        chmod_plus_x(path)
+      yield dist_root
 
-  def tearDown(self):
-    super(MockDistributionTest, self).tearDown()
-    Distribution._CACHE = self._local_cache
+@contextmanager
+def env(**kwargs):
+  environment = dict(JDK_HOME=None, JAVA_HOME=None, PATH=None)
+  environment.update(**kwargs)
+  with environment_as(**environment):
+    yield
 
+
+class DistributionValidationTest(unittest.TestCase):
   def test_validate_basic(self):
-    with self.assertRaises(ValueError):
-      with self.distribution() as dist_root:
+    with distribution() as dist_root:
+      with self.assertRaises(ValueError):
         Distribution(bin_path=os.path.join(dist_root, 'bin')).validate()
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(files='bin/java') as dist_root:
+    with distribution(files='bin/java') as dist_root:
+      with self.assertRaises(Distribution.Error):
         Distribution(bin_path=os.path.join(dist_root, 'bin')).validate()
 
-    with self.distribution(executables=self.exe('bin/java')) as dist_root:
+    with distribution(executables=exe('bin/java')) as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'bin')).validate()
 
   def test_validate_jre(self):
-    with self.distribution(executables=self.exe('bin/java')) as dist_root:
+    with distribution(executables=exe('bin/java')) as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'bin'), jdk=False).validate()
 
   def test_validate_jdk(self):
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('bin/java')) as dist_root:
+    with distribution(executables=exe('bin/java')) as dist_root:
+      with self.assertRaises(Distribution.Error):
         Distribution(bin_path=os.path.join(dist_root, 'bin'), jdk=True).validate()
 
-    with self.distribution(executables=[self.exe('bin/java'), self.exe('bin/javac')]) as dist_root:
+    with distribution(executables=[exe('bin/java'), exe('bin/javac')]) as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'bin'), jdk=True).validate()
 
-    with self.distribution(executables=[self.exe('jre/bin/java'),
-                                        self.exe('bin/javac')],
-                           java_home='jre') as dist_root:
+    with distribution(executables=[exe('jre/bin/java'), exe('bin/javac')],
+                      java_home='jre') as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'jre/bin'), jdk=True).validate()
 
   def test_validate_version(self):
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('bin/java', '1.7.0_25')) as dist_root:
+    with distribution(executables=exe('bin/java', '1.7.0_25')) as dist_root:
+      with self.assertRaises(Distribution.Error):
         Distribution(bin_path=os.path.join(dist_root, 'bin'), minimum_version='1.7.0_45').validate()
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('bin/java', '1.8.0_1')) as dist_root:
-        Distribution(bin_path=os.path.join(dist_root, 'bin'), maximum_version='1.7.9999').validate()
+    with distribution(executables=exe('bin/java', '1.8.0_1')) as dist_root:
+      with self.assertRaises(Distribution.Error):
+        Distribution(bin_path=os.path.join(dist_root, 'bin'), maximum_version='1.8').validate()
 
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_25')) as dist_root:
+    with distribution(executables=exe('bin/java', '1.7.0_25')) as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'bin'), minimum_version='1.7.0_25').validate()
       Distribution(bin_path=os.path.join(dist_root, 'bin'),
-                   minimum_version=Revision.semver('1.6.0')).validate()
+                   minimum_version=Revision.lenient('1.6')).validate()
       Distribution(bin_path=os.path.join(dist_root, 'bin'),
                    minimum_version='1.7.0_25',
                    maximum_version='1.7.999').validate()
 
   def test_validated_binary(self):
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(files='bin/jar', executables=self.exe('bin/java')) as dist_root:
+    with distribution(files='bin/jar', executables=exe('bin/java')) as dist_root:
+      with self.assertRaises(Distribution.Error):
         Distribution(bin_path=os.path.join(dist_root, 'bin')).binary('jar')
 
-    with self.distribution(executables=[self.exe('bin/java'), self.exe('bin/jar')]) as dist_root:
+    with distribution(executables=[exe('bin/java'), exe('bin/jar')]) as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'bin')).binary('jar')
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=[self.exe('jre/bin/java'),
-                                          self.exe('bin/jar')],
-                             java_home='jre') as dist_root:
+    with distribution(executables=[exe('jre/bin/java'), exe('bin/jar')],
+                      java_home='jre') as dist_root:
+      with self.assertRaises(Distribution.Error):
         Distribution(bin_path=os.path.join(dist_root, 'jre', 'bin')).binary('jar')
 
-    with self.distribution(executables=[self.exe('jre/bin/java'),
-                                        self.exe('bin/jar'),
-                                        self.exe('bin/javac')],
-                           java_home='jre') as dist_root:
+    with distribution(executables=[exe('jre/bin/java'), exe('bin/jar'), exe('bin/javac')],
+                      java_home='jre') as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'jre', 'bin')).binary('jar')
 
-    with self.distribution(executables=[self.exe('jre/bin/java'),
-                                        self.exe('jre/bin/java_vm'),
-                                        self.exe('bin/javac')],
-                           java_home='jre') as dist_root:
+    with distribution(executables=[exe('jre/bin/java'), exe('jre/bin/java_vm'), exe('bin/javac')],
+                      java_home='jre') as dist_root:
       Distribution(bin_path=os.path.join(dist_root, 'jre', 'bin')).binary('java_vm')
 
   def test_validated_library(self):
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('bin/java')) as dist_root:
+    with distribution(executables=exe('bin/java')) as dist_root:
+      with self.assertRaises(Distribution.Error):
         Distribution(bin_path=os.path.join(dist_root, 'bin')).find_libs(['tools.jar'])
 
-    with self.distribution(executables=self.exe('bin/java'), files='lib/tools.jar') as dist_root:
-      distribution = Distribution(bin_path=os.path.join(dist_root, 'bin'))
+    with distribution(executables=exe('bin/java'), files='lib/tools.jar') as dist_root:
+      dist = Distribution(bin_path=os.path.join(dist_root, 'bin'))
       self.assertEqual([os.path.join(dist_root, 'lib', 'tools.jar')],
-                       distribution.find_libs(['tools.jar']))
+                       dist.find_libs(['tools.jar']))
 
-    with self.distribution(executables=[self.exe('jre/bin/java'), self.exe('bin/javac')],
-                           files=['lib/tools.jar', 'jre/lib/rt.jar'],
-                           java_home='jre') as dist_root:
-      distribution = Distribution(bin_path=os.path.join(dist_root, 'jre/bin'))
+    with distribution(executables=[exe('jre/bin/java'), exe('bin/javac')],
+                      files=['lib/tools.jar', 'jre/lib/rt.jar'],
+                      java_home='jre') as dist_root:
+      dist = Distribution(bin_path=os.path.join(dist_root, 'jre/bin'))
       self.assertEqual([os.path.join(dist_root, 'lib', 'tools.jar'),
                         os.path.join(dist_root, 'jre', 'lib', 'rt.jar')],
-                       distribution.find_libs(['tools.jar', 'rt.jar']))
+                       dist.find_libs(['tools.jar', 'rt.jar']))
 
-  def test_locate(self):
-    with self.assertRaises(Distribution.Error):
-      with self.env():
+
+class BaseDistributionLocationTest(unittest.TestCase):
+  def set_up_no_linux_discovery(self):
+    isdir = os.path.isdir
+
+    def restore_isdir():
+      os.path.isdir = isdir
+    os.path.isdir = lambda path: False if path == '/usr/lib/jvm' else isdir(path)
+    self.addCleanup(restore_isdir)
+
+  def set_up_no_osx_discovery(self):
+    osx_java_home_exe = Distribution._OSX_JAVA_HOME_EXE
+
+    tmpdir = tempfile.mkdtemp()
+
+    def cleanup_tmpdir():
+      safe_rmtree(tmpdir)
+    self.addCleanup(cleanup_tmpdir)
+
+    def restore_osx_java_home_exe():
+      Distribution._OSX_JAVA_HOME_EXE = osx_java_home_exe
+
+    Distribution._OSX_JAVA_HOME_EXE = os.path.join(tmpdir, 'java_home')
+    self.addCleanup(restore_osx_java_home_exe)
+
+
+class BaseDistributionLocationEnvOnlyTest(BaseDistributionLocationTest):
+  def setUp(self):
+    self.set_up_no_linux_discovery()
+    self.set_up_no_osx_discovery()
+
+
+class DistributionEnvLocationTest(BaseDistributionLocationEnvOnlyTest):
+  def test_locate_none(self):
+    with env():
+      with self.assertRaises(Distribution.Error):
         Distribution.locate()
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(files='bin/java') as dist_root:
-        with self.env(PATH=os.path.join(dist_root, 'bin')):
+  def test_locate_java_not_executable(self):
+    with distribution(files='bin/java') as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
+        with self.assertRaises(Distribution.Error):
           Distribution.locate()
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('bin/java')) as dist_root:
-        with self.env(PATH=os.path.join(dist_root, 'bin')):
+  def test_locate_jdk_is_jre(self):
+    with distribution(executables=exe('bin/java')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
+        with self.assertRaises(Distribution.Error):
           Distribution.locate(jdk=True)
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('bin/java', '1.6.0')) as dist_root:
-        with self.env(PATH=os.path.join(dist_root, 'bin')):
+  def test_locate_version_to_low(self):
+    with distribution(executables=exe('bin/java', '1.6.0')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
+        with self.assertRaises(Distribution.Error):
           Distribution.locate(minimum_version='1.7.0')
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('bin/java', '1.8.0')) as dist_root:
-        with self.env(PATH=os.path.join(dist_root, 'bin')):
+  def test_locate_version_to_high(self):
+    with distribution(executables=exe('bin/java', '1.8.0')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
+        with self.assertRaises(Distribution.Error):
           Distribution.locate(maximum_version='1.7.999')
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('java')) as dist_root:
-        with self.env(JDK_HOME=dist_root):
+  def test_locate_invalid_jdk_home(self):
+    with distribution(executables=exe('java')) as dist_root:
+      with env(JDK_HOME=dist_root):
+        with self.assertRaises(Distribution.Error):
           Distribution.locate()
 
-    with self.assertRaises(Distribution.Error):
-      with self.distribution(executables=self.exe('java')) as dist_root:
-        with self.env(JAVA_HOME=dist_root):
+  def test_locate_invalid_java_home(self):
+    with distribution(executables=exe('java')) as dist_root:
+      with env(JAVA_HOME=dist_root):
+        with self.assertRaises(Distribution.Error):
           Distribution.locate()
 
-    with self.distribution(executables=self.exe('bin/java')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+  def test_locate_jre_by_path(self):
+    with distribution(executables=exe('bin/java')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate()
 
-    with self.distribution(executables=[self.exe('bin/java'), self.exe('bin/javac')]) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+  def test_locate_jdk_by_path(self):
+    with distribution(executables=[exe('bin/java'), exe('bin/javac')]) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(jdk=True)
 
-    with self.distribution(executables=[self.exe('jre/bin/java'),
-                                        self.exe('bin/javac')],
+  def test_locate_jdk_via_jre_path(self):
+    with distribution(executables=[exe('jre/bin/java'),
+                                        exe('bin/javac')],
                            java_home='jre') as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'jre', 'bin')):
+      with env(PATH=os.path.join(dist_root, 'jre', 'bin')):
         Distribution.locate(jdk=True)
 
-    with self.distribution(executables=self.exe('bin/java', '1.7.0')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+  def test_locate_version_greater_then_or_equal(self):
+    with distribution(executables=exe('bin/java', '1.7.0')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(minimum_version='1.6.0')
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+
+  def test_locate_version_less_then_or_equal(self):
+    with distribution(executables=exe('bin/java', '1.7.0')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(maximum_version='1.7.999')
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+
+  def test_locate_version_within_range(self):
+    with distribution(executables=exe('bin/java', '1.7.0')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.locate(minimum_version='1.6.0', maximum_version='1.7.999')
 
-    with self.distribution(executables=self.exe('bin/java')) as dist_root:
-      with self.env(JDK_HOME=dist_root):
+  def test_locate_via_jdk_home(self):
+    with distribution(executables=exe('bin/java')) as dist_root:
+      with env(JDK_HOME=dist_root):
         Distribution.locate()
 
-    with self.distribution(executables=self.exe('bin/java')) as dist_root:
-      with self.env(JAVA_HOME=dist_root):
+  def test_locate_via_java_home(self):
+    with distribution(executables=exe('bin/java')) as dist_root:
+      with env(JAVA_HOME=dist_root):
         Distribution.locate()
+
+
+class DistributionLinuxLocationTest(BaseDistributionLocationTest):
+  def setUp(self):
+    self.set_up_no_osx_discovery()
+
+  @contextmanager
+  def java_dist_dir(self):
+    with distribution(executables=exe('bin/java', version='1')) as jdk1_home:
+      with distribution(executables=exe('bin/java', version='2')) as jdk2_home:
+        with temporary_dir() as java_dist_dir:
+          jdk1_home_link = os.path.join(java_dist_dir, 'jdk1_home')
+          jdk2_home_link = os.path.join(java_dist_dir, 'jdk2_home')
+          os.symlink(jdk1_home, jdk1_home_link)
+          os.symlink(jdk2_home, jdk2_home_link)
+
+          original_java_dist_dir = Distribution._JAVA_DIST_DIR
+          Distribution._JAVA_DIST_DIR = java_dist_dir
+          try:
+            yield jdk1_home_link, jdk2_home_link
+          finally:
+            Distribution._JAVA_DIST_DIR = original_java_dist_dir
+
+  def test_locate_jdk1(self):
+    with env():
+      with self.java_dist_dir() as (jdk1_home, _):
+        dist = Distribution.locate(maximum_version='1')
+        self.assertEqual(jdk1_home, dist.home)
+
+  def test_locate_jdk2(self):
+    with env():
+      with self.java_dist_dir() as (_, jdk2_home):
+        dist = Distribution.locate(minimum_version='2')
+        self.assertEqual(jdk2_home, dist.home)
+
+  def test_locate_trumps_path(self):
+    with self.java_dist_dir() as (jdk1_home, jdk2_home):
+      with distribution(executables=exe('bin/java', version='3')) as path_jdk:
+        with env(PATH=os.path.join(path_jdk, 'bin')):
+          dist = Distribution.locate(minimum_version='2')
+          self.assertEqual(jdk2_home, dist.home)
+          dist = Distribution.locate(minimum_version='3')
+          self.assertEqual(path_jdk, dist.home)
+
+  def test_locate_jdk_home_trumps(self):
+    with self.java_dist_dir() as (jdk1_home, jdk2_home):
+      with distribution(executables=exe('bin/java', version='3')) as jdk_home:
+        with env(JDK_HOME=jdk_home):
+          dist = Distribution.locate()
+          self.assertEqual(jdk_home, dist.home)
+          dist = Distribution.locate(maximum_version='1.1')
+          self.assertEqual(jdk1_home, dist.home)
+          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          self.assertEqual(jdk2_home, dist.home)
+
+  def test_locate_java_home_trumps(self):
+    with self.java_dist_dir() as (jdk1_home, jdk2_home):
+      with distribution(executables=exe('bin/java', version='3')) as java_home:
+        with env(JAVA_HOME=java_home):
+          dist = Distribution.locate()
+          self.assertEqual(java_home, dist.home)
+          dist = Distribution.locate(maximum_version='1.1')
+          self.assertEqual(jdk1_home, dist.home)
+          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          self.assertEqual(jdk2_home, dist.home)
+
+
+class DistributionOSXLocationTest(BaseDistributionLocationTest):
+  def setUp(self):
+    self.set_up_no_linux_discovery()
+
+  @contextmanager
+  def java_home_exe(self):
+    with distribution(executables=exe('bin/java', version='1')) as jdk1_home:
+      with distribution(executables=exe('bin/java', version='2')) as jdk2_home:
+        with temporary_dir() as tmpdir:
+          osx_java_home_exe = os.path.join(tmpdir, 'java_home')
+          with safe_open(osx_java_home_exe, 'w') as fp:
+            fp.write(textwrap.dedent("""
+                #!/bin/sh
+                echo '<?xml version="1.0" encoding="UTF-8"?>
+                <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+                                       "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+                <plist version="1.0">
+                <array>
+                  <dict>
+                    <key>JVMHomePath</key>
+                    <string>{jdk1_home}</string>
+                  </dict>
+                  <dict>
+                    <key>JVMHomePath</key>
+                    <string>{jdk2_home}</string>
+                  </dict>
+                </array>
+                </plist>
+                '
+              """.format(jdk1_home=jdk1_home, jdk2_home=jdk2_home)).strip())
+          chmod_plus_x(osx_java_home_exe)
+
+          original_osx_java_home_exe = Distribution._OSX_JAVA_HOME_EXE
+          Distribution._OSX_JAVA_HOME_EXE = osx_java_home_exe
+          try:
+            yield jdk1_home, jdk2_home
+          finally:
+            Distribution._OSX_JAVA_HOME_EXE = original_osx_java_home_exe
+
+  def test_locate_jdk1(self):
+    with env():
+      with self.java_home_exe() as (jdk1_home, _):
+        dist = Distribution.locate()
+        self.assertEqual(jdk1_home, dist.home)
+
+  def test_locate_jdk2(self):
+    with env():
+      with self.java_home_exe() as (_, jdk2_home):
+        dist = Distribution.locate(minimum_version='2')
+        self.assertEqual(jdk2_home, dist.home)
+
+  def test_locate_trumps_path(self):
+    with self.java_home_exe() as (jdk1_home, jdk2_home):
+      with distribution(executables=exe('bin/java', version='3')) as path_jdk:
+        with env(PATH=os.path.join(path_jdk, 'bin')):
+          dist = Distribution.locate()
+          self.assertEqual(jdk1_home, dist.home)
+          dist = Distribution.locate(minimum_version='3')
+          self.assertEqual(path_jdk, dist.home)
+
+  def test_locate_jdk_home_trumps(self):
+    with self.java_home_exe() as (jdk1_home, jdk2_home):
+      with distribution(executables=exe('bin/java', version='3')) as jdk_home:
+        with env(JDK_HOME=jdk_home):
+          dist = Distribution.locate()
+          self.assertEqual(jdk_home, dist.home)
+          dist = Distribution.locate(maximum_version='1.1')
+          self.assertEqual(jdk1_home, dist.home)
+          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          self.assertEqual(jdk2_home, dist.home)
+
+  def test_locate_java_home_trumps(self):
+    with self.java_home_exe() as (jdk1_home, jdk2_home):
+      with distribution(executables=exe('bin/java', version='3')) as java_home:
+        with env(JAVA_HOME=java_home):
+          dist = Distribution.locate()
+          self.assertEqual(java_home, dist.home)
+          dist = Distribution.locate(maximum_version='1.1')
+          self.assertEqual(jdk1_home, dist.home)
+          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          self.assertEqual(jdk2_home, dist.home)
+
+
+class DistributionCachedTest(BaseDistributionLocationEnvOnlyTest):
+  def setUp(self):
+    super(DistributionCachedTest, self).setUp()
+
+    # Save local cache and then flush so tests get a clean environment.
+    local_cache = Distribution._CACHE
+
+    def restore_cache():
+      Distribution._CACHE = local_cache
+    Distribution._CACHE = {}
+    self.addCleanup(restore_cache)
 
   def test_cached_good_min(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.cached(minimum_version='1.7.0_25')
 
   def test_cached_good_max(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.cached(maximum_version='1.7.0_50')
 
   def test_cached_good_bounds(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         Distribution.cached(minimum_version='1.6.0_35', maximum_version='1.7.0_55')
 
   def test_cached_too_low(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.7.0_40')
 
   def test_cached_too_high(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_83')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_83')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(maximum_version='1.7.0_55')
 
   def test_cached_low_fault(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.7.0_35', maximum_version='1.7.0_55')
 
   def test_cached_high_fault(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.6.0_00', maximum_version='1.6.0_50')
 
   def test_cached_conflicting(self):
-    with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-      with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
           Distribution.cached(minimum_version='1.7.0_00', maximum_version='1.6.0_50')
 
   def test_cached_bad_input(self):
-    with self.assertRaises(ValueError):
-      with self.distribution(executables=self.exe('bin/java', '1.7.0_33')) as dist_root:
-        with self.env(PATH=os.path.join(dist_root, 'bin')):
+    with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
+      with env(PATH=os.path.join(dist_root, 'bin')):
+        with self.assertRaises(ValueError):
           Distribution.cached(minimum_version=1.7, maximum_version=1.8)
 
 

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -51,6 +51,7 @@ def distribution(files=None, executables=None, java_home=None):
         chmod_plus_x(path)
       yield dist_root
 
+
 @contextmanager
 def env(**kwargs):
   environment = dict(JDK_HOME=None, JAVA_HOME=None, PATH=None)
@@ -145,27 +146,28 @@ class DistributionValidationTest(unittest.TestCase):
 
 
 class BaseDistributionLocationTest(unittest.TestCase):
-  def set_up_no_linux_discovery(self):
-    isdir = os.path.isdir
-
-    def restore_isdir():
-      os.path.isdir = isdir
-    os.path.isdir = lambda path: False if path == '/usr/lib/jvm' else isdir(path)
-    self.addCleanup(restore_isdir)
-
-  def set_up_no_osx_discovery(self):
-    osx_java_home_exe = Distribution._OSX_JAVA_HOME_EXE
-
+  def make_tmp_dir(self):
     tmpdir = tempfile.mkdtemp()
 
     def cleanup_tmpdir():
       safe_rmtree(tmpdir)
     self.addCleanup(cleanup_tmpdir)
+    return tmpdir
+
+  def set_up_no_linux_discovery(self):
+    orig_java_dist_dir = Distribution._JAVA_DIST_DIR
+
+    def restore_java_dist_dir():
+      Distribution._JAVA_DIST_DIR = orig_java_dist_dir
+    Distribution._JAVA_DIST_DIR = self.make_tmp_dir()
+    self.addCleanup(restore_java_dist_dir)
+
+  def set_up_no_osx_discovery(self):
+    osx_java_home_exe = Distribution._OSX_JAVA_HOME_EXE
 
     def restore_osx_java_home_exe():
       Distribution._OSX_JAVA_HOME_EXE = osx_java_home_exe
-
-    Distribution._OSX_JAVA_HOME_EXE = os.path.join(tmpdir, 'java_home')
+    Distribution._OSX_JAVA_HOME_EXE = os.path.join(self.make_tmp_dir(), 'java_home')
     self.addCleanup(restore_osx_java_home_exe)
 
 


### PR DESCRIPTION
Both OSX and linux have well-known tools and conventions for discovering
java distributions. This change adds support for scanning the
`/usr/lib/jvm` dir on linux and using the `/usr/libexec/java_home` tool
on OSX along with test coverage for both.

In the course of adding new tests, old tests are refactored and, in
particular, the monolithic locate test is broken apart into tightly
scoped tests.

https://rbcommons.com/s/twitter/r/2242/