### PR TITLE
Upgrade pex to 1.0.2.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -8,7 +8,7 @@ mox==0.5.3
 
 # Until https://github.com/pantsbuild/pex/issues/28 is addressed, we cannot
 # do pex<1.1.0.
-pex>=1.0.1,<1.0.999999
+pex>=1.0.2,<1.0.999999
 
 psutil==3.1.1
 lockfile==0.10.2


### PR DESCRIPTION
Changelog is here:
  https://pypi.python.org/pypi/pex/1.0.2

Notably, this picks up a fix for PEX-INFO trampling as outlined here:
  https://groups.google.com/d/topic/pants-devel/CuAV8AO0Hbg/discussion

https://rbcommons.com/s/twitter/r/2571/