### PR TITLE
psutil upgrade

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ mox==0.5.3
 # do pex<1.1.0.
 pex>=1.0.1,<1.0.999999
 
-psutil==1.1.3
+psutil==3.1.1
 lockfile==0.10.2
 Pygments==1.4
 pystache==0.5.3

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -100,16 +100,16 @@ class NailgunExecutor(Executor, ProcessManager):
     return 'NailgunExecutor({identity}, dist={dist}, pid={pid} socket={socket})'.format(
       identity=self._identity, dist=self._distribution, pid=self.pid, socket=self.socket)
 
-  def _maybe_parse_fingerprint(self, cmdline):
-    if cmdline:
-      fingerprints = [cmd.split('=')[1] for cmd in cmdline if cmd.startswith(
-        self._PANTS_FINGERPRINT_ARG_PREFIX + '=')]
-      return fingerprints[0] if fingerprints else None
+  def _parse_fingerprint(self, cmdline):
+    fingerprints = [cmd.split('=')[1] for cmd in cmdline if cmd.startswith(
+      self._PANTS_FINGERPRINT_ARG_PREFIX + '=')]
+    return fingerprints[0] if fingerprints else None
 
   @property
   def fingerprint(self):
     """This provides the nailgun fingerprint of the running process otherwise None."""
-    return self._maybe_parse_fingerprint(getattr(self.as_process(), 'cmdline', None))
+    if self.cmdline:
+      return self._parse_fingerprint(self.cmdline)
 
   def _create_owner_arg(self, workdir):
     # Currently the owner is identified via the full path to the workdir.
@@ -167,7 +167,7 @@ class NailgunExecutor(Executor, ProcessManager):
                   'new_fingerprint={new_fp} distribution={old_dist} new_distribution={new_dist}'
                   .format(nailgun=self._identity, up=updated, run=running,
                           old_fp=self.fingerprint, new_fp=new_fingerprint,
-                          old_dist=self.exe, new_dist=self._distribution.java))
+                          old_dist=self.cmd, new_dist=self._distribution.java))
     return running, updated
 
   def _get_nailgun_client(self, jvm_options, classpath, stdout, stderr):

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -83,13 +83,6 @@ class ProcessManager(object):
     return self._process_name
 
   @property
-  def exe(self):
-    """The full path of the process executable e.g. '/opt/java/jdk1.7.0/bin/java'.
-       Beware, this can be different than the original command line as it will resolve symlinks.
-    """
-    return getattr(self.as_process(), 'exe', None)
-
-  @property
   def exe_name(self):
     """The basename of the process executable e.g. 'java'."""
     return getattr(self.as_process(), 'name', None)

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -84,13 +84,25 @@ class ProcessManager(object):
 
   @property
   def exe(self):
-    """The full path of the process executable e.g. '/opt/java/jdk1.7.0/Contents/Home/bin/java'."""
+    """The full path of the process executable e.g. '/opt/java/jdk1.7.0/bin/java'.
+       Beware, this can be different than the original command line as it will resolve symlinks.
+    """
     return getattr(self.as_process(), 'exe', None)
 
   @property
   def exe_name(self):
     """The basename of the process executable e.g. 'java'."""
     return getattr(self.as_process(), 'name', None)
+
+  @property
+  def cmdline(self):
+    """The process commandline. e.g. ['/usr/bin/python2.7', 'pants.pex']."""
+    return getattr(self.as_process(), 'cmdline', None)
+
+  @property
+  def cmd(self):
+    """The first element of the process commandline e.g. '/usr/bin/python2.7'."""
+    return (self.cmdline or [None])[0]
 
   @property
   def pid(self):

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -40,7 +40,7 @@ class ProcessGroup(object):
 
   def _instance_from_process(self, process):
     """Default converter from psutil.Process to process instance classes for subclassing."""
-    return ProcessManager(name=process.name, pid=process.pid, process_name=process.name)
+    return ProcessManager(name=process.name(), pid=process.pid(), process_name=process.name())
 
   def iter_processes(self, proc_filter=None):
     proc_filter = proc_filter or (lambda x: True)
@@ -85,12 +85,17 @@ class ProcessManager(object):
   @property
   def exe_name(self):
     """The basename of the process executable e.g. 'java'."""
-    return getattr(self.as_process(), 'name', None)
+    return self._get_process_property('name')
 
   @property
   def cmdline(self):
     """The process commandline. e.g. ['/usr/bin/python2.7', 'pants.pex']."""
-    return getattr(self.as_process(), 'cmdline', None)
+    return self._get_process_property('cmdline')
+
+  @property
+  def status(self):
+    """The process status as reported by psutil. e.g. psutil.PROCESS_IDLE, psutil.PROCESS_ZOMBIE."""
+    return self._get_process_property('status')
 
   @property
   def cmd(self):
@@ -113,6 +118,10 @@ class ProcessManager(object):
       return caster(x)
     except (TypeError, ValueError):
       return x
+
+  def _get_process_property(self, attr):
+    if self.as_process():
+      return getattr(self.as_process(), attr)()
 
   def as_process(self):
     if self._process is None and self.pid:
@@ -209,7 +218,7 @@ class ProcessManager(object):
     """Return a boolean indicating whether the process is running."""
     if self.as_process():
       try:
-        if (self.as_process().status == psutil.STATUS_ZOMBIE or           # Check for walkers.
+        if (self.status == psutil.STATUS_ZOMBIE or                        # Check for walkers.
             (self.process_name and self.process_name != self.exe_name)):  # Check for stale pids.
           return False
       except psutil.NoSuchProcess:
@@ -272,7 +281,6 @@ class ProcessManager(object):
       if second_pid == 0:
         try:
           os.chdir(self._buildroot)
-          os.umask(0)
           self.post_fork_child(**post_fork_child_opts or {})
         except Exception:
           logging.critical(traceback.format_exc())
@@ -301,7 +309,6 @@ class ProcessManager(object):
       try:
         os.setsid()
         os.chdir(self._buildroot)
-        os.umask(0)
         self.post_fork_child(**post_fork_child_opts or {})
       except Exception:
         logging.critical(traceback.format_exc())

--- a/src/python/pants/reporting/reporting_server.py
+++ b/src/python/pants/reporting/reporting_server.py
@@ -18,7 +18,6 @@ import urlparse
 from collections import namedtuple
 from datetime import date, datetime
 
-import psutil
 import pystache
 from six.moves import range
 

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import unittest
 from collections import namedtuple
+from contextlib import contextmanager
 
 import mock
 import psutil
@@ -20,7 +21,11 @@ from pants.util.contextutil import temporary_dir
 PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
-FakeProcess = namedtuple('Process', 'pid name status')
+def fake_process(**kwargs):
+  proc = mock.create_autospec(psutil.Process, spec_set=True)
+  for k, v in kwargs.items():
+    setattr(getattr(proc, k), 'return_value', v)
+  return proc
 
 
 class TestProcessGroup(unittest.TestCase):
@@ -46,8 +51,8 @@ class TestProcessGroup(unittest.TestCase):
   def test_iter_instances(self):
     with mock.patch('psutil.process_iter', **PATCH_OPTS) as mock_process_iter:
       mock_process_iter.return_value = [
-        FakeProcess(name='a_test', pid=3, status=psutil.STATUS_IDLE),
-        FakeProcess(name='b_test', pid=4, status=psutil.STATUS_IDLE)
+        fake_process(name='a_test', pid=3, status=psutil.STATUS_IDLE),
+        fake_process(name='b_test', pid=4, status=psutil.STATUS_IDLE)
       ]
 
       items = [item for item in self.pg.iter_instances()]
@@ -61,6 +66,29 @@ class TestProcessGroup(unittest.TestCase):
 class TestProcessManager(unittest.TestCase):
   def setUp(self):
     self.pm = ProcessManager('test')
+
+  def test_process_properties(self):
+    with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
+      mock_as_process.return_value = fake_process(name='name',
+                                                  cmdline=['cmd', 'line'],
+                                                  status='status')
+      self.assertEqual(self.pm.exe_name, 'name')
+      self.assertEqual(self.pm.cmdline, ['cmd', 'line'])
+      self.assertEqual(self.pm.cmd, 'cmd')
+      self.assertEqual(self.pm.status, 'status')
+
+  def test_process_properties_cmd_indexing(self):
+    with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
+      mock_as_process.return_value = fake_process(cmdline='')
+      self.assertEqual(self.pm.cmd, None)
+
+  def test_process_properties_none(self):
+    with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_asproc:
+      mock_asproc.return_value = None
+      self.assertEqual(self.pm.exe_name, None)
+      self.assertEqual(self.pm.cmdline, None)
+      self.assertEqual(self.pm.cmd, None)
+      self.assertEqual(self.pm.status, None)
 
   def test_maybe_cast(self):
     self.assertIsNone(self.pm._maybe_cast(None, int))
@@ -80,6 +108,13 @@ class TestProcessManager(unittest.TestCase):
       mock_proc.return_value = sentinel
       self.pm._pid = sentinel
       self.assertEqual(self.pm.as_process(), sentinel)
+
+  def test_as_process_no_pid(self):
+    fake_pid = 3
+    with mock.patch('psutil.Process', **PATCH_OPTS) as mock_proc:
+      mock_proc.side_effect = psutil.NoSuchProcess(fake_pid)
+      self.pm._pid = fake_pid
+      self.assertEqual(self.pm.as_process(), None)
 
   def test_as_process_none(self):
     self.assertEqual(self.pm.as_process(), None)
@@ -176,21 +211,21 @@ class TestProcessManager(unittest.TestCase):
 
   def test_is_alive(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
-      mock_as_process.return_value = FakeProcess(name='test', pid=3, status=psutil.STATUS_IDLE)
+      mock_as_process.return_value = fake_process(name='test', pid=3, status=psutil.STATUS_IDLE)
       self.pm._process = mock.Mock(status=psutil.STATUS_IDLE)
       self.assertTrue(self.pm.is_alive())
       mock_as_process.assert_called_with(self.pm)
 
   def test_is_alive_zombie(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
-      mock_as_process.return_value = FakeProcess(name='test', pid=3, status=psutil.STATUS_ZOMBIE)
+      mock_as_process.return_value = fake_process(name='test', pid=3, status=psutil.STATUS_ZOMBIE)
       self.assertFalse(self.pm.is_alive())
       mock_as_process.assert_called_with(self.pm)
 
   def test_is_alive_zombie_exception(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
       mock_as_process.side_effect = iter([
-        FakeProcess(name='test', pid=3, status=psutil.STATUS_IDLE),
+        fake_process(name='test', pid=3, status=psutil.STATUS_IDLE),
         psutil.NoSuchProcess(0)
       ])
       self.assertFalse(self.pm.is_alive())
@@ -198,7 +233,7 @@ class TestProcessManager(unittest.TestCase):
 
   def test_is_alive_stale_pid(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
-      mock_as_process.return_value = FakeProcess(name='not_test', pid=3, status=psutil.STATUS_IDLE)
+      mock_as_process.return_value = fake_process(name='not_test', pid=3, status=psutil.STATUS_IDLE)
       self.pm._process_name = 'test'
       self.assertFalse(self.pm.is_alive())
       mock_as_process.assert_called_with(self.pm)
@@ -221,48 +256,42 @@ class TestProcessManager(unittest.TestCase):
     proc.wait()
     self.assertEqual(proc.communicate()[0].strip(), test_str)
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
+  @contextmanager
+  def mock_daemonize_context(self, chk_pre=True, chk_post_child=False, chk_post_parent=False):
+    with mock.patch.object(ProcessManager, 'post_fork_parent', **PATCH_OPTS) as mock_post_parent:
+      with mock.patch.object(ProcessManager, 'post_fork_child', **PATCH_OPTS) as mock_post_child:
+        with mock.patch.object(ProcessManager, 'pre_fork', **PATCH_OPTS) as mock_pre:
+          with mock.patch('os.chdir', **PATCH_OPTS):
+            with mock.patch('os._exit', **PATCH_OPTS):
+              with mock.patch('os.setsid', **PATCH_OPTS):
+                with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+                  yield mock_fork
+
+                  if chk_pre: mock_pre.assert_called_once_with(self.pm)
+                  if chk_post_child: mock_post_child.assert_called_once_with(self.pm)
+                  if chk_post_parent: mock_post_parent.assert_called_once_with(self.pm)
+
   def test_daemonize_parent(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+    with self.mock_daemonize_context() as mock_fork:
       mock_fork.side_effect = [1, 1]    # Simulate the parent.
       self.pm.daemonize(write_pid=False)
-      # TODO(Kris Wilson): check that callbacks were called appropriately here and for daemon_spawn.
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemonize_child(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+    with self.mock_daemonize_context(chk_post_child=True) as mock_fork:
       mock_fork.side_effect = [0, 0]    # Simulate the child.
       self.pm.daemonize(write_pid=False)
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemonize_child_parent(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+    with self.mock_daemonize_context(chk_post_parent=True) as mock_fork:
       mock_fork.side_effect = [0, 1]    # Simulate the childs parent.
       self.pm.daemonize(write_pid=False)
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemon_spawn_parent(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
-      mock_fork.return_value = 1    # Simulate the parent.
+    with self.mock_daemonize_context(chk_post_parent=True) as mock_fork:
+      mock_fork.return_value = 1        # Simulate the parent.
       self.pm.daemon_spawn()
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemon_spawn_child(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
-      mock_fork.return_value = 0    # Simulate the child.
+    with self.mock_daemonize_context(chk_post_child=True) as mock_fork:
+      mock_fork.return_value = 0        # Simulate the child.
       self.pm.daemon_spawn()


### PR DESCRIPTION
- Upgrade psutil version: 1.1.3 -> 3.1.1 (a full inversion!).
- Supporting code changes - notably, properties are methods now that must be called.
- Test fixes & improvements
- Drop os.umask() while in there modifying tests - this can cause permissions differences in .pants.d files and isn't actually needed in pants' case.