### PR TITLE
Robustify the pants ivy configuration.

### DIFF
--- a/build-support/ivy/ivy.xml
+++ b/build-support/ivy/ivy.xml
@@ -13,6 +13,9 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
   <dependencies defaultconf="default">
     <dependency org="org.apache.ivy" name="ivy" rev="2.4.0"/>
 
+    <!-- Enable support for the more robust commons-httpclient downloader. -->
+    <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1"/>
+
     <!-- support for the pgp signer -->
     <dependency org="org.bouncycastle" name="bcpg-jdk14" rev="1.45"/>
     <dependency org="org.bouncycastle" name="bcprov-jdk14" rev="1.45"/>

--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -4,10 +4,7 @@ Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 Licensed under the Apache License, Version 2.0 (see LICENSE).
 -->
 
-<!-- Attempts to use default ivy settings, with the exception of local .m2 resolution -->
 <ivysettings>
-  <include url="${ivy.default.settings.dir}/ivysettings.xml"/>
-
   <settings defaultResolver="pants-chain-repos"/>
 
   <property name="m2.repo.relpath" value="[organisation]/[module]/[revision]"/>
@@ -18,10 +15,13 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
   <resolvers>
     <chain name="pants-chain-repos" returnFirst="true">
-      <!-- the default resolver shipped with ivy -->
-      <resolver ref="default"/>
+      <!-- By default ivy does not require metadata (or successful metadata downloads).
+           This can lead to jars downloading without their transitive deps which leads
+           to confusing failures later when classpaths are constructed and used.
+           We setup the maven central resolver to require successful pom downloads here. -->
+      <ibiblio name="maven-central" m2compatible="true" descriptor="required"/>
 
-      <!-- mvn standard -->
+      <!-- The mvn standard local filesystem repo/cache -->
       <filesystem name="local.m2" m2compatible="true" local="true" checkmodified="true">
         <ivy pattern="${m2.repo.dir}/${m2.repo.pom}"/>
         <artifact pattern="${m2.repo.dir}/${m2.repo.artifact}"/>


### PR DESCRIPTION
This turns on required pom downloads from maven-central for atrifact
resolves to be considered successful.

It also enables the jakarta commons http-client for downloads which has
the effect of enabling retries leading to less transient resolve
failures.

Inspired by investigatory/expository work in:
  https://github.com/pantsbuild/pants/issues/1779