### PR TITLE
Upgrade pantsbuild/pants to apache thrift 0.9.2.

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -56,30 +56,6 @@ jar_library(name='cucumber-java',
               jar(org='info.cukes', name='cucumber-java', rev='1.1.7'),
             ])
 
-# common rev for all com.twitter%finagle* artifacts
-FINAGLE_REV = '6.24.0'
-
-jar_library(name='finagle-core',
-            jars = [
-              jar(org='com.twitter', name='finagle-core_2.10', rev=FINAGLE_REV),
-            ],
-            dependencies = [
-              ':util-core'
-            ])
-
-# The finagle-thrift lib has a dep on org.apache.thrift#libthrift;0.5.0 which is
-# hosted at maven.twttr.com.  Since finagle-thrift is only used by test code we
-# exclude and then use org.apache.hadoop#libthrift;0.5.0.o instead to avoid the
-# need to setup a custom ivy resolver.
-jar_library(name='finagle-thrift',
-            jars = [
-              jar(org='com.twitter', name='finagle-thrift_2.10', rev=FINAGLE_REV)
-                .exclude(org='org.apache.thrift', name='libthrift'),
-            ],
-            dependencies=[
-              ':libthrift-0.5.0',
-            ])
-
 jar_library(name='log4j',
             jars = [
               jar(org='log4j', name='log4j', rev='1.2.15')
@@ -125,43 +101,20 @@ jar_library(name = 'spindle-runtime',
               jar(org = 'com.foursquare', name = 'spindle-runtime_2.10', rev = '3.0.0-M7'),
             ])
 
-jar_library(name='libthrift-0.5.0',
+jar_library(name='libthrift-0.9.2',
             jars = [
-              jar(org='org.apache.hadoop', name='libthrift', rev='0.5.0.0')
-                # These are un-needed and un-available log4j appender deps pulled in via a
-                # libthrift dep on slf4j-log4j.
-                .exclude(org='javax.jms', name='jms')
-                .exclude(org='com.sun.jdmk', name='jmxtools')
-                .exclude(org='com.sun.jmx', name='jmxri')
+              jar(org='org.apache.thrift', name='libthrift', rev='0.9.2')
             ])
 
-jar_library(name='thrift-0.5.0',
+jar_library(name='thrift-0.9.2',
             dependencies = [
               ':commons-lang',
-              ':libthrift-0.5.0',
+              ':libthrift-0.9.2',
               ':slf4j-api',
             ])
 
-jar_library(name='thrift-0.5.0-finagle',
-            dependencies = [
-              ':thrift-0.5.0',
-
-              # finagle thrift extra deps
-              ':finagle-core',
-              ':finagle-thrift',
-              ':util-core',
-            ])
-
 jar_library(name='thrift',
-            dependencies = [ ':thrift-0.5.0' ])
-
-# common rev for all com.twitter%util* artifacts
-UTIL_REV = '6.23.0'
-
-jar_library(name='util-core',
-            jars = [
-              jar(org='com.twitter', name='util-core_2.10', rev=UTIL_REV),
-            ])
+            dependencies = [ ':thrift-0.9.2' ])
 
 
 ###############

--- a/pants.ini
+++ b/pants.ini
@@ -70,41 +70,13 @@ ivy_settings: %(pants_supportdir)s/ivy/ivysettings.xml
 ivy_profile: %(pants_supportdir)s/ivy/ivy.xml
 
 
-[gen.scrooge]
-strict: False
-verbose: True
-service_deps: {
-    "java": [
-            "3rdparty:commons-lang",
-            "3rdparty:finagle-thrift",
-            "3rdparty:slf4j-api",
-            "3rdparty:util-core"
-            ],
-    "scala": [
-             "3rdparty:finagle-thrift",
-             "3rdparty:scrooge-core",
-             "3rdparty:util-core"
-             ],
-  }
-structs_deps: {
-    "java": [
-            "3rdparty:commons-lang",
-            "3rdparty:thrift"
-            ],
-    "scala": [
-             "3rdparty:scrooge-core",
-             "3rdparty:thrift"
-             ],
-  }
-
-
 [gen.thrift]
 strict: False
 java: {
     "gen": "java:hashcode",
     "deps": {
-      "service": ["3rdparty:thrift-0.5.0-finagle"],
-      "structs": ["3rdparty:thrift-0.5.0"]
+      "service": ["3rdparty:thrift"],
+      "structs": ["3rdparty:thrift"]
     }
   }
 python: {

--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -67,7 +67,7 @@ class ApacheThriftGen(CodeGen):
     register('--supportdir', advanced=True, default='bin/thrift',
              help='Find thrift binaries under this dir.   Used as part of the path to lookup the'
                   'tool with --pants-support-baseurls and --pants-bootstrapdir')
-    register('--version', advanced=True, default='0.5.0-finagle',
+    register('--version', advanced=True, default='0.9.2',
              help='Thrift compiler version.   Used as part of the path to lookup the'
                   'tool with --pants-support-baseurls and --pants-bootstrapdir')
     register('--java', advanced=True, type=Options.dict, help='GenInfo for Java.')


### PR DESCRIPTION
Since the pantsbuild/pants repo does not exercise the customized finagle
bindings of thrift-0.5.0-finagle, upgrade to 0.9.2 and simplify.

As an added benefit, 0.9.2 python gen almost supports python3 - a feature
Clover Health is after (seems to fully support after 2to3 is run over
generated code).