### PR TITLE
Introduce Subsystem dependencies.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -32,7 +32,7 @@ class JvmTask(Task):
 
   def __init__(self, *args, **kwargs):
     super(JvmTask, self).__init__(*args, **kwargs)
-    self.jvm = JVM.instance_for_task(self)
+    self.jvm = JVM.scoped_instance(self)
     self.jvm_options = self.jvm.get_jvm_options()
     self.args = self.jvm.get_program_args()
     self.confs = self.get_options().confs

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -100,7 +100,9 @@ class GoalRunner(object):
     known_scope_infos = [ScopeInfo.for_global_scope()]
 
     # Add scopes for all needed subsystems.
-    subsystems = (set(self.subsystems) | Goal.subsystems() | build_configuration.subsystems())
+    subsystems = Subsystem.closure(set(self.subsystems) |
+                                   Goal.subsystems() |
+                                   build_configuration.subsystems())
     for subsystem in subsystems:
       known_scope_infos.append(ScopeInfo(subsystem.options_scope, ScopeInfo.GLOBAL_SUBSYSTEM))
 

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -54,7 +54,7 @@ class CacheSetup(Subsystem):
 
   @classmethod
   def create_cache_factory_for_task(cls, task):
-    return CacheFactory(cls.instance_for_task(task).get_options(),
+    return CacheFactory(cls.scoped_instance(task).get_options(),
                         task.context.log, task.stable_name())
 
 

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -18,19 +18,53 @@ class Subsystem(Optionable):
   Subsystems encapsulate the configuration and initialization of things like JVMs,
   Python interpreters, SCMs and so on.
 
-  Subsystem instances can be global or per-task. Global instances are useful for representing
-  global concepts, such as the SCM used in the workspace. Per-task instances allow individual
-  tasks to have their own configuration for things such as artifact caches.
+  Subsystem instances can be global or per-optionable. Global instances are useful for representing
+  global concepts, such as the SCM used in the workspace. Per-optionable instances allow individual
+  Optionable objects (notably, tasks) to have their own configuration for things such as artifact
+  caches.
 
   Each subsystem type has an option scope. The global instance of that subsystem initializes
-  itself from options in that scope. A task-specific instance initializes itself from options in
-  an appropriate subscope, which defaults back to the global scope.
+  itself from options in that scope. An optionable-specific instance initializes itself from options
+  in an appropriate subscope, which defaults back to the global scope.
 
   For example, the global artifact cache options would be in scope `cache`, but the
   compile.java task can override those options in scope `cache.compile.java`.
-
-  TODO(benjy): Model dependencies between subsystems? Registration of subsystems?
   """
+
+  @classmethod
+  def closure(cls, subsystem_types):
+    """Gathers the closure of the `subsystem_types` and their transitive `dependencies`.
+
+    NB: Cycles are tolerated here; however this does not protect any initialization cycles in
+    subsystem factory methods.
+
+    :param subsystem_types: An iterable of subsystem types.
+    :returns: A set containing the closure of subsystem types reachable from the given
+              `subsystem_types` roots.
+    """
+    # TODO(John Sirois): Consider detecting and failing cycles; there is probably never a legitimate
+    # use-case for subsystems with cyclic dependencies.
+    known_subsystem_types = set()
+
+    def collect_subsystems(subsystem):
+      if subsystem not in known_subsystem_types:
+        known_subsystem_types.add(subsystem)
+        for dependency in subsystem.dependencies():
+          collect_subsystems(dependency)
+
+    for subsystem_type in subsystem_types:
+      collect_subsystems(subsystem_type)
+
+    return known_subsystem_types
+
+  @classmethod
+  def dependencies(cls):
+    """The subsystems this subsystem uses.
+
+    A tuple of subsystem types.
+    """
+    return tuple()
+
   @classmethod
   def subscope(cls, scope):
     """Create a subscope under this Subsystem's scope."""
@@ -45,20 +79,31 @@ class Subsystem(Optionable):
 
   @classmethod
   def global_instance(cls):
+    """Returns the global instance of this subsystem.
+
+    The global instance is the subsystem singleton instance for the main subsystem `options_scope`.
+
+    :returns: The global subsystem instance.
+    :rtype: :class:`pants.subsystem.subsystem.Subsystem`
+    """
     return cls._instance_for_scope(cls.options_scope)
 
   @classmethod
-  def reset(cls):
-    """Forget all option values and cached subsystem instances.
+  def scoped_instance(cls, optionable):
+    """Returns an instance of this subsystem scoped by the given `optionable`.
 
-    Used for test isolation.
+    The scoped instance is the subsystem singleton instance for the main subsystem `options_scope`
+    qualified by `optionable`'s scope.
+
+    :param optionable: An optionable type or instance to scope this subsystem under.
+    :type: :class:`pants.option.optionable.Optionable`
+    :returns: The scoped subsystem instance.
+    :rtype: :class:`pants.subsystem.subsystem.Subsystem`
     """
-    cls._options = None
-    cls._scoped_instances = {}
-
-  @classmethod
-  def instance_for_task(cls, task):
-    return cls._instance_for_scope(cls.subscope(task.options_scope))
+    if not isinstance(optionable, Optionable) and not issubclass(optionable, Optionable):
+      raise TypeError('Can only scope an instance against an Optionable, given {} of type {}.'
+                      .format(optionable, type(optionable)))
+    return cls._instance_for_scope(cls.subscope(optionable.options_scope))
 
   @classmethod
   def _instance_for_scope(cls, scope):
@@ -69,12 +114,21 @@ class Subsystem(Optionable):
       cls._scoped_instances[key] = cls(scope, cls._options.for_scope(scope))
     return cls._scoped_instances[key]
 
+  @classmethod
+  def reset(cls):
+    """Forget all option values and cached subsystem instances.
+
+    Used for test isolation.
+    """
+    cls._options = None
+    cls._scoped_instances = {}
+
   def __init__(self, scope, scoped_options):
     """Note: A subsystem has no access to options in scopes other than its own.
 
     TODO: We'd like that to be true of Tasks some day. Subsystems will help with that.
 
-    Task code should call instance_for_scope() or global_instance() to get a subsystem instance.
+    Task code should call scoped_instance() or global_instance() to get a subsystem instance.
     Tests can call this constructor directly though.
     """
     super(Subsystem, self).__init__()

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -6,6 +6,7 @@ python_tests(
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python:pytest',
+    'src/python/pants/option',
     'src/python/pants/subsystem',
   ],
 )


### PR DESCRIPTION
This adds the ability for Subsystems to express dependencies on other
susbsystems they depend on for their operation. The notion of per-task
subsystems is correspondingly broadened to include per-Optionable
subsystems, which includes both tasks and subsystems themselves.

New test coverage is added for the new `Subsystem.closure` gathering
method.

https://rbcommons.com/s/twitter/r/2509/