### PR TITLE
add support for android compilation with scrooge

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -80,7 +80,7 @@ jar_library(name='protobuf-test-import',
 jar_library(name='scrooge-core',
             jars = [
               # used by scrooge-generator in BUILD.tools:scrooge-gen
-              jar(org='com.twitter', name='scrooge-core_2.10', rev='3.17.0'),
+              jar(org='com.twitter', name='scrooge-core_2.10', rev='3.20.0'),
             ])
 
 jar_library(name='shapeless',

--- a/BUILD.tools
+++ b/BUILD.tools
@@ -139,12 +139,23 @@ jar_library(name = 'junit',
 
 jar_library(name = 'scrooge-gen',
             jars = [
-              jar(org='com.twitter', name='scrooge-generator_2.10', rev='3.16.3')
+              jar(org='com.twitter', name='scrooge-generator_2.10', rev='3.20.0')
+                # scrooge requires libthrift 0.5.0-1 which is not available on
+                # the default maven repos. Force scrooge to use the lib thirft used
+                # by pants: 3rdparty:thrift
+                .exclude(org = 'org.apache.thrift', name = 'libthrift')
+            ],
+            dependencies = [
+              '3rdparty:thrift',
             ])
 
 jar_library(name = 'scrooge-linter',
             jars = [
-              jar(org='com.twitter', name='scrooge-linter_2.10', rev='3.16.3')
+              jar(org='com.twitter', name='scrooge-linter_2.10', rev='3.20.0')
+                .exclude(org = 'org.apache.thrift', name = 'libthrift')
+            ],
+            dependencies = [
+              '3rdparty:thrift',
             ])
 
 jar_library(name = 'spindle-codegen',

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -31,7 +31,7 @@ from pants.contrib.scrooge.tasks.thrift_util import calculate_compile_sources
 
 _CONFIG_SECTION = 'scrooge-gen'
 
-_TARGET_TYPE_FOR_LANG = dict(scala=ScalaLibrary, java=JavaLibrary)
+_TARGET_TYPE_FOR_LANG = dict(scala=ScalaLibrary, java=JavaLibrary, android=JavaLibrary)
 
 
 class ScroogeGen(NailgunTask):
@@ -319,7 +319,7 @@ class ScroogeGen(NailgunTask):
       return False
 
     language = self._thrift_defaults.language(target)
-    if language not in ('scala', 'java'):
+    if language not in ('scala', 'java', 'android'):
       raise TaskError('Scrooge can not generate {0}'.format(language))
     return True
 

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from mock import MagicMock
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
+from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
@@ -80,15 +81,8 @@ class ScroogeGenTest(TaskTestBase):
     with self.assertRaises(TaskError):
       task._validate_compiler_configs([self.target('test_validate:three')])
 
-  def test_smoke(self):
-    contents = dedent('''namespace java org.pantsbuild.example
-      struct Example {
-      1: optional i64 number
-      }
-    ''')
-
-    self.create_file(relpath='test_smoke/a.thrift', contents=contents)
-    self.add_to_build_file('test_smoke', dedent('''
+  def test_scala(self):
+    build_string = '''
       java_thrift_library(name='a',
         sources=['a.thrift'],
         dependencies=[],
@@ -96,7 +90,33 @@ class ScroogeGenTest(TaskTestBase):
         language='scala',
         rpc_style='finagle'
       )
-    '''))
+    '''
+    sources = [os.path.join(self.task_outdir, 'org/pantsbuild/example/Example.scala')]
+    self._test_help(build_string, ScalaLibrary, sources)
+
+  def test_android(self):
+    build_string = '''
+      java_thrift_library(name='a',
+        sources=['a.thrift'],
+        dependencies=[],
+        compiler='scrooge',
+        language='android',
+        rpc_style='finagle'
+      )
+    '''
+    sources = [os.path.join(self.task_outdir, 'org/pantsbuild/android_example/Example.java')]
+    self._test_help(build_string, JavaLibrary, sources)
+
+  def _test_help(self, build_string, library_type, sources):
+    contents = dedent('''#@namespace android org.pantsbuild.android_example
+      namespace java org.pantsbuild.example
+      struct Example {
+      1: optional i64 number
+      }
+    ''')
+
+    self.create_file(relpath='test_smoke/a.thrift', contents=contents)
+    self.add_to_build_file('test_smoke', dedent(build_string))
 
     target = self.target('test_smoke:a')
     context = self.context(target_roots=[target])
@@ -107,7 +127,6 @@ class ScroogeGenTest(TaskTestBase):
     task._outdir.return_value = self.task_outdir
 
     task.gen = MagicMock()
-    sources = [os.path.join(self.task_outdir, 'org/pantsbuild/example/Example.scala')]
     task.gen.return_value = {'test_smoke/a.thrift': sources}
 
     saved_add_new_target = Context.add_new_target
@@ -118,7 +137,7 @@ class ScroogeGenTest(TaskTestBase):
       spec = '{spec_path}:{name}'.format(spec_path=relative_task_outdir, name='test_smoke.a')
       address = SyntheticAddress.parse(spec=spec)
       Context.add_new_target.assert_called_once_with(address,
-                                                     ScalaLibrary,
+                                                     library_type,
                                                      sources=sources,
                                                      excludes=OrderedSet(),
                                                      dependencies=OrderedSet(),

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -10,6 +10,8 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class ThriftLinterTest(PantsRunIntegrationTest):
 
+  lint_error_token = "LINT-ERROR"
+
   @staticmethod
   def thrift_test_target(name):
     return 'contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter:' + name
@@ -19,55 +21,55 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     cmd = ['thrift-linter', self.thrift_test_target('good-thrift')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertFalse('Lint errors found!' in pants_run.stdout_data)
+    self.assertNotIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_skip_skips_execution(self):
     cmd = ['thrift-linter', '--skip', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertFalse('Lint errors found!' in pants_run.stdout_data)
+    self.assertNotIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_default(self):
     # thrift-linter fails on linter errors.
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=True)
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_non_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=False)
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_default_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
     cmd = ['thrift-linter', '--strict', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_strict_override(self):
     # thrift-linter passes with non-strict command line flag overriding the BUILD section.
     cmd = ['thrift-linter', '--no-strict', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_non_strict_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
     cmd = ['thrift-linter', '--strict', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_pants_ini_strict(self):
     # thrift-linter fails if pants.ini has a thrift-linter:strict=True setting
@@ -75,7 +77,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     pants_ini_config = {'thrift-linter': {'strict': True}}
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_failure(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_pants_ini_strict_overridden(self):
     # thrift-linter passes if pants.ini has a thrift-linter:strict=True setting and
@@ -84,4 +86,4 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     pants_ini_config = {'thrift-linter': {'strict': True}}
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_success(pants_run)
-    self.assertTrue('Lint errors found!' in pants_run.stdout_data)
+    self.assertIn(self.lint_error_token, pants_run.stdout_data)

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
@@ -1,0 +1,15 @@
+java_thrift_library(
+  name='android_generator',
+  sources=['struct.thrift'],
+  compiler='scrooge',
+  language='android',
+  rpc_style='finagle',
+  dependencies=['3rdparty:thrift'],
+  provides=artifact(
+    org='org.archimedes',
+    name='android_generator',
+    repo=Repository(name='test',
+      url='https://dl.bintray.com/somerandom/url',
+      push_db_basedir='/tmp')
+  )
+)

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/struct.thrift
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/struct.thrift
@@ -1,0 +1,26 @@
+#@namespace android thrift.android.test
+typedef i32 MyInteger
+
+enum Day {
+  Mon = 1,
+  Tue = 2,
+}
+
+struct Other {
+}
+
+struct Work {
+  1: i32 num1 = 0,
+  2: MyInteger num2,
+  3: optional string comment,
+  4: set<binary> test_set,
+  5: double d1,
+  6: map<string, string> test_map,
+  7: binary test_binary,
+  8: required i64 req_int,
+  9: required Day day = 1,
+  10: required Other other,
+  11: list<string> test_list,
+  12: required list<i64> user_ids,
+  13: list<Other> other_list,
+}

--- a/examples/src/thrift/org/pantsbuild/example/readme.md
+++ b/examples/src/thrift/org/pantsbuild/example/readme.md
@@ -83,6 +83,19 @@ Use Apache Thrift compiler (the default):
       # maybe set an rpc_style
     )
 
+**Android**
+
+Scrooge compiler can now generate java code with a limited number of getters and
+setters which is more suitable for Android applications which have a 65K limit on the
+number of methods.
+
+    :::python
+    java_thrift_library(  # Yes, a "java" library to generate Scala
+      compiler='scrooge', # default compiler does not gen android; Scrooge does
+      language='android',
+    )
+
+
 Thrift Example
 --------------
 

--- a/src/python/pants/backend/codegen/targets/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/java_thrift_library.py
@@ -17,7 +17,7 @@ class JavaThriftLibrary(JvmTarget):
   # target that can be used by at least 2 tasks - ThriftGen and ScroogeGen.  This is likely not
   # uncommon (gcc & clang) so the arrangement needs to be cleaned up and supported well.
   _COMPILERS = frozenset(['thrift', 'scrooge'])
-  _LANGUAGES = frozenset(['java', 'scala'])
+  _LANGUAGES = frozenset(['java', 'scala', 'android'])
   _RPC_STYLES = frozenset(['sync', 'finagle', 'ostrich'])
 
   def __init__(self,


### PR DESCRIPTION
Problem

New version of scrooge 3.20 support compiling thrift file for android
(which limit the number of methods created in each class).

Solution

Upgraded Scrooge to 3.20 and fix old unit test to work with this new
version. Modified the scrooge_gen.py so that it supports this new 'language'.
Added some unit test to verify the new functionality.