### PR TITLE
[CI] Add a global --tag option to filter targets based on their tags.

### DIFF
--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -95,6 +95,9 @@ def build_file_aliases():
 
 
 def register_goals():
+  # TODO: Most of these (and most tasks in other backends) can probably have their
+  # with_description() removed, as their docstring will be used instead.
+
   # Getting help.
   task(name='goals', action=ListGoals).install().with_description('List all documented goals.')
 
@@ -154,8 +157,7 @@ def register_goals():
   task(name='minimize', action=MinimalCover).install().with_description(
       'Print the minimal cover of the given targets.')
 
-  task(name='filter', action=Filter).install().with_description(
-      'Filter the input targets based on various criteria.')
+  task(name='filter', action=Filter).install()
 
   task(name='sort', action=SortTargets).install().with_description(
       'Topologically sort the targets.')

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -148,6 +148,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/base:target',
+    'src/python/pants/util:filtering',
   ],
 )
 

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -25,6 +25,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/reporting',
     'src/python/pants/subsystem',
+    'src/python/pants/util:filtering',
   ],
 )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -39,12 +39,18 @@ def register_global_options(register):
                 "are used.  Multiple constraints may be added.  They will be ORed together.")
   register('--colors', action='store_true', default=True, recursive=True,
            help='Set whether log messages are displayed in color.')
+
   register('--spec-excludes', action='append', default=[register.bootstrap.pants_workdir],
-           help='Exclude these paths when computing the command-line target specs.')
+           help='Ignore these paths when evaluating the command-line target specs.  Useful with '
+                '::, to avoid descending into unneeded directories.')
   register('--exclude-target-regexp', action='append', default=[], metavar='<regexp>',
-           help='Regex pattern to exclude from the target list (useful in conjunction with ::). '
-                'Multiple patterns may be specified by setting this flag multiple times.',
-           recursive=True)
+           help='Exclude targets that match these regexes. Useful with ::, to ignore broken '
+                'BUILD files.',
+           recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
+  register('--tag', action='append', metavar='[+-]tag1,tag2,...',
+           help="Include only targets with these tags (optional '+' prefix) or without these "
+                "tags ('-' prefix).  Useful with ::, to find subsets of targets "
+                "(e.g., integration tests.)")
 
   # TODO: When we have a model for 'subsystems', create one for artifact caching and move these
   # options to there. When we do that, also drop the cumbersome word 'artifact' from these

--- a/src/python/pants/option/help_formatter.py
+++ b/src/python/pants/option/help_formatter.py
@@ -50,7 +50,7 @@ class PantsHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
             invert_flag = ''
             option_flag = option_string[2:]
 
-          arg_name = action.metavar.upper() if action.metavar else action.dest.upper()
+          arg_name = action.metavar if action.metavar else action.dest
           arg_value = '' if action.nargs == 0 else '={0}'.format(arg_name)
 
           return '--{invert_flag}{heading}-{option_flag}{arg_value}\n'.format(

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -32,6 +32,12 @@ python_library(
 )
 
 python_library(
+  name = 'filtering',
+  sources = ['filtering.py'],
+  dependencies = [],
+)
+
+python_library(
   name = 'meta',
   sources = ['meta.py'],
 )

--- a/src/python/pants/util/filtering.py
+++ b/src/python/pants/util/filtering.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import copy
+import operator
+
+
+_identity = lambda x: x
+
+
+def _extract_modifier(modified_param):
+  if modified_param.startswith('+'):
+    return _identity, modified_param[1:]
+  elif modified_param.startswith('-'):
+    return operator.not_, modified_param[1:]
+  else:
+    return _identity, modified_param
+
+
+def create_filters(predicate_params, predicate_factory):
+  """Create filter functions from a list of string parameters.
+
+  :param predicate_params: A list of predicate_param arguments as in `create_filter`.
+  :param predicate_factory: As in `create_filter`.
+  """
+  filters = []
+  for predicate_param in predicate_params:
+    filters.append(create_filter(predicate_param, predicate_factory))
+  return filters
+
+
+def create_filter(predicate_param, predicate_factory):
+  """Create a filter function from a string parameter.
+
+  :param predicate_param: Create a filter for this param string. Each string is a
+                          comma-separated list of arguments to the predicate_factory.
+                          If the entire comma-separated list is prefixed by a '-' then the
+                          sense of the resulting filter is inverted.
+  :param predicate_factory: A function that takes a parameter and returns a predicate, i.e., a
+                            function that takes a single parameter (of whatever type the filter
+                            operates on) and returns a boolean.
+  :return: A filter function of one argument that is the logical OR of the predicates for each of
+           the comma-separated arguments. If the comma-separated list was prefixed by a '-',
+           the sense of the filter is inverted.
+  """
+  # NOTE: Do not inline this into create_filters above. A separate function is necessary
+  # in order to capture the different closure on each invocation.
+  modifier, param = _extract_modifier(predicate_param)
+  predicates = map(predicate_factory, param.split(','))
+  def filt(x):
+    return modifier(any(map(lambda pred: pred(x), predicates)))
+  return filt
+
+
+def wrap_filters(filters):
+  """Returns a single filter that short-circuit ANDs the specified filters."""
+  def combined_filter(x):
+    for filt in filters:
+      if not filt(x):
+        return False
+    return True
+  return combined_filter

--- a/tests/python/pants_test/tasks/test_filter.py
+++ b/tests/python/pants_test/tasks/test_filter.py
@@ -144,25 +144,14 @@ class FilterTest(BaseFilterTest):
       'overlaps:three',
       'overlaps:foo',
       targets=self.targets('::'),
+      # Note that the comma is inside the string, so these are ORed.
       options={'type': ['python_requirement_library,'
                         'pants.backend.python.targets.python_library.PythonLibrary']}
     )
 
-  @pytest.mark.xfail
   def test_filter_multiple_types(self):
-    # TODO: The 'type' option should accept lists of multiple items, but this doesn't
-    # currently work. Ditto for the other filter flag.
+    # A target can only have one type, so the output should be empty.
     self.assert_console_output(
-      'common/a:a',
-      'common/a:foo',
-      'common/b:b',
-      'common/b:foo',
-      'common/c:c',
-      'common/c:foo',
-      'overlaps:one',
-      'overlaps:two',
-      'overlaps:three',
-      'overlaps:foo',
       targets=self.targets('::'),
       options={'type': ['python_requirement_library',
                         'pants.backend.python.targets.python_library.PythonLibrary']}
@@ -210,9 +199,9 @@ class FilterTest(BaseFilterTest):
     )
 
   def test_filter_ancestor_out_of_context(self):
-    """Tests that targets outside of the context used as filters are parsed before use"""
+    """Tests that targets outside of the context used as filters are parsed before use."""
 
-    # add an additional un-injected target, and then use it as a filter
+    # Add an additional un-injected target, and then use it as a filter.
     self.add_to_build_file("blacklist", "target(name='blacklist', dependencies=['common/a'])")
 
     self.assert_console_output(
@@ -229,9 +218,9 @@ class FilterTest(BaseFilterTest):
     )
 
   def test_filter_ancestor_not_passed_targets(self):
-    """Tests filtering targets based on an ancestor not in that list of targets"""
+    """Tests filtering targets based on an ancestor not in that list of targets."""
 
-    # add an additional un-injected target, and then use it as a filter
+    # Add an additional un-injected target, and then use it as a filter.
     self.add_to_build_file("blacklist", "target(name='blacklist', dependencies=['common/a'])")
 
     self.assert_console_output(
@@ -244,7 +233,7 @@ class FilterTest(BaseFilterTest):
     )
 
     self.assert_console_output(
-      'common/a:a', # a: _should_ show up if we don't filter
+      'common/a:a', # a: _should_ show up if we don't filter.
       'common/a:foo',
       'common/b:b',
       'common/b:foo',
@@ -286,21 +275,21 @@ class FilterTest(BaseFilterTest):
       options={ 'regex': ['-^common,foo$'] }
     )
 
-    # Invalid regex
+    # Invalid regex.
     self.assert_console_raises(TaskError,
       targets=self.targets('::'),
       options={ 'regex': ['abc)']}
     )
 
   def test_filter_tag_regex(self):
-    # Filter two
+    # Filter two.
     self.assert_console_output(
       'overlaps:three',
       targets=self.targets('::'),
       options={ 'tag_regex': ['+e(?=e)'] }
     )
 
-    # Removals
+    # Removals.
     self.assert_console_output(
       'common/a:a',
       'common/a:foo',
@@ -314,21 +303,21 @@ class FilterTest(BaseFilterTest):
       options={ 'tag_regex': ['-one|two'] }
     )
 
-    # Invalid regex
+    # Invalid regex.
     self.assert_console_raises(TaskError,
       targets=self.targets('::'),
       options={ 'tag_regex': ['abc)']}
     )
 
   def test_filter_tag(self):
-    # One match
+    # One match.
     self.assert_console_output(
       'common/a:a',
       targets=self.targets('::'),
       options={ 'tag': ['+a_tag'] }
     )
 
-    # Two matches
+    # Two matches.
     self.assert_console_output(
       'common/a:a',
       'common/b:b',
@@ -336,7 +325,7 @@ class FilterTest(BaseFilterTest):
       options={ 'tag': ['+a_tag,b_tag'] }
     )
 
-    # One removal
+    # One removal.
     self.assert_console_output(
       'common/a:a',
       'common/a:foo',
@@ -351,7 +340,7 @@ class FilterTest(BaseFilterTest):
       options={ 'tag': ['-one_tag'] }
     )
 
-    # Two removals
+    # Two removals.
     self.assert_console_output(
       'common/a:a',
       'common/a:foo',
@@ -365,8 +354,14 @@ class FilterTest(BaseFilterTest):
       options={ 'tag': ['-one_tag,two_tag'] }
     )
 
-    # No match
+    # No match.
     self.assert_console_output(
       targets=self.targets('::'),
       options={ 'tag': ['+abcdefg_tag'] }
+    )
+
+    # No match due to AND of separate predicates.
+    self.assert_console_output(
+      targets=self.targets('::'),
+      options={ 'tag': ['a_tag', 'b_tag'] }
     )

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -34,6 +34,23 @@ python_tests(
 )
 
 python_tests(
+  name = 'fileutil',
+  sources = ['test_fileutil.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:fileutil',
+  ]
+)
+
+python_tests(
+  name = 'filtering',
+  sources = ['test_filtering.py'],
+  dependencies = [
+    'src/python/pants/util:filtering',
+  ]
+)
+
+python_tests(
   name = 'memo',
   sources = ['test_memo.py'],
   dependencies = [
@@ -46,15 +63,6 @@ python_tests(
   sources = ['test_meta.py'],
   dependencies = [
     'src/python/pants/util:meta',
-  ]
-)
-
-python_tests(
-  name = 'fileutil',
-  sources = ['test_fileutil.py'],
-  dependencies = [
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:fileutil',
   ]
 )
 

--- a/tests/python/pants_test/util/test_filtering.py
+++ b/tests/python/pants_test/util/test_filtering.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.util.filtering import create_filter, create_filters, wrap_filters
+
+
+class FilteringTest(unittest.TestCase):
+  def _divides_by(self, divisor_str):
+    return lambda n: n % int(divisor_str) == 0
+
+  def test_create_filter(self):
+    divides_by_2 = create_filter('2', self._divides_by)
+    self.assertTrue(divides_by_2(2))
+    self.assertFalse(divides_by_2(3))
+    self.assertTrue(divides_by_2(4))
+    self.assertTrue(divides_by_2(6))
+
+  def test_create_filters(self):
+    # This tests that create_filters() properly captures different closures.
+    divides_by_2, divides_by_3 = create_filters(['2', '3'], self._divides_by)
+    self.assertTrue(divides_by_2(2))
+    self.assertFalse(divides_by_2(3))
+    self.assertTrue(divides_by_2(4))
+    self.assertTrue(divides_by_2(6))
+
+    self.assertFalse(divides_by_3(2))
+    self.assertTrue(divides_by_3(3))
+    self.assertFalse(divides_by_3(4))
+    self.assertTrue(divides_by_3(6))
+
+  def test_wrap_filters(self):
+    divides_by_6 = wrap_filters(create_filters(['2', '3'], self._divides_by))
+    self.assertFalse(divides_by_6(2))
+    self.assertFalse(divides_by_6(3))
+    self.assertTrue(divides_by_6(6))
+    self.assertFalse(divides_by_6(9))
+    self.assertTrue(divides_by_6(12))
+
+  def test_list_filter(self):
+    divides_by_2_or_3 = create_filter('2,3', self._divides_by)
+    self.assertTrue(divides_by_2_or_3(2))
+    self.assertTrue(divides_by_2_or_3(3))
+    self.assertTrue(divides_by_2_or_3(4))
+    self.assertFalse(divides_by_2_or_3(5))
+    self.assertTrue(divides_by_2_or_3(6))
+
+  def test_explicit_plus_filter(self):
+    divides_by_2_or_3 = create_filter('+2,3', self._divides_by)
+    self.assertTrue(divides_by_2_or_3(2))
+    self.assertTrue(divides_by_2_or_3(3))
+    self.assertTrue(divides_by_2_or_3(4))
+    self.assertFalse(divides_by_2_or_3(5))
+    self.assertTrue(divides_by_2_or_3(6))
+
+  def test_negated_filter(self):
+    # This tests that the negation applies to the entire list.
+    coprime_to_2_and_3 = create_filter('-2,3', self._divides_by)
+    self.assertFalse(coprime_to_2_and_3(2))
+    self.assertFalse(coprime_to_2_and_3(3))
+    self.assertFalse(coprime_to_2_and_3(4))
+    self.assertTrue(coprime_to_2_and_3(5))
+    self.assertFalse(coprime_to_2_and_3(6))


### PR DESCRIPTION
--tag=foo,bar includes only targets that have at least one of those tags.
--tag=-foo,bar includes only targets that have none of those tags.
--tag=foo,bar --tag=-baz includes only targets that have at least one
  of the tags foo or bar, and do not have the tag baz.

The filtering is on target roots, of course, similar to spec_excludes and
exclude_target_regexp. Dependencies are included in the targets passed to
Task.execute() regardless of their tags.

We already had similar filtering functionality in the Filter task. So I
refactored some of that into a new filtering.py file under util.

While doing so, I noticed that the help text on Filter's options was wrong:
In --tag=-foo,bar the '-' prefix applies to both foo and bar, and
--tag=-foo,+bar is not sensible. While fixing up the help strings I realized
that it would be more succinct to move the common help text (the part
explaining about the prefix and how multiple filters are specified) into the
goal description.  Then I realized that it would be pretty verbose to put that
in the with_description() text in register.py, so I added a little thing that
uses the task's docstring as the description, if one isn't provided explicitly.

Note that Filter still has its own --tag option, which we can think
about deprecating in a future change.

IMPORTANT: While testing, I noticed that we had a longstanding bug, where
multiple filters of the same type wouldn't work, because in the loop the
filter() function was capturing the same references in its closure on each
iteration. See the test I added in test_filter.py - that test fails with no
other changes at HEAD.

Also note that the test marked as xfail is behaving as intended: according to
the implementation, separate specifications of the same option are ANDed
(while comma-separated values in a single specification are ORed). If we want
the behavior to be different then we can discuss, but for now at least that xfail
was inappropriate and misleading.