### PR TITLE
Add `pants_plugin` and `contrib_plugin` targets.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -57,7 +57,9 @@ PKG_PANTS_BACKEND_ANDROID=(
 function pkg_pants_backend_android_install_test() {
   PIP_ARGS="$@"
   pip install ${PIP_ARGS} pantsbuild.pants.backend.android==$(local_version) && \
-  python -c "from pants.backend.android import *"
+  execute_packaged_pants_with_internal_backends \
+    --plugins="['pantsbuild.pants.backend.android']" \
+    goals | grep "apk" &> /dev/null
 }
 
 # Once an individual (new) package is declared above, insert it into the array below)
@@ -83,12 +85,6 @@ function run_local_pants() {
 # and it'll fail. To solve that problem, we load the internal backend package
 # dependencies into the pantsbuild.pants venv.
 function execute_packaged_pants_with_internal_backends() {
-  local extra_backend_packages
-  if [[ "$1" =~ "extra_backend_packages=" ]]; then
-    extra_backend_packages=${1#*=}
-    shift
-  fi
-
   local extra_bootstrap_buildfiles
   if [[ "$1" =~ "extra_bootstrap_buildfiles" ]]; then
     extra_bootstrap_buildfiles=${1#*=}
@@ -104,7 +100,6 @@ function execute_packaged_pants_with_internal_backends() {
         'internal_backend.repositories', \
         'internal_backend.sitegen', \
         'internal_backend.utilities', \
-        ${extra_backend_packages}
       ]" \
     --goals-bootstrap-buildfiles="[ \
         '${ROOT}/BUILD', \

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Wrapper for self-bootstrapping virtualenv
 set -e
-VIRTUALENV_VERSION=12.1.1
+VIRTUALENV_VERSION=13.1.0
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.python.org/packages/source/v/virtualenv}
 
 REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -21,6 +21,9 @@ Contrib plugins should generally follow 3 basic setup steps:
      src/python/pants/contrib/example/...
      tests/python/pants_test/contrib/example/...
    ```
+   The only hard requirement though is the `register.py` entry point file in the main src dir -
+   in this example: `contrib/example/src/python/pants/contrib/example/register.py`.
+
    Source roots for this layout would be added to contrib/example/BUILD:
    ```
    source_root('src/python', page, python_library, resources)
@@ -67,32 +70,39 @@ Contrib plugins should generally follow 3 basic setup steps:
      ]
    ```
 
-3. When you're ready for your plugin to be distributed, add a `provides` `contrib_setup_py`
-   descriptor to your main plugin BUILD target and register the plugin with the release script.
-   The `provides` descriptor just requires a name and description for your plugin suitable for
-   [pypi](https://pypi.python.org/pypi):
+3. When you're ready for your plugin to be distributed, convert your main `python_library` plugin
+   target to a `contrib_plugin` target and register the plugin with the release script.
+
+   The `contrib_plugin` target assumes 1 source of `register.py`; so, the sources argument should be
+   removed.  It still accepts dependencies and other python target arguments with some special
+   additions to help define the plugin distribution.  You'll need to supply a `distribution_name`
+   and a `description` of the plugin suitable for [pypi](https://pypi.python.org/pypi) as well
+   parameters indicating which plugin entry points your plugin implements:
    ```python
-   python_library(
-      name='plugin',
-      sources=['register.py'],
-      provides=contrib_setup_py(
-        name='pantsbuild.pants.contrib.example',
-        description='An example pants contrib plugin.'
-      )
+   contrib_plugin(
+     name='plugin',
+     distribution_name='pantsbuild.pants.contrib.example',
+     description='An example pants contrib plugin.'
+     build_file_aliases=True,
+     register_goals=True,
    )
    ```
+   In this example, the plugin implements the `build_file_aliases` and `register_goals` entry point
+   methods, but a plugin may additionally implement the `global_subsystems` entry point method, in
+   which case it's `contrib_plugin` target would have a `global_subsystems=True,` entry as well.
+
    To register with the release script, add an entry to `contrib/release_packages.sh`:
    ```bash
    PKG_EXAMPLE=(
-     "pantsbuild.pants.example"
+     "pantsbuild.pants.contrib.example"
      "//contrib/example/src/python/pants/contrib/example:plugin"
      "pkg_example_install_test"
    )
    function pkg_example_install_test() {
      PIP_ARGS="$@"
-     pip install ${PIP_ARGS} pantsbuild.pants.example==$(local_version) && \
+     pip install ${PIP_ARGS} pantsbuild.pants.contrib.example==$(local_version) && \
      execute_packaged_pants_with_internal_backends \
-       "extra_backend_packages='pants.contrib.example'" \
+       --plugins="['pantsbuild.pants.contrib.example']" \
        goals | grep "example-goal" &> /dev/null
    }
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -76,7 +76,7 @@ Contrib plugins should generally follow 3 basic setup steps:
    The `contrib_plugin` target assumes 1 source of `register.py`; so, the sources argument should be
    removed.  It still accepts dependencies and other python target arguments with some special
    additions to help define the plugin distribution.  You'll need to supply a `distribution_name`
-   and a `description` of the plugin suitable for [pypi](https://pypi.python.org/pypi) as well
+   and a `description` of the plugin suitable for [pypi](https://pypi.python.org/pypi) as well as
    parameters indicating which plugin entry points your plugin implements:
    ```python
    contrib_plugin(

--- a/contrib/cpp/src/python/pants/contrib/cpp/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/BUILD
@@ -1,9 +1,8 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
+contrib_plugin(
   name='plugin',
-  sources=['register.py'],
   dependencies=[
     'contrib/cpp/src/python/pants/contrib/cpp/targets:targets',
     'contrib/cpp/src/python/pants/contrib/cpp/tasks:tasks',
@@ -11,8 +10,8 @@ python_library(
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/goal:task_registrar',
   ],
-  provides=contrib_setup_py(
-    name='pantsbuild.pants.contrib.cpp',
-    description='C++ pants plugin.',
-  ),
+  distribution_name='pantsbuild.pants.contrib.cpp',
+  description='C++ pants plugin.',
+  build_file_aliases=True,
+  register_goals=True,
 )

--- a/contrib/go/src/python/pants/contrib/go/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/BUILD
@@ -1,17 +1,16 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
+contrib_plugin(
   name='plugin',
-  sources=['register.py'],
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/targets',
     'contrib/go/src/python/pants/contrib/go/tasks',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/goal:task_registrar',
   ],
-  provides=contrib_setup_py(
-    name='pantsbuild.pants.contrib.go',
-    description='Go language support for pants.',
-  )
+  distribution_name='pantsbuild.pants.contrib.go',
+  description='Go language support for pants.',
+  build_file_aliases=True,
+  register_goals=True,
 )

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -22,9 +22,11 @@ PKG_SCROOGE=(
 function pkg_scrooge_install_test() {
   PIP_ARGS="$@"
   pip install ${PIP_ARGS} pantsbuild.pants.contrib.scrooge==$(local_version) && \
-  execute_packaged_pants_with_internal_backends "extra_backend_packages='pants.contrib.scrooge'" \
+  execute_packaged_pants_with_internal_backends \
+    --plugins="['pantsbuild.pants.contrib.scrooge']" \
     --explain gen | grep "scrooge" &> /dev/null && \
-  execute_packaged_pants_with_internal_backends "extra_backend_packages='pants.contrib.scrooge'" \
+  execute_packaged_pants_with_internal_backends \
+    --plugins="['pantsbuild.pants.contrib.scrooge']" \
     goals | grep "thrift-linter" &> /dev/null
 }
 
@@ -47,7 +49,8 @@ PKG_SPINDLE=(
 function pkg_spindle_install_test() {
   PIP_ARGS="$@"
   pip install ${PIP_ARGS} pantsbuild.pants.contrib.spindle==$(local_version) && \
-  execute_packaged_pants_with_internal_backends "extra_backend_packages='pants.contrib.spindle'" \
+  execute_packaged_pants_with_internal_backends \
+    --plugins="['pantsbuild.pants.contrib.spindle']" \
     --explain gen | grep "spindle" &> /dev/null
 }
 
@@ -60,8 +63,8 @@ function pkg_go_install_test() {
   PIP_ARGS="$@"
   pip install ${PIP_ARGS} pantsbuild.pants.contrib.go==$(local_version) && \
   execute_packaged_pants_with_internal_backends \
-    "extra_backend_packages='pants.contrib.go'" \
     "extra_bootstrap_buildfiles='${ROOT}/contrib/go/BUILD'" \
+      --plugins="['pantsbuild.pants.contrib.go']" \
       compile.go contrib/go/examples::
 }
 

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/BUILD
@@ -1,18 +1,16 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
+contrib_plugin(
   name='plugin',
-  sources=['register.py'],
   dependencies=[
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks',
     'src/python/pants/goal:task_registrar',
   ],
-  provides=contrib_setup_py(
-    name='pantsbuild.pants.contrib.scrooge',
-    description='Scrooge thrift generator pants plugins.',
-    additional_classifiers=[
-      'Topic :: Software Development :: Code Generators'
-    ]
-  )
+  distribution_name='pantsbuild.pants.contrib.scrooge',
+  description='Scrooge thrift generator pants plugins.',
+  additional_classifiers=[
+    'Topic :: Software Development :: Code Generators'
+  ],
+  register_goals=True,
 )

--- a/contrib/spindle/src/python/pants/contrib/spindle/BUILD
+++ b/contrib/spindle/src/python/pants/contrib/spindle/BUILD
@@ -1,20 +1,19 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
+contrib_plugin(
   name='plugin',
-  sources=['register.py'],
   dependencies=[
     'contrib/spindle/src/python/pants/contrib/spindle/targets',
     'contrib/spindle/src/python/pants/contrib/spindle/tasks',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/goal:task_registrar',
   ],
-  provides=contrib_setup_py(
-    name='pantsbuild.pants.contrib.spindle',
-    description='Spindle thrift -> scala generator pants plugins.',
-    additional_classifiers=[
-      'Topic :: Software Development :: Code Generators'
-    ]
-  )
+  distribution_name='pantsbuild.pants.contrib.spindle',
+  description='Spindle thrift -> scala generator pants plugins.',
+  additional_classifiers=[
+    'Topic :: Software Development :: Code Generators'
+  ],
+  build_file_aliases=True,
+  register_goals=True,
 )

--- a/pants-plugins/src/python/internal_backend/utilities/BUILD
+++ b/pants-plugins/src/python/internal_backend/utilities/BUILD
@@ -6,9 +6,11 @@ python_library(
   sources=['register.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:python_artifact',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:exceptions',
   ]
 )
 

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -10,19 +10,27 @@ import os
 from twitter.common.collections import OrderedSet
 
 from pants.backend.python.python_artifact import PythonArtifact
+from pants.backend.python.targets.python_library import PythonLibrary
 from pants.base.build_environment import get_buildroot, pants_version
 from pants.base.build_file_aliases import BuildFileAliases
+from pants.base.exceptions import TargetDefinitionException
 
 
-def pants_setup_py(name, description, namespace_packages=None, additional_classifiers=None):
+def pants_setup_py(name, description, additional_classifiers=None, **kwargs):
   """Creates the setup_py for a pants artifact.
 
   :param str name: The name of the package.
   :param str description: A brief description of what the package provides.
   :param list additional_classifiers: Any additional trove classifiers that apply to the package,
                                       see: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+  :param kwargs: Any additional keyword arguments to be passed to `setuptools.setup
+                 <https://pythonhosted.org/setuptools/setuptools.html>`_.
   :returns: A setup_py suitable for building and publishing pants components.
   """
+  if not name.startswith('pantsbuild.pants'):
+    raise ValueError("Pants distribution package names must start with 'pantsbuild.pants', "
+                     "given {}".format(name))
+
   standard_classifiers = [
       'Intended Audience :: Developers',
       'License :: OSI Approved :: Apache Software License',
@@ -48,17 +56,19 @@ def pants_setup_py(name, description, namespace_packages=None, additional_classi
       url='https://github.com/pantsbuild/pants',
       license='Apache License, Version 2.0',
       zip_safe=True,
-      namespace_packages=namespace_packages,
-      classifiers=list(classifiers))
+      classifiers=list(classifiers),
+      **kwargs)
 
 
-def contrib_setup_py(name, description, additional_classifiers=None):
+def contrib_setup_py(name, description, additional_classifiers=None, **kwargs):
   """Creates the setup_py for a pants contrib plugin artifact.
 
   :param str name: The name of the package; must start with 'pantsbuild.pants.contrib.'.
   :param str description: A brief description of what the plugin provides.
   :param list additional_classifiers: Any additional trove classifiers that apply to the plugin,
                                       see: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+  :param kwargs: Any additional keyword arguments to be passed to `setuptools.setup
+                 <https://pythonhosted.org/setuptools/setuptools.html>`_.
   :returns: A setup_py suitable for building and publishing pants components.
   """
   if not name.startswith('pantsbuild.pants.contrib.'):
@@ -67,8 +77,85 @@ def contrib_setup_py(name, description, additional_classifiers=None):
 
   return pants_setup_py(name,
                         description,
+                        additional_classifiers=additional_classifiers,
                         namespace_packages=['pants', 'pants.contrib'],
-                        additional_classifiers=additional_classifiers)
+                        **kwargs)
+
+
+class PantsPlugin(PythonLibrary):
+  """Describes a pants plugin published by pantsbuild."""
+
+  @classmethod
+  def create_setup_py(cls, name, description, additional_classifiers=None):
+    return pants_setup_py(name,
+                          description,
+                          additional_classifiers=additional_classifiers,
+                          namespace_packages=['pants', 'pants.backend'])
+
+  def __init__(self,
+               address=None,
+               payload=None,
+               distribution_name=None,
+               description=None,
+               additional_classifiers=None,
+               build_file_aliases=False,
+               global_subsystems=False,
+               register_goals=False,
+               **kwargs):
+    """
+    :param str distribution_name: The name of the plugin package; must start with
+                                  'pantsbuild.pants.'.
+    :param str description: A brief description of what the plugin provides.
+    :param list additional_classifiers: Any additional trove classifiers that apply to the plugin,
+                                        see: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    :param bool build_file_aliases: If `True`, register.py:build_file_aliases must be defined and
+                                    registers the 'build_file_aliases' 'pantsbuild.plugin'
+                                    entrypoint.
+    :param bool global_subsystems: If `True`, register.py:global_subsystems must be defined and
+                                   registers the 'global_subsystems' 'pantsbuild.plugin' entrypoint.
+    :param bool register_goals: If `True`, register.py:register_goals must be defined and
+                                registers the 'register_goals' 'pantsbuild.plugin' entrypoint.
+    """
+    if not distribution_name.startswith('pantsbuild.pants.'):
+      raise ValueError("Pants plugin package distribution names must start with "
+                       "'pantsbuild.pants.', given {}".format(distribution_name))
+
+    if not os.path.exists(os.path.join(get_buildroot(), address.spec_path, 'register.py')):
+      raise TargetDefinitionException(address.spec_path,
+                                      'A PantsPlugin target must have a register.py file in the '
+                                      'same directory.')
+
+    setup_py = self.create_setup_py(distribution_name,
+                                    description,
+                                    additional_classifiers=additional_classifiers)
+
+    super(PantsPlugin, self).__init__(address,
+                                      payload,
+                                      sources=['register.py'],
+                                      provides=setup_py,
+                                      **kwargs)
+
+    if build_file_aliases or register_goals or global_subsystems:
+      module = os.path.relpath(address.spec_path, self.target_base).replace(os.sep, '.')
+      entrypoints = []
+      if build_file_aliases:
+        entrypoints.append('build_file_aliases = {}.register:build_file_aliases'.format(module))
+      if register_goals:
+        entrypoints.append('register_goals = {}.register:register_goals'.format(module))
+      if global_subsystems:
+        entrypoints.append('global_subsystems = {}.register:global_subsystems'.format(module))
+      entry_points = {'pantsbuild.plugin': entrypoints}
+
+      setup_py.setup_py_keywords['entry_points'] = entry_points
+      self.mark_invalidation_hash_dirty()  # To pickup the PythonArtifact (setup_py) changes.
+
+
+class ContribPlugin(PantsPlugin):
+  """Describes a contributed pants plugin published by pantsbuild."""
+
+  @classmethod
+  def create_setup_py(cls, name, description, additional_classifiers=None):
+    return contrib_setup_py(name, description, additional_classifiers=additional_classifiers)
 
 
 def build_file_aliases():
@@ -76,5 +163,9 @@ def build_file_aliases():
     objects={
       'pants_setup_py': pants_setup_py,
       'contrib_setup_py': contrib_setup_py
+    },
+    targets={
+      'pants_plugin': PantsPlugin,
+      'contrib_plugin': ContribPlugin
     }
   )

--- a/src/python/pants/backend/android/BUILD
+++ b/src/python/pants/backend/android/BUILD
@@ -2,50 +2,48 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
-  name = 'plugin',
-  sources = ['register.py'],
-  dependencies = [
+pants_plugin(
+  name='plugin',
+  dependencies=[
     'src/python/pants/backend/android/targets:android',
     'src/python/pants/backend/android/tasks:all',
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/goal:task_registrar',
   ],
-  provides = pants_setup_py(
-    name = 'pantsbuild.pants.backend.android',
-    description = 'Support for android projects.',
-    namespace_packages = ['pants', 'pants.backend'],
-  )
+  distribution_name='pantsbuild.pants.backend.android',
+  description='Support for android projects.',
+  build_file_aliases=True,
+  register_goals=True,
 )
 
 python_library(
-  name = 'android_config_util',
+  name='android_config_util',
   sources =['android_config_util.py'],
-  dependencies = [
+  dependencies=[
     'src/python/pants/util:dirutil',
   ]
 )
 
 python_library(
-  name = 'android_distribution',
-  sources = ['distribution/android_distribution.py'],
-  dependencies = [
+  name='android_distribution',
+  sources=['distribution/android_distribution.py'],
+  dependencies=[
     'src/python/pants/util:dirutil',
   ]
 )
 
 python_library(
-  name = 'keystore_resolver',
-  sources = ['keystore/keystore_resolver.py'],
-  dependencies = [
+  name='keystore_resolver',
+  sources=['keystore/keystore_resolver.py'],
+  dependencies=[
     'src/python/pants/base:config',
   ]
 )
 
 python_library(
-  name = 'android_manifest_parser',
+  name='android_manifest_parser',
   sources =['android_manifest_parser.py'],
-  dependencies = [
+  dependencies=[
     'src/python/pants/util:xml_parser',
   ]
 )

--- a/src/python/pants/base/extension_loader.py
+++ b/src/python/pants/base/extension_loader.py
@@ -43,8 +43,8 @@ def load_plugins(build_configuration, plugins, load_from=None):
   is already on the path and an error will be thrown if it is not. Plugins should define their
   entrypoints in the `pantsbuild.plugin` group when configuring their distribution.
 
-  Like source backends, the `build_file_aliases`, `global_subsystems` and `register_goals` methods are called if
-  those entry points are defined.
+  Like source backends, the `build_file_aliases`, `global_subsystems` and `register_goals` methods
+  are called if those entry points are defined.
 
   * Plugins are loaded in the order they are provided. *
 


### PR DESCRIPTION
These targets support easy adoption of pants own plugin entry_points to
allow for one less step when installing pants plugins.

The existing plugins are converted to use these targets and the contrib
README is updated to reflect the new best-practice boilerplate.

https://rbcommons.com/s/twitter/r/2615/