### PR TITLE
Created DistributionSubsystem with jvm-distribution option-space.

### DIFF
--- a/src/python/pants/backend/android/tasks/sign_apk.py
+++ b/src/python/pants/backend/android/tasks/sign_apk.py
@@ -15,7 +15,7 @@ from pants.backend.android.targets.android_binary import AndroidBinary
 from pants.backend.core.tasks.task import Task
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.util.dirutil import safe_mkdir
 
 
@@ -88,9 +88,9 @@ class SignApkTask(Task):
   def distribution(self):
     if self._dist is None:
       # Currently no Java 8 for Android. I considered max=1.7.0_50. See comment in _render_args().
-      self._dist = Distribution.cached(minimum_version='1.6.0_00',
-                                       maximum_version='1.7.0_99',
-                                       jdk=True)
+      self._dist = DistributionLocator.cached(minimum_version='1.6.0_00',
+                                              maximum_version='1.7.0_99',
+                                              jdk=True)
     return self._dist
 
   def _render_args(self, target, key, unsigned_apk, outdir):

--- a/src/python/pants/backend/codegen/tasks/jaxb_gen.py
+++ b/src/python/pants/backend/codegen/tasks/jaxb_gen.py
@@ -15,7 +15,7 @@ from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.util.dirutil import safe_mkdir
 
 
@@ -34,7 +34,7 @@ class JaxbGen(SimpleCodegenTask, NailgunTask):
       self.gen_langs.add(lang)
 
   def _compile_schema(self, args):
-    classpath = Distribution.cached(jdk=True).find_libs(['tools.jar'])
+    classpath = DistributionLocator.cached(jdk=True).find_libs(['tools.jar'])
     java_main = 'com.sun.tools.internal.xjc.Driver'
     return self.runjava(classpath=classpath, main=java_main, args=args, workunit_name='xjc')
 

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -29,7 +29,6 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/util:strutil',
-    'src/python/pants/util:osutil',
   ],
 )
 

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -6,12 +6,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-import os
 
-from pants.option.custom_types import dict_option, list_option
+from pants.option.custom_types import list_option
 from pants.subsystem.subsystem import Subsystem
-from pants.util.memo import memoized_property
-from pants.util.osutil import OS_ALIASES, normalize_os_name
 from pants.util.strutil import safe_shlex_split
 
 
@@ -41,37 +38,6 @@ class JVM(Subsystem):
              ],
              help='The JVM remote-debugging arguments. {debug_port} will be replaced with '
                   'the value of the --debug-port option.')
-    human_readable_os_aliases = ', '.join('{}: [{}]'.format(str(key), ', '.join(sorted(val)))
-                                         for key, val in OS_ALIASES.items())
-    register('--jdk-paths', advanced=True, recursive=True, type=dict_option,
-             help='Map of os names to lists of paths to jdks. These paths will be searched before '
-                  'everything else (before the JDK_HOME, JAVA_HOME, PATH environment variables) '
-                  'when locating a jvm to use. The same OS can be specified via several different '
-                  'aliases, according to this map: {}'.format(human_readable_os_aliases))
-
-  @memoized_property
-  def _normalized_jdk_paths(self):
-    jdk_paths = self.get_options().jdk_paths or {}
-    normalized = {}
-    for name, paths in sorted(jdk_paths.items()):
-      rename = normalize_os_name(name)
-      if rename in normalized:
-        logger.warning('Multiple OS names alias to "{}"; combining results.'.format(rename))
-        normalized[rename].extend(paths)
-      else:
-        normalized[rename] = paths
-    return normalized
-
-  def get_jdk_paths(self, os_name=None):
-    jdk_paths = self._normalized_jdk_paths
-    if not jdk_paths:
-      return ()
-    if os_name is None:
-      os_name = os.uname()[0].lower()
-    os_name = normalize_os_name(os_name)
-    if os_name not in jdk_paths:
-      logger.warning('--jvm-jdk-paths was specified, but has no entry for "{}".'.format(os_name))
-    return jdk_paths.get(os_name, ())
 
   def get_jvm_options(self):
     """Return the options to run this JVM with.

--- a/src/python/pants/backend/jvm/subsystems/jvm_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_platform.py
@@ -9,7 +9,7 @@ import logging
 
 from pants.base.exceptions import TaskError
 from pants.base.revision import Revision
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.option.custom_types import dict_option
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
@@ -61,6 +61,10 @@ class JvmPlatform(Subsystem):
     register('--default-platform', advanced=True, type=str, default=None, fingerprint=True,
              help='Name of the default platform to use if none are specified.')
 
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JvmPlatform, cls).subsystem_dependencies() + (DistributionLocator,)
+
   def _parse_platform(self, name, platform):
     return JvmPlatformSettings(platform.get('source', platform.get('target')),
                                platform.get('target', platform.get('source')),
@@ -75,9 +79,9 @@ class JvmPlatform(Subsystem):
   @property
   def _fallback_platform(self):
     logger.warn('No default jvm platform is defined.')
-    source_level = JvmPlatform.parse_java_version(Distribution.cached().version)
+    source_level = JvmPlatform.parse_java_version(DistributionLocator.cached().version)
     target_level = source_level
-    platform_name = '(Distribution.cached().version {})'.format(source_level)
+    platform_name = '(DistributionLocator.cached().version {})'.format(source_level)
     return JvmPlatformSettings(source_level, target_level, [], name=platform_name)
 
   @memoized_property

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -56,7 +56,7 @@ class JvmTarget(Target, Jarable):
       for compilation (that is, a key into the --jvm-platform-platforms dictionary). If unspecified,
       the platform will default to the first one of these that exist: (1) the default_platform
       specified for jvm-platform, (2) a platform constructed from whatever java version is returned
-      by Distribution.cached().version.
+      by DistributionLocator.cached().version.
     """
     self.address = address  # Set in case a TargetDefinitionException is thrown early
     if sources_rel_path is None:

--- a/src/python/pants/backend/jvm/tasks/javadoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/javadoc_gen.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.jvm.tasks.jvmdoc_gen import Jvmdoc, JvmdocGen
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.util.memo import memoized
 
@@ -16,6 +16,10 @@ class JavadocGen(JvmdocGen):
   @memoized
   def jvmdoc(cls):
     return Jvmdoc(tool_name='javadoc', product_type='javadoc')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JavadocGen, cls).subsystem_dependencies() + (DistributionLocator,)
 
   def execute(self):
     def is_java(target):
@@ -32,7 +36,7 @@ class JavadocGen(JvmdocGen):
       return None
 
     # Without a JDK/tools.jar we have no javadoc tool and cannot proceed, so check/acquire early.
-    jdk = Distribution.cached(jdk=True)
+    jdk = DistributionLocator.cached(jdk=True)
     tool_classpath = jdk.find_libs(['tools.jar'])
 
     args = ['-quiet',

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -23,7 +23,7 @@ from pants.base.exceptions import TargetDefinitionException, TaskError, TestFail
 from pants.base.revision import Revision
 from pants.base.workunit import WorkUnitLabel
 from pants.binaries import binary_util
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.java.jar.shader import Shader
 from pants.java.util import execute_java
 from pants.util.contextutil import temporary_file_path
@@ -276,10 +276,10 @@ class _JUnitRunner(object):
         complete_classpath.update(classpath_append)
         if self._strict_jvm_version:
           max_version = Revision(*(platform.target_level.components + [9999]))
-          distribution = Distribution.cached(minimum_version=platform.target_level,
-                                             maximum_version=max_version)
+          distribution = DistributionLocator.cached(minimum_version=platform.target_level,
+                                                    maximum_version=max_version)
         else:
-          distribution = Distribution.cached(minimum_version=platform.target_level)
+          distribution = DistributionLocator.cached(minimum_version=platform.target_level)
         with binary_util.safe_args(batch, self._task_exports.task_options) as batch_tests:
           self._context.log.debug('CWD = {}'.format(workdir))
           self._context.log.debug('platform = {}'.format(platform))
@@ -749,6 +749,10 @@ class JUnitRun(JvmToolTaskMixin, JvmTask):
     register('--coverage', action='store_true', help='Collect code coverage data.')
     register('--coverage-processor', advanced=True, default='emma',
              help='Which coverage subsystem to use.')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JUnitRun, cls).subsystem_dependencies() + (DistributionLocator,)
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/java/java_compile.py
@@ -14,6 +14,7 @@ from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
+from pants.java.distribution.distribution import DistributionLocator
 from pants.util.dirutil import relativize_paths, safe_mkdir
 
 
@@ -78,6 +79,10 @@ class JmakeCompile(JvmCompile):
     cls.register_jvm_tool(register, 'jmake')
     cls.register_jvm_tool(register, 'java-compiler')
 
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JmakeCompile, cls).subsystem_dependencies() + (DistributionLocator,)
+
   def select(self, target):
     return self.get_options().use_jmake and super(JmakeCompile, self).select(target)
 
@@ -99,7 +104,8 @@ class JmakeCompile(JvmCompile):
     return os.path.join(self._depfile_folder, 'global_depfile')
 
   def create_analysis_tools(self):
-    return AnalysisTools(self.context.java_home, JMakeAnalysisParser(), JMakeAnalysis)
+    return AnalysisTools(DistributionLocator.cached().real_home, JMakeAnalysisParser(),
+                         JMakeAnalysis)
 
   def compile(self, args, classpath, sources, classes_output_dir, upstream_analysis, analysis_file,
               log_file, settings):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_global_strategy.py
@@ -23,6 +23,7 @@ from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.exceptions import TaskError
 from pants.base.target import Target
 from pants.base.worker_pool import Work
+from pants.java.distribution.distribution import DistributionLocator
 from pants.option.custom_types import list_option
 from pants.util.contextutil import open_zip, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_walk
@@ -700,7 +701,7 @@ class JvmCompileGlobalStrategy(JvmCompileStrategy):
 
   def _find_all_bootstrap_jars(self):
     def get_path(key):
-      return self.context.java_sysprops.get(key, '').split(':')
+      return DistributionLocator.cached().system_properties.get(key, '').split(':')
 
     def find_jars_in_dirs(dirs):
       ret = []

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_dependency_analyzer.py
@@ -17,6 +17,7 @@ from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.base.build_environment import get_buildroot
 from pants.base.build_graph import sort_targets
 from pants.base.exceptions import TaskError
+from pants.java.distribution.distribution import DistributionLocator
 
 
 class JvmDependencyAnalyzer(object):
@@ -219,7 +220,7 @@ class JvmDependencyAnalyzer(object):
     def must_be_explicit_dep(dep):
       # We don't require explicit deps on the java runtime, so we shouldn't consider that
       # a missing dep.
-      return not dep.startswith(self._context.java_home)
+      return not dep.startswith(DistributionLocator.cached().real_home)
 
     def target_or_java_dep_in_targets(target, targets):
       # We want to check if the target is in the targets collection

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -8,11 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.core.tasks.task import Task, TaskBase
-from pants.backend.jvm.subsystems.jvm import JVM
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.exceptions import TaskError
 from pants.java import util
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.java.nailgun_executor import NailgunExecutor, NailgunProcessGroup
 
@@ -33,10 +32,7 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
 
   @classmethod
   def global_subsystems(cls):
-    # TODO(gmalmquist): JVM subsystem dependency is required because Distribution queries it for
-    # jdk_paths when locating a jvm. Distribution should be refactored to be its own subsystem
-    # which depends on JVM, then NailgunTaskBase can depend on Distribution.
-    return super(NailgunTaskBase, cls).global_subsystems() + (JVM,)
+    return super(NailgunTaskBase, cls).global_subsystems() + (DistributionLocator,)
 
   def __init__(self, *args, **kwargs):
     super(NailgunTaskBase, self).__init__(*args, **kwargs)
@@ -51,9 +47,9 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
 
   def set_distribution(self, minimum_version=None, maximum_version=None, jdk=False):
     try:
-      self._dist = Distribution.cached(minimum_version=minimum_version,
-                                       maximum_version=maximum_version, jdk=jdk)
-    except Distribution.Error as e:
+      self._dist = DistributionLocator.cached(minimum_version=minimum_version,
+                                              maximum_version=maximum_version, jdk=jdk)
+    except DistributionLocator.Error as e:
       raise TaskError(e)
 
   def create_java_executor(self):

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -20,7 +20,6 @@ from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnitLabel
 from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
-from pants.java.distribution.distribution import Distribution
 from pants.process.pidlock import OwnerPrintingPIDLockFile
 from pants.reporting.report import Report
 
@@ -121,28 +120,6 @@ class Context(object):
   def workspace(self):
     """Returns the current workspace, if any."""
     return self._workspace
-
-  @property
-  def java_sysprops(self):
-    """The system properties of the JVM we use."""
-    # TODO: In the future we can use these to hermeticize the Java enivronment rather than relying
-    # on whatever's on the shell's PATH. E.g., you either specify a path to the Java home via a
-    # cmd-line flag or .pantsrc, or we infer one from java.home but verify that the java.version
-    # is a supported version.
-    if self._java_sysprops is None:
-      # TODO(John Sirois): Plumb a sane default distribution through 1 point of control
-      self._java_sysprops = Distribution.cached().system_properties
-    return self._java_sysprops
-
-  @property
-  def java_home(self):
-    """Find the java home for the JVM we use."""
-    # Implementation is a kind-of-insane hack: we run the jvm to get it to emit its
-    # system properties. On some platforms there are so many hard and symbolic links into
-    # the JRE dirs that it's actually quite hard to establish what path to use as the java home,
-    # e.g., for the purpose of rebasing. In practice, this seems to work fine.
-    # Note that for our purposes we take the parent of java.home.
-    return os.path.realpath(os.path.dirname(self.java_sysprops['java.home']))
 
   @property
   def spec_excludes(self):

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -7,8 +7,9 @@ python_library(
   resources = globs('*.class'),
   dependencies = [
     '3rdparty/python:six',
-    'src/python/pants/backend/jvm/subsystems:jvm',
     'src/python/pants/base:revision',
+    'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
-  ]
+    'src/python/pants/util:osutil',
+  ],
 )

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -15,17 +15,17 @@ from contextlib import contextmanager
 
 from six import string_types
 
-from pants.backend.jvm.subsystems.jvm import JVM
 from pants.base.revision import Revision
-from pants.subsystem.subsystem import SubsystemError
+from pants.option.custom_types import dict_option
+from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_dir
+from pants.util.memo import memoized_property
+from pants.util.osutil import OS_ALIASES, normalize_os_name
 
 
 logger = logging.getLogger(__name__)
 
 
-# TODO(gmalmquist): Make Distribution a subsystem that depends on JVM.
-# (see discussion on https://rbcommons.com/s/twitter/r/2657/)
 class Distribution(object):
   """Represents a java distribution - either a JRE or a JDK installed on the local system.
 
@@ -36,148 +36,6 @@ class Distribution(object):
 
   class Error(Exception):
     """Indicates an invalid java distribution."""
-
-  _CACHE = {}
-
-  @classmethod
-  def cached(cls, minimum_version=None, maximum_version=None, jdk=False):
-    def scan_constraint_match():
-      # Convert strings to Revision objects for apples-to-apples comparison.
-      max_version = cls._parse_java_version("maximum_version", maximum_version)
-      min_version = cls._parse_java_version("minimum_version", minimum_version)
-
-      for dist in cls._CACHE.values():
-        if min_version and dist.version < min_version:
-          continue
-        if max_version and dist.version > max_version:
-          continue
-        if jdk and not dist.jdk:
-          continue
-        return dist
-
-    key = (minimum_version, maximum_version, jdk)
-    dist = cls._CACHE.get(key)
-    if not dist:
-      dist = scan_constraint_match()
-      if not dist:
-        dist = cls.locate(minimum_version=minimum_version, maximum_version=maximum_version, jdk=jdk)
-      cls._CACHE[key] = dist
-    return dist
-
-  class _Location(namedtuple('Location', ['home_path', 'bin_path'])):
-    """Represents the location of a java distribution."""
-    @classmethod
-    def from_home(cls, home):
-      """Creates a location given the JAVA_HOME directory.
-
-      :param string home: The path of the JAVA_HOME directory.
-      :returns: The java distribution location.
-      """
-      return cls(home_path=home, bin_path=None)
-
-    @classmethod
-    def from_bin(cls, bin_path):
-      """Creates a location given the `java` executable parent directory.
-
-      :param string bin_path: The parent path of the `java` executable.
-      :returns: The java distribution location.
-      """
-      return cls(home_path=None, bin_path=bin_path)
-
-  # The `/usr/lib/jvm` dir is a common target of packages built for redhat and debian as well as
-  # other more exotic distributions.
-  _JAVA_DIST_DIR = '/usr/lib/jvm'
-
-  @classmethod
-  def _linux_java_homes(cls):
-    if os.path.isdir(cls._JAVA_DIST_DIR):
-      for path in os.listdir(cls._JAVA_DIST_DIR):
-        home = os.path.join(cls._JAVA_DIST_DIR, path)
-        if os.path.isdir(home):
-          yield cls._Location.from_home(home)
-
-  _OSX_JAVA_HOME_EXE = '/usr/libexec/java_home'
-
-  @classmethod
-  def _osx_java_homes(cls):
-    # OSX will have a java_home tool that can be used to locate a unix-compatible java home dir.
-    #
-    # See:
-    #   https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/java_home.1.html
-    #
-    # The `--xml` output looks like so:
-    # <?xml version="1.0" encoding="UTF-8"?>
-    # <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    #                        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    # <plist version="1.0">
-    #   <array>
-    #     <dict>
-    #       ...
-    #       <key>JVMHomePath</key>
-    #       <string>/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home</string>
-    #       ...
-    #     </dict>
-    #     ...
-    #   </array>
-    # </plist>
-    if os.path.exists(cls._OSX_JAVA_HOME_EXE):
-      try:
-        plist = subprocess.check_output([cls._OSX_JAVA_HOME_EXE, '--failfast', '--xml'])
-        for distribution in plistlib.readPlistFromString(plist):
-          home = distribution['JVMHomePath']
-          yield cls._Location.from_home(home)
-      except subprocess.CalledProcessError:
-        pass
-
-  @classmethod
-  def locate(cls, minimum_version=None, maximum_version=None, jdk=False):
-    """Finds a java distribution that meets any given constraints and returns it.
-
-    First looks in JDK_HOME and JAVA_HOME if defined falling back to a search on the PATH.
-    Raises Distribution.Error if no suitable java distribution could be found.
-    """
-    def env_home(home_env_var):
-      home = os.environ.get(home_env_var)
-      return cls._Location.from_home(home) if home else None
-
-    def search_path():
-      try:
-        for location in JVM.global_instance().get_jdk_paths():
-          yield cls._Location.from_home(location)
-      except SubsystemError:
-        logger.warning('Java distribution requested before JVM subsystem initialized.')
-        pass
-
-      yield env_home('JDK_HOME')
-      yield env_home('JAVA_HOME')
-
-      for location in cls._linux_java_homes():
-        yield location
-
-      for location in cls._osx_java_homes():
-        yield location
-
-      search_path = os.environ.get('PATH')
-      if search_path:
-        for bin_path in search_path.strip().split(os.pathsep):
-          yield cls._Location.from_bin(bin_path)
-
-    for location in filter(None, search_path()):
-      try:
-        dist = cls(home_path=location.home_path,
-                   bin_path=location.bin_path,
-                   minimum_version=minimum_version,
-                   maximum_version=maximum_version,
-                   jdk=jdk)
-        dist.validate()
-        logger.debug('Located {} for constraints: minimum_version {}, maximum_version {}, jdk {}'
-                     .format(dist, minimum_version, maximum_version, jdk))
-        return dist
-      except (ValueError, cls.Error):
-        pass
-
-    raise cls.Error('Failed to locate a {} distribution with minimum_version {}, maximum_version {}'
-                    .format('JDK' if jdk else 'JRE', minimum_version, maximum_version))
 
   @staticmethod
   def _parse_java_version(name, version):
@@ -224,9 +82,7 @@ class Distribution(object):
 
     self._minimum_version = self._parse_java_version("minimum_version", minimum_version)
     self._maximum_version = self._parse_java_version("maximum_version", maximum_version)
-
     self._jdk = jdk
-
     self._is_jdk = False
     self._system_properties = None
     self._version = None
@@ -291,6 +147,11 @@ class Distribution(object):
           home = jdk_dir
       self._home = home
     return self._home
+
+  @property
+  def real_home(self):
+    """Real path to the distribution java.home (resolving links)."""
+    return os.path.realpath(self.home)
 
   @property
   def java(self):
@@ -406,3 +267,208 @@ class Distribution(object):
   def __repr__(self):
     return ('Distribution({!r}, minimum_version={!r}, maximum_version={!r} jdk={!r})'.format(
             self._bin_path, self._minimum_version, self._maximum_version, self._jdk))
+
+
+class DistributionLocator(Subsystem):
+  """Subsystem that knows how to look up a java Distribution."""
+
+  class Error(Distribution.Error):
+    """Error locating a java distribution."""
+
+  class _Location(namedtuple('Location', ['home_path', 'bin_path'])):
+    """Represents the location of a java distribution."""
+    @classmethod
+    def from_home(cls, home):
+      """Creates a location given the JAVA_HOME directory.
+
+      :param string home: The path of the JAVA_HOME directory.
+      :returns: The java distribution location.
+      """
+      return cls(home_path=home, bin_path=None)
+
+    @classmethod
+    def from_bin(cls, bin_path):
+      """Creates a location given the `java` executable parent directory.
+
+      :param string bin_path: The parent path of the `java` executable.
+      :returns: The java distribution location.
+      """
+      return cls(home_path=None, bin_path=bin_path)
+
+  options_scope = 'jvm-distributions'
+  _CACHE = {}
+  # The `/usr/lib/jvm` dir is a common target of packages built for redhat and debian as well as
+  # other more exotic distributions.
+  _JAVA_DIST_DIR = '/usr/lib/jvm'
+  _OSX_JAVA_HOME_EXE = '/usr/libexec/java_home'
+
+  @classmethod
+  def register_options(cls, register):
+    super(DistributionLocator, cls).register_options(register)
+    human_readable_os_aliases = ', '.join('{}: [{}]'.format(str(key), ', '.join(sorted(val)))
+                                          for key, val in OS_ALIASES.items())
+    register('--paths', advanced=True, recursive=True, type=dict_option,
+             help='Map of os names to lists of paths to jdks. These paths will be searched before '
+                  'everything else (before the JDK_HOME, JAVA_HOME, PATH environment variables) '
+                  'when locating a jvm to use. The same OS can be specified via several different '
+                  'aliases, according to this map: {}'.format(human_readable_os_aliases))
+
+  @memoized_property
+  def _normalized_jdk_paths(self):
+    jdk_paths = self.get_options().paths or {}
+    normalized = {}
+    for name, paths in sorted(jdk_paths.items()):
+      rename = normalize_os_name(name)
+      if rename in normalized:
+        logger.warning('Multiple OS names alias to "{}"; combining results.'.format(rename))
+        normalized[rename].extend(paths)
+      else:
+        normalized[rename] = paths
+    return normalized
+
+  def get_jdk_paths(self, os_name=None):
+    jdk_paths = self._normalized_jdk_paths
+    if not jdk_paths:
+      return ()
+    if os_name is None:
+      os_name = os.uname()[0].lower()
+    os_name = normalize_os_name(os_name)
+    if os_name not in jdk_paths:
+      logger.warning('--jvm-distributions-paths was specified, but has no entry for "{}".'
+                     .format(os_name))
+    return jdk_paths.get(os_name, ())
+
+  @classmethod
+  def java_path_locations(cls):
+    for location in cls.global_instance().get_jdk_paths():
+      yield cls._Location.from_home(location)
+
+  @classmethod
+  def cached(cls, minimum_version=None, maximum_version=None, jdk=False):
+    """Finds a java distribution that meets the given constraints and returns it.
+
+    First looks for a cached version that was previously located, otherwise calls locate().
+    :param minimum_version: minimum jvm version to look for (eg, 1.7).
+    :param maximum_version: maximum jvm version to look for (eg, 1.7.9999).
+    :param bool jdk: whether the found java distribution is required to have a jdk.
+    :return: the Distribution.
+    :rtype: :class:`pants.java.distribution.Distribution`
+    """
+    def scan_constraint_match():
+      # Convert strings to Revision objects for apples-to-apples comparison.
+      max_version = Distribution._parse_java_version("maximum_version", maximum_version)
+      min_version = Distribution._parse_java_version("minimum_version", minimum_version)
+
+      for dist in cls._CACHE.values():
+        if min_version and dist.version < min_version:
+          continue
+        if max_version and dist.version > max_version:
+          continue
+        if jdk and not dist.jdk:
+          continue
+        return dist
+
+    key = (minimum_version, maximum_version, jdk)
+    dist = cls._CACHE.get(key)
+    if not dist:
+      dist = scan_constraint_match()
+      if not dist:
+        dist = cls.locate(minimum_version=minimum_version, maximum_version=maximum_version, jdk=jdk)
+      cls._CACHE[key] = dist
+    return dist
+
+  @classmethod
+  def locate(cls, minimum_version=None, maximum_version=None, jdk=False):
+    """Finds a java distribution that meets any given constraints and returns it.
+
+    First looks through the paths listed for this operating system in the --jvm-distributions-paths
+    map. Then looks in JDK_HOME and JAVA_HOME if defined, falling back to a search on the PATH.
+    Raises Distribution.Error if no suitable java distribution could be found.
+    :param minimum_version: minimum jvm version to look for (eg, 1.7).
+    :param maximum_version: maximum jvm version to look for (eg, 1.7.9999).
+    :param bool jdk: whether the found java distribution is required to have a jdk.
+    :return: the located Distribution.
+    :rtype: :class:`pants.java.distribution.Distribution`
+    """
+    def search_path():
+      for location in cls.global_instance().java_path_locations():
+        yield location
+
+      for location in cls.environment_jvm_locations():
+        yield location
+
+    for location in filter(None, search_path()):
+      try:
+        dist = Distribution(home_path=location.home_path,
+                            bin_path=location.bin_path,
+                            minimum_version=minimum_version,
+                            maximum_version=maximum_version,
+                            jdk=jdk)
+        dist.validate()
+        logger.debug('Located {} for constraints: minimum_version {}, maximum_version {}, jdk {}'
+                     .format(dist, minimum_version, maximum_version, jdk))
+        return dist
+      except (ValueError, Distribution.Error):
+        pass
+
+    raise cls.Error('Failed to locate a {} distribution with minimum_version {}, maximum_version {}'
+                    .format('JDK' if jdk else 'JRE', minimum_version, maximum_version))
+
+  @classmethod
+  def _linux_java_homes(cls):
+    if os.path.isdir(cls._JAVA_DIST_DIR):
+      for path in os.listdir(cls._JAVA_DIST_DIR):
+        home = os.path.join(cls._JAVA_DIST_DIR, path)
+        if os.path.isdir(home):
+          yield cls._Location.from_home(home)
+
+  @classmethod
+  def _osx_java_homes(cls):
+    # OSX will have a java_home tool that can be used to locate a unix-compatible java home dir.
+    #
+    # See:
+    #   https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/java_home.1.html
+    #
+    # The `--xml` output looks like so:
+    # <?xml version="1.0" encoding="UTF-8"?>
+    # <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    #                        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    # <plist version="1.0">
+    #   <array>
+    #     <dict>
+    #       ...
+    #       <key>JVMHomePath</key>
+    #       <string>/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home</string>
+    #       ...
+    #     </dict>
+    #     ...
+    #   </array>
+    # </plist>
+    if os.path.exists(cls._OSX_JAVA_HOME_EXE):
+      try:
+        plist = subprocess.check_output([cls._OSX_JAVA_HOME_EXE, '--failfast', '--xml'])
+        for distribution in plistlib.readPlistFromString(plist):
+          home = distribution['JVMHomePath']
+          yield cls._Location.from_home(home)
+      except subprocess.CalledProcessError:
+        pass
+
+  @classmethod
+  def environment_jvm_locations(cls):
+    def env_home(home_env_var):
+      home = os.environ.get(home_env_var)
+      return cls._Location.from_home(home) if home else None
+
+    yield env_home('JDK_HOME')
+    yield env_home('JAVA_HOME')
+
+    for location in cls._linux_java_homes():
+      yield location
+
+    for location in cls._osx_java_homes():
+      yield location
+
+    search_path = os.environ.get('PATH')
+    if search_path:
+      for bin_path in search_path.strip().split(os.pathsep):
+        yield cls._Location.from_bin(bin_path)

--- a/src/python/pants/java/executor.py
+++ b/src/python/pants/java/executor.py
@@ -15,7 +15,7 @@ from six import string_types
 from twitter.common.collections import maybe_list
 
 from pants.base.build_environment import get_buildroot
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import Distribution, DistributionLocator
 from pants.util.contextutil import environment_as
 from pants.util.dirutil import relativize_paths
 from pants.util.meta import AbstractClass
@@ -78,7 +78,12 @@ class Executor(AbstractClass):
         raise ValueError('A valid distribution is required, given: {}'.format(distribution))
       distribution.validate()
     else:
-      distribution = Distribution.cached()
+      # TODO(gmalmquist): This introduces a dependency on the DistributionLocator subsystem for any
+      # code that uses Executor. This is bad and needs to be fixed -- perhaps by making distribution
+      # a required (rather than optional) argument. Maybe it would also be reasonable for
+      # Distribution to be able to create an executor instance?
+      # See https://github.com/pantsbuild/pants/issues/2056.
+      distribution = DistributionLocator.cached()
 
     self._distribution = distribution
 

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -219,6 +219,7 @@ python_tests(
   dependencies = [
     'src/python/pants/java/distribution',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -19,7 +19,7 @@ from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.goal.products import MultipleRootedProducts
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 from pants_test.subsystem.subsystem_util import subsystem_instance
@@ -85,7 +85,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
     self.create_file(test_java_file_rel_path, content)
 
     # Invoke ivy to resolve classpath for junit.
-    distribution = Distribution.cached(jdk=True)
+    distribution = DistributionLocator.cached(jdk=True)
     executor = SubprocessExecutor(distribution=distribution)
     classpath_file_abs_path = os.path.join(test_abs_path, 'junit.classpath')
     with subsystem_instance(IvySubsystem) as ivy_subsystem:

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -7,16 +7,18 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from unittest import skipIf
 
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
 def missing_jvm(version):
-  try:
-    Distribution.locate(minimum_version=version, maximum_version='{}.9999'.format(version))
-    return False
-  except Distribution.Error:
-    return True
+  with subsystem_instance(DistributionLocator):
+    try:
+      DistributionLocator.locate(minimum_version=version, maximum_version='{}.9999'.format(version))
+      return False
+    except DistributionLocator.Error:
+      return True
 
 
 class JunitRunIntegrationTest(PantsRunIntegrationTest):

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -5,10 +5,11 @@ python_tests(
   name = 'distribution',
   sources = ['test_distribution.py'],
   dependencies = [
-    ':distribution_integration',
     'src/python/pants/base:revision',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'tests/python/pants_test/subsystem:subsystem_utils',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
   ]
 )
 
@@ -19,6 +20,7 @@ python_tests(
     'src/python/pants/java/distribution',
     'src/python/pants/util:osutil',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     '3rdparty/python/twitter/commons:twitter.common.collections',
   ]
 )

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -16,9 +16,10 @@ from contextlib import contextmanager
 from twitter.common.collections import maybe_list
 
 from pants.base.revision import Revision
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import Distribution, DistributionLocator
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import chmod_plus_x, safe_open, safe_rmtree, touch
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
 EXE = namedtuple('Exe', ['relpath', 'contents'])
@@ -40,16 +41,17 @@ def exe(relpath, version=None):
 
 @contextmanager
 def distribution(files=None, executables=None, java_home=None):
-  with temporary_dir() as dist_root:
-    with environment_as(DIST_ROOT=os.path.join(dist_root, java_home) if java_home else dist_root):
-      for f in maybe_list(files or ()):
-        touch(os.path.join(dist_root, f))
-      for executable in maybe_list(executables or (), expected_type=EXE):
-        path = os.path.join(dist_root, executable.relpath)
-        with safe_open(path, 'w') as fp:
-          fp.write(executable.contents or '')
-        chmod_plus_x(path)
-      yield dist_root
+  with subsystem_instance(DistributionLocator):
+    with temporary_dir() as dist_root:
+      with environment_as(DIST_ROOT=os.path.join(dist_root, java_home) if java_home else dist_root):
+        for f in maybe_list(files or ()):
+          touch(os.path.join(dist_root, f))
+        for executable in maybe_list(executables or (), expected_type=EXE):
+          path = os.path.join(dist_root, executable.relpath)
+          with safe_open(path, 'w') as fp:
+            fp.write(executable.contents or '')
+          chmod_plus_x(path)
+        yield dist_root
 
 
 @contextmanager
@@ -152,19 +154,19 @@ class BaseDistributionLocationTest(unittest.TestCase):
     return tmpdir
 
   def set_up_no_linux_discovery(self):
-    orig_java_dist_dir = Distribution._JAVA_DIST_DIR
+    orig_java_dist_dir = DistributionLocator._JAVA_DIST_DIR
 
     def restore_java_dist_dir():
-      Distribution._JAVA_DIST_DIR = orig_java_dist_dir
-    Distribution._JAVA_DIST_DIR = self.make_tmp_dir()
+      DistributionLocator._JAVA_DIST_DIR = orig_java_dist_dir
+    DistributionLocator._JAVA_DIST_DIR = self.make_tmp_dir()
     self.addCleanup(restore_java_dist_dir)
 
   def set_up_no_osx_discovery(self):
-    osx_java_home_exe = Distribution._OSX_JAVA_HOME_EXE
+    osx_java_home_exe = DistributionLocator._OSX_JAVA_HOME_EXE
 
     def restore_osx_java_home_exe():
-      Distribution._OSX_JAVA_HOME_EXE = osx_java_home_exe
-    Distribution._OSX_JAVA_HOME_EXE = os.path.join(self.make_tmp_dir(), 'java_home')
+      DistributionLocator._OSX_JAVA_HOME_EXE = osx_java_home_exe
+    DistributionLocator._OSX_JAVA_HOME_EXE = os.path.join(self.make_tmp_dir(), 'java_home')
     self.addCleanup(restore_osx_java_home_exe)
 
 
@@ -178,84 +180,85 @@ class DistributionEnvLocationTest(BaseDistributionLocationEnvOnlyTest):
   def test_locate_none(self):
     with env():
       with self.assertRaises(Distribution.Error):
-        Distribution.locate()
+        with subsystem_instance(DistributionLocator):
+          DistributionLocator.locate()
 
   def test_locate_java_not_executable(self):
     with distribution(files='bin/java') as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.locate()
+          DistributionLocator.locate()
 
   def test_locate_jdk_is_jre(self):
     with distribution(executables=exe('bin/java')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.locate(jdk=True)
+          DistributionLocator.locate(jdk=True)
 
   def test_locate_version_to_low(self):
     with distribution(executables=exe('bin/java', '1.6.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.locate(minimum_version='1.7.0')
+          DistributionLocator.locate(minimum_version='1.7.0')
 
   def test_locate_version_to_high(self):
     with distribution(executables=exe('bin/java', '1.8.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.locate(maximum_version='1.7.999')
+          DistributionLocator.locate(maximum_version='1.7.999')
 
   def test_locate_invalid_jdk_home(self):
     with distribution(executables=exe('java')) as dist_root:
       with env(JDK_HOME=dist_root):
         with self.assertRaises(Distribution.Error):
-          Distribution.locate()
+          DistributionLocator.locate()
 
   def test_locate_invalid_java_home(self):
     with distribution(executables=exe('java')) as dist_root:
       with env(JAVA_HOME=dist_root):
         with self.assertRaises(Distribution.Error):
-          Distribution.locate()
+          DistributionLocator.locate()
 
   def test_locate_jre_by_path(self):
     with distribution(executables=exe('bin/java')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.locate()
+        DistributionLocator.locate()
 
   def test_locate_jdk_by_path(self):
     with distribution(executables=[exe('bin/java'), exe('bin/javac')]) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.locate(jdk=True)
+        DistributionLocator.locate(jdk=True)
 
   def test_locate_jdk_via_jre_path(self):
     with distribution(executables=[exe('jre/bin/java'), exe('bin/javac')],
                       java_home='jre') as dist_root:
       with env(PATH=os.path.join(dist_root, 'jre', 'bin')):
-        Distribution.locate(jdk=True)
+        DistributionLocator.locate(jdk=True)
 
   def test_locate_version_greater_then_or_equal(self):
     with distribution(executables=exe('bin/java', '1.7.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.locate(minimum_version='1.6.0')
+        DistributionLocator.locate(minimum_version='1.6.0')
 
   def test_locate_version_less_then_or_equal(self):
     with distribution(executables=exe('bin/java', '1.7.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.locate(maximum_version='1.7.999')
+        DistributionLocator.locate(maximum_version='1.7.999')
 
   def test_locate_version_within_range(self):
     with distribution(executables=exe('bin/java', '1.7.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.locate(minimum_version='1.6.0', maximum_version='1.7.999')
+        DistributionLocator.locate(minimum_version='1.6.0', maximum_version='1.7.999')
 
   def test_locate_via_jdk_home(self):
     with distribution(executables=exe('bin/java')) as dist_root:
       with env(JDK_HOME=dist_root):
-        Distribution.locate()
+        DistributionLocator.locate()
 
   def test_locate_via_java_home(self):
     with distribution(executables=exe('bin/java')) as dist_root:
       with env(JAVA_HOME=dist_root):
-        Distribution.locate()
+        DistributionLocator.locate()
 
 
 class DistributionLinuxLocationTest(BaseDistributionLocationTest):
@@ -272,54 +275,54 @@ class DistributionLinuxLocationTest(BaseDistributionLocationTest):
           os.symlink(jdk1_home, jdk1_home_link)
           os.symlink(jdk2_home, jdk2_home_link)
 
-          original_java_dist_dir = Distribution._JAVA_DIST_DIR
-          Distribution._JAVA_DIST_DIR = java_dist_dir
+          original_java_dist_dir = DistributionLocator._JAVA_DIST_DIR
+          DistributionLocator._JAVA_DIST_DIR = java_dist_dir
           try:
             yield jdk1_home_link, jdk2_home_link
           finally:
-            Distribution._JAVA_DIST_DIR = original_java_dist_dir
+            DistributionLocator._JAVA_DIST_DIR = original_java_dist_dir
 
   def test_locate_jdk1(self):
     with env():
       with self.java_dist_dir() as (jdk1_home, _):
-        dist = Distribution.locate(maximum_version='1')
+        dist = DistributionLocator.locate(maximum_version='1')
         self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk2(self):
     with env():
       with self.java_dist_dir() as (_, jdk2_home):
-        dist = Distribution.locate(minimum_version='2')
+        dist = DistributionLocator.locate(minimum_version='2')
         self.assertEqual(jdk2_home, dist.home)
 
   def test_locate_trumps_path(self):
     with self.java_dist_dir() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as path_jdk:
         with env(PATH=os.path.join(path_jdk, 'bin')):
-          dist = Distribution.locate(minimum_version='2')
+          dist = DistributionLocator.locate(minimum_version='2')
           self.assertEqual(jdk2_home, dist.home)
-          dist = Distribution.locate(minimum_version='3')
+          dist = DistributionLocator.locate(minimum_version='3')
           self.assertEqual(path_jdk, dist.home)
 
   def test_locate_jdk_home_trumps(self):
     with self.java_dist_dir() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as jdk_home:
         with env(JDK_HOME=jdk_home):
-          dist = Distribution.locate()
+          dist = DistributionLocator.locate()
           self.assertEqual(jdk_home, dist.home)
-          dist = Distribution.locate(maximum_version='1.1')
+          dist = DistributionLocator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
 
   def test_locate_java_home_trumps(self):
     with self.java_dist_dir() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as java_home:
         with env(JAVA_HOME=java_home):
-          dist = Distribution.locate()
+          dist = DistributionLocator.locate()
           self.assertEqual(java_home, dist.home)
-          dist = Distribution.locate(maximum_version='1.1')
+          dist = DistributionLocator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
 
 
@@ -355,54 +358,54 @@ class DistributionOSXLocationTest(BaseDistributionLocationTest):
               """.format(jdk1_home=jdk1_home, jdk2_home=jdk2_home)).strip())
           chmod_plus_x(osx_java_home_exe)
 
-          original_osx_java_home_exe = Distribution._OSX_JAVA_HOME_EXE
-          Distribution._OSX_JAVA_HOME_EXE = osx_java_home_exe
+          original_osx_java_home_exe = DistributionLocator._OSX_JAVA_HOME_EXE
+          DistributionLocator._OSX_JAVA_HOME_EXE = osx_java_home_exe
           try:
             yield jdk1_home, jdk2_home
           finally:
-            Distribution._OSX_JAVA_HOME_EXE = original_osx_java_home_exe
+            DistributionLocator._OSX_JAVA_HOME_EXE = original_osx_java_home_exe
 
   def test_locate_jdk1(self):
     with env():
       with self.java_home_exe() as (jdk1_home, _):
-        dist = Distribution.locate()
+        dist = DistributionLocator.locate()
         self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk2(self):
     with env():
       with self.java_home_exe() as (_, jdk2_home):
-        dist = Distribution.locate(minimum_version='2')
+        dist = DistributionLocator.locate(minimum_version='2')
         self.assertEqual(jdk2_home, dist.home)
 
   def test_locate_trumps_path(self):
     with self.java_home_exe() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as path_jdk:
         with env(PATH=os.path.join(path_jdk, 'bin')):
-          dist = Distribution.locate()
+          dist = DistributionLocator.locate()
           self.assertEqual(jdk1_home, dist.home)
-          dist = Distribution.locate(minimum_version='3')
+          dist = DistributionLocator.locate(minimum_version='3')
           self.assertEqual(path_jdk, dist.home)
 
   def test_locate_jdk_home_trumps(self):
     with self.java_home_exe() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as jdk_home:
         with env(JDK_HOME=jdk_home):
-          dist = Distribution.locate()
+          dist = DistributionLocator.locate()
           self.assertEqual(jdk_home, dist.home)
-          dist = Distribution.locate(maximum_version='1.1')
+          dist = DistributionLocator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
 
   def test_locate_java_home_trumps(self):
     with self.java_home_exe() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as java_home:
         with env(JAVA_HOME=java_home):
-          dist = Distribution.locate()
+          dist = DistributionLocator.locate()
           self.assertEqual(java_home, dist.home)
-          dist = Distribution.locate(maximum_version='1.1')
+          dist = DistributionLocator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = Distribution.locate(minimum_version='1.1', maximum_version='2')
+          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
 
 
@@ -411,63 +414,63 @@ class DistributionCachedTest(BaseDistributionLocationEnvOnlyTest):
     super(DistributionCachedTest, self).setUp()
 
     # Save local cache and then flush so tests get a clean environment.
-    local_cache = Distribution._CACHE
+    local_cache = DistributionLocator._CACHE
 
     def restore_cache():
-      Distribution._CACHE = local_cache
-    Distribution._CACHE = {}
+      DistributionLocator._CACHE = local_cache
+    DistributionLocator._CACHE = {}
     self.addCleanup(restore_cache)
 
   def test_cached_good_min(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.cached(minimum_version='1.7.0_25')
+        DistributionLocator.cached(minimum_version='1.7.0_25')
 
   def test_cached_good_max(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.cached(maximum_version='1.7.0_50')
+        DistributionLocator.cached(maximum_version='1.7.0_50')
 
   def test_cached_good_bounds(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        Distribution.cached(minimum_version='1.6.0_35', maximum_version='1.7.0_55')
+        DistributionLocator.cached(minimum_version='1.6.0_35', maximum_version='1.7.0_55')
 
   def test_cached_too_low(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.cached(minimum_version='1.7.0_40')
+          DistributionLocator.cached(minimum_version='1.7.0_40')
 
   def test_cached_too_high(self):
     with distribution(executables=exe('bin/java', '1.7.0_83')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.cached(maximum_version='1.7.0_55')
+          DistributionLocator.cached(maximum_version='1.7.0_55')
 
   def test_cached_low_fault(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.cached(minimum_version='1.7.0_35', maximum_version='1.7.0_55')
+          DistributionLocator.cached(minimum_version='1.7.0_35', maximum_version='1.7.0_55')
 
   def test_cached_high_fault(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.cached(minimum_version='1.6.0_00', maximum_version='1.6.0_50')
+          DistributionLocator.cached(minimum_version='1.6.0_00', maximum_version='1.6.0_50')
 
   def test_cached_conflicting(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          Distribution.cached(minimum_version='1.7.0_00', maximum_version='1.6.0_50')
+          DistributionLocator.cached(minimum_version='1.7.0_00', maximum_version='1.6.0_50')
 
   def test_cached_bad_input(self):
     with distribution(executables=exe('bin/java', '1.7.0_33')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(ValueError):
-          Distribution.cached(minimum_version=1.7, maximum_version=1.8)
+          DistributionLocator.cached(minimum_version=1.7, maximum_version=1.8)
 
 
 def exe_path(name):
@@ -495,10 +498,12 @@ class LiveDistributionTest(unittest.TestCase):
     Distribution(bin_path=os.path.dirname(self.JAVA), maximum_version='999.999.999').validate()
     Distribution(bin_path=os.path.dirname(self.JAVA), minimum_version='1.3.1',
                  maximum_version='999.999.999').validate()
-    Distribution.locate(jdk=False)
+    with subsystem_instance(DistributionLocator):
+      DistributionLocator.locate(jdk=False)
 
   @unittest.skipIf(not JAVAC, reason='No javac executable on the PATH.')
   def test_validate_live_jdk(self):
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).validate()
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).binary('javap')
-    Distribution.locate(jdk=True)
+    with subsystem_instance(DistributionLocator):
+      DistributionLocator.locate(jdk=True)

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -5,21 +5,22 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
 from unittest import skipIf
 
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import DistributionLocator
 from pants.util.osutil import OS_ALIASES, get_os_name
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
 def get_two_distributions():
-  try:
-    java7 = Distribution.locate(minimum_version='1.7', maximum_version='1.7.9999')
-    java8 = Distribution.locate(minimum_version='1.8', maximum_version='1.8.9999')
-    return java7, java8
-  except Distribution.Error:
-    return None
+  with subsystem_instance(DistributionLocator):
+    try:
+      java7 = DistributionLocator.locate(minimum_version='1.7', maximum_version='1.7.9999')
+      java8 = DistributionLocator.locate(minimum_version='1.8', maximum_version='1.8.9999')
+      return java7, java8
+    except DistributionLocator.Error:
+      return None
 
 
 class DistributionIntegrationTest(PantsRunIntegrationTest):
@@ -33,8 +34,8 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
     for (one, two) in ((java7, java8), (java8, java7)):
       target_spec = 'testprojects/src/java/org/pantsbuild/testproject/printversion'
       run = self.run_pants(['run', target_spec], config={
-        'jvm': {
-          'jdk_paths': {
+        'jvm-distributions': {
+          'paths': {
             os_name: [one.home],
           }
         }


### PR DESCRIPTION
Moved --jdk-paths in 'jvm' to --paths in 'jvm-distribution'.

All tasks/subsystems that need to locate a jvm Distribution now
depend on the DistributionSubsystem.

Distribution.locate() behavior largely unchanged from previous
patch: looks through --jvm-distribution-paths before everything
else.

Pulled java_home, java_sysprops out of pants/goal/context.py. Those
fields were only used in three places: the JvmDependencyAnalyzer,
JmakeCompile, and ZincCompile. All three of those usages now go
through Distribution directly.

Modified lots of tests that now need instances of the subsystem.