### PR TITLE
[CI] Simplify subsystem option scoping.

### DIFF
--- a/src/python/pants/backend/codegen/subsystems/thrift_defaults.py
+++ b/src/python/pants/backend/codegen/subsystems/thrift_defaults.py
@@ -11,10 +11,7 @@ from pants.subsystem.subsystem import Subsystem
 
 class ThriftDefaults(Subsystem):
   """Tracks defaults for thrift target attributes that influence code generation."""
-
-  @classmethod
-  def scope_qualifier(cls):
-    return 'thrift-defaults'
+  options_scope = 'thrift-defaults'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/core/tasks/group_task.py
+++ b/src/python/pants/backend/core/tasks/group_task.py
@@ -229,9 +229,10 @@ class GroupTask(Task):
 
         @classmethod
         def known_scopes(cls):
-          """Yields all known scopes under this task (i.e., those of its member types.)"""
+          """Yields all known scopes for this task (i.e., those of its member types.)"""
           for member_type in cls._member_types():
-            yield member_type.options_scope
+            for scope in member_type.known_scopes():
+              yield scope
 
         @classmethod
         def register_options_on_scope(cls, options):

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -98,8 +98,12 @@ class TaskBase(AbstractClass):
 
   @classmethod
   def known_scopes(cls):
-    """Yields all known scopes under this task (usually just its own.)"""
+    """Yields all known scopes for this task, in no particular order."""
+    # The task's own scope.
     yield cls.options_scope
+    # The scopes of any task-specific subsystems it uses.
+    for subsystem in cls.task_subsystems():
+      yield subsystem.subscope(cls.options_scope)
 
   @classmethod
   def register_options_on_scope(cls, options):
@@ -108,8 +112,6 @@ class TaskBase(AbstractClass):
     Subclasses should not generally need to override this method.
     """
     cls.register_options(options.registration_function_for_scope(cls.options_scope))
-    for subsystem_type in cls.task_subsystems():
-      subsystem_type.register_options_on_scope(options, cls.options_scope)
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -12,9 +12,7 @@ from pants.subsystem.subsystem import Subsystem
 
 
 class JarTool(JvmToolMixin, Subsystem):
-  @classmethod
-  def scope_qualifier(cls):
-    return 'jar-tool'
+  options_scope = 'jar-tool'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -16,10 +16,7 @@ class ScalaPlatform(JvmToolMixin, Subsystem):
   TODO: Rework so there's a way to specify a default as direct pointers to jar coordinates,
   so we don't require specs in BUILD.tools if the default is acceptable.
   """
-
-  @classmethod
-  def scope_qualifier(cls):
-    return 'scala-platform'
+  options_scope = 'scala-platform'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -17,10 +17,7 @@ from pants.subsystem.subsystem import Subsystem
 
 class PythonSetup(Subsystem):
   """A python environment."""
-
-  @classmethod
-  def scope_qualifier(cls):
-    return 'python-setup'
+  options_scope = 'python-setup'
 
   @classmethod
   def register_options(cls, register):
@@ -116,10 +113,7 @@ class PythonSetup(Subsystem):
 
 class PythonRepos(Subsystem):
   """A python code repository."""
-
-  @classmethod
-  def scope_qualifier(cls):
-    return 'python-repos'
+  options_scope = 'python-repos'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/base/build_configuration.py
+++ b/src/python/pants/base/build_configuration.py
@@ -36,7 +36,7 @@ class BuildConfiguration(object):
     self._exposed_context_aware_object_factories = {}
     self._subsystems = set()
 
-  def subsystem_types(self):
+  def subsystems(self):
     return self._subsystems
 
   def registered_aliases(self):

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -39,11 +39,8 @@ logger = logging.getLogger(__name__)
 
 
 class SourceRootBootstrapper(Subsystem):
-  @classmethod
-  def scope_qualifier(cls):
-    # This is an odd name, but we maintain the legacy scope until we can kill this subsystem
-    # outright.
-    return 'goals'
+  # This is an odd name, but we maintain the legacy scope until we kill this subsystem outright.
+  options_scope = 'goals'
 
   @classmethod
   def register_options(cls, register):
@@ -100,21 +97,21 @@ class GoalRunner(object):
 
     known_scopes = ['']
 
-    # Add scopes for global subsystem instances.
-    global_subsystems = (set(self.subsystems) |
-                         Goal.global_subsystem_types() |
-                         build_configuration.subsystem_types())
-    for subsystem_type in global_subsystems:
-      known_scopes.append(subsystem_type.qualify_scope(Options.GLOBAL_SCOPE))
+    # Add scopes for all needed subsystems.
+    subsystems = (set(self.subsystems) | Goal.subsystems() | build_configuration.subsystems())
+    for subsystem in subsystems:
+      known_scopes.append(subsystem.options_scope)
 
     # Add scopes for all tasks in all goals.
     for goal in Goal.all():
       # Note that enclosing scopes will appear before scopes they enclose.
       known_scopes.extend(filter(None, goal.known_scopes()))
 
+    known_scopes = sorted(known_scopes)
+
     # Now that we have the known scopes we can get the full options.
     self.options = options_bootstrapper.get_full_options(known_scopes=known_scopes)
-    self.register_subsystem_options(global_subsystems)
+    self.register_options(subsystems)
 
     # Make the options values available to all subsystems.
     Subsystem._options = self.options
@@ -164,18 +161,18 @@ class GoalRunner(object):
   def global_options(self):
     return self.options.for_global_scope()
 
-  def register_subsystem_options(self, global_subsystems):
+  def register_options(self, subsystems):
     # Standalone global options.
     register_global_options(self.options.registration_function_for_global_scope())
 
-    # Options for global-level subsystems.
-    for subsystem_type in global_subsystems:
-      subsystem_type.register_options_on_scope(self.options, Options.GLOBAL_SCOPE)
+    # Options for subsystems.
+    for subsystem in subsystems:
+      subsystem.register_options_on_scope(self.options, subsystem.options_scope)
 
     # TODO(benjy): Should Goals be subsystems? Or should the entire goal-running mechanism
     # be a subsystem?
     for goal in Goal.all():
-      # Register task options (including per-task subsystem options).
+      # Register task options.
       goal.register_options(self.options)
 
   def _expand_goals_and_specs(self):

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -44,11 +44,11 @@ class Goal(object):
     return [pair[1] for pair in sorted(Goal._goal_by_name.items())]
 
   @classmethod
-  def global_subsystem_types(cls):
-    """Returns all global subsystem types used by all tasks, in no particular order."""
+  def subsystems(cls):
+    """Returns all subsystem types used by all tasks, in no particular order."""
     ret = set()
     for goal in cls.all():
-      ret.update(goal.global_subsystem_types())
+      ret.update(goal.subsystems())
     return ret
 
 
@@ -154,22 +154,29 @@ class _Goal(object):
       raise GoalError('Cannot uninstall unknown task: {0}'.format(name))
 
   def known_scopes(self):
-    """Yields all known scopes under this goal (including its own.)"""
-    yield self.name
+    """Yields all known scopes under this goal (including its own.) in no particular order."""
+    goal_scope = self.name
+    yield goal_scope
+
+    # Yield an intermediate scope via which task subsystems can inherit options.
+    subsystems = set()
+    for task_type in self.task_types():
+      subsystems.update(task_type.task_subsystems())
+    for subsystem in subsystems:
+      yield subsystem.subscope(goal_scope)
+
+    # Yield scopes for tasks in this goal.
     for task_type in self.task_types():
       for scope in task_type.known_scopes():
-        if scope != self.name:
+        if scope != goal_scope:
           yield scope
-        # Also allow any subsystems in task scope (for the cases when different tasks want to
-        # configure the same subsystem differently).
-        for subsystem in task_type.task_subsystems():
-          yield subsystem.qualify_scope(scope)
 
-  def global_subsystem_types(self):
-    """Returns all global subsystem types used by tasks in this goal, in no particular order."""
+  def subsystems(self):
+    """Returns all subsystem types used by tasks in this goal, in no particular order."""
     ret = set()
     for task_type in self.task_types():
       ret.update(task_type.global_subsystems())
+      ret.update(task_type.task_subsystems())
     return ret
 
   def ordered_task_names(self):

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -44,9 +44,7 @@ class RunTracker(Subsystem):
   Can track execution against multiple 'roots', e.g., one for the main thread and another for
   background threads.
   """
-  @classmethod
-  def scope_qualifier(cls):
-    return 'run-tracker'
+  options_scope = 'run-tracker'
 
   # The name of the tracking root for the main thread (and the foreground worker threads).
   DEFAULT_ROOT_NAME = 'main'

--- a/src/python/pants/ivy/ivy_subsystem.py
+++ b/src/python/pants/ivy/ivy_subsystem.py
@@ -14,15 +14,12 @@ from pants.subsystem.subsystem import Subsystem
 
 class IvySubsystem(Subsystem):
   """Common configuration items for ivy tasks."""
+  options_scope = 'ivy'
 
   _DEFAULT_VERSION = '2.3.0'
   _DEFAULT_URL = ('https://repo1.maven.org/maven2/'
                   'org/apache/ivy/ivy/'
                   '{version}/ivy-{version}.jar'.format(version=_DEFAULT_VERSION))
-
-  @classmethod
-  def scope_qualifier(cls):
-    return 'ivy'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -21,9 +21,7 @@ from pants.util.dirutil import relative_symlink, safe_mkdir, safe_rmtree
 
 
 class Reporting(Subsystem):
-  @classmethod
-  def scope_qualifier(cls):
-    return 'reporting'
+  options_scope = 'reporting'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/subsystem/BUILD
+++ b/src/python/pants/subsystem/BUILD
@@ -5,6 +5,5 @@ python_library(
   name = 'subsystem',
   sources = globs('*.py'),
   dependencies = [
-    'src/python/pants/option',
   ],
 )

--- a/tests/python/pants_test/base/test_extension_loader.py
+++ b/tests/python/pants_test/base/test_extension_loader.py
@@ -41,15 +41,11 @@ class MockMetadata(EmptyProvider):
 
 
 class DummySubsystem1(Subsystem):
-  @classmethod
-  def scope_qualifier(cls):
-    return 'dummy-subsystem1'
+  options_scope = 'dummy-subsystem1'
 
 
 class DummySubsystem2(Subsystem):
-  @classmethod
-  def scope_qualifier(cls):
-    return 'dummy-subsystem2'
+  options_scope = 'dummy-subsystem2'
 
 
 class DummyTarget(Target):
@@ -114,7 +110,7 @@ class LoaderTest(unittest.TestCase):
     self.assertEqual(0, len(registered_aliases.targets))
     self.assertEqual(0, len(registered_aliases.objects))
     self.assertEqual(0, len(registered_aliases.context_aware_object_factories))
-    self.assertEqual(self.build_configuration.subsystem_types(), set())
+    self.assertEqual(self.build_configuration.subsystems(), set())
 
   def test_load_valid_empty(self):
     with self.create_register() as backend_package:
@@ -131,7 +127,7 @@ class LoaderTest(unittest.TestCase):
       self.assertEqual(DummyTarget, registered_aliases.targets['bob'])
       self.assertEqual(DummyObject1, registered_aliases.objects['obj1'])
       self.assertEqual(DummyObject2, registered_aliases.objects['obj2'])
-      self.assertEqual(self.build_configuration.subsystem_types(),
+      self.assertEqual(self.build_configuration.subsystems(),
                        set([DummySubsystem1, DummySubsystem2]))
 
   def test_load_valid_partial_goals(self):
@@ -274,7 +270,7 @@ class LoaderTest(unittest.TestCase):
     self.assertEqual(DummyTarget, registered_aliases.targets['pluginalias'])
     self.assertEqual(DummyObject1, registered_aliases.objects['FROMPLUGIN1'])
     self.assertEqual(DummyObject2, registered_aliases.objects['FROMPLUGIN2'])
-    self.assertEqual(self.build_configuration.subsystem_types(),
+    self.assertEqual(self.build_configuration.subsystems(),
                      {DummySubsystem1, DummySubsystem2})
 
   def test_subsystems(self):
@@ -282,5 +278,5 @@ class LoaderTest(unittest.TestCase):
       return {DummySubsystem1, DummySubsystem2}
     with self.create_register(global_subsystems=global_subsystems) as backend_package:
       load_backend(self.build_configuration, backend_package)
-      self.assertEqual(self.build_configuration.subsystem_types(),
+      self.assertEqual(self.build_configuration.subsystems(),
                        {DummySubsystem1, DummySubsystem2})

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -151,7 +151,7 @@ class BaseTest(unittest.TestCase):
     options = options or {}
 
     option_values = defaultdict(dict)
-    registered_global_subsystems = set()
+    registered_subsystems = set()
     bootstrap_option_values = None  # We fill these in after registering bootstrap options.
 
     # We provide our own test-only registration implementation, bypassing argparse.
@@ -188,12 +188,11 @@ class BaseTest(unittest.TestCase):
         raise TaskError('You must set a scope on your task type before using it in tests.')
       task_type.register_options(register_func(scope))
       for subsystem in (set(task_type.global_subsystems()) |
-                        self._build_configuration.subsystem_types()):
-        if subsystem not in registered_global_subsystems:
-          subsystem.register_options(register_func(subsystem.qualify_scope(Options.GLOBAL_SCOPE)))
-          registered_global_subsystems.add(subsystem)
-      for subsystem in task_type.task_subsystems():
-        subsystem.register_options(register_func(subsystem.qualify_scope(scope)))
+                        set(task_type.task_subsystems()) |
+                        self._build_configuration.subsystems()):
+        if subsystem not in registered_subsystems:
+          subsystem.register_options(register_func(subsystem.options_scope))
+          registered_subsystems.add(subsystem)
 
     # Now default option values override with any caller-specified values.
     # TODO(benjy): Get rid of the options arg, and require tests to call set_options.

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -11,9 +11,7 @@ from pants.subsystem.subsystem import Subsystem
 
 
 class DummySubsystem(Subsystem):
-  @classmethod
-  def scope_qualifier(cls):
-    return 'dummy'
+  options_scope = 'dummy'
 
 
 class DummyOptions(object):
@@ -28,11 +26,6 @@ class DummyTask(object):
 class SubsystemTest(unittest.TestCase):
   def setUp(self):
     DummySubsystem._options = DummyOptions()
-
-  def test_qualify_scope(self):
-    self.assertEquals('dummy', DummySubsystem.qualify_scope(''))
-    self.assertEquals('foo.dummy', DummySubsystem.qualify_scope('foo'))
-    self.assertEquals('foo.bar.dummy', DummySubsystem.qualify_scope('foo.bar'))
 
   def test_global_instance(self):
     # Verify that we get the same instance back every time.


### PR DESCRIPTION
This gets rid of the concept of "scope qualifiers", which was mostly just confusing.
Now subsystems just have scopes ('ivy', 'scala-platform' etc.) and task-specific
instances have options in the appropriate subscope (e.g., `cache.compile.java` instead of
`compile.java.cache` as it was previously). This has many advantages:
  - Option value inheritance "just works": `cache.compile.java` will inherit values from
   `cache`, in the usual way.
  - Overriding values in the subscope will also work as it does today - by registering
    the option as recursive=True.

This change doesn't affect any existing pants.ini etc. because we don't have any
task-specific subsystem instances yet.

It does mean that the section name for a task-specific config would be
[cache.compile.java], not [compile.java.cache], but that doesn't seem like a big deal.