### PR TITLE
Stops unit tests in test_simple_codegen_task.py in master from failing.

### DIFF
--- a/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
@@ -19,6 +19,14 @@ from pants_test.tasks.task_test_base import TaskTestBase
 
 
 class SimpleCodegenTaskTest(TaskTestBase):
+
+  def setUp(self):
+    super(SimpleCodegenTaskTest, self).setUp()
+    # NB(gmalmquist): We always want to re-run codegen rather than just assuming it works and
+    # using cached results. If we could safely assume codegen always worked, we wouldn't need
+    # these tests in the first place.
+    self.disable_artifact_cache()
+
   @classmethod
   def task_type(cls):
     return cls.DummyGen
@@ -95,7 +103,7 @@ class SimpleCodegenTaskTest(TaskTestBase):
                          'Codegen workdir suffix should be stable given the same target!\n'
                          '  target: {}'.format(target.address.spec))
 
-  def test_execute(self):
+  def _test_execute_strategy(self, strategy, expected_execution_count):
     dummy_suffixes = ['a', 'b', 'c',]
 
     self.add_to_build_file('gen-lib', '\n'.join(dedent('''
@@ -109,15 +117,23 @@ class SimpleCodegenTaskTest(TaskTestBase):
                        'org.pantsbuild.example Foo{0}'.format(suffix))
 
     targets = [self.target('gen-lib:{suffix}'.format(suffix=suffix)) for suffix in dummy_suffixes]
-    for strategy in ('global', 'isolated',):
-      task = self._create_dummy_task(target_roots=targets, strategy=strategy)
-      expected_targets = set(targets)
-      found_targets = set(task.codegen_targets())
-      self.assertEqual(expected_targets, found_targets,
-                       'TestGen failed to find codegen target {expected}! Found: [{found}].'
-                       .format(expected=', '.join(t.id for t in expected_targets),
-                               found=', '.join(t.id for t in found_targets)))
-      task.execute()
+    task = self._create_dummy_task(target_roots=targets, strategy=strategy)
+    expected_targets = set(targets)
+    found_targets = set(task.codegen_targets())
+    self.assertEqual(expected_targets, found_targets,
+                     'TestGen failed to find codegen target {expected}! Found: [{found}].'
+                     .format(expected=', '.join(t.id for t in expected_targets),
+                             found=', '.join(t.id for t in found_targets)))
+    task.execute()
+    self.assertEqual(expected_execution_count, task.execution_counts,
+                     '{} strategy had the wrong number of executions!\n  expected: {}\n  got: {}'
+                     .format(strategy, expected_execution_count, task.execution_counts))
+
+  def test_execute_global(self):
+    self._test_execute_strategy('global', 1)
+
+  def test_execute_isolated(self):
+    self._test_execute_strategy('isolated', 3)
 
   def test_execute_fail(self):
     # Ensure whichever strategy is selected, it actually call execute_codegen to trigger our
@@ -230,6 +246,7 @@ class SimpleCodegenTaskTest(TaskTestBase):
       self._all_targets = None
       self.setup_for_testing(None, None)
       self.should_fail = False
+      self.execution_counts = 0
 
     def setup_for_testing(self, test_case, all_targets, forced_codegen_strategy=None,
                           hard_strategy_force=False):
@@ -271,6 +288,7 @@ class SimpleCodegenTaskTest(TaskTestBase):
       return isinstance(target, SimpleCodegenTaskTest.DummyLibrary)
 
     def execute_codegen(self, invalid_targets):
+      self.execution_counts += 1
       if self.should_fail: raise TaskError('Failed to generate target(s)')
       if self.codegen_strategy.name() == 'isolated':
         self._test_case.assertEqual(1, len(invalid_targets),


### PR DESCRIPTION
test_execute() seems to be failing for the same reason antlr_gen
was failing in b2202480258b6f2f5f4e020e86cde975088c7792. For some
reason (presumably caching related), this didn't show up until my
last patch (839b8f86d7d9429d395772594b9aacec09d5c86f), but manual
testing indicates that the unit test fails all the way back to Cody's
patch to improve artifact cache usability.