### PR TITLE
[CI] Reimplement help formatting.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -48,6 +48,7 @@ python_library(
   resources = globs('templates/bash_completion/*.mustache'),
   dependencies = [
     ':console_task',
+    ':task',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/goal',
@@ -62,10 +63,10 @@ python_library(
   dependencies = [
     ':common',
     ':reflect',
+    ':task',
     '3rdparty/python:docutils',
     '3rdparty/python:setuptools',
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/backend/core/tasks:task',
     'src/python/pants/backend/maven_layout',
     'src/python/pants/backend/python:python_requirements',
     'src/python/pants/base:build_environment',
@@ -162,6 +163,7 @@ python_library(
     'src/python/pants/base:build_graph',
     'src/python/pants/base:workunit',
     'src/python/pants/goal',
+    'src/python/pants/option',
   ],
 )
 
@@ -277,7 +279,7 @@ python_library(
   name = 'run_prep_command',
   sources = ['run_prep_command.py'],
   dependencies = [
-    'src/python/pants/backend/core/tasks:task',
+    ':task',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
   ],

--- a/src/python/pants/backend/core/tasks/bash_completion.py
+++ b/src/python/pants/backend/core/tasks/bash_completion.py
@@ -6,122 +6,92 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import re
 from collections import defaultdict
 
 from pkg_resources import resource_string
 
 from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.backend.core.tasks.task import TaskBase
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
 from pants.goal.goal import Goal
 from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.scope import ScopeInfo
 
 
 class BashCompletionTask(ConsoleTask):
   """Generate a Bash shell script that teaches Bash how to autocomplete pants command lines."""
 
-  @staticmethod
-  def expand_option_strings(option_strings):
-    """Expand a list of option string templates into all represented option strings.
+  def get_all_cmd_line_scopes(self):
+    """Return all scopes that may be explicitly specified on the cmd line, in no particular order.
 
-    Optional portions of an option string are marked in brackets. For example, '--[no-]some-bool-option'
-    expands to '--some-bool-option' and '--no-some-bool-option'.
+    Note that this includes only goal and task scopes, and not, say, subsystem scopes,
+    as those aren't specifiable on the cmd line.
     """
-    result = set()
-    for option_string in option_strings:
-      if '[' in option_string:
-        result.add(re.sub(r'\[.*?\]', '', option_string))
-        result.add(option_string.replace('[', '').replace(']', ''))
-      else:
-        result.add(option_string)
-    return result
+    all_scopes = set([''])
+    for goal in Goal.all():
+      for scope_info in goal.known_scope_infos():
+        if scope_info.category in [ScopeInfo.GOAL, ScopeInfo.TASK]:
+          all_scopes.add(scope_info.scope)
+    return all_scopes
 
-  # TODO: This method should use a custom registration function to obtain the options.
-  @staticmethod
-  def option_strings_from_parser(parser):
-    """Return a set of all of the option strings supported by an options parser."""
-    option_strings = set()
-    for action in parser.walk_actions():
-      for option_string in action.option_strings:
-        option_strings.add(option_string)
-    return option_strings
+  def get_autocomplete_options_by_scope(self):
+    """Return all cmd-line options.
 
-  @staticmethod
-  def bash_scope_name(scope):
-    return scope.replace('-', '_').replace('.', '_')
+    These are of two types: scoped and unscoped.  Scoped options are explicitly scoped
+    (e.g., --goal-task-foo-bar) and may appear anywhere on the cmd line. Unscoped options
+    may only appear in the appropriate cmd line scope (e.g., ./pants goal.task --foo-bar).
 
-  @staticmethod
-  def generate_scoped_option_strings(option_strings, scope):
-    escaped_scope = scope.replace('.', '-')
+    Technically, any scoped option can appear anywhere, but in practice, having so many
+    autocomplete options is more confusing than useful. So, as a heuristic:
+     1. In global scope we only autocomplete globally-registered options.
+     2. In a goal scope we only autocomplete options registered by any task in that goal.
+     3/ In a task scope we only autocomplete options registered by that task.
 
-    result = set()
-
-    for option_string in option_strings:
-      if option_string[:2] == '--':
-        if option_string[2:7] == '[no-]':
-          result.add('--{scope}-{arg}'.format(scope=escaped_scope, arg=option_string[7:]))
-          result.add('--no-{scope}-{arg}'.format(scope=escaped_scope, arg=option_string[7:]))
-        else:
-          result.add('--{scope}-{arg}'.format(scope=escaped_scope, arg=option_string[2:]))
-
-    return result
-
-  @staticmethod
-  def parse_all_tasks_and_help(self):
-    """Loads all goals, and mines the options & help text for each one.
-
-    Returns: a set of all_scopes, options_text string, a set of all option strings
+    :return: A map of scope -> options to complete at that scope.
     """
-    options = self.context.options
-
-    goals = Goal.all()
-    all_scopes = set()
-    option_strings_by_scope = defaultdict(set)
-
-    def record(scope, option_strings):
-      option_strings_by_scope[scope] |= self.expand_option_strings(option_strings)
-
-    for goal in goals:
-      for scope in goal.known_scopes():
-        all_scopes.add(scope)
-
-        option_strings_for_scope = set()
-        parser = options.get_parser(scope).get_help_argparser()
-        if parser:
-          option_strings = self.option_strings_from_parser(parser) if parser else set()
-          record(scope, option_strings)
-
-          scoped_option_strings = self.generate_scoped_option_strings(option_strings, scope)
-          record(scope, scoped_option_strings)
-
-          if '.' in scope:
-            outer_scope = scope.partition('.')[0]
-            record(outer_scope, scoped_option_strings)
-
-    # TODO: This does not currently handle subsystem-specific options.
-    global_argparser = options.get_parser(GLOBAL_SCOPE).get_help_argparser()
-    global_option_strings = self.option_strings_from_parser(global_argparser) or []
-    global_option_strings_set = self.expand_option_strings(global_option_strings)
-
-    options_text = '\n'.join([
-      "__pants_options_for_{}='{}'".format(self.bash_scope_name(scope), ' '.join(sorted(list(option_strings))))
-      for scope, option_strings in sorted(option_strings_by_scope.items(), key=lambda x: x[0])
-    ])
-
-    return all_scopes, options_text, global_option_strings_set
+    autocomplete_options_by_scope = defaultdict(set)
+    def get_from_parser(parser):
+      oschi = parser.get_help_info()
+      # We ignore advanced options, as they aren't intended to be used on the cmd line.
+      option_help_infos = oschi.basic + oschi.recursive
+      for ohi in option_help_infos:
+        autocomplete_options_by_scope[oschi.scope].update(ohi.unscoped_cmd_line_args)
+        autocomplete_options_by_scope[oschi.scope].update(ohi.scoped_cmd_line_args)
+        if issubclass(ohi.registering_class, TaskBase):
+          # Note: Recursive options are registered by GlobalOptionsRegisterer, so they won't be
+          # added to the goal scope here. But they are already in the goal scope anyway, because
+          # they recursed through it. So, e.g., in the compile scope we'll autocomplete to
+          # --compile-colors, but not to --compile-java-colors, --compile-scala-colors etc.
+          # This seems like the preferred behavior.
+          goal_scope = oschi.scope.partition('.')[0]
+          autocomplete_options_by_scope[goal_scope].update(ohi.scoped_cmd_line_args)
+    self.context.options.walk_parsers(get_from_parser)
+    return autocomplete_options_by_scope
 
   def console_output(self, targets):
     if targets:
       raise TaskError('This task does not accept any target addresses.')
+    cmd_line_scopes = sorted(self.get_all_cmd_line_scopes())
+    autocomplete_options_by_scope = self.get_autocomplete_options_by_scope()
 
-    (all_scopes, options_text, global_option_strings_set) = self.parse_all_tasks_and_help(self)
+    def bash_scope_key(scope):
+      if scope == GLOBAL_SCOPE:
+        return '__pants_global_options'
+      else:
+        return '__pants_options_for_{}'.format(scope.replace('-', '_').replace('.', '_'))
+
+    options_text_lines = []
+    for scope in cmd_line_scopes:
+      options_text_lines.append("{}='{}'".format(bash_scope_key(scope),
+                                                 ' '.join(autocomplete_options_by_scope[scope])))
+    options_text = '\n'.join(options_text_lines)
 
     generator = Generator(
-      resource_string(__name__, os.path.join('templates', 'bash_completion', 'autocomplete.sh.mustache')),
-      scopes_text=' '.join(sorted(list(all_scopes))),
-      options_text=options_text,
-      global_options=' '.join(sorted(list(global_option_strings_set)))
+      resource_string(__name__,
+                      os.path.join('templates', 'bash_completion', 'autocomplete.sh.mustache')),
+      scopes_text=' '.join(sorted(list(cmd_line_scopes))),
+      options_text=options_text
     )
 
     for line in generator.render().split('\n'):

--- a/src/python/pants/backend/core/tasks/builddictionary.py
+++ b/src/python/pants/backend/core/tasks/builddictionary.py
@@ -100,14 +100,14 @@ class BuildBuildDictionary(Task):
 
   def _gen_options_reference(self):
     """Generate the options reference rst doc."""
-    goals = gen_tasks_options_reference_data()
+    goals = gen_tasks_options_reference_data(self.context.options)
     filtered_goals = []
     omit_impl_regexps = [re.compile(r) for r in self.get_options().omit_impl_re]
     for g in goals:
       if any(r.match(t['impl']) for r in omit_impl_regexps for t in g.tasks):
         continue
       filtered_goals.append(g)
-    glopts = gen_glopts_reference_data()
+    glopts = gen_glopts_reference_data(self.context.options)
 
     # generate the .rst file
     template = resource_string(__name__,

--- a/src/python/pants/backend/core/tasks/group_task.py
+++ b/src/python/pants/backend/core/tasks/group_task.py
@@ -13,6 +13,7 @@ from pants.backend.core.tasks.task import Task, TaskBase
 from pants.base.build_graph import invert_dependencies
 from pants.base.workunit import WorkUnit
 from pants.goal.goal import Goal
+from pants.option.scope import ScopeInfo
 
 
 class GroupMember(TaskBase):
@@ -248,17 +249,17 @@ class GroupTask(Task):
         options_scope = '.'.join(flag_namespace)
 
         @classmethod
-        def known_scopes(cls):
-          """Yields all known scopes for this task (i.e., those of its member types.)"""
+        def known_scope_infos(cls):
+          """Yields ScopeInfos for all known scopes for this task, in no particular order."""
           # We need this because task.py initializes a cache factory for every task type,
           # even if it's never used. This is slightly icky, but is better than forcing tasks
           # to explicitly call a cache setup method. And we want to kill GroupTask anyway.
-          yield cls.options_scope
+          yield ScopeInfo(cls.options_scope, ScopeInfo.TASK)
           for subsystem in cls.task_subsystems():
-            yield subsystem.subscope(cls.options_scope)
+            yield ScopeInfo(subsystem.subscope(cls.options_scope), ScopeInfo.TASK_SUBSYSTEM)
 
           for member_type in cls._member_types():
-            for scope in member_type.known_scopes():
+            for scope in member_type.known_scope_infos():
               yield scope
 
         @classmethod

--- a/src/python/pants/backend/core/tasks/task.py
+++ b/src/python/pants/backend/core/tasks/task.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import itertools
 import os
 import sys
-import threading
 from abc import abstractmethod
 from contextlib import contextmanager
 
@@ -21,6 +20,7 @@ from pants.base.worker_pool import Work
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
 from pants.cache.cache_setup import CacheSetup
 from pants.option.optionable import Optionable
+from pants.option.scope import ScopeInfo
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.util.meta import AbstractClass
 
@@ -94,13 +94,13 @@ class TaskBase(Optionable, AbstractClass):
     return []
 
   @classmethod
-  def known_scopes(cls):
-    """Yields all known scopes for this task, in no particular order."""
+  def known_scope_infos(cls):
+    """Yields ScopeInfo for all known scopes for this task, in no particular order."""
     # The task's own scope.
-    yield cls.options_scope
+    yield ScopeInfo(cls.options_scope, ScopeInfo.TASK)
     # The scopes of any task-specific subsystems it uses.
     for subsystem in cls.task_subsystems():
-      yield subsystem.subscope(cls.options_scope)
+      yield ScopeInfo(subsystem.subscope(cls.options_scope), ScopeInfo.TASK_SUBSYSTEM)
 
   @classmethod
   def supports_passthru_args(cls):

--- a/src/python/pants/backend/core/tasks/templates/bash_completion/autocomplete.sh.mustache
+++ b/src/python/pants/backend/core/tasks/templates/bash_completion/autocomplete.sh.mustache
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 #
 # Pants Autocompletion Support
@@ -10,7 +10,6 @@
 
 __pants_scopes='{{{scopes_text}}}'
 {{{options_text}}}
-__pants_global_options='{{{global_options}}}'
 
 # Pants autocompletion handler.
 __pants_autocomplete() {
@@ -19,12 +18,12 @@ __pants_autocomplete() {
 
   local pants="${COMP_WORDS[0]}"
 
-  # Determine what the user is trying to autocomplete (goal, option, or target).
+  # Determine what the user is trying to autocomplete (scope, option, or target).
 
-  local saw_goal=0
-  local goal_name=''
+  local saw_scope=0
+  local scope_name=''
   local is_option=0
-  local is_goal=0
+  local is_scope=0
 
   local i=1   # Skip index 0 which is the "./pants" command.
   while [[ $i -le $COMP_CWORD ]]; do
@@ -32,16 +31,16 @@ __pants_autocomplete() {
     case "$arg" in
       -*)
         is_option=1
-        is_goal=0
+        is_scope=0
         ;;
       *)
         is_option=0
-        if [[ $saw_goal = 1 ]]; then
-          is_goal=0
+        if [[ $saw_scope = 1 ]]; then
+          is_scope=0
         else
-          is_goal=1
-          saw_goal=1
-          goal_name="$arg"
+          is_scope=1
+          saw_scope=1
+          scope_name="$arg"
         fi
     esac
 
@@ -49,15 +48,18 @@ __pants_autocomplete() {
   done
 
   # Return a response to bash based on the context.
-  if [[ $is_goal = 1 ]]; then
-    # Autocomplete using the goal names.
-    COMPREPLY=($(compgen -W "$__pants_scopes" "${COMP_WORDS[COMP_CWORD]}" ))
+  if [[ $is_scope = 1 ]]; then
+    # Autocomplete using the scope names.
+    # Note: currently this offers the global options (along with scopes) as completions when
+    # nothing has been typed yet, but if you type '-' it refuses to complete that to options.
+    # TODO(tdyas): Fix this.
+    COMPREPLY=($(compgen -W "${__pants_scopes} ${__pants_global_options}" -- "${COMP_WORDS[COMP_CWORD]}" ))
   elif [[ $is_option = 1 ]]; then
-    # Autocomplete using any relevant options for `goal_name` plus the global options.
+    # Autocomplete using any relevant options for `scope_name`.
     local options=''
-    local goal_name_for_var=`echo "${goal_name}" | tr .- __  `
-    eval "options=\"\${__pants_options_for_${goal_name_for_var}}\""
-    COMPREPLY=($(compgen -W "${options} ${__pants_global_options}" -- "${COMP_WORDS[COMP_CWORD]}" ))
+    local scope_name_for_var=`echo "${scope_name}" | tr .- __  `
+    eval "options=\"\${__pants_options_for_${scope_name_for_var}}\""
+    COMPREPLY=($(compgen -W "${options}" -- "${COMP_WORDS[COMP_CWORD]}" ))
   else
     local arg="${COMP_WORDS[COMP_CWORD]}"
     if [[ "$arg" =~ ":" ]]; then

--- a/src/python/pants/backend/core/tasks/templates/bash_completion/autocomplete.sh.mustache
+++ b/src/python/pants/backend/core/tasks/templates/bash_completion/autocomplete.sh.mustache
@@ -49,10 +49,8 @@ __pants_autocomplete() {
 
   # Return a response to bash based on the context.
   if [[ $is_scope = 1 ]]; then
-    # Autocomplete using the scope names.
-    # Note: currently this offers the global options (along with scopes) as completions when
-    # nothing has been typed yet, but if you type '-' it refuses to complete that to options.
-    # TODO(tdyas): Fix this.
+    # Autocomplete using the scope names and global flags.
+    # TODO(tdyas): Fix https://github.com/pantsbuild/pants/issues/1793.
     COMPREPLY=($(compgen -W "${__pants_scopes} ${__pants_global_options}" -- "${COMP_WORDS[COMP_CWORD]}" ))
   elif [[ $is_option = 1 ]]; then
     # Autocomplete using any relevant options for `scope_name`.

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -29,6 +29,7 @@ from pants.logging.setup import setup_logging
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.scope import ScopeInfo
 from pants.reporting.report import Report
 from pants.reporting.reporting import Reporting
 from pants.subsystem.subsystem import Subsystem
@@ -95,19 +96,19 @@ class GoalRunner(object):
     # Now that plugins and backends are loaded, we can gather the known scopes.
     self.targets = []
 
-    known_scopes = ['']
+    known_scope_infos = [ScopeInfo.for_global_scope()]
 
     # Add scopes for all needed subsystems.
     subsystems = (set(self.subsystems) | Goal.subsystems() | build_configuration.subsystems())
     for subsystem in subsystems:
-      known_scopes.append(subsystem.options_scope)
+      known_scope_infos.append(ScopeInfo(subsystem.options_scope, ScopeInfo.GLOBAL_SUBSYSTEM))
 
     # Add scopes for all tasks in all goals.
     for goal in Goal.all():
-      known_scopes.extend(filter(None, goal.known_scopes()))
+      known_scope_infos.extend(filter(None, goal.known_scope_infos()))
 
     # Now that we have the known scopes we can get the full options.
-    self.options = options_bootstrapper.get_full_options(known_scopes=known_scopes)
+    self.options = options_bootstrapper.get_full_options(known_scope_infos)
     self.register_options(subsystems)
 
     # Make the options values available to all subsystems.

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.goal.error import GoalError
+from pants.option.scope import ScopeInfo
 
 
 class Goal(object):
@@ -153,12 +154,13 @@ class _Goal(object):
     else:
       raise GoalError('Cannot uninstall unknown task: {0}'.format(name))
 
-  def known_scopes(self):
-    """Yields all known scopes under this goal in no particular order."""
+  def known_scope_infos(self):
+    """Yields ScopeInfos for all known scopes under this goal."""
+    yield ScopeInfo(self.name, ScopeInfo.GOAL)
     # Yield scopes for tasks in this goal.
     for task_type in self.task_types():
-      for scope in task_type.known_scopes():
-        yield scope
+      for scope_info in task_type.known_scope_infos():
+        yield scope_info
 
   def subsystems(self):
     """Returns all subsystem types used by tasks in this goal, in no particular order."""

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -5,6 +5,7 @@ python_library(
   name='option',
   sources=globs('*.py'),
   dependencies=[
+    '3rdparty/python:ansicolors',
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/option/help_formatter.py
+++ b/src/python/pants/option/help_formatter.py
@@ -1,85 +1,71 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import argparse
+from textwrap import wrap
+
+from colors import blue, cyan, green, red
+
+from pants.option.help_info_extracter import HelpInfoExtracter
 
 
-class PantsHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
-  """A custom argparse help formatter subclass.
+class HelpFormatter(object):
+  def __init__(self, scope, show_advanced, color):
+    self._scope = scope
+    self._show_advanced = show_advanced
+    self._color = color
 
-  Squelches extraneous text, such as usage messages and section headers, because
-  we format those ourselves.  Leaves just the actual flag help.
-  """
+  def _maybe_blue(self, s):
+    return self._maybe_color(blue, s)
 
-  def __init__(self, show_advanced_output, *args, **kwargs):
-    super(PantsHelpFormatter, self).__init__(*args, **kwargs)
-    self._in_advanced_section = False
-    self._pants_scope = None
-    self._show_advanced_output = show_advanced_output
+  def _maybe_cyan(self, s):
+    return self._maybe_color(cyan, s)
 
-  def add_usage(self, usage, actions, groups, prefix=None):
-    pass
+  def _maybe_green(self, s):
+    return self._maybe_color(green, s)
 
-  def add_text(self, text):
-    pass
+  def _maybe_red(self, s):
+    return self._maybe_color(red, s)
 
-  def start_section(self, heading):
-    # The title of the argument group containing advanced features starts with an '*'
-    if heading[:1] == '*':
-      self._in_advanced_section = True
-      self._pants_scope = heading[1:]
-    else:
-      self._pants_scope = heading
+  def _maybe_color(self, color, s):
+    return color(s) if self._color else s
 
-  def end_section(self):
-    self._in_advanced_section = False
+  def format_options(self, header, registration_args):
+    """Return a help message for the specified options.
 
-  def _pants_arg_long_format_helper(self, action):
-    if self._pants_scope:
-      heading = self._pants_scope.replace('.', '-')
-      for option_string in action.option_strings:
-        if option_string[:2] == '--':
-          if option_string[2:7] == '[no-]':
-            invert_flag = '[no-]'
-            option_flag = option_string[7:]
-          else:
-            invert_flag = ''
-            option_flag = option_string[2:]
-
-          arg_name = action.metavar if action.metavar else action.dest
-          arg_value = '' if action.nargs == 0 else '={0}'.format(arg_name)
-
-          return '--{invert_flag}{heading}-{option_flag}{arg_value}\n'.format(
-            invert_flag=invert_flag, heading=heading,
-            option_flag=option_flag, arg_value=arg_value)
-
-  def add_argument(self, action):
-    """Override the stock add_argument() method in HelpFormatter
-
-    Conditionally suppress the advanced options group.
-    Also, add the fully-qualified flag to the help output.
+    :param registration_args: A list of (args, kwargs) pairs, as passed in to options registration.
     """
+    oshi = HelpInfoExtracter(self._scope).get_option_scope_help_info(registration_args)
+    lines = []
+    def add_option(category, ohis):
+      if ohis:
+        lines.append('')
+        lines.append(self._maybe_blue('{}{}{} options:'.format(header,
+                                                               ' ' if category else '',
+                                                               category)))
+        for ohi in ohis:
+          lines.extend(self.format_option(ohi))
+    add_option('', oshi.basic)
+    if self._show_advanced:
+      # We only show recursive options if the user asked for advanced help,
+      # as this is an advanced concept.
+      add_option('recursive', oshi.recursive)
+      add_option('advanced', oshi.advanced)
+    return lines
 
-    if not self._in_advanced_section or self._show_advanced_output:
-      # NB: This uses _add_item() which is a private implementation detail of the
-      # ArgParse.HelpFormatter class.  It is subject to change in future releases of argparse.
-      if self._in_advanced_section:
-        def advanced_prefix_helper():
-          return '(ADVANCED)\n'
-        self._add_item(advanced_prefix_helper, [])
-      self._add_item(self._pants_arg_long_format_helper, [action])
-      super(PantsHelpFormatter, self).add_argument(action)
+  def format_option(self, ohi):
+    lines = []
+    arg_line = '{args} {dflt}'.format(args=self._maybe_cyan(', '.join(ohi.display_args)),
+                                      dflt=self._maybe_green('(default: {})'.format(ohi.default)))
+    lines.append(arg_line)
 
-
-class PantsBasicHelpFormatter(PantsHelpFormatter):
-  def __init__(self, *args, **kwargs):
-    super(PantsBasicHelpFormatter, self).__init__(False, *args, **kwargs)
-
-
-class PantsAdvancedHelpFormatter(PantsHelpFormatter):
-  def __init__(self, *args, **kwargs):
-    super(PantsAdvancedHelpFormatter, self).__init__(True, *args, **kwargs)
+    indent = '    '
+    lines.extend(['{}{}'.format(indent, s) for s in wrap(ohi.help, 76)])
+    if ohi.deprecated_message:
+      lines.append(self._maybe_red('{}{}.'.format(indent, ohi.deprecated_message)))
+      if ohi.deprecated_hint:
+        lines.append(self._maybe_red('{}{}'.format(indent, ohi.deprecated_hint)))
+    return lines

--- a/src/python/pants/option/help_info_extracter.py
+++ b/src/python/pants/option/help_info_extracter.py
@@ -1,0 +1,156 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import namedtuple
+
+from pants.option.custom_types import dict_type, list_type
+from pants.option.option_util import is_boolean_flag
+
+
+class OptionHelpInfo(namedtuple('_OptionHelpInfo',
+    ['registering_class', 'display_args', 'scoped_cmd_line_args', 'unscoped_cmd_line_args',
+     'type', 'default', 'help', 'deprecated_version', 'deprecated_message', 'deprecated_hint'])):
+  """A container for help information for a single option.
+
+  registering_class: The type that registered the option.
+  display args: Arg strings suitable for display in help text, including value examples
+                (e.g., [-f, --[no]-foo-bar, --baz=<metavar>].)
+  scoped_cmd_line_args: The explicitly scoped raw flag names allowed anywhere on the cmd line,
+                        (e.g., [--scope-baz, --no-scope-baz, --scope-qux])
+  unscoped_cmd_line_args: The unscoped raw flag names allowed on the cmd line in this option's
+                          scope context (e.g., [--baz, --no-baz, --qux])
+  type: The type of the option.
+  default: The value of this option if no flags are specified (derived from config and env vars).
+  help: The help message registered for this option.
+  deprecated_version: The version at which this option is to be removed, if any (None otherwise).
+  deprecated_message: A more verbose message explaining the deprecated_version (None otherwise).
+  deprecated_hint: A deprecation hint message registered for this option (None otherwise).
+  """
+  pass
+
+
+class OptionScopeHelpInfo(namedtuple('_OptionScopeHelpInfo',
+                                     ['scope', 'basic', 'recursive', 'advanced'])):
+  """A container for help information for a scope of options.
+
+  scope: The scope of the described options.
+  basic|recursive|advanced: A list of OptionHelpInfo for the options in that group.
+  """
+  pass
+
+
+
+class HelpInfoExtracter(object):
+  """Extracts information useful for displaying help from option registration args."""
+
+  @staticmethod
+  def compute_default(kwargs):
+    """Compute the default value to display in help for an option registered with these kwargs."""
+    ranked_default = kwargs.get('default')
+    default = ranked_default.value if ranked_default else None
+    if default is None:
+      return 'None'
+
+    action = kwargs.get('action')
+    typ = kwargs.get('type', str)
+    if typ == list_type or action == 'append':
+      default_str = '[{}]'.format(','.join(["'{}'".format(s) for s in default]))
+    elif typ == dict_type:
+      default_str = '{{ {} }}'.format(
+        ','.join(["'{}':'{}'".format(k, v) for k, v in default.items()]))
+    else:
+      default_str = str(default)
+    return default_str
+
+  @staticmethod
+  def compute_metavar(kwargs):
+    """Compute the metavar to display in help for an option registered with these kwargs."""
+    action = kwargs.get('action')
+    metavar = kwargs.get('metavar')
+    if not metavar:
+      typ = kwargs.get('type', str)
+      if typ == list_type or action == 'append':
+        metavar = '"[\'str1\',\'str2\',...]"'
+      elif typ == dict_type:
+        metavar = '"{ \'key1\': val1,\'key2\': val2,...}"'
+      else:
+        metavar = '<{}>'.format(typ.__name__)
+    return metavar
+
+  def __init__(self, scope):
+    self._scope = scope
+    self._scope_prefix = scope.replace('.', '-')
+
+  def get_option_scope_help_info(self, registration_args):
+    """Returns an OptionScopeHelpInfo for the options registered with the (args, kwargs) pairs."""
+    basic_options = []
+    recursive_options = []
+    advanced_options = []
+    for args, kwargs in registration_args:
+      ohi = self.get_option_help_info(args, kwargs)
+      if kwargs.get('advanced'):
+        advanced_options.append(ohi)
+      elif kwargs.get('recursive') and not kwargs.get('recursive_root'):
+        recursive_options.append(ohi)
+      else:
+        basic_options.append(ohi)
+
+    return OptionScopeHelpInfo(scope=self._scope,
+                               basic=basic_options,
+                               recursive=recursive_options,
+                               advanced=advanced_options)
+
+  def get_option_help_info(self, args, kwargs):
+    """Returns an OptionHelpInfo for the option registered with the given (args, kwargs)."""
+    display_args = []
+    scoped_cmd_line_args = []
+    unscoped_cmd_line_args = []
+
+    for arg in args:
+      is_short_arg = len(arg) == 2
+      unscoped_cmd_line_args.append(arg)
+      if self._scope_prefix:
+        scoped_arg = '--{}-{}'.format(self._scope_prefix, arg.lstrip('-'))
+      else:
+        scoped_arg = arg
+      scoped_cmd_line_args.append(scoped_arg)
+
+      if is_boolean_flag(kwargs):
+        if is_short_arg:
+          display_arg = scoped_arg
+        else:
+          unscoped_cmd_line_args.append('--no-{}'.format(arg[2:]))
+          scoped_cmd_line_args.append('--no-{}'.format(scoped_arg[2:]))
+          display_arg = '--[no-]{}'.format(scoped_arg[2:])
+      else:
+        display_arg = '{}={}'.format(scoped_arg, self.compute_metavar(kwargs))
+        if kwargs.get('action') == 'append':
+          display_arg = '{arg_str} ({arg_str}) ...'.format(arg_str=display_arg)
+      display_args.append(display_arg)
+
+    if is_boolean_flag(kwargs):
+      typ = bool
+    else:
+      typ = kwargs.get('type', str)
+    default = self.compute_default(kwargs)
+    help_msg = kwargs.get('help', 'No help available.')
+    deprecated_version = kwargs.get('deprecated_version')
+    deprecated_message = ('DEPRECATED. Will be removed in version {}.'.format(deprecated_version)
+                          if deprecated_version else None)
+    deprecated_hint = kwargs.get('deprecated_hint')
+
+    ret = OptionHelpInfo(registering_class=kwargs.get('registering_class', type(None)),
+                         display_args=display_args,
+                         scoped_cmd_line_args=scoped_cmd_line_args,
+                         unscoped_cmd_line_args=unscoped_cmd_line_args,
+                         type=typ,
+                         default=default,
+                         help=help_msg,
+                         deprecated_version=deprecated_version,
+                         deprecated_message=deprecated_message,
+                         deprecated_hint=deprecated_hint)
+    return ret

--- a/src/python/pants/option/option_util.py
+++ b/src/python/pants/option/option_util.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+
+def is_boolean_flag(kwargs):
+  return kwargs.get('action') in ('store_false', 'store_true')

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -29,7 +29,7 @@ class Optionable(AbstractClass):
 
     Subclasses should not generally need to override this method.
     """
-    cls.register_options(options.registration_function_for_scope(cls.options_scope))
+    cls.register_options(options.registration_function_for_optionable(cls))
 
   def __init__(self):
     # Check that the instance's class defines options_scope.

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -105,7 +105,7 @@ class Parser(object):
     # The keys are external dest names (the ones seen by the user, not by argparse).
     self._deprecated_option_dests = {}
 
-  # A Parser instance, or None for the global scope parser.
+    # A Parser instance, or None for the global scope parser.
     self._parent_parser = parent_parser
 
     # List of Parser instances.

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -16,14 +16,19 @@ class ParserHierarchy(object):
   enclosed in the compile scope, which is enclosed in the global scope (represented by an
   empty string.)
   """
-  def __init__(self, env, config, all_scopes, help_request):
+  def __init__(self, env, config, scope_infos):
     # Sorting ensures that ancestors precede descendants.
-    all_scopes = sorted(set(list(all_scopes) + [GLOBAL_SCOPE]))
+    scope_infos = sorted(set(list(scope_infos)), key=lambda si: si.scope)
     self._parser_by_scope = {}
-    for scope in all_scopes:
+    for scope_info in scope_infos:
+      scope = scope_info.scope
       parent_parser = (None if scope == GLOBAL_SCOPE else
                        self._parser_by_scope[scope.rpartition('.')[0]])
-      self._parser_by_scope[scope] = Parser(env, config, scope, help_request, parent_parser)
+      self._parser_by_scope[scope] = Parser(env, config, scope_info, parent_parser)
 
   def get_parser_by_scope(self, scope):
     return self._parser_by_scope[scope]
+
+  def walk(self, callback):
+    """Invoke callback on each parser, in depth-first order."""
+    self._parser_by_scope[GLOBAL_SCOPE].walk(callback)

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -30,5 +30,5 @@ class ParserHierarchy(object):
     return self._parser_by_scope[scope]
 
   def walk(self, callback):
-    """Invoke callback on each parser, in depth-first order."""
+    """Invoke callback on each parser, in pre-order depth-first order."""
     self._parser_by_scope[GLOBAL_SCOPE].walk(callback)

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import namedtuple
+
+
+class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category'])):
+  """Information about a scope."""
+
+  # Symbolic constants for different categories of scope.
+  GLOBAL = 'GLOBAL'
+  GOAL = 'GOAL'
+  TASK = 'TASK'
+  GLOBAL_SUBSYSTEM = 'GLOBAL_SUBSYSTEM'
+  TASK_SUBSYSTEM = 'TASK_SUBSYSTEM'
+  INTERMEDIATE = 'INTERMEDIATE'
+
+
+  @classmethod
+  def for_global_scope(cls):
+    return cls('', cls.GLOBAL)

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -17,7 +17,7 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category'])):
   TASK = 'TASK'
   GLOBAL_SUBSYSTEM = 'GLOBAL_SUBSYSTEM'
   TASK_SUBSYSTEM = 'TASK_SUBSYSTEM'
-  INTERMEDIATE = 'INTERMEDIATE'
+  INTERMEDIATE = 'INTERMEDIATE'  # Scoped added automatically to fill out the scope hierarchy.
 
 
   @classmethod

--- a/tests/python/pants_test/backend/core/tasks/test_bash_completion.py
+++ b/tests/python/pants_test/backend/core/tasks/test_bash_completion.py
@@ -10,9 +10,9 @@ from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
 class MockedBashCompletionTask(BashCompletionTask):
-  """A version of the BashCompletionTask, with the goal/help parsing mocked out."""
-  def parse_all_tasks_and_help(self, _):
-    return set(), '', set()
+  """A version of the BashCompletionTask, with the help introspection mocked out."""
+  def get_autocomplete_options_by_scope(self):
+    return {'': []}
 
 
 class BashCompletionTest(ConsoleTaskTestBase):

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -207,7 +207,7 @@ class BaseTest(unittest.TestCase):
     # Make inner scopes inherit option values from their enclosing scopes.
     all_scopes = set(option_values.keys())
     for task_type in for_task_types:  # Make sure we know about pre-task subsystem scopes.
-      all_scopes.update(task_type.known_scopes())
+      all_scopes.update([si.scope for si in task_type.known_scope_infos()])
     # Iterating in sorted order guarantees that we see outer scopes before inner scopes,
     # and therefore only have to inherit from our immediately enclosing scope.
     for scope in sorted(all_scopes):

--- a/tests/python/pants_test/option/test_help_info_extracter.py
+++ b/tests/python/pants_test/option/test_help_info_extracter.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.option.custom_types import dict_type, list_type
+from pants.option.help_info_extracter import HelpInfoExtracter
+
+
+class HelpInfoExtracterTest(unittest.TestCase):
+  def test_args(self):
+    def do_test(args, kwargs, expected_display_args,
+                expected_scoped_cmd_line_args, expected_unscoped_cmd_line_args=None):
+      if expected_unscoped_cmd_line_args is None:  # We assume global scope in this case.
+        expected_unscoped_cmd_line_args = expected_scoped_cmd_line_args
+
+      ohi = HelpInfoExtracter('').get_option_help_info(args, kwargs)
+      self.assertListEqual(ohi.display_args, expected_display_args)
+      self.assertListEqual(ohi.scoped_cmd_line_args, expected_scoped_cmd_line_args)
+      self.assertListEqual(ohi.unscoped_cmd_line_args, expected_unscoped_cmd_line_args)
+
+    do_test(['-f'], {'action': 'store_true'}, ['-f'], ['-f'])
+    do_test(['--foo'], {'action': 'store_true'}, ['--[no-]foo'], ['--foo', '--no-foo'])
+    do_test(['--foo'], {'action': 'store_false'}, ['--[no-]foo'], ['--foo', '--no-foo'])
+    do_test(['-f', '--foo'], {'action': 'store_true'}, ['-f', '--[no-]foo'],
+                                                       ['-f', '--foo', '--no-foo'])
+
+    do_test(['--foo'], {}, ['--foo=<str>'], ['--foo'])
+    do_test(['--foo'], {'metavar': 'xx'}, ['--foo=xx'], ['--foo'])
+    do_test(['--foo'], {'type': int}, ['--foo=<int>'], ['--foo'])
+    do_test(['--foo'], {'type': list_type}, ['--foo="[\'str1\',\'str2\',...]"'], ['--foo'])
+    do_test(['--foo'], {'type': dict_type}, ['--foo="{ \'key1\': val1,\'key2\': val2,...}"'],
+                                            ['--foo'])
+    do_test(['--foo'], {'action': 'append'},
+            ['--foo="[\'str1\',\'str2\',...]" (--foo="[\'str1\',\'str2\',...]") ...'], ['--foo'])
+
+    do_test(['--foo', '--bar'], {}, ['--foo=<str>', '--bar=<str>'], ['--foo', '--bar'])
+
+  def test_deprecated(self):
+    kwargs = {'deprecated_version': '999.99.9', 'deprecated_hint': 'do not use this'}
+    ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
+    self.assertEquals('999.99.9', ohi.deprecated_version)
+    self.assertEquals('do not use this', ohi.deprecated_hint)
+    self.assertIsNotNone(ohi.deprecated_message)
+
+  def test_grouping(self):
+    def do_test(kwargs, expected_basic=False, expected_recursive=False, expected_advanced=False):
+      def exp_to_len(exp):
+        return int(exp)  # True -> 1, False -> 0.
+
+      oshi = HelpInfoExtracter('').get_option_scope_help_info([([], kwargs)])
+      self.assertEquals(exp_to_len(expected_basic), len(oshi.basic))
+      self.assertEquals(exp_to_len(expected_recursive), len(oshi.recursive))
+      self.assertEquals(exp_to_len(expected_advanced), len(oshi.advanced))
+
+    do_test({}, expected_basic=True)
+    do_test({'advanced': False}, expected_basic=True)
+    do_test({'advanced': True}, expected_advanced=True)
+    do_test({'recursive': True}, expected_recursive=True)
+    do_test({'recursive': True, 'recursive_root': True}, expected_basic=True)
+    do_test({'advanced': True, 'recursive': True}, expected_advanced=True)
+    do_test({'advanced': True, 'recursive': True, 'recursive_root': True}, expected_advanced=True)

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.scope import ScopeInfo
 from pants.util.contextutil import temporary_file
 
 
@@ -110,7 +111,11 @@ class BootstrapOptionsTest(unittest.TestCase):
                                          },
                                          configpath=fp.name,
                                          args=['--pants-workdir=/qux'])
-      opts = bootstrapper.get_full_options(known_scopes=['', 'foo', 'fruit'])
+      opts = bootstrapper.get_full_options(known_scope_infos=[
+        ScopeInfo('', ScopeInfo.GLOBAL),
+        ScopeInfo('foo', ScopeInfo.TASK),
+        ScopeInfo('fruit', ScopeInfo.TASK)
+      ])
       opts.register('', '--pants-workdir')  # So we don't choke on it on the cmd line.
       opts.register('foo', '--bar')
       opts.register('fruit', '--apple')

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -163,8 +163,6 @@ python_tests(
     'src/python/pants/backend/core/tasks:reflect',
     'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/python:plugin',
-    'src/python/pants/goal',
-    'src/python/pants/goal:task_registrar',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/tasks/test_builddict.py
+++ b/tests/python/pants_test/tasks/test_builddict.py
@@ -5,38 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from contextlib import closing
-from StringIO import StringIO
-
 from pants.backend.core.register import build_file_aliases as register_core
 from pants.backend.core.tasks import builddictionary, reflect
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.python.register import build_file_aliases as register_python
 from pants_test.base_test import BaseTest
-from pants_test.tasks.task_test_base import TaskTestBase
-
-
-OUTDIR = '/tmp/dist'
-
-class BaseBuildBuildDictionaryTest(TaskTestBase):
-  @classmethod
-  def task_type(cls):
-    return builddictionary.BuildBuildDictionary
-
-  def execute_task(self):
-    self.set_options(pants_distdir=OUTDIR)
-    with closing(StringIO()) as output:
-      task = self.create_task(self.context())
-      task.execute()
-      return output.getvalue()
-
-
-class BuildBuildDictionaryTestEmpty(BaseBuildBuildDictionaryTest):
-  def test_builddict_empty(self):
-    """Execution should be silent."""
-    # We don't care _that_ much that execution be silent. Nice if at least
-    # one test executes the task and doesn't explode, tho.
-    self.assertEqual('', self.execute_task())
 
 
 class ExtractedContentSanityTests(BaseTest):

--- a/tests/python/pants_test/tasks/test_reflect.py
+++ b/tests/python/pants_test/tasks/test_reflect.py
@@ -7,16 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.core.register import build_file_aliases as register_core
 from pants.backend.core.tasks import reflect
-from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.python.register import build_file_aliases as register_python
-from pants.goal.goal import Goal
-from pants.goal.task_registrar import TaskRegistrar
 from pants_test.base_test import BaseTest
-
-
-class DummyTask(Task):
-  def execute(self): return 42
 
 
 class BuildsymsSanityTests(BaseTest):
@@ -39,12 +32,3 @@ class BuildsymsSanityTests(BaseTest):
     self.assertIn('java_library', jl_text)
     self.assertIn('dependencies', jl_text)
     self.assertIn('sources', jl_text)
-
-
-class GoalDataTest(BaseTest):
-  def test_gen_tasks_options_reference_data(self):
-    # Can we run our reflection-y goal code without crashing? would be nice.
-    Goal.by_name('jack').install(TaskRegistrar('jill', DummyTask))
-    oref_data = reflect.gen_tasks_options_reference_data()
-    self.assertTrue(len(oref_data) > 0,
-                    'Tried to generate data for options reference, got emptiness')


### PR DESCRIPTION
- Using the argparse help formatter was no longer viable: we had
  to customize it in so many ways it was easier to simply implement
  our own.

- This makes a lot of options code quite a lot simpler, so I took
  the opportunity of this refactoring to simplify even further.
  For example, we no longer have separate paths for registering
  boolean and non-boolean options.