### PR TITLE
Add an option --main to the run.jvm task to override the specificatio…

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -39,6 +39,8 @@ class JvmRun(JvmTask):
     # No explicit --cwd at all (defaults to the value of 'default')
     register('--cwd', default=_CWD_NOT_PRESENT, nargs='?',
              help='Set the working directory. If no argument is passed, use the target path.')
+    register('--main', metavar='<main class>',
+             help='Invoke this class (overrides "main"" attribute in jvm_binary targets)')
 
   @classmethod
   def supports_passthru_args(cls):
@@ -94,7 +96,7 @@ class JvmRun(JvmTask):
       self.context.release_lock()
       result = execute_java(
         classpath=(self.classpath([target])),
-        main=binary.main,
+        main=self.get_options().main or binary.main,
         executor=executor,
         jvm_options=self.jvm_options,
         args=self.args,

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -13,6 +13,7 @@ target(
     ':ivy_resolve',
     ':ivy_utils',
     ':junit_run',
+    ':jvm_run',
     ':resources_task',
     ':prepare_resources',
     ':prepare_services',
@@ -140,6 +141,17 @@ python_tests(
     'src/python/pants/java/distribution:distribution',
     'src/python/pants/java:executor',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+  ]
+)
+
+python_tests(
+  name = 'jvm_run',
+  sources = ['test_jvm_run.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/backend/jvm/tasks:jvm_run',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/tasks:task_test_base',
   ]
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from contextlib import contextmanager
 
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jvm_run import JvmRun
@@ -20,16 +21,19 @@ class JvmRunTest(TaskTestBase):
 
   def setUp(self):
     super(JvmRunTest, self).setUp()
-    self.set_options(only_write_cmd_line='a')
 
-  def test_cmdline_only(self):
+  @contextmanager
+  def setup_cmdline_run(self, **options):
+    """Run the JvmRun task in command line only mode  with the specified extra options.
+    :returns: the command line string
+    """
+    self.set_options(only_write_cmd_line='a', **options)
     jvm_binary = self.make_target('src/java/org/pantsbuild:binary', JvmBinary,
                                   main='org.pantsbuild.Binary')
     context = self.context(target_roots=[jvm_binary])
     jvm_run =  self.create_task(context, 'unused')
-    classpath = [os.path.join(self.build_root, c) for c in ['bob', 'fred']]
-    self.populate_compile_classpath(context=jvm_run.context, classpath=classpath)
-
+    self._cmdline_classpath = [os.path.join(self.build_root, c) for c in ['bob', 'fred']]
+    self.populate_compile_classpath(context=jvm_run.context, classpath=self._cmdline_classpath)
     with temporary_dir() as pwd:
       with pushd(pwd):
         cmdline_file = os.path.join(pwd, 'a')
@@ -38,6 +42,16 @@ class JvmRunTest(TaskTestBase):
         self.assertTrue(os.path.exists(cmdline_file))
         with open(cmdline_file) as fp:
           contents = fp.read()
-          expected_suffix = 'java -cp {} org.pantsbuild.Binary'.format(
-            os.path.pathsep.join(classpath))
-          self.assertEquals(expected_suffix, contents[-len(expected_suffix):])
+          yield contents
+
+  def test_cmdline_only(self):
+    with self.setup_cmdline_run() as cmdline:
+      expected_suffix = 'java -cp {} org.pantsbuild.Binary'.format(
+        os.path.pathsep.join(self._cmdline_classpath))
+      self.assertEquals(expected_suffix, cmdline[-len(expected_suffix):])
+
+  def test_opt_main(self):
+    with self.setup_cmdline_run(main='org.pantsbuild.OptMain') as cmdline:
+      expected_suffix = 'java -cp {} org.pantsbuild.OptMain'.format(
+        os.path.pathsep.join(self._cmdline_classpath))
+      self.assertEquals(expected_suffix, cmdline[-len(expected_suffix):])

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -33,7 +33,6 @@ target(
     ':jar_create',
     ':jar_publish',
     ':jar_task',
-    ':jvm_run',
     ':jvm_task',
     ':jvmdoc_gen',
     ':list_goals',
@@ -499,17 +498,6 @@ python_tests(
     'src/python/pants/base:target',
     'src/python/pants/engine:engine',
     'tests/python/pants_test:base_test',
-  ]
-)
-
-python_tests(
-  name = 'jvm_run',
-  sources = ['test_jvm_run.py'],
-  dependencies = [
-    ':task_test_base',
-    'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/tasks:jvm_run',
-    'src/python/pants/util:contextutil',
   ]
 )
 


### PR DESCRIPTION
…n of 'main' on a jvm_binary() target