### PR TITLE
[CI] A uniform way of expressing Task and Subsystem dependencies.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -24,7 +24,7 @@ class GoDistribution(object):
     options_scope = 'go-distribution'
 
     @classmethod
-    def dependencies(cls):
+    def subsystem_dependencies(cls):
       return (BinaryUtil.Factory,)
 
     @classmethod

--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -53,6 +53,11 @@ class ApacheThriftGen(SimpleCodegenTask):
   def task_subsystems(cls):
     return super(ApacheThriftGen, cls).task_subsystems() + (ThriftBinary.Factory,)
 
+  @classmethod
+  def subsystem_dependencies(cls):
+    return (super(ApacheThriftGen, cls).subsystem_dependencies() +
+            (ThriftDefaults, ThriftBinary.Factory.scoped(cls)))
+
   def __init__(self, *args, **kwargs):
     super(ApacheThriftGen, self).__init__(*args, **kwargs)
     self._thrift_defaults = ThriftDefaults.global_instance()

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -334,6 +334,7 @@ python_library(
     'src/python/pants/ivy',
     'src/python/pants/java:executor',
     'src/python/pants/reporting',
+    'src/python/pants/subsystem',
     'src/python/pants/util:meta',
   ],
 )

--- a/src/python/pants/backend/core/tasks/group_task.py
+++ b/src/python/pants/backend/core/tasks/group_task.py
@@ -232,6 +232,11 @@ class GroupTask(Task):
         _MEMBER_TYPES = []
 
         @classmethod
+        def subsystem_dependencies(cls):
+          return (super(SingletonGroupTask, cls).subsystem_dependencies() +
+                  tuple(s for mt in cls._member_types() for s in mt.subsystem_dependencies()))
+
+        @classmethod
         def global_subsystems(cls):
           return (super(SingletonGroupTask, cls).global_subsystems() +
             tuple(s for mt in cls._member_types() for s in mt.global_subsystems()))

--- a/src/python/pants/binaries/thrift_binary.py
+++ b/src/python/pants/binaries/thrift_binary.py
@@ -17,7 +17,7 @@ class ThriftBinary(object):
     options_scope = 'thrift-binary'
 
     @classmethod
-    def dependencies(cls):
+    def subsystem_dependencies(cls):
       return (BinaryUtil.Factory,)
 
     @classmethod

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -166,8 +166,7 @@ class _Goal(object):
     """Returns all subsystem types used by tasks in this goal, in no particular order."""
     ret = set()
     for task_type in self.task_types():
-      ret.update(task_type.global_subsystems())
-      ret.update(task_type.task_subsystems())
+      ret.update([dep.subsystem_cls for dep in task_type.subsystem_dependencies_iter()])
     return ret
 
   def ordered_task_names(self):

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import namedtuple
+
+from pants.option.arg_splitter import GLOBAL_SCOPE
+
+
+class SubsystemClientError(Exception): pass
+
+
+class SubsystemDependency(namedtuple('_SubsystemDependency', ('subsystem_cls', 'scope'))):
+  """Indicates intent to use an instance of `subsystem_cls` scoped to `scope`."""
+  def is_global(self):
+    return self.scope == GLOBAL_SCOPE
+
+  def options_scope(self):
+    """The subscope for options of `subsystem_cls` scoped to `scope`.
+
+    This is the scope that option values are read from when initializing the instance
+    indicated by this dependency.
+    """
+    if self.is_global():
+      return self.scope
+    else:
+      return self.subsystem_cls.subscope(self.scope)
+
+
+class SubsystemClientMixin(object):
+  """A mixin for declaring dependencies on subsystems."""
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    """The subsystems this object uses.
+
+    Override to specify your subsystem dependencies. Always add them to your superclass's value.
+
+    Note: Do not call this directly to retrieve dependencies. See subsystem_dependencies_iter().
+
+    :return: A tuple of SubsystemDependency instances.
+             In the common case where you're an optionable and you want to get an instance scoped
+             to you, call subsystem_cls.scoped(cls) to get an appropriate SubsystemDependency.
+             As a convenience, you may also provide just a subsystem_cls, which is shorthand for
+             SubsystemDependency(subsystem_cls, GLOBAL SCOPE) and indicates that we want to use
+             the global instance of that subsystem.
+    """
+    return tuple()
+
+  @classmethod
+  def subsystem_dependencies_iter(cls):
+    for dep in cls.subsystem_dependencies():
+      if isinstance(dep, SubsystemDependency):
+        yield dep
+      else:
+        yield SubsystemDependency(dep, GLOBAL_SCOPE)
+    # Temporary hack until we replace all the global_subsystems() and task_subsystems()
+    # impls in Task with new-style impls of subsystem_dependencies().
+    # We can't check for isinstance(cls, Task) because we can't depend on it here.
+    if hasattr(cls, 'global_subsystems'):
+      for subsys in cls.global_subsystems():
+        yield SubsystemDependency(subsys, GLOBAL_SCOPE)
+    if hasattr(cls, 'task_subsystems'):
+      for subsys in cls.task_subsystems():
+        yield SubsystemDependency(subsys, cls.options_scope)

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -53,7 +53,7 @@ def temporary_dir(root_dir=None, cleanup=True):
     A with-context that creates a temporary directory.
 
     You may specify the following keyword args:
-    :param str root_dir: The parent directory to create the temporary directory.
+    :param str|unicode root_dir: The parent directory to create the temporary directory.
     :param bool cleanup: Whether or not to clean up the temporary directory.
   """
   path = tempfile.mkdtemp(dir=root_dir)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -155,9 +155,9 @@ class BaseTest(unittest.TestCase):
         raise TaskError('You must set a scope on your task type before using it in tests.')
       optionables.add(task_type)
       extra_scopes.update([si.scope for si in task_type.known_scope_infos()])
-      optionables.update(Subsystem.closure(set(task_type.global_subsystems()) |
-                                           set(task_type.task_subsystems()) |
-                                           self._build_configuration.subsystems()))
+      optionables.update(Subsystem.closure(
+        set([dep.subsystem_cls for dep in task_type.subsystem_dependencies_iter()]) |
+            self._build_configuration.subsystems()))
 
     # Now default the option values and override with any caller-specified values.
     # TODO(benjy): Get rid of the options arg, and require tests to call set_options.

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -57,7 +57,7 @@ class SubsystemTest(unittest.TestCase):
       options_scope = 'a'
 
       @classmethod
-      def dependencies(cls):
+      def subsystem_dependencies(cls):
         return (DummySubsystem, SubsystemB)
 
     self.assertEqual({DummySubsystem, SubsystemA, SubsystemB}, Subsystem.closure((SubsystemA,)))
@@ -71,14 +71,14 @@ class SubsystemTest(unittest.TestCase):
       options_scope = 'b'
 
       @classmethod
-      def dependencies(cls):
+      def subsystem_dependencies(cls):
         return (DummySubsystem,)
 
     class SubsystemA(Subsystem):
       options_scope = 'a'
 
       @classmethod
-      def dependencies(cls):
+      def subsystem_dependencies(cls):
         return (DummySubsystem, SubsystemB)
 
     self.assertEqual({DummySubsystem, SubsystemB}, Subsystem.closure((SubsystemB,)))
@@ -94,21 +94,21 @@ class SubsystemTest(unittest.TestCase):
       options_scope = 'c'
 
       @classmethod
-      def dependencies(cls):
+      def subsystem_dependencies(cls):
         return (SubsystemA,)
 
     class SubsystemB(Subsystem):
       options_scope = 'b'
 
       @classmethod
-      def dependencies(cls):
+      def subsystem_dependencies(cls):
         return (SubsystemC,)
 
     class SubsystemA(Subsystem):
       options_scope = 'a'
 
       @classmethod
-      def dependencies(cls):
+      def subsystem_dependencies(cls):
         return (SubsystemB,)
 
     for root in SubsystemA, SubsystemB, SubsystemC:


### PR DESCRIPTION
Introduces the concept of a subsystem client, which Task
and Subsystem mix in (this is not in Optionable because
the GlobalOptionsRegistrar must not depend on any subsystems).

All subsystem dependencies are expressed by the client by
implementing subsystem_dependencies(). That dependency
consists of a subsystem type and a scope. This generalizes
the previous concept of global and task-specific subsystem
dependencies.

Contains a temporary hack so that the old declarations still
work.  Those will be mopped up in a followup change, just
to keep this one from spiraling out too much.

Issue: https://github.com/pantsbuild/pants/issues/1957