### PR TITLE
[Trigger CI] add debug back to bench, complain on no jvm targets, add test

### DIFF
--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import shutil
 
-from pants.backend.jvm.targets.jvm_target import JvmTarget
+from pants.backend.jvm.targets.benchmark import Benchmark
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.exceptions import TaskError
@@ -56,7 +56,7 @@ class BenchmarkRun(JvmToolTaskMixin, JvmTask):
 
   def execute(self):
     targets = self.context.targets()
-    if not any(isinstance(t, JvmTarget) for t in targets):
+    if not any(isinstance(t, Benchmark) for t in targets):
       raise TaskError('No jvm targets specified for benchmarking.')
 
     # For rewriting JDK classes to work, the JAR file has to be listed specifically in

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -4,6 +4,7 @@
 target(
   name = 'tasks',
   dependencies = [
+    ':benchmark_run',
     ':binary_create',
     ':bootstrap_jvm_tools',
     ':bundle_create',
@@ -47,6 +48,17 @@ python_tests(
     'src/python/pants/java:executor',
     'src/python/pants/java/jar:shader',
     'src/python/pants/util:contextutil',
+    'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+  ]
+)
+
+python_tests(
+  name = 'benchmark_run',
+  sources = ['test_benchmark_run.py'],
+  dependencies = [
+    'src/python/pants/backend/core:plugin',
+    'src/python/pants/backend/jvm:plugin',
+    'src/python/pants/backend/jvm/tasks:benchmark_run',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -56,9 +56,9 @@ python_tests(
   name = 'benchmark_run',
   sources = ['test_benchmark_run.py'],
   dependencies = [
-    'src/python/pants/backend/core:plugin',
-    'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/jvm/tasks:benchmark_run',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:target',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
@@ -42,8 +42,6 @@ class BenchmarkRunTest(JvmToolTaskTestBase):
     return BenchmarkRun
 
   def test_benchmark_complains_on_python_target(self):
-    """Run pants against a `python_tests` target. Should execute without error.
-    """
     self.add_to_build_file('foo', dedent('''
         python_tests(
           name='hello',

--- a/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+from textwrap import dedent
+
+from pants.backend.core.register import build_file_aliases as register_core
+from pants.backend.jvm.register import build_file_aliases as register_jvm
+from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.tasks.benchmark_run import BenchmarkRun
+from pants.backend.python.targets.python_tests import PythonTests
+from pants.base.build_file_aliases import BuildFileAliases
+from pants.base.exceptions import TaskError
+from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+
+
+class BenchmarkRunTest(JvmToolTaskTestBase):
+
+
+  @property
+  def alias_groups(self):
+    # Aliases appearing in our real BUILD.tools.
+    return BuildFileAliases.create(
+      targets={
+        'jar_library': JarLibrary,
+        'java_library': JavaLibrary,
+        'python_tests': PythonTests,
+      },
+      objects={
+        'jar': JarDependency,
+      },
+    )
+
+  @classmethod
+  def task_type(cls):
+    return BenchmarkRun
+
+  def test_benchmark_complains_on_python_target(self):
+    """Run pants against a `python_tests` target. Should execute without error.
+    """
+    self.add_to_build_file('foo', dedent('''
+        python_tests(
+          name='hello',
+          sources=['some_file.py'],
+        )
+        '''))
+
+    self.set_options(target='foo:hello')
+    context = self.context(target_roots=[self.target('foo:hello')])
+    self.populate_compile_classpath(context)
+
+    with self.assertRaises(TaskError):
+      self.execute(context)

--- a/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
@@ -8,46 +8,20 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from textwrap import dedent
 
-from pants.backend.core.register import build_file_aliases as register_core
-from pants.backend.jvm.register import build_file_aliases as register_jvm
-from pants.backend.jvm.targets.jar_dependency import JarDependency
-from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.benchmark_run import BenchmarkRun
 from pants.backend.python.targets.python_tests import PythonTests
-from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 
 
 class BenchmarkRunTest(JvmToolTaskTestBase):
 
-
-  @property
-  def alias_groups(self):
-    # Aliases appearing in our real BUILD.tools.
-    return BuildFileAliases.create(
-      targets={
-        'jar_library': JarLibrary,
-        'java_library': JavaLibrary,
-        'python_tests': PythonTests,
-      },
-      objects={
-        'jar': JarDependency,
-      },
-    )
-
   @classmethod
   def task_type(cls):
     return BenchmarkRun
 
   def test_benchmark_complains_on_python_target(self):
-    self.add_to_build_file('foo', dedent('''
-        python_tests(
-          name='hello',
-          sources=['some_file.py'],
-        )
-        '''))
+    self.make_target('foo:hello', target_type=PythonTests, sources=['some_file.py'])
 
     self.set_options(target='foo:hello')
     context = self.context(target_roots=[self.target('foo:hello')])

--- a/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
@@ -9,8 +9,8 @@ import os
 from textwrap import dedent
 
 from pants.backend.jvm.tasks.benchmark_run import BenchmarkRun
-from pants.backend.python.targets.python_tests import PythonTests
 from pants.base.exceptions import TaskError
+from pants.base.target import Target
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 
 
@@ -21,7 +21,7 @@ class BenchmarkRunTest(JvmToolTaskTestBase):
     return BenchmarkRun
 
   def test_benchmark_complains_on_python_target(self):
-    self.make_target('foo:hello', target_type=PythonTests, sources=['some_file.py'])
+    self.make_target('foo:hello', target_type=Target)
 
     self.set_options(target='foo:hello')
     context = self.context(target_roots=[self.target('foo:hello')])


### PR DESCRIPTION
The jvm subsystem options change broke the bench task. This adds the debug option back in as a task option since it means something slightly different in the bench task.

related issue #1931 