### PR TITLE
Remove unused imports from python files

### DIFF
--- a/build-support/bin/check_header_helper.py
+++ b/build-support/bin/check_header_helper.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 
-
 EXPECTED_HEADER="""# coding=utf-8
 # Copyright YYYY Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/contrib/buildgen/tests/python/pants_test/contrib/buildgen/test_build_file_manipulator.py
+++ b/contrib/buildgen/tests/python/pants_test/contrib/buildgen/test_build_file_manipulator.py
@@ -5,15 +5,13 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import tempfile
-from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.base.address import SyntheticAddress
 from pants_test.base_test import BaseTest
 
 from pants.contrib.buildgen.build_file_manipulator import (BuildFileManipulator,
-                                                           BuildTargetParseError, DependencySpec)
+                                                           BuildTargetParseError)
 
 
 class BuildFileManipulatorTest(BaseTest):

--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_target.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_target.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.base.payload import Payload
-from pants.base.payload_field import SourcesField
 from pants.base.target import Target
 
 

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_binary_create.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_binary_create.py
@@ -10,8 +10,6 @@ import os
 from pants.base.workunit import WorkUnit
 from pants.util.dirutil import safe_mkdir
 
-from pants.contrib.cpp.targets.cpp_binary import CppBinary
-from pants.contrib.cpp.targets.cpp_library import CppLibrary
 from pants.contrib.cpp.tasks.cpp_task import CppTask
 
 

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_library_create.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_library_create.py
@@ -10,7 +10,6 @@ import os
 from pants.base.workunit import WorkUnit
 from pants.util.dirutil import safe_mkdir
 
-from pants.contrib.cpp.targets.cpp_library import CppLibrary
 from pants.contrib.cpp.tasks.cpp_task import CppTask
 
 

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_run.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_run.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.base.workunit import WorkUnit
-from pants.util.dirutil import safe_mkdir
 
 from pants.contrib.cpp.targets.cpp_binary import CppBinary
 from pants.contrib.cpp.tasks.cpp_task import CppTask

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_task.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/cpp_task.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
 import subprocess
 
 from pants.backend.core.tasks.task import Task

--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_toolchain.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_toolchain.py
@@ -9,7 +9,7 @@ import os
 import unittest
 from contextlib import contextmanager
 
-from pants.util.contextutil import environment_as, temporary_dir, temporary_file
+from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import chmod_plus_x, touch
 
 from pants.contrib.cpp.toolchain.cpp_toolchain import CppToolchain

--- a/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
@@ -5,11 +5,9 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import glob
 import os
 import re
 from collections import defaultdict
-from itertools import chain
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary

--- a/migrations/0.0.24/src/python/publish_migration.py
+++ b/migrations/0.0.24/src/python/publish_migration.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 
+
 if len(sys.argv) != 3:
   print("Usage: publish_migration.py <publish.properties> <directory to write new files>")
   exit(1)

--- a/src/python/pants/backend/codegen/targets/BUILD
+++ b/src/python/pants/backend/codegen/targets/BUILD
@@ -26,7 +26,6 @@ python_library(
     'python_thrift_library.py',
   ],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/python/targets:python',
   ],
 )

--- a/src/python/pants/backend/codegen/targets/python_antlr_library.py
+++ b/src/python/pants/backend/codegen/targets/python_antlr_library.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from twitter.common.collections import OrderedSet
-
 from pants.backend.python.targets.python_target import PythonTarget
 
 

--- a/src/python/pants/backend/core/targets/BUILD
+++ b/src/python/pants/backend/core/targets/BUILD
@@ -17,8 +17,6 @@ python_library(
     'resources.py',
   ],
   dependencies = [
-    'src/python/pants/base:address',
-    'src/python/pants/base:build_environment',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/base:target',

--- a/src/python/pants/backend/core/targets/doc.py
+++ b/src/python/pants/backend/core/targets/doc.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.address import SyntheticAddress
-from pants.base.build_environment import get_buildroot
 from pants.base.payload import Payload
 from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes
 from pants.base.target import Target

--- a/src/python/pants/backend/core/tasks/filemap.py
+++ b/src/python/pants/backend/core/tasks/filemap.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-
 from pants.backend.core.tasks.console_task import ConsoleTask
 
 

--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.base.exceptions import TargetDefinitionException
 
 
 class JavaTests(JvmTarget):

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -9,7 +9,6 @@ import os
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.base.target import Target

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -15,7 +15,6 @@ from twitter.common.collections import maybe_list
 
 from pants.backend.jvm.subsystems.jar_tool import JarTool
 from pants.backend.jvm.targets.java_agent import JavaAgent
-from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, JvmBinary, Skip
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -28,7 +28,7 @@ from pants.backend.python.tasks.python_task import PythonTask
 from pants.backend.python.thrift_builder import PythonThriftBuilder
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
-from pants.base.build_graph import BuildGraph, sort_targets
+from pants.base.build_graph import sort_targets
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.util.dirutil import safe_rmtree, safe_walk
 from pants.util.meta import AbstractClass

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -205,7 +205,6 @@ python_library(
   name = 'lazy_source_mapper',
   sources = ['lazy_source_mapper.py'],
   dependencies = [
-    ':build_file',
     ':build_environment',
   ]
 )
@@ -285,7 +284,6 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':address',
     ':build_environment',
-    ':build_manual',
     ':fingerprint_strategy',
     ':hash_utils',
     ':lazy_source_mapper',

--- a/src/python/pants/base/lazy_source_mapper.py
+++ b/src/python/pants/base/lazy_source_mapper.py
@@ -9,7 +9,6 @@ import os
 from collections import defaultdict
 
 from pants.base.build_environment import get_buildroot
-from pants.base.build_file import BuildFile
 
 
 class LazySourceMapper(object):

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import functools
 import os
 from hashlib import sha1
 
@@ -14,7 +13,6 @@ from six import string_types
 from pants.backend.core.wrapped_globs import FilesetWithSpec
 from pants.base.address import Addresses, SyntheticAddress
 from pants.base.build_environment import get_buildroot
-from pants.base.build_manual import manual
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.base.hash_utils import hash_all

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import multiprocessing
-import os
 import signal
 import sys
 import thread

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 import warnings
 
-from pants.base.build_environment import get_buildroot, pants_version
+from pants.base.build_environment import get_buildroot
 from pants.bin.goal_runner import GoalRunner
 
 

--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -7,8 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import os
-import shutil
-import uuid
 from contextlib import contextmanager
 
 from pants.cache.artifact import TarballArtifact

--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -11,11 +11,8 @@ import urlparse
 import requests
 from requests import RequestException
 
-from pants.cache.artifact import TarballArtifact
 from pants.cache.artifact_cache import (ArtifactCache, ArtifactCacheError,
                                         NonfatalArtifactCacheError, UnreadableArtifact)
-from pants.cache.local_artifact_cache import TempLocalArtifactCache
-from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -5,9 +5,7 @@ python_library(
   name = 'task_registrar',
   sources = ['task_registrar.py'],
   dependencies = [
-    ':error',
     ':goal',
-    'src/python/pants/backend/core/tasks:task',
   ],
 )
 

--- a/src/python/pants/goal/task_registrar.py
+++ b/src/python/pants/goal/task_registrar.py
@@ -5,14 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import functools
-import inspect
 import sys
 import traceback
 from textwrap import dedent
 
-from pants.backend.core.tasks.task import Task
-from pants.goal.error import GoalError
 from pants.goal.goal import Goal
 
 

--- a/src/python/pants/process/pidlock.py
+++ b/src/python/pants/process/pidlock.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import sys
 
-import lockfile
 import psutil
 from lockfile import pidlockfile
 

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -64,7 +64,6 @@ python_tests(
   dependencies = [
     ':base_test',
     'src/python/pants:binary_util',
-    'tests/python/pants_test/base:context_utils',
   ]
 )
 

--- a/tests/python/pants_test/backend/codegen/targets/test_java_protobuf_library.py
+++ b/tests/python/pants_test/backend/codegen/targets/test_java_protobuf_library.py
@@ -10,7 +10,6 @@ from textwrap import dedent
 from pants.backend.codegen.targets.java_protobuf_library import JavaProtobufLibrary
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from textwrap import dedent
-
 from pants.backend.jvm.targets.jar_dependency import IvyArtifact, JarDependency
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scala_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala/test_scala_compile_integration.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import xml.etree.ElementTree as ET
-from contextlib import contextmanager
 
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 from pants_test.testutils.compile_strategy_utils import provide_compile_strategies

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_resource_mapping.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_resource_mapping.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-
 from pants.backend.jvm.tasks.jvm_compile.resource_mapping import ResourceMapping
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -209,7 +209,6 @@ python_tests(
   sources = ['test_cmd_line_spec_parser.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:cmd_line_spec_parser',
     'tests/python/pants_test:base_test',

--- a/tests/python/pants_test/base/test_build_graph.py
+++ b/tests/python/pants_test/base/test_build_graph.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from textwrap import dedent
-
 from pants.base.address import SyntheticAddress, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_graph import BuildGraph

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -9,7 +9,6 @@ import os
 import re
 
 from pants.base.address import SyntheticAddress
-from pants.base.build_file import BuildFile
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.target import Target

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.backend.core.wrapped_globs import Globs
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.build_file_aliases import BuildFileAliases
-from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload, PayloadFieldAlreadyDefinedError, PayloadFrozenError
 from pants.base.payload_field import PrimitiveField
 from pants_test.base_test import BaseTest

--- a/tests/python/pants_test/base/test_scm_build_file.py
+++ b/tests/python/pants_test/base/test_scm_build_file.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
 import subprocess
 
 from twitter.common.collections import OrderedSet

--- a/tests/python/pants_test/targets/test_python_binary.py
+++ b/tests/python/pants_test/targets/test_python_binary.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import pytest
 
 from pants.backend.python.targets.python_binary import PythonBinary
-from pants.base.address import SyntheticAddress
 from pants.base.exceptions import TargetDefinitionException
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import unittest
 from xml.etree import ElementTree
 
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/tasks/test_jvm_task.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.jvm_task import JvmTask
-from pants.base.exceptions import TaskError
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants_test.tasks.task_test_base import TaskTestBase
 

--- a/tests/python/pants_test/tasks/test_targets_help.py
+++ b/tests/python/pants_test/tasks/test_targets_help.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os.path
-
 from pants.backend.core.tasks.targets_help import TargetsHelp
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 

--- a/tests/python/pants_test/test_binary_util.py
+++ b/tests/python/pants_test/test_binary_util.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.binary_util import BinaryUtil
-from pants_test.base.context_utils import create_options
 from pants_test.base_test import BaseTest
 
 

--- a/tests/python/pants_test/testutils/compile_strategy_utils.py
+++ b/tests/python/pants_test/testutils/compile_strategy_utils.py
@@ -7,8 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import sys
 
-import pytest
-
 
 """Helpers to provide compile strategies to unit tests.
 


### PR DESCRIPTION
This was done by running Intellij's Optimize Imports tool over the
python files. I then checked the BUILD files against the diff manually.

I reverted a couple of style conflicts with isort (intellij moves
'import sys' to its own section) but other than that this was easy
and took 15-20 mins. The only tedious part was that many BUILD files
use "dependency bags" which meant I often had to grep the entire
module to see if a dep could be removed from the bag or not.