### PR TITLE
[CI] Switch almost all python tasks over to use cached chroots.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -405,11 +405,11 @@ class PytestRun(PythonTask):
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
 
-    with self.temporary_chroot(interpreter=interpreter,
-                               pex_info=pex_info,
-                               targets=targets,
-                               platforms=('current',),
-                               extra_requirements=self._TESTING_TARGETS) as chroot:
+    with self.cached_chroot(interpreter=interpreter,
+                            pex_info=pex_info,
+                            targets=targets,
+                            platforms=('current',),
+                            extra_requirements=self._TESTING_TARGETS) as chroot:
       pex = chroot.pex()
       with self._maybe_shard() as shard_args:
         with self._maybe_emit_junit_xml(targets) as junit_args:

--- a/src/python/pants/backend/python/tasks/python_eval.py
+++ b/src/python/pants/backend/python/tasks/python_eval.py
@@ -133,9 +133,9 @@ class PythonEval(PythonTask):
                             chroot_parent=self.chroot_cache_dir, modules=modules)
       executable_file_content = generator.render()
 
-      with self.temporary_chroot(interpreter=interpreter, pex_info=pexinfo,
-                                 targets=[target], platforms=platforms,
-                                 executable_file_content=executable_file_content) as chroot:
+      with self.cached_chroot(interpreter=interpreter, pex_info=pexinfo,
+                              targets=[target], platforms=platforms,
+                              executable_file_content=executable_file_content) as chroot:
         pex = chroot.pex()
         with self.context.new_workunit(name='eval',
                                        labels=[WorkUnit.COMPILER, WorkUnit.RUN, WorkUnit.TOOL],

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -46,11 +46,11 @@ class PythonRepl(PythonTask):
 
       pex_info = PexInfo.default()
       pex_info.entry_point = entry_point
-      with self.temporary_chroot(interpreter=interpreter,
-                                 pex_info=pex_info,
-                                 targets=targets,
-                                 platforms=None,
-                                 extra_requirements=extra_requirements) as chroot:
+      with self.cached_chroot(interpreter=interpreter,
+                              pex_info=pex_info,
+                              targets=targets,
+                              platforms=None,
+                              extra_requirements=extra_requirements) as chroot:
         pex = chroot.pex()
         self.context.release_lock()
         with stty_utils.preserve_stty_settings():

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -34,8 +34,8 @@ class PythonRun(PythonTask):
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
       # TODO(benjy): Some more elegant way to coordinate how tasks claim targets.
       interpreter = self.select_interpreter_for_targets(self.context.targets())
-      with self.temporary_chroot(interpreter=interpreter, pex_info=binary.pexinfo,
-                                 targets=[binary], platforms=binary.platforms) as chroot:
+      with self.cached_chroot(interpreter=interpreter, pex_info=binary.pexinfo,
+                              targets=[binary], platforms=binary.platforms) as chroot:
         pex = chroot.pex()
         self.context.release_lock()
         with self.context.new_workunit(name='run', labels=[WorkUnit.RUN]):

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -196,4 +196,4 @@ class PythonTask(Task):
       fingerprint_components.append(executable_file_content)
 
     fingerprint = hash_utils.hash_all(fingerprint_components)
-    return os.path.join(python_setup.chroot_cache_dir, fingerprint)
+    return os.path.join(self.chroot_cache_dir, fingerprint)

--- a/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
@@ -60,7 +60,7 @@ class AntlrGenTest(NailgunTaskTestBase):
       """.format(**self.PARTS)))
 
   def create_context(self):
-    # generate a context to contain the build graph for the input target, then execute
+    # generate a context to contain the build graph for the input target.
     antlr_target = self.target('{srcroot}/{dir}:{name}'.format(**self.PARTS))
     return self.context(target_roots=[antlr_target])
 

--- a/tests/python/pants_test/jvm/nailgun_task_test_base.py
+++ b/tests/python/pants_test/jvm/nailgun_task_test_base.py
@@ -6,8 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
-
-from .jvm_tool_task_test_base import JvmToolTaskTestBase
+from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 
 
 class NailgunTaskTestBase(JvmToolTaskTestBase):

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -14,7 +14,6 @@ python_library(
     'src/python/pants/goal',
     'src/python/pants/ivy',
     'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -14,7 +14,6 @@ from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.goal.goal import Goal
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_mkdir
 from pants_test.base_test import BaseTest
 
 
@@ -41,7 +40,7 @@ def ensure_cached(task_cls, expected_num_artifacts=None):
         self.set_options_for_scope('cache.{}'.format(self.options_scope),
                                    write_to=artifact_cache)
         task_cache = os.path.join(artifact_cache, task_cls.stable_name())
-        safe_mkdir(task_cache, clean=True)
+        os.mkdir(task_cache)
 
         test_fn(self, *args, **kwargs)
 


### PR DESCRIPTION
Now that we're on pex 1.0+, this works. And indeed, the effect is dramatic:
On my laptop running all the unittests went from ~5:00 mins to around 1:45 mins.

Note that binary_create doesn't get any benefit from this yet, because the
pex_info contains timestamps, which makes the cache key miss every time.

We can think about a fix for this, and then get rid of temporary_chroot()
entirely.

Also fixes a few random nits that I noticed on the way.