### PR TITLE
Support bdists for setuptools and wheel.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ pystache==0.5.3
 pytest>=2.6,<2.7
 pytest-cov>=1.8,<1.9
 requests>=2.5.0,<2.6
-setuptools==5.4.1
+setuptools==15.2
 six==1.8.0
 thrift==0.9.1
 wheel==0.24.0

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -77,7 +77,6 @@ python_library(
   sources = ['interpreter_cache.py'],
   dependencies = [
     '3rdparty/python:pex',
-    '3rdparty/python:setuptools',
     'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -170,31 +170,16 @@ class PythonInterpreterCache(object):
       if bdist.satisfies(requirement):
         return bdist
 
-    def do_resolve(*precedence):
-      return resolve(requirements=[requirement],
-                     fetchers=self._python_repos.get_fetchers(),
-                     interpreter=interpreter,
-                     context=self._python_repos.get_network_context(),
-                     precedence=precedence,
-                     cache=self._python_setup.resolver_cache_dir,
-                     cache_ttl=self._python_setup.resolver_cache_ttl)
-
-    # TODO(John Sirois): This resolve setup achieves the following logic:
-    #   When resolving, prefer wheels to eggs to sdists, and if an sdist is all that's available,
-    #   then build it as an egg.
-    #
-    # Currently resolve uses the precedence both for precedence purposes and to determine the bdist
-    # translator to pick for sdists.  It's the latter part of the overload that's getting in the
-    # way here and forcing and odd `do_resolve or do_resolve`.  With a single call and precedence
-    # of `WheelPackage, EggPackage, SourcePackage`, sdists get built by the most-preferred
-    # packager; ie: WheelPackage.  This fails systemically when wheel itself is not setup for the
-    # interpreter, and half of this method's job is to setup wheel for the interpreter!
-    #
-    # The TODO is to come up with a better API proposal for pex here that we can consume that
-    # allows for a more sane single resolve call that uses a fetch precedence order seperate from a
-    # translator precedence order, or else tries all available translators in precedence order
-    # before giving up.
-    distributions = do_resolve(WheelPackage, EggPackage) or do_resolve(EggPackage, SourcePackage)
+    # We're bootstrapping interpreters here; so since wheel is no built in we must limit
+    # bootstrapping to eggs.
+    precedence = (EggPackage, SourcePackage)
+    distributions = resolve(requirements=[requirement],
+                            fetchers=self._python_repos.get_fetchers(),
+                            interpreter=interpreter,
+                            context=self._python_repos.get_network_context(),
+                            precedence=precedence,
+                            cache=self._python_setup.resolver_cache_dir,
+                            cache_ttl=self._python_setup.resolver_cache_ttl)
     if not distributions:
       return None
 

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -8,12 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import shutil
 
-from pex.archiver import Archiver
-from pex.crawler import Crawler
-from pex.installer import EggInstaller
 from pex.interpreter import PythonIdentity, PythonInterpreter
-from pex.iterator import Iterator
-from pex.package import EggPackage, SourcePackage
+from pex.package import Package
+from pex.resolver import resolve
 
 from pants.util.dirutil import safe_concurrent_create, safe_mkdir
 
@@ -146,7 +143,6 @@ class PythonInterpreterCache(object):
       return self._resolve_interpreter(interpreter, interpreter_dir,
                                        self._python_setup.wheel_requirement())
 
-
   def _resolve_interpreter(self, interpreter, interpreter_dir, requirement):
     """Given a :class:`PythonInterpreter` and a requirement, return an interpreter with the
     capability of resolving that requirement or ``None`` if it's not possible to install a
@@ -160,42 +156,37 @@ class PythonInterpreterCache(object):
     if not interpreter_dir:
       interpreter_dir = os.path.join(self._cache_dir, str(interpreter.identity))
 
-    def installer_provider(sdist):
-      return EggInstaller(
-        Archiver.unpack(sdist),
-        strict=requirement.key != 'setuptools',
-        interpreter=interpreter)
-
-    egg = self._resolve_and_link(
-      requirement,
-      os.path.join(interpreter_dir, requirement.key),
-      installer_provider)
-
-    if egg:
-      return interpreter.with_extra(egg.name, egg.raw_version, egg.path)
+    target_link = os.path.join(interpreter_dir, requirement.key)
+    bdist = self._resolve_and_link(interpreter, requirement, target_link)
+    if bdist:
+      return interpreter.with_extra(bdist.name, bdist.raw_version, bdist.path)
     else:
       self._logger('Failed to resolve requirement {} for {}'.format(requirement, interpreter))
 
-  def _resolve_and_link(self, requirement, target_link, installer_provider):
+  def _resolve_and_link(self, interpreter, requirement, target_link):
     # Short-circuit if there is a local copy.
     if os.path.exists(target_link) and os.path.exists(os.path.realpath(target_link)):
-      egg = EggPackage(os.path.realpath(target_link))
-      if egg.satisfies(requirement):
-        return egg
+      bdist = Package.from_href(os.path.realpath(target_link))
+      if bdist.satisfies(requirement):
+        return bdist
 
-    fetchers = self._python_repos.get_fetchers()
-    context = self._python_repos.get_network_context()
-    iterator = Iterator(fetchers=fetchers, crawler=Crawler(context))
-    links = [link for link in iterator.iter(requirement) if isinstance(link, SourcePackage)]
+    # We accept the default `precedence` of WheelPackage, EggPackage, SourcePackage here.
+    distributions = resolve(requirements=[requirement],
+                            fetchers=self._python_repos.get_fetchers(),
+                            interpreter=interpreter,
+                            context=self._python_repos.get_network_context(),
+                            cache=self._python_setup.resolver_cache_dir,
+                            cache_ttl=self._python_setup.resolver_cache_ttl)
+    if not distributions:
+      return None
 
-    for link in links:
-      self._logger('    fetching {}'.format(link.url))
-      sdist = context.fetch(link)
-      self._logger('    installing {}'.format(sdist))
-      installer = installer_provider(sdist)
-      dist_location = installer.bdist()
-      target_location = os.path.join(os.path.dirname(target_link), os.path.basename(dist_location))
-      shutil.move(dist_location, target_location)
-      _safe_link(target_location, target_link)
-      self._logger('    installed {}'.format(target_location))
-      return EggPackage(target_location)
+    assert len(distributions) == 1, ('Expected exactly 1 distribution to be resolved for {}, '
+                                     'found:\n\t{}'.format(requirement,
+                                                           '\n\t'.join(map(str, distributions))))
+
+    dist_location = distributions[0].location
+    target_location = os.path.join(os.path.dirname(target_link), os.path.basename(dist_location))
+    shutil.move(dist_location, target_location)
+    _safe_link(target_location, target_link)
+    self._logger('    installed {}'.format(target_location))
+    return Package.from_href(target_location)

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -9,7 +9,7 @@ import os
 import shutil
 
 from pex.interpreter import PythonIdentity, PythonInterpreter
-from pex.package import EggPackage, Package, SourcePackage, WheelPackage
+from pex.package import EggPackage, Package, SourcePackage
 from pex.resolver import resolve
 
 from pants.util.dirutil import safe_concurrent_create, safe_mkdir

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -24,7 +24,7 @@ class PythonSetup(Subsystem):
     super(PythonSetup, cls).register_options(register)
     register('--interpreter-requirement', advanced=True, default='CPython>=2.7,<3',
              help='The interpreter requirement string for this python environment.')
-    register('--setuptools-version', advanced=True, default='5.4.1',
+    register('--setuptools-version', advanced=True, default='15.2',
              help='The setuptools version for this python environment.')
     register('--wheel-version', advanced=True, default='0.24.0',
              help='The wheel version for this python environment.')


### PR DESCRIPTION
Previously the interpreter cache did not accept binary distributions
when building up its interpreter cache.  This change simplifies
interpreter requirement resolution by using the pex resolve toolchain
and accepting any compatible resolved (and built) result.

https://rbcommons.com/s/twitter/r/2497/