### PR TITLE
Added target_level, source_level, and compile_args to jvm_binary.

### DIFF
--- a/migrations/options/src/python/migrate_config.py
+++ b/migrations/options/src/python/migrate_config.py
@@ -272,9 +272,14 @@ notes = {
                          'move to a subsystem, which will fix this requirement.',
   ('jvm', 'debug_args'): 'For now must be defined for each JvmTask subtask separately.  Will soon '
                          'move to a subsystem, which will fix this requirement.',
-  ('java-compile', 'javac_args'): 'source and target args should be moved to separate source: and '
-                                  'target: options. Other args should be placed in args: and '
-                                  'prefixed with -C.',
+  ('java-compile', 'javac_args'): 'Source, target, and bootclasspath args should be specified in '
+                                  'the jvm-platform subsystem. Other args can be placed in args: '
+                                  'and prefixed with -C, or also be included in the jvm-platform '
+                                  'args.',
+  ('java-compile', 'source'): 'source and target args should be defined using the jvm-platform '
+                              'subsystem, rathern than as arguments to java-compile.',
+  ('java-compile', 'target'): 'source and target args should be defined using the jvm-platform '
+                              'subsystem, rathern than as arguments to java-compile.',
   ('jar-tool', 'bootstrap_tools'): 'Each JarTask sub-task can define this in its own section. or '
                                    'this can be defined for everyone in the DEFAULT section.',
   ('ivy-resolve', 'jvm_args'): 'If needed, this should be repeated in resolve.ivy, '

--- a/pants.ini
+++ b/pants.ini
@@ -94,8 +94,6 @@ options: ["-Xmx1g", "-XX:MaxPermSize=256m", "-Dscala.usejavacp=true" ]
 
 [compile.java]
 partition_size_hint: 1000000000
-source: 6
-target: 6
 compiler-bootstrap-tools: ["//:java-compiler"]
 jvm_options: ["-Xmx2G"]
 
@@ -120,6 +118,15 @@ options: [
 [jvm.bench]
 options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 
+# TODO(gmalmquist): Find a way to resolve the -Xbootclasspath automatically, either by putting
+# rt.jars up on the nexus or using some kind of special variable name (see discussion on RB 2494).
+[jvm-platform]
+default_platform: java6
+platforms: {
+    'java6': {'source': '6', 'target': '6', 'args': [] },
+    'java7': {'source': '7', 'target': '7', 'args': [] },
+    'java8': {'source': '8', 'target': '8', 'args': [] },
+  }
 
 [idea]
 python_source_paths: ["src/python"]

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -32,6 +32,17 @@ python_library(
   ],
 )
 
+python_library(
+  name = 'jvm_platform',
+  sources = ['jvm_platform.py'],
+  dependencies = [
+    'src/python/pants/base:revision',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:memo',
+    'src/python/pants/java/distribution',
+  ],
+)
 
 python_library(
   name = 'scala_platform',

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -1,0 +1,196 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+
+from pants.base.exceptions import TaskError
+from pants.base.revision import Revision
+from pants.java.distribution.distribution import Distribution
+from pants.option.options import Options
+from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_method, memoized_property
+
+
+logger = logging.getLogger(__name__)
+
+
+class JvmPlatform(Subsystem):
+  """Used to keep track of repo compile settings."""
+
+  # NB(gmalmquist): These assume a java version number N can be specified as either 'N' or '1.N'
+  # (eg, '7' is equivalent to '1.7'). New versions should only be added to this list
+  # if they follow this convention. If this convention is ever not followed for future
+  # java releases, they can simply be omitted from this list and they will be parsed
+  # strictly (eg, if Java 10 != 1.10, simply leave it out).
+  SUPPORTED_CONVERSION_VERSIONS = (6, 7, 8,)
+
+  class IllegalDefaultPlatform(TaskError):
+    """The --default-platform option was set, but isn't defined in --platforms."""
+
+  class UndefinedJvmPlatform(TaskError):
+    """Platform isn't defined."""
+    def __init__(self, target, platform_name, platforms_by_name):
+      scope_name = JvmPlatform.options_scope
+      messages = ['Undefined jvm platform "{}" (referenced by {}).'
+                    .format(platform_name, target.address.spec if target else 'unknown target')]
+      if not platforms_by_name:
+        messages.append('In fact, no platforms are defined under {0}. These should typically be'
+                        ' specified in [{0}] in pants.ini.'.format(scope_name))
+      else:
+        messages.append('Perhaps you meant one of:{}'.format(
+          ''.join('\n  {}'.format(name) for name in sorted(platforms_by_name.keys()))
+        ))
+        messages.append('\nThese are typically defined under [{}] in pants.ini.'
+                        .format(scope_name))
+      super(JvmPlatform.UndefinedJvmPlatform, self).__init__(' '.join(messages))
+
+  options_scope = 'jvm-platform'
+
+  # Mapping to keep version numbering consistent for ease of comparison.
+
+  @classmethod
+  def register_options(cls, register):
+    super(JvmPlatform, cls).register_options(register)
+    register('--platforms', advanced=True, type=Options.dict, default={}, fingerprint=True,
+             help='Compile settings that can be referred to by name in jvm_targets.')
+    register('--default-platform', advanced=True, type=str, default=None, fingerprint=True,
+             help='Name of the default platform to use if none are specified.')
+
+  def _parse_platform(self, name, platform):
+    return JvmPlatformSettings(platform.get('source', platform.get('target')),
+                               platform.get('target', platform.get('source')),
+                               platform.get('args', ()),
+                               name=name)
+
+  @memoized_property
+  def platforms_by_name(self):
+    platforms = self.get_options().platforms or {}
+    return { name: self._parse_platform(name, platform) for name, platform in platforms.items() }
+
+  @property
+  def _fallback_platform(self):
+    logger.warn('No default jvm platform is defined.')
+    source_level = JvmPlatform.parse_java_version(Distribution.cached().version)
+    target_level = source_level
+    platform_name = '(Distribution.cached().version {})'.format(source_level)
+    return JvmPlatformSettings(source_level, target_level, [], name=platform_name)
+
+  @memoized_property
+  def default_platform(self):
+    name = self.get_options().default_platform
+    if not name:
+      return self._fallback_platform
+    platforms_by_name = self.platforms_by_name
+    if name not in platforms_by_name:
+      raise self.IllegalDefaultPlatform(
+          "The default platform was set to '{0}', but no platform by that name has been "
+          "defined. Typically, this should be defined under [{1}] in pants.ini."
+          .format(name, self.options_scope)
+      )
+    return JvmPlatformSettings(*platforms_by_name[name], name='{} (by default)'.format(name))
+
+  @memoized_method
+  def get_platform_by_name(self, name, for_target=None):
+    """Finds the platform with the given name.
+
+    If the name is empty or None, returns the default platform.
+    If not platform with the given name is defined, raises an error.
+    :param str name: name of the platform.
+    :param JvmTarget for_target: optionally specified target we're looking up the platform for.
+      Only used in error message generation.
+    :return: The jvm platform object.
+    :rtype: JvmPlatformSettings
+    """
+    if not name:
+      return self.default_platform
+    if name not in self.platforms_by_name:
+      raise self.UndefinedJvmPlatform(for_target, name, self.platforms_by_name)
+    return self.platforms_by_name[name]
+
+  def get_platform_for_target(self, target):
+    if not target.payload.platform and target.is_synthetic:
+      derived_from = target.derived_from
+      platform = derived_from and getattr(derived_from, 'platform', None)
+      if platform:
+        return platform
+    return self.get_platform_by_name(target.payload.platform, target)
+
+  @classmethod
+  def parse_java_version(cls, version):
+    """Parses the java version (given a string or Revision object).
+
+    Handles java version-isms, converting things like '7' -> '1.7' appropriately.
+
+    Truncates input versions down to just the major and minor numbers (eg, 1.6), ignoring extra
+    versioning information after the second number.
+
+    :param version: the input version, given as a string or Revision object.
+    :return: the parsed and cleaned version, suitable as a javac -source or -target argument.
+    :rtype: Revision
+    """
+    conversion = { str(i): '1.{}'.format(i) for i in cls.SUPPORTED_CONVERSION_VERSIONS }
+    if str(version) in conversion:
+      return Revision.lenient(conversion[str(version)])
+
+    if not hasattr(version, 'components'):
+      version = Revision.lenient(version)
+    if len(version.components) <= 2:
+      return version
+    return Revision(*version.components[:2])
+
+
+class JvmPlatformSettings(object):
+  """Simple information holder to keep track of common arguments to java compilers."""
+
+  class IllegalSourceTargetCombination(TaskError):
+    """Illegal pair of -source and -target flags to compile java."""
+
+  def __init__(self, source_level, target_level, args, name=None):
+    """
+    :param source_level: Revision object or string for the java source level.
+    :param target_level: Revision object or string for the java target level.
+    :param list args: Additional arguments to pass to the java compiler.
+    :param str name: optional name to identify this platform; not used for anything but logging.
+    """
+    self.source_level = JvmPlatform.parse_java_version(source_level)
+    self.target_level = JvmPlatform.parse_java_version(target_level)
+    self.args = tuple(args or ())
+    self.name = name
+    self._validate_source_target()
+
+  def _validate_source_target(self):
+    if self.source_level > self.target_level:
+      raise self.IllegalSourceTargetCombination(
+        'Platform {platform} has java source level {source_level} but target level {target_level}.'
+        .format(platform=self.name,
+                source_level=self.source_level,
+                target_level=self.target_level)
+      )
+
+  def __iter__(self):
+    yield self.source_level
+    yield self.target_level
+    yield self.args
+
+  def __eq__(self, other):
+    return tuple(self) == tuple(other)
+
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
+  def __hash__(self):
+    return hash(tuple(self))
+
+  def __cmp__(self, other):
+    return cmp(tuple(self), tuple(other))
+
+  def __str__(self):
+    return 'source={source},target={target},args=({args})'.format(
+      source=self.source_level,
+      target=self.target_level,
+      args=' '.join(self.args)
+    )

--- a/src/python/pants/backend/jvm/targets/BUILD
+++ b/src/python/pants/backend/jvm/targets/BUILD
@@ -29,6 +29,7 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     'src/python/pants/backend/core/targets:common',
+    'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/base:address_lookup_error',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_manual',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -64,6 +64,7 @@ python_library(
     ':jvm_compile_isolated_strategy',
     ':jvm_dependency_analyzer',
     'src/python/pants/backend/core/tasks:group_task',
+    'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/goal:products',
     'src/python/pants/option',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet
 
+from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile_strategy import JvmCompileStrategy
 from pants.backend.jvm.tasks.jvm_compile.jvm_dependency_analyzer import JvmDependencyAnalyzer
@@ -28,6 +29,9 @@ from pants.util.dirutil import safe_mkdir, safe_walk
 
 class JvmCompileGlobalStrategy(JvmCompileStrategy):
   """A strategy for JVM compilation that uses a global classpath and analysis."""
+
+  class InternalTargetPartitioningError(Exception):
+    """Error partitioning targets by jvm platform settings."""
 
   @classmethod
   def register_options(cls, register, language, supports_concurrent_execution):
@@ -193,6 +197,122 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
 
     return (self._partition_size_hint, locally_changed_targets)
 
+
+  def ordered_compile_settings_and_targets(self, relevant_targets):
+    """Groups the targets into ordered chunks, dependencies before dependees.
+
+    Each chunk is of the form (compile_setting, targets). Attempts to create as few chunks as
+    possible, under the constraint that targets with different compile settings cannot be in the
+    same chunk, and dependencies must be in the same chunk or an earlier chunk than their
+    dependees.
+
+    Detects impossible combinations/dependency relationships with respect to the java target and
+    source level, and raising errors as necessary (see targets_to_compile and
+    infer_and_validate_java_target_levels).
+
+    :return: a list of tuples of the form (compile_settings, list of targets)
+    """
+    relevant_targets = set(relevant_targets)
+
+    def get_platform(target):
+      return getattr(target, 'platform', None)
+
+    # NB(gmalmquist): Short-circuit if we only have one platform. Asymptotically, this only gives us
+    # O(|V|) time instead of O(|V|+|E|) if we have only one platform, which doesn't seem like much,
+    # but in practice we save a lot of time because the runtime for the non-short-circuited code is
+    # multiplied by a higher constant, because we have to iterate over all the targets several
+    # times.
+    platform_counts = defaultdict(int)
+    for target in relevant_targets:
+      platform_counts[target.platform] += 1
+    if len(platform_counts) == 1:
+      settings, = platform_counts
+      return [(settings, relevant_targets)]
+
+    # Map of target -> dependees.
+    outgoing = defaultdict(set)
+    # Map of target -> dependencies.
+    incoming = defaultdict(set)
+
+    transitive_targets = set()
+
+    def add_edges(target):
+      transitive_targets.add(target)
+      if target.dependencies:
+        for dependency in target.dependencies:
+          outgoing[dependency].add(target)
+          incoming[target].add(dependency)
+
+    self.context.build_graph.walk_transitive_dependency_graph([t.address for t in relevant_targets],
+                                                               work=add_edges)
+    # Topological sort.
+    sorted_targets = []
+    frontier = defaultdict(set)
+
+    def add_node(node):
+      frontier[get_platform(node)].add(node)
+
+    def next_node():
+      next_setting = None
+      if sorted_targets:
+        # Prefer targets with the same settings as whatever we just added to the sorted list, to
+        # greedily create chains that are as long as possible.
+        next_setting = get_platform(sorted_targets[-1])
+      if next_setting not in frontier:
+        if None in frontier:
+          # NB(gmalmquist): compile_settings=None indicates a target that is not actually a
+          # jvm_target, which mean's it's an intermediate dependency. We want to expand these
+          # whenever we can, because they give us more options we can use to create longer chains.
+          next_setting = None
+        else:
+          next_setting = max(frontier.keys(), key=lambda setting: len(frontier[setting]))
+      node = frontier[next_setting].pop()
+      if not frontier[next_setting]:
+        frontier.pop(next_setting)
+      return node
+
+    for target in transitive_targets:
+      if not incoming[target]:
+        add_node(target)
+
+    while frontier:
+      node = next_node()
+      sorted_targets.append(node)
+      if node in outgoing:
+        for dependee in tuple(outgoing[node]):
+          outgoing[node].remove(dependee)
+          incoming[dependee].remove(node)
+          if not incoming[dependee]:
+            add_node(dependee)
+
+    sorted_targets = [target for target in sorted_targets if target in relevant_targets]
+
+    if set(sorted_targets) != relevant_targets:
+      added = '\n  '.join(t.address.spec for t in (set(sorted_targets)-relevant_targets))
+      removed = '\n  '.join(t.address.spec for t in (set(relevant_targets)-sorted_targets))
+      raise self.InternalTargetPartitioningError(
+        'Internal partitioning targets:\nSorted targets =/= original targets!\n'
+        'Added:\n  {}\nRemoved:\n  {}'.format(added, removed)
+      )
+
+    unconsumed_edges = any(len(edges) > 0 for edges in outgoing.values())
+    if unconsumed_edges:
+      raise self.InternalTargetPartitioningError(
+        'Cycle detected while ordering jvm_targets for compilation. This should have been detected '
+        'when constructing the build_graph, so the presence of this error means there is probably '
+        'a bug in this method.'
+      )
+
+    chunks = []
+    for target in sorted_targets:
+      if not isinstance(target, JvmTarget):
+        continue
+      if chunks and chunks[-1][0] == get_platform(target):
+        chunks[-1][1].append(target)
+      else:
+        chunks.append((get_platform(target), [target]))
+    return chunks
+
   def compile_chunk(self,
                     invalidation_check,
                     all_targets,
@@ -202,6 +322,28 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
                     compile_vts,
                     register_vts,
                     update_artifact_cache_vts_work):
+    assert invalid_targets, "compile_chunk should only be invoked if there are invalid targets."
+    settings_and_targets = self.ordered_compile_settings_and_targets(invalid_targets)
+    for settings, targets in settings_and_targets:
+      if targets:
+        self.compile_sub_chunk(invalidation_check,
+                               all_targets,
+                               targets,
+                               extra_compile_time_classpath_elements,
+                               compile_vts,
+                               register_vts,
+                               update_artifact_cache_vts_work,
+                               settings)
+
+  def compile_sub_chunk(self,
+                        invalidation_check,
+                        all_targets,
+                        invalid_targets,
+                        extra_compile_time_classpath_elements,
+                        compile_vts,
+                        register_vts,
+                        update_artifact_cache_vts_work,
+                        settings):
     """Executes compilations for the invalid targets contained in a single chunk.
 
     Has the side effects of populating:
@@ -210,8 +352,6 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
     # classes_by_target product
     # resources_by_target product
     """
-    assert invalid_targets, "compile_chunk should only be invoked if there are invalid targets."
-
     extra_classpath_tuples = self._compute_extra_classpath(extra_compile_time_classpath_elements)
 
     # Get the classpath generated by upstream JVM tasks and our own prepare_compile().
@@ -270,7 +410,8 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
                   compile_classpath,
                   self._classes_dir,
                   None,
-                  progress_message)
+                  progress_message,
+                  settings)
 
       # No exception was thrown, therefore the compile succeeded and analysis_file is now valid.
       if os.path.exists(analysis_file):  # The compilation created an analysis.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
@@ -185,6 +185,7 @@ class JvmCompileIsolatedStrategy(JvmCompileStrategy):
             tmpdir, compile_context.target)
         if os.path.exists(compile_context.analysis_file):
            shutil.copy(compile_context.analysis_file, tmp_analysis_file)
+        target, = vts.targets
         compile_vts(vts,
                     compile_context.sources,
                     tmp_analysis_file,
@@ -192,7 +193,8 @@ class JvmCompileIsolatedStrategy(JvmCompileStrategy):
                     cp_entries,
                     compile_context.classes_dir,
                     log_file,
-                    progress_message)
+                    progress_message,
+                    target.platform)
         atomic_copy(tmp_analysis_file, compile_context.analysis_file)
 
         # Update the products with the latest classes.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_strategy.py
@@ -114,7 +114,8 @@ class JvmCompileStrategy(object):
                     extra_compile_time_classpath_elements,
                     compile_vts,
                     register_vts,
-                    update_artifact_cache_vts_work):
+                    update_artifact_cache_vts_work,
+                    settings):
     """Executes compilations for that invalid targets contained in a single language chunk."""
 
   @abstractmethod

--- a/src/python/pants/base/revision.py
+++ b/src/python/pants/base/revision.py
@@ -87,3 +87,15 @@ class Revision(object):
 
   def __repr__(self):
     return '{}({})'.format(self.__class__.__name__, ', '.join(map(repr, self._components)))
+
+  def __eq__(self, other):
+    return hasattr(other, '_components') and tuple(self._components) == tuple(other._components)
+
+  def __ne__(self, other):
+    return not self.__eq__(other)
+
+  def __hash__(self):
+    return hash(self._components)
+
+  def __str__(self):
+    return '.'.join(str(c) for c in self._components)

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -147,6 +147,7 @@ class Subsystem(Optionable):
     super(Subsystem, self).__init__()
     self._scope = scope
     self._scoped_options = scoped_options
+    self._fingerprint = None
 
   @property
   def options_scope(self):

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='java6',
+  main='org.pantsbuild.testproject.targetlevels.java6.Six',
+  platform='java6',
+  dependencies=[':lib'],
+)
+
+java_library(name='lib',
+  sources=globs('*.java'),
+  platform='java6',
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6/Six.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6/Six.java
@@ -1,0 +1,10 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.targetlevels.java6;
+
+public class Six {
+    public static void main(String[] args) {
+        System.out.println("Six should have been compiled for java 1.6.");
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7/BUILD
@@ -1,0 +1,8 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='java7',
+  source='Seven.java',
+  main='org.pantsbuild.testproject.targetlevels.java7.Seven',
+  platform='java7',
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7/Seven.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7/Seven.java
@@ -1,0 +1,11 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.targetlevels.java7;
+
+public class Seven<T> {
+    public static void main(String[] args) {
+        System.out.println("Seven should have been compiled for java 1.7.");
+        Seven<String> seven = new Seven<>();
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7on6/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7on6/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='java7on6',
+  source='SevenOnSix.java',
+  main='org.pantsbuild.testproject.targetlevels.java7on6.SevenOnSix',
+  platform='java7',
+  dependencies=[
+    'testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6:lib',
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7on6/SevenOnSix.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7on6/SevenOnSix.java
@@ -1,0 +1,17 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.targetlevels.java7on6;
+
+import org.pantsbuild.testproject.targetlevels.java6.Six;
+
+/**
+ * Java 1.7 class depending on a Java 1.6 class.
+ */
+public class SevenOnSix<T> {
+    public static void main(String[] args) {
+        System.out.println("SevenOnSix should have been compiled for java 1.7.");
+        Six.main(args);
+        SevenOnSix<String> sevenOnSix = new SevenOnSix<>(); // Shouldn't compile in java 6.
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java8/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java8/BUILD
@@ -1,0 +1,8 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='java8',
+  source='Eight.java',
+  main='org.pantsbuild.testproject.targetlevels.java8.Eight',
+  platform='java8',
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java8/Eight.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java8/Eight.java
@@ -1,0 +1,11 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.targetlevels.java8;
+
+public class Eight {
+    public static void main(String[] args) {
+        Runnable printMessage = () -> System.out.println("Compiled to java 1.8.");
+        printMessage.run();
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='unspecified',
+  main='org.pantsbuild.testproject.targetlevels.unspecified.Unspecified',
+  dependencies=[
+    ':java6',
+    ':java7',
+    ':lib',
+  ],
+)
+
+java_library(name='lib',
+  sources=globs('Unspecified.java'),
+)
+
+java_library(name='java6',
+  sources=globs('Six.java'),
+  platform='java6',
+  dependencies=[':lib'],
+)
+
+java_library(name='java7',
+  sources=globs('Seven.java'),
+  platform='java7',
+  dependencies=[':lib'],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/Seven.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/Seven.java
@@ -1,0 +1,11 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.targetlevels.unspecified;
+
+public class Seven<T> {
+    public static void main(String[] args) {
+        System.out.println("Java target level seven.");
+        Seven<String> seven = new Seven<>();
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/Six.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/Six.java
@@ -1,0 +1,11 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.targetlevels.unspecified;
+
+public class Six {
+    public static void main(String[] args) {
+        Unspecified.main(args);
+        System.out.println("Java target level six.");
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/Unspecified.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/Unspecified.java
@@ -1,0 +1,10 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.targetlevels.unspecified;
+
+public class Unspecified {
+    public static void main(String[] args) {
+        System.out.println("Ostensibly can be compiled at any level, except :six depends on it.");
+    }
+}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -4,7 +4,10 @@
 target(
   name='java',
   dependencies=[
-    ':jmake_analysis'
+    ':jmake_analysis',
+    ':java_compile_jvm_platform_integration',
+    ':java_zinc_compile_jvm_platform_integration',
+    ':java_compile_settings_partitioning',
   ],
 )
 
@@ -43,4 +46,44 @@ python_tests(
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
   ]
+)
+
+python_tests(
+  name='java_compile_jvm_platform_integration',
+  sources=['test_java_compile_jvm_platform_integration.py'],
+  dependencies=[
+    ':jvm_platform_integration_mixin',
+  ]
+)
+
+python_tests(
+  name='java_zinc_compile_jvm_platform_integration',
+  sources=['test_java_zinc_compile_jvm_platform_integration.py'],
+  dependencies=[
+    ':jvm_platform_integration_mixin',
+  ]
+)
+
+python_tests(
+  name='java_compile_settings_partitioning',
+  sources=['test_java_compile_settings_partitioning.py'],
+  dependencies=[
+    'src/python/pants/backend/jvm/tasks/jvm_compile:java',
+    'src/python/pants/fs',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:base_test',
+  ],
+)
+
+python_tests(
+  name='jvm_platform_integration_mixin',
+  sources=['jvm_platform_integration_mixin.py'],
+  dependencies=[
+    'src/python/pants/backend/jvm/tasks/jvm_compile:java',
+    'src/python/pants/fs',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:int-test',
+  ],
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
@@ -1,0 +1,224 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import re
+from subprocess import PIPE, Popen
+from textwrap import dedent
+
+from pants.fs.archive import ZIP
+from pants.util.contextutil import temporary_dir
+from pants_test.testutils.compile_strategy_utils import provide_compile_strategies
+
+
+class JvmPlatformIntegrationMixin(object):
+  """Mixin providing lots of JvmPlatform-related integration tests to java compilers (eg, jmake)."""
+
+  def get_pants_compile_args(self):
+    raise NotImplementedError
+
+  def determine_version(self, path):
+    """Given the filepath to a class file, invokes the 'file' commandline to find its java version.
+
+    :param str path: filepath (eg, tempdir/Foo.class)
+    :return: A java version string (eg, '1.6').
+    """
+    # Map of target version numbers to their equivalent class file versions, which are different.
+    version_map = {
+      '50.0': '1.6',
+      '51.0': '1.7',
+      '52.0': '1.8',
+    }
+    p = Popen(['file', path], stdout=PIPE, stderr=PIPE)
+    out, err = p.communicate()
+    self.assertEqual(0, p.returncode, 'Failed to run file on {}.'.format(path))
+    match = re.search(r'version (\d+[.]\d+)', out)
+    self.assertTrue(match is not None, 'Could not determine version for {}'.format(path))
+    return version_map[match.group(1)]
+
+  def _get_jar_class_versions(self, jarname):
+    path = os.path.join('dist', jarname)
+    self.assertTrue(os.path.exists(path), '{} does not exist.'.format(path))
+
+    class_to_version = {}
+    with temporary_dir() as tempdir:
+      ZIP.extract(path, tempdir, filter_func=lambda f: f.endswith('.class'))
+      for root, dirs, files in os.walk(tempdir):
+        for name in files:
+          path = os.path.abspath(os.path.join(root, name))
+          class_to_version[os.path.relpath(path, tempdir)] = self.determine_version(path)
+    return class_to_version
+
+  def _get_compiled_class_versions(self, strategy, spec):
+    jar_name = os.path.basename(spec)
+    if ':' in jar_name:
+      if ':' in jar_name[:-1]:
+        jar_name = jar_name[jar_name.find(':')+1:]
+      else:
+        jar_name = jar_name[:-1]
+    with temporary_dir() as cache_dir:
+      config = {'cache.compile.java': {'write_to': [cache_dir]}}
+      with temporary_dir(root_dir=self.workdir_root()) as workdir:
+        pants_run = self.run_pants_with_workdir(
+          ['binary',] + self.get_pants_compile_args()
+          + ['--jvm-compile-strategy={}'.format(strategy), 'compile.checkstyle', '--skip', spec],
+          workdir, config)
+        self.assert_success(pants_run)
+        return self._get_jar_class_versions('{}.jar'.format(jar_name))
+
+  def assert_class_versions(self, expected, received):
+    def format_dict(d):
+      return ''.join('\n    {} = {}'.format(key, val) for key, val in sorted(d.items()))
+    self.assertEqual(expected, received,
+                     'Compiled class versions differed.\n  expected: {}\n  received: {}'
+                     .format(format_dict(expected), format_dict(received)))
+
+  @provide_compile_strategies
+  def test_compile_java6(self, strategy):
+    target_spec = 'testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6'
+    self.assert_class_versions({
+      'org/pantsbuild/testproject/targetlevels/java6/Six.class': '1.6',
+    }, self._get_compiled_class_versions(strategy, target_spec))
+
+  @provide_compile_strategies
+  def test_compile_java7(self, strategy):
+    target_spec = 'testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7'
+    self.assert_class_versions({
+      'org/pantsbuild/testproject/targetlevels/java7/Seven.class': '1.7',
+    }, self._get_compiled_class_versions(strategy, target_spec))
+
+  @provide_compile_strategies
+  def test_compile_java7on6(self, strategy):
+    target_spec = 'testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7on6'
+    self.assert_class_versions({
+      'org/pantsbuild/testproject/targetlevels/java7on6/SevenOnSix.class': '1.7',
+      'org/pantsbuild/testproject/targetlevels/java6/Six.class': '1.6',
+    }, self._get_compiled_class_versions(strategy, target_spec))
+
+  @provide_compile_strategies
+  def test_compile_target_coercion(self, strategy):
+    target_spec = 'testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified'
+    self.assert_class_versions({
+      'org/pantsbuild/testproject/targetlevels/unspecified/Unspecified.class': '1.6',
+      'org/pantsbuild/testproject/targetlevels/unspecified/Six.class': '1.6',
+      'org/pantsbuild/testproject/targetlevels/unspecified/Seven.class': '1.7',
+    }, self._get_compiled_class_versions(strategy, target_spec))
+
+  def _test_compile(self, target_level, class_name, source_contents, strategy, platform_args=None):
+    with temporary_dir(root_dir=os.path.abspath('.')) as tmpdir:
+      with open(os.path.join(tmpdir, 'BUILD'), 'w') as f:
+        f.write(dedent('''
+        java_library(name='{target_name}',
+          sources=['{class_name}.java'],
+          platform='{target_level}',
+        )
+        '''.format(target_name=os.path.basename(tmpdir),
+                   class_name=class_name,
+                   target_level=target_level)))
+      with open(os.path.join(tmpdir, '{}.java'.format(class_name)), 'w') as f:
+        f.write(source_contents)
+      platforms=str({
+        str(target_level): {
+          'source': str(target_level),
+          'target': str(target_level),
+          'args': platform_args or [],
+        }
+      })
+      command = []
+      command.extend(['--jvm-platform-platforms={}'.format(platforms),
+                      '--jvm-platform-default-platform={}'.format(target_level)])
+      command.extend(self.get_pants_compile_args())
+      command.extend(['--strategy={}'.format(strategy), tmpdir])
+
+      pants_run = self.run_pants(command)
+      return pants_run
+
+  @provide_compile_strategies
+  def test_compile_diamond_operator_java7_works(self, strategy):
+    pants_run = self._test_compile('1.7', 'Diamond', dedent('''
+      public class Diamond<T> {
+        public static void main(String[] args) {
+          Diamond<String> diamond = new Diamond<>();
+        }
+      }
+    '''), strategy)
+    self.assert_success(pants_run)
+
+  @provide_compile_strategies
+  def test_compile_diamond_operator_java6_fails(self, strategy):
+    pants_run = self._test_compile('1.6', 'Diamond', dedent('''
+      public class Diamond<T> {
+        public static void main(String[] args) {
+          Diamond<String> diamond = new Diamond<>();
+        }
+      }
+    '''), strategy)
+    self.assert_failure(pants_run)
+
+  @provide_compile_strategies
+  def test_compile_with_javac_args(self, strategy):
+    pants_run = self._test_compile('1.7', 'LintyDiamond', dedent('''
+      public class LintyDiamond<T> {
+        public static void main(String[] args) {
+          LintyDiamond<String> diamond = new LintyDiamond<>();
+        }
+      }
+    '''), strategy, platform_args=['-C-Xlint:cast'])
+    self.assert_success(pants_run)
+
+  def test_compile_stale_platform_settings(self):
+    # Tests that targets are properly re-compiled when their source/target levels change.
+    # This currently fails because JMAKE doesn't realize that the old class files should be removed.
+    with temporary_dir(root_dir=os.path.abspath('.')) as tmpdir:
+      with open(os.path.join(tmpdir, 'BUILD'), 'w') as f:
+        f.write(dedent('''
+        java_library(name='diamond',
+          sources=['Diamond.java'],
+        )
+        '''))
+      with open(os.path.join(tmpdir, 'Diamond.java'), 'w') as f:
+        f.write(dedent('''
+          public class Diamond<T> {
+            public static void main(String[] args) {
+              // The diamond operator <> for generics was introduced in jdk7.
+              Diamond<String> shinyDiamond = new Diamond<>();
+            }
+          }
+        '''))
+      platforms = {
+        'java6': {'source': '6'},
+        'java7': {'source': '7'},
+      }
+
+      # We run these all in the same working directory, because we're testing caching behavior.
+      with temporary_dir(root_dir=self.workdir_root()) as workdir:
+
+        def compile_diamond(platform):
+          return self.run_pants_with_workdir(['--jvm-platform-platforms={}'.format(platforms),
+                                              '--jvm-platform-default-platform={}'.format(platform),
+                                              '--jvm-compile-strategy=isolated',
+                                              '-ldebug',
+                                              'compile',] + self.get_pants_compile_args() +
+                                              ['{}:diamond'.format(tmpdir)], workdir=workdir)
+
+        # We shouldn't be able to compile this with -source=6.
+        self.assert_failure(compile_diamond('java6'), 'Diamond.java was compiled successfully with '
+                                                      'java6 starting from a fresh workdir, but '
+                                                      'that should not be possible.')
+
+        # We should be able to compile this with -source=7.
+        self.assert_success(compile_diamond('java7'), 'Diamond.java failed to compile in java7, '
+                                                      'which it should be able to.')
+
+        # We still shouldn't be able to compile this with -source=6. If the below passes, it means
+        #  that we saved the cached run from java7 and didn't recompile, which is an error.
+        self.assert_failure(compile_diamond('java6'), 'Diamond.java erroneously compiled in java6,'
+                                                      ' which means that either compilation was'
+                                                      ' skipped due to bad fingerprinting/caching,'
+                                                      ' or the compiler (probably jmake) failed to'
+                                                      ' clean up the previous class from the java7'
+                                                      ' compile.')

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_jvm_platform_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_jvm_platform_integration.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import pytest
+
+from pants_test.backend.jvm.tasks.jvm_compile.java.jvm_platform_integration_mixin import \
+  JvmPlatformIntegrationMixin
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class JavaCompileJvmPlatformIntegrationTest(JvmPlatformIntegrationMixin, PantsRunIntegrationTest):
+
+  def get_pants_compile_args(self):
+    return ['compile.java']
+
+  @pytest.mark.xfail
+  def test_compile_stale_platform_settings(self):
+    super(JavaCompileJvmPlatformIntegrationTest, self).test_compile_stale_platform_settings()

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -1,0 +1,229 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import defaultdict
+
+from pants.backend.jvm.subsystems.jvm_platform import JvmPlatformSettings
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.tasks.jvm_compile.java.java_compile import JavaCompile
+from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
+from pants.base.revision import Revision
+from pants.util.memo import memoized_method
+from pants_test.tasks.task_test_base import TaskTestBase
+
+
+class JavaCompileSettingsPartitioningTest(TaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return JavaCompile
+
+  def _java(self, name, platform=None, deps=None, sources=None):
+    return self.make_target(spec='java:{}'.format(name),
+                            target_type=JavaLibrary,
+                            platform=platform,
+                            dependencies=deps or [],
+                            sources=sources)
+
+  def _platforms(self, *versions):
+    return { str(v): {'source': str(v)} for v in versions}
+
+  @memoized_method
+  def _version(self, version):
+    return Revision.lenient(version)
+
+  def _task_setup(self, targets, platforms=None, default_platform=None, **options):
+    options['source'] = options.get('source', '1.7')
+    options['target'] = options.get('target', '1.7')
+    self.set_options(**options)
+    self.set_options_for_scope('jvm-platform', platforms=platforms,
+                               default_platform=default_platform)
+    context = self.context(target_roots=targets)
+    return self.create_task(context)
+
+  def _settings_and_targets(self, targets, ordered=False, **options):
+    if ordered:
+      # Only works in global! Isolated doesn't need this ordering.
+      task = self._task_setup(targets, strategy='global', **options)
+      task.validate_platform_dependencies(targets)
+      return task._strategy.ordered_compile_settings_and_targets(targets)
+    task = self._task_setup(targets, **options)
+    task.validate_platform_dependencies(targets)
+    settings_and_targets = defaultdict(set)
+    for target in targets:
+      settings_and_targets[target.platform].add(target)
+    return settings_and_targets.items()
+
+  def _partition(self, targets, **options):
+    task = self._task_setup(targets, **options)
+    task.validate_platform_dependencies(targets)
+    partition = defaultdict(set)
+    for target in targets:
+      partition[target.platform.target_level].add(target)
+    return partition
+
+  def _format_partition(self, partition):
+    return '{{{}\n  }}'.format(','.join(
+      '\n    {}: [{}]'.format(key, ', '.join(sorted(t.address.spec for t in value)))
+      for key, value in sorted(partition.items())
+    ))
+
+  def assert_partitions_equal(self, expected, received):
+    # Convert to normal dicts and remove empty values.
+    expected = { key: set(val) for key, val in expected.items() if val }
+    received = { key: set(val) for key, val in received.items() if val }
+    self.assertEqual(expected, received, 'Partitions are different!\n  expected: {}\n  received: {}'
+                                        .format(self._format_partition(expected),
+                                                self._format_partition(received)))
+
+  def test_single_target(self):
+    java6 = self._java('six', '1.6')
+    partition = self._partition([java6], platforms=self._platforms('1.6'))
+    self.assertEqual(1, len(partition))
+    self.assertEqual({java6}, set(partition[self._version('1.6')]))
+
+  def test_independent_targets(self):
+    java6 = self._java('six', '1.6')
+    java7 = self._java('seven', '1.7')
+    java8 = self._java('eight', '1.8')
+    partition = self._partition([java6, java7, java8],
+                                platforms=self._platforms('1.6', '1.7', '1.8'))
+    expected = { self._version(java.payload.platform): {java}
+                 for java in (java6, java7, java8) }
+    self.assertEqual(3, len(partition))
+    self.assert_partitions_equal(expected, partition)
+
+  def test_java_version_aliases(self):
+    expected = {}
+    for version in (6,7,8):
+      expected[Revision.lenient('1.{}'.format(version))] = {
+        self._java('j1{}'.format(version), '1.{}'.format(version)),
+        self._java('j{}'.format(version), '{}'.format(version)),
+      }
+    partition = self._partition(list(reduce(set.union, expected.values(), set())),
+                                platforms=self._platforms('6', '7', '8', '1.6', '1.7', '1.8'))
+    self.assertEqual(len(expected), len(partition))
+    self.assert_partitions_equal(expected, partition)
+
+  def test_valid_dependent_targets(self):
+    java6 = self._java('six', '1.6')
+    java7 = self._java('seven', '1.7')
+    java8 = self._java('eight', '1.8', deps=[java6])
+
+    partition = self._partition([java6, java7, java8],
+                                platforms=self._platforms('1.6', '1.7', '1.8'))
+    self.assert_partitions_equal({
+      self._version('1.6'): {java6},
+      self._version('1.7'): {java7},
+      self._version('1.8'): {java8},
+    }, partition)
+
+  def test_invalid_dependent_targets(self):
+    java7 = self._java('seven', '1.7')
+    java6 = self._java('six', '1.6', deps=[java7])
+    with self.assertRaises(JvmCompile.IllegalJavaTargetLevelDependency):
+      self._partition([java6, java7], platforms=self._platforms('1.6', '1.7'))
+
+  def test_invalid_dependent_targets_nonlexographic(self):
+    java7 = self._java('seven', '1.7')
+    java6 = self._java('six', '6', deps=[java7])
+    with self.assertRaises(JvmCompile.IllegalJavaTargetLevelDependency):
+      self._partition([java6, java7], platforms=self._platforms('6', '1.7'))
+
+  def test_unspecified_default(self):
+    java = self._java('unspecified', None)
+    java6 = self._java('six', '1.6', deps=[java])
+    java7 = self._java('seven', '1.7', deps=[java])
+    partition = self._partition([java7, java, java6], source='1.6', target='1.6',
+                                platforms=self._platforms('1.6', '1.7'),
+                                default_platform='1.6')
+    self.assert_partitions_equal({
+      self._version('1.6'): {java, java6},
+      self._version('1.7'): {java7},
+    }, partition)
+
+  def test_invalid_source_target_combination_by_jvm_platform(self):
+    java_wrong = self._java('source7target6', 'bad')
+    with self.assertRaises(JvmPlatformSettings.IllegalSourceTargetCombination):
+      self._settings_and_targets([java_wrong], platforms={
+        'bad': {'source': '1.7', 'target': '1.6'}
+      })
+
+  def test_valid_source_target_combination(self):
+    platforms = {
+      'java67': {'source': 6, 'target': 7},
+      'java78': {'source': 7, 'target': 8},
+      'java68': {'source': 6, 'target': 8},
+    }
+    self._settings_and_targets([
+      self._java('java67', 'java67'),
+      self._java('java78', 'java78'),
+      self._java('java68', 'java68'),
+    ], platforms=platforms)
+
+  def test_compile_setting_equivalence(self):
+    self.assertEqual(JvmPlatformSettings('1.6', '1.6', ['-Xfoo:bar']),
+                     JvmPlatformSettings('1.6', '1.6', ['-Xfoo:bar']))
+
+  def test_compile_setting_inequivalence(self):
+    self.assertNotEqual(JvmPlatformSettings('1.6', '1.6', ['-Xfoo:bar']),
+                        JvmPlatformSettings('1.6', '1.7', ['-Xfoo:bar']))
+
+    self.assertNotEqual(JvmPlatformSettings('1.6', '1.6', ['-Xfoo:bar']),
+                        JvmPlatformSettings('1.6', '1.6', ['-Xbar:foo']))
+
+    self.assertNotEqual(JvmPlatformSettings('1.4', '1.6', ['-Xfoo:bar']),
+                        JvmPlatformSettings('1.6', '1.6', ['-Xfoo:bar']))
+
+  def test_chunks_respect_dependencies(self):
+    # Create the dependency tree:
+    # a <- b <-|
+    #      c <-|<- e <- f <- g <- | <- i <- j <- k
+    #      d <-|             h <- |
+    a = self._java('a', platform='1.6')
+    b = self._java('b', platform='1.6', deps=[a])
+    c = self._java('c', platform='1.6')
+    d = self._java('d', platform='1.7')
+    e = self._java('e', platform='1.7', deps=[b,c,d])
+    f = self._java('f', platform='1.7', deps=[e])
+    g = self._java('g', platform='1.8', deps=[f])
+    h = self._java('h', platform='1.6')
+    i = self._java('i', platform='1.8', deps=[g])
+    j = self._java('j', platform='1.8-bar', deps=[i])
+    k = self._java('k', platform='1.8', deps=[j])
+
+    platforms = {
+      '1.6': {'source': '1.6'},
+      '1.7': {'source': '1.7'},
+      '1.8': {'source': '1.8'},
+      '1.8-bar': {'source': '1.8', 'args': ['-Xfoo:bar']}
+    }
+
+    def _settings(target_level, args=None):
+      return JvmPlatformSettings(target_level, target_level, args)
+
+    def _format_chunk(chunk):
+      settings, targets = chunk
+      return '{}: ({})'.format(str(settings), ', '.join(sorted(t.address.spec for t in targets)))
+
+    expected = [
+      (_settings('1.6'), {a,b,c,h}),
+      (_settings('1.7'), {d,e,f}),
+      (_settings('1.8'), {g,i}),
+      (_settings('1.8', ['-Xfoo:bar']), {j}),
+      (_settings('1.8'), {k})
+    ]
+
+    settings_and_targets = self._settings_and_targets([a,b,c,d,e,f,g,h,i,j,k],
+                                                      ordered=True,
+                                                      platforms=platforms)
+    received = [(settings, set(targets)) for settings, targets in settings_and_targets]
+
+    self.assertEqual(expected, received, 'Expected: {}\n\nReceived: {}'.format(
+      ''.join('\n  {}'.format(_format_chunk(s)) for s in expected),
+      ''.join('\n  {}'.format(_format_chunk(s)) for s in received),
+    ))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_zinc_compile_jvm_platform_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_zinc_compile_jvm_platform_integration.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import pytest
+
+from pants_test.backend.jvm.tasks.jvm_compile.java.jvm_platform_integration_mixin import \
+  JvmPlatformIntegrationMixin
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class JavaZincCompileJvmPlatformIntegrationTest(JvmPlatformIntegrationMixin,
+                                                PantsRunIntegrationTest):
+
+  def get_pants_compile_args(self):
+    return ['--compile-zinc-java-enabled', 'compile.zinc-java']
+
+  def test_compile_stale_platform_settings(self):
+    super(JavaZincCompileJvmPlatformIntegrationTest, self).test_compile_stale_platform_settings()

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -27,6 +27,10 @@ def create_option_values(option_values):
       self.__dict__ = option_values
     def __getitem__(self, key):
       return getattr(self, key)
+    def get(self, key, default=None):
+      if hasattr(self, key):
+        return getattr(self, key, default)
+      return default
   return TestOptionValues()
 
 


### PR DESCRIPTION
jvm_compile automatically partitions targets by their compile
settings before sending them on to the CompileStrategy. Validation
is done to ensure no targets transitively depend on targets with
a higher target_level, and to ensure that no target has a
source_level higher than its target_level.

The partitioning also respects target dependencies, so two dependent
targets with the same compile settings may be compiled in different
chunks if they are separated by an intermediate dependency with
different settings. An example and test of this behavior can be
found in test_java_compile_settings_partitioning#test_chunks_respect_dependencies.