### PR TITLE
coherent error message when scrooge has no sources

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -20,7 +20,7 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.address import SyntheticAddress
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError
+from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.option.options import Options
 from pants.thrift_util import calculate_compile_sources
 from pants.util.dirutil import safe_mkdir, safe_open
@@ -121,6 +121,7 @@ class ScroogeGen(NailgunTask, JvmToolTaskMixin):
   def execute(self):
     targets = self.context.targets()
     self._validate_compiler_configs(targets)
+    self._must_have_sources(targets)
 
     gentargets_by_dependee = self.context.dependents(
         on_predicate=self.is_scroogetarget,
@@ -173,7 +174,6 @@ class ScroogeGen(NailgunTask, JvmToolTaskMixin):
       invalid_targets = []
       for vt in invalidation_check.invalid_vts:
         invalid_targets.extend(vt.targets)
-
       import_paths, changed_srcs = calculate_compile_sources(invalid_targets, self.is_scroogetarget)
       outdir = self._outdir(partial_cmd)
       if changed_srcs:
@@ -346,6 +346,11 @@ class ScroogeGen(NailgunTask, JvmToolTaskMixin):
         for dep in mismatched_compiler_configs[tgt]:
           msg.append('    %s - %s\n' % (dep, compiler_config(dep)))
       raise TaskError(''.join(msg))
+
+  def _must_have_sources(self, targets):
+    for target in targets:
+      if isinstance(target, JavaThriftLibrary) and not target.payload.sources.source_paths:
+        raise TargetDefinitionException(target, 'no thrift files found')
 
 
 NAMESPACE_PARSER = re.compile(r'^\s*namespace\s+([^\s]+)\s+([^\s]+)\s*$')


### PR DESCRIPTION
I wasted way too much time trying to understand this error message:
./pants test geoduck/service/src/main/thrift:thrift-java
...
Exception message: [Errno 2] No such file or directory: u'/Users/thowland/workspace/source/birdcage/.pants.d/gen/scrooge/java-finagle/gen-file-map-by-target/geoduck.service.src.main.thrift.thrift-java'

What pants is trying to say is: the given target has no sources.

With this change we get the more useful message:

Exception message: Invalid target JavaThriftLibrary(BuildFileAddress(FilesystemBuildFile(/Users/thowland/workspace/source/birdcage/factorbird/factorbird-thrift-only/src/main/thrift/BUILD), thrift-scala)): no thrift files found