### PR TITLE
Moved creation of per test data to testStarted method.

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/AntJunitXmlReportListener.java
@@ -11,6 +11,7 @@ import java.io.Writer;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -317,11 +318,6 @@ class AntJunitXmlReportListener extends RunListener {
     this.streamSource = streamSource;
   }
 
-  @Override
-  public void testRunStarted(Description description) throws java.lang.Exception {
-    createSuites(description.getChildren());
-  }
-
   private void createSuites(Iterable<Description> tests) {
     for (Description test : tests) {
       createSuites(test.getChildren());
@@ -341,6 +337,7 @@ class AntJunitXmlReportListener extends RunListener {
 
   @Override
   public void testStarted(Description description) throws java.lang.Exception {
+    createSuites(Collections.singletonList(description));
     suites.get(description.getTestClass()).started();
     cases.get(description).started();
   }

--- a/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
+++ b/src/java/org/pantsbuild/tools/junit/ConsoleRunner.java
@@ -13,13 +13,7 @@ import java.io.PrintStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -182,12 +176,6 @@ public class ConsoleRunner {
       this.printToOriginalOutputs = printToOriginalOutputs;
     }
 
-    @Override
-    public void testRunStarted(Description description) throws Exception {
-      registerTests(description.getChildren());
-      super.testRunStarted(description);
-    }
-
     private void registerTests(Iterable<Description> tests) throws IOException {
       for (Description test : tests) {
         registerTests(test.getChildren());
@@ -219,6 +207,7 @@ public class ConsoleRunner {
 
     @Override
     public void testStarted(Description description) throws Exception {
+      registerTests(Collections.singletonList(description));
       captures.get(description.getTestClass()).open();
       super.testStarted(description);
     }


### PR DESCRIPTION
During an upgrade of Pants at Twitter I found out that some of our tests are using org.powermock.modules.junit4.PowerMockRunner and it doesn't call fireTestRunStarted at all. We were getting NPEs because of that.

According to the docs testRunStarted and testStarted have pretty much the same meaning except testStarted is invoked just before an execution in the same thread.

To test it I built a jar and used it with out tests and they passed.