### PR TITLE
[CI] Some refactoring of global options.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -255,6 +255,7 @@ python_library(
   dependencies = [
     '3rdparty/python:docutils',
     '3rdparty/python:six',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:build_manual',
     'src/python/pants/base:generator',
     'src/python/pants/base:target',

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -26,7 +26,7 @@ from pants.goal.context import Context
 from pants.goal.goal import Goal
 from pants.goal.run_tracker import RunTracker
 from pants.logging.setup import setup_logging
-from pants.option.global_options import register_global_options
+from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.report import Report
@@ -160,7 +160,7 @@ class GoalRunner(object):
 
   def register_options(self, subsystems):
     # Standalone global options.
-    register_global_options(self.options.registration_function_for_global_scope())
+    GlobalOptionsRegistrar.register_options_on_scope(self.options)
 
     # Options for subsystems.
     for subsystem in subsystems:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -5,69 +5,128 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
+import os
+
+from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
+from pants.option.optionable import Optionable
 from pants.option.options import Options
 
 
-def register_global_options(register):
-  """Register options not tied to any particular task.
+class GlobalOptionsRegistrar(Optionable):
+  options_scope = Options.GLOBAL_SCOPE
 
-  It's important to note that another set of global options is registered in
-  `pants.option.options_bootstrapper:register_bootstrap_options`, but those are reserved for options
-  that other options or tasks may need to build upon directly or indirectly.  For a direct-use
-  example, a doc generation task may want to provide an option for its user-visible output location
-  that defaults to `${pants-distdir}/docs` and thus needs to interpolate the bootstrap option of
-  `pants-distdir`.  An indirect example would be logging options that are needed by pants itself to
-  setup logging prior to loading plugins so that plugin registration can log confidently to a
-  configured logging subsystem.
+  @classmethod
+  def register_bootstrap_options(cls, register):
+    """Register bootstrap options.
 
-  Global options here on the other hand are reserved for infrastructure objects (not tasks) that
-  have leaf configuration data.
-  """
-  register('-t', '--timeout', type=int, metavar='<seconds>',
-           help='Number of seconds to wait for http connections.')
-  register('-x', '--time', action='store_true',
-           help='Times tasks and goals and outputs a report.')
-  register('-e', '--explain', action='store_true',
-           help='Explain the execution of goals.')
+    "Bootstrap options" are a small set of options whose values are useful when registering other
+    options. Therefore we must bootstrap them early, before other options are registered, let
+    alone parsed.
 
-  # TODO: After moving to the new options system these abstraction leaks can go away.
-  register('-k', '--kill-nailguns', action='store_true',
-           help='Kill nailguns before exiting')
-  register('-i', '--interpreter', default=[], action='append', metavar='<requirement>',
-           help="Constrain what Python interpreters to use.  Uses Requirement format from "
-                "pkg_resources, e.g. 'CPython>=2.6,<3' or 'PyPy'. By default, no constraints "
-                "are used.  Multiple constraints may be added.  They will be ORed together.")
-  register('--colors', action='store_true', default=True, recursive=True,
-           help='Set whether log messages are displayed in color.')
+    Bootstrap option values can be interpolated into the config file, and can be referenced
+    programatically in registration code, e.g., as register.bootstrap.pants_workdir.
 
-  register('--spec-excludes', action='append', default=[register.bootstrap.pants_workdir],
-           help='Ignore these paths when evaluating the command-line target specs.  Useful with '
-                '::, to avoid descending into unneeded directories.')
-  register('--exclude-target-regexp', action='append', default=[], metavar='<regexp>',
-           help='Exclude targets that match these regexes. Useful with ::, to ignore broken '
-                'BUILD files.',
-           recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
-  register('--tag', action='append', metavar='[+-]tag1,tag2,...',
-           help="Include only targets with these tags (optional '+' prefix) or without these "
-                "tags ('-' prefix).  Useful with ::, to find subsets of targets "
-                "(e.g., integration tests.)")
-  register('--cache-key-gen-version', advanced=True, default='200', recursive=True,
-           help='The cache key generation. Bump this to invalidate every artifact for a scope.')
-  register('--print-exception-stacktrace', action='store_true',
-           help='Print to console the full exception stack trace if encountered.')
-  register('--fail-fast', action='store_true',
-           help='When parsing specs, will stop on the first erronous BUILD file encountered. '
-                'Otherwise, will parse all builds in a spec and then throw an Exception.')
-  register('--pants-support-baseurls', type=Options.list, advanced=True, recursive=True,
-           default = [ 'https://dl.bintray.com/pantsbuild/bin/build-support' ],
-           help='List of urls from which binary tools are downloaded.  Urls are searched in order'
-           'until the requested path is found.')
-  register('--max-subprocess-args', type=int, default=100,  advanced=True, recursive=True,
-           help='Used to limit the number of arguments passed to some subprocesses by breaking'
-           'the command up into multiple invocations')
-  register('--pants-support-fetch-timeout-secs', type=int, default=30, advanced=True, recursive=True,
-           help='Timeout in seconds for url reads when fetching binary tools from the '
-                'repos specified by --pants-support-baseurls')
-  register('--build-file-rev',
-           help='Read BUILD files from this scm rev instead of from the working tree.  This is '
-           'useful for implementing pants-aware sparse checkouts.')
+    Note that regular code can also access these options as normal global-scope options. Their
+    status as "bootstrap options" is only pertinent during option registration.
+    """
+    buildroot = get_buildroot()
+    register('--plugins', advanced=True, type=Options.list, help='Load these plugins.')
+    register('--backend-packages', advanced=True, type=Options.list,
+             help='Load backends from these packages that are already on the path.')
+
+    register('--pants-bootstrapdir', advanced=True, metavar='<dir>', default=get_pants_cachedir(),
+             help='Use this dir for global cache.')
+    register('--pants-configdir', advanced=True, metavar='<dir>', default=get_pants_configdir(),
+             help='Use this dir for global config files.')
+    register('--pants-workdir', metavar='<dir>', default=os.path.join(buildroot, '.pants.d'),
+             help='Write intermediate output files to this dir.')
+    register('--pants-supportdir', metavar='<dir>',
+             default=os.path.join(buildroot, 'build-support'),
+             help='Use support files from this dir.')
+    register('--pants-distdir', metavar='<dir>', default=os.path.join(buildroot, 'dist'),
+             help='Write end-product artifacts to this dir.')
+    register('--config-override', help='A second config file, to override pants.ini.')
+    register('--pantsrc', action='store_true', default=True,
+             help='Use pantsrc files.')
+    register('--pantsrc-files', action='append', metavar='<path>',
+             default=['/etc/pantsrc', '~/.pants.rc'],
+             help='Override config with values from these files. '
+                  'Later files override earlier ones.')
+    register('--pythonpath', action='append',
+             help='Add these directories to PYTHONPATH to search for plugins.')
+    register('--target-spec-file', action='append', dest='target_spec_files',
+             help='Read additional specs from this file, one per line')
+
+    # These logging options are registered in the bootstrap phase so that plugins can log during
+    # registration and not so that their values can be interpolated in configs.
+    register('-d', '--logdir', metavar='<dir>',
+             help='Write logs to files under this directory.')
+
+    # Although logging supports the WARN level, its not documented and could conceivably be yanked.
+    # Since pants has supported 'warn' since inception, leave the 'warn' choice as-is but explicitly
+    # setup a 'WARN' logging level name that maps to 'WARNING'.
+    logging.addLevelName(logging.WARNING, 'WARN')
+    register('-l', '--level', choices=['debug', 'info', 'warn'], default='info', recursive=True,
+             help='Set the logging level.')
+
+    register('-q', '--quiet', action='store_true',
+             help='Squelches all console output apart from errors.')
+
+  @classmethod
+  def register_options(cls, register):
+    """Register options not tied to any particular task or subsystem."""
+    # The bootstrap options need to be registered on the post-bootstrap Options instance, so it
+    # won't choke on them on the command line, and also so we can access their values as regular
+    # global-scope options, for convenience.
+    cls.register_bootstrap_options(register)
+
+    register('-t', '--timeout', type=int, metavar='<seconds>',
+             help='Number of seconds to wait for http connections.')
+    register('-x', '--time', action='store_true',
+             help='Times tasks and goals and outputs a report.')
+    register('-e', '--explain', action='store_true',
+             help='Explain the execution of goals.')
+
+    # TODO: After moving to the new options system these abstraction leaks can go away.
+    register('-k', '--kill-nailguns', action='store_true',
+             help='Kill nailguns before exiting')
+    register('-i', '--interpreter', default=[], action='append', metavar='<requirement>',
+             help="Constrain what Python interpreters to use.  Uses Requirement format from "
+                  "pkg_resources, e.g. 'CPython>=2.6,<3' or 'PyPy'. By default, no constraints "
+                  "are used.  Multiple constraints may be added.  They will be ORed together.")
+    register('--colors', action='store_true', default=True, recursive=True,
+             help='Set whether log messages are displayed in color.')
+
+    register('--spec-excludes', action='append', default=[register.bootstrap.pants_workdir],
+             help='Ignore these paths when evaluating the command-line target specs.  Useful with '
+                  '::, to avoid descending into unneeded directories.')
+    register('--exclude-target-regexp', action='append', default=[], metavar='<regexp>',
+             help='Exclude targets that match these regexes. Useful with ::, to ignore broken '
+                  'BUILD files.',
+             recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
+    register('--tag', action='append', metavar='[+-]tag1,tag2,...',
+             help="Include only targets with these tags (optional '+' prefix) or without these "
+                  "tags ('-' prefix).  Useful with ::, to find subsets of targets "
+                  "(e.g., integration tests.)")
+    register('--cache-key-gen-version', advanced=True, default='200', recursive=True,
+             help='The cache key generation. Bump this to invalidate every artifact for a scope.')
+    register('--print-exception-stacktrace', action='store_true',
+             help='Print to console the full exception stack trace if encountered.')
+    register('--fail-fast', action='store_true',
+             help='When parsing specs, will stop on the first erronous BUILD file encountered. '
+                  'Otherwise, will parse all builds in a spec and then throw an Exception.')
+    register('--pants-support-baseurls', type=Options.list, advanced=True, recursive=True,
+             default = [ 'https://dl.bintray.com/pantsbuild/bin/build-support' ],
+             help='List of urls from which binary tools are downloaded.  Urls are searched in order'
+             'until the requested path is found.')
+    register('--max-subprocess-args', type=int, default=100,  advanced=True, recursive=True,
+             help='Used to limit the number of arguments passed to some subprocesses by breaking'
+             'the command up into multiple invocations')
+    register('--pants-support-fetch-timeout-secs', type=int, default=30, advanced=True,
+             recursive=True,
+             help='Timeout in seconds for url reads when fetching binary tools from the '
+                  'repos specified by --pants-support-baseurls')
+    register('--build-file-rev',
+             help='Read BUILD files from this scm rev instead of from the working tree.  This is '
+             'useful for implementing pants-aware sparse checkouts.')

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -156,14 +156,6 @@ class Options(object):
     """Register an option in the given scope, using argparse params."""
     self.get_parser(scope).register(*args, **kwargs)
 
-  def register_global(self, *args, **kwargs):
-    """Register an option in the global scope, using argparse params."""
-    self.register(GLOBAL_SCOPE, *args, **kwargs)
-
-  def registration_function_for_global_scope(self):
-    """Returns a function for registering argparse args on the global scope."""
-    return self.registration_function_for_scope(GLOBAL_SCOPE)
-
   def registration_function_for_scope(self, scope):
     """Returns a function for registering argparse args on the given scope."""
     # TODO(benjy): Make this an instance of a class that implements __call__, so we can
@@ -179,10 +171,6 @@ class Options(object):
   def get_parser(self, scope):
     """Returns the parser for the given scope, so code can register on it directly."""
     return self._parser_hierarchy.get_parser_by_scope(scope)
-
-  def get_global_parser(self):
-    """Returns the parser for the global scope, so code can register on it directly."""
-    return self.get_parser(GLOBAL_SCOPE)
 
   def for_scope(self, scope):
     """Return the option values for the given scope.
@@ -277,7 +265,7 @@ class Options(object):
 
     if show_all_help or not goals:
       print('\nGlobal options:')
-      print(self.get_global_parser().format_help())
+      print(self.get_parser(GLOBAL_SCOPE).format_help())
 
   def _format_help_for_scope(self, scope):
     """Generate a help message for options at the specified scope."""

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -28,9 +28,8 @@ from pants.base.source_root import SourceRoot
 from pants.base.target import Target
 from pants.goal.goal import Goal
 from pants.goal.products import MultipleRootedProducts, UnionProducts
-from pants.option.global_options import register_global_options
+from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options import Options
-from pants.option.options_bootstrapper import register_bootstrap_options
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree, touch
@@ -175,11 +174,11 @@ class BaseTest(unittest.TestCase):
     # TODO: This sequence is a bit repetitive of the real registration sequence.
 
     # Register bootstrap options and grab their default values for use in subsequent registration.
-    register_bootstrap_options(register_func(Options.GLOBAL_SCOPE), self.build_root)
+    GlobalOptionsRegistrar.register_bootstrap_options(register_func(Options.GLOBAL_SCOPE))
     bootstrap_option_values = create_option_values(copy.copy(option_values[Options.GLOBAL_SCOPE]))
 
-    # Now register the remaining global scope options.
-    register_global_options(register_func(Options.GLOBAL_SCOPE))
+    # Now register the full global scope options.
+    GlobalOptionsRegistrar.register_options(register_func(Options.GLOBAL_SCOPE))
 
     # Now register task and subsystem options for relevant tasks.
     for task_type in for_task_types:

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -6,6 +6,7 @@ python_tests(
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python:pytest',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/option',
     'src/python/pants/util:contextutil',


### PR DESCRIPTION
- Makes global option registration be via an Optionable, for uniformity
  with task and subsystem options.
- Move the bootstrap option registration to the same file as the rest
  of the global options registration, for clarity.
- Removed some special-casing of the global scope.
- Removed the buildroot argument to the options bootstrapper. It was only
  used so that reflect.py could substitute a placeholder for display in
  the builddict. We now do this with a simple string replace. I prefer
  this slightly hackier method, isolated to just inside reflect.py, than
  having it leak into the signature of options bootstrapper.
- This change is to support a future change in which registered options will
  know their category (global, subsystem, task), which in turn will
  be used for better help and builddict generation.