### PR TITLE
Improved error messaging for unknown Target kwargs.

### DIFF
--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -119,7 +119,9 @@ class Target(AbstractTarget):
 
   class WrongNumberOfAddresses(Exception):
     """Internal error, too many elements in Addresses"""
-    pass
+
+  class UnknownArguments(TargetDefinitionException):
+    """Unknown keyword arguments supplied to Target."""
 
   LANG_DISCRIMINATORS = {
     'java':   lambda t: t.is_jvm,
@@ -176,7 +178,8 @@ class Target(AbstractTarget):
     ids = list(ids)  # We can't len a generator.
     return ids[0] if len(ids) == 1 else cls.combine_ids(ids)
 
-  def __init__(self, name, address, build_graph, payload=None, tags=None, description=None):
+  def __init__(self, name, address, build_graph, payload=None, tags=None, description=None,
+               **kwargs):
     """
     :param string name: The name of this target, which combined with this
       build file defines the target address.
@@ -204,6 +207,13 @@ class Target(AbstractTarget):
 
     self._cached_fingerprint_map = {}
     self._cached_transitive_fingerprint_map = {}
+
+    if kwargs:
+      error_message = '{target_type} received unknown arguments: {args}'
+      raise self.UnknownArguments(address.spec, error_message.format(
+        target_type=type(self).__name__,
+        args=''.join('\n  {} = {}'.format(key, value) for key, value in kwargs.items())
+      ))
 
   @property
   def tags(self):

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -84,3 +84,19 @@ class TargetTest(BaseTest):
                                        deferred_sources_address=SyntheticAddress.parse('//:foo'))
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':foo'], list(target.traversable_dependency_specs))
+
+  def test_illegal_kwargs(self):
+    with self.assertRaises(Target.UnknownArguments) as cm:
+      context = self.context()
+      build_file = self.add_to_build_file('foo/BUILD', dedent('''
+      java_library(
+        name='bar',
+        sources=[],
+        foobar='barfoo',
+      )
+      '''))
+      address = BuildFileAddress(build_file, 'bar')
+      context.build_graph.inject_address_closure(address)
+      context.build_graph.get_target(address)
+    self.assertTrue('foobar = barfoo' in str(cm.exception))
+    self.assertTrue('foo:bar' in str(cm.exception))


### PR DESCRIPTION
Instead of crashing with an unhelpful exception message about
`__init__` receiving unexpected kwargs, print out what the kwargs
were (keys and values), and what the target type and address were.