### PR TITLE
[CI] Make sure all Task mixins are on the left.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -35,7 +35,7 @@ _CONFIG_SECTION = 'scrooge-gen'
 _TARGET_TYPE_FOR_LANG = dict(scala=ScalaLibrary, java=JavaLibrary)
 
 
-class ScroogeGen(NailgunTask, JvmToolTaskMixin):
+class ScroogeGen(NailgunTask):
 
   DepInfo = namedtuple('DepInfo', ['service', 'structs'])
 

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -16,7 +16,7 @@ class ThriftLintError(Exception):
   """Raised on a lint failure."""
 
 
-class ThriftLinter(NailgunTask, JvmToolTaskMixin):
+class ThriftLinter(NailgunTask):
   """Print linter warnings for thrift files.
   """
 

--- a/src/python/pants/backend/core/tasks/changed_target_goals.py
+++ b/src/python/pants/backend/core/tasks/changed_target_goals.py
@@ -14,7 +14,7 @@ from pants.backend.core.tasks.what_changed import ChangedFileTaskMixin
 logger = logging.getLogger(__name__)
 
 
-class ChangedTargetTask(NoopExecTask, ChangedFileTaskMixin):
+class ChangedTargetTask(ChangedFileTaskMixin, NoopExecTask):
   """A base class for tasks that find changed targets to act on.
 
   Frequently other tasks already exist that actually do the desired work eg "compile" or "test".

--- a/src/python/pants/backend/core/tasks/console_task.py
+++ b/src/python/pants/backend/core/tasks/console_task.py
@@ -14,7 +14,7 @@ from pants.base.exceptions import TaskError
 from pants.util.dirutil import safe_open
 
 
-class ConsoleTask(Task, QuietTaskMixin):
+class ConsoleTask(QuietTaskMixin, Task):
   """A task whose only job is to print information to the console.
 
   ConsoleTasks are not intended to modify build state.

--- a/src/python/pants/backend/core/tasks/reporting_server.py
+++ b/src/python/pants/backend/core/tasks/reporting_server.py
@@ -18,7 +18,7 @@ from pants.base.build_environment import get_buildroot
 from pants.reporting.reporting_server import ReportingServer, ReportingServerManager
 
 
-class RunServer(Task, QuietTaskMixin):
+class RunServer(QuietTaskMixin, Task):
   """Runs the reporting server."""
 
   @classmethod
@@ -106,7 +106,7 @@ class RunServer(Task, QuietTaskMixin):
     maybe_open(server_port)
 
 
-class KillServer(Task, QuietTaskMixin):
+class KillServer(QuietTaskMixin, Task):
   """Kills the reporting server."""
 
   pidfile_re = re.compile(r'port_(\d+)\.pid')

--- a/src/python/pants/backend/core/tasks/what_changed.py
+++ b/src/python/pants/backend/core/tasks/what_changed.py
@@ -146,7 +146,7 @@ class ChangedFileTaskMixin(object):
                             spec_excludes=spec_excludes)
 
 
-class WhatChanged(ConsoleTask, ChangedFileTaskMixin):
+class WhatChanged(ChangedFileTaskMixin, ConsoleTask):
   """Emits the targets that have been modified since a given commit."""
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -15,7 +15,7 @@ from pants.base.workunit import WorkUnit
 from pants.java.util import execute_java
 
 
-class BenchmarkRun(JvmTask, JvmToolTaskMixin):
+class BenchmarkRun(JvmToolTaskMixin, JvmTask):
   _CALIPER_MAIN = 'com.google.caliper.Runner'
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -711,7 +711,7 @@ class Cobertura(_Coverage):
                         " 'failed to report'".format(main, result))
 
 
-class JUnitRun(JvmTask, JvmToolTaskMixin):
+class JUnitRun(JvmToolTaskMixin, JvmTask):
   _MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -16,7 +16,7 @@ from pants.java.executor import SubprocessExecutor
 from pants.java.nailgun_executor import NailgunExecutor
 
 
-class NailgunTaskBase(TaskBase, JvmToolTaskMixin):
+class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
 
   @staticmethod
   def killall(everywhere=False):

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -12,7 +12,7 @@ from pants.console.stty_utils import preserve_stty_settings
 from pants.java.util import execute_java
 
 
-class ScalaRepl(JvmTask, JvmToolTaskMixin):
+class ScalaRepl(JvmToolTaskMixin, JvmTask):
   @classmethod
   def register_options(cls, register):
     super(ScalaRepl, cls).register_options(register)

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -38,7 +38,7 @@ class FileExcluder(object):
     return True
 
 
-class Scalastyle(NailgunTask, JvmToolTaskMixin):
+class Scalastyle(NailgunTask):
   """Checks scala source files to ensure they're stylish.
 
   Scalastyle only checks scala sources in non-synthetic targets.


### PR DESCRIPTION
Note that tasks that extend NailgunTask cannot have JvmToolTaskMixin on
the left, because NailgunTask is already a JvmToolTaskMixin, and this leads
to a "Cannot create a consistent method resolution order (MRO)" error.
But the solution is simply not to explicitly mix in JvmToolTaskMixin,
and rely on inheriting it from NailgunTask.