### PR TITLE
Fix bootstrap local cache.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -37,7 +37,7 @@ jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 local_artifact_cache = %(pants_bootstrapdir)s/artifact_cache
 
 
-[bootstrap.bootstrap_jvm_tools]
+[bootstrap]
 # The just-in-time tool shading performed by jvm tool bootstrapping is very expensive, so we turn
 # on artifact caching for it that can survive clean-all.
 read_artifact_caches = ["%(local_artifact_cache)s"]


### PR DESCRIPTION
c960c9c3 introduced a finer scope to the `bootstrap` local cache turn-on
in pants.ini and the scope was in-error (used `_`s instead of `-`s).
Instead of fixing the underscores, just revert the change since it was
correct to cache all bootstrap tasks in the first place.

https://rbcommons.com/s/twitter/r/2336/