### PR TITLE
[Trigger CI] Ensure caliper is shaded in bench, add bench desc, use RUN so that ou…

### DIFF
--- a/BUILD.tools
+++ b/BUILD.tools
@@ -60,10 +60,8 @@ jar_library(name = 'cobertura-report',
 jar_library(name = 'benchmark-caliper-0.5',
             jars = [
               # TODO (Eric Ayers) Caliper is old. Add jmh support?
-              jar(org = 'com.google.caliper', name = 'caliper', rev = '0.5-rc1')
-                .exclude(org='com.google.guava', name='guava'),
               # The caliper tool is shaded, and so shouldn't interfere with Guava 16.
-              jar(org='com.google.guava', name='guava', rev='15.0'),
+              jar(org = 'com.google.caliper', name = 'caliper', rev = '0.5-rc1'),
             ])
 
 jar_library(name = 'benchmark-java-allocation-instrumenter-2.1',

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -62,8 +62,8 @@ jar_library(name = 'benchmark-caliper-0.5',
               # TODO (Eric Ayers) Caliper is old. Add jmh support?
               jar(org = 'com.google.caliper', name = 'caliper', rev = '0.5-rc1')
                 .exclude(org='com.google.guava', name='guava'),
-              # The caliper tool is shaded, and so shouldn't interfer with Guava 16.
-              jar(org='com.google.guava', name='guava', rev='15.0', force=True),
+              # The caliper tool is shaded, and so shouldn't interfere with Guava 16.
+              jar(org='com.google.guava', name='guava', rev='15.0'),
             ])
 
 jar_library(name = 'benchmark-java-allocation-instrumenter-2.1',

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -59,9 +59,11 @@ jar_library(name = 'cobertura-report',
 
 jar_library(name = 'benchmark-caliper-0.5',
             jars = [
-              # TODO(Eric Ayers) Caliper is old and breaks with guava 16. Add jmh support?
+              # TODO (Eric Ayers) Caliper is old. Add jmh support?
               jar(org = 'com.google.caliper', name = 'caliper', rev = '0.5-rc1')
-                .exclude(org='com.google.guava', name='guava')
+                .exclude(org='com.google.guava', name='guava'),
+              # The caliper tool is shaded, and so shouldn't interfer with Guava 16.
+              jar(org='com.google.guava', name='guava', rev='15.0', force=True),
             ])
 
 jar_library(name = 'benchmark-java-allocation-instrumenter-2.1',

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -168,7 +168,7 @@ def register_goals():
 
   # Testing.
   task(name='junit', action=JUnitRun).install('test').with_description('Test compiled code.')
-  task(name='bench', action=BenchmarkRun).install('bench')
+  task(name='bench', action=BenchmarkRun).install('bench').with_description('Run benchmark tests.')
 
   # Running.
   task(name='jvm', action=JvmRun, serialize=False).install('run').with_description(

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -42,6 +42,7 @@ python_library(
     ':jvm_task',
     ':jvm_tool_task_mixin',
     'src/python/pants/backend/core/tasks:task',
+    'src/python/pants/base:workunit',
     'src/python/pants/java:util',
   ],
 )


### PR DESCRIPTION
…tput is printed

caliper depends on guava 15 which is incompatible with 16 and 18 due to method deprecations, adding main to the jvm tool registration causes it to be shaded, which means the older guava won't interfer with code under test that depends on newer guava versions.

I also added a description and set the WorkUnit.RUN label so that the caliper output will be printed to the console by default.