### PR TITLE
[CI] Allow jvm tool tests to bootstrap from the artifact cache.

### DIFF
--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -65,7 +65,7 @@ class TaskBase(AbstractClass):
 
   @classmethod
   def _compute_stable_name(cls):
-    return '{}.{}'.format(cls.__module__, cls.__name__)
+    return '{}_{}'.format(cls.__module__, cls.__name__).replace('.', '_')
 
   @classmethod
   def global_subsystems(cls):

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -29,7 +29,7 @@ class TestSetupPy(PythonTaskTest):
   def setUp(self):
     super(TestSetupPy, self).setUp()
 
-    distdir = os.path.join(self._tmpdir, 'dist')
+    distdir = os.path.join(self.pants_workdir, 'dist')
     self.set_options(pants_distdir=distdir)
 
     self.dependency_calculator = SetupPy.DependencyCalculator(self.build_graph)

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -8,6 +8,7 @@ python_library(
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:target',
+    'src/python/pants/base:workunit',
     'src/python/pants/goal:context',
   ]
 )

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from twitter.common.collections import maybe_list
 
 from pants.base.target import Target
+from pants.base.workunit import WorkUnit
 from pants.goal.context import Context
 
 
@@ -62,8 +63,8 @@ class TestContext(Context):
   isolate the parts of the interface that a Task is allowed to use vs. the parts that the
   task-running machinery is allowed to use.
   """
-  class DummyWorkunit(object):
-    """A workunit stand-in that sends all output to stderr
+  class DummyWorkUnit(object):
+    """A workunit stand-in that sends all output to stderr.
 
    These outputs are typically only used by subprocesses spawned by code under test, not
    the code under test itself, and would otherwise go into some reporting black hole.  The
@@ -77,15 +78,34 @@ class TestContext(Context):
       return sys.stderr
 
     def set_outcome(self, outcome):
-      return sys.stderr.write('Outcome: {}'.format(outcome))
+      return sys.stderr.write('\nWorkUnit outcome: {}\n'.format(WorkUnit.outcome_string(outcome)))
+
+  class DummyRunTracker(object):
+    """A runtracker stand-in that does no actual tracking."""
+    class DummyArtifactCacheStats(object):
+      def add_hit(self, cache_name, tgt): pass
+      def add_miss(self, cache_name, tgt): pass
+
+    artifact_cache_stats = DummyArtifactCacheStats()
 
   @contextmanager
   def new_workunit(self, name, labels=None, cmd=''):
-    yield TestContext.DummyWorkunit()
+    sys.stderr.write('\nStarting workunit {}\n'.format(name))
+    yield TestContext.DummyWorkUnit()
 
   @property
   def log(self):
     return logging.getLogger('test')
+
+  def submit_background_work_chain(self, work_chain, parent_workunit_name=None):
+    # Just do the work synchronously, so we don't need a run tracker, background workers and so on.
+    for work in work_chain:
+      for args_tuple in work.args_tuples:
+        work.func(*args_tuple)
+
+  def subproc_map(self, f, items):
+    # Just execute in-process.
+    return map(f, items)
 
 
 # TODO: Make Console and Workspace into subsystems, and simplify this signature.
@@ -99,8 +119,9 @@ def create_context(options=None, target_roots=None, build_graph=None,
   Other params are as for ``Context``.
   """
   options = create_options(options or {})
+  run_tracker = TestContext.DummyRunTracker()
   target_roots = maybe_list(target_roots, Target) if target_roots else []
-  return TestContext(options=options, run_tracker=None, target_roots=target_roots,
+  return TestContext(options=options, run_tracker=run_tracker, target_roots=target_roots,
                      build_graph=build_graph, build_file_parser=build_file_parser,
                      address_mapper=address_mapper, console_outstream=console_outstream,
                      workspace=workspace)

--- a/tests/python/pants_test/jvm/BUILD
+++ b/tests/python/pants_test/jvm/BUILD
@@ -18,6 +18,7 @@ python_library(
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/ivy',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -12,9 +12,9 @@ from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.tasks.bootstrap_jvm_tools import BootstrapJvmTools
+from pants.base.build_environment import get_pants_cachedir
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.ivy.bootstrapper import Bootstrapper
-from pants.util.dirutil import safe_mkdtemp
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
@@ -36,15 +36,32 @@ class JvmToolTaskTestBase(TaskTestBase):
   def setUp(self):
     super(JvmToolTaskTestBase, self).setUp()
 
-    # Use a synthetic subclass for bootstrapping within the test, to isolate this from
-    # any bootstrapping the pants run executing the test might need.
-    self.bootstrap_task_type, bootstrap_scope = self.synthesize_task_subtype(BootstrapJvmTools)
+    # Use a synthetic subclass for proper isolation when bootstrapping within the test.
+    bootstrap_scope = 'bootstrap_scope'
+    self.bootstrap_task_type = self.synthesize_task_subtype(BootstrapJvmTools, bootstrap_scope)
     JvmToolMixin.reset_registered_tools()
 
-    # Cap BootstrapJvmTools memory usage in tests.  The Xmx was empirically arrived upon using
-    # -Xloggc and verifying no full gcs for a test using the full gamut of resolving a multi-jar
-    # tool, constructing a fat jar and then shading that fat jar.
-    self.set_options_for_scope(bootstrap_scope, jvm_options=['-Xmx128m'])
+    # Set some options:
+
+    # 1. Cap BootstrapJvmTools memory usage in tests.  The Xmx was empirically arrived upon using
+    #    -Xloggc and verifying no full gcs for a test using the full gamut of resolving a multi-jar
+    #    tool, constructing a fat jar and then shading that fat jar.
+    #
+    # 2. Allow tests to read/write tool jars from the real artifact cache, so they don't
+    #    each have to resolve and shade them every single time, which is a huge slowdown.
+    #    Note that local artifact cache writes are atomic, so it's fine for multiple concurrent
+    #    tests to write to it.
+    #
+    # Note that we don't have access to the invoking pants instance's options, so we assume that
+    # its artifact cache is in the standard location.  If it isn't, worst case the tests will
+    # populate a second cache at the standard location, which is no big deal.
+    # TODO: We really need a straightforward way for pants's own tests to get to the enclosing
+    # pants instance's options values.
+    artifact_caches = [os.path.join(get_pants_cachedir(), 'artifact_cache')]
+    self.set_options_for_scope(bootstrap_scope,
+                               jvm_options=['-Xmx128m'],
+                               read_artifact_caches=artifact_caches,
+                               write_artifact_caches=artifact_caches)
 
     # Tool option defaults currently point to targets in the real BUILD.tools, so we copy it
     # into our test workspace.
@@ -62,34 +79,33 @@ class JvmToolTaskTestBase(TaskTestBase):
                                                     console_outstream=console_outstream,
                                                     workspace=workspace)
 
-  def prepare_execute(self, context, workdir):
-    """Prepares a jvm tool using task for execution, ensuring any required jvm tools are
-    bootstrapped.
+  def prepare_execute(self, context):
+    """Prepares a jvm tool-using task for execution, first bootstrapping any required jvm tools.
 
-    NB: Other task pre-requisites will not be ensured and tests must instead setup their own product
-    requirements if any.
+    Note: Other task pre-requisites will not be ensured and tests must instead setup their own
+          product requirements if any.
 
-    :returns: The prepared Task
+    :returns: The prepared Task instance.
     """
-    # TODO(John Sirois): This is emulating Engine behavior - construct reverse order, then execute;
-    # instead it should probably just be using an Engine.
-    task = self.create_task(context, workdir)
+    task = self.create_task(context)
     task.invalidate()
-    bootstrap_workdir = os.path.join(workdir, '_bootstrap_jvm_tools')
+
+    # Bootstrap the tools needed by the task under test.
+    # We need the bootstrap task's workdir to be under the test's .pants.d, so that it can
+    # use artifact caching.  Making it a sibling of the main task's workdir achieves this.
+    bootstrap_workdir = os.path.join(os.path.dirname(task.workdir), 'bootstrap_jvm_tools')
     self.bootstrap_task_type(context, bootstrap_workdir).execute()
     return task
 
+
   def execute(self, context):
-    """Executes the given task ensuring any required jvm tools are bootstrapped.
+    """Executes a jvm tool-using task, first bootstrapping any required jvm tools.
 
-    NB: Other task pre-requisites will not be ensured and tests must instead setup their own product
-    requirements if any.
+    Note: Other task pre-requisites will not be ensured and tests must instead setup their own
+          product requirements if any.
 
-    :returns: The Task that was executed
+    :returns: The Task instance that was executed.
     """
-    # TODO(John Sirois): This is emulating Engine behavior - construct reverse order, then execute;
-    # instead it should probably just be using an Engine.
-    workdir = safe_mkdtemp(dir=self.build_root)
-    task = self.prepare_execute(context, workdir)
+    task = self.prepare_execute(context)
     task.execute()
     return task

--- a/tests/python/pants_test/tasks/test_jar_task.py
+++ b/tests/python/pants_test/tasks/test_jar_task.py
@@ -47,7 +47,7 @@ class BaseJarTaskTest(JarTaskTestBase):
     super(BaseJarTaskTest, self).setUp()
 
     self.workdir = safe_mkdtemp()
-    self.jar_task = self.prepare_execute(self.context(), self.workdir)
+    self.jar_task = self.prepare_execute(self.context())
 
   def tearDown(self):
     super(BaseJarTaskTest, self).tearDown()
@@ -62,7 +62,7 @@ class BaseJarTaskTest(JarTaskTestBase):
       yield fd.name
 
   def prepare_jar_task(self, context):
-    return self.prepare_execute(context, self.workdir)
+    return self.prepare_execute(context)
 
   def assert_listing(self, jar, *expected_items):
     self.assertEquals(set(['META-INF/', 'META-INF/MANIFEST.MF']) | set(expected_items),


### PR DESCRIPTION
This makes those tests quite a bit faster. For example,

./pants test tests/python/pants_test/backend/jvm/tasks:junit_run

Runs in 35 seconds with no cached junit jar, but in under 5 seconds with.

This was also a useful exercise in reasoning about test isolation:
To use cached jars they must have the same path under .pants.d, and
in our tests those paths included a randomly named tmpdir and
a randomly named options scope. Switching those to stable names
forced me to think about whether that was OK, and my conclusion was
that it is, which is a good sign for our test isolation.