### PR TITLE
Support plugins resolution in pants.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -55,8 +55,6 @@ PKG_PANTS_BACKEND_ANDROID=(
   "pkg_pants_backend_android_install_test"
 )
 function pkg_pants_backend_android_install_test() {
-  PIP_ARGS="$@"
-  pip install ${PIP_ARGS} pantsbuild.pants.backend.android==$(local_version) && \
   execute_packaged_pants_with_internal_backends \
     --plugins="['pantsbuild.pants.backend.android']" \
     goals | grep "apk" &> /dev/null
@@ -93,7 +91,7 @@ function execute_packaged_pants_with_internal_backends() {
 
   pip install --ignore-installed \
     -r pants-plugins/3rdparty/python/requirements.txt &> /dev/null && \
-  pants \
+  PANTS_PYTHON_REPOS_REPOS="['${ROOT}/dist']" pants \
     --pythonpath="['pants-plugins/src/python']" \
     --backend-packages="[ \
         'internal_backend.optional', \

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -56,7 +56,7 @@ PKG_PANTS_BACKEND_ANDROID=(
 )
 function pkg_pants_backend_android_install_test() {
   execute_packaged_pants_with_internal_backends \
-    --plugins="['pantsbuild.pants.backend.android']" \
+    --plugins="['pantsbuild.pants.backend.android==$(local_version)']" \
     goals | grep "apk" &> /dev/null
 }
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -99,10 +99,8 @@ Contrib plugins should generally follow 3 basic setup steps:
      "pkg_example_install_test"
    )
    function pkg_example_install_test() {
-     PIP_ARGS="$@"
-     pip install ${PIP_ARGS} pantsbuild.pants.contrib.example==$(local_version) && \
      execute_packaged_pants_with_internal_backends \
-       --plugins="['pantsbuild.pants.contrib.example']" \
+       --plugins="['pantsbuild.pants.contrib.example==$(local_version)']" \
        goals | grep "example-goal" &> /dev/null
    }
 

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -21,10 +21,10 @@ PKG_SCROOGE=(
 )
 function pkg_scrooge_install_test() {
   execute_packaged_pants_with_internal_backends \
-    --plugins="['pantsbuild.pants.contrib.scrooge']" \
+    --plugins="['pantsbuild.pants.contrib.scrooge==$(local_version)']" \
     --explain gen | grep "scrooge" &> /dev/null && \
   execute_packaged_pants_with_internal_backends \
-    --plugins="['pantsbuild.pants.contrib.scrooge']" \
+    --plugins="['pantsbuild.pants.contrib.scrooge==$(local_version)']" \
     goals | grep "thrift-linter" &> /dev/null
 }
 
@@ -46,7 +46,7 @@ PKG_SPINDLE=(
 )
 function pkg_spindle_install_test() {
   execute_packaged_pants_with_internal_backends \
-    --plugins="['pantsbuild.pants.contrib.spindle']" \
+    --plugins="['pantsbuild.pants.contrib.spindle==$(local_version)']" \
     --explain gen | grep "spindle" &> /dev/null
 }
 

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -20,8 +20,6 @@ PKG_SCROOGE=(
   "pkg_scrooge_install_test"
 )
 function pkg_scrooge_install_test() {
-  PIP_ARGS="$@"
-  pip install ${PIP_ARGS} pantsbuild.pants.contrib.scrooge==$(local_version) && \
   execute_packaged_pants_with_internal_backends \
     --plugins="['pantsbuild.pants.contrib.scrooge']" \
     --explain gen | grep "scrooge" &> /dev/null && \
@@ -47,8 +45,6 @@ PKG_SPINDLE=(
   "pkg_spindle_install_test"
 )
 function pkg_spindle_install_test() {
-  PIP_ARGS="$@"
-  pip install ${PIP_ARGS} pantsbuild.pants.contrib.spindle==$(local_version) && \
   execute_packaged_pants_with_internal_backends \
     --plugins="['pantsbuild.pants.contrib.spindle']" \
     --explain gen | grep "spindle" &> /dev/null
@@ -60,11 +56,9 @@ PKG_GO=(
   "pkg_go_install_test"
 )
 function pkg_go_install_test() {
-  PIP_ARGS="$@"
-  pip install ${PIP_ARGS} pantsbuild.pants.contrib.go==$(local_version) && \
   execute_packaged_pants_with_internal_backends \
     "extra_bootstrap_buildfiles='${ROOT}/contrib/go/BUILD'" \
-      --plugins="['pantsbuild.pants.contrib.go']" \
+      --plugins="['pantsbuild.pants.contrib.go==$(local_version)']" \
       compile.go contrib/go/examples::
 }
 

--- a/pants.ini
+++ b/pants.ini
@@ -32,8 +32,6 @@ backend_packages: [
     "pants.contrib.go",
   ]
 
-outdir: %(pants_distdir)s
-
 # TODO: Still needed until we migrate jvm tools to subsystems.
 jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
 

--- a/src/python/pants/base/extension_loader.py
+++ b/src/python/pants/base/extension_loader.py
@@ -28,8 +28,8 @@ def load_plugins_and_backends(plugins, working_set, backends):
   """Load named plugins and source backends
 
   :param list<str> plugins: Plugins to load (see `load_plugins`).
-  :param list<str> backends: Source backends to load (see `load_build_configuration_from_source`).
   :param WorkingSet working_set: A pkg_resources.WorkingSet to load plugins from.
+  :param list<str> backends: Source backends to load (see `load_build_configuration_from_source`).
   """
   build_configuration = BuildConfiguration()
   load_plugins(build_configuration, plugins or [], working_set)

--- a/src/python/pants/base/extension_loader.py
+++ b/src/python/pants/base/extension_loader.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import importlib
 import traceback
 
-from pkg_resources import Requirement, working_set
+from pkg_resources import Requirement
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_configuration import BuildConfiguration
@@ -24,19 +24,20 @@ class PluginNotFound(PluginLoadingError): pass
 class PluginLoadOrderError(PluginLoadingError): pass
 
 
-def load_plugins_and_backends(plugins=None, backends=None):
+def load_plugins_and_backends(plugins, working_set, backends):
   """Load named plugins and source backends
 
   :param list<str> plugins: Plugins to load (see `load_plugins`).
   :param list<str> backends: Source backends to load (see `load_build_configuration_from_source`).
+  :param WorkingSet working_set: A pkg_resources.WorkingSet to load plugins from.
   """
   build_configuration = BuildConfiguration()
-  load_plugins(build_configuration, plugins or [])
+  load_plugins(build_configuration, plugins or [], working_set)
   load_build_configuration_from_source(build_configuration, additional_backends=backends or [])
   return build_configuration
 
 
-def load_plugins(build_configuration, plugins, load_from=None):
+def load_plugins(build_configuration, plugins, working_set):
   """Load named plugins from the current working_set into the supplied build_configuration
 
   "Loading" a plugin here refers to calling registration methods -- it is assumed each plugin
@@ -58,13 +59,12 @@ def load_plugins(build_configuration, plugins, load_from=None):
   :param BuildConfiguration build_configuration: The BuildConfiguration (for adding aliases).
   :param list<str> plugins: A list of plugin names optionally with versions, in requirement format.
                             eg ['widgetpublish', 'widgetgen==1.2'].
-  :param WorkingSet load_from: A pkg_resources.WorkingSet to use instead of global (for testing).
+  :param WorkingSet working_set: A pkg_resources.WorkingSet to load plugins from.
   """
-  load_from = load_from or working_set
   loaded = {}
   for plugin in plugins:
     req = Requirement.parse(plugin)
-    dist = load_from.find(req)
+    dist = working_set.find(req)
 
     if not dist:
       raise PluginNotFound('Could not find plugin: {}'.format(req))

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -2,12 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'bin',
-  sources = ['goal_runner.py', 'pants_exe.py'],
-  dependencies = [
+  name='bin',
+  sources=globs('*.py'),
+  dependencies=[
+    '3rdparty/python:pex',
     '3rdparty/python:setuptools',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/backend/python:python_setup',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_address_mapper',
@@ -25,7 +27,9 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/reporting',
     'src/python/pants/subsystem',
+    'src/python/pants/util:dirutil',
     'src/python/pants/util:filtering',
+    'src/python/pants/util:memo',
   ],
 )
 
@@ -34,9 +38,9 @@ python_library(
 # $ pip install pantsbuild.pants
 # $ pants
 python_binary(
-  name = 'pants',
-  entry_point = 'pants.bin.pants_exe:main',
-  dependencies = [
+  name='pants',
+  entry_point='pants.bin.pants_exe:main',
+  dependencies=[
     ':bin',
   ],
 )
@@ -45,9 +49,9 @@ python_binary(
 # publishing in the `pantsbuild.pants` sdist as well as deps on backend plugins published as
 # separate sdists from the core `pantsbuild.pants` sdist that this repo uses.
 python_binary(
-  name = 'pants_local_binary',
-  entry_point = 'pants.bin.pants_exe:main',
-  dependencies = [
+  name='pants_local_binary',
+  entry_point='pants.bin.pants_exe:main',
+  dependencies=[
     ':bin',
     'pants-plugins/src/python/internal_backend:plugins',
     'src/python/pants/backend/android:plugin',

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -28,7 +28,6 @@ from pants.java.nailgun_executor import NailgunProcessGroup  # XXX(pl)
 from pants.logging.setup import setup_logging
 from pants.option.custom_types import list_option
 from pants.option.global_options import GlobalOptionsRegistrar
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.invalidation_report import InvalidationReport
 from pants.reporting.report import Report
 from pants.reporting.reporting import Reporting
@@ -76,8 +75,7 @@ class GoalRunner(object):
     # Subsystems used outside of any task.
     return SourceRootBootstrapper, Reporting, RunTracker
 
-  def setup(self):
-    options_bootstrapper = OptionsBootstrapper()
+  def setup(self, options_bootstrapper, working_set):
     bootstrap_options = options_bootstrapper.get_bootstrap_options()
 
     # Get logging setup prior to loading backends so that they can log as needed.
@@ -91,7 +89,7 @@ class GoalRunner(object):
     # Load plugins and backends.
     plugins = bootstrap_options.for_global_scope().plugins
     backend_packages = bootstrap_options.for_global_scope().backend_packages
-    build_configuration = load_plugins_and_backends(plugins, backend_packages)
+    build_configuration = load_plugins_and_backends(plugins, working_set, backend_packages)
 
     # Now that plugins and backends are loaded, we can gather the known scopes.
     self.targets = []

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -13,6 +13,8 @@ import warnings
 
 from pants.base.build_environment import get_buildroot
 from pants.bin.goal_runner import GoalRunner
+from pants.bin.plugin_resolver import PluginResolver
+from pants.option.options_bootstrapper import OptionsBootstrapper
 
 
 class _Exiter(object):
@@ -60,7 +62,7 @@ def _run(exiter):
   warnings.simplefilter("default")
 
   # The GoalRunner will setup final logging below in `.setup()`, but span the gap until then.
-  logging.basicConfig()
+  logging.basicConfig(level=logging.INFO)
   # This routes the warnings we enabled above through our loggers instead of straight to stderr raw.
   logging.captureWarnings(True)
 
@@ -68,8 +70,13 @@ def _run(exiter):
   if not os.path.exists(root_dir):
     exiter.exit_and_fail('PANTS_BUILD_ROOT does not point to a valid path: {}'.format(root_dir))
 
+  options_bootstrapper = OptionsBootstrapper()
+
+  plugin_resolver = PluginResolver(options_bootstrapper)
+  working_set = plugin_resolver.resolve()
+
   goal_runner = GoalRunner(root_dir)
-  goal_runner.setup()
+  goal_runner.setup(options_bootstrapper, working_set)
   exiter.apply_options(goal_runner.options)
   result = goal_runner.run()
   exiter.do_exit(result)

--- a/src/python/pants/bin/plugin_resolver.py
+++ b/src/python/pants/bin/plugin_resolver.py
@@ -110,6 +110,10 @@ class PluginResolver(object):
 
   @memoized_property
   def _options(self):
+    # NB: The PluginResolver runs very early in the pants startup sequence before the standard
+    # Subsystem facility is wired up.  As a result PluginResolver is not itself a Subsystem with
+    # (PythonRepos, PythonSetup) returned as `dependencies()`.  Instead it does the minimum possible
+    # work to hand-roll bootstrapping of the Subsystems it needs.
     subsystems = Subsystem.closure([PythonRepos, PythonSetup])
     known_scope_infos = [subsystem.get_scope_info() for subsystem in subsystems]
     options = self._options_bootstrapper.get_full_options(known_scope_infos)

--- a/src/python/pants/bin/plugin_resolver.py
+++ b/src/python/pants/bin/plugin_resolver.py
@@ -1,0 +1,125 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import hashlib
+import logging
+import os
+
+from pex import resolver
+from pex.base import requirement_is_exact
+from pex.package import EggPackage, SourcePackage
+from pkg_resources import working_set as global_working_set
+from pkg_resources import Requirement
+
+# TODO(John Sirois): this dependency looks strange although I think it makes sense for pants to
+# ship with the python backend even if all other backends do get broken into seperate sdists.
+# Consider moving PythonRepos and PythonSetup to a non-backend package, perhaps pants.runtime or
+# pants.python
+from pants.backend.python.python_setup import PythonRepos, PythonSetup
+from pants.option.global_options import GlobalOptionsRegistrar
+from pants.subsystem.subsystem import Subsystem
+from pants.util.dirutil import safe_open
+from pants.util.memo import memoized_property
+
+
+logger = logging.getLogger(__name__)
+
+
+class PluginResolver(object):
+  def __init__(self, options_bootstrapper):
+    self._options_bootstrapper = options_bootstrapper
+
+    bootstrap_options = self._options_bootstrapper.get_bootstrap_options().for_global_scope()
+    self._plugin_requirements = bootstrap_options.plugins
+
+  def resolve(self, working_set=None):
+    """Resolves any configured plugins and adds them to the global working set.
+
+    :param working_set: The working set to add the resolved plugins to instead of the global
+                        working set (for testing).
+    :type: :class:`pkg_resources.WorkingSet`
+    """
+    working_set = working_set or global_working_set
+    if self._plugin_requirements:
+      for plugin_location in self._resolve_plugin_locations():
+        working_set.add_entry(plugin_location)
+    return working_set
+
+  def _resolve_plugin_locations(self):
+    # We jump through some hoops here to avoid a live resolve if possible for purposes of speed.
+    # Even with a local resolve cache fully up to date, running a resolve to activate a plugin
+    # takes ~250ms whereas loading from a pre-cached list takes ~50ms.
+    if all(requirement_is_exact(Requirement.parse(req)) for req in self._plugin_requirements):
+      return self._resolve_exact_plugin_locations()
+    else:
+      return (plugin.location for plugin in self._resolve_plugins())
+
+  def _resolve_exact_plugin_locations(self):
+    hasher = hashlib.sha1()
+    for req in sorted(self._plugin_requirements):
+      hasher.update(req)
+    resolve_hash = hasher.hexdigest()
+    resolved_plugins_list = os.path.join(self.plugin_cache_dir,
+                                         'plugins-{}.txt'.format(resolve_hash))
+
+    if not os.path.exists(resolved_plugins_list):
+      tmp_plugins_list = resolved_plugins_list + '~'
+      with safe_open(tmp_plugins_list, 'w') as fp:
+        for plugin in self._resolve_plugins():
+          fp.write(plugin.location)
+          fp.write('\n')
+      os.rename(tmp_plugins_list, resolved_plugins_list)
+    with open(resolved_plugins_list) as fp:
+      for plugin_location in fp:
+        yield plugin_location.strip()
+
+  def _resolve_plugins(self):
+    # When bootstrapping plugins without the full pants python backend machinery in-play, we are not
+    # guaranteed a properly initialized interpreter with wheel support so we enforce eggs only for
+    # bdists with this custom precedence.
+    precedence = (EggPackage, SourcePackage)
+
+    logger.info('Resolving new plugins...:\n  {}'.format('\n  '.join(self._plugin_requirements)))
+    return resolver.resolve(self._plugin_requirements,
+                            fetchers=self._python_repos.get_fetchers(),
+                            context=self._python_repos.get_network_context(),
+                            precedence=precedence,
+                            cache=self.plugin_cache_dir,
+                            cache_ttl=self._python_setup.resolver_cache_ttl)
+
+  @memoized_property
+  def plugin_cache_dir(self):
+    """The path of the directory pants plugins bdists are cached in."""
+    return os.path.join(self._options.for_global_scope().pants_bootstrapdir, 'plugins')
+
+  @memoized_property
+  def _python_repos(self):
+    return self._create_global_subsystem(PythonRepos)
+
+  @memoized_property
+  def _python_setup(self):
+    return self._create_global_subsystem(PythonSetup)
+
+  def _create_global_subsystem(self, subsystem_type):
+    options_scope = subsystem_type.options_scope
+    return subsystem_type(options_scope, self._options.for_scope(options_scope))
+
+  @memoized_property
+  def _options(self):
+    subsystems = Subsystem.closure([PythonRepos, PythonSetup])
+    known_scope_infos = [subsystem.get_scope_info() for subsystem in subsystems]
+    options = self._options_bootstrapper.get_full_options(known_scope_infos)
+
+    # Ignore command line flags since we'd blow up on any we don't understand (most of them).
+    # If someone wants to bootstrap plugins in a one-off custom way they'll need to use env vars
+    # or a --config-override pointing to a custom pants.ini snippet.
+    defaulted_only_options = options.drop_flag_values()
+
+    GlobalOptionsRegistrar.register_options_on_scope(defaulted_only_options)
+    for subsystem in subsystems:
+      subsystem.register_options_on_scope(defaulted_only_options)
+    return defaulted_only_options

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -28,7 +28,7 @@ class OptionsBootstrapper(object):
 
   def get_bootstrap_options(self):
     """:returns: an Options instance that only knows about the bootstrap options.
-    :rtype: Options
+    :rtype: :class:`Options`
     """
     if not self._bootstrap_options:
       flags = set()
@@ -95,7 +95,9 @@ class OptionsBootstrapper(object):
     """Get the full Options instance bootstrapped by this object for the given known scopes.
 
     :param known_scope_infos: ScopeInfos for all scopes that may be encountered.
-    :param bool masked: If `True`, masks
+    :returns: A bootrapped Options instance that also carries options for all the supplied known
+              scopes.
+    :rtype: :class:`Options`
     """
     key = frozenset(sorted(known_scope_infos))
     if key not in self._full_options:

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import copy
+import re
 import sys
 import warnings
 from argparse import ArgumentParser, _HelpAction
@@ -332,6 +333,8 @@ class Parser(object):
       self._dest_forwardings[arg.lstrip('-').replace('-', '_')] = scoped_dest
     return dest
 
+  _ENV_SANITIZER_RE = re.compile(r'[.-]')
+
   def _select_dest(self, args):
     """Select the dest name for the option.
 
@@ -359,7 +362,8 @@ class Parser(object):
       if udest.startswith('PANTS_'):
         env_vars.append(udest)
     else:
-      env_vars = ['PANTS_{0}_{1}'.format(config_section.upper().replace('.', '_'), udest)]
+      sanitized_env_var_scope = self._ENV_SANITIZER_RE.sub('_', config_section.upper())
+      env_vars = ['PANTS_{0}_{1}'.format(sanitized_env_var_scope, udest)]
     value_type = self.str_to_bool if is_boolean_flag(kwargs) else kwargs.get('type', str)
     env_val_str = None
     if self._env:

--- a/tests/python/pants_test/base/test_extension_loader.py
+++ b/tests/python/pants_test/base/test_extension_loader.py
@@ -85,7 +85,8 @@ class LoaderTest(unittest.TestCase):
     Goal.clear()
 
   @contextmanager
-  def create_register(self, build_file_aliases=None, register_goals=None, global_subsystems=None, module_name='register'):
+  def create_register(self, build_file_aliases=None, register_goals=None, global_subsystems=None,
+                      module_name='register'):
 
     package_name = b'__test_package_{0}'.format(uuid.uuid4().hex)
     self.assertFalse(package_name in sys.modules)
@@ -218,7 +219,7 @@ class LoaderTest(unittest.TestCase):
     return Distribution(project_name=name, version=version, metadata=MockMetadata(metadata))
 
   def load_plugins(self, plugins):
-    load_plugins(self.build_configuration, plugins, load_from=self.working_set)
+    load_plugins(self.build_configuration, plugins, self.working_set)
 
   def test_plugin_load_and_order(self):
     d1 = self.get_mock_plugin('demo1', '0.0.1', after=lambda: ['demo2'])

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -1,0 +1,22 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name='bin',
+  dependencies=[
+    ':plugin_resolver',
+  ]
+)
+
+python_tests(
+  name='plugin_resolver',
+  sources=['test_plugin_resolver.py'],
+  dependencies=[
+    '3rdparty/python:pex',
+    '3rdparty/python:setuptools',
+    'src/python/pants/bin',
+    'src/python/pants/option',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+  ]
+)

--- a/tests/python/pants_test/bin/test_plugin_resolver.py
+++ b/tests/python/pants_test/bin/test_plugin_resolver.py
@@ -1,0 +1,128 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import time
+from contextlib import contextmanager
+from textwrap import dedent
+
+import pytest
+from pex.installer import Packager
+from pex.resolver import Unsatisfiable
+from pkg_resources import Requirement, WorkingSet
+
+from pants.bin.plugin_resolver import PluginResolver
+from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_open, safe_rmtree, touch
+
+
+req = Requirement.parse
+
+
+def create_plugin(distribution_repo_dir, plugin, version=None):
+  with safe_open(os.path.join(distribution_repo_dir, plugin, 'setup.py'), 'w') as fp:
+    fp.write(dedent("""
+      from setuptools import setup
+
+
+      setup(name="{plugin}", version="{version}")
+    """).format(plugin=plugin, version=version or '0.0.0'))
+  packager = Packager(source_dir=os.path.join(distribution_repo_dir, plugin),
+                      install_dir=distribution_repo_dir)
+  packager.run()
+
+
+@contextmanager
+def plugin_resolution(chroot=None, plugins=None):
+  @contextmanager
+  def provide_chroot(existing):
+    if existing:
+      yield existing, False
+    else:
+      with temporary_dir() as new_chroot:
+        yield new_chroot, True
+
+  with provide_chroot(chroot) as (root_dir, create_artifacts):
+    env = {'PANTS_BOOTSTRAPDIR': root_dir}
+    repo_dir = None
+    if plugins:
+      repo_dir = os.path.join(root_dir, 'repo')
+      env.update(PANTS_PYTHON_REPOS_REPOS='[{!r}]'.format(repo_dir),
+                 PANTS_PYTHON_REPOS_INDEXES='[]',
+                 PANTS_PYTHON_SETUP_RESOLVER_CACHE_TTL='1')
+      plugin_list = []
+      for plugin in plugins:
+        version = None
+        if isinstance(plugin, tuple):
+          plugin, version = plugin
+        plugin_list.append('{}=={}'.format(plugin, version) if version else plugin)
+        if create_artifacts:
+          create_plugin(repo_dir, plugin, version)
+      env['PANTS_PLUGINS'] = '[{}]'.format(','.join(map(repr, plugin_list)))
+
+    configpath = os.path.join(root_dir, 'pants.ini')
+    if create_artifacts:
+      touch(configpath)
+
+    options_bootstrapper = OptionsBootstrapper(env=env, configpath=configpath, args=[])
+    plugin_resolver = PluginResolver(options_bootstrapper)
+    cache_dir = plugin_resolver.plugin_cache_dir
+    yield plugin_resolver.resolve(WorkingSet(entries=[])), root_dir, repo_dir, cache_dir
+
+
+def test_no_plugins():
+  with plugin_resolution() as (working_set, _, _, _):
+    assert [] == working_set.entries
+
+
+def test_plugins():
+  with plugin_resolution(plugins=[('jake', '1.2.3'), 'jane']) as (working_set, _, _, cache_dir):
+    assert 2 == len(working_set.entries)
+
+    dist = working_set.find(req('jake'))
+    assert dist is not None
+    assert cache_dir == os.path.dirname(dist.location)
+
+    dist = working_set.find(req('jane'))
+    assert dist is not None
+    assert cache_dir == os.path.dirname(dist.location)
+
+
+def test_exact_requirements():
+  with plugin_resolution(plugins=[('jake', '1.2.3'), ('jane', '3.4.5')]) as results:
+    working_set, chroot, repo_dir, cache_dir = results
+
+    assert 2 == len(working_set.entries)
+
+    # Kill the the repo source dir and re-resolve.  If the PluginResolver truly detects exact
+    # requirements it should skip any resolves and load directly from the still in-tact cache.
+    safe_rmtree(repo_dir)
+
+    with plugin_resolution(chroot=chroot,
+                           plugins=[('jake', '1.2.3'), ('jane', '3.4.5')]) as results2:
+      working_set2, _, _, _ = results2
+
+      assert working_set.entries == working_set2.entries
+
+
+def test_inexact_requirements():
+  with plugin_resolution(plugins=[('jake', '1.2.3'), 'jane']) as results:
+    working_set, chroot, repo_dir, cache_dir = results
+
+    assert 2 == len(working_set.entries)
+
+    # Kill the cache and the repo source dir and wait past our 1s test TTL, if the PluginResolver
+    # truly detects inexact plugin requirements it should skip perma-caching and fall through to
+    # pex to a TLL expiry resolve and then fail.
+    safe_rmtree(repo_dir)
+    safe_rmtree(cache_dir)
+    time.sleep(1.5)
+
+    with pytest.raises(Unsatisfiable):
+      with plugin_resolution(chroot=chroot, plugins=[('jake', '1.2.3'), 'jane']):
+        assert False, 'Should not reach here, should raise first.'

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -420,7 +420,7 @@ class OptionsTest(unittest.TestCase):
     self.assertEqual(33, options.for_global_scope().num)
     self.assertEqual(99, defaulted_only_options.for_global_scope().num)
 
-    # An config specified option value.
+    # A config specified option value.
     self.assertEqual(1, options.for_scope('simple').num)
     self.assertEqual(42, defaulted_only_options.for_scope('simple').num)
 


### PR DESCRIPTION
Previously, pants could only load plugins already in the working set
(PYTHONPATH).  With this change, pants both resolves (and caches)
plugins as well as loading backends through their entry points.

In order to support this, two small changes were made to the options
system:

 1. OptionsBootstrapper was altered to cache full options per-known
    scope info set.  This allows the work of bootstrapping to be shared
    by the PluginResolver and the main options loading sequence.
 2. Options was refactored to support creating a copy that behaves the
    same as the original except that option values from command line
    flags are ignored.

These changes combine to give the early stage PluginResolver a clean,
performant means of using the configured PythonSetup and PythonRepos
subsystems to resolve plugins from the repos and indices the user has
set up for their pants installation.

https://rbcommons.com/s/twitter/r/2622/