### PR TITLE
Upgrade to pex 1.0.3.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -8,7 +8,7 @@ mox==0.5.3
 
 # Until https://github.com/pantsbuild/pex/issues/28 is addressed, we cannot
 # do pex<1.1.0.
-pex>=1.0.2,<1.0.999999
+pex>=1.0.3,<1.0.999999
 
 psutil==3.1.1
 lockfile==0.10.2


### PR DESCRIPTION
The changelog is here:
  https://pypi.python.org/pypi/pex/1.0.3

Of note to pants are fixes for python interpreter discovery on OSX and
handling of sys.exit in pexes generated by pants.

https://rbcommons.com/s/twitter/r/2596/