### PR TITLE
[CI] Simplify known scopes computation.

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -107,8 +107,6 @@ class GoalRunner(object):
       # Note that enclosing scopes will appear before scopes they enclose.
       known_scopes.extend(filter(None, goal.known_scopes()))
 
-    known_scopes = sorted(known_scopes)
-
     # Now that we have the known scopes we can get the full options.
     self.options = options_bootstrapper.get_full_options(known_scopes=known_scopes)
     self.register_options(subsystems)

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -154,22 +154,11 @@ class _Goal(object):
       raise GoalError('Cannot uninstall unknown task: {0}'.format(name))
 
   def known_scopes(self):
-    """Yields all known scopes under this goal (including its own) in no particular order."""
-    goal_scope = self.name
-    yield goal_scope
-
-    # Yield an intermediate scope via which task subsystems can inherit options.
-    subsystems = set()
-    for task_type in self.task_types():
-      subsystems.update(task_type.task_subsystems())
-    for subsystem in subsystems:
-      yield subsystem.subscope(goal_scope)
-
+    """Yields all known scopes under this goal in no particular order."""
     # Yield scopes for tasks in this goal.
     for task_type in self.task_types():
       for scope in task_type.known_scopes():
-        if scope != goal_scope:
-          yield scope
+        yield scope
 
   def subsystems(self):
     """Returns all subsystem types used by tasks in this goal, in no particular order."""

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -65,7 +65,7 @@ class ArgSplitter(object):
   _VERSION_ARGS = ('-V', '--version')
 
   def __init__(self, known_scopes):
-    self._known_scopes = set(known_scopes + ['help', 'help-advanced', 'help-all'])
+    self._known_scopes = set(known_scopes) | set(['help', 'help-advanced', 'help-all'])
     self._unconsumed_args = []  # In reverse order, for efficient popping off the end.
     self._help_request = None  # Will be set if we encounter any help flags.
 

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -96,7 +96,10 @@ class Options(object):
     :param bootstrap_option_values: An optional namespace containing the values of bootstrap
            options. We can use these values when registering other options.
     """
-    splitter = ArgSplitter(known_scopes)
+    # We need parsers for all the intermediate scopes, so inherited option values
+    # can propagate through them.
+    complete_known_scopes = self.complete_scopes(known_scopes)
+    splitter = ArgSplitter(complete_known_scopes)
     self._goals, self._scope_to_flags, self._target_specs, self._passthru, self._passthru_owner = \
       splitter.split_args(args)
 
@@ -108,9 +111,7 @@ class Options(object):
             self._target_specs.extend(filter(None, [line.strip() for line in f]))
 
     self._help_request = splitter.help_request
-    # We need parsers for all the intermediate scopes, so inherited option values
-    # can propagate through them.
-    complete_known_scopes = self.complete_scopes(known_scopes)
+
     self._parser_hierarchy = ParserHierarchy(env, config, complete_known_scopes, self._help_request)
     self._values_by_scope = {}  # Arg values, parsed per-scope on demand.
     self._bootstrap_option_values = bootstrap_option_values

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -72,6 +72,19 @@ class Options(object):
   # will replace the default with the cmd-line value.
   list = staticmethod(custom_types.list_type)
 
+  @classmethod
+  def complete_scopes(cls, scopes):
+    """Expand a set of scopes to include all enclosing scopes.
+
+    E.g., if the set contains `foo.bar.baz`, ensure that it also contains `foo.bar` and `foo`.
+    """
+    ret = {''}
+    for scope in scopes:
+      while scope != '':
+        ret.add(scope)
+        scope = scope.rpartition('.')[0]
+    return ret
+
 
   def __init__(self, env, config, known_scopes, args=sys.argv, bootstrap_option_values=None):
     """Create an Options instance.
@@ -95,7 +108,10 @@ class Options(object):
             self._target_specs.extend(filter(None, [line.strip() for line in f]))
 
     self._help_request = splitter.help_request
-    self._parser_hierarchy = ParserHierarchy(env, config, known_scopes, self._help_request)
+    # We need parsers for all the intermediate scopes, so inherited option values
+    # can propagate through them.
+    complete_known_scopes = self.complete_scopes(known_scopes)
+    self._parser_hierarchy = ParserHierarchy(env, config, complete_known_scopes, self._help_request)
     self._values_by_scope = {}  # Arg values, parsed per-scope on demand.
     self._bootstrap_option_values = bootstrap_option_values
     self._known_scopes = set(known_scopes)

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -521,3 +521,13 @@ class OptionsTest(unittest.TestCase):
     self.assertEquals(100, options.for_global_scope().a)
     self.assertEquals(100, options.for_scope('compile').a)
     self.assertEquals(100, options.for_scope('compile.java').a)
+
+  def test_complete_scopes(self):
+    self.assertEquals({'', 'foo', 'foo.bar', 'foo.bar.baz'},
+                      Options.complete_scopes({'foo.bar.baz'}))
+    self.assertEquals({'', 'foo', 'foo.bar', 'foo.bar.baz'},
+                      Options.complete_scopes({'', 'foo.bar.baz'}))
+    self.assertEquals({'', 'foo', 'foo.bar', 'foo.bar.baz'},
+                      Options.complete_scopes({'foo', 'foo.bar.baz'}))
+    self.assertEquals({'', 'foo', 'foo.bar', 'foo.bar.baz', 'qux', 'qux.quux'},
+                      Options.complete_scopes({'foo.bar.baz', 'qux.quux'}))


### PR DESCRIPTION
Previously we were requiring the goal/task code to compute intermediate
scopes (e.g., to know that if `compile.java` is a scope then so is
`compile`).

However the arg splitter doesn't need this - it only needs to know about
scopes that actually register options.

The parser hierarchy needs to know about those intermediate scopes, but
it can simply compute them as an implementation detail.

So now the goal/task code only computes scopes that you could actually
register options on.

Also removes some superfluous sorting.