### PR TITLE
Allow specification of kwargs that are not currently known.

### DIFF
--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -39,6 +39,7 @@ from pants.backend.core.wrapped_globs import Globs, RGlobs, ZGlobs
 from pants.base.build_environment import get_buildroot, pants_version
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.source_root import SourceRoot
+from pants.base.target import Target
 from pants.goal.task_registrar import TaskRegistrar as task
 
 
@@ -186,3 +187,7 @@ def register_goals():
 
   task(name='bash-completion', action=BashCompletionTask).install().with_description(
     'Dump bash shell script for autocompletion of pants command lines.')
+
+
+def global_subsystems():
+  return (Target.UnknownArguments,)

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -294,6 +294,8 @@ python_library(
     ':source_root',
     ':target_addressable',
     'src/python/pants/backend/core:wrapped_globs',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
   ],
 )
 

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -86,8 +86,8 @@ class TargetTest(BaseTest):
     self.assertSequenceEqual([':foo'], list(target.traversable_dependency_specs))
 
   def test_illegal_kwargs(self):
-    with self.assertRaises(Target.UnknownArguments) as cm:
-      context = self.context()
+    with self.assertRaises(Target.UnknownArguments.Error) as cm:
+      context = self.context(for_subsystems=[Target.UnknownArguments])
       build_file = self.add_to_build_file('foo/BUILD', dedent('''
       java_library(
         name='bar',

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -143,10 +143,16 @@ class BaseTest(unittest.TestCase):
     self.options[scope].update(kwargs)
 
   def context(self, for_task_types=None, options=None, target_roots=None, console_outstream=None,
-              workspace=None):
+              workspace=None, for_subsystems=None):
 
     optionables = set()
     extra_scopes = set()
+
+    for_subsystems = for_subsystems or ()
+    for subsystem in for_subsystems:
+      if subsystem.options_scope is None:
+        raise TaskError('You must set a scope on your subsystem type before using it in tests.')
+      optionables.add(subsystem)
 
     for_task_types = for_task_types or ()
     for task_type in for_task_types:

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -24,7 +24,17 @@ target(
   name = 'integration',
   dependencies = [
     ':scala_library_integration',
+    ':unknown_arguments_integration',
   ],
+)
+
+python_tests(
+  name = 'unknown_arguments_integration',
+  sources = ['test_unknown_arguments_integration.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ]
 )
 
 python_tests(

--- a/tests/python/pants_test/targets/test_unknown_arguments_integration.py
+++ b/tests/python/pants_test/targets/test_unknown_arguments_integration.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+from contextlib import contextmanager
+from textwrap import dedent
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class TestUnknownArgumentsIntegration(PantsRunIntegrationTest):
+
+  @contextmanager
+  def temp_target_spec(self, **kwargs):
+    with temporary_dir('.') as tmpdir:
+      spec = os.path.basename(tmpdir)
+      with open(os.path.join(tmpdir, 'BUILD'), 'w') as f:
+        f.write(dedent('''
+          java_library(name='{name}',
+            {parameters}
+          )
+        ''').format(name=spec, parameters=''.join('\n    {}="{}",'.format(key, val)
+                                                  for key, val in kwargs.items())))
+      yield spec
+
+
+  def test_future_params(self):
+    param = 'nonexistant_parameter'
+    with self.temp_target_spec(**{param: 'value'}) as spec:
+      run = self.run_pants(['--unknown-arguments-ignored={"JavaLibrary": ["nonexistant_parameter"]}',
+                            '-ldebug',
+                            'clean-all', spec])
+      self.assert_success(run)
+      self.assertIn('{} ignoring the unimplemented arguments: {}'.format(spec, param),
+                    run.stderr_data)
+
+  def test_unknown_params(self):
+    future = 'nonexistant_parameter'
+    unknown = 'unexpected_nonexistant_parameter'
+    with self.temp_target_spec(**{future: 'value', unknown: 'other value'}) as spec:
+      run = self.run_pants(['--unknown-arguments-ignored={{"JavaLibrary": ["{}"]}}'.format(future),
+                            'clean-all', spec])
+      self.assert_failure(run)
+      self.assertIn('Invalid target {}'.format(spec), run.stderr_data)


### PR DESCRIPTION
This is useful when preparing BUILD files for versions of pants
that aren't ready to be used yet.

From discussion on pants-devel: Ignoring known unconsumed target
  kwargs.

This change was controversial/distasteful to many on the
pants-devel discussion. I think this is a pretty small change that
doesn't add too much complexity, but if reviewers disagree, we can
just use this patch internally.