### PR TITLE
[CI] Explicitly re-register subsystem options on all per-optionable scopes.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -29,10 +29,10 @@ class GoDistribution(object):
 
     @classmethod
     def register_options(cls, register):
-      register('--supportdir', recursive=True, advanced=True, default='bin/go',
+      register('--supportdir', advanced=True, default='bin/go',
                help='Find the go distributions under this dir.  Used as part of the path to lookup '
                     'the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', recursive=True, advanced=True, default='1.4.2',
+      register('--version', advanced=True, default='1.4.2',
                help='Go distribution version.  Used as part of the path to lookup the distribution '
                     'with --binary-util-baseurls and --pants-bootstrapdir')
 

--- a/src/python/pants/backend/core/tasks/group_task.py
+++ b/src/python/pants/backend/core/tasks/group_task.py
@@ -281,8 +281,10 @@ class GroupTask(Task):
               yield scope
 
         @classmethod
-        def register_options_on_scope(cls, options):
+        def register_options_on_scope(cls, options, scope=None):
           for member_type in cls._member_types():
+            # Note: we ignore the passed-in scope (which will be None anyway), as we want to
+            # register each member on their own scope.
             member_type.register_options_on_scope(options)
 
         @classmethod

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -26,15 +26,15 @@ class JVM(Subsystem):
   def register_options(cls, register):
     super(JVM, cls).register_options(register)
     # TODO(benjy): Options to specify the JVM version?
-    register('--options', action='append', recursive=True, metavar='<option>...',
+    register('--options', action='append', metavar='<option>...',
              help='Run with these extra JVM options.')
-    register('--program-args', action='append', recursive=True, metavar='<arg>...',
+    register('--program-args', action='append', metavar='<arg>...',
              help='Run with these extra program args.')
-    register('--debug', action='store_true', recursive=True,
+    register('--debug', action='store_true',
              help='Run the JVM with remote debugging.')
-    register('--debug-port', advanced=True, recursive=True, type=int, default=5005,
+    register('--debug-port', advanced=True, type=int, default=5005,
              help='The JVM will listen for a debugger on this port.')
-    register('--debug-args', advanced=True, recursive=True, type=list_option,
+    register('--debug-args', advanced=True, type=list_option,
              default=[
                '-Xdebug',
                '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address={debug_port}'
@@ -43,7 +43,7 @@ class JVM(Subsystem):
                   'the value of the --debug-port option.')
     human_readable_os_aliases = ', '.join('{}: [{}]'.format(str(key), ', '.join(sorted(val)))
                                          for key, val in OS_ALIASES.items())
-    register('--jdk-paths', advanced=True, recursive=True, type=dict_option,
+    register('--jdk-paths', advanced=True, type=dict_option,
              help='Map of os names to lists of paths to jdks. These paths will be searched before '
                   'everything else (before the JDK_HOME, JAVA_HOME, PATH environment variables) '
                   'when locating a jvm to use. The same OS can be specified via several different '

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -24,7 +24,7 @@ class BenchmarkRun(JvmToolTaskMixin, JvmTask):
     super(BenchmarkRun, cls).register_options(register)
     register('--target', help='Name of the benchmark class. This is a mandatory argument.')
     register('--memory', default=False, action='store_true', help='Enable memory profiling.')
-    register('--debug', action='store_true', recursive=True, help='Run the benchmark tool with in process debugging.')
+    register('--debug', action='store_true', help='Run the benchmark tool with in process debugging.')
 
     cls.register_jvm_tool(register, 'benchmark-tool', main=cls._CALIPER_MAIN, default=['//:benchmark-caliper-0.5'])
     cls.register_jvm_tool(register, 'benchmark-agent',

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -105,7 +105,10 @@ class GoalRunner(object):
 
     known_scope_infos = [GlobalOptionsRegistrar.get_scope_info()]
 
-    # Add scopes for all needed subsystems.
+    # Add (global instance) scopes for all needed subsystems.  Even if we never use the
+    # global instance of some subsystem we still need to register options on it, so that
+    # other instances of that subsystem can inherit option values from it, and so that
+    # ArgSplitter will recogize that scope prefix.
     subsystems = Subsystem.closure(set(self.subsystems) |
                                    Goal.subsystems() |
                                    build_configuration.subsystems())
@@ -169,17 +172,17 @@ class GoalRunner(object):
     return self.options.for_global_scope()
 
   def register_options(self, subsystems):
-    # Standalone global options.
+    # Register standalone global options.
     GlobalOptionsRegistrar.register_options_on_scope(self.options)
 
-    # Options for subsystems.
+    # Register options for global subsystems (and their dependencies).
     for subsystem in subsystems:
       subsystem.register_options_on_scope(self.options)
 
     # TODO(benjy): Should Goals be subsystems? Or should the entire goal-running mechanism
     # be a subsystem?
     for goal in Goal.all():
-      # Register task options.
+      # Register task options (and their dependencies).
       goal.register_options(self.options)
 
   def _expand_goals_and_specs(self):

--- a/src/python/pants/binaries/thrift_binary.py
+++ b/src/python/pants/binaries/thrift_binary.py
@@ -22,10 +22,10 @@ class ThriftBinary(object):
 
     @classmethod
     def register_options(cls, register):
-      register('--supportdir', recursive=True, advanced=True, default='bin/thrift',
+      register('--supportdir', advanced=True, default='bin/thrift',
                help='Find thrift binaries under this dir.   Used as part of the path to lookup the'
                     'tool with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', recursive=True, advanced=True, default='0.9.2', fingerprint=True,
+      register('--version', advanced=True, default='0.9.2', fingerprint=True,
                help='Thrift compiler version.   Used as part of the path to lookup the'
                     'tool with --binary-util-baseurls and --pants-bootstrapdir')
 

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -41,24 +41,24 @@ class CacheSetup(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(CacheSetup, cls).register_options(register)
-    register('--read', action='store_true', default=True, recursive=True,
+    register('--read', action='store_true', default=True,
              help='Read build artifacts from cache, if available.')
-    register('--write', action='store_true', default=True, recursive=True,
+    register('--write', action='store_true', default=True,
              help='Write build artifacts to cache, if available.')
-    register('--overwrite', action='store_true', recursive=True,
+    register('--overwrite', action='store_true',
              help='If writing build artifacts to cache, overwrite existing artifacts '
                   'instead of skipping them.')
-    register('--read-from', type=list_option, recursive=True,
+    register('--read-from', type=list_option,
              help='The URIs of artifact caches to read from. Each entry is a URL of a RESTful '
                   'cache, a path of a filesystem cache, or a pipe-separated list of alternate '
                   'caches to choose from.')
-    register('--write-to', type=list_option, recursive=True,
+    register('--write-to', type=list_option,
              help='The URIs of artifact caches to write to. Each entry is a URL of a RESTful '
                   'cache, a path of a filesystem cache, or a pipe-separated list of alternate '
                   'caches to choose from.')
-    register('--compression-level', advanced=True, type=int, default=5, recursive=True,
+    register('--compression-level', advanced=True, type=int, default=5,
              help='The gzip compression level (0-9) for created artifacts.')
-    register('--max-entries-per-target', advanced=True, recursive=True, type=int, default=None,
+    register('--max-entries-per-target', advanced=True, type=int, default=None,
              help='Maximum number of old cache files to keep per task target pair')
 
   @classmethod

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -163,7 +163,10 @@ class _Goal(object):
         yield scope_info
 
   def subsystems(self):
-    """Returns all subsystem types used by tasks in this goal, in no particular order."""
+    """Returns all subsystem types used by tasks in this goal, in no particular order.
+
+    Returns types of global and task-specific subsystem dependencies.
+    """
     ret = set()
     for task_type in self.task_types():
       ret.update([dep.subsystem_cls for dep in task_type.subsystem_dependencies_iter()])

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -40,12 +40,18 @@ class Optionable(AbstractClass):
     """
 
   @classmethod
-  def register_options_on_scope(cls, options):
+  def register_options_on_scope(cls, options, scope=None):
     """Trigger registration of this optionable's options.
+
+    :param options: Register on parsers obtained from this Options instance.
+    :param scope: Register on the parser for this scope. If unspecified, use this
+                  Optionable class's scope.  We use this when registering subsystem
+                  options for per-optionable subsystems.
 
     Subclasses should not generally need to override this method.
     """
-    cls.register_options(options.registration_function_for_optionable(cls))
+    scope = scope or cls.options_scope
+    cls.register_options(options.registration_function_for_optionable(cls, scope))
 
   def __init__(self):
     # Check that the instance's class defines options_scope.

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -191,17 +191,17 @@ class Options(object):
     """Register an option in the given scope, using argparse params."""
     self.get_parser(scope).register(*args, **kwargs)
 
-  def registration_function_for_optionable(self, optionable_class):
+  def registration_function_for_optionable(self, optionable_class, scope):
     """Returns a function for registering argparse args on the given scope."""
     # TODO(benjy): Make this an instance of a class that implements __call__, so we can
     # docstring it, and so it's less weird than attatching properties to a function.
     def register(*args, **kwargs):
       kwargs['registering_class'] = optionable_class
-      self.register(optionable_class.options_scope, *args, **kwargs)
+      self.register(scope, *args, **kwargs)
     # Clients can access the bootstrap option values as register.bootstrap.
     register.bootstrap = self.bootstrap_option_values()
     # Clients can access the scope as register.scope.
-    register.scope = optionable_class.options_scope
+    register.scope = scope
     return register
 
   def get_parser(self, scope):

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -212,7 +212,10 @@ class Parser(object):
     """
     if self._frozen:
       raise RegistrationError('Cannot register option {0} in scope {1} after registering options '
-                              'in any of its inner scopes.'.format(args[0], self._scope))
+                              'in any of its inner scopes.'.format(args[0], self.scope))
+
+    if not args:
+      raise ParseError('No option names provided for some option in scope {0}'.format(self.scope))
 
     # Prevent further registration in enclosing scopes.
     ancestor = self._parent_parser
@@ -223,6 +226,9 @@ class Parser(object):
     self._validate(args, kwargs)
     dest = self._set_dest(args, kwargs)
     if 'recursive' in kwargs:
+      if self.scope != GLOBAL_SCOPE:
+        raise ParseError('Attempting to register option {0} in scope {1} with recursive=True, '
+                         'but only global options can be recursive.'.format(args[0], self.scope))
       kwargs['recursive_root'] = True  # So we can distinguish the original registrar.
     self._register(dest, args, kwargs)  # Note: May modify kwargs (to remove recursive_root).
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_scala_repl_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scala_repl_integration.py
@@ -14,7 +14,7 @@ class ScalaReplIntegrationTest(PantsRunIntegrationTest):
 
   def run_repl(self, target, program, repl_args=None):
     """Run a repl for the given target with the given input, and return stdout_data"""
-    command = ['repl']
+    command = ['repl.scala']
     if repl_args:
       command.extend(repl_args)
     command.extend([target, '--quiet'])

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -82,7 +82,6 @@ class OptionsTest(unittest.TestCase):
     options.register('test', '--xlong', type=int)
 
     # For the design doc example test.
-    options.register('compile', '--c', type=int, recursive=True)
     options.register('compile.java', '--b', type=str, default='foo')
 
     # Test deprecated options with a scope
@@ -308,21 +307,15 @@ class OptionsTest(unittest.TestCase):
       'PANTS_COMPILE_C': '66'
     }
 
-    options = self._parse('./pants --a=1 compile --b=2 compile.java --a=3 --c=4',
+    options = self._parse('./pants --a=1 compile --b=2 compile.java --a=3',
                           env=env, config=config)
 
     self.assertEqual(1, options.for_global_scope().a)
     self.assertEqual(99, options.for_global_scope().b)
-    with self.assertRaises(AttributeError):
-      _ = options.for_global_scope().c
-
     self.assertEqual(1, options.for_scope('compile').a)
     self.assertEqual(2, options.for_scope('compile').b)
-    self.assertEqual(66, options.for_scope('compile').c)
-
     self.assertEqual(3, options.for_scope('compile.java').a)
     self.assertEqual('foo', options.for_scope('compile.java').b)
-    self.assertEqual(4, options.for_scope('compile.java').c)
 
   def test_file_spec_args(self):
     with tempfile.NamedTemporaryFile() as tmp:

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -3,8 +3,9 @@
 
 python_tests(
   name='subsystem',
-  sources=['test_subsystem.py'],
+  sources=['test_subsystem.py', 'test_subsystem_client_mixin.py'],
   dependencies=[
+    '3rdparty/python:mock',
     '3rdparty/python:pytest',
     'src/python/pants/option',
     'src/python/pants/subsystem',

--- a/tests/python/pants_test/subsystem/test_subsystem_client_mixin.py
+++ b/tests/python/pants_test/subsystem/test_subsystem_client_mixin.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from mock import MagicMock, call
+
+from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.optionable import Optionable
+from pants.subsystem.subsystem import Subsystem
+from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin, SubsystemDependency
+
+
+class MockOptions(object):
+  def __init__(self):
+    self.scope_to_registration_func = {}
+
+  def registration_function_for_optionable(self, optionable, scope):
+    ret = MagicMock()
+    self.scope_to_registration_func[scope] = ret
+    return ret
+
+  def reg_func_mock(self, scope):
+    return self.scope_to_registration_func[scope]
+
+
+class DummySubsystem1(Subsystem):
+  options_scope = 'subsys1'
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return (DummySubsystem2,)
+
+  @classmethod
+  def register_options(cls, register):
+    register('subsys1.opt1')
+
+
+class DummySubsystem2(Subsystem):
+  options_scope = 'subsys2'
+
+  @classmethod
+  def register_options(cls, register):
+    register('subsys2.opt1')
+    register('subsys2.opt2')
+
+
+class DummyOptionable(SubsystemClientMixin, Optionable):
+  options_scope = 'foo'
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return (DummySubsystem1, DummySubsystem2.scoped(cls))
+
+  @classmethod
+  def register_options(cls, register):
+    register('foo.opt1')
+
+
+class SubsystemClientMixinTest(unittest.TestCase):
+  def test_dependencies_iter(self):
+    expected_deps = [SubsystemDependency(DummySubsystem1, GLOBAL_SCOPE),
+                     SubsystemDependency(DummySubsystem2, 'foo')]
+    self.assertEquals(expected_deps, list(DummyOptionable.subsystem_dependencies_iter()))
+
+  def test_register_options_on_scope(self):
+    mock_options = MockOptions()
+    DummyOptionable.register_options_on_scope(mock_options)
+    self.assertSetEqual({'subsys1', 'subsys2', 'foo', 'subsys2.foo'},
+                        set(mock_options.scope_to_registration_func.keys()))
+    self.assertEquals(mock_options.reg_func_mock('subsys1').mock_calls, [call('subsys1.opt1')])
+    self.assertEquals(mock_options.reg_func_mock('subsys2').mock_calls,
+                      [call('subsys2.opt1'), call('subsys2.opt2')])
+    self.assertEquals(mock_options.reg_func_mock('foo').mock_calls, [call('foo.opt1')])
+    # Verify that DummySubsystem2's options are registered twice - once for the global instance
+    # and once for DummyOptionable's scoped instance.
+    self.assertEquals(mock_options.reg_func_mock('subsys2.foo').mock_calls,
+                      [call('subsys2.opt1'), call('subsys2.opt2')])


### PR DESCRIPTION
Previously we registered all subsystem options only on their global
instance scope, and relied on "recursive=True" to allow per-optionable
instances to have different option values.  However this is an abuse
of recursive=True, which was really intended only for a small set of
global options, such as log level, to be overridden in specific scopes.

An optionable-specific subsystem exists entirely so that its options
can be set differently than the global instance, so we shouldn't
require recursive=True for that to work, we should just register
everything on every necessary scope.