### PR TITLE
Minor fix for issue 465

### DIFF
--- a/src/python/pants/base/cache_manager.py
+++ b/src/python/pants/base/cache_manager.py
@@ -7,10 +7,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import sys
 
+from pants.base.exceptions import TaskError
 from pants.base.build_graph import sort_targets
 from pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
 from pants.base.target import Target
-
 
 try:
   import cPickle as pickle
@@ -184,7 +184,9 @@ class InvalidationCacheManager(object):
   Note that this is distinct from the ArtifactCache concept, and should probably be renamed.
   """
 
-  class CacheValidationError(Exception):
+  # NOTE: This should extend TaskError so that it doesn't bubble up past the Engine;
+  #       specifically this addresses https://github.com/pantsbuild/pants/issues/465
+  class CacheValidationError(TaskError):
     """Indicates a problem accessing the cache."""
 
   def __init__(self,

--- a/src/python/pants/base/cache_manager.py
+++ b/src/python/pants/base/cache_manager.py
@@ -7,10 +7,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import sys
 
-from pants.base.exceptions import TaskError
 from pants.base.build_graph import sort_targets
 from pants.base.build_invalidator import BuildInvalidator, CacheKeyGenerator
+from pants.base.exceptions import TaskError
 from pants.base.target import Target
+
 
 try:
   import cPickle as pickle


### PR DESCRIPTION
IOErrors from missing target source paths were being marshalled into CacheValidationErrors by cache_manager.py:_key_for and were bubbling up past the engine.py:execute's catch for TaskErrors.

I'm not sure if this is the right approach, I'm new to the code base and haven't touched python in a (very long) while.  Specifically, I'm not totally convinced that a CacheValidationError should be a fatal TaskError; or if catching further down in payload_field.py:_compute_fingerprint and failing semi-silently on IOErrors would be preferable.  This seemed like the simplest fix, I'm definitely open to feedback though.