### PR TITLE
[CI] Make qualified option scopes inherit from their qualified parents.

### DIFF
--- a/src/python/pants/backend/core/tasks/bash_completion.py
+++ b/src/python/pants/backend/core/tasks/bash_completion.py
@@ -16,6 +16,7 @@ from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
 from pants.goal.goal import Goal
 from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.scope_hierarchy import ScopeHierarchy
 
 
 class BashCompletionTask(ConsoleTask):
@@ -81,7 +82,9 @@ class BashCompletionTask(ConsoleTask):
       option_strings_by_scope[scope] |= self.expand_option_strings(option_strings)
 
     for goal in goals:
-      for scope in goal.known_scopes():
+      scope_hierarchy = ScopeHierarchy()
+      goal.gather_scopes(scope_hierarchy)
+      for scope in scope_hierarchy.get_known_scopes():
         all_scopes.add(scope)
 
         option_strings_for_scope = set()

--- a/src/python/pants/backend/core/tasks/group_task.py
+++ b/src/python/pants/backend/core/tasks/group_task.py
@@ -191,7 +191,7 @@ class GroupTask(Task):
   from the dependency relationships between the targets selected by the groups members.
   """
 
-  _GROUPS = dict()
+  _GROUPS = {}
 
   @classmethod
   def named(cls, name, product_type, flag_namespace=None):
@@ -228,10 +228,12 @@ class GroupTask(Task):
         parent_options_scope = '.'.join(flag_namespace)
 
         @classmethod
-        def known_scopes(cls):
-          """Yields all known scopes under this task (i.e., those of its member types.)"""
+        def gather_scopes(cls, scope_hierarchy):
+          scope_hierarchy.register(name)
+          for subsystem in (set(cls.global_subsystems()) | set(cls.task_subsystems())):
+            scope_hierarchy.register(subsystem.qualify_scope(name), qualified=True)
           for member_type in cls._member_types():
-            yield member_type.options_scope
+            member_type.gather_scopes(scope_hierarchy)
 
         @classmethod
         def register_options_on_scope(cls, options):

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -97,9 +97,11 @@ class TaskBase(AbstractClass):
   options_scope = None
 
   @classmethod
-  def known_scopes(cls):
-    """Yields all known scopes under this task (usually just its own.)"""
-    yield cls.options_scope
+  def gather_scopes(cls, scope_hierarchy):
+    task_scope = cls.options_scope
+    scope_hierarchy.register(task_scope)
+    for subsystem in cls.task_subsystems():
+      scope_hierarchy.register(subsystem.qualify_scope(task_scope), qualified=True)
 
   @classmethod
   def register_options_on_scope(cls, options):

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources=globs('*.py'),
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python/twitter/commons:twitter.common.util',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:config',
     'src/python/pants/base:deprecated',

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -65,7 +65,7 @@ class ArgSplitter(object):
   _VERSION_ARGS = ('-V', '--version')
 
   def __init__(self, known_scopes):
-    self._known_scopes = set(known_scopes + ['help', 'help-advanced', 'help-all'])
+    self._known_scopes = set(known_scopes) | set(['help', 'help-advanced', 'help-all'])
     self._unconsumed_args = []  # In reverse order, for efficient popping off the end.
     self._help_request = None  # Will be set if we encounter any help flags.
 

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -12,9 +12,9 @@ import sys
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
 from pants.base.config import Config
-from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.options import Options
 from pants.option.parser import Parser
+from pants.option.scope_hierarchy import ScopeHierarchy
 
 
 def register_bootstrap_options(register, buildroot=None):
@@ -120,7 +120,7 @@ class OptionsBootstrapper(object):
 
       def bootstrap_options_from_config(config):
         bootstrap_options = Options(env=self._env, config=config,
-                                    known_scopes=[GLOBAL_SCOPE], args=bargs)
+                                    scope_hierarchy=ScopeHierarchy(), args=bargs)
         register_bootstrap_options(bootstrap_options.register_global, buildroot=self._buildroot)
         return bootstrap_options
 
@@ -146,14 +146,14 @@ class OptionsBootstrapper(object):
 
     return self._bootstrap_options
 
-  def get_full_options(self, known_scopes):
+  def get_full_options(self, scope_hierarchy):
     if not self._full_options:
       # Note: Don't inline this into the Options() call, as this populates
       # self._post_bootstrap_config, which is another argument to that call.
       bootstrap_options = self.get_bootstrap_options()
       self._full_options = Options(self._env,
                                    self._post_bootstrap_config,
-                                   known_scopes,
+                                   scope_hierarchy,
                                    args=self._args,
                                    bootstrap_option_values=bootstrap_options.for_global_scope())
 

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -10,19 +10,15 @@ from pants.option.parser import Parser
 
 
 class ParserHierarchy(object):
-  """A hierarchy of scoped Parser instances.
-
-  A scope is a dotted string: E.g., compile.java. In this example the compile.java scope is
-  enclosed in the compile scope, which is enclosed in the global scope (represented by an
-  empty string.)
-  """
-  def __init__(self, env, config, all_scopes, help_request):
-    # Sorting ensures that ancestors precede descendants.
-    all_scopes = sorted(set(list(all_scopes) + [GLOBAL_SCOPE]))
+  """A hierarchy of scoped Parser instances."""
+  def __init__(self, env, config, scope_hierarchy, help_request):
+    # Scopes are returned in topological order - parents preceding children.
+    # This is necessary for the code below to work.
+    all_scopes = scope_hierarchy.get_known_scopes()
     self._parser_by_scope = {}
     for scope in all_scopes:
       parent_parser = (None if scope == GLOBAL_SCOPE else
-                       self._parser_by_scope[scope.rpartition('.')[0]])
+                       self._parser_by_scope[scope_hierarchy.get_parent(scope)])
       self._parser_by_scope[scope] = Parser(env, config, scope, help_request, parent_parser)
 
   def get_parser_by_scope(self, scope):

--- a/src/python/pants/option/scope_hierarchy.py
+++ b/src/python/pants/option/scope_hierarchy.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from twitter.common.util import topological_sort
+
+from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.errors import OptionsError
+
+
+class ScopeHierarchy(object):
+  """Gathers information about how scopes relate to each other.
+
+  A scope inherits option values from its parent scope, as described below in compute_parent().
+  A if an option on the parent scope is recursive, then it may also be overridden in the
+  inner scope (non-recursive options have their values set on the inner scope, but they cannot
+  be overridden there).
+  """
+
+  @classmethod
+  def compute_parent(cls, scope, qualified):
+    """Compute the scope that the given scope inherits option values from.
+
+    If the scope is unqualified, this is simply the immediately enclosing scope.
+    If the scope is qualified, this is the immediately enclosing scope of the unqualified scope,
+    qualified.
+
+    For example:
+    - `foo.bar` inherits from `foo`, which inherits from the global scope.
+    - `foo.bar.qualifier` inherits from `foo.qualifier`, which inherits from `qualifier`.
+    - `qualifier` inherits from the global scope.
+
+    :param scope: Return the option values for this scope.
+    :param qualified: Whether the scope is qualified.
+    """
+    if qualified:
+      parent, _, qualifier = scope.rpartition('.')
+      if parent == '':
+        ret = GLOBAL_SCOPE
+      else:
+        unqualified_parent = parent.rpartition('.')[0]
+        ret = '{}.{}'.format(unqualified_parent, qualifier) if unqualified_parent else qualifier
+    else:
+      ret = scope.rpartition('.')[0]
+    return ret
+
+  def __init__(self):
+    self._scope_to_parent = {
+      GLOBAL_SCOPE: None
+    }
+
+  def register(self, scope, qualified=False):
+    parent = self.compute_parent(scope, qualified)
+    existing_parent = self._scope_to_parent.get(scope)
+    if existing_parent and existing_parent != parent:
+      raise OptionsError('Cannot re-add scope {0} with parent {1}, when it already had '
+                         'parent {2}'.format(scope, parent, existing_parent))
+    # Otherwise, no harm-no foul, so continue silently.
+    self._scope_to_parent[scope] = parent
+
+  def get_known_scopes(self):
+    """Return the known scopes, sorted such that parents precede children."""
+    tsorted = []
+    for group in topological_sort(self._scope_to_parent):
+      tsorted.extend(group)
+    return tsorted
+
+  def get_parent(self, scope):
+    return self._scope_to_parent[scope]
+
+  @property
+  def scope_to_parent(self):
+    return self._scope_to_parent

--- a/tests/python/pants_test/goal/BUILD
+++ b/tests/python/pants_test/goal/BUILD
@@ -6,9 +6,14 @@ python_tests(
   sources=globs('*.py'),
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/core/tasks:group_task',
+    'src/python/pants/backend/core/tasks:task',
     'src/python/pants/base:address',
     'src/python/pants/base:target',
+    'src/python/pants/goal',
     'src/python/pants/goal:products',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/goal/test_goal.py
+++ b/tests/python/pants_test/goal/test_goal.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.backend.core.tasks.group_task import GroupMember, GroupTask
+from pants.backend.core.tasks.task import Task
+from pants.goal.goal import Goal
+from pants.option.scope_hierarchy import ScopeHierarchy
+from pants.subsystem.subsystem import Subsystem
+
+
+class DummySubsystem(Subsystem):
+  @classmethod
+  def scope_qualifier(cls):
+    return 'subsystem'
+
+
+class DummyTask(Task):
+  @classmethod
+  def task_subsystems(cls):
+    return (DummySubsystem, )
+
+
+class DummyTaskRegistrar(object):
+  def __init__(self, name):
+    self.name = name
+    self.task_type = DummyTask
+    self.serialize = False
+
+
+class DummyGroupMember1(GroupMember):
+  @classmethod
+  def name(cls):
+    return 'gm1'
+
+
+class DummyGroupMember2(GroupMember):
+  @classmethod
+  def name(cls):
+    return 'gm2'
+
+  @classmethod
+  def task_subsystems(cls):
+    return (DummySubsystem, )
+
+
+class DummyGroupRegistrar(object):
+  def __init__(self, name, group_task):
+    self.name = name
+    self.task_type = group_task
+    self.serialize = False
+
+
+class GoalTest(unittest.TestCase):
+  def setUp(self):
+    super(GoalTest, self).setUp()
+    self.addCleanup(Goal.clear)
+    def clean_group_task():
+      GroupTask._GROUPS = {}
+    self.addCleanup(clean_group_task)
+
+  def test_scope_gathering(self):
+    # Test the scope-gathering logic in Goal and GroupTask.
+    goal = Goal.by_name('foo')
+    goal.install(DummyTaskRegistrar('foo'))  # Same name as goal: foo.foo should be elided to foo.
+    goal.install(DummyTaskRegistrar('bar'))
+    goal.install(DummyTaskRegistrar('baz'))
+
+    group_task = GroupTask.named('qux', 'product', ['qux'])
+    group_task.add_member(DummyGroupMember1)
+    group_task.add_member(DummyGroupMember2)
+    goal.install(DummyGroupRegistrar('qux', group_task))
+
+    scope_hierarchy = ScopeHierarchy()
+    scope_hierarchy.register(DummySubsystem.qualify_scope(''), qualified=True)
+    goal.gather_scopes(scope_hierarchy)
+    expected = {
+      '': None,
+      'foo': '',
+      'foo.bar': 'foo',
+      'foo.bar.subsystem': 'foo.subsystem',
+      'foo.baz': 'foo',
+      'foo.baz.subsystem': 'foo.subsystem',
+      'foo.subsystem': 'subsystem',
+      'qux': '',
+      'qux.gm1': 'qux',
+      'qux.gm2': 'qux',
+      'qux.gm2.subsystem': 'qux.subsystem',
+      'qux.subsystem': 'subsystem',
+      'subsystem': ''
+    }
+    self.assertItemsEqual(expected.keys(), scope_hierarchy.get_known_scopes())
+    self.assertEqual(expected, scope_hierarchy.scope_to_parent)

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -9,6 +9,7 @@ import unittest
 from textwrap import dedent
 
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.scope_hierarchy import ScopeHierarchy
 from pants.util.contextutil import temporary_file
 
 
@@ -104,7 +105,10 @@ class BootstrapOptionsTest(unittest.TestCase):
                                          },
                                          configpath=fp.name,
                                          args=['--pants-workdir=/qux'])
-      opts = bootstrapper.get_full_options(known_scopes=['', 'foo', 'fruit'])
+      scope_hierarchy = ScopeHierarchy()
+      scope_hierarchy.register('foo')
+      scope_hierarchy.register('fruit')
+      opts = bootstrapper.get_full_options(scope_hierarchy=scope_hierarchy)
       opts.register('foo', '--bar')
       opts.register('fruit', '--apple')
     self.assertEquals('/qux/baz', opts.for_scope('foo').bar)

--- a/tests/python/pants_test/option/test_scope_hierarchy.py
+++ b/tests/python/pants_test/option/test_scope_hierarchy.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.option.scope_hierarchy import ScopeHierarchy
+
+
+class ScopeHierarchyTest(unittest.TestCase):
+  def test_compute_inheritance_scope(self):
+    def unqualified(scope):
+      return ScopeHierarchy.compute_parent(scope, qualified=False)
+
+    def qualified(scope):
+      return ScopeHierarchy.compute_parent(scope, qualified=True)
+
+    self.assertEquals('foo.bar', unqualified('foo.bar.baz'))
+    self.assertEquals('foo', unqualified('foo.bar'))
+    self.assertEquals('', unqualified('foo'))
+
+    self.assertEquals('foo.bar.qual', qualified('foo.bar.baz.qual'))
+    self.assertEquals('foo.qual', qualified('foo.bar.qual'))
+    self.assertEquals('qual', qualified('foo.qual'))
+    self.assertEquals('', qualified('qual'))


### PR DESCRIPTION
Previously `foo.bar.qualifier` inherited from `foo.bar`, which isn't
particularly useful. Now it inherits from `foo.qualifier`, and so on.

The motivation is this: I have a separate change to retrofit artifact
cache setup to be a subsystem. This means that global artifact cache
option values will be in scope `cache`, and each task will have
task-specific artifact cache option values in, e.g., `compile.java.cache`.

It makes no sense for `compile.java.cache` to inherit option values from
`compile.java`, but we do want it to inherit from `cache` (indirectly via
`compile.cache`). For example, this will allow turning off caching globally.

Note that we currently have no uses of task-specific subystem instances,
so this change doesn't affect any current code.