### PR TITLE
Hack around a few Distribution issues in py tests.

### DIFF
--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -16,6 +16,11 @@ python_tests(
   dependencies=[
     '3rdparty/python:pex',
     'src/python/pants/backend/codegen/targets:python',
+
+    # TODO(John Sirois): XXX this dep needs to be fixed.  All pants/java utility code needs to live
+    # in pants java since non-jvm backends depend on it to run things.
+    'src/python/pants/backend/jvm/subsystems:jvm',
+
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python:python_chroot',

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -78,8 +78,14 @@ python_tests(
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:mock',
     ':python_task_test_base',
+
+    # TODO(John Sirois): XXX this dep needs to be fixed.  All pants/java utility code needs to live
+    # in pants java since non-jvm backends depend on it to run things.
+    'src/python/pants/backend/jvm/subsystems:jvm',
+
     'src/python/pants/backend/python/tasks:python',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'tests/python/pants_test/subsystem:subsystem_utils'
   ],
 )


### PR DESCRIPTION
Distribution gained an undeclared direct dependency on the JVM
subsystem, fouling pyhton tests exercising the antlr builder when run
in isolation.  This change hacks in the deps - which point out that the
JVM Subsystem needs to move out of the jvm backend - and props up a JVM
Subsystem by hand in the 2 affected tests.