### PR TITLE
add the goal "attributes"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,4 +51,5 @@ Ted Dziuba <tdziuba@ebay.com>
 Tejal Desai <tdesai@twitter.com>
 Tina Huang <tina@twitter.com>
 Todd Stumpf <tstumpf@twitter.com>
+Tom Howland <thowland@twitter.com>
 Travis Crawford <travis@twitter.com>

--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -13,6 +13,7 @@ from pants.backend.core.targets.dependencies import Dependencies, DeprecatedDepe
 from pants.backend.core.targets.doc import Page, Wiki, WikiArtifact
 from pants.backend.core.targets.prep_command import PrepCommand
 from pants.backend.core.targets.resources import Resources
+from pants.backend.core.tasks.attributes import Attributes
 from pants.backend.core.tasks.builddictionary import BuildBuildDictionary
 from pants.backend.core.tasks.changed_target_goals import CompileChanged, TestChanged
 from pants.backend.core.tasks.clean import Cleaner, Invalidator
@@ -97,6 +98,9 @@ def build_file_aliases():
 def register_goals():
   # Getting help.
   task(name='goals', action=ListGoals).install().with_description('List all documented goals.')
+
+  task(name='attributes', action=Attributes).install().with_description(
+    'List attributes of targets such as platform or language.')
 
   task(name='targets', action=TargetsHelp).install().with_description(
       'List target types and BUILD file symbols (python_tests, jar, etc).')

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -4,6 +4,7 @@
 target(
   name = 'all',
   dependencies = [
+    ':attributes',
     ':builddictionary',
     ':changed_target_goals',
     ':clean',
@@ -43,6 +44,15 @@ target(
 )
 
 python_library(
+  name = 'attributes',
+  sources = ['attributes.py'],
+  dependencies = [
+    ':common',
+    ':console_task',
+    ],
+)
+
+python_library(
   name = 'builddictionary',
   sources = ['builddictionary.py'],
   resources = globs('templates/builddictionary/*.mustache'),
@@ -58,6 +68,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_parser',
     'src/python/pants/base:build_manual',
+    'src/python/pants/base:config',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/base:target',
@@ -252,6 +263,7 @@ python_library(
     '3rdparty/python:docutils',
     '3rdparty/python:six',
     'src/python/pants/base:build_manual',
+    'src/python/pants/base:config',
     'src/python/pants/base:generator',
     'src/python/pants/base:target',
     'src/python/pants/goal:goal',
@@ -304,7 +316,6 @@ python_library(
   sources = ['targets_help.py'],
   resources = globs('templates/targets_help/*.mustache'),
   dependencies = [
-    ':builddictionary',
     ':common',
     ':console_task',
     ':reflect',

--- a/src/python/pants/backend/core/tasks/attributes.py
+++ b/src/python/pants/backend/core/tasks/attributes.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import collections
+import json
+
+from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.base.exceptions import TaskError
+
+
+class Attributes(ConsoleTask):
+  """Show the attributes platform and language for the given targets.
+  """
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(Attributes, cls).prepare(options, round_manager)
+
+  @classmethod
+  def register_options(cls, register):
+    super(Attributes, cls).register_options(register)
+
+  def __init__(self, *args, **kwargs):
+    super(Attributes, self).__init__(*args, **kwargs)
+
+  def console_output(self, targets):
+    if not targets:
+      raise TaskError("Please specify a target.")
+    yield json.dumps(self._find_attributes(), indent=2)
+
+  def _find_attributes(self):
+    metadata = collections.defaultdict(dict)
+    for target in self.context.target_roots:
+      for (key, val) in [self._language(target), self._platform(target)]:
+        if val:
+          metadata[target.address.spec][key] = val
+    return metadata
+
+  def _language(self, target):
+    language = None
+    if target.is_java:
+      language = 'java'
+    elif target.is_python:
+      language = 'python'
+    elif target.is_scala:
+      language = 'scala'
+    return ('language', language)
+
+  def _platform(self, target):
+    platform = None
+    if target.is_jvm:
+      platform = 'jvm'
+    elif target.is_python:
+      platform = 'python'
+    return ('platform', platform)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -8,6 +8,7 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/core/tasks:task',
+    'src/python/pants/base:config',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:target',
     'src/python/pants/goal:context',
@@ -52,9 +53,11 @@ target(
   name = 'integration',
   dependencies = [
     ':antlr_integration',
+    ':attributes_integration',
     ':depmap_integration',
     ':eclipse_integration',
     ':ensime_integration',
+    ':export_integration',
     ':idea_integration',
     ':ivy_resolve_integration',
     ':jar_publish_integration',
@@ -75,6 +78,18 @@ python_tests(
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
+    ]
+)
+
+python_tests(
+  name='attributes_integration',
+  sources=['test_attributes_integration.py'],
+  dependencies=[
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+    ],
+  coverage=[
+    'pants.backend.core.tasks.attributes',
     ]
 )
 
@@ -235,6 +250,16 @@ python_tests(
 )
 
 python_tests(
+  name = 'export_integration',
+  sources = ['test_export_integration.py'],
+  dependencies = [
+    'src/python/pants/base:build_environment',
+    'src/python/pants/ivy',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ],
+)
+python_tests(
   name = 'filemap',
   sources = ['test_filemap.py'],
   dependencies = [
@@ -329,12 +354,11 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jar_publish',
     'src/python/pants/base:build_file_aliases',
-    'src/python/pants/base:generator',
     'src/python/pants/base:source_root',
     'src/python/pants/scm:scm',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test/testutils',
+    'tests/python/pants_test/backend/jvm/tasks/jvm_compile:utils',
   ],
 )
 

--- a/tests/python/pants_test/tasks/test_attributes_integration.py
+++ b/tests/python/pants_test/tasks/test_attributes_integration.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import json
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class TestAttributesIntegration(PantsRunIntegrationTest):
+
+  def test_platform(self):
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      J = 'src/scala/org/pantsbuild/zinc:zinc'
+      P = 'src/python/pants/goal:goal'
+      pants_run = self.run_pants_with_workdir(['-q', 'attributes', J, P],
+                                              workdir)
+    data = json.loads(pants_run.stdout_data)
+    self.assertEqual(data[J]['language'], 'scala')
+    self.assertEqual(data[J]['platform'], 'jvm')
+    self.assertEqual(data[P]['language'], 'python')
+    self.assertEqual(data[P]['platform'], 'python')


### PR DESCRIPTION
We need a way of determining what platform a target is meant to run on,
or what language the target is for. We have scripts that behave
differently for a given target. If it is python, we parse the output one
way, if it is jvm, we parse it another. Similarly, depending on the
platform, we may retry a failing goal differently.