### PR TITLE
Fixed errors in how arguments are passed to wire_gen.

### DIFF
--- a/examples/src/java/org/pantsbuild/example/wire/roots/BUILD
+++ b/examples/src/java/org/pantsbuild/example/wire/roots/BUILD
@@ -1,0 +1,12 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='roots',
+  basename='wire-roots-example',
+  dependencies=[
+    'examples/src/wire/org/pantsbuild/example/roots',
+  ],
+  source='WireRootsExample.java',
+  main='org.pantsbuild.example.wire.roots.WireRootsExample',
+)
+

--- a/examples/src/java/org/pantsbuild/example/wire/roots/WireRootsExample.java
+++ b/examples/src/java/org/pantsbuild/example/wire/roots/WireRootsExample.java
@@ -1,0 +1,10 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.wire.roots;
+
+class WireRootsExample {
+
+  public static void main(String[] args) {
+  }
+}

--- a/examples/src/wire/org/pantsbuild/example/roots/BUILD
+++ b/examples/src/wire/org/pantsbuild/example/roots/BUILD
@@ -1,0 +1,16 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_wire_library(name='roots',
+  sources=[
+    'foo.proto',
+    'bar.proto',
+    'foobar.proto',
+  ],
+  dependencies=[],
+  roots = [
+    'org.pantsbuild.example.roots.Bar',
+    'org.pantsbuild.example.roots.Foobar',
+    'org.pantsbuild.example.roots.Fooboo',
+  ],
+)

--- a/examples/src/wire/org/pantsbuild/example/roots/bar.proto
+++ b/examples/src/wire/org/pantsbuild/example/roots/bar.proto
@@ -1,0 +1,9 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.roots;
+
+message Bar {
+  optional string param1 = 1;
+  optional string param2 = 2;
+}

--- a/examples/src/wire/org/pantsbuild/example/roots/foo.proto
+++ b/examples/src/wire/org/pantsbuild/example/roots/foo.proto
@@ -1,0 +1,9 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.roots;
+
+message Foo {
+  optional string param1 = 1;
+  optional string param2 = 2;
+}

--- a/examples/src/wire/org/pantsbuild/example/roots/foobar.proto
+++ b/examples/src/wire/org/pantsbuild/example/roots/foobar.proto
@@ -1,0 +1,20 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.roots;
+
+message Foobar {
+  optional string param = 1;
+}
+
+message Barfoo {
+  optional string param = 1;
+}
+
+message Fooboo {
+  optional string param = 1;
+}
+
+message Farbar {
+  required string param = 1;
+}

--- a/src/python/pants/backend/codegen/targets/java_wire_library.py
+++ b/src/python/pants/backend/codegen/targets/java_wire_library.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-from textwrap import dedent
 
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.base.payload import Payload
@@ -50,12 +49,6 @@ class JavaWireLibrary(ExportableJvmLibrary):
 
     if service_writer_options:
       logger.warn('The service_writer_options flag is ignored.')
-    if roots:
-      logger.warn(dedent('''
-          It is known that passing in roots may not work as intended. Pants tries to predict what
-          files Wire will generate then does a verification to see if all of those files were
-          generated.  With the roots flag set, it may be the case that not all predicted files will
-          be generated and the verification will fail.'''))
 
     super(JavaWireLibrary, self).__init__(payload=payload, **kwargs)
     self.add_labels('codegen')

--- a/src/python/pants/backend/codegen/tasks/wire_gen.py
+++ b/src/python/pants/backend/codegen/tasks/wire_gen.py
@@ -110,11 +110,11 @@ class WireGen(JvmToolTaskMixin, SimpleCodegenTask):
       if registry_class:
         args.append('--registry_class={0}'.format(registry_class))
 
-      for root in target.payload.roots:
-        args.append('--roots={0}'.format(root))
+      if target.payload.roots:
+        args.append('--roots={0}'.format(','.join(target.payload.roots)))
 
-      for enum_option in target.payload.enum_options:
-        args.append('--enum_options={0}'.format(enum_option))
+      if target.payload.enum_options:
+        args.append('--enum_options={0}'.format(','.join(target.payload.enum_options)))
 
       args.append('--proto_path={0}'.format(os.path.join(get_buildroot(),
                                                          SourceRoot.find(target))))


### PR DESCRIPTION
It turns out that wire (currently) does not support multiple --proto-paths.
To work around this, we have to symlink all the sources we need into a
temporary directory and invoke wire there.

Additionally, commands such as 'roots' and 'enum_options' are expected to
be comma-delimited when multiple arguments exist, not added by repeated
specifications of the --roots or --enum_options flags.