### PR TITLE
[Trigger CI] When using soft-excludes, ignore all target defined excludes

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -369,7 +369,7 @@ class IvyUtils(object):
       generator.write(output)
 
   @classmethod
-  def calculate_classpath(cls, targets, automatic_excludes=True):
+  def calculate_classpath(cls, targets, gather_excludes=True, automatic_excludes=True):
     jars = OrderedDict()
     excludes = set()
     targets_processed = set()
@@ -385,32 +385,42 @@ class IvyUtils(object):
       )
 
     def collect_jars(target):
-      targets_processed.add(target)
-      if isinstance(target, JarLibrary):
-        # Combine together requests for jars with different classifiers from the same jar_library
-        # TODO(Eric Ayers) This is a short-term fix for dealing with the same ivy module that
-        # wants to download multiple jar files with different classifiers as binary dependencies.
-        # I am trying to work out a better long-term solution in this design doc:
-        # https://docs.google.com/document/d/1sEMXUmj7v-YCBZ_wHLpCFjkHOeWjsc1NR1hRIJ9uCZ8
-        target_jars = []
-        for jar in target.jar_dependencies:
-          target_jars.append(jar)
-        for jar in cls._combine_jars(target_jars):
-          if jar.rev:
-            add_jar(jar)
+      if not isinstance(target, JarLibrary):
+        return
+      # Combine together requests for jars with different classifiers from the same jar_library
+      # TODO(Eric Ayers) This is a short-term fix for dealing with the same ivy module that
+      # wants to download multiple jar files with different classifiers as binary dependencies.
+      # I am trying to work out a better long-term solution in this design doc:
+      # https://docs.google.com/document/d/1sEMXUmj7v-YCBZ_wHLpCFjkHOeWjsc1NR1hRIJ9uCZ8
+      target_jars = [jar for jar in target.jar_dependencies]
+      for jar in cls._combine_jars(target_jars):
+        if jar.rev:
+          add_jar(jar)
 
+    def collect_excludes(target):
       target_excludes = target.payload.get_field_value('excludes')
       if target_excludes:
         excludes.update(target_excludes)
-      if target.is_exported and automatic_excludes:
-        # if a source dep is exported, it should always override remote/binary versions
-        # of itself, ie "round trip" dependencies
-        logger.debug('Automatically excluding jar {}.{}, which is provided by {}'.format(
-          target.provides.org, target.provides.name, target))
-        excludes.add(Exclude(org=target.provides.org, name=target.provides.name))
+
+    def collect_automatic_excludes(target):
+      if not target.is_exported:
+        return
+      # if a source dep is exported, it should always override remote/binary versions
+      # of itself, ie "round trip" dependencies
+      logger.debug('Automatically excluding jar {}.{}, which is provided by {}'.format(
+        target.provides.org, target.provides.name, target))
+      excludes.add(Exclude(org=target.provides.org, name=target.provides.name))
+
+    def collect_elements(target):
+      targets_processed.add(target)
+      collect_jars(target)
+      if gather_excludes:
+        collect_excludes(target)
+        if automatic_excludes:
+          collect_automatic_excludes(target)
 
     for target in targets:
-      target.walk(collect_jars, predicate=lambda target: target not in targets_processed)
+      target.walk(collect_elements, predicate=lambda target: target not in targets_processed)
 
     return jars.values(), excludes
 

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -392,8 +392,7 @@ class IvyUtils(object):
       # wants to download multiple jar files with different classifiers as binary dependencies.
       # I am trying to work out a better long-term solution in this design doc:
       # https://docs.google.com/document/d/1sEMXUmj7v-YCBZ_wHLpCFjkHOeWjsc1NR1hRIJ9uCZ8
-      target_jars = [jar for jar in target.jar_dependencies]
-      for jar in cls._combine_jars(target_jars):
+      for jar in cls._combine_jars(target.jar_dependencies):
         if jar.rev:
           add_jar(jar)
 

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -293,16 +293,3 @@ class IvyTaskMixin(object):
           raise TaskError('Ivy returned {result}. cmd={cmd}'.format(result=result, cmd=runner.cmd))
       except runner.executor.Error as e:
         raise TaskError(e)
-
-  @staticmethod
-  def _exclude_is_not_contained_in_jars(jars):
-    """
-    :type jars: list[JarDependency]
-    """
-    jars = { (jar.org, jar.name) for jar in jars }
-    def exclude_filter(exclude):
-      """
-      :type exclude: Exclude
-      """
-      return (exclude.org, exclude.name) not in jars
-    return exclude_filter

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -269,9 +269,10 @@ class IvyTaskMixin(object):
     ivyxml = os.path.join(target_workdir, 'ivy.xml')
 
     if not jars:
-      jars, excludes = IvyUtils.calculate_classpath(targets, self.get_options().automatic_excludes)
-      if use_soft_excludes:
-        excludes = filter(self._exclude_is_not_contained_in_jars(jars), excludes)
+      automatic_excludes = self.get_options().automatic_excludes
+      jars, excludes = IvyUtils.calculate_classpath(targets,
+                                                    gather_excludes=not use_soft_excludes,
+                                                    automatic_excludes=automatic_excludes)
     else:
       excludes = set()
 


### PR DESCRIPTION
currently soft-excludes only removes excludes that are for jars explicitly included. This means that excludes for transitive dependencies of artifacts remain even with soft-excludes enabled.

This change causes soft-excludes to just skip all target defined excludes.