### PR TITLE
Fixup the etree xml import.

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -10,7 +10,7 @@ import logging
 import os
 import pkgutil
 import threading
-import xml
+import xml.etree.ElementTree as ET
 from collections import OrderedDict, defaultdict, namedtuple
 from contextlib import contextmanager
 from copy import deepcopy
@@ -289,7 +289,7 @@ class IvyUtils(object):
   def _parse_xml_report(cls, path):
     logger.debug("Parsing ivy report {}".format(path))
     ret = IvyInfo()
-    etree = xml.etree.ElementTree.parse(path)
+    etree = ET.parse(path)
     doc = etree.getroot()
     for module in doc.findall('dependencies/module'):
       org = module.get('organisation')


### PR DESCRIPTION
The xml package uses some funky `__init__.py`s and it seems that
following the import style used in the tutorials at
https://docs.python.org/2/library/xml.etree.elementtree.html is for the
best.

Without this change, at least one test that used IvyUtils would fail
to import etree.

https://rbcommons.com/s/twitter/r/2459/