### PR TITLE
export-no-libs

### DIFF
--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -39,8 +39,21 @@ function pkg_buildgen_install_test() {
   python -c "from pants.contrib.buildgen.build_file_manipulator import *"
 }
 
+PKG_SPINDLE=(
+  "pantsbuild.pants.contrib.spindle"
+  "//contrib/spindle/src/python/pants/contrib/spindle:plugin"
+  "pkg_spindle_install_test"
+)
+function pkg_spindle_install_test() {
+  PIP_ARGS="$@"
+  pip install ${PIP_ARGS} pantsbuild.pants.contrib.spindle==$(local_version) && \
+  execute_packaged_pants_with_internal_backends "extra_backend_packages='pants.contrib.spindle'" \
+    --explain gen | grep "spindle" &> /dev/null
+}
+
 # Once individual (new) package is declared above, insert it into the array below)
 CONTRIB_PACKAGES=(
   PKG_SCROOGE
   PKG_BUILDGEN
+  PKG_SPINDLE
 )

--- a/contrib/spindle/src/python/pants/contrib/__init__.py
+++ b/contrib/spindle/src/python/pants/contrib/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
@@ -21,6 +21,7 @@ from twitter.common.dirutil import safe_mkdir
 
 from pants.contrib.spindle.targets.spindle_thrift_library import SpindleThriftLibrary
 
+
 class SpindleGen(NailgunTask):
   def __init__(self, context, workdir):
     super(SpindleGen, self).__init__(context, workdir)

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -108,6 +108,7 @@ class Export(ConsoleTask):
   def console_output(self, targets):
     targets_map = {}
     resource_target_map = {}
+    ivy_info = None
     if self.get_options().libraries:
       ivy_jar_products = self.context.products.get_data('ivy_jar_products') or {}
       # This product is a list for historical reasons (exclusives groups) but in practice should
@@ -119,8 +120,6 @@ class Export(ConsoleTask):
           ' since we no longer have exclusives groups.'
         )
         ivy_info = ivy_info_list[0]
-      else:
-        ivy_info = None
 
     def process_target(current_target):
       """

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -103,6 +103,7 @@ class Export(ConsoleTask):
     super(Export, self).__init__(*args, **kwargs)
     self.format = self.get_options().formatted
     self.target_aliases_map = None
+    self.ivy_jar_memo = {}
 
   def console_output(self, targets):
     targets_map = {}
@@ -120,7 +121,6 @@ class Export(ConsoleTask):
         )
         ivy_info = ivy_info_list[0]
 
-    ivy_jar_memo = {}
     def process_target(current_target):
       """
       :type current_target:pants.base.target.Target
@@ -138,18 +138,6 @@ class Export(ConsoleTask):
           else:
             return Export.SourceRootTypes.SOURCE
 
-      def get_transitive_jars(jar_lib):
-        """
-        :type jar_lib: pants.backend.jvm.targets.jar_library.JarLibrary
-        :rtype: twitter.common.collections.orderedset.OrderedSet
-        """
-        if not ivy_info or not self.get_options().libraries:
-          return OrderedSet()
-        transitive_jars = OrderedSet()
-        for jar in jar_lib.jar_dependencies:
-          transitive_jars.update(ivy_info.get_jars_for_ivy_module(jar, memo=ivy_jar_memo))
-        return transitive_jars
-
       info = {
         'targets': [],
         'libraries': [],
@@ -166,14 +154,14 @@ class Export(ConsoleTask):
 
       target_libraries = set()
       if isinstance(current_target, JarLibrary):
-        target_libraries = get_transitive_jars(current_target)
+        target_libraries = self._get_transitive_jars(current_target, ivy_info)
       for dep in current_target.dependencies:
         info['targets'].append(self._address(dep.address))
         if isinstance(dep, JarLibrary):
           for jar in dep.jar_dependencies:
             target_libraries.add(IvyModuleRef(jar.org, jar.name, jar.rev))
           # Add all the jars pulled in by this jar_library
-          target_libraries.update(get_transitive_jars(dep))
+          target_libraries.update(self._get_transitive_jars(dep, ivy_info))
         if isinstance(dep, Resources):
           resource_target_map[dep] = current_target
 
@@ -209,6 +197,18 @@ class Export(ConsoleTask):
       return json.dumps(graph_info, indent=4, separators=(',', ': ')).splitlines()
     else:
       return [json.dumps(graph_info)]
+
+  def _get_transitive_jars(self, jar_lib, ivy_info):
+    """
+    :type jar_lib: pants.backend.jvm.targets.jar_library.JarLibrary
+    :rtype: twitter.common.collections.orderedset.OrderedSet
+    """
+    if not ivy_info or not self.get_options().libraries:
+      return OrderedSet()
+    transitive_jars = OrderedSet()
+    for jar in jar_lib.jar_dependencies:
+      transitive_jars.update(ivy_info.get_jars_for_ivy_module(jar, memo=self.ivy_jar_memo))
+    return transitive_jars
 
   def _resolve_jars_info(self):
     """Consults ivy_jar_products to export the external libraries.

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -140,9 +140,11 @@ class Export(ConsoleTask):
             return Export.SourceRootTypes.SOURCE
 
       def get_transitive_jars(jar_lib):
-        if not self.get_options().libraries:
-          return []
-        if not ivy_info:
+        """
+        :type jar_lib: pants.backend.jvm.targets.jar_library.JarLibrary
+        :rtype: twitter.common.collections.orderedset.OrderedSet
+        """
+        if not ivy_info or not self.get_options().libraries:
           return OrderedSet()
         transitive_jars = OrderedSet()
         for jar in jar_lib.jar_dependencies:

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -103,6 +103,7 @@ class Export(ConsoleTask):
     super(Export, self).__init__(*args, **kwargs)
     self.format = self.get_options().formatted
     self.target_aliases_map = None
+    self.ivy_jar_memo = {}
 
   def console_output(self, targets):
     targets_map = {}
@@ -121,7 +122,6 @@ class Export(ConsoleTask):
       else:
         ivy_info = None
 
-    ivy_jar_memo = {}
     def process_target(current_target):
       """
       :type current_target:pants.base.target.Target
@@ -139,18 +139,6 @@ class Export(ConsoleTask):
           else:
             return Export.SourceRootTypes.SOURCE
 
-      def get_transitive_jars(jar_lib):
-        """
-        :type jar_lib: pants.backend.jvm.targets.jar_library.JarLibrary
-        :rtype: twitter.common.collections.orderedset.OrderedSet
-        """
-        if not ivy_info or not self.get_options().libraries:
-          return OrderedSet()
-        transitive_jars = OrderedSet()
-        for jar in jar_lib.jar_dependencies:
-          transitive_jars.update(ivy_info.get_jars_for_ivy_module(jar, memo=ivy_jar_memo))
-        return transitive_jars
-
       info = {
         'targets': [],
         'libraries': [],
@@ -167,14 +155,14 @@ class Export(ConsoleTask):
 
       target_libraries = set()
       if isinstance(current_target, JarLibrary):
-        target_libraries = get_transitive_jars(current_target)
+        target_libraries = self._get_transitive_jars(current_target, ivy_info)
       for dep in current_target.dependencies:
         info['targets'].append(self._address(dep.address))
         if isinstance(dep, JarLibrary):
           for jar in dep.jar_dependencies:
             target_libraries.add(IvyModuleRef(jar.org, jar.name, jar.rev))
           # Add all the jars pulled in by this jar_library
-          target_libraries.update(get_transitive_jars(dep))
+          target_libraries.update(self._get_transitive_jars(dep, ivy_info))
         if isinstance(dep, Resources):
           resource_target_map[dep] = current_target
 
@@ -210,6 +198,18 @@ class Export(ConsoleTask):
       return json.dumps(graph_info, indent=4, separators=(',', ': ')).splitlines()
     else:
       return [json.dumps(graph_info)]
+
+  def _get_transitive_jars(self, jar_lib, ivy_info):
+    """
+    :type jar_lib: pants.backend.jvm.targets.jar_library.JarLibrary
+    :rtype: twitter.common.collections.orderedset.OrderedSet
+    """
+    if not ivy_info or not self.get_options().libraries:
+      return OrderedSet()
+    transitive_jars = OrderedSet()
+    for jar in jar_lib.jar_dependencies:
+      transitive_jars.update(ivy_info.get_jars_for_ivy_module(jar, memo=self.ivy_jar_memo))
+    return transitive_jars
 
   def _resolve_jars_info(self):
     """Consults ivy_jar_products to export the external libraries.

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -103,7 +103,6 @@ class Export(ConsoleTask):
     super(Export, self).__init__(*args, **kwargs)
     self.format = self.get_options().formatted
     self.target_aliases_map = None
-    self.ivy_jar_memo = {}
 
   def console_output(self, targets):
     targets_map = {}

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -259,8 +259,7 @@ class ProjectInfoTest(ConsoleTaskTestBase):
       options=dict(libraries=False),
       targets=[self.target('project_info:java_test')]
     ))
-    self.assertEqual([],
-                     result['targets']['project_info:java_test']['libraries'])
+    self.assertIsNone(result['targets']['project_info:java_test']['libraries'])
 
   def test_java_test(self):
     result = get_json(self.execute_console_task(

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -259,7 +259,8 @@ class ProjectInfoTest(ConsoleTaskTestBase):
       options=dict(libraries=False),
       targets=[self.target('project_info:java_test')]
     ))
-    self.assertIsNone(result['targets']['project_info:java_test']['libraries'])
+    self.assertEqual([],
+                     result['targets']['project_info:java_test']['libraries'])
 
   def test_java_test(self):
     result = get_json(self.execute_console_task(


### PR DESCRIPTION
Fixed 'has no attribute' exception because get_transitive_jars was returning a list or a set.

Fixed 'variable 'ivy_info' referenced before assignment'

Refactored tests for export goal to verify --no-export-libraries option is working.