### PR TITLE
[Trigger CI] rm Exception.message calls

### DIFF
--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -148,7 +148,7 @@ class CmdLineSpecParser(object):
             raise self.BadSpecError(e)
           errored_out.append('--------------------')
           errored_out.append(traceback.format_exc())
-          errored_out.append('Exception message: {0}'.format(e.message))
+          errored_out.append('Exception message: {0}'.format(e))
 
       if errored_out:
         error_msg = '\n'.join(errored_out + ["Invalid BUILD files for [{0}]".format(spec)])

--- a/src/python/pants/cache/artifact.py
+++ b/src/python/pants/cache/artifact.py
@@ -120,4 +120,4 @@ class TarballArtifact(Artifact):
         tarin.extractall(self._artifact_root)
         self._relpaths.update(paths)
     except tarfile.ReadError as e:
-      raise ArtifactError(e.message)
+      raise ArtifactError(str(e))

--- a/tests/python/pants_test/authentication/test_netrc_util.py
+++ b/tests/python/pants_test/authentication/test_netrc_util.py
@@ -35,7 +35,7 @@ class TestNetrcUtil(object):
     netrc = Netrc()
     with pytest.raises(netrc.NetrcError) as exc:
       netrc._ensure_loaded()
-    assert exc.value.message == 'A ~/.netrc file is required to authenticate'
+    assert str(exc.value) == 'A ~/.netrc file is required to authenticate'
 
   def test_netrc_parse_error(self, MockOsPath):
     with self.netrc('machine test') as netrc:
@@ -47,7 +47,7 @@ class TestNetrcUtil(object):
     with self.netrc('') as netrc:
       with pytest.raises(netrc.NetrcError) as exc:
         netrc._ensure_loaded()
-      assert exc.value.message == 'Found no usable authentication blocks in ~/.netrc'
+      assert str(exc.value) == 'Found no usable authentication blocks in ~/.netrc'
 
   @contextmanager
   def netrc(self, netrc_contents):


### PR DESCRIPTION
While testing things, I noticed that Exception.message was deprecated in 2.6. This removes calls to it, replacing them with using str where applicable