### PR TITLE
Detect new package when doing ownership checks.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -367,9 +367,9 @@ function list_owners() {
 
 function check_owner() {
    username="$1"
-   packagename="$2"
+   package_name="$2"
 
-   for owner in $(get_owners ${packagename})
+   for owner in $(get_owners ${package_name})
    do
      if [[ "${username}" == "${owner}" ]]
      then
@@ -395,7 +395,7 @@ function check_owners() {
     then
       if ! check_owner "${username}" "${package_name}"
       then
-        dont_own+=("${packagename}")
+        dont_own+=("${package_name}")
       fi
     else
       echo "The ${package_name} package is new!  There are no owners yet."

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -327,6 +327,12 @@ function list_packages() {
   done
 }
 
+function package_exists() {
+  package_name="$1"
+
+  curl --fail --head https://pypi.python.org/pypi/${package_name} &>/dev/null
+}
+
 function get_owners() {
   package_name="$1"
 
@@ -344,12 +350,17 @@ function list_owners() {
   for PACKAGE in "${RELEASE_PACKAGES[@]}"
   do
     package_name=$(pkg_name $PACKAGE)
-    echo "Owners of ${package_name}:"
-    owners=($(get_owners ${package_name}))
-    for owner in "${owners[@]}"
-    do
-      echo "  ${owner}"
-    done
+    if package_exists ${package_name}
+    then
+      echo "Owners of ${package_name}:"
+      owners=($(get_owners ${package_name}))
+      for owner in "${owners[@]}"
+      do
+        echo "  ${owner}"
+      done
+    else
+      echo "The ${package_name} package is new!  There are no owners yet."
+    fi
     echo
   done
 }
@@ -378,11 +389,16 @@ function check_owners() {
   for PACKAGE in "${RELEASE_PACKAGES[@]}"
   do
     index=$((index+1))
-    packagename="$(pkg_name $PACKAGE)"
-    banner "[${index}/${total}] checking that ${username} owns ${packagename}..."
-    if ! check_owner "${username}" "${packagename}"
+    package_name="$(pkg_name $PACKAGE)"
+    banner "[${index}/${total}] checking that ${username} owns ${package_name}..."
+    if package_exists ${package_name}
     then
-      dont_own+=("${packagename}")
+      if ! check_owner "${username}" "${package_name}"
+      then
+        dont_own+=("${packagename}")
+      fi
+    else
+      echo "The ${package_name} package is new!  There are no owners yet."
     fi
   done
 


### PR DESCRIPTION
Both the main release and the -o ownership listing now check to see if a
package is new.  The release script skips the ownership check for new
packages now since it will register the package and the ownership
listing just notes the package is new.

https://rbcommons.com/s/twitter/r/2637/