### PR TITLE
Promote PANTS_DEV=1 to the only ./pants mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ out/
 arc.sh
 BUILD.release*
 pants.ini.sitegen
-pants.pex
 target
 GPATH
 GRTAGS

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -134,7 +134,7 @@ fi
 if [[ "${skip_distribution:-false}" == "false" ]]; then
   banner "Running pants distribution tests"
   (
-    ./build-support/bin/release.sh -pn
+    ./build-support/bin/release.sh -n
   ) || die "Failed to create pants distributions."
 fi
 

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -380,9 +380,8 @@ function usage() {
   echo "PyPi.  Credentials are needed for this as described in the"
   echo "release docs: http://pantsbuild.github.io/release.html"
   echo
-  echo "Usage: $0 (-h|-pntlo)"
+  echo "Usage: $0 (-h|-ntlo)"
   echo " -h  Prints out this help message."
-  echo " -p  Use pants.pex to do the release instead of PANTS_DEV=1 ./pants."
   echo " -n  Performs a release dry run."
   echo "       All package distributions will be built, installed locally in"
   echo "       an ephemeral virtualenv and exercised to validate basic"
@@ -402,12 +401,9 @@ function usage() {
   fi
 }
 
-use_pex="false"
-
-while getopts "hpntlo" opt; do
+while getopts "hntlo" opt; do
   case ${opt} in
     h) usage ;;
-    p) use_pex="true" ;;
     n) dry_run="true" ;;
     t) test_release="true" ;;
     l) list_packages && exit 0 ;;
@@ -415,10 +411,6 @@ while getopts "hpntlo" opt; do
     *) usage "Invalid option: -${OPTARG}" ;;
   esac
 done
-
-if [[ "${use_pex}" != "true" ]]; then
-  export PANTS_DEV=1
-fi
 
 if [[ "${dry_run}" == "true" && "${test_release}" == "true" ]]; then
   usage "The dry run and test options are mutually exclusive, pick one."

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -12,14 +12,7 @@ REQUIREMENTS=(
 )
 
 function venv_dir() {
-  # You might think PANTS_DEV requirements are the same as regular requirements so we
-  # don't want separate dirs. But we worry that might not play nice with the
-  # pip_extra="--egg" in activate_pants_env
-  if [ ! -z "${PANTS_DEV}" ]; then
-    echo ${REPO_ROOT}/build-support/pants_dev_deps.venv
-  else
-    echo ${REPO_ROOT}/build-support/pants_deps.venv
-  fi
+  echo ${REPO_ROOT}/build-support/pants_dev_deps.venv
 }
 
 function activate_venv() {
@@ -42,16 +35,9 @@ function activate_pants_venv() {
 
   if ! [ -f ${BOOTSTRAPPED_FILE} ]; then
     log "Bootstrapping pants_deps with requirements:"
-    if [ ! -z "${PANTS_DEV}" ]; then
-      # Install as an egg so IDEs can grok all deps. Installing as sources may
-      # run afoul of this bug: http://youtrack.jetbrains.com/issue/PY-6477.
-      # TODO: Remove the --egg once this is resolved. It won't work in the wheel world anyway.
-      # Use -f ${REPO_ROOT}/third_party if patching in local dependencies
-      # pip_extra="--egg -f ${REPO_ROOT}/third_party"
-      pip_extra="--egg"
-    else
-      pip_extra=""
-    fi
+    # Use -f ${REPO_ROOT}/third_party if patching in local dependencies like so
+    # pip_extra="-f ${REPO_ROOT}/third_party"
+    pip_extra=""
 
     for req in ${REQUIREMENTS[@]}; do
       log "  ${req}"

--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -2,8 +2,6 @@
 
 PANTS_BASE=$(dirname $0)/../..
 rm -rf ${HOME}/.pex
-rm -rf ${PANTS_BASE}/build-support/pants_deps.venv
 rm -rf ${PANTS_BASE}/build-support/pants_dev_deps.venv
-rm -f  ${PANTS_BASE}/pants.pex
 rm -rf ${PANTS_BASE}/.pants.d
 find ${PANTS_BASE} -name '*.pyc' | xargs rm -f

--- a/pants
+++ b/pants
@@ -2,13 +2,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# This bootstrap script runs in 2 modes controlled by environment variables.
-#
-# With no special environment variables exported, the script will create a pants.pex from local
-# sources if there is none at the root of the repo and then run that.
-#
-# If PANTS_DEV is exported then this script will instead run pants from the live sources in this
-# repo.
+# This bootstrap script runs pants from the live sources in this repo.
 #
 # If PANTS_PROFILE=results.pstats is exported, then this script will run pants with python profiling
 # enabled. It will create a pstats file named with the value of PANTS_PROFILE that you can analyze.
@@ -58,14 +52,9 @@ if [ ! -z "${PANTS_PROFILE}" ]; then
   export PEX_PROFILE=${PANTS_PROFILE}
 fi
 
-PANTS_BINARY=src/python/pants/bin:pants_local_binary
-PANTS_PEX="${HERE}/pants.pex"
-FAILED_BOOTSTRAP_SENTINEL="${HERE}/.pants.d/BOOTSTRAP_FAILED"
-
 PY=${PY:-$(which python2.7)}
 
 if [[ ! -z "${WRAPPER_REQUIREMENTS}" ]]; then
-  PANTS_DEV=1
   REQUIREMENTS=(
     $(echo ${WRAPPER_REQUIREMENTS} | tr : ' ')
     ${REQUIREMENTS[@]}
@@ -76,7 +65,6 @@ PANTS_SRCPATH=(
   ${HERE}/src/python
 )
 if [[ ! -z "${WRAPPER_SRCPATH}" ]]; then
-  PANTS_DEV=1
   PANTS_SRCPATH=(
     $(echo ${WRAPPER_SRCPATH} | tr : ' ')
     ${PANTS_SRCPATH[@]}
@@ -84,47 +72,16 @@ if [[ ! -z "${WRAPPER_SRCPATH}" ]]; then
 fi
 PANTS_SRCPATH="$(echo ${PANTS_SRCPATH[@]} | tr ' ' :)"
 
-function run_pants_bare() {
-  activate_pants_venv
-  PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" python ${PANTS_EXE} "$@"
-}
-
 function exec_pants_bare() {
   activate_pants_venv
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" exec python ${PANTS_EXE} "$@"
 }
 
-if [ ! -z "${PANTS_DEV}" ]; then
-  log "*** Running pants in dev mode from ${PANTS_EXE} ***"
-  if [[ ! -z "${WRAPPER_REQUIREMENTS}" ]]; then
-    log "***   with extra requirements: ${WRAPPER_REQUIREMENTS} ***"
-  fi
-  if [[ ! -z "${WRAPPER_SRCPATH}" ]]; then
-    log "***   with extra sources ${WRAPPER_SRCPATH} ***"
-  fi
-  exec_pants_bare "$@"
-else
-  if [ ! -e "${PANTS_PEX}" ]; then
-    if [ -f ${FAILED_BOOTSTRAP_SENTINEL} ] ; then
-      log "Last bootstrap failed, cleaning up .pants.d"
-      rm -rf ${HERE}/.pants.d
-    fi
-    log "Building pants.pex to ${PANTS_PEX}..."
-    # TODO(John sirois): Re-plumb build such that it grabs constraints from the built python_binary
-    # target(s).
-    rm -rf ${PANTS_PEX} && \
-    run_pants_bare binary ${PANTS_BINARY} && \
-    mv -v ${HERE}/dist/pants_local_binary.pex ${PANTS_PEX} && \
-    chmod +x ${PANTS_PEX}
-    exit_status=$?
-    if [ $exit_status != 0 ] ; then
-      echo "*** Pants bootstrapping failed."
-      echo "This file is left as a sentinel to record that bootstrapping pants failed." \
-        > ${FAILED_BOOTSTRAP_SENTINEL}
-      exit $exit_status
-    fi
-  fi
-  if [ -e "${PANTS_PEX}" ]; then
-    exec "${PANTS_PEX}" "$@"
-  fi
+if [[ ! -z "${WRAPPER_REQUIREMENTS}" ]]; then
+  log "*** Running pants with extra requirements: ${WRAPPER_REQUIREMENTS} ***"
 fi
+if [[ ! -z "${WRAPPER_SRCPATH}" ]]; then
+  log "*** Running pants with extra sources ${WRAPPER_SRCPATH} ***"
+fi
+
+exec_pants_bare "$@"

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_analysis.py
@@ -28,7 +28,7 @@ class ZincAnalysis(Analysis):
   To run a dev pants against zincutils sources, without having to publish, just add its root dir
   to your PYTHONPATH, e.g.:
 
-  PANTS_DEV=1 PYTHONPATH=/path/to/zincutils/ \
+   PYTHONPATH=/path/to/zincutils/ \
     ./pants test tests/python/pants_test/backend/jvm/tasks/jvm_compile/scala:zinc_analysis
   """
 

--- a/src/python/pants/docs/dev_tasks_publish_extras.md
+++ b/src/python/pants/docs/dev_tasks_publish_extras.md
@@ -71,7 +71,8 @@ unique name. With the above config in your pants.ini, invoke pants like
 this, to do a test publish:
 
     :::bash
-    WRAPPER_SRCPATH=examples/src/python PANTS_DEV=1 ./pants publish examples/src/java/org/pantsbuild/example/hello/greet --no-publish-jar-dryrun --publish-jar-local=~/tmp
+    WRAPPER_SRCPATH=examples/src/python ./pants publish.jar --no-dryrun --local=~/tmp \
+      examples/src/java/org/pantsbuild/example/hello/greet
 
 Now if you examine the `/tmp` directory, you'll notice that an extra jar
 has been published for the `greet` target:

--- a/src/python/pants/docs/howto_develop.md
+++ b/src/python/pants/docs/howto_develop.md
@@ -14,45 +14,11 @@ Running from sources
 As pants is implemented in python it can be run directly from sources.
 
     :::bash
-    $ PANTS_DEV=1 ./pants goals
-    *** running pants in dev mode from ./src/python/pants/bin/pants_exe.py ***
+    $ ./pants goals
     <remainder of output omitted for brevity>
 
 Notice this invocation specifies the `PANTS_DEV` environment variable.
 By defining `PANTS_DEV` pants will be run from sources.
-
-Building a Pants PEX for Testing
---------------------------------
-
-The `./pants` wrapper provides a convenient way to produce a `.pex` file for testing pants on
-your local workstation. If you call it without the `PANTS_DEV=1` environment described above, it
-
-+   Checks the source tree's top directory for a `pants.pex` and runs
-    it if it exists. Otherwise `./pants`...
-+   Builds a new `pants.pex`, moves it to the source tree's top
-    directory, and runs that.
-
-It looks something like
-
-    :::bash
-    $ rm pants.pex
-    $ ./pants my-new-feature
-    Building pants.pex to /Users/zundel/Src/Pants/pants.pex...
-    ...
-    Build operating on top level addresses: set([BuildFileAddress(/Users/pantsdev/Src/pants/src/python/pants/bin/BUILD, pants_local_binary)])
-    Building PythonBinary PythonBinary(BuildFileAddress(/Users/pantsdev/Src/pants/src/python/pants/bin/BUILD, pants_local_binary)):
-    Wrote /Users/pantsdev/Src/pants/dist/pants_local_binary.pex
-    /Users/pantsdev/Src/Pants/dist/pants_local_binary.pex -> /Users/pantsdev/Src/Pants/pants.pex
-    AMAZING NEW FEATURE PRINTS HERE
-    $ ls pants.pex # gets moved here, though originally "Wrote" to ./dist/
-    pants.pex
-    $ ./pants my-new-feature
-    AMAZING NEW FEATURE PRINTS HERE
-
-Using `./pants` to launch Pants thus gives a handy workflow: generate `pants.pex`.
-Go back and forth between trying the generated `pants.pex` and fixing source code as inspired by
-its misbehaviors. When the fixed source code is in a consistent state, remove `pants.pex` so
-that it will get replaced on the next `./pants` run.
 
 Building a Pants PEX for Production
 -----------------------------------

--- a/src/python/pants/docs/intellij.md
+++ b/src/python/pants/docs/intellij.md
@@ -27,7 +27,7 @@ the way you want to run pants when iterating and it also prepares a
 virtual environment suitable for IDEs:
 
     :::bash
-    $ PANTS_DEV=1 ./pants
+    $ ./pants
 
 Next open IntelliJ and select "Create New Project".
 
@@ -44,11 +44,7 @@ SDK".
 ![image](images/intellij-new-pythonsdk.png)
 
 This will be a "local" interpreter and you'll need to select the virtual
-environment bootstrapped above; it's in
-`build-support/pants_dev_deps.venv` (not
-`build-support/pants_deps.venv`). This is **important** because the dev
-virtual environment is designed to have 3rdparty dependencies that IDEs
-can handle.
+environment bootstrapped above; it's in `build-support/pants_dev_deps.venv`.
 
 ![image](images/intellij-select-venv.png)
 

--- a/src/python/pants/docs/release_jvm.md
+++ b/src/python/pants/docs/release_jvm.md
@@ -121,13 +121,13 @@ this, you can test out the publish in 2 ways:
   1. A dry run to get a preview of what will be published and why:
 
         :::bash
-        $ PANTS_DEV=1 ./pants clean-all publish.jar src/{java,scala}::
+        $ ./pants clean-all publish.jar src/{java,scala}::
 
   2. A local publish to get a preview of both what will be published
      and why as well as the changelogs:
 
         :::bash
-        $ PANTS_DEV=1 ./pants clean-all publish.jar --no-dryrun --local=/tmp/m2 src/{java,scala}::
+        $ ./pants clean-all publish.jar --no-dryrun --local=/tmp/m2 src/{java,scala}::
 
      Note that this "dry-run" technique somewhat confusingly passes
      `--no-dryrun` but only because the publish is local and to a
@@ -151,7 +151,7 @@ to use the following command, which will publish everything that's
 changed and only those things that have changed since the last publish:
 
     :::bash
-    $ PANTS_DEV=1 ./pants publish.jar --no-dryrun src/{java,scala}::
+    $ ./pants publish.jar --no-dryrun src/{java,scala}::
 
 ## Promoting to Maven Central ##
 

--- a/src/python/pants/docs/taskdev/taskdev.asc
+++ b/src/python/pants/docs/taskdev/taskdev.asc
@@ -178,7 +178,7 @@ task(name='pagerank', action=PageRank)
 
 In the science repo:
 
-+PANTS_DEV=1 ./pants+
++ ./pants+
 
 image::falcon.gif[falcon!]
 

--- a/tests/java/org/pantsbuild/tools/junit/impl/README
+++ b/tests/java/org/pantsbuild/tools/junit/impl/README
@@ -5,7 +5,7 @@ if they change anything under src/java/org/pantsbuild/junit:
 
 I.) On the dev branch:
 1) Create a self-contained binary
-$ PANTS_DEV=1 ./pants binary src/java/org/pantsbuild/tools/junit:main
+$ ./pants binary src/java/org/pantsbuild/tools/junit:main
 
 2) Edit BUILD.tools to pick up the self-contained binary you created in 1,
 so that the end result looks like (modulo the exact path to the binary jar you created in 1):


### PR DESCRIPTION
When hacking on pants it only makes sense to run pants from live
sources.  Remove the mode that generated a pants.pex and ran from it
since it only led to confusing breaks and offered no benefit whatsoever.

The CI script still builds a local pex to prove pants can bootstrap
itself as a pex binary, but it does that directly anyhow.

https://rbcommons.com/s/twitter/r/2401/