### PR TITLE
[CI] Improve cmd-line help output.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
@@ -43,6 +43,7 @@ _JMAKE_ERROR_CODES.update((256 + code, msg) for code, msg in _JMAKE_ERROR_CODES.
 
 
 class JmakeCompile(JvmCompile):
+  """Compile Java code with JMake."""
   _name = 'java'
   _file_suffix = '.java'
   _supports_concurrent_execution = False

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -5,7 +5,9 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import sys
+from abc import ABCMeta
 from collections import namedtuple
 
 from twitter.common.collections import OrderedSet
@@ -35,16 +37,36 @@ class SplitArgs(namedtuple('SplitArgs',
   pass
 
 
-class HelpRequest(namedtuple('HelpRequest', ['version', 'advanced', 'all_scopes'])):
-  """A help request from the user.
+class HelpRequest(object):
+  """Represents an implicit or explicit request for help by the user."""
+  __metaclass__ = ABCMeta
 
-  version: Did the user ask for version info.
-  advanced: Did the user ask for advanced help (e.g., using --help-advanced).
-  all_scopes: Did the user ask for help for all goals and tasks (e.g., using --help-all).
-  """
-  @classmethod
-  def basic(cls):
-    return cls(version=False, advanced=False, all_scopes=False)
+
+class VersionHelp(HelpRequest):
+  """The user requested the version of pants."""
+  pass
+
+
+class OptionsHelp(HelpRequest):
+  def __init__(self, advanced=False, all_scopes=False):
+    """The user requested help for cmd-line options.
+
+    :param advanced: Did the user ask for advanced help (e.g., using --help-advanced).
+    :param all_scopes: Did the user ask for help for all goals and tasks (e.g., using --help-all).
+    """
+    self.advanced = advanced
+    self.all_scopes = all_scopes
+
+
+class UnknownGoalHelp(HelpRequest):
+  """The user specified an unknown goal (or task)."""
+  def __init__(self, unknown_goals):
+    self.unknown_goals = unknown_goals
+
+
+class NoGoalHelp(HelpRequest):
+  """The user specified no goals."""
+  pass
 
 
 class ArgSplitter(object):
@@ -70,6 +92,7 @@ class ArgSplitter(object):
     self._known_scope_infos = known_scope_infos
     self._known_scopes = (set([si.scope for si in known_scope_infos]) |
                           {'help', 'help-advanced', 'help-all'})
+    self._unknown_scopes = []
     self._unconsumed_args = []  # In reverse order, for efficient popping off the end.
     self._help_request = None  # Will be set if we encounter any help flags.
 
@@ -91,13 +114,14 @@ class ArgSplitter(object):
   def _check_for_help_request(self, arg):
     if not arg in self._HELP_ARGS:
       return False
-    # First ensure that we have a basic HelpRequest.
+    # First ensure that we have a basic OptionsHelp.
     if not self._help_request:
-      self._help_request = HelpRequest.basic()
+      self._help_request = OptionsHelp()
     # Now see if we need to enhance it.
-    advanced = self._help_request.advanced or arg in self._HELP_ADVANCED_ARGS
-    all_scopes = self._help_request.all_scopes or arg in self._HELP_ALL_SCOPES_ARGS
-    self._help_request = HelpRequest(False, advanced, all_scopes)
+    if isinstance(self._help_request, OptionsHelp):
+      advanced = self._help_request.advanced or arg in self._HELP_ADVANCED_ARGS
+      all_scopes = self._help_request.all_scopes or arg in self._HELP_ALL_SCOPES_ARGS
+      self._help_request = OptionsHelp(advanced=advanced, all_scopes=all_scopes)
     return True
 
   def split_args(self, args=None):
@@ -142,7 +166,7 @@ class ArgSplitter(object):
     for version_arg in self._VERSION_ARGS:
       if version_arg in global_flags:
         if not self._help_request:
-          self._help_request = HelpRequest(True, False, False)
+          self._help_request = VersionHelp()
         global_flags.remove(version_arg)
 
     add_scope(GLOBAL_SCOPE)
@@ -164,15 +188,21 @@ class ArgSplitter(object):
         # We assume any args here are in global scope.
         if not self._check_for_help_request(arg):
           assign_flag_to_scope(arg, GLOBAL_SCOPE)
-      else:
+      elif os.path.sep in arg or ':' in arg or os.path.isdir(arg):
         targets.append(arg)
+      else:
+        self._unknown_scopes.append(arg)
 
     if self._at_double_dash():
       self._unconsumed_args.pop()
       passthru = list(reversed(self._unconsumed_args))
 
+    if self._unknown_scopes:
+      self._help_request = UnknownGoalHelp(self._unknown_scopes)
+
     if not goals and not self._help_request:
-      self._help_request = HelpRequest.basic()
+      self._help_request = NoGoalHelp()
+
     return SplitArgs(goals, scope_to_flags, targets, passthru, passthru_owner if passthru else None)
 
   def _consume_scope(self):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -126,5 +126,5 @@ class GlobalOptionsRegistrar(Optionable):
              help='Read BUILD files from this scm rev instead of from the working tree.  This is '
              'useful for implementing pants-aware sparse checkouts.')
     register('--lock', action='store_true', default=True,
-             help='Use a global lock to exclude other versions of pants from running during critical'
-                  'operations.')
+             help='Use a global lock to exclude other versions of pants from running during '
+                  'criticaloperations.')

--- a/src/python/pants/option/help_formatter.py
+++ b/src/python/pants/option/help_formatter.py
@@ -33,7 +33,7 @@ class HelpFormatter(object):
   def _maybe_color(self, color, s):
     return color(s) if self._color else s
 
-  def format_options(self, header, registration_args):
+  def format_options(self, scope, description, registration_args):
     """Return a help message for the specified options.
 
     :param registration_args: A list of (args, kwargs) pairs, as passed in to options registration.
@@ -43,9 +43,13 @@ class HelpFormatter(object):
     def add_option(category, ohis):
       if ohis:
         lines.append('')
-        lines.append(self._maybe_blue('{}{}{} options:'.format(header,
-                                                               ' ' if category else '',
-                                                               category)))
+        if category:
+          lines.append(self._maybe_blue('{} {} options:'.format(scope, category)))
+        else:
+          lines.append(self._maybe_blue('{}:'.format(scope)))
+          if description:
+            lines.append(description)
+        lines.append(' ')
         for ohi in ohis:
           lines.extend(self.format_option(ohi))
     add_option('', oshi.basic)

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -21,10 +21,16 @@ class Optionable(AbstractClass):
 
   @classmethod
   def get_scope_info(cls):
+    """Returns a ScopeInfo instance representing this Optionable's options scope."""
     if cls.options_scope is None or cls.options_scope_category is None:
       raise OptionsError(
         '{} must set options_scope and options_scope_category.'.format(cls.__name__))
     return ScopeInfo(cls.options_scope, cls.options_scope_category, cls)
+
+  @classmethod
+  def get_description(cls):
+    # First line of docstring.
+    return '' if cls.__doc__ is None else cls.__doc__.partition('\n')[0]
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -248,9 +248,11 @@ class Options(object):
       elif isinstance(self._help_request, UnknownGoalHelp):
         print('Unknown goals: {}'.format(', '.join(self._help_request.unknown_goals)))
         print_hint()
+        # TODO: Should probably cause a non-zero exit code.
       elif isinstance(self._help_request, NoGoalHelp):
         print('No goals specified.')
         print_hint()
+        # TODO: Should probably cause a non-zero exit code.
       return True
     else:
       return False
@@ -274,26 +276,13 @@ class Options(object):
         if scope.partition('.')[0] in help_scopes:
           help_scopes.add(scope)
 
-    help_scopes = sorted(help_scopes)
-    help_scope_infos = [self._known_scope_to_info[s] for s in help_scopes]
+    help_scope_infos = [self._known_scope_to_info[s] for s in sorted(help_scopes)]
     if help_scope_infos:
       for scope_info in help_scope_infos:
         help_str = self._format_options_help_for_scope(scope_info)
         if help_str:
           print(help_str)
       return
-
-    # goals = (Goal.all() if show_all_help else [Goal.by_name(goal_name) for goal_name in self.goals])
-    # if goals:
-    #   for goal in goals:
-    #     if not goal.ordered_task_names():
-    #       print('\nUnknown goal: {}'.format(goal.name))
-    #     else:
-    #       print('\n{0}: {1}\n'.format(goal.name, goal.description))
-    #       for scope_info in goal.known_scope_infos():
-    #         help_str = self._format_options_help_for_scope(scope_info)
-    #         if help_str:
-    #           print(help_str)
     else:
       print(pants_release())
       print('\nUsage:')

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -10,7 +10,8 @@ import sys
 
 from pants.base.build_environment import pants_release, pants_version
 from pants.goal.goal import Goal
-from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
+from pants.option.arg_splitter import (GLOBAL_SCOPE, ArgSplitter, NoGoalHelp, OptionsHelp,
+                                       UnknownGoalHelp, VersionHelp)
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.parser_hierarchy import ParserHierarchy
@@ -109,7 +110,7 @@ class Options(object):
     self._parser_hierarchy = ParserHierarchy(env, config, complete_known_scope_infos)
     self._values_by_scope = {}  # Arg values, parsed per-scope on demand.
     self._bootstrap_option_values = bootstrap_option_values
-    self._known_scopes = set([s.scope for s in known_scope_infos])
+    self._known_scope_to_info = {s.scope: s for s in complete_known_scope_infos}
 
   @property
   def target_specs(self):
@@ -123,7 +124,7 @@ class Options(object):
 
   def is_known_scope(self, scope):
     """Whether the given scope is known by this instance."""
-    return scope in self._known_scopes
+    return scope in self._known_scope_to_info
 
   def passthru_args_for_scope(self, scope):
     # Passthru args "belong" to the last scope mentioned on the command-line.
@@ -237,31 +238,62 @@ class Options(object):
     Otherwise return False.
     """
     if self._help_request:
-      if self._help_request.version:
+      def print_hint():
+        print('Use `pants goals` to list goals.')
+        print('Use `pants help` to get help.')
+      if isinstance(self._help_request, VersionHelp):
         print(pants_version())
-      else:
-        self._print_help()
+      elif isinstance(self._help_request, OptionsHelp):
+        self._print_options_help()
+      elif isinstance(self._help_request, UnknownGoalHelp):
+        print('Unknown goals: {}'.format(', '.join(self._help_request.unknown_goals)))
+        print_hint()
+      elif isinstance(self._help_request, NoGoalHelp):
+        print('No goals specified.')
+        print_hint()
       return True
     else:
       return False
 
-  def _print_help(self):
-    """Print a help screen, followed by an optional message.
+  def _print_options_help(self):
+    """Print a help screen.
+
+    Assumes that self._help_request is an instance of OptionsHelp.
 
     Note: Ony useful if called after options have been registered.
     """
-    show_all_help = self._help_request and self._help_request.all_scopes
-    goals = (Goal.all() if show_all_help else [Goal.by_name(goal_name) for goal_name in self.goals])
-    if goals:
-      for goal in goals:
-        if not goal.ordered_task_names():
-          print('\nUnknown goal: {}'.format(goal.name))
-        else:
-          print('\n{0}: {1}\n'.format(goal.name, goal.description))
-          for scope_info in goal.known_scope_infos():
-            help_str = self._format_help_for_scope(scope_info.scope)
-            if help_str:
-              print(help_str)
+    show_all_help = self._help_request.all_scopes
+    if show_all_help:
+      help_scopes = self._known_scope_to_info.keys()
+    else:
+      # The scopes explicitly mentioned by the user on the cmd line.
+      help_scopes = set(self._scope_to_flags.keys()) - set([GLOBAL_SCOPE])
+      # Add all subscopes (e.g., so that `pants help compile` shows help for all tasks under
+      # `compile`.) Note that sorting guarantees that we only need to check the immediate parent.
+      for scope in sorted(self._known_scope_to_info.keys()):
+        if scope.partition('.')[0] in help_scopes:
+          help_scopes.add(scope)
+
+    help_scopes = sorted(help_scopes)
+    help_scope_infos = [self._known_scope_to_info[s] for s in help_scopes]
+    if help_scope_infos:
+      for scope_info in help_scope_infos:
+        help_str = self._format_options_help_for_scope(scope_info)
+        if help_str:
+          print(help_str)
+      return
+
+    # goals = (Goal.all() if show_all_help else [Goal.by_name(goal_name) for goal_name in self.goals])
+    # if goals:
+    #   for goal in goals:
+    #     if not goal.ordered_task_names():
+    #       print('\nUnknown goal: {}'.format(goal.name))
+    #     else:
+    #       print('\n{0}: {1}\n'.format(goal.name, goal.description))
+    #       for scope_info in goal.known_scope_infos():
+    #         help_str = self._format_options_help_for_scope(scope_info)
+    #         if help_str:
+    #           print(help_str)
     else:
       print(pants_release())
       print('\nUsage:')
@@ -277,9 +309,15 @@ class Options(object):
       print('    dir:: to include all targets found recursively under the directory.')
       print('\nFriendly docs:\n  http://pantsbuild.github.io/')
 
-    if show_all_help or not goals:
       print(self.get_parser(GLOBAL_SCOPE).format_help('Global', self._help_request.advanced))
 
-  def _format_help_for_scope(self, scope):
-    """Generate a help message for options at the specified scope."""
-    return self.get_parser(scope).format_help(scope, self._help_request.advanced)
+  def _format_options_help_for_scope(self, scope_info):
+    """Generate a help message for options at the specified scope.
+
+    Assumes that self._help_request is an instance of OptionsHelp.
+
+    :param scope_info: A ScopeInfo for the speicified scope.
+    """
+    description = scope_info.optionable_cls.get_description() if scope_info.optionable_cls else None
+    return self.get_parser(scope_info.scope).format_help(scope_info.scope, description,
+                                                         self._help_request.advanced)

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -186,17 +186,18 @@ class Parser(object):
     """
     return HelpInfoExtracter(self._scope).get_option_scope_help_info(self._registration_args)
 
-  def format_help(self, header, show_advanced=False, color=None):
+  def format_help(self, scope, description, show_advanced=False, color=None):
     """Return a help message for the options registered on this object.
 
-    :param header: Value to display as a header.
+    :param scope: Scope of the options.
+    :param description: Description of scope.
     :param bool show_advanced: Whether to display advanced options.
     :param bool color: Whether to use color. If None, use color only if writing to a terminal.
     """
     if color is None:
       color = sys.stdout.isatty()
     help_formatter = HelpFormatter(scope=self._scope, show_advanced=show_advanced, color=color)
-    return '\n'.join(help_formatter.format_options(header, self._registration_args))
+    return '\n'.join(help_formatter.format_options(scope, description, self._registration_args))
 
   def register(self, *args, **kwargs):
     """Register an option, using argparse params.

--- a/tests/python/pants_test/option/test_help_formatter.py
+++ b/tests/python/pants_test/option/test_help_formatter.py
@@ -27,8 +27,9 @@ class OptionHelpFormatterTest(unittest.TestCase):
     args = ['--foo']
     kwargs = {'advanced': True}
     lines = HelpFormatter(scope='', show_advanced=False, color=False).format_options(
-      '', [(args, kwargs)])
+      '', '', [(args, kwargs)])
     self.assertEquals(0, len(lines))
     lines = HelpFormatter(scope='', show_advanced=True, color=False).format_options(
-      '', [(args, kwargs)])
-    self.assertEquals(4, len(lines))
+      '', '', [(args, kwargs)])
+    print(lines)
+    self.assertEquals(5, len(lines))

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -102,8 +102,8 @@ class OptionsTest(unittest.TestCase):
     options = self._parse('./pants --verbose')
     self.assertEqual(True, options.for_global_scope().verbose)
     self.assertEqual(True, options.for_global_scope().v)
-    options = self._parse('./pants -v compile tgt')
-    self.assertEqual(['tgt'], options.target_specs)
+    options = self._parse('./pants -v compile path/to/tgt')
+    self.assertEqual(['path/to/tgt'], options.target_specs)
     self.assertEqual(True, options.for_global_scope().verbose)
     self.assertEqual(True, options.for_global_scope().v)
 
@@ -319,12 +319,13 @@ class OptionsTest(unittest.TestCase):
         '''
       ))
       tmp.flush()
-      cmdline = './pants --target-spec-file={filename} compile morx fleem'.format(filename=tmp.name)
+      cmdline = './pants --target-spec-file={filename} compile morx:tgt fleem:tgt'.format(
+        filename=tmp.name)
       bootstrapper = OptionsBootstrapper(args=shlex.split(cmdline))
       bootstrap_options = bootstrapper.get_bootstrap_options().for_global_scope()
       options = self._parse(cmdline, bootstrap_option_values=bootstrap_options)
       sorted_specs = sorted(options.target_specs)
-      self.assertEqual(['bar', 'fleem', 'foo', 'morx'], sorted_specs)
+      self.assertEqual(['bar', 'fleem:tgt', 'foo', 'morx:tgt'], sorted_specs)
 
   def test_passthru_args(self):
     options = self._parse('./pants compile foo -- bar --baz')


### PR DESCRIPTION
- Only print help for the scopes the user asked for (and anything
  under them).  Previously we printed help for all tasks under any
  goals the user specified. E.g., `./pants help compile.java` would
  print all compile help, including those for other tasks.
- Print help for subsystems, if asked. E.g., ./pants help cache
  now shows help for global cache options. This falls nicely out of the
  implementation of the point above.
- Be smarter about detecting whether a cmd-line token is a target spec
  or an unrecognized scope, so we can issue an appropriate error in
  the second case.
- Print the first line of an optionable's docstring in the help.

TODO: The subsytem help printing still needs some work. For example
      you can do 'pants help jvm' and get help for the global jvm
      subsystem, even though nothing uses it.  John's pending change
      to have subsystems know what scope they're embedded in should
      help here.