### PR TITLE
Integrate go with the binary goal.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/register.py
+++ b/contrib/go/src/python/pants/contrib/go/register.py
@@ -11,6 +11,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 from pants.contrib.go.targets.go_binary import GoBinary
 from pants.contrib.go.targets.go_library import GoLibrary
 from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary
+from pants.contrib.go.tasks.go_binary_create import GoBinaryCreate
 from pants.contrib.go.tasks.go_buildgen import GoBuilden
 from pants.contrib.go.tasks.go_compile import GoCompile
 from pants.contrib.go.tasks.go_fetch import GoFetch
@@ -36,5 +37,6 @@ def register_goals():
     'Automatically generate BUILD files.')
   task(name='go', action=GoFetch).install('resolve')
   task(name='go', action=GoCompile).install('compile')
+  task(name='go', action=GoBinaryCreate).install('binary')
   task(name='go', action=GoRun).install('run')
   task(name='go', action=GoTest).install('test')

--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -1,11 +1,23 @@
 target(
   name='tasks',
   dependencies=[
+    ':go_binary_create',
     ':go_buildgen',
     ':go_compile',
     ':go_fetch',
     ':go_run',
     ':go_test',
+  ]
+)
+
+python_library(
+  name='go_binary_create',
+  sources=['go_binary_create.py'],
+  dependencies=[
+    'contrib/go/src/python/pants/contrib/go/tasks:go_task',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ]
 )
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_binary_create.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_binary_create.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import shutil
+
+from pants.base.build_environment import get_buildroot
+from pants.util.dirutil import safe_mkdir
+from pants.util.memo import memoized_property
+
+from pants.contrib.go.tasks.go_task import GoTask
+
+
+class GoBinaryCreate(GoTask):
+  """Creates self contained go executables."""
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(GoBinaryCreate, cls).prepare(options, round_manager)
+    round_manager.require_data('exec_binary')
+
+  @memoized_property
+  def dist_root(self):
+    # TODO(John Sirois): impose discipline on dist/ output by tasks - they should all be
+    # namespacing with a top-level `dist/` dir of their own.
+    return os.path.join(self.get_options().pants_distdir, 'go', 'bin')
+
+  def execute(self):
+    binaries = self.context.targets(self.is_binary)
+    if not binaries:
+      return
+
+    # TODO(John Sirois): Consider adding invalidation support; although, copying a binary is
+    # very fast.
+    executable_by_binary = self.context.products.get_data('exec_binary')
+    safe_mkdir(self.dist_root)
+    rel_dist_root = os.path.relpath(self.dist_root, get_buildroot())
+    for binary in binaries:
+      executable = executable_by_binary[binary]
+      shutil.copy(executable, os.path.join(self.dist_root))
+      self.context.log.info('creating {}'.format(os.path.join(rel_dist_root,
+                                                              os.path.basename(executable))))

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-from collections import defaultdict
 
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
@@ -33,7 +32,7 @@ class GoCompile(GoWorkspaceTask):
     return ['exec_binary']
 
   def execute(self):
-    self.context.products.safe_create_data('exec_binary', lambda: defaultdict(str))
+    self.context.products.safe_create_data('exec_binary', lambda: {})
     with self.invalidated(self.context.targets(self.is_go),
                           invalidate_dependents=True,
                           topological_order=True) as invalidation_check:
@@ -55,8 +54,8 @@ class GoCompile(GoWorkspaceTask):
   def _go_install(self, target, gopath):
     args = self.get_options().build_flags.split() + [target.import_path]
     result, go_cmd = self.go_dist.execute_go_cmd('install', gopath=gopath, args=args,
-                                         workunit_factory=self.context.new_workunit,
-                                         workunit_labels=[WorkUnitLabel.COMPILER])
+                                                 workunit_factory=self.context.new_workunit,
+                                                 workunit_labels=[WorkUnitLabel.COMPILER])
     if result != 0:
       raise TaskError('{} failed with exit code {}'.format(go_cmd, result))
 

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -9,6 +9,7 @@ target(
 target(
   name='unit',
   dependencies=[
+    ':go_binary_create',
     ':go_buildgen',
     ':go_compile',
     ':go_fetch',
@@ -23,6 +24,19 @@ target(
     ':go_fetch_integration',
     ':go_run_integration',
     ':go_test_integration',
+  ]
+)
+
+python_tests(
+  name='go_binary_create',
+  sources=['test_go_binary_create.py'],
+  dependencies=[
+    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
+    'contrib/go/src/python/pants/contrib/go/tasks:go_binary_create',
+    'src/python/pants/base:target',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/tasks:task_test_base',
   ]
 )
 

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_binary_create.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_binary_create.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.base.target import Target
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import touch
+from pants_test.tasks.task_test_base import TaskTestBase
+
+from pants.contrib.go.targets.go_binary import GoBinary
+from pants.contrib.go.tasks.go_binary_create import GoBinaryCreate
+
+
+class GoBinaryCreateTest(TaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return GoBinaryCreate
+
+  def test_noop_empty(self):
+    task = self.create_task(self.context())
+    task.execute()
+    self.assertFalse(os.path.exists(task.dist_root))
+
+  def test_noop_na(self):
+    task = self.create_task(self.context(target_roots=[self.make_target(':a', Target)]))
+    task.execute()
+    self.assertFalse(os.path.exists(task.dist_root))
+
+  def test_execute(self):
+    with temporary_dir() as bin_source_dir:
+      def create_binary(name):
+        target = self.make_target(name, GoBinary)
+        executable = os.path.join(bin_source_dir, '{}.exe'.format(name))
+        touch(executable)
+        return target, executable
+
+      a, a_exe = create_binary('thing/a')
+      b, b_exe = create_binary('thing/b')
+
+      context = self.context(target_roots=[a, b])
+      context.products.safe_create_data('exec_binary', init_func=lambda: {a: a_exe, b: b_exe})
+
+      task = self.create_task(context)
+      task.execute()
+
+      binaries = self.buildroot_files(task.dist_root)
+      rel_dist_root = os.path.relpath(task.dist_root, self.build_root)
+      self.assertEqual({os.path.join(rel_dist_root, os.path.basename(a_exe)),
+                        os.path.join(rel_dist_root, os.path.basename(b_exe))},
+                       binaries)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -134,6 +134,19 @@ class BaseTest(unittest.TestCase):
     self.address_mapper = BuildFileAddressMapper(self.build_file_parser, FilesystemBuildFile)
     self.build_graph = BuildGraph(address_mapper=self.address_mapper)
 
+  def buildroot_files(self, relpath=None):
+    """Returns the set of all files under the test build root.
+
+    :param string relpath: If supplied, only collect files from this subtree.
+    :returns: All file paths found.
+    :rtype: set
+    """
+    def scan():
+      for root, dirs, files in os.walk(os.path.join(self.build_root, relpath or '')):
+        for f in files:
+          yield os.path.relpath(os.path.join(root, f), self.build_root)
+    return set(scan())
+
   def reset_build_graph(self):
     """Start over with a fresh build graph with no targets in it."""
     self.address_mapper = BuildFileAddressMapper(self.build_file_parser, FilesystemBuildFile)


### PR DESCRIPTION
The GoCompile already does the hard work of creating the go executables,
they're just tucked away under `.pants.d/`.  The GoBinaryCreate task
just copies them over to `dist/` for easy discovery and a stable path to
rely on for higher level build automation.

https://rbcommons.com/s/twitter/r/2681/