### PR TITLE
Fix off by one error

### DIFF
--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -86,7 +86,7 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     """
 
     max_entries_per_target = self._max_entries_per_target
-    if os.path.isdir(root) and max_entries_per_target is not None:
+    if os.path.isdir(root) and max_entries_per_target:
       found_files = []
       for old_file in os.listdir(root):
         full_path = os.path.join(root, old_file)
@@ -101,8 +101,8 @@ class LocalArtifactCache(BaseLocalArtifactCache):
   def _store_tarball(self, cache_key, src):
     dest = self._cache_file_for_key(cache_key)
     safe_mkdir_for(dest)
-    self.prune(os.path.dirname(dest))  # Remove old cache files.
     os.rename(src, dest)
+    self.prune(os.path.dirname(dest))  # Remove old cache files.
     return dest
 
   def use_cached_files(self, cache_key):

--- a/tests/python/pants_test/backend/core/tasks/test_cache_cleanup.py
+++ b/tests/python/pants_test/backend/core/tasks/test_cache_cleanup.py
@@ -36,8 +36,7 @@ class CacheCleanupTest(PantsRunIntegrationTest):
                                  config=config)
       self.assert_success(pants_run)
 
-      # One artifact for java 6 and one old cache file
-
+      # One artifact for java 6
       self.assertEqual(len(os.listdir(artifact_dir)), 1)
 
       # Rerun for java 7
@@ -48,7 +47,7 @@ class CacheCleanupTest(PantsRunIntegrationTest):
                                  config)
       self.assert_success(pants_run)
 
-      # One artifact for java 6 (old cache file) and one for 7
+      # One artifact for java 7
       self.assertEqual(len(os.listdir(artifact_dir)), 1)
 
   def test_leave_none(self):

--- a/tests/python/pants_test/backend/core/tasks/test_cache_cleanup.py
+++ b/tests/python/pants_test/backend/core/tasks/test_cache_cleanup.py
@@ -38,7 +38,7 @@ class CacheCleanupTest(PantsRunIntegrationTest):
 
       # One artifact for java 6 and one old cache file
 
-      self.assertEqual(len(os.listdir(artifact_dir)), 2)
+      self.assertEqual(len(os.listdir(artifact_dir)), 1)
 
       # Rerun for java 7
       pants_run = self.run_pants(['compile.java',
@@ -49,7 +49,7 @@ class CacheCleanupTest(PantsRunIntegrationTest):
       self.assert_success(pants_run)
 
       # One artifact for java 6 (old cache file) and one for 7
-      self.assertEqual(len(os.listdir(artifact_dir)), 2)
+      self.assertEqual(len(os.listdir(artifact_dir)), 1)
 
   def test_leave_none(self):
     """ Ensure that max-old of zero removes all files
@@ -76,9 +76,9 @@ class CacheCleanupTest(PantsRunIntegrationTest):
                                  config=config)
       self.assert_success(pants_run)
 
-      # One artifact for java 6 and one old cache file
+      # Cache cleanup disabled for 0
 
-      self.assertEqual(len(os.listdir(artifact_dir)), 1)
+      self.assertEqual(len(os.listdir(artifact_dir)), 6)
 
       # Rerun for java 7
       pants_run = self.run_pants(['compile.java',
@@ -88,5 +88,5 @@ class CacheCleanupTest(PantsRunIntegrationTest):
                                  config)
       self.assert_success(pants_run)
 
-      # One artifact for java 6 (old cache file) and one for 7
-      self.assertEqual(len(os.listdir(artifact_dir)), 1)
+      # Cache cleanup disabled for 0
+      self.assertEqual(len(os.listdir(artifact_dir)), 7)


### PR DESCRIPTION
During design discussions the name of the argument changed and no longer reflected the implementation.
Changing the implementation to more clearly reflect the intent communicated by the name of the
argument.