### PR TITLE
Fixup memoization key_factory bugs.

### DIFF
--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -33,8 +33,8 @@ def per_instance(*args, **kwargs):
   # instead of relying on `==` since different instances may evaluate as `==`.  Additionally, we
   # pair the id with the instance to ensure the instance is not GC'd since `id` allows for re-use
   # of ids under GC.
-  instace = args[0]
-  unique_retained_instance = (id(instace), instace)
+  instance = args[0]
+  unique_retained_instance = (id(instance), instance)
 
   instance_and_rest = (unique_retained_instance,) + args[1:]
   return equal_args(*instance_and_rest, **kwargs)

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -9,11 +9,16 @@ import functools
 import inspect
 
 
+# Used as a sentinel that disambiguates tuples passed in *args from coincidentally matching tuples
+# formed from kwargs item pairs.
+_kwargs_separator = (object(),)
+
+
 def equal_args(*args, **kwargs):
   """A memoized key factory that compares the equality (`==`) of a stable sort of the parameters."""
   key = args
   if kwargs:
-    key += tuple(sorted(kwargs.items()))
+    key += _kwargs_separator + tuple(sorted(kwargs.items()))
   return key
 
 
@@ -25,8 +30,13 @@ def per_instance(*args, **kwargs):
   instance method in a class hierarchy that defines a custom `__hash__`/`__eq__`.
   """
   # For methods, the cache should be per-instance, so we take the id of the self/cls argument
-  # instead of relying on `==` since different instances may evaluate as `==`.
-  instance_and_rest = (id(args[0]),) + args[1:]
+  # instead of relying on `==` since different instances may evaluate as `==`.  Additionally, we
+  # pair the id with the instance to ensure the instance is not GC'd since `id` allows for re-use
+  # of ids under GC.
+  instace = args[0]
+  unique_retained_instance = (id(instace), instace)
+
+  instance_and_rest = (unique_retained_instance,) + args[1:]
   return equal_args(*instance_and_rest, **kwargs)
 
 

--- a/tests/python/pants_test/util/test_memo.py
+++ b/tests/python/pants_test/util/test_memo.py
@@ -54,6 +54,20 @@ class MemoizeTest(unittest.TestCase):
     self.assertEqual([(('a',), {'fred': 42, 'jane': True}),
                       (('a', 42), {'jane': True})], calculations)
 
+  def test_function_application_potentially_ambiguous_parameters(self):
+    calculations = []
+
+    @memoized
+    def func(*args, **kwargs):
+      calculations.append((args, kwargs))
+      return args, kwargs
+
+    self.assertEqual(((('a', 42),), {}), func(('a', 42)))
+    self.assertEqual(((), {'a': 42}), func(a=42))
+
+    self.assertEqual([((('a', 42),), {}),
+                      ((), {'a': 42})], calculations)
+
   def test_key_factory(self):
     def create_key(num):
       return num % 2


### PR DESCRIPTION
Patrick pointed out 2 issues in https://rbcommons.com/s/twitter/r/2040/
that can lead to bad cache keys and thus incorrect memoized function
return values.

This adds a failing test for the ambiguous *args/**kwargs case and fixes
it.  The GC'd object `id()` case is not tested/testable.