### PR TITLE
Fixup the Git Scm detection of server_url.

### DIFF
--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -124,7 +124,8 @@ class Git(Scm):
 
     origins = list(origin_urls())
     if len(origins) != 1:
-      raise Scm.LocalException('Unable to find origin remote amongst: ' + git_output)
+      raise Scm.LocalException("Unable to find remote named 'origin' that accepts pushes "
+                               "amongst:\n{}".format(git_output))
     return origins[0]
 
   @property

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -9,7 +9,6 @@ import os
 import StringIO
 import subprocess
 import traceback
-from collections import namedtuple
 from contextlib import contextmanager
 
 from pants.scm.scm import Scm

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -9,6 +9,7 @@ import os
 import StringIO
 import subprocess
 import traceback
+from collections import namedtuple
 from contextlib import contextmanager
 
 from pants.scm.scm import Scm
@@ -115,11 +116,17 @@ class Git(Scm):
   @property
   def server_url(self):
     git_output = self._check_output(['remote', '--verbose'], raise_type=Scm.LocalException)
-    origin_push_line = [line.split()[1] for line in git_output.splitlines()
-                                        if 'origin' in line and '(push)' in line]
-    if len(origin_push_line) != 1:
+
+    def origin_urls():
+      for line in git_output.splitlines():
+        name, url, action = line.split()
+        if name == 'origin' and action == '(push)':
+          yield url
+
+    origins = list(origin_urls())
+    if len(origins) != 1:
       raise Scm.LocalException('Unable to find origin remote amongst: ' + git_output)
-    return origin_push_line[0]
+    return origins[0]
 
   @property
   def tag_name(self):
@@ -218,7 +225,6 @@ class Git(Scm):
 
   def add(self, *paths):
     self._check_call(['add'] + list(paths), raise_type=Scm.LocalException)
-
 
   def commit_date(self, commit_reference):
     return self._check_output(['log', '-1', '--pretty=tformat:%ci', commit_reference],

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -248,8 +248,10 @@ class GitTest(unittest.TestCase):
 
     with environment_as(GIT_DIR=self.gitdir, GIT_WORK_TREE=self.worktree):
       with self.mkremote('origin') as origin_uri:
-        origin_url = self.git.server_url
-        self.assertEqual(origin_url, origin_uri)
+        # We shouldn't be fooled by remotes with origin in their name.
+        with self.mkremote('temp_origin'):
+          origin_url = self.git.server_url
+          self.assertEqual(origin_url, origin_uri)
 
     self.assertTrue(self.git.tag_name.startswith('first-'), msg='un-annotated tags should be found')
     self.assertEqual('master', self.git.branch_name)
@@ -346,7 +348,6 @@ class GitTest(unittest.TestCase):
             os.mkdir(subdir)
           actual = Git.detect_worktree(subdir=subdir)
           self.assertEqual(expected, actual)
-
 
         worktree_relative_to('..', None)
         worktree_relative_to('.', clone)


### PR DESCRIPTION
Previously any remote with origin in its name would suffice, leading to
a failure to detect remotes actually named 'origin' or else
mis-identifying an un-intended server_url.