### PR TITLE
Fixup SourceRoot to handle the buildroot.

### DIFF
--- a/src/python/pants/base/source_root.py
+++ b/src/python/pants/base/source_root.py
@@ -26,7 +26,6 @@ class SourceRootTree(object):
   class NestedSourceRootError(Exception):
     pass
 
-
   class Node(object):
     """Node in the tree that represents a directory"""
 
@@ -54,6 +53,10 @@ class SourceRootTree(object):
     def __eq__(self, other):
       return self.key == other.key
 
+  @staticmethod
+  def _dir_list(path):
+    normpath = os.path.normpath(path)
+    return [] if normpath == '.' else normpath.split(os.path.sep)
 
   def __init__(self):
     self._root = self.Node(key="ROOT")
@@ -66,8 +69,7 @@ class SourceRootTree(object):
     :type types: set of classes derived from Target
     """
     curr_node = self._root
-    dir_list = os.path.normpath(source_root).split(os.path.sep)
-    for subdir in dir_list:
+    for subdir in self._dir_list(source_root):
       curr_node = curr_node.get_or_add(subdir)
 
     if curr_node.is_leaf and types != curr_node.types:
@@ -92,8 +94,7 @@ class SourceRootTree(object):
     """
     found = curr_node = self._root
     found_path = []
-    dir_list = os.path.normpath(path).split(os.path.sep)
-    for subdir in dir_list:
+    for subdir in self._dir_list(path):
       curr_node = curr_node.get(subdir)
       if not curr_node:
         break
@@ -215,7 +216,7 @@ class SourceRoot(object):
     """
     target_path = target.address.spec_path
     found_source_root, allowed_types = cls._SOURCE_ROOT_TREE.get_root_and_types(target_path)
-    if not found_source_root:
+    if found_source_root is None:  # NB: '' represents the buildroot, so we explicitly check None.
       # If the source root is not registered, use the path from the spec.
       found_source_root = target_path
 

--- a/tests/python/pants_test/base/test_source_root.py
+++ b/tests/python/pants_test/base/test_source_root.py
@@ -104,7 +104,7 @@ class SourceRootTest(unittest.TestCase):
   def check_here_buildroot(self, buildroot_path):
     target = TestTarget("//mock/foo/bar:baz")
     self.assertEqual("mock/foo/bar", SourceRoot.find(target))
-    SourceRoot(".").here()
+    SourceRoot(buildroot_path).here()
     self.assertEqual("", SourceRoot.find(target))
 
   def test_here_buildroot_dot(self):

--- a/tests/python/pants_test/base/test_source_root.py
+++ b/tests/python/pants_test/base/test_source_root.py
@@ -59,6 +59,24 @@ class SourceRootTest(unittest.TestCase):
     self.assertEquals(OrderedSet([TestTarget]), SourceRoot.types("tests"))
     self.assertEquals(OrderedSet(["tests"]), SourceRoot.roots(TestTarget))
 
+  def check_buildroot(self, buildroot_path):
+    self._assert_source_root_empty()
+
+    SourceRoot.register(buildroot_path, TestTarget)
+
+    self.assertEquals({".": OrderedSet([TestTarget])}, SourceRoot.all_roots())
+    self.assertEquals(OrderedSet([TestTarget]), SourceRoot.types("."))
+    self.assertEquals(OrderedSet(["."]), SourceRoot.roots(TestTarget))
+
+    target = TestTarget("//mock/foo/bar:baz")
+    self.assertEqual("", SourceRoot.find(target))
+
+  def test_register_buildroot_dot(self):
+    self.check_buildroot(".")
+
+  def test_register_buildroot_empty(self):
+    self.check_buildroot("")
+
   def test_register_none(self):
     self._assert_source_root_empty()
 
@@ -79,12 +97,21 @@ class SourceRootTest(unittest.TestCase):
 
   def test_here(self):
     target = TestTarget("//mock/foo/bar:baz")
-    proxy = AddressableCallProxy(addressable_type=target.get_addressable_type(),
-                                 build_file=None,
-                                 registration_callback=None)
     self.assertEqual("mock/foo/bar", SourceRoot.find(target))
-    SourceRoot("mock/foo").here(proxy)
+    SourceRoot("mock/foo").here()
     self.assertEqual("mock/foo", SourceRoot.find(target))
+
+  def check_here_buildroot(self, buildroot_path):
+    target = TestTarget("//mock/foo/bar:baz")
+    self.assertEqual("mock/foo/bar", SourceRoot.find(target))
+    SourceRoot(".").here()
+    self.assertEqual("", SourceRoot.find(target))
+
+  def test_here_buildroot_dot(self):
+    self.check_buildroot(".")
+
+  def test_here_buildroot_empty(self):
+    self.check_buildroot("")
 
   def test_find(self):
     # When no source_root is registered, it should just return the path from the address


### PR DESCRIPTION
Previously, you could register the buildroot as the sole source_root via
the '' or '.' relpaths or via the `here()` method, but the registration
would systemically fail to match paths under the buildroot.

This change adds failing tests for buildroot SourceRoots and then fixes
them.

https://rbcommons.com/s/twitter/r/2514/