### PR TITLE
Elevate the pants version to a 1st class option.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -119,7 +119,8 @@ if [[ "${skip_bootstrap:-false}" == "false" ]]; then
     ./pants ${PANTS_ARGS[@]} ${bootstrap_compile_args[@]} binary \
       src/python/pants/bin:pants_local_binary && \
     mv dist/pants_local_binary.pex pants.pex && \
-    ./pants.pex --version
+    ./pants.pex --version && \
+    ./pants.pex --pants-version
   ) || die "Failed to bootstrap pants."
 fi
 

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -34,7 +34,7 @@ function pkg_pants_install_test() {
   PIP_ARGS="$@"
   pip install ${PIP_ARGS} pantsbuild.pants==$(local_version) || die "pip install of pantsbuild.pants failed!"
   execute_packaged_pants_with_internal_backends list src:: || die "'pants list src::' failed in venv!"
-  [[ "$(execute_packaged_pants_with_internal_backends --version 2>/dev/null)" \
+  [[ "$(execute_packaged_pants_with_internal_backends --pants-version 2>/dev/null)" \
      == "$(local_version)" ]] || die "Installed version of pants does match local version!"
 }
 
@@ -125,7 +125,7 @@ function pkg_install_test_func() {
 }
 
 function local_version() {
-  run_local_pants --version 2>/dev/null
+  run_local_pants --pants-version 2>/dev/null
 }
 
 function build_packages() {

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -77,18 +77,25 @@ class GoalRunner(object):
 
   def setup(self, options_bootstrapper, working_set):
     bootstrap_options = options_bootstrapper.get_bootstrap_options()
+    global_bootstrap_options = bootstrap_options.for_global_scope()
+
+    # The pants_version may be set in pants.ini for bootstrapping, so we make sure the user actually
+    # requested the version on the command line before deciding to print the version and exit.
+    if global_bootstrap_options.is_flagged('pants_version'):
+      print(global_bootstrap_options.pants_version)
+      sys.exit(0)
 
     # Get logging setup prior to loading backends so that they can log as needed.
-    self._setup_logging(bootstrap_options.for_global_scope())
+    self._setup_logging(global_bootstrap_options)
 
     # Add any extra paths to python path (eg for loading extra source backends)
-    for path in bootstrap_options.for_global_scope().pythonpath:
+    for path in global_bootstrap_options.pythonpath:
       sys.path.append(path)
       pkg_resources.fixup_namespace_packages(path)
 
     # Load plugins and backends.
-    plugins = bootstrap_options.for_global_scope().plugins
-    backend_packages = bootstrap_options.for_global_scope().backend_packages
+    plugins = global_bootstrap_options.plugins
+    backend_packages = global_bootstrap_options.backend_packages
     build_configuration = load_plugins_and_backends(plugins, working_set, backend_packages)
 
     # Now that plugins and backends are loaded, we can gather the known scopes.

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -64,11 +64,13 @@ class SourceRootBootstrapper(Subsystem):
 class GoalRunner(object):
   """Lists installed goals or else executes a named goal."""
 
-  def __init__(self, root_dir):
+  def __init__(self, root_dir, exiter=sys.exit):
     """
     :param root_dir: The root directory of the pants workspace.
+    :param exiter: An optional function that accepts an int exit code value and exits (for testing).
     """
     self.root_dir = root_dir
+    self._exiter = exiter
 
   @property
   def subsystems(self):
@@ -83,7 +85,7 @@ class GoalRunner(object):
     # requested the version on the command line before deciding to print the version and exit.
     if global_bootstrap_options.is_flagged('pants_version'):
       print(global_bootstrap_options.pants_version)
-      sys.exit(0)
+      self._exiter(0)
 
     # Get logging setup prior to loading backends so that they can log as needed.
     self._setup_logging(global_bootstrap_options)
@@ -191,7 +193,7 @@ class GoalRunner(object):
                        "a goal. If this is incorrect, disambiguate it with ./{0}.".format(goal))
 
     if self.options.print_help_if_requested():
-      sys.exit(0)
+      self._exiter(0)
 
     self.requested_goals = goals
 

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -11,7 +11,6 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:config',
     'src/python/pants/base:deprecated',
-    'src/python/pants/goal',
     'src/python/pants/util:meta',
   ]
 )

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -42,11 +42,6 @@ class HelpRequest(AbstractClass):
   pass
 
 
-class VersionHelp(HelpRequest):
-  """The user requested the version of pants."""
-  pass
-
-
 class OptionsHelp(HelpRequest):
   def __init__(self, advanced=False, all_scopes=False):
     """The user requested help for cmd-line options.
@@ -87,8 +82,6 @@ class ArgSplitter(object):
   _HELP_ADVANCED_ARGS = ('--help-advanced', 'help-advanced')
   _HELP_ALL_SCOPES_ARGS = ('--help-all', 'help-all')
   _HELP_ARGS = _HELP_BASIC_ARGS + _HELP_ADVANCED_ARGS + _HELP_ALL_SCOPES_ARGS
-
-  _VERSION_ARGS = ('-V', '--version')
 
   def __init__(self, known_scope_infos):
     self._known_scope_infos = known_scope_infos
@@ -166,13 +159,6 @@ class ArgSplitter(object):
       scope_to_flags[flag_scope].append(descoped_flag)
 
     global_flags = self._consume_flags()
-    # We only check for _VERSION_ARGS in the global flags. It's reasonable for tasks
-    # to have a --version flag with different meaning.
-    for version_arg in self._VERSION_ARGS:
-      if version_arg in global_flags:
-        if not self._help_request:
-          self._help_request = VersionHelp()
-        global_flags.remove(version_arg)
 
     add_scope(GLOBAL_SCOPE)
     for flag in global_flags:

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -8,7 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 
-from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
+from pants.base.build_environment import (get_buildroot, get_pants_cachedir, get_pants_configdir,
+                                          pants_version)
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import list_option
 from pants.option.optionable import Optionable
@@ -47,6 +48,21 @@ class GlobalOptionsRegistrar(Optionable):
     # after -l and -q in help output, which is conveniently contextual.
     register('--colors', action='store_true', default=True, recursive=True,
              help='Set whether log messages are displayed in color.')
+
+    # NB: Right now this option is a placeholder that is unused within pants itself except when
+    # specified on the command line to print the OSS pants version.  Both the IntelliJ Pants plugin
+    # and the pantsbuild/setup bootstrap script grep for pants_version though so this option
+    # registration serves in part as documentation of the dependency.
+    # TODO(John Sirois): Move pantsbuild.pants bootstrapping into pants itself and have it use this
+    # version option directly.
+    register('-V', '--pants-version', '--version',  # NB: pants_version is the 1st long option
+                                                    # since that's the one read from pants.ini;
+                                                    # the version form only works from the CLI.
+             nargs='?',  # Allows using the flag with no args on the CLI to print version as well
+                         # as setting the version in pants.ini
+             default=pants_version(),  # Displays the current version correctly in `./pants -h`.
+             const=pants_version(),  # Displays the current version via `./pants -V`.
+             help="Prints pants' version number and exits.")
 
     register('--plugins', advanced=True, type=list_option, help='Load these plugins.')
     register('--backend-packages', advanced=True, type=list_option,

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -8,10 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import copy
 import sys
 
-from pants.base.build_environment import pants_release, pants_version
-from pants.goal.goal import Goal
+from pants.base.build_environment import pants_release
 from pants.option.arg_splitter import (GLOBAL_SCOPE, ArgSplitter, NoGoalHelp, OptionsHelp,
-                                       UnknownGoalHelp, VersionHelp)
+                                       UnknownGoalHelp)
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.parser_hierarchy import ParserHierarchy
@@ -282,9 +281,7 @@ class Options(object):
       def print_hint():
         print('Use `pants goals` to list goals.')
         print('Use `pants help` to get help.')
-      if isinstance(self._help_request, VersionHelp):
-        print(pants_version())
-      elif isinstance(self._help_request, OptionsHelp):
+      if isinstance(self._help_request, OptionsHelp):
         self._print_options_help()
       elif isinstance(self._help_request, UnknownGoalHelp):
         print('Unknown goals: {}'.format(', '.join(self._help_request.unknown_goals)))

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -4,7 +4,20 @@
 target(
   name='bin',
   dependencies=[
+    ':goal_runner',
     ':plugin_resolver',
+  ]
+)
+
+python_tests(
+  name='goal_runner',
+  sources=['test_goal_runner.py'],
+  dependencies=[
+    '3rdparty/python:mock',
+    '3rdparty/python:setuptools',
+    'src/python/pants/bin',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/option/util',
   ]
 )
 

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -13,7 +13,6 @@ python_tests(
   name='goal_runner',
   sources=['test_goal_runner.py'],
   dependencies=[
-    '3rdparty/python:mock',
     '3rdparty/python:setuptools',
     'src/python/pants/bin',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/bin/test_goal_runner.py
+++ b/tests/python/pants_test/bin/test_goal_runner.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import mock
 import pytest
 from pkg_resources import WorkingSet
 
@@ -21,13 +20,10 @@ def test_version_request(version_flag):
       self.exit_code = exit_code
 
   with temporary_dir() as build_root:
-    on_exit = mock.Mock()
-
-    def exited(exit_code):
+    def exiter(exit_code):
       raise ExitException(exit_code)
-    on_exit.side_effect = exited
 
-    goal_runner = GoalRunner(build_root, exiter=on_exit)
+    goal_runner = GoalRunner(build_root, exiter=exiter)
     options_bootstrapper = OptionsBootstrapper(args=[version_flag])
 
     with pytest.raises(ExitException) as excinfo:

--- a/tests/python/pants_test/bin/test_goal_runner.py
+++ b/tests/python/pants_test/bin/test_goal_runner.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import mock
+import pytest
+from pkg_resources import WorkingSet
+
+from pants.bin.goal_runner import GoalRunner
+from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.util.contextutil import temporary_dir
+
+
+@pytest.mark.parametrize('version_flag', ['-V', '--version', '--pants-version'])
+def test_version_request(version_flag):
+  class ExitException(Exception):
+    def __init__(self, exit_code):
+      self.exit_code = exit_code
+
+  with temporary_dir() as build_root:
+    on_exit = mock.Mock()
+
+    def exited(exit_code):
+      raise ExitException(exit_code)
+    on_exit.side_effect = exited
+
+    goal_runner = GoalRunner(build_root, exiter=on_exit)
+    options_bootstrapper = OptionsBootstrapper(args=[version_flag])
+
+    with pytest.raises(ExitException) as excinfo:
+      goal_runner.setup(options_bootstrapper=options_bootstrapper, working_set=WorkingSet())
+    assert 0 == excinfo.value.exit_code

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -8,8 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import shlex
 import unittest
 
-from pants.option.arg_splitter import (ArgSplitter, NoGoalHelp, OptionsHelp, UnknownGoalHelp,
-                                       VersionHelp)
+from pants.option.arg_splitter import ArgSplitter, NoGoalHelp, OptionsHelp, UnknownGoalHelp
 from pants.option.scope import ScopeInfo
 
 
@@ -49,7 +48,6 @@ class ArgSplitterTest(unittest.TestCase):
     self.assertEquals(expected_help_all,
                       (isinstance(splitter.help_request, OptionsHelp) and
                        splitter.help_request.all_scopes))
-    self.assertFalse(isinstance(splitter.help_request, VersionHelp))
 
   def _split_help(self, args_str, expected_goals, expected_scope_to_flags, expected_target_specs,
                   expected_help_advanced=False, expected_help_all=False):
@@ -58,11 +56,6 @@ class ArgSplitterTest(unittest.TestCase):
                 expected_is_help=True,
                 expected_help_advanced=expected_help_advanced,
                 expected_help_all=expected_help_all)
-
-  def _split_version(self, args_str):
-    splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
-    splitter.split_args(shlex.split(args_str))
-    self.assertTrue(isinstance(splitter.help_request, VersionHelp))
 
   def _split_unknown_goal(self, args_str, unknown_goals):
     splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
@@ -210,13 +203,3 @@ class ArgSplitterTest(unittest.TestCase):
 
   def test_no_goal_detection(self):
     self._split_no_goal('./pants foo/bar:baz')
-
-  def test_version_request_detection(self):
-    self._split_version('./pants -V')
-    self._split_version('./pants --version')
-
-    # --version in a non-global scope is OK, and not a version request.
-    self._split('./pants compile --version src/java/org/pantsbuild/foo',
-                ['compile'],
-                {'': [], 'compile': ['--version']},
-                ['src/java/org/pantsbuild/foo'])


### PR DESCRIPTION
Currently `pants_version` is a config option relied on by pants tooling
but not formalized as a registered option in the pants codebase.  This
change lifts all forms of pants version (`-V`, `--version` and the new
`--pants-version`) to be a global option.  The option is configured to
work as both a 0-arg command-line flag to trigger version help printing
as well as an option to use for setting the desired pants_version in
pants.ini (or via an the PANTS_VERSION env var).  The pantsbuild/setup
script and other proprietary pants bootstrap scripts use this option to
bootstrap pants to the requested version today and in the future pants
itself will use the version in this way.

https://rbcommons.com/s/twitter/r/2627/