### PR TITLE
Fix isort in git hook context.

### DIFF
--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -5,7 +5,8 @@
 source build-support/common.sh
 
 echo "Checking packages" && ./build-support/bin/check_packages.sh || exit 1
-echo "Checking imports" && ./build-support/bin/isort.sh || \
+echo "Checking imports" && GIT_HOOK=1 ./build-support/bin/isort.sh || \
   die "To fix import sort order, run \`build-support/bin/isort.sh -f\`"
 echo "Checking headers" && ./build-support/bin/check_header.sh || exit 1
 echo "Success"
+


### PR DESCRIPTION
The isort pre-commit fails to find nested .isort.cfg files when run via
python subprocess commits during `./pants publish`.  This fix adds an
explicit GIT_HOOK mode that uses an isort git_hook API instead of the
isort script which runs without false negatives both as a normally
executed hook and via more complex python subprocess git call.

https://rbcommons.com/s/twitter/r/2430/