### PR TITLE
Integrating Patrick's SimpleCodegenTask base class with JaxbGen and WireGen.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/BUILD
+++ b/src/python/pants/backend/codegen/tasks/BUILD
@@ -79,6 +79,7 @@ python_library(
   dependencies = [
     ':code_gen',
     ':common',
+    ':simple_codegen_task',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:address',
@@ -99,6 +100,7 @@ python_library(
     ':code_gen',
     ':common',
     ':protobuf_parse',
+    ':simple_codegen_task',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/python/targets:python',
@@ -137,6 +139,16 @@ python_library(
 )
 
 python_library(
+  name = 'simple_codegen_task',
+  sources = ['simple_codegen_task.py'],
+  dependencies = [
+    ':common',
+    'src/python/pants/base:address',
+    'src/python/pants/base:build_environment',
+  ],
+)
+
+python_library(
   name = 'wire_gen',
   sources = ['wire_gen.py'],
   dependencies = [
@@ -144,6 +156,7 @@ python_library(
     ':code_gen',
     ':protobuf_gen',
     ':protobuf_parse',
+    ':simple_codegen_task',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',

--- a/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
+++ b/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
@@ -1,0 +1,160 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.backend.core.tasks.task import Task
+from pants.base.address import SyntheticAddress
+from pants.base.build_environment import get_buildroot
+from pants.base.source_root import SourceRoot
+
+
+class SimpleCodegenTask(Task):
+  """Simpler base-class for single-language code-gen.
+
+  Subclasses should implement at minimum: synthetic_target_type, is_gentarget, execute_codegen, and
+  sources_generated_by_target.
+  """
+
+  @classmethod
+  def get_fingerprint_strategy(cls):
+    """Override this method to use a fingerprint strategy other than the default one.
+
+    :return: a fingerprint strategy, or None to use the default strategy.
+    """
+    return None
+
+  def synthetic_target_extra_dependencies(self, target):
+    """Gets any extra dependencies generated synthetic targets should have. This method is optional
+    for subclasses to implement, because some code generators may have no extra dependencies.
+
+    :param target: the Target from which we are generating a synthetic Target. E.g., 'target' might
+    be a JavaProtobufLibrary, whose corresponding synthetic Target would be a JavaLibrary. It is not
+    necessary to use this parameter; it may be unnecessary depending on the details of the subclass.
+    :return: a list of dependencies.
+    """
+    return []
+
+  @property
+  def synthetic_target_type(self):
+    """The type of target this codegen task generates. For example, the target type for JaxbGen
+    would simply be JavaLibrary.
+
+    :return: a type (class) that inherits from Target.
+    """
+    raise NotImplementedError
+
+  def is_gentarget(self, target):
+    """Predicate which determines whether the target in question is relevant to this codegen task.
+    E.g., the JaxbGen task considers JaxbLibrary targets to be relevant, and nothing else.
+
+    :param target: The target to check.
+    :return: True if this class can generate code for the given target, False otherwise.
+    """
+    raise NotImplementedError
+
+  def execute_codegen(self, invalid_targets):
+    """Generated code for the given list of targets.
+
+    :param invalid_targets: an iterable of targets (a subset of codegen_targets()).
+    """
+    raise NotImplementedError
+
+  def sources_generated_by_target(self, target):
+    """Predicts what source files will be generated from the given codegen target.
+
+    :param target: the codegen target in question (eg a .proto library).
+    :return: an iterable of strings containing the file system paths to the sources files.
+    """
+    raise NotImplementedError
+
+  def codegen_targets(self):
+    """Finds codegen targets in the depencency graph.
+
+    :return: an iterable of dependency targets.
+    """
+    return self.context.targets(self.is_gentarget)
+
+  def codegen_workdir(self, target):
+    """The path to the directory code should be generated in. E.g., this might be something like
+    /home/user/repo/.pants.d/gen/jaxb/...
+
+    :return: The absolute file path.
+    """
+    # TODO(gm): This method will power the isolated/global strategies for what directories to put
+    # generated code in, once that exists. This will work in a similar fashion to the jvm_compile
+    # tasks' isolated vs global strategies, generated code per-target in a way that avoids
+    # collisions.
+    return self.workdir
+
+  def execute(self):
+    targets = self.codegen_targets()
+    with self.invalidated(targets,
+                          invalidate_dependents=True,
+                          fingerprint_strategy=self.get_fingerprint_strategy()) as invalidation_check:
+      for vts in invalidation_check.invalid_vts_partitioned:
+        invalid_targets = vts.targets
+        self.execute_codegen(invalid_targets)
+
+      invalid_vts_by_target = dict([(vt.target, vt) for vt in invalidation_check.invalid_vts])
+      vts_artifactfiles_pairs = []
+
+      for target in targets:
+        target_workdir = self.codegen_workdir(target)
+        synthetic_name = target.id
+        sources_rel_path = os.path.relpath(target_workdir, get_buildroot())
+        spec_path = '{0}{1}'.format(type(self).__name__, sources_rel_path)
+        synthetic_address = SyntheticAddress(spec_path, synthetic_name)
+        raw_generated_sources = self.sources_generated_by_target(target)
+        # Make the sources robust regardless of whether subclasses return relative paths, or
+        # absolute paths that are subclasses of the workdir.
+        generated_sources = [src if src.startswith(target_workdir)
+                             else os.path.join(target_workdir, src)
+                             for src in raw_generated_sources]
+        relative_generated_sources = [os.path.relpath(src, target_workdir)
+                                      for src in generated_sources]
+
+        self.target = self.context.add_new_target(
+          address=synthetic_address,
+          target_type=self.synthetic_target_type,
+          dependencies=self.synthetic_target_extra_dependencies(target),
+          sources_rel_path=sources_rel_path,
+          sources=relative_generated_sources,
+          derived_from=target,
+          provides=target.provides,
+        )
+        synthetic_target = self.target
+
+        build_graph = self.context.build_graph
+
+        # NOTE(pl): This bypasses the convenience function (Target.inject_dependency) in order
+        # to improve performance.  Note that we can walk the transitive dependee subgraph once
+        # for transitive invalidation rather than walking a smaller subgraph for every single
+        # dependency injected.
+        for dependent_address in build_graph.dependents_of(target.address):
+          build_graph.inject_dependency(
+            dependent=dependent_address,
+            dependency=synthetic_target.address,
+          )
+        # NOTE(pl): See the above comment.  The same note applies.
+        for concrete_dependency_address in build_graph.dependencies_of(target.address):
+          build_graph.inject_dependency(
+            dependent=synthetic_target.address,
+            dependency=concrete_dependency_address,
+          )
+        build_graph.walk_transitive_dependee_graph(
+          build_graph.dependencies_of(target.address),
+          work=lambda t: t.mark_transitive_invalidation_hash_dirty(),
+        )
+
+        if target in self.context.target_roots:
+          self.context.target_roots.append(synthetic_target)
+        if target in invalid_vts_by_target:
+          vts_artifactfiles_pairs.append((invalid_vts_by_target[target], generated_sources))
+
+      if self.artifact_cache_writes_enabled():
+        self.update_artifact_cache(vts_artifactfiles_pairs)

--- a/src/python/pants/backend/codegen/tasks/wire_gen.py
+++ b/src/python/pants/backend/codegen/tasks/wire_gen.py
@@ -8,18 +8,16 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import itertools
 import logging
 import os
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 
-from twitter.common.collections import OrderedSet, maybe_list
+from twitter.common.collections import OrderedSet
 
-from pants.backend.codegen.targets.java_protobuf_library import JavaProtobufLibrary
 from pants.backend.codegen.targets.java_wire_library import JavaWireLibrary
-from pants.backend.codegen.tasks.code_gen import CodeGen
 from pants.backend.codegen.tasks.protobuf_gen import check_duplicate_conflicting_protos
 from pants.backend.codegen.tasks.protobuf_parse import ProtobufParse
+from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
-from pants.base.address import SyntheticAddress
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -31,7 +29,7 @@ from pants.option.options import Options
 logger = logging.getLogger(__name__)
 
 
-class WireGen(CodeGen, JvmToolTaskMixin):
+class WireGen(SimpleCodegenTask, JvmToolTaskMixin):
   @classmethod
   def register_options(cls, register):
     super(WireGen, cls).register_options(register)
@@ -42,7 +40,23 @@ class WireGen(CodeGen, JvmToolTaskMixin):
   def __init__(self, *args, **kwargs):
     """Generates Java files from .proto files using the Wire protobuf compiler."""
     super(WireGen, self).__init__(*args, **kwargs)
-    self.java_out = os.path.join(self.workdir, 'gen-java')
+
+  @property
+  def synthetic_target_type(self):
+    return JavaLibrary
+
+  def is_gentarget(self, target):
+    return isinstance(target, JavaWireLibrary)
+
+  def sources_generated_by_target(self, target):
+    genfiles = []
+    for source in target.sources_relative_to_source_root():
+      path = os.path.join(target.target_base, source)
+      genfiles.extend(self.calculate_genfiles(
+        path,
+        source,
+        target.payload.service_writer))
+    return genfiles
 
   def resolve_deps(self, unresolved_deps):
     deps = OrderedSet()
@@ -53,20 +67,10 @@ class WireGen(CodeGen, JvmToolTaskMixin):
         raise self.DepLookupError('{message}\n  on dependency {dep}'.format(message=e, dep=dep))
     return deps
 
-  @property
-  def javadeps(self):
+  def synthetic_target_extra_dependencies(self, target):
     return self.resolve_deps(self.get_options().javadeps)
 
-  def is_gentarget(self, target):
-    return isinstance(target, JavaWireLibrary)
-
-  def is_proto_target(self, target):
-    return isinstance(target, JavaProtobufLibrary)
-
-  def genlangs(self):
-    return {'java': lambda t: t.is_jvm}
-
-  def genlang(self, lang, targets):
+  def execute_codegen(self, targets):
     # Invoke the generator once per target.  Because the wire compiler has flags that try to reduce
     # the amount of code emitted, Invoking them all together will break if one target specifies a
     # service_writer and another does not, or if one specifies roots and another does not.
@@ -82,10 +86,7 @@ class WireGen(CodeGen, JvmToolTaskMixin):
         relative_sources.add(relative_source)
       check_duplicate_conflicting_protos(self, sources_by_base, relative_sources, self.context.log)
 
-      if lang != 'java':
-        raise TaskError('Unrecognized wire gen lang: {0}'.format(lang))
-
-      args = ['--java_out={0}'.format(self.java_out)]
+      args = ['--java_out={0}'.format(self.codegen_workdir(target))]
 
       # Add all params in payload to args
 
@@ -134,36 +135,6 @@ class WireGen(CodeGen, JvmToolTaskMixin):
       sources_by_base[base].update(sources)
     return sources_by_base
 
-  def createtarget(self, lang, gentarget, dependees):
-    if lang == 'java':
-      return self._create_java_target(gentarget, dependees)
-    else:
-      raise TaskError('Unrecognized wire gen lang: {0}'.format(lang))
-
-  def _create_java_target(self, target, dependees):
-    genfiles = []
-    for source in target.sources_relative_to_source_root():
-      path = os.path.join(target.target_base, source)
-      genfiles.extend(self.calculate_genfiles(
-        path,
-        source,
-        target.payload.service_writer).get('java', []))
-
-    spec_path = os.path.relpath(self.java_out, get_buildroot())
-    address = SyntheticAddress(spec_path, target.id)
-    deps = OrderedSet(self.javadeps)
-    tgt = self.context.add_new_target(address,
-                                      JavaLibrary,
-                                      derived_from=target,
-                                      sources=genfiles,
-                                      provides=target.provides,
-                                      dependencies=deps,
-                                      excludes=target.payload.excludes)
-    for dependee in dependees:
-      dependee.inject_dependency(tgt.address)
-    return tgt
-
-
   def calculate_genfiles(self, path, source, service_writer):
     protobuf_parse = ProtobufParse(path, source)
     protobuf_parse.parse()
@@ -176,16 +147,11 @@ class WireGen(CodeGen, JvmToolTaskMixin):
     if protobuf_parse.extends:
       types |= set(["Ext_{0}".format(protobuf_parse.filename)])
 
-    genfiles = defaultdict(set)
-    java_files = list(self.calculate_java_genfiles(protobuf_parse.package, types))
+    java_files = self.calculate_java_genfiles(protobuf_parse.package, types)
     logger.debug('Path {path} yielded types {types} got files {java_files}'
                  .format(path=path, types=types, java_files=java_files))
-    genfiles['java'].update(java_files)
-    return genfiles
+    return set(java_files)
 
   def calculate_java_genfiles(self, package, types):
     basepath = package.replace('.', '/')
-    for type_ in types:
-      filename = os.path.join(basepath, '{0}.java'.format(type_))
-      logger.debug("Expecting {filename} from type {type_}".format(filename=filename, type_=type_))
-      yield filename
+    return [os.path.join(basepath, '{0}.java'.format(t)) for t in types]

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -1042,6 +1042,12 @@ class JarPublish(ScmPublishMixin, JarTask):
     # ends up creating 2 jars one scala and other java both including the java_sources.
 
     def abs_and_relative_sources(target):
+      sources = target.payload.get_field('sources')
+      if sources:
+        source_root = sources.rel_path
+        for source in sources.source_paths:
+          yield os.path.join(source_root, source), source
+        return
       abs_source_root = os.path.join(get_buildroot(), target.target_base)
       for source in target.sources_relative_to_source_root():
         yield os.path.join(abs_source_root, source), source

--- a/tests/python/pants_test/backend/codegen/tasks/test_jaxb_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_jaxb_gen.py
@@ -5,17 +5,27 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import unittest
-
+from pants.backend.codegen.register import build_file_aliases as register_codegen
 from pants.backend.codegen.tasks.jaxb_gen import JaxbGen
+from pants.backend.core.register import build_file_aliases as register_core
 from pants.util.contextutil import temporary_file
+from pants_test.tasks.task_test_base import TaskTestBase
 
 
-class JaxbGenTestBase(unittest.TestCase):
-  """Basically copied from test_protobuf_gen.py.
+class JaxbGenJavaTest(TaskTestBase):
+  """Test the java code generation.
 
-  Contains helper method to check generated temp files.
+  Mostly just tests that code would be put in the proper package, since that's the easiest point of
+  failure.
   """
+  @classmethod
+  def task_type(cls):
+    return JaxbGen
+
+  @property
+  def alias_groups(self):
+    return register_core().merge(register_codegen())
+
   def assert_files(self, package, contents, *expected_files):
     with temporary_file() as fp:
       fp.write(contents)
@@ -38,13 +48,6 @@ class JaxbGenTestBase(unittest.TestCase):
               </xsd:sequence>
             </xsd:complexType>'''.format(name=name)
     )
-
-class JaxbGenJavaTest(JaxbGenTestBase):
-  """Test the java code generation.
-
-  Mostly just tests that code would be put in the proper package, since that's the easiest point of
-  failure.
-  """
 
   def test_plain(self):
     self.assert_files(

--- a/tests/python/pants_test/tasks/test_wire_integration.py
+++ b/tests/python/pants_test/tasks/test_wire_integration.py
@@ -28,7 +28,7 @@ class WireIntegrationTest(PantsRunIntegrationTest):
       'Compiling proto source file',
       'Created output directory',
       'Writing generated code',
-      '/gen/wire/gen-java/org/pantsbuild/example/temperature/Temperature.java',
+      '/gen/wire/org/pantsbuild/example/temperature/Temperature.java',
     ]
     for expected_output in expected_outputs:
       self.assertIn(expected_output, pants_run.stdout_data)


### PR DESCRIPTION
    Refactoring ProtobufGen, JaxbGen, and WireGen to use Patrick's SimpleCodegenTask base class.
    
    As per John Sirois's recommendation, the python generation code was removed from ProtobufGen,
    because it apparently isn't used and muddles the purpose of the JavaProtobufLibrary target.
    
    There are some TODO's for integrating isolated code-generation strategies. I have this
    functionality mostly working in a separate branch, which I hope to put up for review
    separately once this patch is landed.

I also updated the JaxbGenJavaTest to use the TaskTestBase, to be consistent with Wire etc.

Posting here for internal review before RBCommons.