### PR TITLE
Added a hash to a jar name for a bootstrapped jvm tool

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -37,7 +37,7 @@ jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 local_artifact_cache = %(pants_bootstrapdir)s/artifact_cache
 
 
-[bootstrap]
+[bootstrap.bootstrap_jvm_tools]
 # The just-in-time tool shading performed by jvm tool bootstrapping is very expensive, so we turn
 # on artifact caching for it that can survive clean-all.
 read_artifact_caches = ["%(local_artifact_cache)s"]

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -52,6 +52,7 @@ target(
   name = 'integration',
   dependencies = [
     ':antlr_integration',
+    ':bootstrap_jvm_tools_integration',
     ':depmap_integration',
     ':eclipse_integration',
     ':ensime_integration',
@@ -126,6 +127,15 @@ python_tests(
   name = 'jvm_run_integration',
   sources = ['test_jvm_run_integration.py'],
   dependencies = [
+    'tests/python/pants_test:int-test',
+  ],
+)
+
+python_tests(
+  name = 'bootstrap_jvm_tools_integration',
+  sources = ['test_bootstrap_jvm_tools_integration.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
 )

--- a/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
+++ b/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
@@ -10,7 +10,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class BootstrapJvmToolsIntegrationTest(PantsRunIntegrationTest):
-  def test_scala_java_collision(self):
+  def test_scala_java_reuse(self):
     with temporary_dir(root_dir=self.workdir_root()) as artifact_cache:
       bootstrap_args = [
         'bootstrap.bootstrap-jvm-tools',
@@ -23,41 +23,11 @@ class BootstrapJvmToolsIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(pants_run)
       self.assertTrue('[shade-zinc]' in pants_run.stdout_data)
 
-      # java compilation should also bootstrap and shade zinc
-      # because fingerprints are different for zinc and zinc-java tools
-      pants_run = self.run_pants(bootstrap_args +
-                                 ['compile',
-                                  'examples/src/java/org/pantsbuild/example/hello/simple',
-                                  '--compile-zinc-java-enabled'])
-      self.assert_success(pants_run)
-      self.assertTrue('[shade-zinc]' in pants_run.stdout_data)
-
-      # but shouldn't bootstrap and shade after clean-all
+      # java compilation shouldn't bootstrap and shade zinc after clean-all
       pants_run = self.run_pants(bootstrap_args +
                                  ['clean-all',
                                   'compile',
                                   'examples/src/java/org/pantsbuild/example/hello/simple',
                                   '--compile-zinc-java-enabled'])
-      self.assert_success(pants_run)
-      self.assertFalse('[shade-zinc]' in pants_run.stdout_data)
-
-  def test_survive_clean_all(self):
-    with temporary_dir(root_dir=self.workdir_root()) as artifact_cache:
-      def run_compile():
-        bootstrap_args = [
-          'bootstrap.bootstrap-jvm-tools',
-          "--write-artifact-caches=['{}']".format(artifact_cache),
-          "--read-artifact-caches=['{}']".format(artifact_cache)
-        ]
-        compile_args = ['clean-all', 'compile', 'examples/src/scala/org/pantsbuild/example/hello']
-        return self.run_pants(bootstrap_args + compile_args)
-
-      # bootstrap
-      pants_run = run_compile()
-      self.assert_success(pants_run)
-      self.assertTrue('[shade-zinc]' in pants_run.stdout_data)
-
-      # compilation should reuse already shaded zinc
-      pants_run = run_compile()
       self.assert_success(pants_run)
       self.assertFalse('[shade-zinc]' in pants_run.stdout_data)

--- a/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
+++ b/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class BootstrapJvmToolsIntegrationTest(PantsRunIntegrationTest):
+  def test_scala_java_collision(self):
+    with temporary_dir(root_dir=self.workdir_root()) as artifact_cache:
+      bootstrap_args = [
+        'bootstrap.bootstrap-jvm-tools',
+        "--write-artifact-caches=['{}']".format(artifact_cache),
+        "--read-artifact-caches=['{}']".format(artifact_cache)
+      ]
+
+      # scala compilation should bootstrap and shade zinc
+      pants_run = self.run_pants(bootstrap_args + ['compile', 'examples/src/scala/org/pantsbuild/example/hello'])
+      self.assert_success(pants_run)
+      self.assertTrue('[shade-zinc]' in pants_run.stdout_data)
+
+      # java compilation should also bootstrap and shade zinc
+      # because fingerprints are different for zinc and zinc-java tools
+      pants_run = self.run_pants(bootstrap_args +
+                                 ['compile',
+                                  'examples/src/java/org/pantsbuild/example/hello/simple',
+                                  '--compile-zinc-java-enabled'])
+      self.assert_success(pants_run)
+      self.assertTrue('[shade-zinc]' in pants_run.stdout_data)
+
+      # but shouldn't bootstrap and shade after clean-all
+      pants_run = self.run_pants(bootstrap_args +
+                                 ['clean-all',
+                                  'compile',
+                                  'examples/src/java/org/pantsbuild/example/hello/simple',
+                                  '--compile-zinc-java-enabled'])
+      self.assert_success(pants_run)
+      self.assertFalse('[shade-zinc]' in pants_run.stdout_data)
+
+  def test_survive_clean_all(self):
+    with temporary_dir(root_dir=self.workdir_root()) as artifact_cache:
+      def run_compile():
+        bootstrap_args = [
+          'bootstrap.bootstrap-jvm-tools',
+          "--write-artifact-caches=['{}']".format(artifact_cache),
+          "--read-artifact-caches=['{}']".format(artifact_cache)
+        ]
+        compile_args = ['clean-all', 'compile', 'examples/src/scala/org/pantsbuild/example/hello']
+        return self.run_pants(bootstrap_args + compile_args)
+
+      # bootstrap
+      pants_run = run_compile()
+      self.assert_success(pants_run)
+      self.assertTrue('[shade-zinc]' in pants_run.stdout_data)
+
+      # compilation should reuse already shaded zinc
+      pants_run = run_compile()
+      self.assert_success(pants_run)
+      self.assertFalse('[shade-zinc]' in pants_run.stdout_data)

--- a/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
+++ b/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
@@ -18,12 +18,12 @@ class BootstrapJvmToolsIntegrationTest(PantsRunIntegrationTest):
         "--read-artifact-caches=['{}']".format(artifact_cache)
       ]
 
-      # scala compilation should bootstrap and shade zinc
+      # Scala compilation should bootstrap and shade zinc.
       pants_run = self.run_pants(bootstrap_args + ['compile', 'examples/src/scala/org/pantsbuild/example/hello'])
       self.assert_success(pants_run)
       self.assertTrue('[shade-zinc]' in pants_run.stdout_data)
 
-      # java compilation shouldn't bootstrap and shade zinc after clean-all
+      # Java compilation shouldn't bootstrap and shade zinc after clean-all.
       pants_run = self.run_pants(bootstrap_args +
                                  ['clean-all',
                                   'compile',


### PR DESCRIPTION
Added a hash to a jar name for a bootstrapped jvm tool

Before fingerprints for scala and zinc for java tools were the same but the actual paths of shaded jars in artifacts were different. Removed scope and key from the jar_path and added a hash.

Example:

We compile a java target with Zinc and it will shade zinc and store it to an artifact. The artifact will contain only one jar file `bootstrap/bootstrap-jvm-tools/tool_cache/shaded_jars/compile.zinc-java/zinc/org.pantsbuild.zinc.Main.jar`. 

Then we'll try to compile a Scala target and because the fingerprint is the same as for zinc-java it will use an artifact from zinc-java. But it will fail to locate a shaded jar at `bootstrap-jvm-tools/tool_cache/shaded_jars/compile.zinc/zinc/org.pantsbuild.zinc.Main.jar` and will shade it again.