### PR TITLE
Fixup formatting of CONTRIBUTORS.md.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,14 @@
+# We use the mailmap to map email addresses to canonical full names.
+# Some folks submit changes under several different email addresses
+# and sometimes the full names associated with those email addresses
+# varies.  The entries below correct the full names for alternate
+# email addresses such that all email addresses used by a single
+# person are associated with the same full name.
+#
+# See `git help shortlog` which has a section describing
+# 'MAPPING AUTHORS', which can also be found here:
+# ftp://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html
+
 Benjy Weinberger <benjy@foursquare.com>
 Benjy Weinberger <benjyw@gmail.com>
 Brian Wickman <wickman@apache.org>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,92 +1,92 @@
 Created by running `./build-support/bin/contributors.sh`.
 
-Alexander Johnson
-Andy Reitz
-Antoine Tollenaere
-Benjy Weinberger
-Bill Farner
-Brian Larson
-Brian Wickman
-Chris Aniszczyk
-Chris Chen
-Craig Schertz
-Dan Davydov
-Daniel Anderson
-David Taylor
-David Turner
-Divij Rajkumar
-Dominic Hamon
-Dumitru Daniliuc
-Eric Ayers
-Eric Danielson
-Eric Lindvall
-Evan Jones
-Fedor Korotkov
-Florian Leibert
-Garrett Malmquist
-Harley Cooper
-Hwasung Lee
-Igor Morozov
-Itay Donanhirsh
-Ity Kaul
-Jackson Davis
-Jake Donham
-James Mouradian
-Jason Jackson
-Jeff Jenkins
-Jessica Rosenfield
-Jin Feng
-Joe Crobak
-Joe Ennever
-Joe Smith
-Johan Oskarsson
-John Chee
-John Gallagher
-John Ioannidis
-John Sirois
-John Townsend
-Jon Boulle
-Jonathan Coveney
-Jonathan Sokolowski
-Joshua Cohen
-Joshua Humphries
-Ken Kawamoto
-Kevin Sweeney
-Kris Wilson
-Kushal Dave
-Larry Hosken
-Lei Wang
-Leo Kim
-Marc Abramowitz
-Marius Eriksen
-Mark Chu-Carroll
-Mark McBride
-Mateo Rodriguez
-Mathew Jennings
-Matthew Jeffryes
-Maxim Khutornenko
-Michael Doherty
-Mike Lindsey
-Misho Krastev
-Neil Sanchala
-Nick Howard
-Nik Shkrob
-Oliver Gould
-Patrick Lawson
-Paul Groudas
-Peiyu Wang
-Peter Seibel
-Ryan Williams
-Senthil Kumaran
-Sergey Serebryakov
-Simeon Franklin
-Stu Hood
-Ted Dziuba
-Tejal Desai
-Tien Nguyen
-Tina Huang
-Todd Stumpf
-Tom Dyas
-Tom Howland
-Travis Crawford
-Ugo Di Girolamo
++ Alexander Johnson
++ Andy Reitz
++ Antoine Tollenaere
++ Benjy Weinberger
++ Bill Farner
++ Brian Larson
++ Brian Wickman
++ Chris Aniszczyk
++ Chris Chen
++ Craig Schertz
++ Dan Davydov
++ Daniel Anderson
++ David Taylor
++ David Turner
++ Divij Rajkumar
++ Dominic Hamon
++ Dumitru Daniliuc
++ Eric Ayers
++ Eric Danielson
++ Eric Lindvall
++ Evan Jones
++ Fedor Korotkov
++ Florian Leibert
++ Garrett Malmquist
++ Harley Cooper
++ Hwasung Lee
++ Igor Morozov
++ Itay Donanhirsh
++ Ity Kaul
++ Jackson Davis
++ Jake Donham
++ James Mouradian
++ Jason Jackson
++ Jeff Jenkins
++ Jessica Rosenfield
++ Jin Feng
++ Joe Crobak
++ Joe Ennever
++ Joe Smith
++ Johan Oskarsson
++ John Chee
++ John Gallagher
++ John Ioannidis
++ John Sirois
++ John Townsend
++ Jon Boulle
++ Jonathan Coveney
++ Jonathan Sokolowski
++ Joshua Cohen
++ Joshua Humphries
++ Ken Kawamoto
++ Kevin Sweeney
++ Kris Wilson
++ Kushal Dave
++ Larry Hosken
++ Lei Wang
++ Leo Kim
++ Marc Abramowitz
++ Marius Eriksen
++ Mark Chu-Carroll
++ Mark McBride
++ Mateo Rodriguez
++ Mathew Jennings
++ Matthew Jeffryes
++ Maxim Khutornenko
++ Michael Doherty
++ Mike Lindsey
++ Misho Krastev
++ Neil Sanchala
++ Nick Howard
++ Nik Shkrob
++ Oliver Gould
++ Patrick Lawson
++ Paul Groudas
++ Peiyu Wang
++ Peter Seibel
++ Ryan Williams
++ Senthil Kumaran
++ Sergey Serebryakov
++ Simeon Franklin
++ Stu Hood
++ Ted Dziuba
++ Tejal Desai
++ Tien Nguyen
++ Tina Huang
++ Todd Stumpf
++ Tom Dyas
++ Tom Howland
++ Travis Crawford
++ Ugo Di Girolamo

--- a/build-support/bin/contributors.sh
+++ b/build-support/bin/contributors.sh
@@ -50,5 +50,5 @@ Created by running \`$0\`.
 
 HEADER
 
-  contributors | sort -u >> CONTRIBUTORS.md
+  contributors | sort -u | sed -E -e "s|^|+ |" >> CONTRIBUTORS.md
 fi


### PR DESCRIPTION
This aligns the contributors vertically via a bulleted list.

The change also adds some explanation to `.mailmap` about its purpose.

https://rbcommons.com/s/twitter/r/2378/