### PR TITLE
Helpful error message when 'sources' is specified for jvm_binary.

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -278,6 +278,7 @@ class JvmBinary(JvmTarget):
     this means the jar has a manifest specifying the main class.
   * ``run`` - Executes the main class of this binary locally.
   """
+
   def __init__(self,
                name=None,
                address=None,
@@ -331,6 +332,12 @@ class JvmBinary(JvmTarget):
                                       'manifest_entries must be a dict. got {}'
                                       .format(type(manifest_entries).__name__))
     sources = [source] if source else None
+    if 'sources' in kwargs:
+      raise self.IllegalArgument(address.spec,
+        'jvm_binary only supports a single "source" argument, typically used to specify a main '
+        'class source file. Other sources should instead be placed in a java_library, which '
+        'should be referenced in the jvm_binary\'s dependencies.'
+      )
     payload = payload or Payload()
     payload.add_fields({
       'basename' : PrimitiveField(basename or name),

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -123,6 +123,9 @@ class Target(AbstractTarget):
   class UnknownArguments(TargetDefinitionException):
     """Unknown keyword arguments supplied to Target."""
 
+  class IllegalArgument(TargetDefinitionException):
+    """Argument that isn't allowed supplied to Target."""
+
   LANG_DISCRIMINATORS = {
     'java':   lambda t: t.is_jvm,
     'python': lambda t: t.is_python,

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_binary.py
@@ -10,10 +10,12 @@ from textwrap import dedent
 
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.targets.exclude import Exclude
-from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, ManifestEntries, Skip
+from pants.backend.jvm.targets.jvm_binary import (Duplicate, JarRules, JvmBinary, ManifestEntries,
+                                                  Skip)
 from pants.base.address import BuildFileAddress
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload_field import FingerprintedField
+from pants.base.target import Target
 from pants_test.base_test import BaseTest
 
 
@@ -124,6 +126,11 @@ class JvmBinaryTest(BaseTest):
     with self.assertRaisesRegexp(TargetDefinitionException,
                                  r'Invalid target JvmBinary.*foo.*source must be a single'):
       self.build_graph.inject_address_closure(BuildFileAddress(build_file, 'foo'))
+
+  def test_bad_sources_declaration(self):
+    with self.assertRaisesRegexp(Target.IllegalArgument,
+                                 r'jvm_binary only supports a single "source" argument'):
+      self.make_target('foo:foo', target_type=JvmBinary, main='com.example.Foo', sources=['foo.py'])
 
   def test_bad_main_declaration(self):
     build_file = self.add_to_build_file('BUILD', dedent('''


### PR DESCRIPTION
This addresses: https://github.com/pantsbuild/pants/issues/871

jvm_binary will now give a more human readible error message that
typical pants users can understand and act on.