### PR TITLE
Fix test_execute_fail.

### DIFF
--- a/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
@@ -25,9 +25,9 @@ class SimpleCodegenTaskTest(TaskTestBase):
 
   @property
   def alias_groups(self):
-      return register_core().merge(register_codegen()).merge(BuildFileAliases.create({
-        'dummy_library': SimpleCodegenTaskTest.DummyLibrary
-      }))
+    return register_core().merge(register_codegen()).merge(BuildFileAliases.create({
+      'dummy_library': SimpleCodegenTaskTest.DummyLibrary
+    }))
 
   def _create_dummy_task(self, target_roots=None, forced_codegen_strategy=None,
                          hard_strategy_force=False, **options):
@@ -45,7 +45,6 @@ class SimpleCodegenTaskTest(TaskTestBase):
           )
         '''.format(name=spec_name)))
     return set([self.target(spec) for spec in target_specs])
-
 
   def test_codegen_strategy(self):
     self.set_options(strategy='global')
@@ -121,9 +120,9 @@ class SimpleCodegenTaskTest(TaskTestBase):
       task.execute()
 
   def test_execute_fail(self):
-    task = self._create_dummy_task()
+    task = self._create_dummy_task(strategy='global')
     task.should_fail = True
-    self.assertRaisesRegexp(TaskError, 'Failed to generate target(s)', task.execute())
+    self.assertRaisesRegexp(TaskError, r'Failed to generate target\(s\)', task.execute)
 
   def _get_duplication_test_targets(self):
     self.add_to_build_file('gen-parent', dedent('''
@@ -193,7 +192,6 @@ class SimpleCodegenTaskTest(TaskTestBase):
     with self.assertRaises(SimpleCodegenTask.UnsupportedStrategyError):
       task.codegen_strategy
 
-
   class DummyLibrary(JvmTarget):
     """Library of .dummy files, which are just text files which generate empty java files.
 
@@ -212,7 +210,6 @@ class SimpleCodegenTaskTest(TaskTestBase):
     Which would compile, but do nothing.
     """
 
-
   class DummyGen(SimpleCodegenTask):
     """Task which generates .java files for DummyLibraries.
 
@@ -227,7 +224,7 @@ class SimpleCodegenTaskTest(TaskTestBase):
       super(SimpleCodegenTaskTest.DummyGen, self).__init__(*vargs, **kwargs)
       self._test_case = None
       self._all_targets = None
-      self.setup_for_testing(None, None, None)
+      self.setup_for_testing(None, None)
       self.should_fail = False
 
     def setup_for_testing(self, test_case, all_targets, forced_codegen_strategy=None,
@@ -245,7 +242,7 @@ class SimpleCodegenTaskTest(TaskTestBase):
       """
       self._test_case = test_case
       self._all_targets = all_targets
-      cls = SimpleCodegenTaskTest.DummyGen
+      cls = type(self)
       cls._forced_codegen_strategy = forced_codegen_strategy
       cls._hard_forced_codegen_strategy = forced_codegen_strategy if hard_strategy_force else None
 

--- a/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
@@ -120,7 +120,11 @@ class SimpleCodegenTaskTest(TaskTestBase):
       task.execute()
 
   def test_execute_fail(self):
-    task = self._create_dummy_task(strategy='global')
+    # Ensure whichever strategy is selected, it actually call execute_codegen to trigger our
+    # DummyTask `should_fail` logic.  The isolated strategy, for example, short circuits that call
+    # if there are no targets.
+    dummy = self.make_target(spec='dummy', target_type=self.DummyLibrary)
+    task = self._create_dummy_task(target_roots=[dummy])
     task.should_fail = True
     self.assertRaisesRegexp(TaskError, r'Failed to generate target\(s\)', task.execute)
 


### PR DESCRIPTION
This fixes test_execute, but not the underlying global state used in
DummyTask.  Its that state, that appears to have supported a successful
run under certain sharding / test method ordering, although I was not
able to positively identify a sequence of calls that would lead to
test_execute ever passing.  In particular, it had 2 local errors that
look systemic:
1. The raises regex did not escape the parens.
   Before this fix, the regex only could match 'Failed to generate
   targets' - with s being in an unused capture group.
2. The assertRaisesRegexp callable argument was not a callable.
   The _result_ of task.execute() was passed instead of the task.execute
   method.

These system errors were in addition to the lack of setup of the global
strategy explicitly.  That strategy is needed to ensure DummyGen's
execute_codegen is called leading to the raise.  Using the isolated
strategy (which was the default) with no targets sort circuits the
execute_codegen call, failing to ever engage the `should_fail` forced
raise.