### PR TITLE
[CI] Remove some convenience references on Options.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -20,7 +20,7 @@ from pants.base.address import SyntheticAddress
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
-from pants.option.options import Options
+from pants.option.custom_types import dict_option, list_option
 from pants.util.dirutil import safe_mkdir, safe_open
 from twitter.common.collections import OrderedSet
 
@@ -61,12 +61,12 @@ class ScroogeGen(NailgunTask):
     super(ScroogeGen, cls).register_options(register)
     register('--verbose', default=False, action='store_true', help='Emit verbose output.')
     register('--strict', default=False, action='store_true', help='Enable strict compilation.')
-    register('--jvm-options', default=[], advanced=True, type=Options.list,
+    register('--jvm-options', default=[], advanced=True, type=list_option,
              help='Use these jvm options when running Scrooge.')
-    register('--service-deps', default={}, advanced=True, type=Options.dict,
+    register('--service-deps', default={}, advanced=True, type=dict_option,
              help='A map of language to targets to add as dependencies of '
                   'synthetic thrift libraries that contain services.')
-    register('--structs-deps', default={}, advanced=True, type=Options.dict,
+    register('--structs-deps', default={}, advanced=True, type=dict_option,
              help='A map of language to targets to add as dependencies of '
                   'synthetic thrift libraries that contain structs.')
     cls.register_jvm_tool(register, 'scrooge-gen')

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 
 
 class ThriftLintError(Exception):
@@ -35,7 +35,7 @@ class ThriftLinter(NailgunTask):
     register('--strict-default', default=False, advanced=True, action='store_true',
              help='Sets the default strictness for targets. The `strict` option overrides '
                   'this value if it is set.')
-    register('--linter-args', default=[], advanced=True, type=Options.list,
+    register('--linter-args', default=[], advanced=True, type=list_option,
              help='Additional options passed to the linter.')
     register('--jvm-options', action='append', metavar='<option>...', advanced=True,
              help='Run with these extra jvm options.')

--- a/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
@@ -16,7 +16,7 @@ from pants.base.address import SyntheticAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from twitter.common.dirutil import safe_mkdir
 
 from pants.contrib.spindle.targets.spindle_thrift_library import SpindleThriftLibrary
@@ -36,14 +36,14 @@ class SpindleGen(NailgunTask):
       '--jvm-options',
       default=[],
       advanced=True,
-      type=Options.list,
+      type=list_option,
       help='Use these jvm options when running Spindle.',
     )
     register(
       '--runtime-dependency',
       default=['3rdparty:spindle-runtime'],
       advanced=True,
-      type=Options.list,
+      type=list_option,
       help='A list of targets that all spindle codegen depends on at runtime.',
     )
     cls.register_jvm_tool(register, 'spindle-codegen')

--- a/migrations/options/src/python/migrate_config.py
+++ b/migrations/options/src/python/migrate_config.py
@@ -442,13 +442,13 @@ def check_config_file(path):
       value = value.strip()
       if value.startswith('['):
         try:
-          custom_types.list_type(value)
+          custom_types.list_option(value)
         except ParseError:
           print('Value of {key} in section {section} is not a valid '
                 'JSON list.'.format(key=green(key), section=section(sec)))
       elif value.startswith('{'):
         try:
-          custom_types.dict_type(value)
+          custom_types.dict_option(value)
         except ParseError:
           print('Value of {key} in section {section} is not a valid '
                 'JSON object.'.format(key=green(key), section=section(sec)))

--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -20,7 +20,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit
 from pants.binaries.thrift_binary import ThriftBinary
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.util.dirutil import safe_mkdir
 from pants.util.memo import memoized_property
 
@@ -39,9 +39,9 @@ class ApacheThriftGen(SimpleCodegenTask):
 
     register('--gen-options', advanced=True, fingerprint=True,
              help='Use these apache thrift java gen options.')
-    register('--deps', advanced=True, type=Options.list,
+    register('--deps', advanced=True, type=list_option,
              help='A list of specs pointing to dependencies of thrift generated java code.')
-    register('--service-deps', advanced=True, type=Options.list,
+    register('--service-deps', advanced=True, type=list_option,
              help='A list of specs pointing to dependencies of thrift generated java service '
                   'code.  If not supplied, then --deps will be used for service deps.')
 

--- a/src/python/pants/backend/codegen/tasks/wire_gen.py
+++ b/src/python/pants/backend/codegen/tasks/wire_gen.py
@@ -22,7 +22,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
 from pants.java import util
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class WireGen(JvmToolTaskMixin, SimpleCodegenTask):
   @classmethod
   def register_options(cls, register):
     super(WireGen, cls).register_options(register)
-    register('--javadeps', type=Options.list, default=['//:wire-runtime'],
+    register('--javadeps', type=list_option, default=['//:wire-runtime'],
              help='Runtime dependencies for wire-using Java code.')
     cls.register_jvm_tool(register, 'wire-compiler')
 

--- a/src/python/pants/backend/core/tasks/scm_publish.py
+++ b/src/python/pants/backend/core/tasks/scm_publish.py
@@ -10,7 +10,7 @@ import traceback
 from abc import abstractmethod
 
 from pants.base.exceptions import TaskError
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.scm.scm import Scm
 
 
@@ -142,9 +142,9 @@ class ScmPublishMixin(object):
     super(ScmPublishMixin, cls).register_options(register)
     register('--scm-push-attempts', type=int, default=cls._SCM_PUSH_ATTEMPTS,
              help='Try pushing the pushdb to the SCM this many times before aborting.')
-    register('--restrict-push-branches', advanced=True, type=Options.list,
+    register('--restrict-push-branches', advanced=True, type=list_option,
              help='Allow pushes only from one of these branches.')
-    register('--restrict-push-urls', advanced=True, type=Options.list,
+    register('--restrict-push-urls', advanced=True, type=list_option,
              help='Allow pushes to only one of these urls.')
 
   @property

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.base.workunit import WorkUnit
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -18,7 +18,7 @@ class JarTool(JvmToolMixin, Subsystem):
   def register_options(cls, register):
     super(JarTool, cls).register_options(register)
     # TODO: All jvm tools will need this option, so might as well have register_jvm_tool add it?
-    register('--jvm-options', advanced=True, type=Options.list, default=['-Xmx64M'],
+    register('--jvm-options', advanced=True, type=list_option, default=['-Xmx64M'],
              help='Run the jar tool with these JVM options.')
     cls.register_jvm_tool(register, 'jar-tool')
 

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.subsystem.subsystem import Subsystem
 from pants.util.strutil import safe_shlex_split
 
@@ -26,7 +26,7 @@ class JVM(Subsystem):
              help='Run the JVM with remote debugging.')
     register('--debug-port', advanced=True, recursive=True, type=int, default=5005,
              help='The JVM will listen for a debugger on this port.')
-    register('--debug-args', advanced=True, recursive=True, type=Options.list,
+    register('--debug-args', advanced=True, recursive=True, type=list_option,
              default=[
                '-Xdebug',
                '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address={debug_port}'

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -10,7 +10,7 @@ import logging
 from pants.base.exceptions import TaskError
 from pants.base.revision import Revision
 from pants.java.distribution.distribution import Distribution
-from pants.option.options import Options
+from pants.option.custom_types import dict_option
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
 
@@ -56,7 +56,7 @@ class JvmPlatform(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(JvmPlatform, cls).register_options(register)
-    register('--platforms', advanced=True, type=Options.dict, default={}, fingerprint=True,
+    register('--platforms', advanced=True, type=dict_option, default={}, fingerprint=True,
              help='Compile settings that can be referred to by name in jvm_targets.')
     register('--default-platform', advanced=True, type=str, default=None, fingerprint=True,
              help='Name of the default platform to use if none are specified.')

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.exceptions import TaskError
-from pants.option.options import Options
+from pants.option.custom_types import target_list_option
 
 
 class JvmToolMixin(object):
@@ -45,7 +45,7 @@ class JvmToolMixin(object):
     """
     register('--{0}'.format(key),
              advanced=True,
-             type=Options.target_list,
+             type=target_list_option,
              default=['//:{0}'.format(key)] if default is None else default,
              help='Target specs for bootstrapping the {0} tool.'.format(key),
              fingerprint=fingerprint)

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -23,7 +23,7 @@ class ScalaPlatform(JvmToolMixin, Subsystem):
     super(ScalaPlatform, cls).register_options(register)
     # No need to fingerprint --runtime, because it is automatically inserted as a
     # dependency for the scala_library target.
-    register('--runtime', advanced=True, type=Options.list, default=['//:scala-library'],
+    register('--runtime', advanced=True, type=list_option, default=['//:scala-library'],
              help='Target specs pointing to the scala runtime libraries.')
     cls.register_jvm_tool(register, 'scalac', default=['//:scala-compiler'], fingerprint=True)
 

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -12,7 +12,7 @@ from twitter.common.collections import OrderedSet
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.java.jar.shader import Shader
-from pants.option.options import Options
+from pants.option.custom_types import dict_option, file_option
 from pants.process.xargs import Xargs
 from pants.util.dirutil import safe_open
 
@@ -30,9 +30,9 @@ class Checkstyle(NailgunTask):
     super(Checkstyle, cls).register_options(register)
     register('--skip', action='store_true', fingerprint=True,
              help='Skip checkstyle.')
-    register('--configuration', type=Options.file, fingerprint=True,
+    register('--configuration', type=file_option, fingerprint=True,
              help='Path to the checkstyle configuration file.')
-    register('--properties', type=Options.dict, default={}, fingerprint=True,
+    register('--properties', type=dict_option, default={}, fingerprint=True,
              help='Dictionary of property mappings to use for checkstyle.properties.')
     register('--confs', default=['default'],
              help='One or more ivy configurations to resolve for this target. This parameter is '

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -34,7 +34,7 @@ from pants.base.generator import Generator, TemplateData
 from pants.base.target import Target
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy import Ivy
-from pants.option.options import Options
+from pants.option.custom_types import dict_option, list_option
 from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree
 from pants.util.strutil import ensure_text
 
@@ -432,12 +432,12 @@ class JarPublish(ScmPublishMixin, JarTask):
                   'Or: --restart-at=src/java/com/twitter/common/base')
     register('--ivy_settings', advanced=True, default=None,
              help='Specify a custom ivysettings.xml file to be used when publishing.')
-    register('--jvm-options', advanced=True, type=Options.list,
+    register('--jvm-options', advanced=True, type=list_option,
              help='Use these jvm options when running Ivy.')
-    register('--repos', advanced=True, type=Options.dict,
+    register('--repos', advanced=True, type=dict_option,
              help='Settings for repositories that can be pushed to. See '
                   'https://pantsbuild.github.io/publish.html for details.')
-    register('--publish-extras', advanced=True, type=Options.dict,
+    register('--publish-extras', advanced=True, type=dict_option,
              help='Extra products to publish. See '
                   'https://pantsbuild.github.io/dev_tasks_publish_extras.html for details.')
     register('--individual-plugins', advanced=True, default=False, type=bool,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -11,16 +11,14 @@ from collections import defaultdict
 
 from pants.backend.core.tasks.group_task import GroupMember
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
-from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile_global_strategy import JvmCompileGlobalStrategy
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile_isolated_strategy import \
   JvmCompileIsolatedStrategy
 from pants.backend.jvm.tasks.jvm_compile.jvm_dependency_analyzer import JvmDependencyAnalyzer
 from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
-from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import TaskIdentityFingerprintStrategy
 from pants.goal.products import MultipleRootedProducts
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.reporting.reporting_utils import items_to_report_element
 
 
@@ -38,14 +36,14 @@ class JvmCompile(NailgunTaskBase, GroupMember):
              help='Roughly how many source files to attempt to compile together. Set to a large '
                   'number to compile all sources together. Set to 0 to compile target-by-target.')
 
-    register('--jvm-options', type=Options.list, default=[],
+    register('--jvm-options', type=list_option, default=[],
              help='Run the compiler with these JVM options.')
 
     register('--args', action='append',
              default=list(cls.get_args_default(register.bootstrap)), fingerprint=True,
              help='Pass these args to the compiler.')
 
-    register('--confs', type=Options.list, default=['default'],
+    register('--confs', type=list_option, default=['default'],
              help='Compile for these Ivy confs.')
 
     # TODO: Stale analysis should be automatically ignored via Task identities:
@@ -167,7 +165,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     :param list args: Arguments to the compiler (such as jmake or zinc).
     :param list classpath: List of classpath entries.
     :param list sources: Source files.
-    :param str classess_output_dir: Where to put the compiled output.
+    :param str classes_output_dir: Where to put the compiled output.
     :param upstream_analysis:
     :param analysis_file: Where to write the compile analysis.
     :param log_file: Where to write logs.
@@ -324,7 +322,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
                      log_file, settings)
 
   def check_artifact_cache(self, vts):
-    post_process_cached_vts = lambda vts: self._strategy.post_process_cached_vts(vts)
+    post_process_cached_vts = lambda cvts: self._strategy.post_process_cached_vts(cvts)
     return self.do_check_artifact_cache(vts, post_process_cached_vts=post_process_cached_vts)
 
   def _create_empty_products(self):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
@@ -22,7 +22,7 @@ from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.exceptions import TaskError
 from pants.base.target import Target
 from pants.base.worker_pool import Work
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.util.contextutil import open_zip, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_walk
 
@@ -49,7 +49,7 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
                   'implementation detail. However it may still be useful to use this on '
                   'occasion. '.format(compile_task_name))
 
-    register('--missing-deps-whitelist', type=Options.list,
+    register('--missing-deps-whitelist', type=list_option,
              help="Don't report these targets even if they have missing deps.")
 
     register('--unnecessary-deps', choices=['off', 'warn', 'fatal'], default='off',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/scala/zinc_compile.py
@@ -21,7 +21,7 @@ from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnit
 from pants.java.distribution.distribution import Distribution
 from pants.java.jar.shader import Shader
-from pants.option.options import Options
+from pants.option.custom_types import dict_option
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import relativize_paths, safe_open
 
@@ -71,7 +71,7 @@ class ZincCompile(JvmCompile):
     super(ZincCompile, cls).register_options(register)
     register('--plugins', action='append', fingerprint=True,
              help='Use these scalac plugins.')
-    register('--plugin-args', advanced=True, type=Options.dict, default={}, fingerprint=True,
+    register('--plugin-args', advanced=True, type=dict_option, default={}, fingerprint=True,
              help='Map from plugin name to list of arguments for that plugin.')
     register('--name-hashing', action='store_true', default=False, fingerprint=True,
              help='Use zinc name hashing.')

--- a/src/python/pants/backend/jvm/tasks/resources_task.py
+++ b/src/python/pants/backend/jvm/tasks/resources_task.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from pants.backend.core.tasks.task import Task
 from pants.base.build_environment import get_buildroot
 from pants.goal.products import MultipleRootedProducts
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.util.dirutil import relativize_path, safe_mkdir
 
 
@@ -29,7 +29,7 @@ class ResourcesTask(Task):
   @classmethod
   def register_options(cls, register):
     super(ResourcesTask, cls).register_options(register)
-    register('--confs', advanced=True, type=Options.list, default=['default'],
+    register('--confs', advanced=True, type=list_option, default=['default'],
              help='Prepare resources for these Ivy confs.')
 
   @classmethod

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -11,7 +11,7 @@ from pex.fetcher import Fetcher, PyPIFetcher
 from pex.http import Context
 from pkg_resources import Requirement
 
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -28,7 +28,7 @@ class PythonSetup(Subsystem):
              help='The setuptools version for this python environment.')
     register('--wheel-version', advanced=True, default='0.24.0',
              help='The wheel version for this python environment.')
-    register('--platforms', advanced=True, type=Options.list, default=['current'],
+    register('--platforms', advanced=True, type=list_option, default=['current'],
              help='The wheel version for this python environment.')
     register('--interpreter-cache-dir', advanced=True, default=None, metavar='<dir>',
              help='The parent directory for the interpreter cache. '
@@ -118,9 +118,9 @@ class PythonRepos(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(PythonRepos, cls).register_options(register)
-    register('--repos', advanced=True, type=Options.list, default=[],
+    register('--repos', advanced=True, type=list_option, default=[],
              help='URLs of code repositories.')
-    register('--indexes', advanced=True, type=Options.list,
+    register('--indexes', advanced=True, type=list_option,
              default=['https://pypi.python.org/simple/'],
              help='URLs of code repository indexes.')
 

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -12,7 +12,7 @@ from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.target import Target
 from pants.base.workunit import WorkUnit
 from pants.console import stty_utils
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 
 
 class PythonRepl(PythonTask):
@@ -23,7 +23,7 @@ class PythonRepl(PythonTask):
              help='Run an IPython REPL instead of the standard python one.')
     register('--ipython-entry-point', advanced=True, default='IPython:start_ipython',
              help='The IPython REPL entry point.')
-    register('--ipython-requirements', advanced=True, type=Options.list, default=['ipython==1.0.0'],
+    register('--ipython-requirements', advanced=True, type=list_option, default=['ipython==1.0.0'],
              help='The IPython interpreter version to use.')
 
   # NB: **pex_run_kwargs is used by tests only, execute nominally has (void)void signature.

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -26,8 +26,8 @@ from pants.goal.goal import Goal
 from pants.goal.run_tracker import RunTracker
 from pants.java.nailgun_executor import NailgunProcessGroup  # XXX(pl)
 from pants.logging.setup import setup_logging
+from pants.option.custom_types import list_option
 from pants.option.global_options import GlobalOptionsRegistrar
-from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import ScopeInfo
 from pants.reporting.invalidation_report import InvalidationReport
@@ -49,7 +49,7 @@ class SourceRootBootstrapper(Subsystem):
     super(SourceRootBootstrapper, cls).register_options(register)
     # TODO: Get rid of bootstrap buildfiles in favor of source root registration at backend load
     # time.
-    register('--bootstrap-buildfiles', advanced=True, type=Options.list, default=[],
+    register('--bootstrap-buildfiles', advanced=True, type=list_option, default=[],
              help='Initialize state by evaluating these buildfiles.')
 
   def bootstrap(self, address_mapper, build_file_parser):

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -16,7 +16,7 @@ import six.moves.urllib.request as urllib_request
 from twitter.common.collections import OrderedSet
 
 from pants.base.exceptions import TaskError
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_delete, safe_open
@@ -52,7 +52,7 @@ class BinaryUtil(object):
 
     @classmethod
     def register_options(cls, register):
-      register('--baseurls', type=Options.list, advanced=True,
+      register('--baseurls', type=list_option, advanced=True,
                default=['https://dl.bintray.com/pantsbuild/bin/build-support'],
                help='List of urls from which binary tools are downloaded.  Urls are searched in '
                     'order until the requested path is found.')
@@ -211,10 +211,10 @@ def safe_args(args,
   """
   max_args = max_args or options.max_subprocess_args
   if len(args) > max_args:
-    def create_argfile(fp):
-      fp.write(delimiter.join(args))
-      fp.close()
-      return [quoter(fp.name) if quoter else '@{}'.format(fp.name)]
+    def create_argfile(f):
+      f.write(delimiter.join(args))
+      f.close()
+      return [quoter(f.name) if quoter else '@{}'.format(f.name)]
 
     if argfile:
       try:

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -16,7 +16,7 @@ from pants.cache.artifact_cache import ArtifactCacheError
 from pants.cache.local_artifact_cache import LocalArtifactCache, TempLocalArtifactCache
 from pants.cache.pinger import Pinger
 from pants.cache.restful_artifact_cache import RESTfulArtifactCache
-from pants.option.options import Options
+from pants.option.custom_types import list_option
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -48,11 +48,11 @@ class CacheSetup(Subsystem):
     register('--overwrite', action='store_true', recursive=True,
              help='If writing build artifacts to cache, overwrite existing artifacts '
                   'instead of skipping them.')
-    register('--read-from', type=Options.list, recursive=True,
+    register('--read-from', type=list_option, recursive=True,
              help='The URIs of artifact caches to read from. Each entry is a URL of a RESTful '
                   'cache, a path of a filesystem cache, or a pipe-separated list of alternate '
                   'caches to choose from.')
-    register('--write-to', type=Options.list, recursive=True,
+    register('--write-to', type=list_option, recursive=True,
              help='The URIs of artifact caches to write to. Each entry is a URL of a RESTful '
                   'cache, a path of a filesystem cache, or a pipe-separated list of alternate '
                   'caches to choose from.')

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -20,7 +20,7 @@ def _parse_error(s, msg):
   return ParseError('Error while parsing option value {0}: {1}'.format(s, msg))
 
 
-def dict_type(s):
+def dict_option(s):
   """An option of type 'dict'.
 
   The value (on the command-line, in an env var or in the config file) must be eval'able to a dict.
@@ -28,7 +28,7 @@ def dict_type(s):
   return _convert(s, (dict,))
 
 
-def list_type(s):
+def list_option(s):
   """An option of type 'list'.
 
   The value (on the command-line, in an env var or in the config file) must be eval'able to a
@@ -37,12 +37,12 @@ def list_type(s):
   return _convert(s, (list, tuple))
 
 
-def target_list_type(s):
-  """Same type as 'list_type', but indicates list contents are target specs."""
+def target_list_option(s):
+  """Same type as 'list_option', but indicates list contents are target specs."""
   return _convert(s, (list, tuple))
 
 
-def file_type(s):
+def file_option(s):
   """Same type as 'str', but indicates string represents a filepath."""
   if not os.path.isfile(s):
     raise ParseError('Options file "{filepath}" does not exist.'.format(filepath=s))

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -9,12 +9,13 @@ import logging
 import os
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
+from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.custom_types import list_option
 from pants.option.optionable import Optionable
-from pants.option.options import Options
 
 
 class GlobalOptionsRegistrar(Optionable):
-  options_scope = Options.GLOBAL_SCOPE
+  options_scope = GLOBAL_SCOPE
 
   @classmethod
   def register_bootstrap_options(cls, register):
@@ -31,8 +32,8 @@ class GlobalOptionsRegistrar(Optionable):
     status as "bootstrap options" is only pertinent during option registration.
     """
     buildroot = get_buildroot()
-    register('--plugins', advanced=True, type=Options.list, help='Load these plugins.')
-    register('--backend-packages', advanced=True, type=Options.list,
+    register('--plugins', advanced=True, type=list_option, help='Load these plugins.')
+    register('--backend-packages', advanced=True, type=list_option,
              help='Load backends from these packages that are already on the path.')
 
     register('--pants-bootstrapdir', advanced=True, metavar='<dir>', default=get_pants_cachedir(),

--- a/src/python/pants/option/help_info_extracter.py
+++ b/src/python/pants/option/help_info_extracter.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from collections import namedtuple
 
-from pants.option.custom_types import dict_type, list_type
+from pants.option.custom_types import dict_option, list_option
 from pants.option.option_util import is_boolean_flag
 
 
@@ -56,9 +56,9 @@ class HelpInfoExtracter(object):
 
     action = kwargs.get('action')
     typ = kwargs.get('type', str)
-    if typ == list_type or action == 'append':
+    if typ == list_option or action == 'append':
       default_str = '[{}]'.format(','.join(["'{}'".format(s) for s in default]))
-    elif typ == dict_type:
+    elif typ == dict_option:
       default_str = '{{ {} }}'.format(
         ','.join(["'{}':'{}'".format(k, v) for k, v in default.items()]))
     else:
@@ -72,9 +72,9 @@ class HelpInfoExtracter(object):
     metavar = kwargs.get('metavar')
     if not metavar:
       typ = kwargs.get('type', str)
-      if typ == list_type or action == 'append':
+      if typ == list_option or action == 'append':
         metavar = '"[\'str1\',\'str2\',...]"'
-      elif typ == dict_type:
+      elif typ == dict_option:
         metavar = '"{ \'key1\': val1,\'key2\': val2,...}"'
       else:
         metavar = '<{}>'.format(typ.__name__)

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -10,7 +10,6 @@ import sys
 
 from pants.base.build_environment import pants_release, pants_version
 from pants.goal.goal import Goal
-from pants.option import custom_types
 from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.parser_hierarchy import ParserHierarchy
@@ -61,24 +60,6 @@ class Options(object):
     - The hard-coded value provided at registration time.
     - None.
   """
-  GLOBAL_SCOPE = GLOBAL_SCOPE
-
-  # Custom option types. You can specify these with type= when registering options.
-
-  # A dict-typed option.
-  dict = staticmethod(custom_types.dict_type)
-
-  # A list-typed option. Note that this is different than an action='append' option:
-  # An append option will append the cmd-line values to the default. A list-typed option
-  # will replace the default with the cmd-line value.
-  list = staticmethod(custom_types.list_type)
-
-  # A list-typed option that indicates the list elements are target specs.
-  target_list = staticmethod(custom_types.target_list_type)
-
-  # A string-typed option that indicates the string is a filepath.
-  file = staticmethod(custom_types.file_type)
-
   @classmethod
   def complete_scopes(cls, scope_infos):
     """Expand a set of scopes to include all enclosing scopes.

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import json
 from hashlib import sha1
 
-from pants.option.options import Options
+from pants.option.custom_types import file_option, target_list_option
 
 
 def stable_json_dumps(obj):
@@ -33,9 +33,9 @@ class OptionsFingerprinter(object):
     if option_val is None:
       return None
 
-    if option_type == Options.target_list:
+    if option_type == target_list_option:
       return self._fingerprint_target_specs(option_val)
-    elif option_type == Options.file:
+    elif option_type == file_option:
       return self._fingerprint_file(option_val)
     else:
       return self._fingerprint_primitive(option_val)

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.errors import OptionsError
 from pants.option.parser import Parser
 
 
@@ -27,7 +28,10 @@ class ParserHierarchy(object):
       self._parser_by_scope[scope] = Parser(env, config, scope_info, parent_parser)
 
   def get_parser_by_scope(self, scope):
-    return self._parser_by_scope[scope]
+    try:
+      return self._parser_by_scope[scope]
+    except KeyError:
+      raise OptionsError('No such options scope: {}'.format(scope))
 
   def walk(self, callback):
     """Invoke callback on each parser, in pre-order depth-first order."""

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -28,9 +28,8 @@ from pants.base.source_root import SourceRoot
 from pants.base.target import Target
 from pants.goal.goal import Goal
 from pants.goal.products import MultipleRootedProducts, UnionProducts
+from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.global_options import GlobalOptionsRegistrar
-from pants.option.options import Options
-from pants.option.ranked_value import RankedValue
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree, touch
@@ -170,11 +169,11 @@ class BaseTest(unittest.TestCase):
     # TODO: This sequence is a bit repetitive of the real registration sequence.
 
     # Register bootstrap options and grab their default values for use in subsequent registration.
-    GlobalOptionsRegistrar.register_bootstrap_options(register_func(Options.GLOBAL_SCOPE))
-    bootstrap_option_values = create_option_values(copy.copy(option_values[Options.GLOBAL_SCOPE]))
+    GlobalOptionsRegistrar.register_bootstrap_options(register_func(GLOBAL_SCOPE))
+    bootstrap_option_values = create_option_values(copy.copy(option_values[GLOBAL_SCOPE]))
 
     # Now register the full global scope options.
-    GlobalOptionsRegistrar.register_options(register_func(Options.GLOBAL_SCOPE))
+    GlobalOptionsRegistrar.register_options(register_func(GLOBAL_SCOPE))
 
     # Now register task and subsystem options for relevant tasks.
     for task_type in for_task_types:
@@ -207,7 +206,7 @@ class BaseTest(unittest.TestCase):
     # Iterating in sorted order guarantees that we see outer scopes before inner scopes,
     # and therefore only have to inherit from our immediately enclosing scope.
     for scope in sorted(all_scopes):
-      if scope != Options.GLOBAL_SCOPE:
+      if scope != GLOBAL_SCOPE:
         enclosing_scope = scope.rpartition('.')[0]
         opts = option_values[scope]
         for key, val in option_values.get(enclosing_scope, {}).items():

--- a/tests/python/pants_test/ivy/test_bootstrapper.py
+++ b/tests/python/pants_test/ivy/test_bootstrapper.py
@@ -10,7 +10,7 @@ import os
 from pants.backend.core.tasks.task import Task
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.option.options import Options
+from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 
 
@@ -35,7 +35,7 @@ class BootstrapperTest(JvmToolTaskTestBase):
     super(BootstrapperTest, self).setUp()
     # Make sure subsystems are initialized with the given options.
     self.context(options={
-      Options.GLOBAL_SCOPE: {'pants_bootstrapdir': self.test_workdir}
+      GLOBAL_SCOPE: {'pants_bootstrapdir': self.test_workdir}
     })
 
   def test_simple(self):

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-from pants.option.custom_types import dict_type, list_type
+from pants.option.custom_types import dict_option, list_option
 from pants.option.errors import ParseError
 
 
@@ -15,9 +15,9 @@ class CustomTypesTest(unittest.TestCase):
 
   def _do_test(self, expected_val, s):
     if isinstance(expected_val, dict):
-      val = dict_type(s)
+      val = dict_option(s)
     elif isinstance(expected_val, (list, tuple)):
-      val = list_type(s)
+      val = list_option(s)
     else:
       raise Exception('Expected value {0} is of unsupported type: {1}'.format(expected_val,
                                                                               type(expected_val)))

--- a/tests/python/pants_test/option/test_help_info_extracter.py
+++ b/tests/python/pants_test/option/test_help_info_extracter.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-from pants.option.custom_types import dict_type, list_type
+from pants.option.custom_types import dict_option, list_option
 from pants.option.help_info_extracter import HelpInfoExtracter
 
 
@@ -32,8 +32,8 @@ class HelpInfoExtracterTest(unittest.TestCase):
     do_test(['--foo'], {}, ['--foo=<str>'], ['--foo'])
     do_test(['--foo'], {'metavar': 'xx'}, ['--foo=xx'], ['--foo'])
     do_test(['--foo'], {'type': int}, ['--foo=<int>'], ['--foo'])
-    do_test(['--foo'], {'type': list_type}, ['--foo="[\'str1\',\'str2\',...]"'], ['--foo'])
-    do_test(['--foo'], {'type': dict_type}, ['--foo="{ \'key1\': val1,\'key2\': val2,...}"'],
+    do_test(['--foo'], {'type': list_option}, ['--foo="[\'str1\',\'str2\',...]"'], ['--foo'])
+    do_test(['--foo'], {'type': dict_option}, ['--foo="{ \'key1\': val1,\'key2\': val2,...}"'],
                                             ['--foo'])
     do_test(['--foo'], {'action': 'append'},
             ['--foo="[\'str1\',\'str2\',...]" (--foo="[\'str1\',\'str2\',...]") ...'], ['--foo'])

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -13,6 +13,8 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.base.deprecated import PastRemovalVersionError
+from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.custom_types import dict_option, file_option, list_option, target_list_option
 from pants.option.errors import ParseError
 from pants.option.options import Options
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -36,7 +38,7 @@ class OptionsTest(unittest.TestCase):
 
   def _register(self, options):
     def register_global(*args, **kwargs):
-      options.register(Options.GLOBAL_SCOPE, *args, **kwargs)
+      options.register(GLOBAL_SCOPE, *args, **kwargs)
 
     register_global('-v', '--verbose', action='store_true', help='Verbose output.', recursive=True)
     register_global('-n', '--num', type=int, default=99, recursive=True)
@@ -52,10 +54,10 @@ class OptionsTest(unittest.TestCase):
     register_global('--store-false-def-true-flag', action='store_false', default=True)
 
     # Custom types.
-    register_global('--dicty', type=Options.dict, default='{"a": "b"}')
-    register_global('--listy', type=Options.list, default='[1, 2, 3]')
-    register_global('--target_listy', type=Options.target_list, default=[':a', ':b'])
-    register_global('--filey', type=Options.file, default='default.txt')
+    register_global('--dicty', type=dict_option, default='{"a": "b"}')
+    register_global('--listy', type=list_option, default='[1, 2, 3]')
+    register_global('--target_listy', type=target_list_option, default=[':a', ':b'])
+    register_global('--filey', type=file_option, default='default.txt')
 
     # For the design doc example test.
     register_global('--a', type=int, recursive=True)
@@ -381,8 +383,8 @@ class OptionsTest(unittest.TestCase):
   def test_deprecated_option_past_removal(self):
     with self.assertRaises(PastRemovalVersionError):
       options = Options({}, FakeConfig({}), OptionsTest._known_scope_infos, "./pants")
-      options.register(Options.GLOBAL_SCOPE, '--too-old-option', deprecated_version='0.0.24',
-                              deprecated_hint='The semver for this option has already passed.')
+      options.register(GLOBAL_SCOPE, '--too-old-option', deprecated_version='0.0.24',
+                       deprecated_hint='The semver for this option has already passed.')
 
   @contextmanager
   def warnings_catcher(self):

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
-from pants.option.options import Options
+from pants.option.custom_types import dict_option, file_option, list_option, target_list_option
 from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants_test.base_test import BaseTest
 
@@ -22,7 +22,7 @@ class OptionsFingerprinterTest(BaseTest):
     d1 = {'b': 1, 'a': 2}
     d2 = {'a': 2, 'b': 1}
     d3 = {'a': 1, 'b': 2}
-    fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(Options.dict, d)
+    fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(dict_option, d)
                      for d in (d1, d2, d3))
     self.assertEquals(fp1, fp2)
     self.assertNotEquals(fp1, fp3)
@@ -30,7 +30,7 @@ class OptionsFingerprinterTest(BaseTest):
   def test_fingerprint_list(self):
     l1 = [1, 2, 3]
     l2 = [1, 3, 2]
-    fp1, fp2 = (self.options_fingerprinter.fingerprint(Options.list, l)
+    fp1, fp2 = (self.options_fingerprinter.fingerprint(list_option, l)
                      for l in (l1, l2))
     self.assertNotEquals(fp1, fp2)
 
@@ -42,7 +42,7 @@ class OptionsFingerprinterTest(BaseTest):
       self.make_target(s, payload=p)
     s1, s2, s3 = specs
 
-    fp_specs = lambda specs: self.options_fingerprinter.fingerprint(Options.target_list, specs)
+    fp_specs = lambda specs: self.options_fingerprinter.fingerprint(target_list_option, specs)
     fp1 = fp_specs([s1, s2])
     fp2 = fp_specs([s2, s1])
     fp3 = fp_specs([s1, s3])
@@ -50,7 +50,7 @@ class OptionsFingerprinterTest(BaseTest):
     self.assertNotEquals(fp1, fp3)
 
   def test_fingerprint_file(self):
-    fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(Options.file,
+    fp1, fp2, fp3 = (self.options_fingerprinter.fingerprint(file_option,
                                                             self.create_file(f, contents=c))
                      for (f, c) in (('foo/bar.config', 'blah blah blah'),
                                     ('foo/bar.config', 'meow meow meow'),


### PR DESCRIPTION
Currently, optionables that want to use custom option types
must import Options, which is overkill and will lead do
circular import problems in a pending #docfixit change to
improve help output.