### PR TITLE
Robustify the release process.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -2,8 +2,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
-source ${REPO_ROOT}/contrib/release_packages.sh
+ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+source ${ROOT}/build-support/common.sh
+
+PY=$(which python2.7)
+[[ -n "${PY}" ]] || die "You must have python2.7 installed and on the path to release."
+export PY
+
+source ${ROOT}/contrib/release_packages.sh
 
 #
 # List of packages to be released
@@ -65,9 +71,6 @@ RELEASE_PACKAGES=(
 # End of package declarations.
 #
 
-
-ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
-source ${ROOT}/build-support/common.sh
 
 function run_local_pants() {
   ${ROOT}/pants "$@"
@@ -143,7 +146,8 @@ function publish_packages() {
     targets+=($(pkg_build_target $PACKAGE))
   done
   banner "Publishing packages ..."
-  run_local_pants setup-py --run="register sdist upload" --recursive ${targets[@]} || \
+  run_local_pants setup-py --run="register sdist upload --sign --identity=$(get_pgp_keyid)" \
+    --recursive ${targets[@]} || \
   die "Failed to publish packages!"
 }
 
@@ -183,33 +187,197 @@ function dry_run_install() {
   install_and_test_packages --find-links=file://${ROOT}/dist
 }
 
+ALLOWED_ORIGIN_URLS=(
+  git@github.com:pantsbuild/pants.git
+  https://github.com/pantsbuild/pants.git
+)
+
+function check_origin() {
+  banner "Checking for a valid git origin"
+
+  origin_url="$(git remote -v | grep origin | grep "\(push\)" | cut -f2 | cut -d' ' -f1)"
+  for url in "${ALLOWED_ORIGIN_URLS[@]}"
+  do
+    if [[ "${origin_url}" == "${url}" ]]
+    then
+      return
+    fi
+  done
+  msg=$(cat << EOM
+Your origin url is not valid for releasing:
+  ${origin_url}
+
+It must be one of:
+$(echo "${ALLOWED_ORIGIN_URLS[@]}" | tr ' ' '\n' | sed -E "s|^|  |")
+EOM
+)
+  die "$msg"
+}
+
 function check_clean_master() {
+  banner "Checking for a clean master branch"
+
   [[
     -z "$(git status --porcelain)" &&
-    "$(git branch | grep -E '^* ' | cut -d' ' -f2-)" == "master"
+    "$(git branch | grep -E '^\* ' | cut -d' ' -f2-)" == "master"
   ]] || die "You are not on a clean master branch."
+}
+
+function check_pgp() {
+  banner "Checking pgp setup"
+
+  msg=$(cat << EOM
+You must configure your release signing pgp key.
+
+You can configure the key by running:
+  git config --add user.signingkey [key id]
+
+Key id should be the id of the pgp key you have registered with pypi.
+EOM
+)
+  get_pgp_keyid &> /dev/null || die "${msg}"
+  echo "Found the following key for release signing:"
+  gpg -k $(get_pgp_keyid)
+  read -p "Is this the correct key? [Yn]: " answer
+  [[ "${answer:-y}" =~ [Yy]([Ee][Ss])? ]] || die "${msg}"
+}
+
+function get_pgp_keyid() {
+  git config --get user.signingkey
+}
+
+function check_pypi() {
+  if [[ ! -r ~/.pypirc ]]
+  then
+    msg=$(cat << EOM
+You must create a ~/.pypirc file with your pypi credentials:
+cat << EOF > ~/.pypirc && chmod 600 ~/.pypirc
+[server-login]
+username: <fill me in>
+password: <fill me in>
+EOF
+
+More information is here: https://wiki.python.org/moin/EnhancedPyPI
+EOM
+)
+    die "${msg}"
+  fi
+  ${PY} << EOF || die
+from __future__ import print_function
+
+import os
+import sys
+from ConfigParser import ConfigParser
+
+config = ConfigParser()
+config.read(os.path.expanduser('~/.pypirc'))
+
+def check_option(section, option):
+  if config.has_option(section, option):
+    return config.get(section, option)
+  print('Your ~/.pypirc must define a {} option in the {} section'.format(option, section))
+
+username = check_option('server-login', 'username')
+if not (username or check_option('server-login', 'password')):
+  sys.exit(1)
+else:
+  print(username)
+EOF
 }
 
 function tag_release() {
   release_version="$(local_version)" && \
   tag_name="release_${release_version}" && \
-  git tag --sign -m "pantsbuild.pants release ${release_version}" ${tag_name} && \
-    git push git@github.com:pantsbuild/pants.git ${tag_name}
+  git tag \
+    --local-user=$(get_pgp_keyid) \
+    -m "pantsbuild.pants release ${release_version}" \
+    ${tag_name} && \
+  git push git@github.com:pantsbuild/pants.git ${tag_name}
+}
+
+function list_packages() {
+  echo "Releases the following source distributions to PyPi."
+  version="$(local_version)"
+  for PACKAGE in "${RELEASE_PACKAGES[@]}"
+  do
+    echo "  $(pkg_name $PACKAGE)-${version}"
+  done
+}
+
+function get_owners() {
+  package_name="$1"
+
+  curl -s "https://pypi.python.org$(curl -s https://pypi.python.org/pypi/${package_name} | \
+    grep -oE  "/pypi/${package_name}/[0-9]*\.[0-9]*\.[0-9]*" | head -n1)" | \
+    grep -A1 "Owner" | tail -1 | \
+    cut -d'>' -f2 | cut -d'<' -f1 | \
+    tr ',' ' ' | sed -E -e "s|\s+| |g"
+}
+
+function list_owners() {
+  for PACKAGE in "${RELEASE_PACKAGES[@]}"
+  do
+    package_name=$(pkg_name $PACKAGE)
+    echo "Owners of ${package_name}:"
+    owners=($(get_owners ${package_name}))
+    for owner in "${owners[@]}"
+    do
+      echo "  ${owner}"
+    done
+    echo
+  done
+}
+
+function check_owner() {
+   username="$1"
+   packagename="$2"
+
+   for owner in $(get_owners ${packagename})
+   do
+     if [[ "${username}" == "${owner}" ]]
+     then
+       return 0
+     fi
+   done
+   return 1
+}
+
+function check_owners() {
+  username="$(check_pypi)"
+
+  total=${#RELEASE_PACKAGES[@]}
+  banner "Checking package ownership for pypi user ${username} of ${total} packages ..."
+  dont_own=()
+  index=0
+  for PACKAGE in "${RELEASE_PACKAGES[@]}"
+  do
+    index=$((index+1))
+    packagename="$(pkg_name $PACKAGE)"
+    banner "[${index}/${total}] checking that ${username} owns ${packagename}..."
+    if ! check_owner "${username}" "${packagename}"
+    then
+      dont_own+=("${packagename}")
+    fi
+  done
+
+  if (( ${#dont_own[@]} > 0 ))
+  then
+    msg=$(cat << EOM
+Your pypi account ${username} needs to be added as an owner for the
+following packages:
+$(echo "${dont_own[@]}" | tr ' ' '\n' | sed -E "s|^|  |")
+EOM
+)
+    die "${msg}"
+  fi
 }
 
 function usage() {
-  echo "Releases the following source distributions to PyPi."
-  for PACKAGE in "${RELEASE_PACKAGES[@]}"
-  do
-    NAME=$(pkg_name $PACKAGE)
-    echo "    ${NAME}-$(local_version)"
-  done
-  echo
   echo "With no options all packages are built, smoke tested and published to"
   echo "PyPi.  Credentials are needed for this as described in the"
   echo "release docs: http://pantsbuild.github.io/release.html"
   echo
-  echo "Usage: $0 (-h|-pnt)"
+  echo "Usage: $0 (-h|-pntlo)"
   echo " -h  Prints out this help message."
   echo " -p  Use pants.pex to do the release instead of PANTS_DEV=1 ./pants."
   echo " -n  Performs a release dry run."
@@ -219,6 +387,8 @@ function usage() {
   echo " -t  Tests a live release."
   echo "       Ensures the latest packages have been propagated to PyPi"
   echo "       and can be installed in an ephemeral virtualenv."
+  echo " -l  Lists all pantsbuild packages that this script releases."
+  echo " -o  Lists all pantsbuild package owners."
   echo
   echo "All options are mutually exclusive."
 
@@ -231,12 +401,14 @@ function usage() {
 
 use_pex="false"
 
-while getopts "hpnt" opt; do
+while getopts "hpntlo" opt; do
   case ${opt} in
     h) usage ;;
     p) use_pex="true" ;;
     n) dry_run="true" ;;
     t) test_release="true" ;;
+    l) list_packages && exit 0 ;;
+    o) list_owners && exit 0 ;;
     *) usage "Invalid option: -${OPTARG}" ;;
   esac
 done
@@ -262,7 +434,8 @@ elif [[ "${test_release}" == "true" ]]; then
 else
   banner "Releasing packages to PyPi." && \
   (
-    check_clean_master && dry_run_install && publish_packages && tag_release && \
-    banner "Successfully released packages to PyPi."
+    check_origin && check_clean_master && check_pgp && check_owners && \
+      dry_run_install && publish_packages && tag_release && \
+        banner "Successfully released packages to PyPi."
   ) || die "Failed to release packages to PyPi."
 fi

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -307,11 +307,14 @@ function list_packages() {
 function get_owners() {
   package_name="$1"
 
-  curl -s "https://pypi.python.org$(curl -s https://pypi.python.org/pypi/${package_name} | \
-    grep -oE  "/pypi/${package_name}/[0-9]*\.[0-9]*\.[0-9]*" | head -n1)" | \
+  latest_package_path=$(
+    curl -s https://pypi.python.org/pypi/${package_name} | \
+      grep -oE  "/pypi/${package_name}/[0-9]*\.[0-9]*\.[0-9]*" | head -n1
+  )
+  curl -s "https://pypi.python.org${latest_package_path}" | \
     grep -A1 "Owner" | tail -1 | \
     cut -d'>' -f2 | cut -d'<' -f1 | \
-    tr ',' ' ' | sed -E -e "s|\s+| |g"
+    tr ',' ' ' | sed -E -e "s|[[:space:]]+| |g"
 }
 
 function list_owners() {

--- a/src/python/pants/docs/release.md
+++ b/src/python/pants/docs/release.md
@@ -24,7 +24,7 @@ Prerequisites
 There are several things that require one-time setup in order to be
 able to perform pants releases.  The release script checks that all
 these steps have been performed in one way or another, but you might
-like to go though this list ahead of time rather than have the release
+like to go through this list ahead of time rather than have the release
 script fail:
 
   - Create a pgp signing key if you don't already have one.

--- a/src/python/pants/docs/release.md
+++ b/src/python/pants/docs/release.md
@@ -18,14 +18,47 @@ At a high level, releasing pants involves:
 -   Publishing the release to PyPi.
 -   Announce the release on pants-devel.
 
-The current list of packages that are part of this release process:
+Prerequisites
+-------------
 
--   pantsbuild.pants
--   pantsbuild.pants.backend.android
--   pantsbuild.pants.contrib.buildgen
--   pantsbuild.pants.contrib.scrooge
--   pantsbuild.pants.contrib.spindle
--   pantsbuild.pants.testinfra
+There are several things that require one-time setup in order to be
+able to perform pants releases.  The release script checks that all
+these steps have been performed in one way or another, but you might
+like to go though this list ahead of time rather than have the release
+script fail:
+
+  - Create a pgp signing key if you don't already have one.
+  
+    You might use the gpg implemntation of pgp and start here:
+    https://www.gnupg.org/gph/en/manual/c14.html
+  
+  - Configure git to use your pgp key for signing release tags.
+    
+    A description of the configuration can be found here:
+    https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work#GPG-Introduction
+  
+  - Create a pypi account if you don't already have one.
+  
+    You can register here: https://pypi.python.org/pypi?%3Aaction=register_form
+    Don't forget to include your pgp key id even though pypi considers
+    this step optional.
+    
+  - Get your pypi account added as an `owner` for all pantsbuild.pants packages.
+  
+    You can ask any one of the [Owners](#owners) listed below to do this.
+    Once this is done and you've performed your 1st release, add yourself to
+    the [Owners](#owners) section below.
+  
+  - Configure your pypi credentials locally in `~/.pypirc`
+  
+    This will do it:
+    
+        :::bash
+        cat << EOF > ~/.pypirc && chmod 600 ~/.pypirc
+        [server-login]
+        username: <fill me in>
+        password: <fill me in>
+        EOF
 
 Prepare Release
 ---------------
@@ -35,7 +68,7 @@ Index](https://pypi.python.org/pypi) per the Python community
 convention.
 
 Although the build and publish are automated, the version bumping and
-CHANGELOG  and CONTRIBUTORS management are not.
+CHANGELOG and CONTRIBUTORS management are not.
 
 You'll need to edit the version number in
 [src/python/pants/version.py](https://github.com/pantsbuild/pants/tree/master/src/python/pants/version.py)
@@ -50,26 +83,13 @@ up to date you just run `build-support/bin/contributors.sh`.
 
 Finally, send these three changes out for review.
 
-Dry Run
--------
+Dry Run (Optional)
+------------------
 
-In order to publish the prepared release you'll need to be a
-pantsbuild.pants package owner; otherwise you'll need to hand off to
-someone who is. The list is on the [pantsbuild.pants package index
-page](https://pypi.python.org/pypi/pantsbuild.pants) in the
-Package Index Owner field:
-
-    :::bash
-    $ curl -s "https://pypi.python.org`(curl -s https://pypi.python.org/pypi/pantsbuild.pants | grep -oE  "/pypi/pantsbuild.pants/[0-9]*\.[0-9]*\.[0-9]*" | head -n1)`" | grep -A1 "Owner"
-    <strong>Package Index Owner:</strong>
-    <span>john.sirois, benjyw, traviscrawford, ericzundel, ity</span>
-
-All the other packages that are part of this simultaneous release
-process must have the same owner list or the release script would break.
-
-Releases should only be published from master, so get on master and
-ensure your version number commit is present. After confirming this,
-publish locally and verify the release.
+A dry run is not strictly required since CI includes one, but you might
+like to try one anyway; if so, releases should only be published from
+master, so get on master and ensure your version number commit is present.
+After confirming this, run.
 
     :::bash
     $ ./build-support/bin/release.sh -n
@@ -78,8 +98,9 @@ This will perform a dry run local build of the pantsbuild.pants sdist
 and other related package sdists, install them in a virtualenv and then
 smoke test basic operations.
 
-Note that the release publish flow also performs a mandatory dry run so
-executing a dry run separately is not required.
+Note that in addition to CI checking dry runs work, the release publish
+flow also performs a mandatory dry run so executing a dry run separately
+is not required.
 
 Publish to PyPi
 ---------------
@@ -108,5 +129,44 @@ To test the packages are installable:
 This will attempt to install the just-published packages from pypi and
 then smoke test them.
 
-Finally, announce the release to pants-devel.
+Finally, announce the release to pants-devel.  You can get a
+contributor list for the email by running the following where `<tag>`
+if the tag for the prior release (eg: release_0.0.33)
 
+    :::bash
+    $ ./build-support/bin/contributors.sh -s <tag>
+
+Owners
+------
+
+The following folks are set up to publish to pypi for
+pantsbuild.pants sdists:
+
+Name             | Email                 | PYPI Usename
+-----------------|-----------------------|-------------
+John Sirois      | john.sirois@gmail.com | john.sirois 
+Benjy Weinberger | benjyw@gmail.com      | benjyw
+Eric Ayers       | zundel@squareup.com   | ericzundel
+Ity Kaul         | itykaul@gmail.com     | ity
+Stu Hood         | stuhood@gmail.com     | stuhood
+
+And the current list of packages that these folks can release can
+be obtained via:
+   
+    :::bash
+    $ ./build-support/bin/release.sh -l
+   
+Right now that's:
+
+- pantsbuild.pants
+- pantsbuild.pants.backend.android
+- pantsbuild.pants.contrib.buildgen
+- pantsbuild.pants.contrib.scrooge
+- pantsbuild.pants.contrib.spindle
+- pantsbuild.pants.testinfra
+
+You can run the following to get a full ownership roster for each
+package :
+
+    :::bash
+    $ ./build-support/bin/release.sh -o

--- a/src/python/pants/docs/release.md
+++ b/src/python/pants/docs/release.md
@@ -28,31 +28,31 @@ like to go though this list ahead of time rather than have the release
 script fail:
 
   - Create a pgp signing key if you don't already have one.
-  
+
     You might use the gpg implemntation of pgp and start here:
     https://www.gnupg.org/gph/en/manual/c14.html
-  
+
   - Configure git to use your pgp key for signing release tags.
-    
+
     A description of the configuration can be found here:
     https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work#GPG-Introduction
-  
+
   - Create a pypi account if you don't already have one.
-  
+
     You can register here: https://pypi.python.org/pypi?%3Aaction=register_form
     Don't forget to include your pgp key id even though pypi considers
     this step optional.
-    
+
   - Get your pypi account added as an `owner` for all pantsbuild.pants packages.
-  
+
     You can ask any one of the [Owners](#owners) listed below to do this.
     Once this is done and you've performed your 1st release, add yourself to
     the [Owners](#owners) section below.
-  
+
   - Configure your pypi credentials locally in `~/.pypirc`
-  
+
     This will do it:
-    
+
         :::bash
         cat << EOF > ~/.pypirc && chmod 600 ~/.pypirc
         [server-login]
@@ -144,7 +144,7 @@ pantsbuild.pants sdists:
 
 Name             | Email                 | PYPI Usename
 -----------------|-----------------------|-------------
-John Sirois      | john.sirois@gmail.com | john.sirois 
+John Sirois      | john.sirois@gmail.com | john.sirois
 Benjy Weinberger | benjyw@gmail.com      | benjyw
 Eric Ayers       | zundel@squareup.com   | ericzundel
 Ity Kaul         | itykaul@gmail.com     | ity
@@ -152,10 +152,10 @@ Stu Hood         | stuhood@gmail.com     | stuhood
 
 And the current list of packages that these folks can release can
 be obtained via:
-   
+
     :::bash
     $ ./build-support/bin/release.sh -l
-   
+
 Right now that's:
 
 - pantsbuild.pants


### PR DESCRIPTION
This addresses several issues:
+ Fixup detection of the current branch to work with OSX/bsd sed
+ Add a check for the git origin being valid for release tagging
+ Add a check for git configuration of the desired release pgp key and
  use this key to sign sdists as well.
+ Add a check that a proper ~/.pypirc is setup.
+ Add a check that the releaser has permissions to publish all packages
  to pypi.

Utility commands are also added to list packages and package owners and
the release documentation is updated with all prerequisites.

https://rbcommons.com/s/twitter/r/2388/