### PR TITLE
[CI] Make qualified option scopes inherit from their qualified parents.

### DIFF
--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -84,7 +84,7 @@ class Subsystem(object):
     key = (cls, scope)
     if key not in cls._scoped_instances:
       qscope = cls.qualify_scope(scope)
-      cls._scoped_instances[key] = cls(qscope, cls._options.for_scope(qscope))
+      cls._scoped_instances[key] = cls(qscope, cls._options.for_scope(qscope, qualified=True))
     return cls._scoped_instances[key]
 
   def __init__(self, scope, scoped_options):

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -39,7 +39,10 @@ def create_options(options):
   :param dict options: A dict of scope -> (dict of option name -> value).
   """
   class TestOptions(object):
-    def for_scope(self, scope):
+    def for_scope(self, scope, qualified=False):
+      # We ignore the qualified arg here, as we don't do option inheritance in tests.
+      # It's up to each test to set option values appropriately on the scopes they're
+      # going to be read from.
       return create_option_values(options[scope])
 
     def for_global_scope(self):

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -76,6 +76,22 @@ class OptionsTest(unittest.TestCase):
     self._register(options)
     return options
 
+  def test_compute_inheritance_scope(self):
+    def unqualified(scope):
+      return Options.compute_inheritance_scope(scope, qualified=False)
+
+    def qualified(scope):
+      return Options.compute_inheritance_scope(scope, qualified=True)
+
+    self.assertEquals('foo.bar', unqualified('foo.bar.baz'))
+    self.assertEquals('foo', unqualified('foo.bar'))
+    self.assertEquals('', unqualified('foo'))
+
+    self.assertEquals('foo.bar.qual', qualified('foo.bar.baz.qual'))
+    self.assertEquals('foo.qual', qualified('foo.bar.qual'))
+    self.assertEquals('qual', qualified('foo.qual'))
+    self.assertEquals('', qualified('qual'))
+
   def test_arg_scoping(self):
     # Some basic smoke tests.
     options = self._parse('./pants --verbose')

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -17,7 +17,7 @@ class DummySubsystem(Subsystem):
 
 
 class DummyOptions(object):
-  def for_scope(self, scope):
+  def for_scope(self, scope, qualified=False):
     return object()
 
 


### PR DESCRIPTION
Previously foo.bar.qualifier inherited from foo.bar, which isn't
particularly useful. Now it inherits from foo.qualifier, and so on.

The motivation is this: I have a separate change to retrofit artifact
cache setup to be a subsystem. This means that global artifact cache
option values will be in scope `cache`, and each task will have
task-specific artifact cache option values in, e.g., `compile.java.cache`.

It makes no sense for `compile.java.cache` to inherit option values from
`compile.java`, but we do want it to inherit from `compile.cache` <- `cache`.

For example, this will allow turning off caching globally, if needed.

Note that we currently have no uses of task-specific subystems, so this
change doesn't affect any current code.