### PR TITLE
[CI] Share the python interpreter/egg caches between tests.

### DIFF
--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -98,7 +98,6 @@ python_library(
   dependencies = [
     ':antlr_builder',
     ':python_requirement',
-    ':python_setup',
     ':resolver',
     ':thrift_builder',
     '3rdparty/python:pex',

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -5,8 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import errno
 import os
 import shutil
+import uuid
 
 from pex.archiver import Archiver
 from pex.crawler import Crawler
@@ -50,7 +52,7 @@ class PythonInterpreterCache(object):
   def __init__(self, python_setup, python_repos, logger=None):
     self._python_setup = python_setup
     self._python_repos = python_repos
-    self._cache_dir = os.path.join(python_setup.scratch_dir, 'interpreters')
+    self._cache_dir = python_setup.interpreter_cache_dir
     safe_mkdir(self._cache_dir)
     self._interpreters = set()
     self._logger = logger or (lambda msg: True)
@@ -74,11 +76,22 @@ class PythonInterpreterCache(object):
     return None
 
   def _setup_interpreter(self, interpreter, cache_path):
-    safe_mkdir(cache_path)
-    _safe_link(interpreter.binary, os.path.join(cache_path, 'python'))
-    return self._resolve(interpreter)
+    tmp_cache_path = '{0}.tmp.{1}'.format(cache_path, uuid.uuid4().hex)
+    os.makedirs(tmp_cache_path)
+    os.symlink(interpreter.binary, os.path.join(tmp_cache_path, 'python'))
+    ret = self._resolve(interpreter, tmp_cache_path)
+    try:
+      shutil.move(tmp_cache_path, cache_path)
+    except IOError as e:
+      if e.errno != errno.EEXIST:
+        raise e
+      # Otherwise there was a race condition with some other process, and it doesn't matter
+      # who wins, so just continue.
+    return ret
+
 
   def _setup_cached(self, filters):
+    """Find all currently-cached interpreters."""
     for interpreter_dir in os.listdir(self._cache_dir):
       path = os.path.join(self._cache_dir, interpreter_dir)
       pi = self._interpreter_from_path(path, filters)
@@ -87,6 +100,7 @@ class PythonInterpreterCache(object):
         self._interpreters.add(pi)
 
   def _setup_paths(self, paths, filters):
+    """Find interpreters under paths, and cache them."""
     for interpreter in self._matching(PythonInterpreter.all(paths), filters):
       identity_str = str(interpreter.identity)
       cache_path = os.path.join(self._cache_dir, identity_str)
@@ -134,22 +148,27 @@ class PythonInterpreterCache(object):
       self._logger('Found no valid interpreters!')
     return matches
 
-  def _resolve(self, interpreter):
+  def _resolve(self, interpreter, interpreter_dir=None):
     """Resolve and cache an interpreter with a setuptools and wheel capability."""
-    interpreter = self._resolve_interpreter(interpreter,
+    interpreter = self._resolve_interpreter(interpreter, interpreter_dir,
                                             self._python_setup.setuptools_requirement())
     if interpreter:
-      return self._resolve_interpreter(interpreter, self._python_setup.wheel_requirement())
+      return self._resolve_interpreter(interpreter, interpreter_dir,
+                                       self._python_setup.wheel_requirement())
 
 
-  def _resolve_interpreter(self, interpreter, requirement):
+  def _resolve_interpreter(self, interpreter, interpreter_dir, requirement):
     """Given a :class:`PythonInterpreter` and a requirement, return an interpreter with the
     capability of resolving that requirement or ``None`` if it's not possible to install a
     suitable requirement.
+
+    If interpreter_dir is unspecified, operates on the default location.
     """
-    interpreter_dir = os.path.join(self._cache_dir, str(interpreter.identity))
     if interpreter.satisfies([requirement]):
       return interpreter
+
+    if not interpreter_dir:
+      interpreter_dir = os.path.join(self._cache_dir, str(interpreter.identity))
 
     def installer_provider(sdist):
       return EggInstaller(

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -23,7 +23,6 @@ from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.prep_command import PrepCommand
 from pants.backend.python.antlr_builder import PythonAntlrBuilder
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.backend.python.resolver import resolve_multi
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -80,7 +79,7 @@ class PythonChroot(object):
       self._python_setup.scratch_dir, 'artifacts', str(self._interpreter.identity))
 
     self._key_generator = CacheKeyGenerator()
-    self._build_invalidator = BuildInvalidator( self._egg_cache_root)
+    self._build_invalidator = BuildInvalidator(self._egg_cache_root)
 
   def delete(self):
     """Deletes this chroot from disk if it has been dumped."""

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -33,6 +33,9 @@ class PythonSetup(Subsystem):
              help='The wheel version for this python environment.')
     register('--platforms', advanced=True, type=Options.list, default=['current'],
              help='The wheel version for this python environment.')
+    register('--interpreter-cache-dir', advanced=True, default=None, metavar='<dir>',
+             help='The parent directory for the interpreter cache. '
+                  'If unspecified, a standard path under the workdir is used.')
 
   @property
   def interpreter_requirement(self):
@@ -51,9 +54,12 @@ class PythonSetup(Subsystem):
     return self.get_options().platforms
 
   @property
+  def interpreter_cache_dir(self):
+    return (self.get_options().interpreter_cache_dir or
+            os.path.join(self.scratch_dir, 'interpreters'))
+
+  @property
   def scratch_dir(self):
-    # Note that this gives us a separate scratch dir for every instance of this subsystem,
-    # which allows us to have multiple python setups in play in a single pants run.
     return os.path.join(self.get_options().pants_workdir, *self.options_scope.split('.'))
 
   def setuptools_requirement(self):

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-import logging.config
 import sys
 
 import pkg_resources

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -31,9 +31,9 @@ def safe_mkdir(directory, clean=False):
 
 
 def safe_mkdir_for(path, clean=False):
-  """
-    Ensure that the parent directory for a file is present.  If it's not there, create it.
-    If it is, no-op. If clean is True, ensure the directory is empty.
+  """Ensure that the parent directory for a file is present.
+
+  If it's not there, create it. If it is, no-op. If clean is True, ensure the directory is empty.
   """
   safe_mkdir(os.path.dirname(path), clean)
 
@@ -98,26 +98,19 @@ def register_rmtree(directory, cleaner=_mkdtemp_atexit_cleaner):
 
 
 def safe_rmtree(directory):
-  """
-    Delete a directory if it's present. If it's not present, no-op.
-  """
+  """Delete a directory if it's present. If it's not present, no-op."""
   if os.path.exists(directory):
     shutil.rmtree(directory, True)
 
 
 def safe_open(filename, *args, **kwargs):
-  """
-    Open a file safely (ensuring that the directory components leading up to it
-    have been created first.)
-  """
+  """Open a file safely, ensuring that its directory exists."""
   safe_mkdir(os.path.dirname(filename))
   return open(filename, *args, **kwargs)
 
 
 def safe_delete(filename):
-  """
-    Delete a file safely. If it's not present, no-op.
-  """
+  """Delete a file safely. If it's not present, no-op."""
   try:
     os.unlink(filename)
   except OSError as e:
@@ -125,10 +118,20 @@ def safe_delete(filename):
       raise
 
 
+def safe_concurrent_rename(src, dst):
+  """Rename src to dst, ignoring errors due to dst already existing.
+
+  Useful when concurrent processes my attempt to create dst, and it doesn't matter who wins.
+  """
+  try:
+    shutil.move(src, dst)
+  except IOError as e:
+    if e.errno != errno.EEXIST:
+      raise
+
+
 def chmod_plus_x(path):
-  """
-    Equivalent of unix `chmod a+x path`
-  """
+  """Equivalent of unix `chmod a+x path`"""
   path_mode = os.stat(path).st_mode
   path_mode &= int('777', 8)
   if path_mode & stat.S_IRUSR:

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -13,10 +13,7 @@ python_library(
   sources=['python_task_test.py'],
   dependencies=[
     'src/python/pants/backend/python:plugin',
-    'src/python/pants/backend/python:python_setup',
     'src/python/pants/base:address',
-    'src/python/pants/base:build_file_aliases',
-    'src/python/pants/util:dirutil',
     'tests/python/pants_test/tasks:task_test_base'
   ]
 )
@@ -42,7 +39,6 @@ python_tests(
     ':python_task_test',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
-    'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',
   ]
 )

--- a/tests/python/pants_test/backend/python/tasks/python_task_test.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test.py
@@ -6,36 +6,24 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import tempfile
 from textwrap import dedent
 
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.base.address import SyntheticAddress
-from pants.util.dirutil import safe_rmtree
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
 class PythonTaskTest(TaskTestBase):
-  @classmethod
-  def setUpClass(cls):
-    cls.workdir = tempfile.mkdtemp()
-
-  @classmethod
-  def tearDownClass(cls):
-    safe_rmtree(cls.workdir)
-
   def setUp(self):
     super(PythonTaskTest, self).setUp()
-
-    # This is a test performance hack.  Instead of using a new workdir per test setUp/tearDown
-    # (per-each test function/method executed) as is normal for `TaskTestBase`, re-use a single
-    # workdir across all test test function/method executions in a given concrete `PythonTaskTest`
-    # subclass.  The important bit of savings here is the dep resolution and interpreter setup.  At
-    # the time of writing, this packages tests run at 43s with this hack and 194s without (line
-    # below commented out).
-    self.set_options_for_scope('', pants_workdir=self.workdir)
-
     self.set_options_for_scope('', python_chroot_requirements_ttl=1000000000)
+    # Use the "real" interpreter cache, so tests don't waste huge amounts of time recreating it.
+    # It would be nice to get the location of the real interpreter cache from PythonSetup,
+    # but unfortunately real subsystems aren't available here (for example, we have no access
+    # to the enclosing pants instance's options), so we have to hard-code it.
+    self.set_options_for_scope('python-setup',
+        interpreter_cache_dir=os.path.join(self.real_build_root, '.pants.d',
+                                           'python-setup', 'interpreters'))
 
   @property
   def alias_groups(self):

--- a/tests/python/pants_test/backend/python/tasks/test_python_eval.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_eval.py
@@ -10,7 +10,6 @@ from textwrap import dedent
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.tasks.python_eval import PythonEval
-from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
 from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
 
@@ -116,7 +115,7 @@ class PythonEvalTest(PythonTaskTest):
   def test_compile_fail_closure(self):
     python_eval = self._create_task(target_roots=[self.b_library], options={'closure': True})
 
-    with self.assertRaises(TaskError) as e:
+    with self.assertRaises(PythonEval.Error) as e:
       python_eval.execute()
     self.assertEqual([self.a_library], e.exception.compiled)
     self.assertEqual([self.b_library], e.exception.failed)
@@ -124,7 +123,7 @@ class PythonEvalTest(PythonTaskTest):
   def test_compile_incremental_progress(self):
     python_eval = self._create_task(target_roots=[self.b_library], options={'closure': True})
 
-    with self.assertRaises(TaskError) as e:
+    with self.assertRaises(PythonEval.Error) as e:
       python_eval.execute()
     self.assertEqual([self.a_library], e.exception.compiled)
     self.assertEqual([self.b_library], e.exception.failed)
@@ -146,7 +145,7 @@ class PythonEvalTest(PythonTaskTest):
   def test_compile_fail_compile_time_check_decorator(self):
     python_eval = self._create_task(target_roots=[self.b_library])
 
-    with self.assertRaises(TaskError) as e:
+    with self.assertRaises(PythonEval.Error) as e:
       python_eval.execute()
     self.assertEqual([], e.exception.compiled)
     self.assertEqual([self.b_library], e.exception.failed)
@@ -155,7 +154,7 @@ class PythonEvalTest(PythonTaskTest):
     python_eval = self._create_task(target_roots=[self.a_library, self.b_library, self.d_library],
                                     options={'fail_slow': True})
 
-    with self.assertRaises(TaskError) as e:
+    with self.assertRaises(PythonEval.Error) as e:
       python_eval.execute()
     self.assertEqual({self.a_library, self.d_library}, set(e.exception.compiled))
     self.assertEqual([self.b_library], e.exception.failed)
@@ -175,7 +174,7 @@ class PythonEvalTest(PythonTaskTest):
   def test_entry_point_does_not_exist(self):
     python_eval = self._create_task(target_roots=[self.g_binary])
 
-    with self.assertRaises(TaskError) as e:
+    with self.assertRaises(PythonEval.Error) as e:
       python_eval.execute()
     self.assertEqual([], e.exception.compiled)
     self.assertEqual([self.g_binary], e.exception.failed)
@@ -183,7 +182,7 @@ class PythonEvalTest(PythonTaskTest):
   def test_entry_point_missing_build_dep(self):
     python_eval = self._create_task(target_roots=[self.h_binary])
 
-    with self.assertRaises(TaskError) as e:
+    with self.assertRaises(PythonEval.Error) as e:
       python_eval.execute()
     self.assertEqual([], e.exception.compiled)
     self.assertEqual([self.h_binary], e.exception.failed)

--- a/tests/python/pants_test/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/python/test_interpreter_cache.py
@@ -32,7 +32,7 @@ class TestInterpreterCache(unittest.TestCase):
       return_value=interpreter_requirement)
 
     with temporary_dir() as path:
-      mock_setup.scratch_dir = path
+      mock_setup.interpreter_cache_dir = path
       cache = PythonInterpreterCache(mock_setup, mock.MagicMock())
 
       def set_interpreters(_):


### PR DESCRIPTION
Speeds things up dramatically.

This removes the previous speed hack, and is even faster, especially
when iterating over the same test many times.  For example,

time ./pants test tests/python/pants_test/backend/python/tasks:python_eval

on my laptop takes:

~2m30s with no speed hacks.
~0m16s with the previous speed hack.
~0m9s with this speed hack.