### PR TITLE
Re-compute the classpath for each batch of junit tests.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -19,7 +19,6 @@ from pants import binary_util
 from pants.backend.jvm.targets.java_tests import JavaTests as junit_tests
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
-from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError, TestFailedTaskError
 from pants.base.workunit import WorkUnit
@@ -31,8 +30,6 @@ from pants.util.dirutil import (relativize_paths, safe_delete, safe_mkdir, safe_
 from pants.util.strutil import safe_shlex_split
 from pants.util.xml_parser import XmlParser
 
-
-_CWD_NOT_PRESENT='CWD NOT PRESENT'
 
 # TODO(ji): Add unit tests.
 # TODO(ji): Add coverage in ci.run (https://github.com/pantsbuild/pants/issues/83)
@@ -90,10 +87,8 @@ class _JUnitRunner(object):
                   'For example, 1/3 means run tests number 2, 5, 8, 11, ...')
     register('--suppress-output', action='store_true', default=True,
              help='Redirect test output to files in .pants.d/test/junit.')
-    # TODO(gmalmquist): Use the build root instead of the path of the first target by default.
-    register('--cwd', default=_CWD_NOT_PRESENT, nargs='?',
-             help='Set the working directory. If no argument is passed, use the first target path. '
-                  'If cwd is set on a target, it will supersede this argument.')
+    register('--cwd', help='Set the working directory. If no argument is passed, use the build '
+                           'root. If cwd is set on a target, it will supersede this argument.')
     register_jvm_tool(register,
                       'junit',
                       main=JUnitRun._MAIN,
@@ -113,7 +108,7 @@ class _JUnitRunner(object):
     self._tests_to_run = options.test
     self._batch_size = options.batch_size
     self._fail_fast = options.fail_fast
-    self._working_dir = self._pick_working_dir(options.cwd, context)
+    self._working_dir = options.cwd or get_buildroot()
     self._args = copy.copy(task_exports.args)
     if options.suppress_output:
       self._args.append('-suppress-output')
@@ -155,7 +150,7 @@ class _JUnitRunner(object):
     def _do_report(exception=None):
       self.report(targets, tests_and_targets.keys(), tests_failed_exception=exception)
     try:
-      self.run(tests_and_targets, junit_classpath)
+      self.run(tests_and_targets)
       _do_report(exception=None)
     except TaskError as e:
       _do_report(exception=e)
@@ -173,18 +168,16 @@ class _JUnitRunner(object):
     """
     pass
 
-  def run(self, tests_and_targets, junit_classpath):
+  def run(self, tests_and_targets):
     """Run the tests in the appropriate environment.
 
     Subclasses should override this if they need more work done.
 
     :param tests_and_targets: a dict that contains all the test class names
       mapped to their targets extracted from the testing targets.
-    :param junit_classpath: the collective classpath value under which
-      the junit tests will be executed.
     """
 
-    self._run_tests(tests_and_targets, junit_classpath, JUnitRun._MAIN)
+    self._run_tests(tests_and_targets, JUnitRun._MAIN)
 
   def report(self, targets, tests, tests_failed_exception):
     """Post-processing of any test output.
@@ -222,17 +215,6 @@ class _JUnitRunner(object):
     else:
       return tests_from_targets
 
-  def _pick_working_dir(self, cwd_opt, context):
-    if not cwd_opt and context.target_roots:
-      # If the --cwd flag is present with no value and there are target roots,
-      # set the working dir to the first target root's BUILD file path
-      return context.target_roots[0].address.spec_path
-    elif cwd_opt != _CWD_NOT_PRESENT and cwd_opt:
-      # If the --cwd is present and has a value other than _CWD_NOT_PRESENT, use the value
-      return cwd_opt
-    else:
-      return get_buildroot()
-
   def _get_failed_targets(self, tests_and_targets):
     """Return a list of failed targets.
 
@@ -265,16 +247,23 @@ class _JUnitRunner(object):
 
     return failed_targets
 
-  def _run_tests(self, tests_to_targets, classpath, main, extra_jvm_options=None):
+  def _run_tests(self, tests_to_targets, main, extra_jvm_options=None, classpath_prepend=(),
+                 classpath_append=()):
     extra_jvm_options = extra_jvm_options or []
 
     result = 0
     for workdir, tests in self._tests_by_workdir(tests_to_targets).items():
       for batch in self._partition(tests):
+        classpath = self._task_exports.classpath(map(tests_to_targets.get, batch),
+                                                 cp=self._task_exports.tool_classpath('junit'))
+        complete_classpath = OrderedSet()
+        complete_classpath.update(classpath_prepend)
+        complete_classpath.update(classpath)
+        complete_classpath.update(classpath_append)
         with binary_util.safe_args(batch, self._task_exports.task_options) as batch_tests:
           self._context.log.debug('CWD = {}'.format(workdir))
           result += abs(execute_java(
-            classpath=classpath,
+            classpath=complete_classpath,
             main=main,
             jvm_options=self._task_exports.jvm_options + extra_jvm_options,
             args=self._args + batch_tests + [u'-xmlreport'],
@@ -420,7 +409,7 @@ class _Coverage(_JUnitRunner):
     pass
 
   @abstractmethod
-  def run(self, tests_and_targets, junit_classpath):
+  def run(self, tests_and_targets):
     pass
 
   @abstractmethod
@@ -483,10 +472,11 @@ class Emma(_Coverage):
         raise TaskError("java {0} ... exited non-zero ({1})"
                         " 'failed to instrument'".format(main, result))
 
-  def run(self, tests_and_targets, junit_classpath):
+  def run(self, tests_and_targets):
     self._run_tests(tests_and_targets,
-                    [self._coverage_instrument_dir] + junit_classpath + self._emma_classpath,
                     JUnitRun._MAIN,
+                    classpath_prepend=[self._coverage_instrument_dir],
+                    classpath_append=self._emma_classpath,
                     extra_jvm_options=['-Demma.coverage.out.file={0}'.format(self._coverage_file)])
 
   def report(self, targets, tests, tests_failed_exception=None):
@@ -622,14 +612,14 @@ class Cobertura(_Coverage):
         raise TaskError("java {0} ... exited non-zero ({1})"
                         " 'failed to instrument'".format(main, result))
 
-  def run(self, tests_and_targets, junit_classpath):
+  def run(self, tests_and_targets):
     if self._nothing_to_instrument:
       self._context.log.warn('Nothing found to instrument, skipping tests...')
       return
     cobertura_cp = self._task_exports.tool_classpath('cobertura-run')
     self._run_tests(tests_and_targets,
-                    cobertura_cp + junit_classpath,
                     JUnitRun._MAIN,
+                    classpath_prepend=cobertura_cp,
                     extra_jvm_options=['-Dnet.sourceforge.cobertura.datafile=' + self._coverage_datafile])
 
   def _build_sources_by_class(self):

--- a/testprojects/maven_layout/junit_resource_collision/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+maven_layout()
+
+target(name='junit_resource_collision',
+  dependencies=[
+    'testprojects/maven_layout/junit_resource_collision/onedir/src/test/java',
+    'testprojects/maven_layout/junit_resource_collision/twodir/src/test/java',
+  ],
+)

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+junit_tests(name='java',
+  sources=[
+    'org/pantsbuild/duplicates/FirstTest.java'
+  ],
+  dependencies=[
+    '3rdparty:junit',
+  ],
+  resources=[
+    'testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources'
+  ],
+  cwd='testprojects/maven_layout/junit_resource_collision/onedir',
+)

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/org/pantsbuild/duplicates/FirstTest.java
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/org/pantsbuild/duplicates/FirstTest.java
@@ -1,0 +1,27 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.duplicates;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Relies on textfile.txt, whose fully qualified resource name is duplicated in twodir.
+ */
+public class FirstTest {
+
+    @Test
+    public void testTextFile() throws Exception {
+        BufferedReader in = new BufferedReader(new InputStreamReader(
+                getClass().getResourceAsStream("/org/pantsbuild/duplicates/textfile.txt")
+        ));
+        assertEquals("Textfile One.", in.readLine());
+        in.close();
+    }
+
+}

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+resources(name='resources',
+  sources=['org/pantsbuild/duplicates/textfile.txt'],
+)

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources/org/pantsbuild/duplicates/textfile.txt
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources/org/pantsbuild/duplicates/textfile.txt
@@ -1,0 +1,1 @@
+Textfile One.

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+junit_tests(name='java',
+  sources=[
+    'org/pantsbuild/duplicates/SecondTest.java'
+  ],
+  dependencies=[
+    '3rdparty:junit',
+  ],
+  resources=[
+    'testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources'
+  ],
+  cwd='testprojects/maven_layout/junit_resource_collision/twodir',
+)

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/org/pantsbuild/duplicates/SecondTest.java
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/org/pantsbuild/duplicates/SecondTest.java
@@ -1,0 +1,27 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.duplicates;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Relies on textfile.txt, whose fully qualified resource name is duplicated in onedir.
+ */
+public class SecondTest {
+
+    @Test
+    public void testTextFile() throws Exception {
+        BufferedReader in = new BufferedReader(new InputStreamReader(
+                getClass().getResourceAsStream("/org/pantsbuild/duplicates/textfile.txt")
+        ));
+        assertEquals("Textfile Two.", in.readLine());
+        in.close();
+    }
+
+}

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+resources(name='resources',
+  sources=['org/pantsbuild/duplicates/textfile.txt'],
+)

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources/org/pantsbuild/duplicates/textfile.txt
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources/org/pantsbuild/duplicates/textfile.txt
@@ -1,0 +1,1 @@
+Textfile Two.

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -163,25 +163,13 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         '--test-junit-cwd=testprojects/src/java/org/pantsbuild/testproject/cwdexample/subdir'])
     self.assert_success(pants_run)
 
-  def test_junit_test_requiring_cwd_passes_with_option_with_no_value_specified(self):
+  def test_junit_test_requiring_cwd_fails_with_option_with_no_value_specified(self):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
         '--interpreter=CPython>=2.6,<3',
         '--interpreter=CPython>=3.3',
-        '--jvm-test-junit-options=-Dcwd.test.enabled=true',
-        '--test-junit-cwd',])
-    self.assert_success(pants_run)
-
-  def test_junit_test_requiring_cwd_fails_when_target_not_first(self):
-    pants_run = self.run_pants([
-        'test',
-        'examples/tests/scala/org/pantsbuild/example/hello/welcome',
-        'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
-        '--interpreter=CPython>=2.6,<3',
-        '--interpreter=CPython>=3.3',
-        '--jvm-test-junit-options=-Dcwd.test.enabled=true',
-        '--test-junit-cwd',])
+        '--jvm-test-junit-options=-Dcwd.test.enabled=true'])
     self.assert_failure(pants_run)
 
   @unittest.skip("junit-runner-0.0.7 is not published yet")
@@ -197,5 +185,20 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
       'test',
       'testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir',
+    ])
+    self.assert_success(pants_run)
+
+  def test_junit_test_duplicate_resources(self):
+    pants_run = self.run_pants([
+      'test',
+      'testprojects/maven_layout/junit_resource_collision',
+    ])
+    self.assert_success(pants_run)
+
+  def test_junit_test_target_cwd_overrides_option(self):
+    pants_run = self.run_pants([
+      'test',
+      'testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir',
+      '--test-junit-cwd=testprojects/tests/java/org/pantsbuild/testproject/dummies'
     ])
     self.assert_success(pants_run)


### PR DESCRIPTION
This handles the case where tests define duplicate resources,
which is a common use-case for Square.

Also changed the default working directory for tests to be the build
root, instead of being the (very arbitrary) spec_path of the first
target in the set of test targets.