### PR TITLE
[CI] Reorganize option help.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -29,10 +29,10 @@ class GoDistribution(object):
 
     @classmethod
     def register_options(cls, register):
-      register('--supportdir', recursive=True, advanced=True, default='bin/go',
+      register('--supportdir', advanced=True, default='bin/go',
                help='Find the go distributions under this dir.  Used as part of the path to lookup '
                     'the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', recursive=True, advanced=True, default='1.5',
+      register('--version', advanced=True, default='1.5',
                help='Go distribution version.  Used as part of the path to lookup the distribution '
                     'with --binary-util-baseurls and --pants-bootstrapdir')
 

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -52,6 +52,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/goal',
+    'src/python/pants/help',
     'src/python/pants/option',
     ],
   )
@@ -263,6 +264,7 @@ python_library(
     'src/python/pants/base:generator',
     'src/python/pants/base:target',
     'src/python/pants/goal:goal',
+    'src/python/pants/help',
     'src/python/pants/option',
   ],
 )

--- a/src/python/pants/backend/core/tasks/bash_completion.py
+++ b/src/python/pants/backend/core/tasks/bash_completion.py
@@ -15,6 +15,7 @@ from pants.backend.core.tasks.task import TaskBase
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
 from pants.goal.goal import Goal
+from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.scope import ScopeInfo
 
@@ -52,7 +53,7 @@ class BashCompletionTask(ConsoleTask):
     """
     autocomplete_options_by_scope = defaultdict(set)
     def get_from_parser(parser):
-      oschi = parser.get_help_info()
+      oschi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser)
       # We ignore advanced options, as they aren't intended to be used on the cmd line.
       option_help_infos = oschi.basic + oschi.recursive
       for ohi in option_help_infos:

--- a/src/python/pants/backend/core/tasks/reflect.py
+++ b/src/python/pants/backend/core/tasks/reflect.py
@@ -19,6 +19,7 @@ from pants.base.exceptions import TaskError
 from pants.base.generator import TemplateData
 from pants.base.target import Target
 from pants.goal.goal import Goal
+from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -430,7 +431,9 @@ def bootstrap_option_values():
 
 
 def gen_glopts_reference_data(options):
-  return oref_template_data_from_help_info(options.get_parser(GLOBAL_SCOPE).get_help_info())
+  parser = options.get_parser(GLOBAL_SCOPE)
+  oschi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser)
+  return oref_template_data_from_help_info(oschi)
 
 
 def oref_template_data_from_help_info(oschi):
@@ -476,7 +479,8 @@ def gen_tasks_options_reference_data(options):
 
       doc_rst = indent_docstring_by_n(authored_task_type.__doc__ or '', 2)
       doc_html = rst_to_html(dedent_docstring(authored_task_type.__doc__))
-      oschi = options.get_parser(task_type.options_scope).get_help_info()
+      parser = options.get_parser(task_type.options_scope)
+      oschi = HelpInfoExtracter.get_option_scope_help_info_from_parser(parser)
       impl = '{0}.{1}'.format(authored_task_type.__module__, authored_task_type.__name__)
       tasks.append(TemplateData(
           impl=impl,

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -26,15 +26,15 @@ class JVM(Subsystem):
   def register_options(cls, register):
     super(JVM, cls).register_options(register)
     # TODO(benjy): Options to specify the JVM version?
-    register('--options', action='append', recursive=True, metavar='<option>...',
+    register('--options', action='append', metavar='<option>...',
              help='Run with these extra JVM options.')
-    register('--program-args', action='append', recursive=True, metavar='<arg>...',
+    register('--program-args', action='append', metavar='<arg>...',
              help='Run with these extra program args.')
-    register('--debug', action='store_true', recursive=True,
+    register('--debug', action='store_true',
              help='Run the JVM with remote debugging.')
-    register('--debug-port', advanced=True, recursive=True, type=int, default=5005,
+    register('--debug-port', advanced=True, type=int, default=5005,
              help='The JVM will listen for a debugger on this port.')
-    register('--debug-args', advanced=True, recursive=True, type=list_option,
+    register('--debug-args', advanced=True, type=list_option,
              default=[
                '-Xdebug',
                '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address={debug_port}'
@@ -43,7 +43,7 @@ class JVM(Subsystem):
                   'the value of the --debug-port option.')
     human_readable_os_aliases = ', '.join('{}: [{}]'.format(str(key), ', '.join(sorted(val)))
                                          for key, val in OS_ALIASES.items())
-    register('--jdk-paths', advanced=True, recursive=True, type=dict_option,
+    register('--jdk-paths', advanced=True, type=dict_option,
              help='Map of os names to lists of paths to jdks. These paths will be searched before '
                   'everything else (before the JDK_HOME, JAVA_HOME, PATH environment variables) '
                   'when locating a jvm to use. The same OS can be specified via several different '

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -24,9 +24,11 @@ class BenchmarkRun(JvmToolTaskMixin, JvmTask):
     super(BenchmarkRun, cls).register_options(register)
     register('--target', help='Name of the benchmark class. This is a mandatory argument.')
     register('--memory', default=False, action='store_true', help='Enable memory profiling.')
-    register('--debug', action='store_true', recursive=True, help='Run the benchmark tool with in process debugging.')
+    register('--debug', action='store_true',
+             help='Run the benchmark tool with in process debugging.')
 
-    cls.register_jvm_tool(register, 'benchmark-tool', main=cls._CALIPER_MAIN, default=['//:benchmark-caliper-0.5'])
+    cls.register_jvm_tool(register, 'benchmark-tool', main=cls._CALIPER_MAIN,
+                          default=['//:benchmark-caliper-0.5'])
     cls.register_jvm_tool(register, 'benchmark-agent',
                           default=['//:benchmark-java-allocation-instrumenter-2.1'])
 

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -13,8 +13,8 @@ from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 class JvmTask(Task):
 
   @classmethod
-  def task_subsystems(cls):
-    return super(JvmTask, cls).task_subsystems() + (JVM,)
+  def subsystem_dependencies(cls):
+    return super(JvmTask, cls).subsystem_dependencies() + (JVM.scoped(cls),)
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -23,6 +23,7 @@ python_library(
     'src/python/pants/goal',
     'src/python/pants/goal:context',
     'src/python/pants/goal:run_tracker',
+    'src/python/pants/help',
     'src/python/pants/logging',
     'src/python/pants/option',
     'src/python/pants/reporting',

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -24,6 +24,7 @@ from pants.engine.round_engine import RoundEngine
 from pants.goal.context import Context
 from pants.goal.goal import Goal
 from pants.goal.run_tracker import RunTracker
+from pants.help.help_printer import HelpPrinter
 from pants.java.nailgun_executor import NailgunProcessGroup  # XXX(pl)
 from pants.logging.setup import setup_logging
 from pants.option.custom_types import list_option
@@ -90,7 +91,7 @@ class GoalRunner(object):
     # Get logging setup prior to loading backends so that they can log as needed.
     self._setup_logging(global_bootstrap_options)
 
-    # Add any extra paths to python path (eg for loading extra source backends)
+    # Add any extra paths to python path (e.g., for loading extra source backends).
     for path in global_bootstrap_options.pythonpath:
       sys.path.append(path)
       pkg_resources.fixup_namespace_packages(path)
@@ -192,7 +193,9 @@ class GoalRunner(object):
         logger.warning(" Command-line argument '{0}' is ambiguous and was assumed to be "
                        "a goal. If this is incorrect, disambiguate it with ./{0}.".format(goal))
 
-    if self.options.print_help_if_requested():
+    if self.options.help_request:
+      help_printer = HelpPrinter(self.options)
+      help_printer.print_help()
       self._exiter(0)
 
     self.requested_goals = goals

--- a/src/python/pants/binaries/thrift_binary.py
+++ b/src/python/pants/binaries/thrift_binary.py
@@ -22,10 +22,10 @@ class ThriftBinary(object):
 
     @classmethod
     def register_options(cls, register):
-      register('--supportdir', recursive=True, advanced=True, default='bin/thrift',
+      register('--supportdir', advanced=True, default='bin/thrift',
                help='Find thrift binaries under this dir.   Used as part of the path to lookup the'
                     'tool with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', recursive=True, advanced=True, default='0.9.2', fingerprint=True,
+      register('--version', advanced=True, default='0.9.2', fingerprint=True,
                help='Thrift compiler version.   Used as part of the path to lookup the'
                     'tool with --binary-util-baseurls and --pants-bootstrapdir')
 

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -41,24 +41,24 @@ class CacheSetup(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(CacheSetup, cls).register_options(register)
-    register('--read', action='store_true', default=True, recursive=True,
+    register('--read', action='store_true', default=True,
              help='Read build artifacts from cache, if available.')
-    register('--write', action='store_true', default=True, recursive=True,
+    register('--write', action='store_true', default=True,
              help='Write build artifacts to cache, if available.')
-    register('--overwrite', action='store_true', recursive=True,
+    register('--overwrite', advanced=True, action='store_true',
              help='If writing build artifacts to cache, overwrite existing artifacts '
                   'instead of skipping them.')
-    register('--read-from', type=list_option, recursive=True,
+    register('--read-from', advanced=True, type=list_option,
              help='The URIs of artifact caches to read from. Each entry is a URL of a RESTful '
                   'cache, a path of a filesystem cache, or a pipe-separated list of alternate '
                   'caches to choose from.')
-    register('--write-to', type=list_option, recursive=True,
+    register('--write-to', advanced=True, type=list_option,
              help='The URIs of artifact caches to write to. Each entry is a URL of a RESTful '
                   'cache, a path of a filesystem cache, or a pipe-separated list of alternate '
                   'caches to choose from.')
-    register('--compression-level', advanced=True, type=int, default=5, recursive=True,
+    register('--compression-level', advanced=True, type=int, default=5,
              help='The gzip compression level (0-9) for created artifacts.')
-    register('--max-entries-per-target', advanced=True, recursive=True, type=int, default=None,
+    register('--max-entries-per-target', advanced=True, type=int, default=None,
              help='Maximum number of old cache files to keep per task target pair')
 
   @classmethod

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name='help',
+  sources=globs('*.py'),
+  dependencies=[
+    'src/python/pants/base:build_environment',
+    'src/python/pants/option',
+  ]
+)

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -9,12 +9,13 @@ from textwrap import wrap
 
 from colors import blue, cyan, green, red
 
-from pants.option.help_info_extracter import HelpInfoExtracter
+from pants.help.help_info_extracter import HelpInfoExtracter
 
 
 class HelpFormatter(object):
-  def __init__(self, scope, show_advanced, color):
+  def __init__(self, scope, show_recursive, show_advanced, color):
     self._scope = scope
+    self._show_recursive = show_recursive
     self._show_advanced = show_advanced
     self._color = color
 
@@ -43,20 +44,20 @@ class HelpFormatter(object):
     def add_option(category, ohis):
       if ohis:
         lines.append('')
+        display_scope = scope or 'Global'
         if category:
-          lines.append(self._maybe_blue('{} {} options:'.format(scope, category)))
+          lines.append(self._maybe_blue('{} {} options:'.format(display_scope, category)))
         else:
-          lines.append(self._maybe_blue('{}:'.format(scope)))
+          lines.append(self._maybe_blue('{} options:'.format(display_scope)))
           if description:
             lines.append(description)
         lines.append(' ')
         for ohi in ohis:
           lines.extend(self.format_option(ohi))
     add_option('', oshi.basic)
-    if self._show_advanced:
-      # We only show recursive options if the user asked for advanced help,
-      # as this is an advanced concept.
+    if self._show_recursive:
       add_option('recursive', oshi.recursive)
+    if self._show_advanced:
       add_option('advanced', oshi.advanced)
     return lines
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -46,6 +46,14 @@ class OptionScopeHelpInfo(namedtuple('_OptionScopeHelpInfo',
 class HelpInfoExtracter(object):
   """Extracts information useful for displaying help from option registration args."""
 
+  @classmethod
+  def get_option_scope_help_info_from_parser(cls, parser):
+    """Returns a dict of help information for the options registered on the given parser.
+
+    Callers can format this dict into cmd-line help, HTML or whatever.
+    """
+    return cls(parser.scope).get_option_scope_help_info(parser.registration_args)
+
   @staticmethod
   def compute_default(kwargs):
     """Compute the default value to display in help for an option registered with these kwargs."""

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -1,0 +1,136 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import sys
+
+from pants.base.build_environment import pants_release
+from pants.help.help_formatter import HelpFormatter
+from pants.option.arg_splitter import GLOBAL_SCOPE, NoGoalHelp, OptionsHelp, UnknownGoalHelp
+from pants.option.global_options import GlobalOptionsRegistrar
+from pants.option.parser_hierarchy import enclosing_scope
+from pants.option.scope import ScopeInfo
+from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
+
+
+class HelpPrinter(object):
+  """Prints help to the console."""
+  def __init__(self, options):
+    self._options = options
+
+  @property
+  def _help_request(self):
+    return self._options.help_request
+
+  @property
+  def _known_scope_to_info(self):
+    return self._options.known_scope_to_info
+
+  def print_help(self):
+    """Print help to the console."""
+    def print_hint():
+      print('Use `pants goals` to list goals.')
+      print('Use `pants help` to get help.')
+    if isinstance(self._help_request, OptionsHelp):
+      self._print_options_help()
+    elif isinstance(self._help_request, UnknownGoalHelp):
+      print('Unknown goals: {}'.format(', '.join(self._help_request.unknown_goals)))
+      print_hint()
+      # TODO: Should probably cause a non-zero exit code.
+    elif isinstance(self._help_request, NoGoalHelp):
+      print('No goals specified.')
+      print_hint()
+      # TODO: Should probably cause a non-zero exit code.
+
+  def _print_options_help(self):
+    """Print a help screen.
+
+    Assumes that self._help_request is an instance of OptionsHelp.
+
+    Note: Ony useful if called after options have been registered.
+    """
+    show_all_help = self._help_request.all_scopes
+    if show_all_help:
+      help_scopes = self._known_scope_to_info.keys()
+    else:
+      # The scopes explicitly mentioned by the user on the cmd line.
+      help_scopes = set(self._options.scope_to_flags.keys()) - set([GLOBAL_SCOPE])
+      # As a user-friendly heuristic, add all task scopes under requested scopes, so that e.g.,
+      # `./pants help compile` will show help for compile.java, compile.scala etc.
+      # Note that we don't do anything similar for subsystems - that would just create noise by
+      # repeating options for every task-specific subsystem instance.
+      for scope, info in self._known_scope_to_info.items():
+        if info.category == ScopeInfo.TASK:
+          outer = enclosing_scope(scope)
+          while outer != GLOBAL_SCOPE:
+            if outer in help_scopes:
+              help_scopes.add(scope)
+              break
+            outer = enclosing_scope(outer)
+
+    help_scope_infos = [self._known_scope_to_info[s] for s in sorted(help_scopes)]
+    if help_scope_infos:
+      for scope_info in self._help_subscopes_iter(help_scope_infos):
+        description = (scope_info.optionable_cls.get_description() if scope_info.optionable_cls
+                       else None)
+        help_str = self._format_help(scope_info, description)
+        if help_str:
+          print(help_str)
+      return
+    else:
+      print(pants_release())
+      print('\nUsage:')
+      print('  ./pants [option ...] [goal ...] [target...]  Attempt the specified goals.')
+      print('  ./pants help                                 Get help.')
+      print('  ./pants help [goal]                          Get help for a goal.')
+      print('  ./pants help-advanced [goal]                 Get help for a goal\'s advanced options.')
+      print('  ./pants help-all                             Get help for all goals.')
+      print('  ./pants goals                                List all installed goals.')
+      print('')
+      print('  [target] accepts two special forms:')
+      print('    dir:  to include all targets in the specified directory.')
+      print('    dir:: to include all targets found recursively under the directory.')
+      print('\nFriendly docs:\n  http://pantsbuild.github.io/')
+
+      print(self._format_help(ScopeInfo(GLOBAL_SCOPE, ScopeInfo.GLOBAL), ''))
+
+  def _help_subscopes_iter(self, scope_infos):
+    """Yields the scopes to actually show help for when the user asks for help for scope_info."""
+    for scope_info in scope_infos:
+      yield scope_info
+      # We don't currently subclass GlobalOptionsRegistrar, and I can't think of any reason why
+      # we would, but might as well be robust.
+      if scope_info.optionable_cls is not None:
+        if issubclass(scope_info.optionable_cls, GlobalOptionsRegistrar):
+          for scope, info in self._known_scope_to_info.items():
+            if info.category == ScopeInfo.SUBSYSTEM and enclosing_scope(scope) == GLOBAL_SCOPE:
+              # This is a global subsystem, so show it when asked for global help.
+              yield info
+        elif issubclass(scope_info.optionable_cls, SubsystemClientMixin):
+          def yield_deps(subsystem_client_cls):
+            for dep in subsystem_client_cls.subsystem_dependencies_iter():
+              if dep.scope != GLOBAL_SCOPE:
+                yield self._known_scope_to_info[dep.options_scope()]
+                for info in yield_deps(dep.subsystem_cls):
+                  yield info
+          for info in yield_deps(scope_info.optionable_cls):
+            yield info
+
+  def _format_help(self, scope_info, description):
+    """Return a help message for the options registered on this object.
+
+    Assumes that self._help_request is an instance of OptionsHelp.
+
+    :param scope_info: Scope of the options.
+    :param description: Description of scope.
+    """
+    scope = scope_info.scope
+    show_recursive = self._help_request.advanced
+    show_advanced = self._help_request.advanced
+    color = sys.stdout.isatty()
+    registration_args = self._options.get_parser(scope).registration_args
+    help_formatter = HelpFormatter(scope, show_recursive, show_advanced, color)
+    return '\n'.join(help_formatter.format_options(scope, description, registration_args))

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -141,7 +141,7 @@ class GlobalOptionsRegistrar(Optionable):
     register('--cache-key-gen-version', advanced=True, default='200', recursive=True,
              help='The cache key generation. Bump this to invalidate every artifact for a scope.')
     register('--max-subprocess-args', advanced=True, type=int, default=100, recursive=True,
-             help='Used to limit the number of arguments passed to some subprocesses by breaking'
+             help='Used to limit the number of arguments passed to some subprocesses by breaking '
              'the command up into multiple invocations')
     register('--print-exception-stacktrace', advanced=True, action='store_true',
              help='Print to console the full exception stack trace if encountered.')

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -8,12 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import copy
 import sys
 
-from pants.base.build_environment import pants_release
-from pants.option.arg_splitter import (GLOBAL_SCOPE, ArgSplitter, NoGoalHelp, OptionsHelp,
-                                       UnknownGoalHelp)
+from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_value_container import OptionValueContainer
-from pants.option.parser_hierarchy import ParserHierarchy
+from pants.option.parser_hierarchy import ParserHierarchy, enclosing_scope
 from pants.option.scope import ScopeInfo
 
 
@@ -77,7 +75,7 @@ class Options(object):
       while scope != '':
         if scope not in original_scopes:
           ret.add(ScopeInfo(scope, ScopeInfo.INTERMEDIATE))
-        scope = scope.rpartition('.')[0]
+        scope = enclosing_scope(scope)
     return ret
 
   @classmethod
@@ -131,6 +129,28 @@ class Options(object):
     self._bootstrap_option_values = bootstrap_option_values
     self._known_scope_to_info = known_scope_to_info
 
+  @property
+  def help_request(self):
+    return self._help_request
+
+  @property
+  def target_specs(self):
+    """The targets to operate on."""
+    return self._target_specs
+
+  @property
+  def goals(self):
+    """The requested goals, in the order specified on the cmd line."""
+    return self._goals
+
+  @property
+  def known_scope_to_info(self):
+    return self._known_scope_to_info
+
+  @property
+  def scope_to_flags(self):
+    return self._scope_to_flags
+
   def drop_flag_values(self):
     """Returns a copy of these options that ignores values specified via flags.
 
@@ -151,16 +171,6 @@ class Options(object):
                    no_values,
                    self._bootstrap_option_values,
                    self._known_scope_to_info)
-
-  @property
-  def target_specs(self):
-    """The targets to operate on."""
-    return self._target_specs
-
-  @property
-  def goals(self):
-    """The requested goals, in the order specified on the cmd line."""
-    return self._goals
 
   def is_known_scope(self, scope):
     """Whether the given scope is known by this instance."""
@@ -225,7 +235,7 @@ class Options(object):
     if scope == GLOBAL_SCOPE:
       values = OptionValueContainer()
     else:
-      values = copy.deepcopy(self.for_scope(scope.rpartition('.')[0]))
+      values = copy.deepcopy(self.for_scope(enclosing_scope(scope)))
 
     # Now add our values.
     flags_in_scope = self._scope_to_flags.get(scope, [])
@@ -264,7 +274,7 @@ class Options(object):
         val_type = kwargs.get('type', '')
         pairs.append((val_type, val))
       registration_scope = (None if registration_scope == ''
-                            else registration_scope.rpartition('.')[0])
+                            else enclosing_scope(registration_scope))
     return pairs
 
   def __getitem__(self, scope):
@@ -283,81 +293,3 @@ class Options(object):
   def for_global_scope(self):
     """Return the option values for the global scope."""
     return self.for_scope(GLOBAL_SCOPE)
-
-  def print_help_if_requested(self):
-    """If help was requested, print it and return True.
-
-    Otherwise return False.
-    """
-    if self._help_request:
-      def print_hint():
-        print('Use `pants goals` to list goals.')
-        print('Use `pants help` to get help.')
-      if isinstance(self._help_request, OptionsHelp):
-        self._print_options_help()
-      elif isinstance(self._help_request, UnknownGoalHelp):
-        print('Unknown goals: {}'.format(', '.join(self._help_request.unknown_goals)))
-        print_hint()
-        # TODO: Should probably cause a non-zero exit code.
-      elif isinstance(self._help_request, NoGoalHelp):
-        print('No goals specified.')
-        print_hint()
-        # TODO: Should probably cause a non-zero exit code.
-      return True
-    else:
-      return False
-
-  def _print_options_help(self):
-    """Print a help screen.
-
-    Assumes that self._help_request is an instance of OptionsHelp.
-
-    Note: Ony useful if called after options have been registered.
-    """
-    show_all_help = self._help_request.all_scopes
-    if show_all_help:
-      help_scopes = self._known_scope_to_info.keys()
-    else:
-      # The scopes explicitly mentioned by the user on the cmd line.
-      help_scopes = set(self._scope_to_flags.keys()) - set([GLOBAL_SCOPE])
-      # Add all subscopes (e.g., so that `pants help compile` shows help for all tasks under
-      # `compile`.) Note that sorting guarantees that we only need to check the immediate parent.
-      for scope in sorted(self._known_scope_to_info.keys()):
-        if scope.partition('.')[0] in help_scopes:
-          help_scopes.add(scope)
-
-    help_scope_infos = [self._known_scope_to_info[s] for s in sorted(help_scopes)]
-    if help_scope_infos:
-      for scope_info in help_scope_infos:
-        help_str = self._format_options_help_for_scope(scope_info)
-        if help_str:
-          print(help_str)
-      return
-    else:
-      print(pants_release())
-      print('\nUsage:')
-      print('  ./pants [option ...] [goal ...] [target...]  Attempt the specified goals.')
-      print('  ./pants help                                 Get help.')
-      print('  ./pants help [goal]                          Get help for a goal.')
-      print('  ./pants help-advanced [goal]                 Get help for a goal\'s advanced options.')
-      print('  ./pants help-all                             Get help for all goals.')
-      print('  ./pants goals                                List all installed goals.')
-      print('')
-      print('  [target] accepts two special forms:')
-      print('    dir:  to include all targets in the specified directory.')
-      print('    dir:: to include all targets found recursively under the directory.')
-      print('\nFriendly docs:\n  http://pantsbuild.github.io/')
-
-      print(self.get_parser(GLOBAL_SCOPE).format_help('Global', 'Global options',
-                                                      show_advanced=self._help_request.advanced))
-
-  def _format_options_help_for_scope(self, scope_info):
-    """Generate a help message for options at the specified scope.
-
-    Assumes that self._help_request is an instance of OptionsHelp.
-
-    :param scope_info: A ScopeInfo for the speicified scope.
-    """
-    description = scope_info.optionable_cls.get_description() if scope_info.optionable_cls else None
-    return self.get_parser(scope_info.scope).format_help(scope_info.scope, description,
-                                                         self._help_request.advanced)

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import copy
 import re
-import sys
 import warnings
 from argparse import ArgumentParser, _HelpAction
 from collections import defaultdict
@@ -17,10 +16,9 @@ import six
 from pants.base.deprecated import check_deprecated_semver
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.errors import ParseError, RegistrationError
-from pants.option.help_formatter import HelpFormatter
-from pants.option.help_info_extracter import HelpInfoExtracter
 from pants.option.option_util import is_boolean_flag
 from pants.option.ranked_value import RankedValue
+from pants.option.scope import ScopeInfo
 
 
 # Standard ArgumentParser prints usage and exits on error. We subclass so we can raise instead.
@@ -167,38 +165,27 @@ class Parser(object):
                           stacklevel=9999)  # Out of range stacklevel to suppress printing src line.
     return namespace
 
+  @property
+  def registration_args(self):
+    """Returns the registration args, in registration order.
+
+    :return: A list of (args, kwargs) pairs.
+    """
+    return self._registration_args
+
   def registration_args_iter(self):
     """Returns an iterator over the registration arguments of each option in this parser.
 
     Each yielded item is a (dest, args, kwargs) triple.  `dest` is the canonical name that can be
     used to retrieve the option value, if the option has multiple names.
     See comment on self._registration_args above for caveats re (args, kwargs).
+
     For consistency, items are iterated over in lexicographical order, not registration order.
     """
     for args, kwargs in sorted(self._registration_args):
       if args:  # Otherwise all args have been shadowed, so ignore.
         dest = self._select_dest(args)
         yield dest, args, kwargs
-
-  def get_help_info(self):
-    """Returns a dict of help information for the options registered on this object.
-
-    Callers can format this dict into cmd-line help, HTML or whatever.
-    """
-    return HelpInfoExtracter(self._scope).get_option_scope_help_info(self._registration_args)
-
-  def format_help(self, scope, description, show_advanced=False, color=None):
-    """Return a help message for the options registered on this object.
-
-    :param scope: Scope of the options.
-    :param description: Description of scope.
-    :param bool show_advanced: Whether to display advanced options.
-    :param bool color: Whether to use color. If None, use color only if writing to a terminal.
-    """
-    if color is None:
-      color = sys.stdout.isatty()
-    help_formatter = HelpFormatter(scope=self._scope, show_advanced=show_advanced, color=color)
-    return '\n'.join(help_formatter.format_options(scope, description, self._registration_args))
 
   def register(self, *args, **kwargs):
     """Register an option, using argparse params.
@@ -223,7 +210,12 @@ class Parser(object):
     self._validate(args, kwargs)
     dest = self._set_dest(args, kwargs)
     if 'recursive' in kwargs:
+      if self._scope_info.category == ScopeInfo.SUBSYSTEM:
+        raise ParseError('Option {} in scope {} registered as recursive, but subsystem options '
+                         'may not set recursive=True.'.format(args[0], self.scope))
       kwargs['recursive_root'] = True  # So we can distinguish the original registrar.
+    if self._scope_info.category == ScopeInfo.SUBSYSTEM:
+      kwargs['subsystem'] = True
     self._register(dest, args, kwargs)  # Note: May modify kwargs (to remove recursive_root).
 
   def _deprecated_message(self, dest):
@@ -241,6 +233,9 @@ class Parser(object):
     hint = deprecated_hint or ''
     return '{}. {}'.format(message, hint)
 
+  _custom_kwargs = ('advanced', 'recursive', 'recursive_root', 'subsystem', 'registering_class',
+                    'fingerprint', 'deprecated_version', 'deprecated_hint')
+
   def _clean_argparse_kwargs(self, dest, args, kwargs):
     ranked_default = self._compute_default(dest, kwargs=kwargs)
     kwargs_with_default = dict(kwargs, default=ranked_default)
@@ -253,25 +248,22 @@ class Parser(object):
       self._arg_lists_by_arg[arg] = args_copy
     self._registration_args.append((args_copy, kwargs_with_default))
 
-    # For argparse registration, remove our custom kwargs.
-    argparse_kwargs = dict(kwargs_with_default)
-    argparse_kwargs.pop('advanced', False)
-    recursive = argparse_kwargs.pop('recursive', False)
-    argparse_kwargs.pop('recursive_root', False)
-    argparse_kwargs.pop('registering_class', None)
-    argparse_kwargs.pop('fingerprint', False)
-    deprecated_version = argparse_kwargs.pop('deprecated_version', None)
-    deprecated_hint = argparse_kwargs.pop('deprecated_hint', '')
+    deprecated_version = kwargs.get('deprecated_version', None)
+    deprecated_hint = kwargs.get('deprecated_hint', '')
 
     if deprecated_version is not None:
       check_deprecated_semver(deprecated_version)
       self._deprecated_option_dests[dest] = (deprecated_version, deprecated_hint)
 
-    return argparse_kwargs, recursive
+    # For argparse registration, remove our custom kwargs.
+    argparse_kwargs = dict(kwargs_with_default)
+    for custom_kwarg in self._custom_kwargs:
+      argparse_kwargs.pop(custom_kwarg, None)
+    return argparse_kwargs
 
   def _register(self, dest, args, kwargs):
     """Register the option for parsing (recursively if needed)."""
-    argparse_kwargs, recursive = self._clean_argparse_kwargs(dest, args, kwargs)
+    argparse_kwargs = self._clean_argparse_kwargs(dest, args, kwargs)
     if is_boolean_flag(argparse_kwargs):
       inverse_args = self._create_inverse_args(args)
       if inverse_args:
@@ -284,7 +276,7 @@ class Parser(object):
     else:
       self._argparser.add_argument(*args, **argparse_kwargs)
 
-    if recursive:
+    if kwargs.get('recursive', False) or kwargs.get('subsystem', False):
       # Propagate registration down to inner scopes.
       for child_parser in self._child_parsers:
         kwargs.pop('recursive_root', False)

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -10,6 +10,11 @@ from pants.option.errors import OptionsError
 from pants.option.parser import Parser
 
 
+def enclosing_scope(scope):
+  """Utility function to return the scope immediately enclosing a given scope."""
+  return scope.rpartition('.')[0]
+
+
 class ParserHierarchy(object):
   """A hierarchy of scoped Parser instances.
 
@@ -24,7 +29,7 @@ class ParserHierarchy(object):
     for scope_info in scope_infos:
       scope = scope_info.scope
       parent_parser = (None if scope == GLOBAL_SCOPE else
-                       self._parser_by_scope[scope.rpartition('.')[0]])
+                       self._parser_by_scope[enclosing_scope(scope)])
       self._parser_by_scope[scope] = Parser(env, config, scope_info, parent_parser)
 
   def get_parser_by_scope(self, scope):

--- a/tests/python/pants_test/option/test_help_formatter.py
+++ b/tests/python/pants_test/option/test_help_formatter.py
@@ -7,8 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-from pants.option.help_formatter import HelpFormatter
-from pants.option.help_info_extracter import OptionHelpInfo
+from pants.help.help_formatter import HelpFormatter
+from pants.help.help_info_extracter import OptionHelpInfo
 
 
 class OptionHelpFormatterTest(unittest.TestCase):
@@ -18,7 +18,8 @@ class OptionHelpFormatterTest(unittest.TestCase):
                          type=bool, default='MYDEFAULT', help='help for foo',
                          deprecated_version=None, deprecated_message=None, deprecated_hint=None)
 
-    lines = HelpFormatter(scope='', show_advanced=False, color=False).format_option(ohi)
+    lines = HelpFormatter(scope='', show_recursive=False, show_advanced=False,
+                          color=False).format_option(ohi)
     self.assertEquals(len(lines), 2)
     self.assertEquals('--foo (default: MYDEFAULT)', lines[0])
     self.assertIn('help for foo', lines[1])
@@ -26,10 +27,10 @@ class OptionHelpFormatterTest(unittest.TestCase):
   def test_suppress_advanced(self):
     args = ['--foo']
     kwargs = {'advanced': True}
-    lines = HelpFormatter(scope='', show_advanced=False, color=False).format_options(
-      '', '', [(args, kwargs)])
+    lines = HelpFormatter(scope='', show_recursive=False, show_advanced=False,
+                          color=False).format_options('', '', [(args, kwargs)])
     self.assertEquals(0, len(lines))
-    lines = HelpFormatter(scope='', show_advanced=True, color=False).format_options(
-      '', '', [(args, kwargs)])
+    lines = HelpFormatter(scope='', show_recursive=True, show_advanced=True,
+                          color=False).format_options('', '', [(args, kwargs)])
     print(lines)
     self.assertEquals(5, len(lines))

--- a/tests/python/pants_test/option/test_help_info_extracter.py
+++ b/tests/python/pants_test/option/test_help_info_extracter.py
@@ -9,8 +9,8 @@ import unittest
 
 from mock import mock
 
+from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.option.custom_types import dict_option, list_option
-from pants.option.help_info_extracter import HelpInfoExtracter
 
 
 class HelpInfoExtracterTest(unittest.TestCase):

--- a/tests/python/pants_test/option/test_help_integration.py
+++ b/tests/python/pants_test/option/test_help_integration.py
@@ -17,7 +17,7 @@ class TestHelpIntegration(PantsRunIntegrationTest):
     self.assertIn('Usage:', pants_run.stdout_data)
     # spot check to see that a public global option is printed
     self.assertIn('--level', pants_run.stdout_data)
-    self.assertIn('Global:', pants_run.stdout_data)
+    self.assertIn('Global options:', pants_run.stdout_data)
 
   def test_help_advanced(self):
     command = ['help-advanced']
@@ -32,7 +32,7 @@ class TestHelpIntegration(PantsRunIntegrationTest):
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
     # Spot check to see that scope headings are printed
-    self.assertIn('test.junit:', pants_run.stdout_data)
+    self.assertIn('test.junit options:', pants_run.stdout_data)
     # Spot check to see that full args for all options are printed
     self.assertIn('--binary-dup-max-dups', pants_run.stdout_data)
 
@@ -41,7 +41,7 @@ class TestHelpIntegration(PantsRunIntegrationTest):
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
     # Spot check to see that scope headings are printed
-    self.assertIn('test.junit:', pants_run.stdout_data)
+    self.assertIn('test.junit options:', pants_run.stdout_data)
     # Spot check to see that full args for all options are printed
     self.assertIn('--binary-dup-max-dups', pants_run.stdout_data)
     # Spot check to see that subsystem options are printing
@@ -52,7 +52,7 @@ class TestHelpIntegration(PantsRunIntegrationTest):
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
     # Spot check to see that scope headings are printed even for advanced options
-    self.assertIn('test.junit:', pants_run.stdout_data)
+    self.assertIn('test.junit options:', pants_run.stdout_data)
     self.assertIn('cache.test.junit advanced options:', pants_run.stdout_data)
     # Spot check to see that full args for all options are printed
     self.assertIn('--binary-dup-max-dups', pants_run.stdout_data)


### PR DESCRIPTION
- Print subsystem help alongside the scope that subsystem serves.
  E.g., if you ask for help for test.junit, it'll show help
  for jvm.test.junit as well.

- This required handling subsystem option 'recursion' explicitly,
  rather than relying on the subsystem author adding recursive=True
  to all their option registrations. The distinction is that
  subsystem options registered recursively from the global
  subsystem are really basic options for the purpose of help printing.
  It's obviously also nicer to not require the subsystem author to
  add recursive=True everywhere.

- More correctly implement the heuristic of showing help for all
  tasks under a goal when './pants help <goal>' is requested.
  The previous logic just showed help for any subscope of a
  requested scope, which meant it would repeat subsystem help
  once for every task-specific instance, which is obviously not
  useful for the user.

- Moves help-related code out of pants/option and into a new
  pants/help package.  This is because help code needs to depend
  on pants/subsystem, which pants/option cannot depend on.
  But it's also more organized, and makes more sense for non-option
  help.