### PR TITLE
Add support for fetching test deps.

### DIFF
--- a/contrib/go/examples/3rdparty/go/github.com/bmizerany/assert/BUILD
+++ b/contrib/go/examples/3rdparty/go/github.com/bmizerany/assert/BUILD
@@ -1,0 +1,4 @@
+go_remote_library(
+  name='assert',
+  rev='e17e99893cb6509f428e1728281c2ad60a6b31e3',
+)

--- a/contrib/go/examples/3rdparty/go/github.com/kr/pretty/BUILD
+++ b/contrib/go/examples/3rdparty/go/github.com/kr/pretty/BUILD
@@ -1,0 +1,4 @@
+go_remote_library(
+  name='pretty',
+  rev='bc9499caa0f45ee5edb2f0209fbd61fbf3d9018f',
+)

--- a/contrib/go/examples/3rdparty/go/github.com/kr/text/BUILD
+++ b/contrib/go/examples/3rdparty/go/github.com/kr/text/BUILD
@@ -1,0 +1,4 @@
+go_remote_library(
+  name='text',
+  rev='6807e777504f54ad073ecef66747de158294b639',
+)

--- a/contrib/go/examples/3rdparty/go/gopkg.in/check.v1/BUILD
+++ b/contrib/go/examples/3rdparty/go/gopkg.in/check.v1/BUILD
@@ -1,0 +1,3 @@
+go_remote_library(
+  name='check.v1',
+)

--- a/contrib/go/examples/3rdparty/go/gopkg.in/check.v1/BUILD
+++ b/contrib/go/examples/3rdparty/go/gopkg.in/check.v1/BUILD
@@ -1,3 +1,9 @@
 go_remote_library(
   name='check.v1',
+  # NB: We pin this rev for 2 reasons:
+  # 1. It turns out v1 is backed by a branch and not a tag so despite the gopkg.in version pinning,
+  #    The v1 branch can float.
+  # 2. Without a pin, integration tests hit the github API to resolve the latest compatible v1
+  #    tag/branch and this runs into rate-limit issues quickly on Travis CI.
+  rev='9217c9979615bf07fc41eb86b91e334b093ff20d'
 )

--- a/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
@@ -2,6 +2,22 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
+  name='fetchers',
+  sources=['fetchers.py'],
+  dependencies=[
+    '3rdparty/python:requests',
+    '3rdparty/python:six',
+    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
+    'src/python/pants/fs',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
+  ],
+)
+
+python_library(
   name='go_distribution',
   sources=['go_distribution.py'],
   dependencies=[
@@ -11,20 +27,5 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',
-  ],
-)
-
-python_library(
-  name='fetchers',
-  sources=['fetchers.py'],
-  dependencies=[
-    '3rdparty/python:requests',
-    '3rdparty/python:six',
-    'src/python/pants/fs',
-    'src/python/pants/option',
-    'src/python/pants/subsystem',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:memo',
-    'src/python/pants/util:meta',
   ],
 )

--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
@@ -24,6 +24,8 @@ from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import AbstractClass
 from six.moves.urllib.parse import urlparse
 
+from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary
+
 
 class Fetcher(AbstractClass):
   """Knows how to interpret some remote import paths and fetch code to satisfy them."""
@@ -48,13 +50,14 @@ class Fetcher(AbstractClass):
     """
 
   @abstractmethod
-  def fetch(self, go_remote_library, dest):
+  def fetch(self, import_path, dest, rev=None):
     """Fetches to remote library to the given dest dir.
 
     The dest dir provided will be an existing empty directory.
 
-    :param go_remote_library: The library describing the remote package to fetch.
-    :type: :class:`pants.contrib.go.targets.go_remote_library.GoRemoteLibrary`
+    :param string import_path: The remote import path to fetch.
+    :param string rev: The version to fetch - may be `None` or empty indicating the latest version
+                       should be fetched.
     :param string dest: The path of an existing empty directory to extract package containing the
                         remote library's contents to.
     :raises: :class:`Fetcher.FetchError` if there was a problem fetching the remote package.
@@ -182,13 +185,13 @@ class Fetchers(Subsystem):
                   "or else an installed alias for a fetcher type; ie the builtin "
                   "`contrib.go.subsystems.fetchers.ArchiveFetcher` is aliased as 'ArchiveFetcher'.")
 
-  class GetFetchError(Exception):
+  class GetFetcherError(Exception):
     """Indicates an error finding an appropriate Fetcher."""
 
-  class UnfetchableRemote(GetFetchError):
+  class UnfetchableRemote(GetFetcherError):
     """Indicates no Fetcher claims the given remote import path."""
 
-  class InvalidFetcherError(GetFetchError):
+  class InvalidFetcherError(GetFetcherError):
     """Indicates an invalid Fetcher type or an un-instantiable Fetcher."""
 
   class InvalidFetcherModule(InvalidFetcherError):
@@ -257,8 +260,8 @@ class ArchiveFetcher(Fetcher, Subsystem):
   logger = logging.getLogger(__name__)
 
   class UrlInfo(namedtuple('UrlInfo', ['url_format', 'default_rev', 'strip_level'])):
-    def rev(self, go_remote_library):
-      return go_remote_library.rev or self.default_rev
+    def rev(self, rev):
+      return rev or self.default_rev
 
   options_scope = 'archive-fetcher'
 
@@ -321,10 +324,10 @@ class ArchiveFetcher(Fetcher, Subsystem):
     match, _ = self._matcher(import_path)
     return match.string[:match.end()]
 
-  def fetch(self, go_remote_library, dest):
-    match, url_info = self._matcher(go_remote_library.import_path)
-    archive_url = match.expand(url_info.url_format).format(rev=url_info.rev(go_remote_library),
-                                                           pkg=go_remote_library.pkg)
+  def fetch(self, import_path, dest, rev=None):
+    match, url_info = self._matcher(import_path)
+    pkg = GoRemoteLibrary.remote_package_path(self.root(import_path), import_path)
+    archive_url = match.expand(url_info.url_format).format(rev=url_info.rev(rev), pkg=pkg)
     try:
       archiver = archiver_for_path(archive_url)
     except ValueError:
@@ -356,17 +359,20 @@ class ArchiveFetcher(Fetcher, Subsystem):
       with self._download(url) as download_path:
         yield download_path
 
-  @contextmanager
-  def _download(self, url):
-    # TODO(jsirois): Wrap with workunits, progress meters, checksums.
-    self.logger.info('Downloading {}...'.format(url))
+  def session(self):
     session = requests.session()
     # Override default http adapters with a retriable one.
     retriable_http_adapter = requests.adapters.HTTPAdapter(max_retries=self.get_options().retries)
     session.mount("http://", retriable_http_adapter)
     session.mount("https://", retriable_http_adapter)
-    with closing(session.get(url, stream=True)) as res:
-      if not res.status_code == requests.codes.ok:
+    return session
+
+  @contextmanager
+  def _download(self, url):
+    # TODO(jsirois): Wrap with workunits, progress meters, checksums.
+    self.logger.info('Downloading {}...'.format(url))
+    with closing(self.session().get(url, stream=True)) as res:
+      if res.status_code != requests.codes.ok:
         raise self.FetchError('Failed to download {} ({} error)'.format(url, res.status_code))
       with temporary_file() as archive_fp:
         # NB: Archives might be very large so we play it safe and buffer them to disk instead of
@@ -378,7 +384,163 @@ class ArchiveFetcher(Fetcher, Subsystem):
         yield archive_fp.name
 
 
+class GopkgInFetcher(Fetcher, Subsystem):
+  """A fetcher implementing the URL re-writing protocol of gopkg.in.
+
+  The protocol rewrites a versioned remote import path scheme to a github URL + rev and delegates
+  to the ArchiveFetcher to do the rest.
+
+  The versioning URL scheme is described here: http://gopkg.in
+  """
+  options_scope = 'gopkg.in'
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return (ArchiveFetcher,)
+
+  @property
+  def _fetcher(self):
+    return ArchiveFetcher.global_instance()
+
+  def root(self, import_path):
+    return import_path
+
+  #VisibleForTesting
+  def _do_fetch(self, import_path, dest, rev=None):
+    return self._fetcher.fetch(import_path, dest, rev=rev)
+
+  def fetch(self, import_path, dest, rev=None):
+    github_root, github_rev = self._map_import_path(import_path, rev)
+    self._do_fetch(github_root, dest, rev=rev or github_rev)
+
+  _PACKAGE_AND_REV_RE = re.compile(r'(?P<package>[^/]+).(?P<rev>v[0-9]+)')
+
+  @memoized_method
+  def _map_import_path(self, import_path, rev=None):
+    components = import_path.split('/', 2)
+
+    domain = components.pop(0)
+    if 'gopkg.in' != domain:
+      raise self.FetchError('Can only fetch packages for pkgio.in, given: {}'.format(import_path))
+
+    user = components.pop(0) if len(components) == 2 else None
+
+    match = self._PACKAGE_AND_REV_RE.match(components[0])
+    if not match:
+      raise self.FetchError('Invalid gopkg.in package and rev in: {}'.format(import_path))
+    package, raw_rev = match.groups()
+
+    user = user or 'go-{}'.format(package)
+    rev = rev or self._find_highest_compatible(user, package, raw_rev)
+    root = 'github.com/{user}/{pkg}'.format(user=user, pkg=package)
+    return root, rev
+
+  class ApiError(Fetcher.FetchError):
+    """Indicates a compatible version could not be found due to github API errors."""
+
+  class NoMatchingVersionError(Fetcher.FetchError):
+    """Indicates versions were found, but none matched."""
+
+  class NoVersionsError(Fetcher.FetchError):
+    """Indicates no versions were found even there there were no github API errors - unexpected."""
+
+  def _find_highest_compatible(self, user, repo, raw_rev):
+    # http://labix.org/gopkg.in defines v0 as master.
+    if raw_rev == 'v0':
+      return 'master'
+
+    candidates = set()
+    errors = []
+
+    def collect_refs(search):
+      try:
+        return candidates.update(self._iter_refs(user, repo, search))
+      except self.FetchError as e:
+        errors.append(e)
+
+    collect_refs('refs/tags')
+    highest_compatible = self._select_highest_compatible(candidates, raw_rev)
+    if highest_compatible:
+      return highest_compatible
+
+    collect_refs('refs/heads')
+    highest_compatible = self._select_highest_compatible(candidates, raw_rev)
+    if highest_compatible:
+      return highest_compatible
+
+    if len(errors) == 2:
+      raise self.ApiError('Failed to fetch both tags and branches:\n\t{}\n\t{}'
+                          .format(errors[0], errors[1]))
+    elif not candidates:
+      raise self.NoVersionsError('Found no tags or branches for github.com/{user}/{repo} - this '
+                                 'is unexpected.'.format(user=user, repo=repo))
+    elif errors:
+      raise self.FetchError('Found no tag or branch for github.com/{user}/{repo} to match {rev}, '
+                            'but encountered an error while searching:\n\t{}', errors.pop())
+    else:
+      raise self.NoMatchingVersionError('Found no tags or branches for github.com/{user}/{repo} '
+                                        'compatible with {rev} amongst these refs:\n\t{refs}'
+                                        .format(user=user, repo=repo, rev=raw_rev,
+                                                refs='\n\t'.join(sorted(candidates))))
+
+  # VisibleForTesting
+  def _do_get(self, url):
+    res = self._fetcher.session().get(url)
+    if res.status_code != requests.codes.ok:
+      raise self.FetchError('Failed to scan for the highest compatible version of {} ({} error)'
+                            .format(url, res.status_code))
+    return res.json()
+
+  def _do_get_json(self, url):
+    try:
+      return self._do_get(url)
+    except requests.RequestException as e:
+      raise self.FetchError('Failed to scan for the highest compatible version of {} ({} error)'
+                            .format(url, e))
+
+  def _iter_refs(self, user, repo, search):
+    # See: https://developer.github.com/v3/git/refs/#get-all-references
+    # https://api.github.com/repos/{user}/{repo}/git/refs/tags
+    # https://api.github.com/repos/{user}/{repo}/git/refs/heads
+    # [{"ref": "refs/heads/v1", ...}, ...]
+    url = ('https://api.github.com/repos/{user}/{repo}/git/{search}'
+           .format(user=user, repo=repo, search=search))
+
+    json = self._do_get_json(url)
+    for ref in json:
+      ref_name = ref.get('ref')
+      if ref_name:
+        components = ref_name.split(search + '/', 1)
+        if len(components) == 2:
+          prefix, raw_ref = components
+          yield raw_ref
+
+  def _select_highest_compatible(self, candidates, raw_rev):
+    prefix = raw_rev + '.'
+    matches = []
+    for candidate in candidates:
+      if candidate == raw_rev:
+        matches.append(((0, 0), candidate))
+      elif candidate.startswith(prefix):
+        rest = candidate[len(prefix):]
+        xs = rest.split('.', 1)
+        try:
+          matches.append(((int(xs[0]), (0 if len(xs) == 1 else int(xs[1]))),
+                          candidate))
+        except ValueError:
+          pass
+    if not matches:
+      return None
+    else:
+      _, candidate = max(matches, key=lambda t: t[0])
+      return candidate
+
+
 # All builtin fetchers should be advertised and registered as defaults here, 1st advertise,
 # then register:
+Fetchers.advertise(GopkgInFetcher, namespace='')
+Fetchers._register_default(r'^gopkg\.in/.*$', GopkgInFetcher)
+
 Fetchers.advertise(ArchiveFetcher, namespace='')
-Fetchers._register_default(r'github.com/.*', ArchiveFetcher)
+Fetchers._register_default(r'^bitbucket\.org/.*$', ArchiveFetcher)
+Fetchers._register_default(r'^github\.com/.*$', ArchiveFetcher)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
@@ -116,6 +116,8 @@ class GoFetch(GoTask):
           # canonical owner target for the fetched files that 'child' targets (subpackages) can
           # depend on and share the fetch from.
           dest_dir = os.path.join(gopath, 'src', root)
+          # We may have been `invalidate`d and not `clean-all`ed so we need a new empty symlink
+          # chroot to avoid collision; thus `clean=True`.
           safe_mkdir(dest_dir, clean=True)
           for path in os.listdir(root_dir):
             os.symlink(os.path.join(root_dir, path), os.path.join(dest_dir, path))

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -25,6 +25,8 @@ class GoTest(GoWorkspaceTask):
   @classmethod
   def register_options(cls, register):
     super(GoTest, cls).register_options(register)
+    register('--remote', action='store_true',
+             help='Enables running tests found in go_remote_libraries.')
     register('--build-and-test-flags', default='',
              help='Flags to pass in to `go test` tool.')
 
@@ -35,7 +37,9 @@ class GoTest(GoWorkspaceTask):
   def execute(self):
     # Only executes the tests from the package specified by the target roots, so
     # we don't run the tests for _all_ dependencies of said package.
-    for target in filter(self.is_local_src, self.context.target_roots):
+    targets = filter(self.is_go if self.get_options().remote else self.is_local_src,
+                     self.context.target_roots)
+    for target in targets:
       self.ensure_workspace(target)
       self._go_test(target)
 

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -4,7 +4,7 @@
 target(
   name='subsystems',
   dependencies=[
-    ':fetchers'
+    ':fetchers',
     ':go_distribution',
   ]
 )

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -4,7 +4,20 @@
 target(
   name='subsystems',
   dependencies=[
+    ':fetchers'
     ':go_distribution',
+  ]
+)
+
+python_tests(
+  name='fetchers',
+  sources=['test_fetchers.py'],
+  dependencies=[
+    '3rdparty/python:mock',
+    '3rdparty/python:requests',
+    'contrib/go/src/python/pants/contrib/go/subsystems:fetchers',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
 

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
@@ -1,0 +1,129 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+from contextlib import contextmanager
+
+import mock
+import requests
+from pants.util.contextutil import temporary_dir
+from pants_test.subsystem.subsystem_util import subsystem_instance
+
+from pants.contrib.go.subsystems.fetchers import Fetchers, GopkgInFetcher
+
+
+class FetchersTest(unittest.TestCase):
+  # TODO(John Sirois): Add more tests of the Fetches subsystem: advertisement and aliasing as part
+  # of: https://github.com/pantsbuild/pants/issues/2018
+
+  @contextmanager
+  def fetcher(self, import_path):
+    with subsystem_instance(Fetchers) as fetchers:
+      yield fetchers.get_fetcher(import_path)
+
+  def check_unmapped(self, import_path):
+    with self.assertRaises(Fetchers.UnfetchableRemote):
+      with self.fetcher(import_path):
+        self.fail('Expected get_fetcher to raise.')
+
+  def test_default_unmapped(self):
+    self.check_unmapped('')
+    self.check_unmapped('https://github.com')
+    self.check_unmapped('api.github.com')
+
+  def check_default(self, import_path, expected_root):
+    with self.fetcher(import_path) as fetcher:
+      self.assertEqual(expected_root, fetcher.root(import_path))
+
+  def test_default_bitbucket(self):
+    self.check_default('bitbucket.org/rj/sqlite3-go',
+                       expected_root='bitbucket.org/rj/sqlite3-go')
+    self.check_default('bitbucket.org/neuronicnobody/go-opencv/opencv',
+                       expected_root='bitbucket.org/neuronicnobody/go-opencv')
+
+  def test_default_github(self):
+    self.check_default('github.com/bitly/go-simplejson',
+                       expected_root='github.com/bitly/go-simplejson')
+    self.check_default('github.com/docker/docker/daemon/events',
+                       expected_root='github.com/docker/docker')
+
+  def test_default_gopkg(self):
+    self.check_default('gopkg.in/check.v1', expected_root='gopkg.in/check.v1')
+
+
+class GopkgInFetcherTest(unittest.TestCase):
+
+  def do_fetch(self, import_path, github_api_responses, expected_fetch=None):
+    # Simulate a series of github api calls to list refs for the given import paths.
+    # Optionally asserts an expected fetch call to the underlying fetcher.
+    with subsystem_instance(GopkgInFetcher) as fetcher:
+      fetcher._do_get = mock.Mock(spec=fetcher._do_get)
+      fetcher._do_get.side_effect = github_api_responses
+      fetcher._do_fetch = mock.Mock(spec=fetcher._do_fetch)
+      with temporary_dir() as dest:
+        fetcher.fetch(import_path, dest)
+      if expected_fetch:
+        expected_url, expected_rev = expected_fetch
+        fetcher._do_fetch.assert_called_once_with(expected_url, dest, expected_rev)
+
+  def test_no_tags_or_branches(self):
+    with self.assertRaises(GopkgInFetcher.NoVersionsError):
+      self.do_fetch('gopkg.in/check.v1', [], [])
+
+  def test_invalid_tags_or_branches(self):
+    with self.assertRaises(GopkgInFetcher.NoMatchingVersionError):
+      self.do_fetch('gopkg.in/check.v1', github_api_responses=([{'ref': 'refs/tags/v1BAD'},
+                                                                {'ref': 'refs/tags/v1.BAD'}],
+                                                               [{'ref': 'refs/heads/v1WORSE'},
+                                                                {'ref': 'refs/heads/v1.WORSE'},
+                                                                {'ref': 'refs/heads/v1.W.O.R'},
+                                                                {'ref': 'refs/heads/v1.W.2'}]))
+
+  def test_no_tags_or_branches_one_error(self):
+    with self.assertRaises(GopkgInFetcher.FetchError):
+      self.do_fetch('gopkg.in/check.v1', github_api_responses=([], requests.RequestException()))
+
+    with self.assertRaises(GopkgInFetcher.FetchError):
+      self.do_fetch('gopkg.in/check.v1', github_api_responses=(requests.RequestException(), []))
+
+  def test_no_tags_or_branches_two_errors(self):
+    with self.assertRaises(GopkgInFetcher.ApiError):
+      self.do_fetch('gopkg.in/check.v1', github_api_responses=(requests.RequestException(),
+                                                               requests.RequestException()))
+
+  def test_tag_match_exact(self):
+    self.do_fetch('gopkg.in/check.v1', github_api_responses=([{'ref': 'refs/tags/v1'}], []))
+
+  def test_tag_match_major_beats_minor(self):
+    self.do_fetch('gopkg.in/check.v1',
+                  github_api_responses=([{'ref': 'refs/tags/v1'},
+                                         {'ref': 'refs/tags/v1.1'},
+                                         {'ref': 'refs/tags/v1.0.1'}],
+                                        []),
+                  expected_fetch=('github.com/go-check/check', 'v1.1'))
+
+  def test_tag_match_short_circuits(self):
+    no_branches_call = AssertionError('Expected tag match to short circuit branches api call')
+    self.do_fetch('gopkg.in/check.v1',
+                  github_api_responses=([{'ref': 'refs/tags/v1.5'}], no_branches_call))
+
+  def test_branch_match_exact(self):
+    self.do_fetch('gopkg.in/check.v1', github_api_responses=([], [{'ref': 'refs/heads/v1'}]))
+
+  def test_branch_match_major_beats_minor(self):
+    self.do_fetch('gopkg.in/check.v1',
+                  github_api_responses=([],
+                                        [{'ref': 'refs/heads/v1'},
+                                         {'ref': 'refs/heads/v1.1'},
+                                         {'ref': 'refs/heads/v1.0.1'}]),
+                  expected_fetch=('github.com/go-check/check', 'v1.1'))
+
+  def test_branch_match_fall_through(self):
+    self.do_fetch('gopkg.in/check.v1',
+                  github_api_responses=([{'ref': 'refs/tags/v2'}],  # non-matching tag
+                                        [{'ref': 'refs/heads/v1.2.3'}]),
+                  expected_fetch=('github.com/go-check/check', 'v1.2.3'))

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch_integration.py
@@ -30,3 +30,17 @@ class GoFetchIntegrationTest(PantsRunIntegrationTest):
             'contrib/go/examples/3rdparty/go/github.com/AdRoll/goamz:dynamodb']
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
+
+  def test_issues2004(self):
+    # The target used here has test imports outside those used by the source code it tests (that
+    # code only depends on the stdlib).  These must be resolved for the test to be compiled and run:
+    #
+    # github.com/bitly/go-simplejson
+    # -> github.com/bmizerany/assert (testing)
+    #    -> github.com/kr/pretty (testing)
+    #       -> github.com/kr/text (testing)
+    args = ['test.go',
+            '--remote'
+            'contrib/go/examples/3rdparty/go/github.com/bitly/go-simplejson']
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch_integration.py
@@ -40,7 +40,7 @@ class GoFetchIntegrationTest(PantsRunIntegrationTest):
     #    -> github.com/kr/pretty (testing)
     #       -> github.com/kr/text (testing)
     args = ['test.go',
-            '--remote'
+            '--remote',
             'contrib/go/examples/3rdparty/go/github.com/bitly/go-simplejson']
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -59,7 +59,7 @@ function pkg_go_install_test() {
   execute_packaged_pants_with_internal_backends \
     "extra_bootstrap_buildfiles='${ROOT}/contrib/go/BUILD'" \
       --plugins="['pantsbuild.pants.contrib.go==$(local_version)']" \
-      compile.go contrib/go/examples::
+      test.go contrib/go/examples::
 }
 
 # Once individual (new) package is declared above, insert it into the array below)


### PR DESCRIPTION
This necessitated adding support for the gopkg.in fetch protocol.

Add a flag to turn on testing of remote libraries and use that to
create an integration test for #2004.