### PR TITLE
Remove comments that said these classes returned something.

### DIFF
--- a/src/python/pants/backend/core/wrapped_globs.py
+++ b/src/python/pants/backend/core/wrapped_globs.py
@@ -123,8 +123,6 @@ class Globs(FilesetRelPathWrapper):
     strings to exclude.  E.g. ``globs('*',exclude=[globs('*.java'),
     'foo.py'])`` gives all files in this directory except ``.java``
     files and ``foo.py``.
-  :return: FilesetWithSpec containing matching files in same directory as this BUILD file.
-  :rtype: FilesetWithSpec
 
   Deprecated:
   You might see that old code uses "math" on the return value of
@@ -145,8 +143,6 @@ class RGlobs(FilesetRelPathWrapper):
   :param exclude: a list of {,r,z}globs objects, strings, or lists of
     strings to exclude.  E.g. ``rglobs('config/*',exclude=[globs('config/*.java'),
     'config/foo.py'])`` gives all files under config except ``.java`` files and ``config/foo.py``.
-  :return: FilesetWithSpec matching files in this directory and its descendents.
-  :rtype: FilesetWithSpec
 
   Deprecated:
   You might see that old code uses "math" on the return value of ``rglobs()``. E.g.,


### PR DESCRIPTION
These comments were making it into the BUILD dictionary. They refered to
a type that BUILD folks don't officially know about. And they were in a
class' doc, and I couldn't figure out a good way to handle a class'
return value anyhow.