### PR TITLE
[CI] Fix test bugs introduced in b22024802.

### DIFF
--- a/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
@@ -31,9 +31,6 @@ class AntlrGenTest(NailgunTaskTestBase):
       targets={
         'java_antlr_library': JavaAntlrLibrary,
       },
-      context_aware_object_factories={
-        'source_root': SourceRoot.factory,
-      },
     ))
 
   PARTS = {'srcroot': 'testprojects/src/antlr',
@@ -48,36 +45,7 @@ class AntlrGenTest(NailgunTaskTestBase):
   def setUp(self):
     super(AntlrGenTest, self).setUp()
 
-    # There are some weird errors happening when caching is enabled on Antlr tests,
-    # which is why the use of the artifact cache is disabled. These bugs do not surface
-    # in Antlr integration tests (tasks/test_antlr_integration.py), which explicitly
-    # test caching, because the issue lies within what the following tests expect
-    # the SyntheticAddress of a target to be -- when caching is enabled, the expected
-    # SyntheticAddress is always incorrect, however, it would seem that everything else
-    # works just fine.
-    #
-    # Here's what happens without caching. In CodeGen->execute, within the self.invalidated
-    # block, self.genlang is called for all of the invalidated targets. In AntlrGen->genlang,
-    # the antlr classpath is computed with a call to self.tool_classpath(antlr_version).
-    # This is where things get weird. This call has the strange side-effect of changing
-    # each target.target_base: the sole test target prior to this call has a
-    # target_base = "testprojects/src/antlr/this/is/a/directory", but _after_ this call,
-    # it has a target_base = "testprojects/src/antlr". Note that self.tool_classpath does
-    # not take the target as an argument, rather, somewhere deep down the callstack it is
-    # muddling around with SourceRoot. Because target.target_base is used to compute a
-    # SyntheticAddress, the tests rely on this seemingly magic change of target_base.
-    #
-    # When caching is enabled, the first test passes and caches the sole test target.
-    # The rest of the tests run Antlr, but each one hits the cache, and thus none of the
-    # targets are invalidated. Recall that self.genlang is called on invalidated targets,
-    # so self.genlang is never called. Thus our sole test target's target_base is never
-    # changed from "testprojects/src/antlr/this/is/a/directory" to "testprojects/src/antlr",
-    # which causes the tests to fail, because the actual and expected SyntheticAddresses differ.
-    self.disable_artifact_cache()
-
-    self.add_to_build_file('BUILD', dedent("""
-      source_root('{srcroot}', java_antlr_library)
-    """.format(**self.PARTS)))
+    SourceRoot.register('{srcroot}'.format(**self.PARTS), JavaAntlrLibrary)
 
     for ver in self.VERSIONS:
       self.create_file(

--- a/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
@@ -19,14 +19,6 @@ from pants_test.tasks.task_test_base import TaskTestBase
 
 
 class SimpleCodegenTaskTest(TaskTestBase):
-
-  def setUp(self):
-    super(SimpleCodegenTaskTest, self).setUp()
-    # NB(gmalmquist): We always want to re-run codegen rather than just assuming it works and
-    # using cached results. If we could safely assume codegen always worked, we wouldn't need
-    # these tests in the first place.
-    self.disable_artifact_cache()
-
   @classmethod
   def task_type(cls):
     return cls.DummyGen

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -144,10 +144,6 @@ class BaseTest(unittest.TestCase):
   def set_options_for_scope(self, scope, **kwargs):
     self.options[scope].update(kwargs)
 
-  def del_options_for_scope(self, scope, *args):
-    for option in args:
-      self.options[scope].pop(option, None)
-
   def context(self, for_task_types=None, options=None, target_roots=None,
               console_outstream=None, workspace=None):
     for_task_types = for_task_types or []

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -8,12 +8,12 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/core/tasks:task',
-    'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:target',
     'src/python/pants/goal:context',
     'src/python/pants/goal',
     'src/python/pants/ivy',
+    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',
   ]

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -75,13 +75,6 @@ class TaskTestBase(BaseTest):
     # TODO: Push this down to JVM-related tests only? Seems wrong to have an ivy-specific
     # action in this non-JVM-specific, high-level base class.
     Bootstrapper.reset_instance()
-    self.artifact_cache = os.path.join(get_pants_cachedir(), 'artifact_cache')
-    self.set_options_for_scope('cache',
-                               read_from=[self.artifact_cache],
-                               write_to=[self.artifact_cache])
-
-  def disable_artifact_cache(self):
-    self.del_options_for_scope('cache', 'read_from', 'write_to')
 
   @property
   def test_workdir(self):


### PR DESCRIPTION
That change turned on artifact caching globally in tests.
The outcome was that many tests were actually not doing anything.
Instead, they were reading from the real artifact cache.

So, for example, the antlr gen test wasn't running antlr - it was
finding the expected outputs in the cache...

This commit removes the code that turned universal caching on,
and then re-enables caching just for tool bootstrapping, for test
performance.

This fixed the weird issue with antlr gen, so that large comment
is gone too.

Incidentally, this commit also changes the way we register the
source root in the antlr gen test. Instead of eval'ing it in a
BUILD file it just registers it directly, as other tests do.