### PR TITLE
Add an affordance for 1 flag implying another.

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -17,7 +17,7 @@ python_tests(
   dependencies=[
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:java_thrift_library_fingerprint_strategy',
     'src/python/pants/backend/codegen/subsystems:thrift_defaults',
-    'tests/python/pants_test/base:context_utils',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )
@@ -30,8 +30,13 @@ python_tests(
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:scrooge_gen',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/base:address',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
+    'src/python/pants/goal:context',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/option/util',
     'tests/python/pants_test/tasks:task_test_base',
   ],
 )

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
@@ -7,8 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.codegen.subsystems.thrift_defaults import ThriftDefaults
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
-from pants_test.base.context_utils import create_option_values
 from pants_test.base_test import BaseTest
+from pants_test.subsystem.subsystem_util import create_subsystem
 
 from pants.contrib.scrooge.tasks.java_thrift_library_fingerprint_strategy import \
   JavaThriftLibraryFingerprintStrategy
@@ -21,7 +21,7 @@ class JavaThriftLibraryFingerprintStrategyTest(BaseTest):
               'rpc_style': 'async'}
 
   def create_strategy(self, option_values):
-    thrift_defaults = ThriftDefaults('test-scope', create_option_values(option_values))
+    thrift_defaults = create_subsystem(ThriftDefaults, **option_values)
     return JavaThriftLibraryFingerprintStrategy(thrift_defaults)
 
   def test_fp_diffs_due_to_option(self):
@@ -36,10 +36,8 @@ class JavaThriftLibraryFingerprintStrategyTest(BaseTest):
     self.assertNotEquals(fp1, fp2)
 
   def test_fp_diffs_due_to_target_change(self):
-    a = self.make_target(':a', target_type=JavaThriftLibrary,
-                         rpc_style='sync', dependencies=[])
-    b = self.make_target(':b', target_type=JavaThriftLibrary,
-                         rpc_style='finagle', dependencies=[])
+    a = self.make_target(':a', target_type=JavaThriftLibrary, rpc_style='sync', dependencies=[])
+    b = self.make_target(':b', target_type=JavaThriftLibrary, rpc_style='finagle', dependencies=[])
 
     fp1 = self.create_strategy(self.options1).compute_fingerprint(a)
     fp2 = self.create_strategy(self.options1).compute_fingerprint(b)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from textwrap import dedent
 
-from mock import MagicMock, patch
+from mock import MagicMock
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.address import SyntheticAddress
@@ -17,7 +17,7 @@ from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants.goal.context import Context
 from pants.util.dirutil import safe_rmtree
-from pants_test.base.context_utils import create_options
+from pants_test.option.util.fakes import create_options
 from pants_test.tasks.task_test_base import TaskTestBase
 from twitter.common.collections import OrderedSet
 

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -45,7 +45,9 @@ class JVM(Subsystem):
     for opt in self.get_options().options:
       ret.extend(safe_shlex_split(opt))
 
-    if self.get_options().debug:
+    if (self.get_options().debug or
+        self.get_options().is_flagged('debug_port') or
+        self.get_options().is_flagged('debug_args')):
       debug_port = self.get_options().debug_port
       ret.extend(arg.format(debug_port=debug_port) for arg in self.get_options().debug_args)
     return ret

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -81,7 +81,7 @@ class JvmRun(JvmTask):
       working_dir = self.get_options().cwd
       if not working_dir:
         working_dir = target.address.spec_path
-    logger.debug ("Working dir is {0}".format(working_dir))
+    logger.debug("Working dir is {0}".format(working_dir))
 
     if isinstance(target, JvmApp):
       binary = target.binary

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -71,6 +71,22 @@ class OptionValueContainer(object):
     else:  # Values without rank are assumed to be flag values set by argparse.
       return RankedValue.FLAG
 
+  def is_flagged(self, key):
+    """Returns `True` if the value for the specified key was supplied via a flag.
+
+    A convenience equivalent to `get_rank(key) == RankedValue.FLAG`.
+
+    This check can be useful to determine whether or not a user explicitly set an option for this
+    run.  Although a user might also set an option explicitly via an environment variable, ie via:
+    `ENV_VAR=value ./pants ...`, this is an ambiguous case since the environment variable could also
+    be permanently set in the user's environment.
+
+    :param string key: The name of the option to check.
+    :returns: `True` if the option was explicitly flagged by the user from the command line.
+    :rtype: bool
+    """
+    return self.get_rank(key) == RankedValue.FLAG
+
   def update(self, attrs):
     """Set attr values on this object from the data in the attrs dict."""
     for k, v in attrs.items():

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -44,6 +44,7 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/base:context_utils',
+    'tests/python/pants_test/option/util',
   ]
 )
 

--- a/tests/python/pants_test/backend/codegen/subsystems/BUILD
+++ b/tests/python/pants_test/backend/codegen/subsystems/BUILD
@@ -15,7 +15,7 @@ python_tests(
     'src/python/pants/backend/codegen/subsystems:thrift_defaults',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/base:target',
-    'tests/python/pants_test/base:context_utils',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/backend/codegen/subsystems/test_thrift_defaults.py
+++ b/tests/python/pants_test/backend/codegen/subsystems/test_thrift_defaults.py
@@ -5,20 +5,19 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import functools
 import uuid
 from contextlib import contextmanager
 
 from pants.backend.codegen.subsystems.thrift_defaults import ThriftDefaults
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
 from pants.base.target import Target
-from pants_test.base.context_utils import create_option_values
 from pants_test.base_test import BaseTest
+from pants_test.subsystem.subsystem_util import create_subsystem
 
 
 class TestThriftDefaults(BaseTest):
-  def create_thrift_defaults(self, compiler=None, language=None, rpc_style=None):
-    option_values = dict(compiler=compiler, language=language, rpc_style=rpc_style)
-    return ThriftDefaults('test-scope', create_option_values(option_values))
+  create_thrift_defaults = functools.partial(create_subsystem, ThriftDefaults)
 
   @contextmanager
   def invalid_fixtures(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -19,9 +19,6 @@ class JvmRunTest(TaskTestBase):
   def task_type(cls):
     return JvmRun
 
-  def setUp(self):
-    super(JvmRunTest, self).setUp()
-
   @contextmanager
   def setup_cmdline_run(self, **options):
     """Run the JvmRun task in command line only mode  with the specified extra options.
@@ -31,7 +28,7 @@ class JvmRunTest(TaskTestBase):
     jvm_binary = self.make_target('src/java/org/pantsbuild:binary', JvmBinary,
                                   main='org.pantsbuild.Binary')
     context = self.context(target_roots=[jvm_binary])
-    jvm_run =  self.create_task(context, 'unused')
+    jvm_run = self.create_task(context, 'unused')
     self._cmdline_classpath = [os.path.join(self.build_root, c) for c in ['bob', 'fred']]
     self.populate_compile_classpath(context=jvm_run.context, classpath=self._cmdline_classpath)
     with temporary_dir() as pwd:

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -27,7 +27,7 @@ python_tests(
     'src/python/pants/binaries:thrift_util',
     'src/python/pants/ivy',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/base:context_utils',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -29,8 +29,8 @@ from pants.binaries.thrift_binary import ThriftBinary
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.util.contextutil import temporary_dir
-from pants_test.base.context_utils import create_option_values
 from pants_test.base_test import BaseTest
+from pants_test.subsystem.subsystem_util import create_subsystem
 
 
 def test_get_current_platform():
@@ -41,32 +41,19 @@ def test_get_current_platform():
 class PythonChrootTest(BaseTest):
   @contextmanager
   def dumped_chroot(self, targets):
-    def options(**kwargs):
-      return create_option_values(kwargs)
-
     with temporary_dir() as chroot:
-      # TODO(John Sirois): Find a way to get easy access to pants option defaults.
       python_setup_workdir = os.path.join(self.real_build_root, '.pants.d', 'python-setup')
 
-      python_setup_options = options(
-          artifact_cache_dir=os.path.join(python_setup_workdir, 'artifacts'),
-          interpreter_cache_dir=os.path.join(python_setup_workdir, 'interpreters'),
-          interpreter_requirement='CPython>=2.7,<3',
-          resolver_cache_dir=os.path.join(python_setup_workdir, 'resolved_requirements'),
-          resolver_cache_ttl=None,
-          setuptools_version='5.4.1',
-          wheel_version='0.24.0')
-      python_setup = PythonSetup('test-scope', python_setup_options)
-      python_repos = PythonRepos('test-scope',
-                                 options(repos=[], indexes=['https://pypi.python.org/simple/']))
+      def cache_dir(name):
+        return os.path.join(python_setup_workdir, name)
 
-      ivy_subsystem_options = options(ivy_profile='2.4.0',
-                                      ivy_settings=None,
-                                      cache_dir=os.path.expanduser('~/.ivy2/pants'),
-                                      http_proxy=None,
-                                      https_proxy=None,
-                                      pants_bootstrapdir=get_pants_cachedir())
-      ivy_subsystem = IvySubsystem('test-scope', ivy_subsystem_options)
+      python_setup = create_subsystem(PythonSetup,
+                                      artifact_cache_dir=cache_dir('artifacts'),
+                                      interpreter_cache_dir=cache_dir('interpreters'),
+                                      resolver_cache_dir=cache_dir('resolved_requirements'))
+      python_repos = create_subsystem(PythonRepos)
+
+      ivy_subsystem = create_subsystem(IvySubsystem, pants_bootstrapdir=get_pants_cachedir())
       ivy_bootstrapper = Bootstrapper(ivy_subsystem=ivy_subsystem)
 
       def thrift_binary_factory():

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -5,11 +5,11 @@ python_library(
   name = 'context_utils',
   sources = ['context_utils.py'],
   dependencies = [
-    '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:target',
     'src/python/pants/base:workunit',
     'src/python/pants/goal:context',
+    'tests/python/pants_test/option/util',
   ]
 )
 

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -14,56 +14,7 @@ from twitter.common.collections import maybe_list
 from pants.base.target import Target
 from pants.base.workunit import WorkUnit
 from pants.goal.context import Context
-
-
-def create_option_values(option_values):
-  """Create a fake OptionValues object for testing.
-
-  :param dict option_values: A dict of option name -> value.
-  """
-  class TestOptionValues(object):
-    def __init__(self):
-      self.__dict__ = option_values
-    def __getitem__(self, key):
-      return getattr(self, key)
-    def get(self, key, default=None):
-      if hasattr(self, key):
-        return getattr(self, key, default)
-      return default
-  return TestOptionValues()
-
-
-def create_options(options):
-  """Create a fake Options object for testing.
-
-  Note that the returned object only provides access to the provided options values. There is
-  no registration mechanism on this object. Code under test shouldn't care about resolving
-  cmd-line flags vs. config vs. env vars etc. etc.
-
-  :param dict options: A dict of scope -> (dict of option name -> value).
-  """
-  class TestOptions(object):
-    def for_scope(self, scope):
-      return create_option_values(options[scope])
-
-    def for_global_scope(self):
-      return self.for_scope('')
-
-    def passthru_args_for_scope(self, scope):
-      return []
-
-    def items(self):
-      return options.items()
-
-    def registration_args_iter_for_scope(self, scope):
-      return []
-
-    def get_fingerprintable_for_scope(self, scope):
-      return []
-
-    def __getitem__(self, key):
-      return self.for_scope(key)
-  return TestOptions()
+from pants_test.option.util.fakes import create_options
 
 
 class TestContext(Context):

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -30,10 +30,12 @@ from pants.goal.goal import Goal
 from pants.goal.products import MultipleRootedProducts, UnionProducts
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options import Options
+from pants.option.ranked_value import RankedValue
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree, touch
-from pants_test.base.context_utils import create_context, create_option_values
+from pants_test.base.context_utils import create_context
+from pants_test.option.util.fakes import create_option_values, options_registration_function
 
 
 # TODO: Rename to 'TestBase', for uniformity, and also for logic: This is a baseclass
@@ -159,14 +161,8 @@ class BaseTest(unittest.TestCase):
     # All this does is make the names available in code, with the default values.
     # Individual tests can then override the option values they care about.
     def register_func(on_scope):
-      def register(*rargs, **rkwargs):
-        scoped_options = option_values[on_scope]
-        default = rkwargs.get('default')
-        if default is None and rkwargs.get('action') == 'append':
-          default = []
-        for flag_name in rargs:
-          option_name = flag_name.lstrip('-').replace('-', '_')
-          scoped_options[option_name] = default
+      scoped_options = option_values[on_scope]
+      register = options_registration_function(scoped_options)
       register.bootstrap = bootstrap_option_values
       register.scope = on_scope
       return register

--- a/tests/python/pants_test/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/jvm/subsystems/BUILD
@@ -1,0 +1,18 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name='subsystems',
+  dependencies=[
+    ':jvm',
+  ]
+)
+
+python_tests(
+  name='jvm',
+  sources=['test_jvm.py'],
+  dependencies=[
+    'src/python/pants/backend/jvm/subsystems:jvm',
+    'tests/python/pants_test/subsystem:subsystem_utils',
+  ]
+)

--- a/tests/python/pants_test/jvm/subsystems/test_jvm.py
+++ b/tests/python/pants_test/jvm/subsystems/test_jvm.py
@@ -14,6 +14,11 @@ from pants_test.subsystem.subsystem_util import create_subsystem
 create_JVM = functools.partial(create_subsystem, JVM)
 
 
+def test_options_default():
+  jvm = create_JVM()
+  assert [] == jvm.get_jvm_options()
+
+
 def test_options_simple():
   jvm = create_JVM(options=['-ea'])
   assert ['-ea'] == jvm.get_jvm_options()
@@ -63,6 +68,11 @@ def test_explicit_debug_args():
 def test_explicit_debug_args_with_options():
   jvm = create_JVM(options=['-ea'], debug_args=['fred'])
   assert sorted(['-ea', 'fred']) == sorted(jvm.get_jvm_options())
+
+
+def test_args_default():
+  jvm = create_JVM()
+  assert [] == jvm.get_program_args()
 
 
 def test_args_single_simple():

--- a/tests/python/pants_test/jvm/subsystems/test_jvm.py
+++ b/tests/python/pants_test/jvm/subsystems/test_jvm.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import functools
+
+from pants.backend.jvm.subsystems.jvm import JVM
+from pants_test.subsystem.subsystem_util import create_subsystem
+
+
+create_JVM = functools.partial(create_subsystem, JVM)
+
+
+def test_options_simple():
+  jvm = create_JVM(options=['-ea'])
+  assert ['-ea'] == jvm.get_jvm_options()
+
+
+def test_options_single_complex():
+  jvm = create_JVM(options=['-ea "-cp mono.jar" -server'])
+  assert ['-ea', '-cp mono.jar', '-server'] == jvm.get_jvm_options()
+
+
+def test_options_multiple():
+  jvm = create_JVM(options=['-ea', '"-cp mono.jar"', '-server'])
+  assert ['-ea', '-cp mono.jar', '-server'] == jvm.get_jvm_options()
+
+
+def test_explicit_debug():
+  jvm = create_JVM(debug=True)
+  assert '-Xdebug' in jvm.get_jvm_options()
+
+
+def test_explicit_debug_with_options():
+  jvm = create_JVM(options=['-ea'], debug=True)
+  assert '-ea' in jvm.get_jvm_options()
+  assert '-Xdebug' in jvm.get_jvm_options()
+
+
+def test_implicit_via_debug_port():
+  jvm = create_JVM(debug_port=1137)
+  jvm_options = jvm.get_jvm_options()
+
+  assert '-Xdebug' in jvm_options
+
+  jdwp_options = None
+  for option in jvm_options:
+    if option.startswith('-Xrunjdwp:'):
+      jdwp_options = dict(kv.split('=', 1) for kv in option.replace('-Xrunjdwp:', '').split(','))
+      assert 'address' in jdwp_options
+      assert '1137' in jdwp_options['address']
+  assert jdwp_options is not None, 'Expected jdwp options to be present specifying the debug port.'
+
+
+def test_explicit_debug_args():
+  jvm = create_JVM(debug_args=['fred'])
+  assert ['fred'] == jvm.get_jvm_options()
+
+
+def test_explicit_debug_args_with_options():
+  jvm = create_JVM(options=['-ea'], debug_args=['fred'])
+  assert sorted(['-ea', 'fred']) == sorted(jvm.get_jvm_options())
+
+
+def test_args_single_simple():
+  jvm = create_JVM(program_args=['a'])
+  assert ['a'] == jvm.get_program_args()
+
+
+def test_args_single_complex():
+  jvm = create_JVM(program_args=['a "b c" d'])
+  assert ['a', 'b c', 'd'] == jvm.get_program_args()
+
+
+def test_args_multiple():
+  jvm = create_JVM(program_args=['a', '"b c"', 'd'])
+  assert ['a', 'b c', 'd'] == jvm.get_program_args()

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -13,3 +13,11 @@ python_tests(
     'tests/python/pants_test:base_test',
   ],
 )
+
+python_tests(
+  name='testing',
+  sources=globs('*.py'),
+  dependencies=[
+    'src/python/pants/option',
+  ],
+)

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -54,6 +54,22 @@ class OptionValueContainerTest(unittest.TestCase):
     self.assertEqual(44, o.foo)
     self.assertEqual(RankedValue.FLAG, o.get_rank('foo'))
 
+  def test_is_flagged(self):
+    o = OptionValueContainer()
+    o.add_forwardings({'foo': 'bar'})
+
+    o.bar = RankedValue(RankedValue.NONE, 11)
+    self.assertFalse(o.is_flagged('foo'))
+
+    o.bar = RankedValue(RankedValue.CONFIG, 11)
+    self.assertFalse(o.is_flagged('foo'))
+
+    o.bar = RankedValue(RankedValue.ENVIRONMENT, 11)
+    self.assertFalse(o.is_flagged('foo'))
+
+    o.bar = RankedValue(RankedValue.FLAG, 11)
+    self.assertTrue(o.is_flagged('foo'))
+
   def test_indexing(self):
     o = OptionValueContainer()
     o.add_forwardings({'foo': 'bar'})

--- a/tests/python/pants_test/option/util/BUILD
+++ b/tests/python/pants_test/option/util/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name='util',
+  sources=globs('*.py'),
+  dependencies=[
+    'src/python/pants/option',
+  ],
+)

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.option.optionable import Optionable
+from pants.option.ranked_value import RankedValue
+
+
+def create_option_values(option_values):
+  """Create a fake OptionValueContainer object for testing.
+
+  :param **options: Keyword args representing option values explicitly set via the command line.
+  :returns: A fake `OptionValueContainer` encapsulating the given option values.
+  """
+  class FakeOptionValues(object):
+    def __getitem__(self, key):
+      return getattr(self, key)
+
+    def get(self, key, default=None):
+      if hasattr(self, key):
+        return getattr(self, key, default)
+      return default
+
+    def __getattr__(self, key):
+      value = option_values[key]
+      return value.value if isinstance(value, RankedValue) else value
+
+    def get_rank(self, key):
+      value = option_values[key]
+      return value.rank if isinstance(value, RankedValue) else RankedValue.FLAG
+
+    def is_flagged(self, key):
+      return self.get_rank(key) == RankedValue.FLAG
+  return FakeOptionValues()
+
+
+def options_registration_function(defaults):
+  """Creates an options registration function suitable for passing to `Optionable.register_options`.
+
+  :param dict defaults: An option value dictionary the registration function will register default
+                        option values in.
+  :returns: a registration function suitable for passing to `Optionable.register_options`.
+  """
+  def register(*args, **kwargs):
+    default = kwargs.get('default')
+    if default is None:
+      action = kwargs.get('action')
+      if action == 'store_true':
+        default = False
+      if action == 'append':
+        default = []
+    for flag_name in args:
+      normalized_flag_name = flag_name.lstrip('-').replace('-', '_')
+      defaults[normalized_flag_name] = RankedValue(RankedValue.HARDCODED, default)
+  return register
+
+
+def create_option_values_for_optionable(optionable_type, **options):
+  """Create a fake OptionValueContainer with appropriate defaults for the given `Optionable` type."
+
+  :param type optionable_type: An :class:`pants.option.optionable.Optionable` subclass.
+  :param **options: Keyword args representing option values explicitly set via the command line.
+  :returns: A fake `OptionValueContainer`, ie: the value returned from `get_options()`.
+  """
+  if not issubclass(optionable_type, Optionable):
+    raise TypeError('The given `optionable_type` was not a subclass of `Optionable`: {}'
+                    .format(optionable_type))
+
+  option_values = {}
+  registration_function = options_registration_function(option_values)
+  optionable_type.register_options(registration_function)
+  option_values.update(**options)
+  return create_option_values(option_values)
+
+
+def create_options(options):
+  """Create a fake Options object for testing.
+
+  Note that the returned object only provides access to the provided options values. There is
+  no registration mechanism on this object. Code under test shouldn't care about resolving
+  cmd-line flags vs. config vs. env vars etc. etc.
+
+  :param dict options: A dict of scope -> (dict of option name -> value).
+  :returns: An fake `Options` object encapsulating the given scoped options.
+  """
+  class FakeOptions(object):
+    def for_scope(self, scope):
+      return create_option_values(options[scope])
+
+    def for_global_scope(self):
+      return self.for_scope('')
+
+    def passthru_args_for_scope(self, scope):
+      return []
+
+    def items(self):
+      return options.items()
+
+    def registration_args_iter_for_scope(self, scope):
+      return []
+
+    def get_fingerprintable_for_scope(self, scope):
+      return []
+
+    def __getitem__(self, key):
+      return self.for_scope(key)
+  return FakeOptions()

--- a/tests/python/pants_test/python/BUILD
+++ b/tests/python/pants_test/python/BUILD
@@ -90,7 +90,7 @@ python_tests(
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python:python_setup',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/base:context_utils',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ],
 )
 

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -2,11 +2,20 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'subsystem',
-  sources = globs('*.py'),
-  dependencies = [
+  name='subsystem',
+  sources=['test_subsystem.py'],
+  dependencies=[
     '3rdparty/python:pytest',
     'src/python/pants/option',
     'src/python/pants/subsystem',
+  ],
+)
+
+python_library(
+  name='subsystem_utils',
+  sources=['subsystem_util.py'],
+  dependencies=[
+    'src/python/pants/subsystem',
+    'tests/python/pants_test/option/util',
   ],
 )

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.subsystem.subsystem import Subsystem
+from pants_test.option.util.fakes import create_option_values_for_optionable
+
+
+def create_subsystem(subsystem_type, scope='test-scope', **options):
+  """Creates a Subsystem for test.
+
+  :param type subsystem_type: The subclass of :class:`pants.subsystem.subsystem.Subsystem`
+                              to create.
+  :param string scope: The scope to create the subsystem in.
+  :param **options: Keyword args representing option values explicitly set via the command line.
+  """
+  if not issubclass(subsystem_type, Subsystem):
+    raise TypeError('The given `subsystem_type` was not a subclass of `Subsystem`: {}'
+                    .format(subsystem_type))
+
+  option_values = create_option_values_for_optionable(subsystem_type, **options)
+  return subsystem_type(scope, option_values)


### PR DESCRIPTION
This adds an is_flagged helper to the OptionValueContainer
(get_options()), and the JVM subsystem leverages it to turn on debugging
whenever a user explicitly flags a custom debug port or custom debug
args on the command line.

The change also introduces a subsystem test utility and refactors option
value container faking.