### PR TITLE
Adding jdk_paths option to jvm subsystem.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -73,7 +73,7 @@ class ScroogeGen(NailgunTask):
 
   @classmethod
   def global_subsystems(cls):
-    return (ThriftDefaults,)
+    return super(ScroogeGen, cls).global_subsystems() + (ThriftDefaults,)
 
   @classmethod
   def product_types(cls):

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -29,6 +29,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/util:strutil',
+    'src/python/pants/util:osutil',
   ],
 )
 

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -5,9 +5,17 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.option.custom_types import list_option
+import logging
+import os
+
+from pants.option.custom_types import dict_option, list_option
 from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_property
+from pants.util.osutil import OS_ALIASES, normalize_os_name
 from pants.util.strutil import safe_shlex_split
+
+
+logger = logging.getLogger(__name__)
 
 
 class JVM(Subsystem):
@@ -33,6 +41,37 @@ class JVM(Subsystem):
              ],
              help='The JVM remote-debugging arguments. {debug_port} will be replaced with '
                   'the value of the --debug-port option.')
+    human_readable_os_aliases = ', '.join('{}: [{}]'.format(str(key), ', '.join(sorted(val)))
+                                         for key, val in OS_ALIASES.items())
+    register('--jdk-paths', advanced=True, recursive=True, type=dict_option,
+             help='Map of os names to lists of paths to jdks. These paths will be searched before '
+                  'everything else (before the JDK_HOME, JAVA_HOME, PATH environment variables) '
+                  'when locating a jvm to use. The same OS can be specified via several different '
+                  'aliases, according to this map: {}'.format(human_readable_os_aliases))
+
+  @memoized_property
+  def _normalized_jdk_paths(self):
+    jdk_paths = self.get_options().jdk_paths or {}
+    normalized = {}
+    for name, paths in sorted(jdk_paths.items()):
+      rename = normalize_os_name(name)
+      if rename in normalized:
+        logger.warning('Multiple OS names alias to "{}"; combining results.'.format(rename))
+        normalized[rename].extend(paths)
+      else:
+        normalized[rename] = paths
+    return normalized
+
+  def get_jdk_paths(self, os_name=None):
+    jdk_paths = self._normalized_jdk_paths
+    if not jdk_paths:
+      return ()
+    if os_name is None:
+      os_name = os.uname()[0].lower()
+    os_name = normalize_os_name(os_name)
+    if os_name not in jdk_paths:
+      logger.warning('--jvm-jdk-paths was specified, but has no entry for "{}".'.format(os_name))
+    return jdk_paths.get(os_name, ())
 
   def get_jvm_options(self):
     """Return the options to run this JVM with.

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.core.tasks.task import Task, TaskBase
+from pants.backend.jvm.subsystems.jvm import JVM
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.exceptions import TaskError
 from pants.java import util
@@ -29,6 +30,13 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
              help='Timeout (secs) for nailgun startup.')
     register('--nailgun-connect-attempts', advanced=True, default=5,
              help='Max attempts for nailgun connects.')
+
+  @classmethod
+  def global_subsystems(cls):
+    # TODO(gmalmquist): JVM subsystem dependency is required because Distribution queries it for
+    # jdk_paths when locating a jvm. Distribution should be refactored to be its own subsystem
+    # which depends on JVM, then NailgunTaskBase can depend on Distribution.
+    return super(NailgunTaskBase, cls).global_subsystems() + (JVM,)
 
   def __init__(self, *args, **kwargs):
     super(NailgunTaskBase, self).__init__(*args, **kwargs)

--- a/src/python/pants/binaries/BUILD
+++ b/src/python/pants/binaries/BUILD
@@ -12,6 +12,7 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:osutil',
   ],
 )
 

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -7,6 +7,7 @@ python_library(
   resources = globs('*.class'),
   dependencies = [
     '3rdparty/python:six',
+    'src/python/pants/backend/jvm/subsystems:jvm',
     'src/python/pants/base:revision',
     'src/python/pants/util:contextutil',
   ]

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -43,6 +43,11 @@ python_library(
 )
 
 python_library(
+  name = 'osutil',
+  sources = ['osutil.py'],
+)
+
+python_library(
   name = 'strutil',
   sources = ['strutil.py'],
   dependencies = [

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+import os
+
+
+logger = logging.getLogger(__name__)
+
+
+_ID_BY_OS = {
+  'linux': lambda release, machine: ('linux', machine),
+  'darwin': lambda release, machine: ('darwin', release.split('.')[0]),
+}
+
+
+OS_ALIASES = {
+  'darwin': {'macos', 'darwin', 'macosx', 'mac os x', 'mac'},
+  'linux': {'linux', 'linux2'},
+}
+
+
+def get_os_name():
+  return os.uname()[0].lower()
+
+
+def get_os_id(uname_func=None):
+  uname_func = uname_func or os.uname
+  sysname, _, release, _, machine = uname_func()
+  os_id = _ID_BY_OS[sysname.lower()]
+  if os_id:
+    return os_id(release, machine)
+  return None
+
+
+def normalize_os_name(os_name):
+  if os_name not in OS_ALIASES:
+    for proper_name, aliases in OS_ALIASES.items():
+      if os_name in aliases:
+        return proper_name
+  logger.warning('Unknown operating system name: {bad}, known names are: {known}'
+                 .format(bad=os_name, known=', '.join(sorted(known_os_names()))))
+  return os_name
+
+
+def known_os_names():
+  return reduce(set.union, OS_ALIASES.values())

--- a/testprojects/src/java/org/pantsbuild/testproject/printversion/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/printversion/BUILD
@@ -1,0 +1,5 @@
+jvm_binary(name='printversion',
+  main='org.pantsbuild.testproject.printversion.PrintVersion',
+  basename='printversion',
+  source='PrintVersion.java',
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/printversion/PrintVersion.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/printversion/PrintVersion.java
@@ -1,0 +1,14 @@
+package org.pantsbuild.testproject.printversion;
+
+/**
+ * This is used in test_distribution_integration.py to make sure
+ * Distribution.locate finds the correct java installation.
+ */
+public class PrintVersion {
+
+  public static void main(String[] args) {
+    System.out.println("java.version:" + System.getProperty("java.version"));
+    System.out.println("java.home:" + System.getProperty("java.home"));
+  }
+
+}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
@@ -69,7 +69,7 @@ class JvmPlatformIntegrationMixin(object):
       with temporary_dir(root_dir=self.workdir_root()) as workdir:
         pants_run = self.run_pants_with_workdir(
           ['binary'] + self.get_pants_compile_args()
-          + ['--jvm-compile-strategy={}'.format(strategy), 'compile.checkstyle', '--skip', spec]
+          + ['--strategy={}'.format(strategy), 'compile.checkstyle', '--skip', spec]
           + more_args,
           workdir, config)
         self.assert_success(pants_run)
@@ -207,10 +207,10 @@ class JvmPlatformIntegrationMixin(object):
         def compile_diamond(platform):
           return self.run_pants_with_workdir(['--jvm-platform-platforms={}'.format(platforms),
                                               '--jvm-platform-default-platform={}'.format(platform),
-                                              '--jvm-compile-strategy=isolated',
                                               '-ldebug',
                                               'compile'] + self.get_pants_compile_args() +
-                                              ['{}:diamond'.format(tmpdir)], workdir=workdir)
+                                              ['--strategy=isolated',
+                                               '{}:diamond'.format(tmpdir)], workdir=workdir)
 
         # We shouldn't be able to compile this with -source=6.
         self.assert_failure(compile_diamond('java6'), 'Diamond.java was compiled successfully with '

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -3,11 +3,23 @@
 
 python_tests(
   name = 'distribution',
-  sources = globs('*.py'),
+  sources = ['test_distribution.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
+    ':distribution_integration',
     'src/python/pants/base:revision',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ]
 )
+
+python_tests(
+  name = 'distribution_integration',
+  sources = ['test_distribution_integration.py'],
+  dependencies = [
+    'src/python/pants/java/distribution',
+    'src/python/pants/util:osutil',
+    'tests/python/pants_test:int-test',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+  ]
+)
+

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+from unittest import skipIf
+
+from pants.java.distribution.distribution import Distribution
+from pants.util.osutil import OS_ALIASES, get_os_name
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+def get_two_distributions():
+  try:
+    java7 = Distribution.locate(minimum_version='1.7', maximum_version='1.7.9999')
+    java8 = Distribution.locate(minimum_version='1.8', maximum_version='1.8.9999')
+    return java7, java8
+  except Distribution.Error:
+    return None
+
+
+class DistributionIntegrationTest(PantsRunIntegrationTest):
+
+  def _test_two_distributions(self, os_name=None):
+    java7, java8 = get_two_distributions()
+    os_name = os_name or get_os_name()
+
+    self.assertNotEqual(java7.home, java8.home)
+
+    for (one, two) in ((java7, java8), (java8, java7)):
+      target_spec = 'testprojects/src/java/org/pantsbuild/testproject/printversion'
+      run = self.run_pants(['run', target_spec], config={
+        'jvm': {
+          'jdk_paths': {
+            os_name: [one.home],
+          }
+        }
+      }, extra_env={
+        'JDK_HOME': two.home,
+      })
+      self.assert_success(run)
+      self.assertIn('java.home:{}'.format(one.home), run.stdout_data)
+
+  @skipIf(get_two_distributions() is None, 'Could not find java 7 and java 8 jvms to test with.')
+  def test_jvm_jdk_paths_supercedes_environment_variables(self):
+    self._test_two_distributions()
+
+  @skipIf(get_two_distributions() is None, 'Could not find java 7 and java 8 jvms to test with.')
+  def test_jdk_paths_with_aliased_os_names(self):
+    # NB(gmalmquist): This test will silently no-op and do nothing if the testing machine is running
+    # an esoteric os (eg, windows).
+    os_name = get_os_name()
+    if os_name in OS_ALIASES:
+      for other in OS_ALIASES[os_name]:
+        if other != os_name:
+          self._test_two_distributions(other)


### PR DESCRIPTION
Distribution.locate now first checks the paths set in the jdk_paths
dictionary (according to the os name).

Changed option reference in unrelated test to avoid collision with
jvm subsystem.