### PR TITLE
Fix python_requirements to tie PRLs to req files.

### DIFF
--- a/src/python/pants/backend/python/python_requirements.py
+++ b/src/python/pants/backend/python/python_requirements.py
@@ -57,4 +57,5 @@ def python_requirements(parse_context, requirements_relpath='requirements.txt'):
     req = parse_context.create_object('python_requirement', requirement, repository=repository)
     parse_context.create_object('python_requirement_library',
                                 name=req.project_name,
+                                requirements_relpath=requirements_relpath,
                                 requirements=[req])

--- a/src/python/pants/backend/python/targets/python_requirement_library.py
+++ b/src/python/pants/backend/python/targets/python_requirement_library.py
@@ -14,16 +14,24 @@ from pants.base.validation import assert_list
 
 class PythonRequirementLibrary(Target):
   """Named target for some pip requirements."""
-  def __init__(self, payload=None, requirements=None, **kwargs):
+  def __init__(self, address=None, payload=None, requirements=None, **kwargs):
     """
     :param requirements: pip requirements as `python_requirement <#python_requirement>`_\s.
     :type requirements: List of python_requirement calls
     """
     payload = payload or Payload()
 
+    # A 'private' constructor parameter - `requirements_relpath` - is used by the
+    # `python_requirements` macro to associate a requirements text file with each
+    # PythonRequirementLibrary it expands to.
+    requirements_relpath = kwargs.pop('requirements_relpath', None)
+    if requirements_relpath:
+      sources_field = self.create_sources_field(sources=[requirements_relpath],
+                                                sources_rel_path=address.spec_path,
+                                                key_arg='sources')
+      payload.add_field('sources', sources_field)
+
     assert_list(requirements, expected_type=PythonRequirement, key_arg='requirements')
-    payload.add_fields({
-      'requirements': PythonRequirementsField(requirements or []),
-    })
-    super(PythonRequirementLibrary, self).__init__(payload=payload, **kwargs)
+    payload.add_field('requirements', PythonRequirementsField(requirements or []))
+    super(PythonRequirementLibrary, self).__init__(address=address, payload=payload, **kwargs)
     self.add_labels('python')

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -4,8 +4,8 @@
 target(
   name='python',
   dependencies=[
-    ':test_python_requirement_list',
     ':test_python_chroot',
+    'tests/python/pants_test/backend/python/targets',
     'tests/python/pants_test/backend/python/tasks'
   ]
 )
@@ -16,16 +16,5 @@ python_tests(
   dependencies=[
     '3rdparty/python:pex',
     'src/python/pants/backend/python:python_chroot',
-  ]
-)
-
-python_tests(
-  name='test_python_requirement_list',
-  sources=['test_python_requirement_list.py'],
-  dependencies=[
-    'src/python/pants/backend/python:python_requirement',
-    'src/python/pants/backend/python/targets:python',
-    'src/python/pants/base:build_file_aliases',
-    'tests/python/pants_test:base_test'
   ]
 )

--- a/tests/python/pants_test/backend/python/targets/BUILD
+++ b/tests/python/pants_test/backend/python/targets/BUILD
@@ -1,0 +1,20 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name='targets',
+  dependencies=[
+    ':python_requirement_library',
+  ]
+)
+
+python_tests(
+  name='python_requirement_library',
+  sources=['test_python_requirement_library.py'],
+  dependencies=[
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/base:build_file_aliases',
+    'tests/python/pants_test:base_test'
+  ]
+)

--- a/tests/python/pants_test/backend/python/targets/test_python_requirement_library.py
+++ b/tests/python/pants_test/backend/python/targets/test_python_requirement_library.py
@@ -13,7 +13,7 @@ from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
 
 
-class PythonRequirementListTest(BaseTest):
+class PythonRequirementLibraryTest(BaseTest):
   @property
   def alias_groups(self):
     return BuildFileAliases.create(


### PR DESCRIPTION
Previously the python_requirements would expand a python requirements
file to a list of PythonRequirementLibrary instances that were each
divorced from their python requirements file source.  This change adds a
private PythonRequirmentLibrary constructor parameter (avoids
documentation in the BUILD dictionary) that python_requirements uses to
associate the requirements file as a sources file that each
PythonRequirmentLibrary generated from it owns.  This makes goals like
`filemap`, `filedeps` and `changed` work as expected.

https://rbcommons.com/s/twitter/r/2397/