### PR TITLE
[CI] Add a get_rank() method to OptionValueContainer.

### DIFF
--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -58,6 +58,19 @@ class OptionValueContainer(object):
     """
     self._forwardings.update(forwardings)
 
+  def get_rank(self, key):
+    """Returns the rank of the value at the specified key.
+
+    Returns one of the constants in RankedValue.
+    """
+    if key not in self._forwardings:
+      raise AttributeError('No such forwarded attribute: {}'.format(key))
+    val = getattr(self, self._forwardings[key])
+    if isinstance(val, RankedValue):
+      return val.rank
+    else:  # Values without rank are assumed to be flag values set by argparse.
+      return RankedValue.FLAG
+
   def update(self, attrs):
     """Set attr values on this object from the data in the attrs dict."""
     for k, v in attrs.items():

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -43,12 +43,16 @@ class OptionValueContainerTest(unittest.TestCase):
     o.add_forwardings({'foo': 'bar'})
     o.bar = RankedValue(RankedValue.CONFIG, 11)
     self.assertEqual(11, o.foo)
+    self.assertEqual(RankedValue.CONFIG, o.get_rank('foo'))
     o.bar = RankedValue(RankedValue.HARDCODED, 22)
     self.assertEqual(11, o.foo)
+    self.assertEqual(RankedValue.CONFIG, o.get_rank('foo'))
     o.bar = RankedValue(RankedValue.ENVIRONMENT, 33)
     self.assertEqual(33, o.foo)
+    self.assertEqual(RankedValue.ENVIRONMENT, o.get_rank('foo'))
     o.bar = 44  # No explicit rank is assumed to be a FLAG.
     self.assertEqual(44, o.foo)
+    self.assertEqual(RankedValue.FLAG, o.get_rank('foo'))
 
   def test_indexing(self):
     o = OptionValueContainer()


### PR DESCRIPTION
It returns the rank of the value at the specified key.
This will be useful in another change I'm working on that
reworks the option help system.