### PR TITLE
Support for running junit tests with different jvm versions.

### DIFF
--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -5,20 +5,36 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.jvm_target import JvmTarget
+from pants.base.payload import Payload
+from pants.base.payload_field import PrimitiveField
 
 
 class JavaTests(JvmTarget):
   """Tests JVM sources with JUnit."""
 
-  def __init__(self, cwd=None, **kwargs):
+  def __init__(self, cwd=None, test_platform=None, payload=None, **kwargs):
     """
     :param str cwd: working directory (relative to the build root) for the tests under this
       target. If unspecified (None), the working directory will be controlled by junit_run's --cwd.
+    :param str test_platform: The name of the platform (defined under the jvm-platform subsystem) to
+      use for running tests (that is, a key into the --jvm-platform-platforms dictionary). If
+      unspecified, the platform will default to the same one used for compilation.
     """
-    super(JavaTests, self).__init__(**kwargs)
     self.cwd = cwd
+    payload = payload or Payload()
+    payload.add_fields({
+      'test_platform': PrimitiveField(test_platform)
+    })
+    super(JavaTests, self).__init__(payload=payload, **kwargs)
 
     # TODO(John Sirois): These could be scala, clojure, etc.  'jvm' and 'tests' are the only truly
     # applicable labels - fixup the 'java' misnomer.
     self.add_labels('java', 'tests')
+
+  @property
+  def test_platform(self):
+    if self.payload.test_platform:
+      return JvmPlatform.global_instance().get_platform_by_name(self.payload.test_platform)
+    return self.platform

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -20,8 +20,10 @@ from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError, TestFailedTaskError
+from pants.base.revision import Revision
 from pants.base.workunit import WorkUnitLabel
 from pants.binaries import binary_util
+from pants.java.distribution.distribution import Distribution
 from pants.java.jar.shader import Shader
 from pants.java.util import execute_java
 from pants.util.contextutil import temporary_file_path
@@ -90,6 +92,10 @@ class _JUnitRunner(object):
     register('--cwd', advanced=True,
              help='Set the working directory. If no argument is passed, use the build root. '
                   'If cwd is set on a target, it will supersede this argument.')
+    register('--strict-jvm-version', action='store_true', default=False, advanced=True,
+             help='If true, will strictly require running junits with the same version of java as '
+                  'the platform -target level. Otherwise, the platform -target level will be '
+                  'treated as the minimum jvm to run.')
     register_jvm_tool(register,
                       'junit',
                       main=JUnitRun._MAIN,
@@ -110,6 +116,7 @@ class _JUnitRunner(object):
     self._batch_size = options.batch_size
     self._fail_fast = options.fail_fast
     self._working_dir = options.cwd or get_buildroot()
+    self._strict_jvm_version = options.strict_jvm_version
     self._args = copy.copy(task_exports.args)
     if options.suppress_output:
       self._args.append('-suppress-output')
@@ -253,8 +260,12 @@ class _JUnitRunner(object):
                  classpath_append=()):
     extra_jvm_options = extra_jvm_options or []
 
+    tests_by_properties = self._tests_by_properties(tests_to_targets,
+                                                    self._infer_workdir,
+                                                    lambda target: target.test_platform)
+
     result = 0
-    for workdir, tests in self._tests_by_workdir(tests_to_targets).items():
+    for (workdir, platform), tests in tests_by_properties.items():
       for batch in self._partition(tests):
         # Batches of test classes will likely exist within the same targets: dedupe them.
         relevant_targets = set(map(tests_to_targets.get, batch))
@@ -264,8 +275,15 @@ class _JUnitRunner(object):
         complete_classpath.update(classpath_prepend)
         complete_classpath.update(classpath)
         complete_classpath.update(classpath_append)
+        if self._strict_jvm_version:
+          max_version = Revision(*(platform.target_level.components + [9999]))
+          distribution = Distribution.cached(minimum_version=platform.target_level,
+                                             maximum_version=max_version)
+        else:
+          distribution = Distribution.cached(minimum_version=platform.target_level)
         with binary_util.safe_args(batch, self._task_exports.task_options) as batch_tests:
           self._context.log.debug('CWD = {}'.format(workdir))
+          self._context.log.debug('platform = {}'.format(platform))
           result += abs(execute_java(
             classpath=complete_classpath,
             main=main,
@@ -275,6 +293,7 @@ class _JUnitRunner(object):
             workunit_name='run',
             workunit_labels=[WorkUnitLabel.TEST],
             cwd=workdir,
+            distribution=distribution,
           ))
 
           if result != 0 and self._fail_fast:
@@ -293,11 +312,18 @@ class _JUnitRunner(object):
       return target.cwd
     return self._working_dir
 
-  def _tests_by_workdir(self, tests_to_targets):
-    workdirs = defaultdict(OrderedSet)
+  def _tests_by_property(self, tests_to_targets, get_property):
+    properties = defaultdict(OrderedSet)
     for test, target in tests_to_targets.items():
-      workdirs[self._infer_workdir(target)].add(test)
-    return {workdir: list(tests) for workdir, tests in workdirs.items()}
+      properties[get_property(target)].add(test)
+    return {property: list(tests) for property, tests in properties.items()}
+
+  def _tests_by_properties(self, tests_to_targets, *properties):
+    def combined_property(target):
+      return tuple(prop(target) for prop in properties)
+
+    return self._tests_by_property(tests_to_targets, combined_property)
+
 
   def _partition(self, tests):
     stride = min(self._batch_size, len(tests))

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -12,7 +12,7 @@ from pants.java.nailgun_executor import NailgunExecutor
 
 def execute_java(classpath, main, jvm_options=None, args=None, executor=None,
                  workunit_factory=None, workunit_name=None, workunit_labels=None,
-                 cwd=None, workunit_log_config=None):
+                 cwd=None, workunit_log_config=None, distribution=None):
   """Executes the java program defined by the classpath and main.
 
   If `workunit_factory` is supplied, does so in the context of a workunit.
@@ -32,7 +32,7 @@ def execute_java(classpath, main, jvm_options=None, args=None, executor=None,
   Returns the exit code of the java program.
   Raises `pants.java.Executor.Error` if there was a problem launching java itself.
   """
-  executor = executor or SubprocessExecutor()
+  executor = executor or SubprocessExecutor(distribution)
   if not isinstance(executor, Executor):
     raise ValueError('The executor argument must be a java Executor instance, give {} of type {}'
                      .format(executor, type(executor)))

--- a/testprojects/tests/java/org/pantsbuild/testproject/testjvms/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/testjvms/BUILD
@@ -1,0 +1,41 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(name='testjvms',
+  dependencies=[
+    ':six',
+    ':seven',
+    ':eight',
+    ':eight-test-platform',
+  ],
+)
+
+junit_tests(name='six',
+  sources=['TestSix.java'],
+  platform='java6',
+  dependencies=[':base'],
+)
+
+junit_tests(name='seven',
+  sources=['TestSeven.java'],
+  platform='java7',
+  dependencies=[':base'],
+)
+
+junit_tests(name='eight',
+  sources=['TestEight.java'],
+  platform='java8',
+  dependencies=[':base'],
+)
+
+junit_tests(name='eight-test-platform',
+  sources=['TestEight.java'],
+  platform='java7',
+  test_platform='java8',
+  dependencies=[':base'],
+)
+
+java_library(name='base',
+  sources=['TestBase.java'],
+  dependencies=['3rdparty:junit'],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestBase.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestBase.java
@@ -1,0 +1,17 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.testjvms;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Base class for testing what version of java is running.
+ * */
+public class TestBase {
+  public void assertJavaVersion(String expected) {
+    String version = System.getProperty("java.version");
+    version = version.substring(0, version.indexOf('.', version.indexOf('.')+1));
+    assertEquals(expected, version);
+  }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestEight.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestEight.java
@@ -1,0 +1,16 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.testjvms;
+
+import org.junit.Test;
+
+/**
+ * Ensure this test is run with java 1.8.
+ * */
+public class TestEight extends TestBase {
+  @Test
+  public void testEight() {
+    assertJavaVersion("1.8");
+  }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestSeven.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestSeven.java
@@ -1,0 +1,16 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.testjvms;
+
+import org.junit.Test;
+
+/**
+ * Ensure this test is run with java 1.7.
+ * */
+public class TestSeven extends TestBase {
+  @Test
+  public void testSeven() {
+    assertJavaVersion("1.7");
+  }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestSix.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/testjvms/TestSix.java
@@ -1,0 +1,16 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.testjvms;
+
+import org.junit.Test;
+
+/**
+ * Ensure this test is run with java 1.6.
+ * */
+public class TestSix extends TestBase {
+  @Test
+  public void testSix() {
+    assertJavaVersion("1.6");
+  }
+}

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -15,6 +15,7 @@ target(
     ':ivy_resolve',
     ':ivy_utils',
     ':junit_run',
+    ':junit_run_integration',
     ':jvm_platform_analysis',
     ':jvm_platform_analysis_integration',
     ':jvm_run',
@@ -201,6 +202,15 @@ python_tests(
     'src/python/pants/java:executor',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',
+  ]
+)
+
+python_tests(
+  name = 'junit_run_integration',
+  sources = ['test_junit_run_integration.py'],
+  dependencies = [
+    'src/python/pants/java/distribution',
+    'tests/python/pants_test:int-test',
   ]
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from unittest import skipIf
+
+from pants.java.distribution.distribution import Distribution
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+def missing_jvm(version):
+  try:
+    Distribution.locate(minimum_version=version, maximum_version='{}.9999'.format(version))
+    return False
+  except Distribution.Error:
+    return True
+
+
+class JunitRunIntegrationTest(PantsRunIntegrationTest):
+
+  def _testjvms(self, spec_name):
+    spec = 'testprojects/tests/java/org/pantsbuild/testproject/testjvms:{}'.format(spec_name)
+    self.assert_success(self.run_pants(['clean-all', 'test.junit', '--strict-jvm-version', spec]))
+
+  @skipIf(missing_jvm('1.8'), 'no java 1.8 installation on testing machine')
+  def test_java_eight(self):
+    self._testjvms('eight')
+
+  @skipIf(missing_jvm('1.7'), 'no java 1.7 installation on testing machine')
+  def test_java_seven(self):
+    self._testjvms('seven')
+
+  @skipIf(missing_jvm('1.6'), 'no java 1.6 installation on testing machine')
+  def test_java_six(self):
+    self._testjvms('six')
+
+  @skipIf(missing_jvm('1.8'), 'no java 1.8 installation on testing machine')
+  def test_with_test_platform(self):
+    self._testjvms('eight-test-platform')


### PR DESCRIPTION
Junit tests now run using a java Distribution found to match the
platform.target_level of the test target. By default any jvm whose
version is *at least* the target_level is used. Using jvms which
are of the exact same version of the junit_tests can be forced via
the --strict-jvm-version flag.