### PR TITLE
Avoid ivy cache thrash due to ivydata updates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@
 # cache configured below.
 sudo: false
 
+
+before_cache:
+  # The ivydata files' effect on resolution time is in the noise, but
+  # they are re-timestamped in a comment on each run and lead to cache
+  # thrash.  Kill these files before the cache check to avoid un-needed
+  # cache re-packing and re-upload (a ~100s operation).
+  - find $HOME/.ivy2 -type f -name "ivydata-*.properties" -delete
+
 cache:
   directories:
     - $HOME/.cache/pants

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,19 @@ sudo: false
 
 
 before_cache:
-  # The `ivydata-*.properties` & `resolved-*.xml` files' effect on
-  # resolution time is in the noise, but they are re-timestamped in
-  # internal comments and fields on each run and this leads to
-  # travis-ci cache thrash.  Kill these files before the cache check
-  # to avoid un-needed cache re-packing and re-upload (a ~100s
+  # The `ivydata-*.properties` & root level `*.{properties,xml}` files'
+  # effect on resolution time is in the noise, but they are
+  # re-timestamped in internal comments and fields on each run and this
+  # leads to travis-ci cache thrash.  Kill these files before the cache
+  # check to avoid un-needed cache re-packing and re-upload (a ~100s
   # operation).
-  - find $HOME/.ivy2 -type f \( -name "ivydata-*.properties" -o -name "resolved-*.xml" \) -print -delete
+  - find $HOME/.ivy2/pants -type f -name "ivydata-*.properties" -print -delete
+  - rm -fv $HOME/.ivy2/pants/*.{css,properties,xml,xsl}
 
 cache:
   directories:
     - $HOME/.cache/pants
-    - $HOME/.ivy2
+    - $HOME/.ivy2/pants
     - build-support/isort.venv
     - build-support/pants_dev_deps.venv
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_cache:
   # travis-ci cache thrash.  Kill these files before the cache check
   # to avoid un-needed cache re-packing and re-upload (a ~100s
   # operation).
-  - find $HOME/.ivy2 -type f -name "ivydata-*.properties" -o -name "resolved-*.xml" -print -delete
+  - find $HOME/.ivy2 -type f \( -name "ivydata-*.properties" -o -name "resolved-*.xml" \) -print -delete
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ sudo: false
 
 
 before_cache:
-  # The ivydata files' effect on resolution time is in the noise, but
-  # they are re-timestamped in a comment on each run and lead to cache
-  # thrash.  Kill these files before the cache check to avoid un-needed
-  # cache re-packing and re-upload (a ~100s operation).
-  - find $HOME/.ivy2 -type f -name "ivydata-*.properties" -delete
+  # The `ivydata-*.properties` & `resolved-*.xml` files' effect on
+  # resolution time is in the noise, but they are re-timestamped in
+  # internal comments and fields on each run and this leads to
+  # travis-ci cache thrash.  Kill these files before the cache check
+  # to avoid un-needed cache re-packing and re-upload (a ~100s
+  # operation).
+  - find $HOME/.ivy2 -type f -name "ivydata-*.properties" -o -name "resolved-*.xml" -print -delete
 
 cache:
   directories:


### PR DESCRIPTION
The ivydata files' effect on resolution time is in the noise, but
they are re-timestamped in a comment by ivy on each run and lead to
cache thrash in travis-ci.  Kill these files before the cache check to
avoid un-needed cache re-packing and re-upload which is a ~100s
operation that occurs at the end of the build on 9 or our 10 ci shards.