### PR TITLE
Add support for python test sharding.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -29,8 +29,9 @@ env:
     # - CI_FLAGS="-clpnet 'Various pants self checks'"  # (fkmsr)
     - CI_FLAGS="-fkmsrcn 'Unit tests for pants and pants-plugins'"  # (jlp)
     - CI_FLAGS="-fkmsrcjlp 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrjlpn -i 2:0 'Python integration tests for pants - shard 1'"  # (c)
-    - CI_FLAGS="-fkmsrjlpn -i 2:1 'Python integration tests for pants - shard 2'"
+    - CI_FLAGS="-fkmsrjlpn -i 0/3 'Python integration tests for pants - shard 1'"  # (c)
+    - CI_FLAGS="-fkmsrjlpn -i 1/3 'Python integration tests for pants - shard 2'"
+    - CI_FLAGS="-fkmsrjlpn -i 2/3 'Python integration tests for pants - shard 3'"
 
 before_install:
   # We need a sane python and as of 3/5/2015 on OSX 10.9 the provided python 2.7.5 encounters

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,14 +33,15 @@ env:
     - secure: VvwbndU++a2/iNAjk9cd67ATiipDwqcKnxDR4/J2Ik3GH10wHEDUhJ1+MK4WLhedfaOakDOEmarZQS3GwtgvCHO3knpTJuJc8d/bCfZovYuSqdi//BEv4dS7hDt6tQeJfkbBjG0T4yNjPJ3W9R9KDWCy/vj2CUm90BGg2CmxUbg=
   matrix:
     - CI_FLAGS="-cjlpn 'Various pants self checks'"  # (fkmsr)
-    - CI_FLAGS="-fkmsrcn 'Unit tests for pants and pants-plugins'"  # (jlp)
+    - CI_FLAGS="-fkmsrcn -u 0/2 'Unit tests for pants and pants-plugins - shard 1'"  # (jlp)
+    - CI_FLAGS="-fkmsrcn -u 1/2 'Unit tests for pants and pants-plugins - shard 2'"
     - CI_FLAGS="-fkmsrcjlp 'Python contrib tests'"  # (n)
-    - CI_FLAGS="-fkmsrjlpn -i 6:0 'Python integration tests for pants - shard 1'"  # (c)
-    - CI_FLAGS="-fkmsrjlpn -i 6:1 'Python integration tests for pants - shard 2'"
-    - CI_FLAGS="-fkmsrjlpn -i 6:2 'Python integration tests for pants - shard 3'"
-    - CI_FLAGS="-fkmsrjlpn -i 6:3 'Python integration tests for pants - shard 4'"
-    - CI_FLAGS="-fkmsrjlpn -i 6:4 'Python integration tests for pants - shard 5'"
-    - CI_FLAGS="-fkmsrjlpn -i 6:5 'Python integration tests for pants - shard 6'"
+    - CI_FLAGS="-fkmsrjlpn -i 0/6 'Python integration tests for pants - shard 1'"  # (c)
+    - CI_FLAGS="-fkmsrjlpn -i 1/6 'Python integration tests for pants - shard 2'"
+    - CI_FLAGS="-fkmsrjlpn -i 2/6 'Python integration tests for pants - shard 3'"
+    - CI_FLAGS="-fkmsrjlpn -i 3/6 'Python integration tests for pants - shard 4'"
+    - CI_FLAGS="-fkmsrjlpn -i 4/6 'Python integration tests for pants - shard 5'"
+    - CI_FLAGS="-fkmsrjlpn -i 5/6 'Python integration tests for pants - shard 6'"
 
 before_script: |
   ./build-support/bin/ci-sync.sh

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -162,7 +162,7 @@ fi
 if [[ "${skip_jvm:-false}" == "false" ]]; then
   banner "Running core jvm tests"
   (
-    ./pants.pex ${PANTS_ARGS[@]} test tests/java:: src:: zinc::
+    ./pants.pex ${PANTS_ARGS[@]} test tests/java:: src/{java,scala}:: zinc::
   ) || die "Core jvm test failure"
 fi
 
@@ -172,13 +172,15 @@ if [[ "${skip_internal_backends:-false}" == "false" ]]; then
     PANTS_PYTHON_TEST_FAILSOFT=1 \
       ./pants.pex ${PANTS_ARGS[@]} test \
         $(./pants.pex list pants-plugins/tests/python:: | \
-            xargs ./pants.pex filter --filter-type=python_tests | \
-            grep -v integration)
+            xargs ./pants.pex filter --filter-type=python_tests)
   ) || die "Internal backend python test failure"
 fi
 
 if [[ "${skip_python:-false}" == "false" ]]; then
-  banner "Running core python tests"
+  if [[ "0/1" != "${python_unit_shard}" ]]; then
+    shard_desc=" [shard ${python_unit_shard}]"
+  fi
+  banner "Running core python tests${shard_desc}"
   (
     PANTS_PY_COVERAGE=paths:pants/ \
       PANTS_PYTHON_TEST_FAILSOFT=1 \
@@ -201,8 +203,8 @@ if [[ "${skip_contrib:-false}" == "false" ]]; then
 fi
 
 if [[ "${skip_integration:-false}" == "false" ]]; then
-  if [[ ! -z "${TOTAL_SHARDS}" ]]; then
-    shard_desc=" [shard $((SHARD_NUMBER+1)) of ${TOTAL_SHARDS}]"
+  if [[ "0/1" != "${python_intg_shard}" ]]; then
+    shard_desc=" [shard ${python_intg_shard}]"
   fi
   banner "Running Pants Integration tests${shard_desc}"
   (

--- a/tests/python/pants_test/backend/python/tasks/python_task_test.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test.py
@@ -27,10 +27,12 @@ class PythonTaskTest(TaskTestBase):
   def setUp(self):
     super(PythonTaskTest, self).setUp()
 
-    # This is a test performance hack - instead of using a new workdir per test run, re-use a
-    # workdir across all test runs.  The important bit of savings here is the dep resolution and
-    # interpreter setup.  At the time of writing, this packages tests run at 43s with this hack and
-    # 194s without (line below commented out).
+    # This is a test performance hack.  Instead of using a new workdir per test setUp/tearDown
+    # (per-each test function/method executed) as is normal for `TaskTestBase`, re-use a single
+    # workdir across all test test function/method executions in a given concrete `PythonTaskTest`
+    # subclass.  The important bit of savings here is the dep resolution and interpreter setup.  At
+    # the time of writing, this packages tests run at 43s with this hack and 194s without (line
+    # below commented out).
     self.set_options_for_scope('', pants_workdir=self.workdir)
 
     self.set_options_for_scope('', python_chroot_requirements_ttl=1000000000)

--- a/tests/python/pants_test/backend/python/tasks/python_task_test.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test.py
@@ -6,17 +6,33 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import tempfile
 from textwrap import dedent
 
-from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.base.address import SyntheticAddress
+from pants.util.dirutil import safe_rmtree
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
 class PythonTaskTest(TaskTestBase):
+  @classmethod
+  def setUpClass(cls):
+    cls.workdir = tempfile.mkdtemp()
+
+  @classmethod
+  def tearDownClass(cls):
+    safe_rmtree(cls.workdir)
+
   def setUp(self):
     super(PythonTaskTest, self).setUp()
+
+    # This is a test performance hack - instead of using a new workdir per test run, re-use a
+    # workdir across all test runs.  The important bit of savings here is the dep resolution and
+    # interpreter setup.  At the time of writing, this packages tests run at 43s with this hack and
+    # 194s without (line below commented out).
+    self.set_options_for_scope('', pants_workdir=self.workdir)
+
     self.set_options_for_scope('', python_chroot_requirements_ttl=1000000000)
 
   @property


### PR DESCRIPTION
The option follows the format of the similar option in the junit-runner
and the sharding happens at the finest-grained test function/method
level.

Use this new feature to replace the target-level sharding implemented
in the ci.sh script.

https://rbcommons.com/s/twitter/r/2243/