### PR TITLE
Fixup BuildFile must_exist logic.

### DIFF
--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -33,7 +33,6 @@ target(
     ':address',
     ':build_configuration',
     ':build_environment',
-    ':build_file',
     ':build_file_address_mapper',
     ':build_file_aliases',
     ':build_file_parser',
@@ -44,6 +43,7 @@ target(
     ':config',
     ':deprecated',
     ':extension_loader',
+    ':filesystem_build_file',
     ':fingerprint_strategy',
     ':generator',
     ':hash_utils',
@@ -99,14 +99,13 @@ python_library(
   name = 'build_file_test_base',
   sources = ['build_file_test_base.py'],
   dependencies = [
-    'src/python/pants/base:build_file',
     'src/python/pants/util:dirutil',
   ]
 )
 
 python_tests(
-  name = 'build_file',
-  sources = ['test_build_file.py'],
+  name = 'filesystem_build_file',
+  sources = ['test_filesystem_build_file.py'],
   dependencies = [
     ':build_file_test_base',
     '3rdparty/python/twitter/commons:twitter.common.collections',

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -10,7 +10,6 @@ import shutil
 import tempfile
 import unittest
 
-from pants.base.build_file import FilesystemBuildFile
 from pants.util.dirutil import safe_mkdir, touch
 
 
@@ -23,9 +22,6 @@ class BuildFileTestBase(unittest.TestCase):
 
   def touch(self, path):
     touch(self.fullpath(path))
-
-  def create_buildfile(self, path):
-    return FilesystemBuildFile(self.root_dir, path)
 
   def setUp(self):
     self.base_dir = tempfile.mkdtemp()
@@ -50,6 +46,12 @@ class BuildFileTestBase(unittest.TestCase):
     self.touch('grandparent/parent/child5/BUILD')
     self.makedirs('path-that-does-exist')
     self.touch('path-that-does-exist/BUILD.invalid.suffix')
+
+    # This exercises https://github.com/pantsbuild/pants/issues/1742
+    # Prior to that fix, BUILD directories were handled, but not if there was a valid BUILD file
+    # sibling.
+    self.makedirs('issue_1742/BUILD')
+    self.touch('issue_1742/BUILD.sibling')
 
   def tearDown(self):
     shutil.rmtree(self.base_dir)

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -15,10 +15,13 @@ from pants.util.dirutil import safe_open
 from pants_test.base.build_file_test_base import BuildFileTestBase
 
 
-class BuildFileTest(BuildFileTestBase):
+class FilesystemBuildFileTest(BuildFileTestBase):
   def setUp(self):
-    super(BuildFileTest, self).setUp()
+    super(FilesystemBuildFileTest, self).setUp()
     self.buildfile = self.create_buildfile('grandparent/parent/BUILD')
+
+  def create_buildfile(self, path):
+    return FilesystemBuildFile(self.root_dir, path)
 
   def testSiblings(self):
     buildfile = self.create_buildfile('grandparent/parent/BUILD.twitter')
@@ -146,6 +149,7 @@ class BuildFileTest(BuildFileTestBase):
                        self.create_buildfile('grandparent/parent/BUILD'),
                        self.create_buildfile('grandparent/parent/BUILD.twitter'),
                        self.create_buildfile('grandparent/parent/child5/BUILD'),
+                       self.create_buildfile('issue_1742/BUILD.sibling'),
                        ],
                       buildfiles)
 
@@ -161,8 +165,13 @@ class BuildFileTest(BuildFileTestBase):
                        self.create_buildfile('grandparent/parent/BUILD'),
                        self.create_buildfile('grandparent/parent/BUILD.twitter'),
                        self.create_buildfile('grandparent/parent/child5/BUILD'),
+                       self.create_buildfile('issue_1742/BUILD.sibling'),
                        ],
                       buildfiles)
+
+  def test_dir_is_primary(self):
+    buildfile = self.create_buildfile('issue_1742')
+    self.assertEqual([self.create_buildfile('issue_1742/BUILD.sibling')], list(buildfile.family()))
 
   def test_invalid_root_dir_error(self):
     self.touch('BUILD')


### PR DESCRIPTION
Relax the BuildFile.must_exist logic to ensure a logical BUILD file
exists.  Previously the logic required the primary canonical BUILD file
(no extension) to be a valid BUILD file and not a directory if a valid
sibling BUILD file existed.

This change adds a failing test that is then fixed.
Along the way, centralize BUILD file `._isfile` testing in
`_get_all_build_files`.

https://rbcommons.com/s/twitter/r/2441/