### PR TITLE
Move jvm release pgp config to XDG_CONFIG_HOME.

### DIFF
--- a/build-support/ivy/publish.ivysettings.xml
+++ b/build-support/ivy/publish.ivysettings.xml
@@ -6,10 +6,10 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 <ivysettings>
   <!-- TODO(John Sirois): Find a better way to get the pgp passphrase than this
-       by-convention-only, chmod 400 file.  This may require writing an ivy signer
+       by-convention-only, chmod 600 file.  This may require writing an ivy signer
        plugin that shells out to pgp and invokes it password dialog. Tracked by:
        https://github.com/pantsbuild/pants/issues/1407 -->
-  <properties file="${user.home}/.pantsbuild.pants.pgp.properties"/>
+  <properties file="${user.home}/.config/pants/release/jvm/pgp.properties"/>
   <property name="pgp.secring" value="${user.home}/.gnupg/secring.gpg" override="false"/>
   <property name="pgp.keyid" value="auto" override="false"/>
 

--- a/src/python/pants/docs/release_jvm.md
+++ b/src/python/pants/docs/release_jvm.md
@@ -45,7 +45,7 @@ satisfy in order to be able publish to Maven Central:
     they can use as a template.  Once this is done and you've performed
     your 1st release, add yourself to the [Releasers](#releasers)
     section below.
-  - Create a `~/.pantsbuild.pants.pgp.properties` file to store the
+  - Create a `~/.config/pants/release/jvm/pgp.properties` file to store the
     credentials Pants needs to sign artifacts uploaded to sonatype.org.
     This process is [described below](#pgp-credentials).
 
@@ -62,7 +62,9 @@ First you'll need to create a secure
 to hold your pgp credentials:
 
     :::bash
-    $ touch ~/.pantsbuild.pants.pgp.properties && chmod 600 ~/.pantsbuild.pants.pgp.properties
+    $ mkdir -p ~/.config/pants/release/jvm && \
+      touch ~/.config/pants/release/jvm/pgp.properties && \
+      chmod 600 ~/.config/pants/release/jvm/pgp.properties
 
 The properties file supports the following keys with noted defaults if omitted:
 
@@ -92,7 +94,7 @@ The properties file supports the following keys with noted defaults if omitted:
     setting if you prefer to be explicit like so:
 
         :::bash
-        $ echo pgp.keyid=67B5C626 >> ~/.pantsbuild.pants.pgp.properties
+        $ echo pgp.keyid=67B5C626 >> ~/.config/pants/release/jvm/pgp.properties
 
   - `pgp.password`
 


### PR DESCRIPTION
This lines up with the rest of pants global config.

NB: The actual XDG_CONFIG_HOME env var could not be used; the ivy
`<properties file="..."/>` element refused to expand
`${env.XDG_CONFIG_HOME}` even when `<properties environment="env"/>`
was declared on a prior line and `-debug` output showed the
`${env.XDG_CONFIG_HOME}` value being loaded correctly.  In contrast the
`${user.home}` system property is expanded correctly and properties are
loaded from `~/.config/pants/release/jvm/pgp.properties` as proven with
`-debug` output.

https://rbcommons.com/s/twitter/r/2292/diff/1#index_header