### PR TITLE
Invoke jvm doc tools via java.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -247,9 +247,9 @@ python_library(
   sources = ['javadoc_gen.py'],
   dependencies = [
     ':jvmdoc_gen',
-    'pants/java/distribution',
-    'pants/java:executor',
-    'pants/util:memo',
+    'src/python/pants/java/distribution',
+    'src/python/pants/java:executor',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -185,15 +185,11 @@ python_library(
   name = 'jar_create',
   sources = ['jar_create.py'],
   dependencies = [
-    ':common',
-    ':javadoc_gen',
     ':jar_task',
-    ':scaladoc_gen',
-    'src/python/pants/base:build_environment',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:workunit',
     'src/python/pants/fs',
-    'src/python/pants/java/jar:manifest',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/util:dirutil',
   ],
 )
@@ -251,6 +247,9 @@ python_library(
   sources = ['javadoc_gen.py'],
   dependencies = [
     ':jvmdoc_gen',
+    'pants/java/distribution',
+    'pants/java:executor',
+    'pants/util:memo',
   ],
 )
 
@@ -325,9 +324,9 @@ python_library(
   name = 'jvmdoc_gen',
   sources = ['jvmdoc_gen.py'],
   dependencies = [
-    ':common',
     ':jvm_task',
     'src/python/pants:binary_util',
+    'src/python/pants/base:exceptions',
     'src/python/pants/util:dirutil',
   ],
 )
@@ -365,6 +364,9 @@ python_library(
   sources = ['scaladoc_gen.py'],
   dependencies = [
     ':jvmdoc_gen',
+    'src/python/pants/backend/jvm/subsystems:scala_platform',
+    'src/python/pants/java:executor',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -73,10 +73,6 @@ class JvmdocGen(JvmTask):
   def __init__(self, *args, **kwargs):
     super(JvmdocGen, self).__init__(*args, **kwargs)
 
-    jvmdoc_tool_name = self.jvmdoc().tool_name
-
-    config_section = '{}-gen'.format(jvmdoc_tool_name)
-
     options = self.get_options()
     self._include_codegen = options.include_codegen
     self.transitive = options.transitive

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -5,23 +5,27 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.tasks.jvmdoc_gen import Jvmdoc, JvmdocGen
-
-
-scaladoc = Jvmdoc(tool_name='scaladoc', product_type='scaladoc')
-
-
-def is_scala(target):
-  return target.has_sources('.scala')
+from pants.java.executor import SubprocessExecutor
+from pants.util.memo import memoized
 
 
 class ScaladocGen(JvmdocGen):
   @classmethod
+  @memoized
   def jvmdoc(cls):
-    return scaladoc
+    return Jvmdoc(tool_name='scaladoc', product_type='scaladoc')
+
+  @classmethod
+  def task_subsystems(cls):
+    return (ScalaPlatform,)
 
   def execute(self):
-    self.generate_doc(lambda t: t.is_scala, self.create_scaladoc_command)
+    def is_scala(target):
+      return target.has_sources('.scala')
+
+    self.generate_doc(is_scala, self.create_scaladoc_command)
 
   def create_scaladoc_command(self, classpath, gendir, *targets):
     sources = []
@@ -34,21 +38,20 @@ class ScaladocGen(JvmdocGen):
     if not sources:
       return None
 
-    # TODO(John Chee): try scala.tools.nsc.ScalaDoc via ng
-    command = [
-      'scaladoc',
-      '-usejavacp',
-      '-classpath', ':'.join(classpath),
-      '-d', gendir,
-    ]
+    scala_platform = ScalaPlatform.global_instance()
+    tool_classpath = scala_platform.compiler_classpath(self.context.products)
 
-    for jvm_option in self.jvm_options:
-      if jvm_option.startswith('-D'):
-        command.append(jvm_option)  # Scaladoc takes sysprop settings directly.
-      else:
-        command.append('-J{0}'.format(jvm_option))
+    args = ['-usejavacp',
+            '-classpath', ':'.join(classpath),
+            '-d', gendir]
 
-    command.extend(self.args)
+    args.extend(self.args)
 
-    command.extend(sources)
-    return command
+    args.extend(sources)
+
+    java_executor = SubprocessExecutor()
+    runner = java_executor.runner(jvm_options=self.jvm_options,
+                                  classpath=tool_classpath,
+                                  main='scala.tools.nsc.ScalaDoc',
+                                  args=args)
+    return runner.command

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -342,8 +342,9 @@ python_tests(
   name = 'jar_publish_integration',
   sources = ['test_jar_publish_integration.py'],
   dependencies = [
-    ':task_test_base',
+    'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
   ],
 )

--- a/tests/python/pants_test/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/tasks/test_jar_publish_integration.py
@@ -8,13 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
-import pytest
-
 from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_rmtree
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants_test.tasks.task_test_base import is_exe
 
 
 def shared_artifacts(version, extra_jar=None):
@@ -55,8 +52,6 @@ def publish_extra_config(unique_config):
 
 
 class JarPublishIntegrationTest(PantsRunIntegrationTest):
-  SCALADOC = is_exe('scaladoc')
-  JAVADOC = is_exe('javadoc')
   GOLDEN_DATA_DIR = 'tests/python/pants_test/tasks/jar_publish_resources/'
 
   # This is where all pushdb properties files will end up.
@@ -92,8 +87,6 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
                       expected_primary_artifact_count=3,
                       assert_publish_config_contents=True)
 
-  @pytest.mark.skipif('not JarPublishIntegrationTest.JAVADOC',
-                      reason='No javadoc binary on the PATH.')
   def test_java_publish(self):
     self.publish_test('testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet',
                       shared_artifacts('0.0.1-SNAPSHOT'),
@@ -190,8 +183,6 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
                                artifact_name='hello-greet-0.0.1-SNAPSHOT.jar',
                                success_expected=False)
 
-  @pytest.mark.skipif('not JarPublishIntegrationTest.SCALADOC',
-                      reason='No scaladoc binary on the PATH.')
   def test_scala_publish_classifiers(self):
     self.publish_test('testprojects/src/scala/org/pantsbuild/testproject/publish/classifiers',
                       dict({


### PR DESCRIPTION
This removes dependence on the `javadoc` and `scaladoc` binaries which
immediately opens up javadoc and scaladoc testing on Travis-CI.

For `javadoc` this is not so important today, since the new invocation
scheme requires a jdk for `tools.jar` which necessarily means `javadoc`
is present.  That said, it does set the stage for invoking javadoc
using the correct JDK based on the repo-wide or per-target JDK
constraints.