### PR TITLE
[CI] An iterator over OptionValueContainer keys.

### DIFF
--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -127,3 +127,16 @@ class OptionValueContainer(object):
       return val.value
     else:
       return val
+
+  def __iter__(self):
+    """Returns an iterator over all option names, in lexicographical order.
+
+    In the rare (for us) case of an option with multiple names, we pick the
+    lexicographically smallest one, for consistency.
+    """
+    inverse_forwardings = {}  # internal attribute -> external attribute.
+    for k, v in self._forwardings.items():
+      if v not in inverse_forwardings or inverse_forwardings[v] > k:
+        inverse_forwardings[v] = k
+    for name in sorted(inverse_forwardings.values()):
+      yield name

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -69,6 +69,15 @@ class OptionValueContainerTest(unittest.TestCase):
     with self.assertRaises(AttributeError):
       o['baz']
 
+  def test_iterator(self):
+    o = OptionValueContainer()
+    o.add_forwardings({'a': '_a'})
+    o.add_forwardings({'b': '_b'})
+    o.add_forwardings({'b_prime': '_b'})  # Should be elided in favor of b.
+    o.add_forwardings({'c': '_c'})
+    names = list(iter(o))
+    self.assertListEqual(['a', 'b', 'c'], names)
+
   def test_copy(self):
     # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
     o = OptionValueContainer()


### PR DESCRIPTION
Yields exactly one key per option. If multiple keys point to the same
value (because the underlying option was registered with multiple names),
only yields one of them.

Also fixes a minor bug with inverse dest mapping computation. That computation
must properly be done only after all options have been registered, so it's
not confounded by options on inner scopes that shadow names in outer scopes.