### PR TITLE
Upgrade psutil to 3.1.1

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ mox==0.5.3
 # do pex<1.1.0.
 pex>=1.0.1,<1.0.999999
 
-psutil==1.1.3
+psutil==3.1.1
 lockfile==0.10.2
 Pygments==1.4
 pystache==0.5.3

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -16,6 +16,14 @@ pants.ini to retain the old default behavior and turn strict checking off:
   [gen.thrift]
   strict: False
 
+Small improvements, Refactoring and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* The psutil dependency used by pants has been upgraded to 3.1.1. Supporting eggs have been uploaded
+  to https://github.com/pantsbuild/cheeseshop/tree/gh-pages/third_party/python/dist. *Please note*
+  that beyond this update, no further binary dependency updates will be provided at this location.
+  `RB #2543 <https://rbcommons.com/s/twitter/r/2543>`_
+
 
 0.0.39 (7/23/2015)
 ------------------

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -16,14 +16,9 @@ pants.ini to retain the old default behavior and turn strict checking off:
   [gen.thrift]
   strict: False
 
-Small improvements, Refactoring and Tooling
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-* The psutil dependency used by pants has been upgraded to 3.1.1. Supporting eggs have been uploaded
-  to https://github.com/pantsbuild/cheeseshop/tree/gh-pages/third_party/python/dist. *Please note*
-  that beyond this update, no further binary dependency updates will be provided at this location.
-  `RB #2543 <https://rbcommons.com/s/twitter/r/2543>`_
-
+The psutil dependency used by pants has been upgraded to 3.1.1. Supporting eggs have been uploaded
+to https://github.com/pantsbuild/cheeseshop/tree/gh-pages/third_party/python/dist. *Please note*
+that beyond this update, no further binary dependency updates will be provided at this location.
 
 0.0.39 (7/23/2015)
 ------------------

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -272,6 +272,12 @@ class ProcessManager(object):
        and also makes the first child a session leader (which can still acquire a tty). By forking a
        second time, we ensure that the second child can never acquire a controlling terminal because
        it's no longer a session leader - but it now has its own separate process group.
+
+       Additionally, a normal daemon implementation would typically perform an os.umask(0) to reset
+       the processes file mode creation mask post-fork. We do not do this here (and in daemon_spawn
+       below) due to the fact that the daemons that pants would run are typically personal user
+       daemons. Having a disparate umask from pre-vs-post fork causes files written in each phase to
+       differ in their permissions without good reason - in this case, we want to inherit the umask.
     """
     self.pre_fork(**pre_fork_opts or {})
     pid = os.fork()

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -8,7 +8,6 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.threading',
     '3rdparty/python:ansicolors',
-    '3rdparty/python:psutil',
     '3rdparty/python:pystache',
     '3rdparty/python:six',
     ':report',

--- a/src/python/pants/reporting/reporting_server.py
+++ b/src/python/pants/reporting/reporting_server.py
@@ -18,7 +18,6 @@ import urlparse
 from collections import namedtuple
 from datetime import date, datetime
 
-import psutil
 import pystache
 from six.moves import range
 

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import unittest
 from collections import namedtuple
+from contextlib import contextmanager
 
 import mock
 import psutil
@@ -20,7 +21,10 @@ from pants.util.contextutil import temporary_dir
 PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
-FakeProcess = namedtuple('Process', 'pid name status')
+def fake_process(**kwargs):
+  proc = mock.create_autospec(psutil.Process, spec_set=True)
+  [setattr(getattr(proc, k), 'return_value', v) for k, v in kwargs.items()]
+  return proc
 
 
 class TestProcessGroup(unittest.TestCase):
@@ -46,8 +50,8 @@ class TestProcessGroup(unittest.TestCase):
   def test_iter_instances(self):
     with mock.patch('psutil.process_iter', **PATCH_OPTS) as mock_process_iter:
       mock_process_iter.return_value = [
-        FakeProcess(name='a_test', pid=3, status=psutil.STATUS_IDLE),
-        FakeProcess(name='b_test', pid=4, status=psutil.STATUS_IDLE)
+        fake_process(name='a_test', pid=3, status=psutil.STATUS_IDLE),
+        fake_process(name='b_test', pid=4, status=psutil.STATUS_IDLE)
       ]
 
       items = [item for item in self.pg.iter_instances()]
@@ -61,6 +65,29 @@ class TestProcessGroup(unittest.TestCase):
 class TestProcessManager(unittest.TestCase):
   def setUp(self):
     self.pm = ProcessManager('test')
+
+  def test_process_properties(self):
+    with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
+      mock_as_process.return_value = fake_process(name='name',
+                                                  cmdline=['cmd', 'line'],
+                                                  status='status')
+      self.assertEqual(self.pm.exe_name, 'name')
+      self.assertEqual(self.pm.cmdline, ['cmd', 'line'])
+      self.assertEqual(self.pm.cmd, 'cmd')
+      self.assertEqual(self.pm.status, 'status')
+
+  def test_process_properties_cmd_indexing(self):
+    with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
+      mock_as_process.return_value = fake_process(cmdline='')
+      self.assertEqual(self.pm.cmd, None)
+
+  def test_process_properties_none(self):
+    with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_asproc:
+      mock_asproc.return_value = None
+      self.assertEqual(self.pm.exe_name, None)
+      self.assertEqual(self.pm.cmdline, None)
+      self.assertEqual(self.pm.cmd, None)
+      self.assertEqual(self.pm.status, None)
 
   def test_maybe_cast(self):
     self.assertIsNone(self.pm._maybe_cast(None, int))
@@ -80,6 +107,13 @@ class TestProcessManager(unittest.TestCase):
       mock_proc.return_value = sentinel
       self.pm._pid = sentinel
       self.assertEqual(self.pm.as_process(), sentinel)
+
+  def test_as_process_no_pid(self):
+    fake_pid = 3
+    with mock.patch('psutil.Process', **PATCH_OPTS) as mock_proc:
+      mock_proc.side_effect = psutil.NoSuchProcess(fake_pid)
+      self.pm._pid = fake_pid
+      self.assertEqual(self.pm.as_process(), None)
 
   def test_as_process_none(self):
     self.assertEqual(self.pm.as_process(), None)
@@ -176,21 +210,21 @@ class TestProcessManager(unittest.TestCase):
 
   def test_is_alive(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
-      mock_as_process.return_value = FakeProcess(name='test', pid=3, status=psutil.STATUS_IDLE)
+      mock_as_process.return_value = fake_process(name='test', pid=3, status=psutil.STATUS_IDLE)
       self.pm._process = mock.Mock(status=psutil.STATUS_IDLE)
       self.assertTrue(self.pm.is_alive())
       mock_as_process.assert_called_with(self.pm)
 
   def test_is_alive_zombie(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
-      mock_as_process.return_value = FakeProcess(name='test', pid=3, status=psutil.STATUS_ZOMBIE)
+      mock_as_process.return_value = fake_process(name='test', pid=3, status=psutil.STATUS_ZOMBIE)
       self.assertFalse(self.pm.is_alive())
       mock_as_process.assert_called_with(self.pm)
 
   def test_is_alive_zombie_exception(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
       mock_as_process.side_effect = iter([
-        FakeProcess(name='test', pid=3, status=psutil.STATUS_IDLE),
+        fake_process(name='test', pid=3, status=psutil.STATUS_IDLE),
         psutil.NoSuchProcess(0)
       ])
       self.assertFalse(self.pm.is_alive())
@@ -198,7 +232,7 @@ class TestProcessManager(unittest.TestCase):
 
   def test_is_alive_stale_pid(self):
     with mock.patch.object(ProcessManager, 'as_process', **PATCH_OPTS) as mock_as_process:
-      mock_as_process.return_value = FakeProcess(name='not_test', pid=3, status=psutil.STATUS_IDLE)
+      mock_as_process.return_value = fake_process(name='not_test', pid=3, status=psutil.STATUS_IDLE)
       self.pm._process_name = 'test'
       self.assertFalse(self.pm.is_alive())
       mock_as_process.assert_called_with(self.pm)
@@ -221,48 +255,42 @@ class TestProcessManager(unittest.TestCase):
     proc.wait()
     self.assertEqual(proc.communicate()[0].strip(), test_str)
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
+  @contextmanager
+  def mock_daemonize_context(self, chk_pre=True, chk_post_child=False, chk_post_parent=False):
+    with mock.patch.object(ProcessManager, 'post_fork_parent', **PATCH_OPTS) as mock_post_parent:
+      with mock.patch.object(ProcessManager, 'post_fork_child', **PATCH_OPTS) as mock_post_child:
+        with mock.patch.object(ProcessManager, 'pre_fork', **PATCH_OPTS) as mock_pre:
+          with mock.patch('os.chdir', **PATCH_OPTS):
+            with mock.patch('os._exit', **PATCH_OPTS):
+              with mock.patch('os.setsid', **PATCH_OPTS):
+                with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+                  yield mock_fork
+
+                  if chk_pre: mock_pre.assert_called_once_with(self.pm)
+                  if chk_post_child: mock_post_child.assert_called_once_with(self.pm)
+                  if chk_post_parent: mock_post_parent.assert_called_once_with(self.pm)
+
   def test_daemonize_parent(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+    with self.mock_daemonize_context() as mock_fork:
       mock_fork.side_effect = [1, 1]    # Simulate the parent.
       self.pm.daemonize(write_pid=False)
-      # TODO(Kris Wilson): check that callbacks were called appropriately here and for daemon_spawn.
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemonize_child(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+    with self.mock_daemonize_context(chk_post_child=True) as mock_fork:
       mock_fork.side_effect = [0, 0]    # Simulate the child.
       self.pm.daemonize(write_pid=False)
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemonize_child_parent(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
+    with self.mock_daemonize_context(chk_post_parent=True) as mock_fork:
       mock_fork.side_effect = [0, 1]    # Simulate the childs parent.
       self.pm.daemonize(write_pid=False)
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemon_spawn_parent(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
-      mock_fork.return_value = 1    # Simulate the parent.
+    with self.mock_daemonize_context(chk_post_parent=True) as mock_fork:
+      mock_fork.return_value = 1        # Simulate the parent.
       self.pm.daemon_spawn()
 
-  @mock.patch('os.umask', **PATCH_OPTS)
-  @mock.patch('os.chdir', **PATCH_OPTS)
-  @mock.patch('os._exit', **PATCH_OPTS)
-  @mock.patch('os.setsid', **PATCH_OPTS)
   def test_daemon_spawn_child(self, *args):
-    with mock.patch('os.fork', **PATCH_OPTS) as mock_fork:
-      mock_fork.return_value = 0    # Simulate the child.
+    with self.mock_daemonize_context(chk_post_child=True) as mock_fork:
+      mock_fork.return_value = 0        # Simulate the child.
       self.pm.daemon_spawn()


### PR DESCRIPTION
- Upgrade psutil from 1.1.3 -> 3.1.1
- Drop orphaned import of psutil in reporting_server.py/BUILD.
- Port usage to new style & refine property access - notably, psutil.Process properties are now methods.
- Misc test cleanup.
- Tack-on change: drop usage of os.umask() in ProcessManager & related test changes - noticed this was causing some files to be written with different permission masks depending if they're written pre/post daemonization and was likely unnecessary for our case.