### PR TITLE
Option to expose intransitive target dependencies

### DIFF
--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -30,8 +30,8 @@ class Dependencies(ConsoleTask):
              help='Specifies that only external dependencies should be included in the graph '
                   'output (only external jars).')
     register('--transitive', default=True, action='store_true',
-             help='List transitive dependencies. Prepend with "--no-" to exclusively output '
-                  'the dependencies listed in the BUILD file of each target.')
+             help='List transitive dependencies. Disable to only list dependencies defined '
+                  'in target BUILD file(s).')
 
   def __init__(self, *args, **kwargs):
     super(Dependencies, self).__init__(*args, **kwargs)
@@ -45,10 +45,10 @@ class Dependencies(ConsoleTask):
   def console_output(self, unused_method_argument):
     for target in self.context.target_roots:
       ordered_closure = OrderedSet()
-      if not self._transitive:
-        ordered_closure.update(dep for dep in target.dependencies)
-      else:
+      if self._transitive:
         target.walk(ordered_closure.add)
+      else:
+        ordered_closure.update(target.dependencies)
       for tgt in ordered_closure:
         if not self.is_external_only:
           yield tgt.address.spec

--- a/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
@@ -116,6 +116,21 @@ class NonPythonDependenciesTest(ConsoleTaskTestBase):
       targets=[self.target('project:dep-bag')]
     )
 
+  def test_intransitive_internal_dependencies(self):
+    self.assert_console_output_ordered(
+      'dependencies:first',
+      'dependencies:second',
+      targets=[self.target('project:project')],
+      options={'transitive': False, 'internal_only': True}
+    )
+
+  def test_intransitive_external_dependencies(self):
+    self.assert_console_output_ordered(
+      'org.apache:apache-jar:12.12.2012',
+      targets=[self.target('project:project')],
+      options={'transitive': False, 'external_only': True}
+    )
+
 
 class PythonDependenciesTests(ConsoleTaskTestBase):
   @classmethod
@@ -180,4 +195,19 @@ class PythonDependenciesTests(ConsoleTaskTestBase):
       'antlr-python-runtime==3.1.3',
       targets=[self.target('dependencies:python_root')],
       options={'external_only': True}
+    )
+
+  def test_intransitive_internal_dependencies(self):
+    self.assert_console_output_ordered(
+      'dependencies:python_inner',
+      'dependencies:python_inner_with_external',
+      targets=[self.target('dependencies:python_root')],
+      options={'transitive': False, 'internal_only': True}
+    )
+
+  def test_intransitive_external_dependencies(self):
+    self.assert_console_output_ordered(
+      'antlr-python-runtime==3.1.3',
+      targets=[self.target('dependencies:python_root')],
+      options={'transitive': False, 'external_only': True}
     )


### PR DESCRIPTION
This commit exposes intransitive dependencies with a new `./pants dependencies` option without changing the existing functionality.

Later on, it may be worthwhile to set `default=False` for the `--transitive` option. I think users first expect to see the buildfile-defined dependencies of a target file when running `./pants dependencies`.