### PR TITLE
Kill custom repos and cross-platform pex setup.

### DIFF
--- a/3rdparty/python/twitter/commons/requirements.txt
+++ b/3rdparty/python/twitter/commons/requirements.txt
@@ -1,9 +1,3 @@
-# To toggle to private releases, un-comment these search override flags and remove version
-# constraints from the requirements below.
-
-#--find-links https://pantsbuild.github.io/cheeseshop/third_party/twitter-commons/0da0aff8fc7cce4d2d3991e36bc13f021ec66133/index.html
-#--no-index
-
 twitter.common.collections>=0.3.1,<0.4
 twitter.common.config>=0.3.1,<0.4
 twitter.common.confluence>=0.3.1,<0.4

--- a/pants.ini
+++ b/pants.ini
@@ -198,6 +198,10 @@ restrict_push_urls: [
 interpreter_requirement: CPython>=2.7,<3
 
 
+[python-repos]
+indexes: ["https://pypi.python.org/simple/"]
+
+
 [sign]
 # Default to debug keystore installed with SDK.
 # You can change this to point to a config.ini holding the definition of your keys.

--- a/pants.ini
+++ b/pants.ini
@@ -198,15 +198,6 @@ restrict_push_urls: [
 interpreter_requirement: CPython>=2.7,<3
 
 
-[python-repos]
-repos: [
-    "https://pantsbuild.github.io/cheeseshop/third_party/python/dist/index.html",
-    "https://pantsbuild.github.io/cheeseshop/third_party/python/index.html"
-  ]
-
-indexes: ["https://pypi.python.org/simple/"]
-
-
 [sign]
 # Default to debug keystore installed with SDK.
 # You can change this to point to a config.ini holding the definition of your keys.

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -33,17 +33,9 @@ python_library(
 # pip installers, ie: it is why this works to get `pants` on your PATH:
 # $ pip install pantsbuild.pants
 # $ pants
-# NB: The platforms below are _only_ used when building a pex from this target.  They are
-# not used in the sdist generation.
 python_binary(
   name = 'pants',
   entry_point = 'pants.bin.pants_exe:main',
-  # TODO(John Sirois): Nuke this - we don't publish pexes so we need not build cross-platform pexes.
-  platforms=[
-    'current',
-    'linux-x86_64',
-    'macosx-10.4-x86_64',
-  ],
   compatibility='CPython>=2.7,<3',
   dependencies = [
     ':bin',

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -36,7 +36,6 @@ python_library(
 python_binary(
   name = 'pants',
   entry_point = 'pants.bin.pants_exe:main',
-  compatibility='CPython>=2.7,<3',
   dependencies = [
     ':bin',
   ],

--- a/src/python/pants/docs/howto_develop.md
+++ b/src/python/pants/docs/howto_develop.md
@@ -113,7 +113,7 @@ To (re-)generate a `pants.pex` you then run these 2 commands:
 1. In your pantsbuild/pants clone, create a local pants release from master:
 
         :::bash
-        $ rm -rf dist && ./build-support/bin/releash.sh -n
+        $ rm -rf dist && ./build-support/bin/release.sh -n
 
 2. In your own repo the following command will create a locally built `pants.pex` for all platforms:
 


### PR DESCRIPTION
We no longer use commons from HEAD so kill the custom
cheeseshop --find-links.

We no longer build cross-platform pexes, so kill vestiges.

Re-work the `Pants Developers Guide` section on `Building a Pants PEX
for Production` to use freshly built sdists from pantsbuild/pants in
combination with locally controlled ini, requirements and BUILD files.

https://rbcommons.com/s/twitter/r/2402/