### PR TITLE
Added cwd argument to allow JavaTest targets to require particular working directories.

### DIFF
--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -11,9 +11,13 @@ from pants.backend.jvm.targets.jvm_target import JvmTarget
 class JavaTests(JvmTarget):
   """Tests JVM sources with JUnit."""
 
-  def __init__(self, **kwargs):
-
+  def __init__(self, cwd=None, **kwargs):
+    """
+    :param str cwd: working directory (relative to the build root) for the tests under this
+      target. If unspecified (None), the working directory will be controlled by junit_run's --cwd.
+    """
     super(JavaTests, self).__init__(**kwargs)
+    self.cwd = cwd
 
     # TODO(John Sirois): These could be scala, clojure, etc.  'jvm' and 'tests' are the only truly
     # applicable labels - fixup the 'java' misnomer.

--- a/testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+junit_tests(name='onedir',
+  sources=globs('*.java'),
+  dependencies=[
+    '3rdparty:junit',
+  ],
+  cwd='testprojects/tests/java/org/pantsbuild/testproject/workdirs/twodir',
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir/WorkdirTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir/WorkdirTest.java
@@ -1,0 +1,22 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.workdirs.onedir;
+
+import org.junit.Test;
+import java.io.File;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Ensure cwd works correctly.
+ *
+ * This test depends on the contents of org/pantsbuild/testproject/workdirs/twodir.
+ * */
+public class WorkdirTest {
+    @Test
+    public void testPlaceholderExists() {
+        assertTrue("Could not find placeholder.txt, working directory must be wrong!",
+                   new File("placeholder.txt").exists());
+    }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/workdirs/twodir/placeholder.txt
+++ b/testprojects/tests/java/org/pantsbuild/testproject/workdirs/twodir/placeholder.txt
@@ -1,0 +1,4 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+Placeholder file used in ../onedir/WorkdirTest.java.

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -192,3 +192,10 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         'testprojects/tests/java/org/pantsbuild/testproject/dummies:passing_target'])
     self.assertIn('Hello from test1!', pants_run.stdout_data)
     self.assertIn('Hello from test2!', pants_run.stdout_data)
+
+  def test_junit_test_target_cwd(self):
+    pants_run = self.run_pants([
+      'test',
+      'testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir',
+    ])
+    self.assert_success(pants_run)


### PR DESCRIPTION
Square has tests that break if they don't run in specific directories, so the previous
strategy of picking the first target's spec_path as the cwd did not work for us in all
cases.

Testing Done:
  Added a test under testprojects/ to test cwd behavior.