### PR TITLE
Add a CONTRIBUTORS maintenance script.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+Benjy Weinberger <benjy@foursquare.com>
+Benjy Weinberger <benjyw@gmail.com>
+Brian Wickman <wickman@apache.org>
+Craig Schertz <cschertz@CraigLinuxMint.(none)>
+John Chee <cheecheeo+rbcommons@gmail.com>
+John Ioannidis <rbcommons@tla.org>
+Nick Howard <nhoward@twitter.com>
+Nick Howard <nhoward@twopensource.com>
+Ugo Di Girolamo <ugodiggi@gmail.com>
+Dan Davydov <ddavydov@twitter.com>
+Fedor Korotkov <fkorotkov@twitter.com>
+Jon Boulle <jon@twitter.com>
+John Sirois <jsirois@twitter.com>
+Larry Hosken <mister@lahosken.san-francisco.ca.us>
+Leo Kim <leo@foursquare.com>
+Marius Eriksen <marius@monkey.org>
+Mark Chu-Carroll <markcc@foursquare.com>
+Mark McBride <mmcbride@twitter.com>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,102 +1,92 @@
-Created by running `git shortlog -nse | cut -f2- | sort` and then
-manually trimming duplicates and editing missing names.
+Created by running `./build-support/bin/contributors.sh`.
 
-Adam Retter <adam.retter@googlemail.com>
-Alexander Johnson <anicelyjohnson@gmail.com>
-Alyssa Pohahau <arp@squareup.com>
-Andy Reitz <ajr9@po.cwru.edu>
-Antoine Tollenaere <atollenaere@twitter.com>
-Benjy Weinberger <benjy@foursquare.com>
-Bill Farner <terasurfer@gmail.com>
-Brian Larson <blarson@twitter.com>
-Brian Wickman <wickman@twitter.com>
-Caspar Krieger <caspar@asparck.com>
-Chris Aniszczyk <caniszczyk@gmail.com>
-Chris Chen <chenchris@gmail.com>
-Craig <cschertz@CraigLinuxMint.(none)>
-Dan Davydov <ddavydov@twitter.com>
-Daniel Anderson <daniel@dattrix.com>
-David Taylor <davidtaylor@foursquare.com>
-David Turner <dturner@twitter.com>
-Divij Rajkumar <drajkumar@twitter.com>
-Dominic Hamon <dhamon@twopensource.com>
-Dumitru Daniliuc <ddaniliuc@twitter.com>
-Eric Ayers <ericzundel@gmail.com>
-Eric Danielson <edanielson@twitter.com>
-Eric Lindvall <eric@5stops.com>
-Eugene Yokota <eed3si9n@gmail.com>
-Evan Jones <ejones@twitter.com>
-Fedor Korotkov <fedor.korotkov@gmail.com>
-Florian Leibert <flo@leibert.de>
-Fredrik Ekholdt <freekh@gmail.com>
-Garrett Malmquist <garrett.malmquist@gmail.com>
-Grzegorz Kossakowski <grzegorz.kossakowski@gmail.com>
-Harley Cooper <hcooper@twitter.com>
-Hwasung Lee <hwasung.lee@oriel.oxon.org>
-Igor Morozov <igmorv@gmail.com>
-Itay Donanhirsh <itay@twitter.com>
-Ity Kaul <itykaul@gmail.com>
-Jackson Davis <jackson@foursquare.com>
-Jake Donham <jake@donham.org>
-James Mouradian <james.a.mouradian@gmail.com>
-Jason Jackson <jackson@twitter.com>
-Jeff Jenkins <jj@foursquare.com>
-Jessica Rosenfield <jrosenfield@squareup.com>
-Jin Feng <jinfeng@outlook.com>
-Joe Crobak <joe@foursquare.com>
-Joe Ennever <jennever@foursquare.com>
-Joe Smith <jsmith@twitter.com>
-Johan Oskarsson <johan@oskarsson.nu>
-John Gallagher <john@foursquare.com>
-John Ioannidis <jioannidis@twitter.com>
-John Sirois <john.sirois@gmail.com>
-John Townsend <jtownsend@twitter.com>
-Jonathan Boulle <jon@twitter.com>
-Jonathan Coveney <jcoveney@twitter.com>
-Jonathan Sokolowski <jonathan.sokolowski@gmail.com>
-Jon Boulle <jon@twitter.com>
-Josh Suereth <joshua.suereth@gmail.com>
-Joshua Cohen <jcohen@twitter.com>
-Joshua Humphries <jh@squareup.com>
-Ken Kawamoto <kentaro@twitter.com>
-Kevin Sweeney <ksweeney@twopensource.com>
-Kushal Dave <kushal@foursquare.com>
-Larry Hosken <mister@lahosken.san-francisco.ca.us>
-Lei Wang <wonlay@gmail.com>
-Leo Kim <leo@foursquare.com>
-Marc Abramowitz <marc@marc-abramowitz.com>
-Marius Eriksen <marius@monkey.org>
-Mark C. Chu-Carroll <markcc@foursquare.com>
-Mark McBride <mmcbride@twitter.com>
-Mateo Rodriguez <mateorod9@gmail.com>
-Mathew Jennings <mjennings@foursquare.com>
-Matthew Jeffryes <rbcommons@mjeffryes.net>
-Maxim Khutornenko <mkhutornenko@twitter.com>
-Michael Doherty <mdoherty@twitter.com>
-Mike Lindsey <mlindsey@twitter.com>
-Misho Krastev <misho.kr@gmail.com>
-Neil Sanchala <nsanch@foursquare.com>
-Nick Howard  <ndh@baroquebobcat.com>
-Nik Shkrob <n.shkrob@gmail.com>
-Oliver Gould <ver@twitter.com>
-Patrick Lawson <pl@foursquare.com>
-Paul Groudas <me@paulgroudas.com>
-Paul Phillips <paulp@improving.org>
-Peiyu Wang <wangpeiyu@gmail.com>
-Peter Seibel <peter@gigamonkeys.com>
-Peter Vlugter <pvlugter@gmail.com>
-Pierre DAL-PRA <dalpra.pierre@gmail.com>
-Ryan Williams <ryan.blake.williams@gmail.com>
-Senthil Kumaran <senthil@uthcode.com>
-Sergey Serebryakov <hellomind@gmail.com>
-Simeon Franklin <sfranklin@twopensource.com>
-Stu Hood <stuhood@twitter.com>
-Ted Dziuba <tdziuba@ebay.com>
-Tejal Desai <tdesai@twitter.com>
-Tien Nguyen <tien@squareup.com>
-Tina Huang <tina@twitter.com>
-Todd Stumpf <tstumpf@twitter.com>
-Tom Dyas <tdyas@foursquare.com>
-Tom Howland <thowland@twitter.com>
-Travis Crawford <traviscrawford@gmail.com>
-Ugo DG <ugodiggi@gmail.com>
+Alexander Johnson
+Andy Reitz
+Antoine Tollenaere
+Benjy Weinberger
+Bill Farner
+Brian Larson
+Brian Wickman
+Chris Aniszczyk
+Chris Chen
+Craig Schertz
+Dan Davydov
+Daniel Anderson
+David Taylor
+David Turner
+Divij Rajkumar
+Dominic Hamon
+Dumitru Daniliuc
+Eric Ayers
+Eric Danielson
+Eric Lindvall
+Evan Jones
+Fedor Korotkov
+Florian Leibert
+Garrett Malmquist
+Harley Cooper
+Hwasung Lee
+Igor Morozov
+Itay Donanhirsh
+Ity Kaul
+Jackson Davis
+Jake Donham
+James Mouradian
+Jason Jackson
+Jeff Jenkins
+Jessica Rosenfield
+Jin Feng
+Joe Crobak
+Joe Ennever
+Joe Smith
+Johan Oskarsson
+John Chee
+John Gallagher
+John Ioannidis
+John Sirois
+John Townsend
+Jon Boulle
+Jonathan Coveney
+Jonathan Sokolowski
+Joshua Cohen
+Joshua Humphries
+Ken Kawamoto
+Kevin Sweeney
+Kris Wilson
+Kushal Dave
+Larry Hosken
+Lei Wang
+Leo Kim
+Marc Abramowitz
+Marius Eriksen
+Mark Chu-Carroll
+Mark McBride
+Mateo Rodriguez
+Mathew Jennings
+Matthew Jeffryes
+Maxim Khutornenko
+Michael Doherty
+Mike Lindsey
+Misho Krastev
+Neil Sanchala
+Nick Howard
+Nik Shkrob
+Oliver Gould
+Patrick Lawson
+Paul Groudas
+Peiyu Wang
+Peter Seibel
+Ryan Williams
+Senthil Kumaran
+Sergey Serebryakov
+Simeon Franklin
+Stu Hood
+Ted Dziuba
+Tejal Desai
+Tien Nguyen
+Tina Huang
+Todd Stumpf
+Tom Dyas
+Tom Howland
+Travis Crawford
+Ugo Di Girolamo

--- a/build-support/bin/contributors.sh
+++ b/build-support/bin/contributors.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+REPO_ROOT=$(cd "$(git rev-parse --show-toplevel)" && pwd)
+
+source ${REPO_ROOT}/build-support/common.sh
+
+function usage() {
+  echo "Generates contributor lists."
+  echo
+  echo "Usage: $0 (-h|-s revision)"
+  echo " -h           print out this help message"
+  echo " -s           generate the contribution roster since the given revision"
+  echo
+  echo "By default, CONTRIBUTORS.md is re-generated to account for any new"
+  echo "since the last re-generation."
+  echo
+  echo "If \`-s [revision]\` is specified, then the contribution roster since that"
+  echo "revision is output.  This is useful to generate a thank-you list for"
+  echo "release announcements by specifying \`-s [previous release tag]\`."
+
+  if (( $# > 0 )); then
+    die "$@"
+  else
+    exit 0
+  fi
+}
+
+since=""
+
+while getopts "hs:" opt; do
+  case ${opt} in
+    h) usage ;;
+    s) since="${OPTARG}" ;;
+    *) usage "Invalid option: -${OPTARG}" ;;
+  esac
+done
+
+function contributors() {
+  range="${1:-HEAD}"
+
+  # Include all commits in range but exclude all commits from the imported zinc tree.
+  git log --use-mailmap --format=format:%aN ${range} ^imported_zinc_tree
+}
+
+if [[ -n "${since}" ]]; then
+  contributors ${since}..HEAD | sort | uniq -c | sort -rn
+else
+  cat << HEADER > CONTRIBUTORS.md
+Created by running \`$0\`.
+
+HEADER
+
+  contributors | sort -u >> CONTRIBUTORS.md
+fi

--- a/src/python/pants/docs/release.md
+++ b/src/python/pants/docs/release.md
@@ -21,6 +21,10 @@ At a high level, releasing pants involves:
 The current list of packages that are part of this release process:
 
 -   pantsbuild.pants
+-   pantsbuild.pants.backend.android
+-   pantsbuild.pants.contrib.buildgen
+-   pantsbuild.pants.contrib.scrooge
+-   pantsbuild.pants.contrib.spindle
 -   pantsbuild.pants.testinfra
 
 Prepare Release
@@ -31,11 +35,20 @@ Index](https://pypi.python.org/pypi) per the Python community
 convention.
 
 Although the build and publish are automated, the version bumping and
-CHANGELOG management are not. You'll need to edit the version number in
+CHANGELOG  and CONTRIBUTORS management are not.
+
+You'll need to edit the version number in
 [src/python/pants/version.py](https://github.com/pantsbuild/pants/tree/master/src/python/pants/version.py)
 and add an entry in the CHANGELOG at
-[src/python/pants/CHANGELOG.rst](https://github.com/pantsbuild/pants/tree/master/src/python/pants/CHANGELOG.rst)
-then send this out for review.
+[src/python/pants/CHANGELOG.rst](https://github.com/pantsbuild/pants/tree/master/src/python/pants/CHANGELOG.rst).
+You can run `./build-support/bin/release-changelog-helper.sh` to get a
+head-start on the CHANGELOG entry.
+
+To bring the CONTRIBUTORS roster in
+[CONTRIBUTORS.md](https://github.com/pantsbuild/pants/tree/master/CONTRIBUTORS.md)
+up to date you just run `build-support/bin/contributors.sh`.
+
+Finally, send these three changes out for review.
 
 Dry Run
 -------


### PR DESCRIPTION
This includes a .mailmap for regularizing contributor ids as well as
handling of the portion of the zinc subtree history before-pants.