### PR TITLE
add support for android compilation with scrooge

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -80,7 +80,7 @@ jar_library(name='protobuf-test-import',
 jar_library(name='scrooge-core',
             jars = [
               # used by scrooge-generator in BUILD.tools:scrooge-gen
-              jar(org='com.twitter', name='scrooge-core_2.10', rev='3.17.0'),
+              jar(org='com.twitter', name='scrooge-core_2.10', rev='3.20.0'),
             ])
 
 jar_library(name='shapeless',

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -139,12 +139,13 @@ jar_library(name = 'junit',
 
 jar_library(name = 'scrooge-gen',
             jars = [
-              jar(org='com.twitter', name='scrooge-generator_2.10', rev='3.16.3')
+              jar(org='com.twitter', name='scrooge-generator_2.10', rev='3.20.0')
+                .exclude(org = 'org.apache.thrift', name = 'libthrift')
             ])
 
 jar_library(name = 'scrooge-linter',
             jars = [
-              jar(org='com.twitter', name='scrooge-linter_2.10', rev='3.16.3')
+              jar(org='com.twitter', name='scrooge-linter_2.10', rev='3.20.0')
             ])
 
 jar_library(name = 'spindle-codegen',

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -31,7 +31,7 @@ from pants.contrib.scrooge.tasks.thrift_util import calculate_compile_sources
 
 _CONFIG_SECTION = 'scrooge-gen'
 
-_TARGET_TYPE_FOR_LANG = dict(scala=ScalaLibrary, java=JavaLibrary)
+_TARGET_TYPE_FOR_LANG = dict(scala=ScalaLibrary, java=JavaLibrary, android=JavaLibrary)
 
 
 class ScroogeGen(NailgunTask):
@@ -318,7 +318,7 @@ class ScroogeGen(NailgunTask):
       return False
 
     language = self._thrift_defaults.language(target)
-    if language not in ('scala', 'java'):
+    if language not in ('scala', 'java', 'android'):
       raise TaskError('Scrooge can not generate {0}'.format(language))
     return True
 

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -9,6 +9,9 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class ThriftLinterTest(PantsRunIntegrationTest):
+
+  lint_error_token = "LINT-ERROR"
+
   @staticmethod
   def thrift_test_target(name):
     return 'contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter:' + name
@@ -18,55 +21,55 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     cmd = ['thrift-linter', self.thrift_test_target('good-thrift')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertFalse('Lint errors found!' in pants_run.stdout_data)
+    self.assertFalse(self.lint_error_token in pants_run.stdout_data)
 
   def test_skip_skips_execution(self):
     cmd = ['thrift-linter', '--skip', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertFalse('Lint errors found!' in pants_run.stdout_data)
+    self.assertFalse(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_default(self):
     # thrift-linter fails on linter errors.
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=True)
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_non_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=False)
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_default_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
     cmd = ['thrift-linter', '--strict', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_strict_override(self):
     # thrift-linter passes with non-strict command line flag overriding the BUILD section.
     cmd = ['thrift-linter', '--no-strict', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_non_strict_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
     cmd = ['thrift-linter', '--strict', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_pants_ini_strict(self):
     # thrift-linter fails if pants.ini has a thrift-linter:strict=True setting
@@ -74,7 +77,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     pants_ini_config = {'thrift-linter': {'strict': True}}
     pants_run = self.run_pants(cmd, config = pants_ini_config)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)
 
   def test_bad_pants_ini_strict_overridden(self):
     # thrift-linter passes if pants.ini has a thrift-linter:strict=True setting and
@@ -83,4 +86,4 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     pants_ini_config = {'thrift-linter': {'strict': True}}
     pants_run = self.run_pants(cmd, config = pants_ini_config)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertTrue(self.lint_error_token in pants_run.stdout_data)

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
@@ -1,0 +1,11 @@
+java_thrift_library(
+  name = 'android_generator',
+  sources = ['struct.thrift'],
+  dependencies = ['3rdparty:scrooge-core',
+                  '3rdparty:thrift-0.9.2'],
+  compiler='scrooge',
+  language='android',
+  rpc_style='finagle'
+)
+
+

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/struct.thrift
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/struct.thrift
@@ -1,0 +1,26 @@
+#@namespace android thrift.android.test
+typedef i32 MyInteger
+
+enum Day {
+  Mon = 1,
+  Tue = 2,
+}
+
+struct Other {
+}
+
+struct Work {
+  1: i32 num1 = 0,
+  2: MyInteger num2,
+  3: optional string comment,
+  4: set<binary> test_set,
+  5: double d1,
+  6: map<string, string> test_map,
+  7: binary test_binary,
+  8: required i64 req_int,
+  9: required Day day = 1,
+  10: required Other other,
+  11: list<string> test_list,
+  12: required list<i64> user_ids,
+  13: list<Other> other_list,
+}

--- a/src/python/pants/backend/codegen/targets/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/java_thrift_library.py
@@ -17,7 +17,7 @@ class JavaThriftLibrary(JvmTarget):
   # target that can be used by at least 2 tasks - ThriftGen and ScroogeGen.  This is likely not
   # uncommon (gcc & clang) so the arrangement needs to be cleaned up and supported well.
   _COMPILERS = frozenset(['thrift', 'scrooge'])
-  _LANGUAGES = frozenset(['java', 'scala'])
+  _LANGUAGES = frozenset(['java', 'scala', 'android'])
   _RPC_STYLES = frozenset(['sync', 'finagle', 'ostrich'])
 
   def __init__(self,


### PR DESCRIPTION
Problem

New version of scrooge 3.20 support compiling thrift file for android
(which limit the number of methods created in each class).

Solution

Upgraded Scrooge to 3.20 and fix old unit test to work with this new
version. Modified the scrooge_gen.py so that it supports this new 'language'.
Added some unit test to verify the new functionality.