### PR TITLE
Fixup PythonTask chroot caching.

### DIFF
--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -33,7 +33,7 @@ class PythonRun(PythonTask):
       # We can't throw if binary isn't a PythonBinary, because perhaps we were called on a
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
       # TODO(benjy): Some more elegant way to coordinate how tasks claim targets.
-      interpreter = self.select_interpreter_for_targets(self.context.targets())
+      interpreter = self.select_interpreter_for_targets(binary.closure())
       with self.cached_chroot(interpreter=interpreter, pex_info=binary.pexinfo,
                               targets=[binary], platforms=binary.platforms) as chroot:
         pex = chroot.pex()

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -4,13 +4,14 @@ target(
     ':pytest_run',
     ':python_eval',
     ':python_repl',
+    ':python_task',
     ':setup_py',
   ]
 )
 
 python_library(
-  name='python_task_test',
-  sources=['python_task_test.py'],
+  name='python_task_test_base',
+  sources=['python_task_test_base.py'],
   dependencies=[
     'src/python/pants/backend/python:plugin',
     'src/python/pants/base:address',
@@ -19,14 +20,23 @@ python_library(
 )
 
 python_tests(
+  name='python_task',
+  sources=['test_python_task.py'],
+  dependencies=[
+    ':python_task_test_base',
+    'src/python/pants/backend/python/tasks:python',
+  ]
+)
+
+python_tests(
   name='pytest_run',
   sources=['test_pytest_run.py'],
   dependencies=[
-    ':python_task_test',
     '3rdparty/python:coverage',
     '3rdparty/python:pex',
-    'src/python/pants/backend/python:python_setup',
+    ':python_task_test_base',
     'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/backend/python:python_setup',
     'src/python/pants/util:contextutil',
   ]
 )
@@ -36,7 +46,7 @@ python_tests(
   name='python_eval',
   sources=['test_python_eval.py'],
   dependencies=[
-    ':python_task_test',
+    ':python_task_test_base',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
     'src/python/pants/base:source_root',
@@ -47,7 +57,7 @@ python_tests(
   name='python_repl',
   sources=['test_python_repl.py'],
   dependencies=[
-    ':python_task_test',
+    ':python_task_test_base',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
     'src/python/pants/backend/python:all_utils',
@@ -64,10 +74,10 @@ python_tests(
   name='setup_py',
   sources=['test_setup_py.py'],
   dependencies=[
-    ':python_task_test',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:mock',
+    ':python_task_test_base',
     'src/python/pants/backend/python/tasks:python',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -13,20 +13,18 @@ from pants.base.address import SyntheticAddress
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
-class PythonTaskTest(TaskTestBase):
+class PythonTaskTestBase(TaskTestBase):
   def setUp(self):
-    super(PythonTaskTest, self).setUp()
+    super(PythonTaskTestBase, self).setUp()
+
     # Use the "real" interpreter cache, so tests don't waste huge amounts of time recreating it.
     # It would be nice to get the location of the real interpreter cache from PythonSetup,
     # but unfortunately real subsystems aren't available here (for example, we have no access
     # to the enclosing pants instance's options), so we have to hard-code it.
+    python_setup_workdir = os.path.join(self.real_build_root, '.pants.d', 'python-setup')
     self.set_options_for_scope('python-setup',
-        interpreter_requirement='CPython>=2.7,<3',
-        interpreter_cache_dir=os.path.join(self.real_build_root, '.pants.d',
-                                           'python-setup', 'interpreters'),
-        chroot_cache_dir=os.path.join(self.real_build_root, '.pants.d',
-                                      'python-setup', 'chroots'),
-        resolver_cache_ttl=1000000000)  # TODO: Do we need this now that there's a default?
+        interpreter_cache_dir=os.path.join(python_setup_workdir, 'interpreters'),
+        chroot_cache_dir=os.path.join(python_setup_workdir, 'chroots'))
 
   @property
   def alias_groups(self):

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -15,10 +15,10 @@ import coverage
 from pants.backend.python.tasks.pytest_run import PytestRun
 from pants.base.exceptions import TestFailedTaskError
 from pants.util.contextutil import pushd
-from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
 
-class PythonTestBuilderTestBase(PythonTaskTest):
+class PythonTestBuilderTestBase(PythonTaskTestBase):
   @classmethod
   def task_type(cls):
     return PytestRun

--- a/tests/python/pants_test/backend/python/tasks/test_python_eval.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_eval.py
@@ -11,10 +11,10 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.tasks.python_eval import PythonEval
 from pants.base.source_root import SourceRoot
-from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
 
-class PythonEvalTest(PythonTaskTest):
+class PythonEvalTest(PythonTaskTestBase):
   @classmethod
   def task_type(cls):
     return PythonEval

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -20,10 +20,10 @@ from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
 from pants.base.target import Target
 from pants.util.contextutil import temporary_dir
-from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
 
-class PythonReplTest(PythonTaskTest):
+class PythonReplTest(PythonTaskTestBase):
   @classmethod
   def task_type(cls):
     return PythonRepl

--- a/tests/python/pants_test/backend/python/tasks/test_python_task.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_task.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import subprocess
+from contextlib import contextmanager
+from textwrap import dedent
+
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.tasks.python_task import PythonTask
+from pants.base.source_root import SourceRoot
+from pants.util.contextutil import temporary_file_path
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
+
+
+class PythonTaskTest(PythonTaskTestBase):
+  class NoopPythonTask(PythonTask):
+    def execute(self):
+      pass
+
+  @classmethod
+  def task_type(cls):
+    return cls.NoopPythonTask
+
+  def setUp(self):
+    super(PythonTaskTest, self).setUp()
+
+    SourceRoot.register('3rdparty', PythonRequirementLibrary)
+    SourceRoot.register('src', PythonBinary, PythonLibrary)
+
+    self.requests = self.create_python_requirement_library('3rdparty/requests', 'requests',
+                                                           requirements=['requests==2.6.0'])
+    self.six = self.create_python_requirement_library('3rdparty/six', 'six',
+                                                      requirements=['six==1.9.0'])
+
+    self.library = self.create_python_library('src/lib', 'lib', {'lib.py': dedent("""
+    import six
+
+
+    def go():
+      six.print_('go', 'go', 'go!', sep='')
+    """)}, dependencies=['//3rdparty/six'])
+
+    self.binary = self.create_python_binary('src/bin', 'bin', 'lib.lib:go',
+                                            dependencies=['//src/lib'])
+
+  def rebind_targets(self):
+    # Creates new Target objects to ensure any cached fingerprints are reset and ready to be
+    # re-calculated.
+    self.reset_build_graph()
+    self.requests = self.target('3rdparty/requests')
+    self.six = self.target('3rdparty/six')
+    self.library = self.target('src/lib')
+    self.binary = self.target('src/bin')
+
+  @contextmanager
+  def cached_chroot(self):
+    python_task = self.create_task(self.context(target_roots=[self.binary]))
+
+    interpreter = python_task.select_interpreter_for_targets(self.binary.closure())
+    pex_info = self.binary.pexinfo
+    platforms = self.binary.platforms
+
+    with python_task.cached_chroot(interpreter, pex_info, [self.binary], platforms) as chroot:
+      with temporary_file_path() as pex:
+        chroot.dump()
+        chroot.package_pex(pex)
+        yield chroot, pex
+
+  def test_cached_chroot_reuse(self):
+    with self.cached_chroot() as (chroot1, pex1):
+      self.rebind_targets()
+      with self.cached_chroot() as (chroot2, pex2):
+        self.assertEqual(chroot1.path(), chroot2.path())
+        self.assertEqual(subprocess.check_output(pex1), subprocess.check_output(pex2))
+
+  # TODO(John Sirois): Test direct python_binary.source modification after moving
+  # PythonTaskTestBase to self.make_target
+
+  def test_cached_chroot_direct_dep_invalidation(self):
+    with self.cached_chroot() as (chroot1, pex1):
+      self.rebind_targets()
+      self.binary.inject_dependency(self.requests.address)
+      with self.cached_chroot() as (chroot2, pex2):
+        self.assertNotEqual(chroot1.path(), chroot2.path())
+        # Adding an unused requests dep does not change the behavior of the binary despite
+        # invalidating the chroot
+        self.assertEqual(subprocess.check_output(pex1), subprocess.check_output(pex2))
+
+  def test_cached_chroot_transitive_source_invalidation(self):
+    with self.cached_chroot() as (chroot1, pex1):
+      self.rebind_targets()
+      self.create_file('src/lib/lib.py', mode='ab', contents="  six.print_('Mad River Glen!')")
+      with self.cached_chroot() as (chroot2, pex2):
+        self.assertNotEqual(chroot1.path(), chroot2.path())
+        self.assertNotEqual(subprocess.check_output(pex1), subprocess.check_output(pex2))
+
+  def test_cached_chroot_transitive_dep_invalidation(self):
+    with self.cached_chroot() as (chroot1, pex1):
+      self.rebind_targets()
+      self.library.inject_dependency(self.requests.address)
+      with self.cached_chroot() as (chroot2, pex2):
+        self.assertNotEqual(chroot1.path(), chroot2.path())
+        # Adding an unused requests dep does not change the behavior of the binary despite
+        # invalidating the chroot
+        self.assertEqual(subprocess.check_output(pex1), subprocess.check_output(pex2))

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -22,10 +22,10 @@ from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
 from pants.util.contextutil import temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir
-from pants_test.backend.python.tasks.python_task_test import PythonTaskTest
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
 
-class TestSetupPy(PythonTaskTest):
+class TestSetupPy(PythonTaskTestBase):
   @classmethod
   def task_type(cls):
     return SetupPy


### PR DESCRIPTION
Previously there were a few issues that could lead to over-invalidation,
but most importantly, there was an issue leading to under-invalidation.

Fixup chroot target fingerprinting to be transitive, previously just the
top-level targets were fingerprinted.  This fixes under-invalidation
based on changes to python chroot trabsitive target dependency edits.

Also fixup unstable portions of the fingerprint with a few TODOs added
to do these more cleanly.

Add a PythonTaskTest that exercises these cases as well as the unchanged
chroot case.