### PR TITLE
[CI] Remove some coverage-related options from test.junit.

### DIFF
--- a/migrations/options/src/python/migrate_config.py
+++ b/migrations/options/src/python/migrate_config.py
@@ -258,6 +258,8 @@ migrations = {
 
   ('compile.cpp-compile', 'cc_options'): ('compile.cpp', 'cc_options'),
   ('compile.cpp-compile', 'cc_extensions'): ('compile.cpp', 'cc_extensions'),
+
+  ('test.junit', 'coverage_html_open'): ('test.junit', 'coverage_open'),
 }
 
 ng_daemons_note = ('The global "ng_daemons" option has been replaced by a "use_nailgun" option '
@@ -360,6 +362,9 @@ notes = {
   ('compile.cpp-compile', 'cc_extensions'): 'Value used to be a string (but default was a list), '
                                             'is now a list. Values also now include the dot, e.g.,'
                                             'it\'s now .cpp, not cpp.',
+  ('test.junit', 'coverage_console'): 'Option no longer exists. Coverage always written to stdout.',
+  ('test.junit', 'coverage_html'): 'Option no longer exists. Coverage always written to html file.',
+  ('test.junit', 'coverage_xml'): 'Option no longer exists. Coverage always written to xml file.',
 }
 
 

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -87,8 +87,6 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           '--interpreter=CPython>=3.3',
           '--test-junit-coverage-processor=emma',
           '--test-junit-coverage',
-          '--test-junit-coverage-xml',
-          '--test-junit-coverage-html',
           '--test-junit-coverage-jvm-options=-Xmx1g',
           '--test-junit-coverage-jvm-options=-XX:MaxPermSize=256m'],
           workdir)
@@ -127,8 +125,6 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           '--interpreter=CPython>=3.3',
           '--test-junit-coverage-processor=cobertura',
           '--test-junit-coverage',
-          '--test-junit-coverage-xml',
-          '--test-junit-coverage-html',
           '--test-junit-coverage-jvm-options=-Xmx1g',
           '--test-junit-coverage-jvm-options=-XX:MaxPermSize=256m'],
           workdir)


### PR DESCRIPTION
There's no harm in always generating all three formats (text, xml, html)
when running coverage. The performance difference is almost certainly
negligible compared with the time it takes to run tests (and my manual
benchmarking showed no difference).

Also made several other options advanced.