### PR TITLE
Support eggs for setuptools and wheel.

### DIFF
--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -78,7 +78,6 @@ python_library(
   sources = ['interpreter_cache.py'],
   dependencies = [
     '3rdparty/python:pex',
-    '3rdparty/python:setuptools',
     'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -8,12 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import shutil
 
-from pex.archiver import Archiver
-from pex.crawler import Crawler
-from pex.installer import EggInstaller
 from pex.interpreter import PythonIdentity, PythonInterpreter
-from pex.iterator import Iterator
-from pex.package import EggPackage, SourcePackage
+from pex.package import EggPackage, Package, SourcePackage
+from pex.resolver import resolve
 
 from pants.util.dirutil import safe_concurrent_create, safe_mkdir
 
@@ -146,7 +143,6 @@ class PythonInterpreterCache(object):
       return self._resolve_interpreter(interpreter, interpreter_dir,
                                        self._python_setup.wheel_requirement())
 
-
   def _resolve_interpreter(self, interpreter, interpreter_dir, requirement):
     """Given a :class:`PythonInterpreter` and a requirement, return an interpreter with the
     capability of resolving that requirement or ``None`` if it's not possible to install a
@@ -160,42 +156,39 @@ class PythonInterpreterCache(object):
     if not interpreter_dir:
       interpreter_dir = os.path.join(self._cache_dir, str(interpreter.identity))
 
-    def installer_provider(sdist):
-      return EggInstaller(
-        Archiver.unpack(sdist),
-        strict=requirement.key != 'setuptools',
-        interpreter=interpreter)
-
-    egg = self._resolve_and_link(
-      requirement,
-      os.path.join(interpreter_dir, requirement.key),
-      installer_provider)
-
-    if egg:
-      return interpreter.with_extra(egg.name, egg.raw_version, egg.path)
+    target_link = os.path.join(interpreter_dir, requirement.key)
+    bdist = self._resolve_and_link(interpreter, requirement, target_link)
+    if bdist:
+      return interpreter.with_extra(bdist.name, bdist.raw_version, bdist.path)
     else:
       self._logger('Failed to resolve requirement {} for {}'.format(requirement, interpreter))
 
-  def _resolve_and_link(self, requirement, target_link, installer_provider):
+  def _resolve_and_link(self, interpreter, requirement, target_link):
     # Short-circuit if there is a local copy.
     if os.path.exists(target_link) and os.path.exists(os.path.realpath(target_link)):
-      egg = EggPackage(os.path.realpath(target_link))
-      if egg.satisfies(requirement):
-        return egg
+      bdist = Package.from_href(os.path.realpath(target_link))
+      if bdist.satisfies(requirement):
+        return bdist
 
-    fetchers = self._python_repos.get_fetchers()
-    context = self._python_repos.get_network_context()
-    iterator = Iterator(fetchers=fetchers, crawler=Crawler(context))
-    links = [link for link in iterator.iter(requirement) if isinstance(link, SourcePackage)]
+    # Since we're resolving to bootstrap a bare interpreter, we won't have wheel available.
+    # Explicitly set the precedence to avoid resolution of wheels or distillation of sdists into
+    # wheels.
+    precedence = (EggPackage, SourcePackage)
+    distributions = resolve(requirements=[requirement],
+                            fetchers=self._python_repos.get_fetchers(),
+                            interpreter=interpreter,
+                            context=self._python_repos.get_network_context(),
+                            precedence=precedence)
+    if not distributions:
+      return None
 
-    for link in links:
-      self._logger('    fetching {}'.format(link.url))
-      sdist = context.fetch(link)
-      self._logger('    installing {}'.format(sdist))
-      installer = installer_provider(sdist)
-      dist_location = installer.bdist()
-      target_location = os.path.join(os.path.dirname(target_link), os.path.basename(dist_location))
-      shutil.move(dist_location, target_location)
-      _safe_link(target_location, target_link)
-      self._logger('    installed {}'.format(target_location))
-      return EggPackage(target_location)
+    assert len(distributions) == 1, ('Expected exactly 1 distribution to be resolved for {}, '
+                                     'found:\n\t{}'.format(requirement,
+                                                           '\n\t'.join(map(str, distributions))))
+
+    dist_location = distributions[0].location
+    target_location = os.path.join(os.path.dirname(target_link), os.path.basename(dist_location))
+    shutil.move(dist_location, target_location)
+    _safe_link(target_location, target_link)
+    self._logger('    installed {}'.format(target_location))
+    return Package.from_href(target_location)

--- a/tests/python/pants_test/python/BUILD
+++ b/tests/python/pants_test/python/BUILD
@@ -86,8 +86,11 @@ python_tests(
   sources = ['test_interpreter_cache.py'],
   dependencies = [
     '3rdparty/python:mock',
+    '3rdparty/python:pex',
     'src/python/pants/backend/python:interpreter_cache',
+    'src/python/pants/backend/python:python_setup',
     'src/python/pants/util:contextutil',
+    'tests/python/pants_test/base:context_utils',
   ],
 )
 

--- a/tests/python/pants_test/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/python/test_interpreter_cache.py
@@ -5,12 +5,17 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import unittest
 
 import mock
+from pex.package import EggPackage, Package, SourcePackage
+from pex.resolver import resolve
 
 from pants.backend.python.interpreter_cache import PythonInterpreter, PythonInterpreterCache
+from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.util.contextutil import temporary_dir
+from pants_test.base.context_utils import create_option_values
 
 
 class TestInterpreterCache(unittest.TestCase):
@@ -53,3 +58,52 @@ class TestInterpreterCache(unittest.TestCase):
     self._do_test(self._make_bad_requirement(self._interpreter.identity.requirement),
                   (str(self._interpreter.identity.requirement), ),
                   [self._interpreter])
+
+  def test_setup_using_eggs(self):
+    def options(**kwargs):
+      return create_option_values(kwargs)
+
+    def link_egg(repo_root, requirement):
+      existing_dist_location = self._interpreter.get_location(requirement)
+      if existing_dist_location is not None:
+        existing_dist = Package.from_href(existing_dist_location)
+        requirement = '{}=={}'.format(existing_dist.name, existing_dist.raw_version)
+
+      distributions = resolve([requirement],
+                              interpreter=self._interpreter,
+                              precedence=(EggPackage, SourcePackage))
+      self.assertEqual(1, len(distributions))
+      dist_location = distributions[0].location
+
+      self.assertRegexpMatches(dist_location, r'\.egg$')
+      os.symlink(dist_location, os.path.join(repo_root, os.path.basename(dist_location)))
+
+      return Package.from_href(dist_location).raw_version
+
+    with temporary_dir() as root:
+      egg_dir = os.path.join(root, 'eggs')
+      os.makedirs(egg_dir)
+      setuptools_version = link_egg(egg_dir, 'setuptools')
+      wheel_version = link_egg(egg_dir, 'wheel')
+
+      python_setup_options = options(interpreter_cache_dir=None,
+                                     pants_workdir=os.path.join(root, 'workdir'),
+                                     interpreter_requirement=self._interpreter.identity.requirement,
+                                     setuptools_version=setuptools_version,
+                                     wheel_version=wheel_version)
+      python_setup = PythonSetup('test-scope', python_setup_options)
+      python_repos = PythonRepos('test-scope', options(indexes=[], repos=[egg_dir]))
+      cache = PythonInterpreterCache(python_setup, python_repos)
+
+      interpereters = cache.setup(paths=[os.path.dirname(self._interpreter.binary)],
+                                  filters=[str(self._interpreter.identity.requirement)])
+      self.assertGreater(len(interpereters), 0)
+
+      def assert_egg_extra(interpreter, name, version):
+        location = interpreter.get_location('{}=={}'.format(name, version))
+        self.assertIsNotNone(location)
+        self.assertIsInstance(Package.from_href(location), EggPackage)
+
+      for interpreter in interpereters:
+        assert_egg_extra(interpreter, 'setuptools', setuptools_version)
+        assert_egg_extra(interpreter, 'wheel', wheel_version)


### PR DESCRIPTION
Previously the interpreter cache did not accept egg bdists when
building up its interpreter cache.  This change fixes that and also
simplifies requirement resolution by using the pex resolve toolchain.

Add a test that an interpreter can be bootstrapped from  a local
eggs only repo.

https://rbcommons.com/s/twitter/r/2529/