### PR TITLE
Add support for a fixed list of contributors.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -94,4 +94,3 @@ Created by running `./build-support/bin/contributors.sh`.
 + Tom Howland
 + Travis Crawford
 + Ugo Di Girolamo
-

--- a/build-support/bin/contributors.sh
+++ b/build-support/bin/contributors.sh
@@ -50,5 +50,17 @@ Created by running \`$0\`.
 
 HEADER
 
-  contributors | sort -u | sed -E -e "s|^|+ |" >> CONTRIBUTORS.md
+  (cat - - <(contributors) << FIXED_LIST
+# You can add contributors that don't show up as an author in the git log
+# manually here.  Just add a line for their full name.  Comments and blank
+# lines are ignored.
+
+# Contributor from Square shepherded by Eric.
+Alyssa Pohahau
+
+FIXED_LIST
+) | grep -v -E "^[[:space:]]*#" | \
+    grep -v -E "^[[:space:]]*$" | \
+    sort -u | \
+    sed -E -e "s|^|+ |" >> CONTRIBUTORS.md
 fi


### PR DESCRIPTION
This supports known contributors who are not authors in the git log for
whatever reason.

Add Alyssa Pohahau as our 1st fixed contributor and regenerate
CONTRIBUTORS.md programmatically.

https://rbcommons.com/s/twitter/r/2480/