### PR TITLE
Add options for specifying python cache dirs.

### DIFF
--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -75,9 +75,7 @@ class PythonChroot(object):
                                           interpreter=self._interpreter)
 
     # Note: unrelated to the general pants artifact cache.
-    self._egg_cache_root = os.path.join(
-      self._python_setup.scratch_dir, 'artifacts', str(self._interpreter.identity))
-
+    self._egg_cache_root = self._python_setup.artifact_cache_dir
     self._key_generator = CacheKeyGenerator()
     self._build_invalidator = BuildInvalidator(self._egg_cache_root)
 

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -36,6 +36,12 @@ class PythonSetup(Subsystem):
     register('--interpreter-cache-dir', advanced=True, default=None, metavar='<dir>',
              help='The parent directory for the interpreter cache. '
                   'If unspecified, a standard path under the workdir is used.')
+    register('--egg-cache-dir', advanced=True, default=None, metavar='<dir>',
+             help='The parent directory for the egg cache. '
+                  'If unspecified, a standard path under the workdir is used.')
+    register('--artifact-cache-dir', advanced=True, default=None, metavar='<dir>',
+             help='The parent directory for the python artifact cache. '
+                  'If unspecified, a standard path under the workdir is used.')
 
   @property
   def interpreter_requirement(self):
@@ -57,6 +63,17 @@ class PythonSetup(Subsystem):
   def interpreter_cache_dir(self):
     return (self.get_options().interpreter_cache_dir or
             os.path.join(self.scratch_dir, 'interpreters'))
+
+  @property
+  def egg_cache_dir(self):
+    return (self.get_options().egg_cache_dir or
+            os.path.join(self.scratch_dir, 'eggs'))
+
+  @property
+  def artifact_cache_dir(self):
+    """ Note that this is unrelated to the general pants artifact cache."""
+    return (self.get_options().artifact_cache_dir or
+            os.path.join(self.scratch_dir, 'artifacts'))
 
   @property
   def scratch_dir(self):

--- a/src/python/pants/backend/python/resolver.py
+++ b/src/python/pants/backend/python/resolver.py
@@ -50,7 +50,7 @@ def resolve_multi(python_setup,
   if not isinstance(interpreter, PythonInterpreter):
     raise TypeError('Expected interpreter to be a PythonInterpreter, got {}'.format(type(interpreter)))
 
-  cache = os.path.join(python_setup.scratch_dir, 'eggs')
+  cache = python_setup.egg_cache_dir
   platforms = get_platforms(platforms or python_setup.platforms)
   fetchers = python_repos.get_fetchers()
   if find_links:


### PR DESCRIPTION
Specifically, the 'egg' cache, where third party eggs
are downloaded, and the 'artifact' cache.

It can be useful to put these outside of the default
pants workdir to circumvent 'pants clean-all' blowing
them away.  In a repo with many external python deps,
killing the egg cache can add minutes to the next
python-related pants invocation.