### PR TITLE
Prevent nailgun on nailgun violence when using symlinked java paths

### DIFF
--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -100,16 +100,16 @@ class NailgunExecutor(Executor, ProcessManager):
     return 'NailgunExecutor({identity}, dist={dist}, pid={pid} socket={socket})'.format(
       identity=self._identity, dist=self._distribution, pid=self.pid, socket=self.socket)
 
-  def _maybe_parse_fingerprint(self, cmdline):
-    if cmdline:
-      fingerprints = [cmd.split('=')[1] for cmd in cmdline if cmd.startswith(
-        self._PANTS_FINGERPRINT_ARG_PREFIX + '=')]
-      return fingerprints[0] if fingerprints else None
+  def _parse_fingerprint(self, cmdline):
+    fingerprints = [cmd.split('=')[1] for cmd in cmdline if cmd.startswith(
+      self._PANTS_FINGERPRINT_ARG_PREFIX + '=')]
+    return fingerprints[0] if fingerprints else None
 
   @property
   def fingerprint(self):
     """This provides the nailgun fingerprint of the running process otherwise None."""
-    return self._maybe_parse_fingerprint(getattr(self.as_process(), 'cmdline', None))
+    if self.cmdline:
+      return self._parse_fingerprint(self.cmdline)
 
   def _create_owner_arg(self, workdir):
     # Currently the owner is identified via the full path to the workdir.
@@ -167,7 +167,7 @@ class NailgunExecutor(Executor, ProcessManager):
                   'new_fingerprint={new_fp} distribution={old_dist} new_distribution={new_dist}'
                   .format(nailgun=self._identity, up=updated, run=running,
                           old_fp=self.fingerprint, new_fp=new_fingerprint,
-                          old_dist=self.exe, new_dist=self._distribution.java))
+                          old_dist=self.cmd, new_dist=self._distribution.java))
     return running, updated
 
   def _get_nailgun_client(self, jvm_options, classpath, stdout, stderr):

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -83,13 +83,6 @@ class ProcessManager(object):
     return self._process_name
 
   @property
-  def exe(self):
-    """The full path of the process executable e.g. '/opt/java/jdk1.7.0/bin/java'.
-       Beware, this can be different than the original command line as it will resolve symlinks.
-    """
-    return getattr(self.as_process(), 'exe', None)
-
-  @property
   def exe_name(self):
     """The basename of the process executable e.g. 'java'."""
     return getattr(self.as_process(), 'name', None)

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -84,13 +84,25 @@ class ProcessManager(object):
 
   @property
   def exe(self):
-    """The full path of the process executable e.g. '/opt/java/jdk1.7.0/Contents/Home/bin/java'."""
+    """The full path of the process executable e.g. '/opt/java/jdk1.7.0/bin/java'.
+       Beware, this can be different than the original command line as it will resolve symlinks.
+    """
     return getattr(self.as_process(), 'exe', None)
 
   @property
   def exe_name(self):
     """The basename of the process executable e.g. 'java'."""
     return getattr(self.as_process(), 'name', None)
+
+  @property
+  def cmdline(self):
+    """The process commandline. e.g. ['/usr/bin/python2.7', 'pants.pex']."""
+    return getattr(self.as_process(), 'cmdline', None)
+
+  @property
+  def cmd(self):
+    """The first element of the process commandline e.g. '/usr/bin/python2.7'."""
+    return (self.cmdline or [None])[0]
 
   @property
   def pid(self):


### PR DESCRIPTION
When nailguns startup, they check that the java distribution they were started with is the same as in the running process (assuming a prior normal startup). If it's not the same path, the nailgun is killed and a new one is started in its place. In a recent case in a verification job in our production CI, we discovered that nailgun clients were killing each others servers because they disagreed on the java distribution that the prior server was ran with vs the command that it was starting up with.

In this case, a recent commit introduced a regression that changed the checking of  psutil.Process.cmdline\[0\] (the first member of the command line of the process) vs psutil.Process.exe (the process executable). This was originally assumed to be the same thing, but when symlinks are involved they are subtly different due to the fact the process executable name resolves symlinks.

In our case, we had a subdir of the jvm path symlinked which caused disagreement when checking the process executable vs the passed command:

```
        distribution=/usr/lib/jvm/java-1.7.0-openjdk7/bin/java
    new_distribution=/usr/lib/jvm/java-1.7.0-openjdk/bin/java
```

This patch improves a few properties of both the ProcessManager and NailgunExecutor, fixes the above issue and improves logging for all cases under which the nailgun can be restarted.