### PR TITLE
Move thrift utils only used by scrooge to contrib/scrooge.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -2,19 +2,20 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'tasks',
-  dependencies = [
+  name='tasks',
+  dependencies=[
     ':scrooge_gen',
     ':thrift_linter',
   ],
 )
 
 python_library(
-  name = 'scrooge_gen',
-  sources = ['scrooge_gen.py'],
-  dependencies = [
-    ':java_thrift_library_fingerprint_strategy',
+  name='scrooge_gen',
+  sources=['scrooge_gen.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    ':java_thrift_library_fingerprint_strategy',
+    ':thrift_util',
     'src/python/pants/backend/codegen/subsystems:thrift_defaults',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/jvm/targets:java',
@@ -27,14 +28,13 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/option',
     'src/python/pants/util:dirutil',
-    'src/python/pants:thrift_util',
   ],
 )
 
 python_library(
-  name = 'thrift_linter',
-  sources = ['thrift_linter.py'],
-  dependencies = [
+  name='thrift_linter',
+  sources=['thrift_linter.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:exceptions',
@@ -44,9 +44,14 @@ python_library(
 )
 
 python_library(
-  name = 'java_thrift_library_fingerprint_strategy',
-  sources = ['java_thrift_library_fingerprint_strategy.py'],
-  dependencies = [
+  name='thrift_util',
+  sources=['thrift_util.py'],
+)
+
+python_library(
+  name='java_thrift_library_fingerprint_strategy',
+  sources=['java_thrift_library_fingerprint_strategy.py'],
+  dependencies=[
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/base:fingerprint_strategy',
   ],

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_util.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_util.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -7,10 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import re
-
-from pants.binary_util import BinaryUtil
-from pants.subsystem.subsystem import Subsystem
-from pants.util.memo import memoized_property
 
 
 INCLUDE_PARSER = re.compile(r'^\s*include\s+"([^"]+)"\s*([\/\/|\#].*)*$')
@@ -80,52 +76,3 @@ def calculate_compile_sources(targets, is_thrift_target):
   for target in targets:
     target.walk(collect_sources, predicate=is_thrift_target)
   return basedirs, sources
-
-
-# TODO(John Sirois): Extract this subsystem to its own file.
-class ThriftBinary(object):
-  """Encapsulates access to pre-built thrift static binaries."""
-
-  class Factory(Subsystem):
-    options_scope = 'thrift-binary'
-
-    @classmethod
-    def dependencies(cls):
-      return (BinaryUtil.Factory,)
-
-    @classmethod
-    def register_options(cls, register):
-      register('--supportdir', recursive=True, advanced=True, default='bin/thrift',
-               help='Find thrift binaries under this dir.   Used as part of the path to lookup the'
-                    'tool with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', recursive=True, advanced=True, default='0.9.2',
-               help='Thrift compiler version.   Used as part of the path to lookup the'
-                    'tool with --binary-util-baseurls and --pants-bootstrapdir')
-
-    def create(self):
-      # NB: create is an instance method to allow the user to choose global or scoped.
-      # Its not unreasonable to imagine python and jvm stacks using different versions.
-      binary_util = BinaryUtil.Factory.create()
-      options = self.get_options()
-      return ThriftBinary(binary_util, options.supportdir, options.version)
-
-  def __init__(self, binary_util, relpath, version):
-    self._binary_util = binary_util
-    self._relpath = relpath
-    self._version = version
-
-  @property
-  def version(self):
-    """Returns the version of the thrift binary.
-
-    :returns string version: The thrift version number string.
-    """
-    return self._version
-
-  @memoized_property
-  def path(self):
-    """Selects a thrift compiler binary matching the current os and architecture.
-
-    :returns: The absolute path to a locally bootstrapped thrift compiler binary.
-    """
-    return self._binary_util.select_binary(self._relpath, self.version, 'thrift')

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -2,18 +2,30 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name = 'tasks',
-  dependencies = [
+  name='tasks',
+  dependencies=[
+    ':java_thrift_library_fingerprint_strategy',
     ':scrooge_gen',
     ':thrift_linter_integration',
-    ':java_thrift_library_fingerprint_strategy',
+    ':thrift_util',
   ],
 )
 
 python_tests(
-  name = 'scrooge_gen',
-  sources = ['test_scrooge_gen.py'],
-  dependencies = [
+  name='java_thrift_library_fingerprint_strategy',
+  sources=['test_java_thrift_library_fingerprint_strategy.py'],
+  dependencies=[
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:java_thrift_library_fingerprint_strategy',
+    'src/python/pants/backend/codegen/subsystems:thrift_defaults',
+    'tests/python/pants_test/base:context_utils',
+    'tests/python/pants_test/tasks:task_test_base',
+  ]
+)
+
+python_tests(
+  name='scrooge_gen',
+  sources=['test_scrooge_gen.py'],
+  dependencies=[
     '3rdparty/python:mock',
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:scrooge_gen',
     'src/python/pants/backend/codegen/targets:java',
@@ -25,20 +37,20 @@ python_tests(
 )
 
 python_tests(
-  name = 'thrift_linter_integration',
-  sources = ['test_thrift_linter_integration.py'],
-  dependencies = [
+  name='thrift_linter_integration',
+  sources=['test_thrift_linter_integration.py'],
+  dependencies=[
     'tests/python/pants_test:int-test',
   ],
 )
 
 python_tests(
-  name = 'java_thrift_library_fingerprint_strategy',
-  sources = ['test_java_thrift_library_fingerprint_strategy.py'],
-  dependencies = [
-    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:java_thrift_library_fingerprint_strategy',
-    'src/python/pants/backend/codegen/subsystems:thrift_defaults',
-    'tests/python/pants_test/base:context_utils',
-    'tests/python/pants_test/tasks:task_test_base',
+  name='thrift_util',
+  sources=['test_thrift_util.py'],
+  dependencies=[
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_util',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:base_test',
   ]
 )

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -102,27 +102,27 @@ class ScroogeGenTest(TaskTestBase):
     context = self.context(target_roots=[target])
     task = self.create_task(context)
 
-    with patch('pants.contrib.scrooge.tasks.scrooge_gen.calculate_services'):
-      task._outdir = MagicMock()
-      task._outdir.return_value = self.task_outdir
+    task._declares_service = lambda source: False
+    task._outdir = MagicMock()
+    task._outdir.return_value = self.task_outdir
 
-      task.gen = MagicMock()
-      sources = [os.path.join(self.task_outdir, 'org/pantsbuild/example/Example.scala')]
-      task.gen.return_value = {'test_smoke/a.thrift': sources}
+    task.gen = MagicMock()
+    sources = [os.path.join(self.task_outdir, 'org/pantsbuild/example/Example.scala')]
+    task.gen.return_value = {'test_smoke/a.thrift': sources}
 
-      saved_add_new_target = Context.add_new_target
-      try:
-        Context.add_new_target = MagicMock()
-        task.execute()
-        relative_task_outdir = os.path.relpath(self.task_outdir, get_buildroot())
-        spec = '{spec_path}:{name}'.format(spec_path=relative_task_outdir, name='test_smoke.a')
-        address = SyntheticAddress.parse(spec=spec)
-        Context.add_new_target.assert_called_once_with(address,
-                                                       ScalaLibrary,
-                                                       sources=sources,
-                                                       excludes=OrderedSet(),
-                                                       dependencies=OrderedSet(),
-                                                       provides=None,
-                                                       derived_from=target)
-      finally:
-        Context.add_new_target = saved_add_new_target
+    saved_add_new_target = Context.add_new_target
+    try:
+      Context.add_new_target = MagicMock()
+      task.execute()
+      relative_task_outdir = os.path.relpath(self.task_outdir, get_buildroot())
+      spec = '{spec_path}:{name}'.format(spec_path=relative_task_outdir, name='test_smoke.a')
+      address = SyntheticAddress.parse(spec=spec)
+      Context.add_new_target.assert_called_once_with(address,
+                                                     ScalaLibrary,
+                                                     sources=sources,
+                                                     excludes=OrderedSet(),
+                                                     dependencies=OrderedSet(),
+                                                     provides=None,
+                                                     derived_from=target)
+    finally:
+      Context.add_new_target = saved_add_new_target

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_util.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_util.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -8,9 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import unittest
 
-from pants.thrift_util import find_includes, find_root_thrifts
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open
+
+from pants.contrib.scrooge.tasks.thrift_util import find_includes, find_root_thrifts
 
 
 class ThriftUtilTest(unittest.TestCase):
@@ -35,8 +36,8 @@ class ThriftUtilTest(unittest.TestCase):
       b_included = self.write(os.path.join(b, 'b_included.thrift'), '# noop')
       c_included = self.write(os.path.join(b, 'c_included.thrift'), '# noop')
 
-      self.assertEquals(set([a_included, b_included, c_included]),
-                        find_includes(basedirs=set([a, b]), source=main))
+      self.assertEquals({a_included, b_included, c_included},
+                        find_includes(basedirs={a, b}, source=main))
 
   def test_find_includes_exception(self):
     with temporary_dir() as dir:
@@ -47,13 +48,13 @@ class ThriftUtilTest(unittest.TestCase):
         include "b_included.thrift"
       ''')
       self.write(os.path.join(a, 'sub', 'a_included.thrift'), '# noop')
-      self.assertRaises(ValueError, find_includes, basedirs=set([a]), source=main)
+      self.assertRaises(ValueError, find_includes, basedirs={a}, source=main)
 
   def test_find_root_thrifts(self):
     with temporary_dir() as dir:
       root_1 = self.write(os.path.join(dir, 'root_1.thrift'), '# noop')
       root_2 = self.write(os.path.join(dir, 'root_2.thrift'), '# noop')
-      self.assertEquals(set([root_1, root_2]),
+      self.assertEquals({root_1, root_2},
                         find_root_thrifts(basedirs=[], sources=[root_1, root_2]))
 
     with temporary_dir() as dir:
@@ -61,4 +62,4 @@ class ThriftUtilTest(unittest.TestCase):
       self.write(os.path.join(dir, 'mid_1.thrift'), 'include "leaf_1.thrift"')
       self.write(os.path.join(dir, 'leaf_1.thrift'), '# noop')
       root_2 = self.write(os.path.join(dir, 'root_2.thrift'), 'include "root_1.thrift"')
-      self.assertEquals(set([root_2]), find_root_thrifts(basedirs=[], sources=[root_1, root_2]))
+      self.assertEquals({root_2}, find_root_thrifts(basedirs=[], sources=[root_1, root_2]))

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -24,31 +24,6 @@ page(name='readme',
   source='README.md',
 )
 
-# XXX move into base or thrift
-python_library(
-  name='binary_util',
-  sources=['binary_util.py'],
-  dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:six',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/option',
-    'src/python/pants/subsystem',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
-  ],
-)
-
-python_library(
-  name='thrift_util',
-  sources=['thrift_util.py'],
-  dependencies=[
-    ':binary_util',
-    'src/python/pants/subsystem',
-    'src/python/pants/util:memo',
-  ],
-)
-
 python_library(
   name='version',
   sources=['version.py'],

--- a/src/python/pants/backend/codegen/tasks/BUILD
+++ b/src/python/pants/backend/codegen/tasks/BUILD
@@ -37,10 +37,10 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
+    'src/python/pants/binaries:thrift_util',
     'src/python/pants/option',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-    'src/python/pants:thrift_util',
   ],
 )
 
@@ -102,7 +102,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',
-    'src/python/pants:binary_util',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ],
@@ -125,10 +125,10 @@ python_library(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-    'src/python/pants:binary_util',
   ],
 )
 

--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -19,8 +19,8 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
+from pants.binaries.thrift_binary import ThriftBinary
 from pants.option.options import Options
-from pants.thrift_util import ThriftBinary
 from pants.util.dirutil import safe_mkdir
 from pants.util.memo import memoized_property
 

--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -22,7 +22,7 @@ from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
-from pants.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtil
 from pants.fs.archive import ZIP
 from pants.util.dirutil import safe_mkdir
 from pants.util.memo import memoized_property

--- a/src/python/pants/backend/codegen/tasks/ragel_gen.py
+++ b/src/python/pants/backend/codegen/tasks/ragel_gen.py
@@ -14,7 +14,7 @@ from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
-from pants.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtil
 from pants.util.dirutil import safe_mkdir_for
 from pants.util.memo import memoized_property
 

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -94,10 +94,11 @@ python_library(
   name = 'confluence_publish',
   sources = ['confluence_publish.py'],
   dependencies = [
-    ':common',
     '3rdparty/python/twitter/commons:twitter.common.confluence',
+    ':task',
     'src/python/pants/backend/core/targets:common',
-    'src/python/pants:binary_util',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/util:dirutil',
   ],
 )
@@ -201,8 +202,8 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/base:workunit',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/util:dirutil',
-    'src/python/pants:binary_util',
   ],
 )
 
@@ -246,8 +247,8 @@ python_library(
     ':task',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:run_info',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/reporting',
-    'src/python/pants:binary_util',
   ],
 )
 

--- a/src/python/pants/backend/core/tasks/confluence_publish.py
+++ b/src/python/pants/backend/core/tasks/confluence_publish.py
@@ -10,10 +10,10 @@ import textwrap
 
 from twitter.common.confluence import Confluence, ConfluenceError
 
-from pants import binary_util
 from pants.backend.core.targets.doc import Page
 from pants.backend.core.tasks.task import Task
 from pants.base.exceptions import TaskError
+from pants.binaries import binary_util
 from pants.util.dirutil import safe_open
 
 

--- a/src/python/pants/backend/core/tasks/markdown_to_html.py
+++ b/src/python/pants/backend/core/tasks/markdown_to_html.py
@@ -20,7 +20,6 @@ from pygments.styles import get_all_styles
 from pygments.util import ClassNotFound
 from six.moves import range
 
-from pants import binary_util
 from pants.backend.core.targets.doc import Page
 from pants.backend.core.tasks.task import Task
 from pants.base.address import SyntheticAddress
@@ -28,6 +27,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
 from pants.base.workunit import WorkUnit
+from pants.binaries import binary_util
 from pants.util.dirutil import safe_mkdir, safe_open
 
 

--- a/src/python/pants/backend/core/tasks/reporting_server.py
+++ b/src/python/pants/backend/core/tasks/reporting_server.py
@@ -6,12 +6,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-import signal
-import sys
 
-from pants import binary_util
 from pants.backend.core.tasks.task import QuietTaskMixin, Task
-from pants.base.build_environment import get_buildroot
+from pants.binaries import binary_util
 from pants.reporting.reporting_server import ReportingServerManager
 
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -153,11 +153,11 @@ python_library(
   dependencies = [
     ':ivy_task_mixin',
     ':nailgun_task',
-    'src/python/pants:binary_util',
     'src/python/pants/backend/jvm:ivy_utils',
     'src/python/pants/base:cache_manager',
-    'src/python/pants/ivy',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/goal:products',
+    'src/python/pants/ivy',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
   ],
@@ -226,17 +226,17 @@ python_library(
   name = 'jar_task',
   sources = ['jar_task.py'],
   dependencies = [
-    ':nailgun_task',
-    '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:six',
+    ':nailgun_task',
     'src/python/pants/backend/jvm/subsystems:jar_tool',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/java/jar:manifest',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:meta',
-    'src/python/pants:binary_util',
   ],
 )
 
@@ -262,12 +262,12 @@ python_library(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:workunit',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/java/jar:shader',
     'src/python/pants/java:util',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:xml_parser',
-    'src/python/pants:binary_util',
   ],
 )
 
@@ -321,9 +321,9 @@ python_library(
   sources = ['jvmdoc_gen.py'],
   dependencies = [
     ':jvm_task',
-    'src/python/pants:binary_util',
     'src/python/pants/base:exceptions',
-    'src/python/pants/util:dirutil',
+    'src/python/pants/binaries:binary_util',
+    'src/python/pants/util:dirutil',\
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -11,13 +11,13 @@ import time
 from collections import defaultdict
 from textwrap import dedent
 
-from pants import binary_util
 from pants.backend.jvm.ivy_utils import IvyUtils
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.cache_manager import VersionedTargetSet
 from pants.base.exceptions import TaskError
+from pants.binaries import binary_util
 from pants.goal.products import UnionProducts
 from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.util.dirutil import safe_mkdir

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -18,7 +18,7 @@ from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, JvmBinary, Skip
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
-from pants.binary_util import safe_args
+from pants.binaries.binary_util import safe_args
 from pants.java.jar.manifest import Manifest
 from pants.util.contextutil import temporary_dir
 from pants.util.meta import AbstractClass

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -15,13 +15,13 @@ from collections import defaultdict, namedtuple
 from six.moves import range
 from twitter.common.collections import OrderedSet
 
-from pants import binary_util
 from pants.backend.jvm.targets.java_tests import JavaTests as junit_tests
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError, TestFailedTaskError
 from pants.base.workunit import WorkUnit
+from pants.binaries import binary_util
 from pants.java.jar.shader import Shader
 from pants.java.util import execute_java
 from pants.util.contextutil import temporary_file_path

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -11,9 +11,9 @@ import multiprocessing
 import os
 import subprocess
 
-from pants import binary_util
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.base.exceptions import TaskError
+from pants.binaries import binary_util
 from pants.util.dirutil import safe_mkdir, safe_walk
 
 

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -102,8 +102,8 @@ python_library(
   name = 'ide_gen',
   sources = ['ide_gen.py'],
   dependencies = [
-    ':projectutils',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    ':projectutils',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:scala',
@@ -111,7 +111,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',
-    'src/python/pants:binary_util',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/util:dirutil',
   ],
 )

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 
 from twitter.common.collections.orderedset import OrderedSet
 
-from pants import binary_util
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
@@ -21,6 +20,7 @@ from pants.backend.project_info.tasks.projectutils import get_jar_infos
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
+from pants.binaries import binary_util
 from pants.util.dirutil import safe_mkdir, safe_walk
 
 

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -133,7 +133,7 @@ python_library(
     'src/python/pants/backend/codegen/targets:python',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:build_environment',
-    'src/python/pants:thrift_util',
+    'src/python/pants/binaries:thrift_util',
     'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -1,8 +1,8 @@
 python_library(
-  name = 'python',
-  sources = globs('*.py'),
-  resources = globs('templates/python_eval/*.mustache'),
-  dependencies = [
+  name='python',
+  sources=globs('*.py'),
+  resources=globs('templates/python_eval/*.mustache'),
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:coverage',
@@ -28,6 +28,7 @@ python_library(
     'src/python/pants/base:hash_utils',
     'src/python/pants/base:target',
     'src/python/pants/base:workunit',
+    'src/python/pants/binaries:thrift_util',
     'src/python/pants/console:stty_utils',
     'src/python/pants/ivy',
     'src/python/pants/option',
@@ -37,6 +38,5 @@ python_library(
     'src/python/pants/util:meta',
     'src/python/pants/util:strutil',
     'src/python/pants/util:xml_parser',
-    'src/python/pants:thrift_util',
   ]
 )

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -20,9 +20,9 @@ from pants.backend.python.python_chroot import PythonChroot
 from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.base import hash_utils
 from pants.base.exceptions import TaskError
+from pants.binaries.thrift_binary import ThriftBinary
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.thrift_util import ThriftBinary
 
 
 class PythonTask(Task):

--- a/src/python/pants/binaries/BUILD
+++ b/src/python/pants/binaries/BUILD
@@ -1,0 +1,26 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name='binary_util',
+  sources=['binary_util.py'],
+  dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:six',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+  ],
+)
+
+python_library(
+  name='thrift_util',
+  sources=['thrift_binary.py'],
+  dependencies=[
+    ':binary_util',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:memo',
+  ],
+)

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -44,7 +44,6 @@ _PATH_BY_ID = {
 logger = logging.getLogger(__name__)
 
 
-# TODO(John Sirois): Extract this subsystem to its own file.
 class BinaryUtil(object):
   """Wraps utility methods for finding binary executables."""
 

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,

--- a/src/python/pants/binaries/thrift_binary.py
+++ b/src/python/pants/binaries/thrift_binary.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.binaries.binary_util import BinaryUtil
+from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_property
+
+
+class ThriftBinary(object):
+  """Encapsulates access to pre-built thrift static binaries."""
+
+  class Factory(Subsystem):
+    options_scope = 'thrift-binary'
+
+    @classmethod
+    def dependencies(cls):
+      return (BinaryUtil.Factory,)
+
+    @classmethod
+    def register_options(cls, register):
+      register('--supportdir', recursive=True, advanced=True, default='bin/thrift',
+               help='Find thrift binaries under this dir.   Used as part of the path to lookup the'
+                    'tool with --binary-util-baseurls and --pants-bootstrapdir')
+      register('--version', recursive=True, advanced=True, default='0.9.2',
+               help='Thrift compiler version.   Used as part of the path to lookup the'
+                    'tool with --binary-util-baseurls and --pants-bootstrapdir')
+
+    def create(self):
+      # NB: create is an instance method to allow the user to choose global or scoped.
+      # Its not unreasonable to imagine python and jvm stacks using different versions.
+      binary_util = BinaryUtil.Factory.create()
+      options = self.get_options()
+      return ThriftBinary(binary_util, options.supportdir, options.version)
+
+  def __init__(self, binary_util, relpath, version):
+    self._binary_util = binary_util
+    self._relpath = relpath
+    self._version = version
+
+  @property
+  def version(self):
+    """Returns the version of the thrift binary.
+
+    :returns string version: The thrift version number string.
+    """
+    return self._version
+
+  @memoized_property
+  def path(self):
+    """Selects a thrift compiler binary matching the current os and architecture.
+
+    :returns: The absolute path to a locally bootstrapped thrift compiler binary.
+    """
+    return self._binary_util.select_binary(self._relpath, self.version, 'thrift')

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -59,32 +59,12 @@ python_library(
 )
 
 python_tests(
-  name = 'test_binary_util',
-  sources = ['test_binary_util.py',],
-  dependencies = [
-    ':base_test',
-    'src/python/pants:binary_util',
-  ]
-)
-
-python_tests(
   name = 'test_maven_layout',
   sources = ['test_maven_layout.py'],
   dependencies = [
     ':base_test',
     'src/python/pants/backend/maven_layout',
     'src/python/pants/base:build_file_aliases',
-  ]
-)
-
-python_tests(
-  name = 'test_thrift_util',
-  sources = ['test_thrift_util.py'],
-  dependencies = [
-    ':base_test',
-    'src/python/pants:thrift_util',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
   ]
 )
 
@@ -102,9 +82,7 @@ target(
 target(
   name = 'all',
   dependencies = [
-    ':test_binary_util',
     ':test_maven_layout',
-    ':test_thrift_util',
     'tests/python/pants_test/android',
     'tests/python/pants_test/authentication:netrc',
     'tests/python/pants_test/backend',

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -4,14 +4,14 @@
 target(
   name='python',
   dependencies=[
-    ':test_python_requirement_list',
-    ':test_python_chroot',
+    ':python_chroot',
+    ':python_requirement_list',
     'tests/python/pants_test/backend/python/tasks'
   ]
 )
 
 python_tests(
-  name='test_python_chroot',
+  name='python_chroot',
   sources=['test_python_chroot.py'],
   dependencies=[
     '3rdparty/python:pex',
@@ -23,21 +23,21 @@ python_tests(
     'src/python/pants/backend/python:python_setup',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:source_root',
+    'src/python/pants/binaries:binary_util',
+    'src/python/pants/binaries:thrift_util',
     'src/python/pants/ivy',
     'src/python/pants/util:contextutil',
-    'src/python/pants:binary_util',
-    'src/python/pants:thrift_util',
     'tests/python/pants_test/base:context_utils',
     'tests/python/pants_test:base_test',
   ]
 )
 
 python_tests(
-  name='test_python_requirement_list',
+  name='python_requirement_list',
   sources=['test_python_requirement_list.py'],
   dependencies=[
-    'src/python/pants/backend/python:python_requirement',
     'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python:python_requirement',
     'src/python/pants/base:build_file_aliases',
     'tests/python/pants_test:base_test'
   ]

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -24,10 +24,10 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.base.build_environment import get_pants_cachedir
 from pants.base.source_root import SourceRoot
-from pants.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtil
+from pants.binaries.thrift_binary import ThriftBinary
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.thrift_util import ThriftBinary
 from pants.util.contextutil import temporary_dir
 from pants_test.base.context_utils import create_option_values
 from pants_test.base_test import BaseTest

--- a/tests/python/pants_test/binaries/BUILD
+++ b/tests/python/pants_test/binaries/BUILD
@@ -1,0 +1,18 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name='binaries',
+  dependencies=[
+    ':binary_util',
+  ]
+)
+
+python_tests(
+  name='binary_util',
+  sources=['test_binary_util.py'],
+  dependencies=[
+    'src/python/pants/binaries:binary_util',
+    'tests/python/pants_test:base_test',
+  ]
+)

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -1,11 +1,11 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtil
 from pants_test.base_test import BaseTest
 
 


### PR DESCRIPTION
Since the top-level utility functions are moved out of thrift_util,
this change takes the opportunity to also rename thrift_util.py and
likewise its dependency, binary_util.py.  The rest is import and BUILD
dep fallout.

https://rbcommons.com/s/twitter/r/2535/