### PR TITLE
[CI] Two changes that affect invalidation and artifact caching.

### DIFF
--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -65,7 +65,7 @@ class TaskBase(AbstractClass):
 
   @classmethod
   def _compute_stable_name(cls):
-    return '{}.{}'.format(cls.__module__, cls.__name)
+    return '{}.{}'.format(cls.__module__, cls.__name__)
 
   @classmethod
   def global_subsystems(cls):

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -61,7 +61,11 @@ class TaskBase(AbstractClass):
     may have random names (e.g., in tests), so this gives us a stable name to use across runs,
     e.g., in artifact cache references.
     """
-    return cls._stable_name or cls.__name__
+    return cls._stable_name or cls._compute_stable_name()
+
+  @classmethod
+  def _compute_stable_name(cls):
+    return '{}.{}'.format(cls.__module__, cls.__name)
 
   @classmethod
   def global_subsystems(cls):

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -51,7 +51,7 @@ class TaskBase(AbstractClass):
   """
   # Tests may override this to provide a stable name despite the class name being a unique,
   # synthetic name.
-  _stable_name = __name__
+  _stable_name = None
 
   @classmethod
   def stable_name(cls):
@@ -61,7 +61,7 @@ class TaskBase(AbstractClass):
     may have random names (e.g., in tests), so this gives us a stable name to use across runs,
     e.g., in artifact cache references.
     """
-    return cls._stable_name
+    return cls._stable_name or cls.__name__
 
   @classmethod
   def global_subsystems(cls):

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -49,6 +49,19 @@ class TaskBase(AbstractClass):
   of the helpers.  Ideally console tasks don't inherit a workdir, invalidator or build cache for
   example.
   """
+  # Tests may override this to provide a stable name despite the class name being a unique,
+  # synthetic name.
+  _stable_name = __name__
+
+  @classmethod
+  def stable_name(cls):
+    """The stable name of this task type.
+
+    We synthesize subclasses of the task types at runtime, and these synthesized subclasses
+    may have random names (e.g., in tests), so this gives us a stable name to use across runs,
+    e.g., in artifact cache references.
+    """
+    return cls._stable_name
 
   @classmethod
   def global_subsystems(cls):
@@ -172,7 +185,7 @@ class TaskBase(AbstractClass):
     self._build_invalidator_dir = os.path.join(
       self.context.options.for_global_scope().pants_workdir,
       'build_invalidator',
-      self.__class__.__name__)
+      self.stable_name())
 
   def get_options(self):
     """Returns the option values for this task's scope."""
@@ -180,7 +193,7 @@ class TaskBase(AbstractClass):
 
   def get_passthru_args(self):
     if not self.supports_passthru_args():
-      raise TaskError('{0} Does not support passthru args.'.format(self.__class__.__name__))
+      raise TaskError('{0} Does not support passthru args.'.format(self.stable_name()))
     else:
       return self.context.options.passthru_args_for_scope(self.options_scope)
 
@@ -217,12 +230,11 @@ class TaskBase(AbstractClass):
     if len(spec) > 0:
       pants_workdir = self.context.options.for_global_scope().pants_workdir
       compression = self.get_options().cache_compression
-      my_name = self.__class__.__name__
       return create_artifact_cache(
         log=self.context.log,
         artifact_root=pants_workdir,
         spec=spec,
-        task_name=my_name,
+        task_name=self.stable_name(),
         compression=compression,
         action=action)
     else:

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -26,12 +26,10 @@ from pants.util.dirutil import safe_mkdir_for
 
 
 class ShadedToolFingerprintStrategy(IvyResolveFingerprintStrategy):
-  def __init__(self, key, scope, main, custom_rules=None):
+  def __init__(self, main, custom_rules=None):
     # The bootstrapper uses no custom confs in its resolves.
     super(ShadedToolFingerprintStrategy, self).__init__(confs=None)
 
-    self._key = key
-    self._scope = scope
     self._main = main
     self._custom_rules = custom_rules
 
@@ -45,8 +43,6 @@ class ShadedToolFingerprintStrategy(IvyResolveFingerprintStrategy):
 
     # NB: this series of updates must always cover the same fields that populate `_tuple`'s slots
     # to ensure proper invalidation.
-    hasher.update(self._key)
-    hasher.update(self._scope)
     hasher.update(self._main)
     if self._custom_rules:
       for rule in self._custom_rules:
@@ -57,7 +53,7 @@ class ShadedToolFingerprintStrategy(IvyResolveFingerprintStrategy):
   def _tuple(self):
     # NB: this tuple's slots - used for `==/hash()` - must be kept in agreement with the hashed
     # fields in `compute_fingerprint` to ensure proper invalidation.
-    return self._key, self._scope, self._main, tuple(self._custom_rules or ())
+    return self._main, tuple(self._custom_rules or ())
 
   def __hash__(self):
     return hash((type(self),) + self._tuple())
@@ -153,8 +149,7 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
                               'shaded_jars', scope, key, '{}.jar'.format(main))
 
     targets = list(self._resolve_tool_targets(tools, key, scope))
-    fingerprint_strategy = ShadedToolFingerprintStrategy(key, scope, main,
-                                                         custom_rules=custom_rules)
+    fingerprint_strategy = ShadedToolFingerprintStrategy(main, custom_rules=custom_rules)
     with self.invalidated(targets,
                           # We're the only dependent in reality since we shade.
                           invalidate_dependents=False,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
+from pants.backend.jvm.tasks.jvm_compile.java.java_compile import JavaCompile
 from pants.backend.jvm.tasks.jvm_compile.java.jmake_analysis_parser import JMakeAnalysisParser
 from pants.fs.archive import TarArchiver
 from pants.util.contextutil import temporary_dir
@@ -64,10 +65,12 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
   @provide_compile_strategies
   def test_nocache(self, strategy):
     with temporary_dir() as cache_dir:
-      bad_artifact_dir = os.path.join(cache_dir, 'JavaCompile',
-                                  'testprojects.src.java.org.pantsbuild.testproject.nocache.nocache')
-      good_artifact_dir = os.path.join(cache_dir, 'JavaCompile',
-                                  'testprojects.src.java.org.pantsbuild.testproject.nocache.cache_me')
+      bad_artifact_dir = os.path.join(cache_dir,
+          JavaCompile.stable_name(),
+          'testprojects.src.java.org.pantsbuild.testproject.nocache.nocache')
+      good_artifact_dir = os.path.join(cache_dir,
+          JavaCompile.stable_name(),
+          'testprojects.src.java.org.pantsbuild.testproject.nocache.cache_me')
       config = {'compile.java': {'write_artifact_caches': [cache_dir]}}
 
       pants_run = self.run_pants(['compile.java',
@@ -88,8 +91,8 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
     # produces two different artifacts.
 
     with temporary_dir() as cache_dir:
-      artifact_dir = os.path.join(cache_dir, 'JavaCompile',
-                                  'testprojects.src.java.org.pantsbuild.testproject.unicode.main.main')
+      artifact_dir = os.path.join(cache_dir, JavaCompile.stable_name(),
+          'testprojects.src.java.org.pantsbuild.testproject.unicode.main.main')
       config = {'compile.java': {'write_artifact_caches': [cache_dir]}}
 
       pants_run = self.run_pants(['compile.java',
@@ -118,8 +121,9 @@ class JavaCompileIntegrationTest(PantsRunIntegrationTest):
     # the artifact contains that resource mapping.
 
     with temporary_dir() as cache_dir:
-      artifact_dir = os.path.join(cache_dir, 'JavaCompile',
-                                  'testprojects.src.java.org.pantsbuild.testproject.annotation.main.main')
+      artifact_dir = os.path.join(cache_dir,
+          JavaCompile.stable_name(),
+          'testprojects.src.java.org.pantsbuild.testproject.annotation.main.main')
       config = {'compile.java': {'write_artifact_caches': [cache_dir]}}
 
       pants_run = self.run_pants(['compile.java',

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -61,7 +61,8 @@ class TaskTestBase(BaseTest):
     """
     options_scope = uuid.uuid4().hex
     subclass_name = b'test_{0}_{1}'.format(task_type.__name__, options_scope)
-    return type(subclass_name, (task_type,), {'options_scope': options_scope}), options_scope
+    return type(subclass_name, (task_type,), {'_stable_name': task_type.__name__,
+                                              'options_scope': options_scope}), options_scope
 
   def set_options(self, **kwargs):
     self.set_options_for_scope(self.options_scope, **kwargs)

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -61,7 +61,7 @@ class TaskTestBase(BaseTest):
     """
     options_scope = uuid.uuid4().hex
     subclass_name = b'test_{0}_{1}'.format(task_type.__name__, options_scope)
-    return type(subclass_name, (task_type,), {'_stable_name': task_type.__name__,
+    return type(subclass_name, (task_type,), {'_stable_name': task_type._compute_stable_name(),
                                               'options_scope': options_scope}), options_scope
 
   def set_options(self, **kwargs):


### PR DESCRIPTION
1. Don't use the task class name in cache paths. This name may not
   be stable across runs because we generate synthetic subclasses at runtime,
   and we make no guarantees about their names (e.g., in tests we inject a
   uuid into the synthetic subclass's name). Instead we introduce a
   stable name, based on the non-synthetic, authored class's name.
   Note that this will all go away once we no longer have any class-level
   task state at runtime.

2. Don't use the registration key or option scope in the cache keys of
   JVM tools. They aren't needed - those are just how the tool is accessed
   by code, they have no effect on which tool jars are resolved or how
   those are shaded.

Both these changes will enable us to get huge test performance speedups by having
tests share shaded JVM tool jars via the local artifact cache.