### PR TITLE
Fix PythonThriftBuilder to operate on 1 target.

### DIFF
--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -129,11 +129,10 @@ python_library(
   name = 'thrift_builder',
   sources = ['thrift_builder.py'],
   dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     ':code_generator',
-    'src/python/pants/backend/codegen/targets:python',
-    'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:build_environment',
-    'src/python/pants/binaries:thrift_util',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ]
 )

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -47,8 +47,6 @@ class PythonChroot(object):
     PythonTests: 'tests'
   }
 
-  MEMOIZED_THRIFTS = {}
-
   class InvalidDependencyException(Exception):
     def __init__(self, target):
       Exception.__init__(self, "Not a valid Python dependency! Found: {}".format(target))
@@ -197,11 +195,8 @@ class PythonChroot(object):
 
     generated_reqs = OrderedSet()
     if targets['thrifts']:
-      for thr in set(targets['thrifts']):
-        if thr not in self.MEMOIZED_THRIFTS:
-          self.MEMOIZED_THRIFTS[thr] = self._generate_thrift_requirement(thr)
-        generated_reqs.add(self.MEMOIZED_THRIFTS[thr])
-
+      for thr in targets['thrifts']:
+        generated_reqs.add(self._generate_thrift_requirement(thr))
       generated_reqs.add(PythonRequirement('thrift', use_2to3=True))
 
     for antlr in targets['antlrs']:

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -600,7 +600,7 @@ class SetupPy(PythonTask):
     for target in targets:
       create(target)
 
-    executed = []  # Collected and returned for tests.
+    executed = {}  # Collected and returned for tests, processed target -> sdist|setup_dir
     for target in reversed(sort_targets(created.keys())):
       setup_dir = created.get(target)
       if setup_dir:
@@ -608,12 +608,14 @@ class SetupPy(PythonTask):
           self.context.log.info('Running packager against {}'.format(setup_dir))
           setup_runner = Packager(setup_dir)
           tgz_name = os.path.basename(setup_runner.sdist())
-          self.context.log.info('Writing {}'.format(os.path.join(dist_dir, tgz_name)))
-          shutil.move(setup_runner.sdist(), os.path.join(dist_dir, tgz_name))
+          sdist_path = os.path.join(dist_dir, tgz_name)
+          self.context.log.info('Writing {}'.format(sdist_path))
+          shutil.move(setup_runner.sdist(), sdist_path)
           safe_rmtree(setup_dir)
+          executed[target] = sdist_path
         else:
           self.context.log.info('Running {} against {}'.format(self._run, setup_dir))
           setup_runner = SetupPyRunner(setup_dir, self._run)
           setup_runner.run()
-        executed.append(target)
+          executed[target] = setup_dir
     return executed

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -600,7 +600,7 @@ class SetupPy(PythonTask):
     for target in targets:
       create(target)
 
-    executed = {}  # Collected and returned for tests, processed target -> sdist|setup_dir
+    executed = {}  # Collected and returned for tests, processed target -> sdist|setup_dir.
     for target in reversed(sort_targets(created.keys())):
       setup_dir = created.get(target)
       if setup_dir:

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -84,6 +84,7 @@ python_tests(
     'src/python/pants/backend/jvm/subsystems:jvm',
 
     'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/subsystem:subsystem_utils'

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -23,6 +23,7 @@ from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.tasks.setup_py import SetupPy
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
+from pants.fs.archive import TGZ
 from pants.util.contextutil import temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
@@ -85,9 +86,10 @@ class TestSetupPy(PythonTaskTestBase):
     dep_map = OrderedDict(foo=['bar'], bar=['baz'], baz=[])
     target_map = self.create_dependencies(dep_map)
     with self.run_execute(target_map['foo'], recursive=False) as created:
-      self.assertEqual([target_map['foo']], created)
+      self.assertEqual([target_map['foo']], created.keys())
     with self.run_execute(target_map['foo'], recursive=True) as created:
-      self.assertEqual([target_map['baz'], target_map['bar'], target_map['foo']], created)
+      self.assertEqual({target_map['baz'], target_map['bar'], target_map['foo']},
+                       set(created.keys()))
 
   def test_reduced_dependencies_2(self):
     # foo --> baz
@@ -150,10 +152,10 @@ class TestSetupPy(PythonTaskTestBase):
     self.assertEqual(entry_points, {'foo_binary': 'foo.bin:foo'})
 
     with self.run_execute(foo, recursive=False) as created:
-      self.assertEqual([foo], created)
+      self.assertEqual([foo], created.keys())
 
     with self.run_execute(foo, recursive=True) as created:
-      self.assertEqual([foo], created)
+      self.assertEqual([foo], created.keys())
 
   def test_binary_target_injected_into_reduced_dependencies_with_provider(self):
     bar_bin_dep = self.create_python_library(
@@ -196,10 +198,10 @@ class TestSetupPy(PythonTaskTestBase):
     self.assertEqual(entry_points, {'bar_binary': 'bar.bin:bar'})
 
     with self.run_execute(bar, recursive=False) as created:
-      self.assertEqual([bar], created)
+      self.assertEqual([bar], created.keys())
 
     with self.run_execute(bar, recursive=True) as created:
-      self.assertEqual([bar_bin_dep, bar], created)
+      self.assertEqual({bar_bin_dep, bar}, set(created.keys()))
 
   def test_pants_contrib_case(self):
     def create_requirement_lib(name):
@@ -346,7 +348,7 @@ class TestSetupPy(PythonTaskTestBase):
                               antlr_version='3.1.3',
                               sources=['exported.g'],
                               module='exported',
-                              provides=PythonArtifact(name='test.exported', version='0.0.0.'))
+                              provides=PythonArtifact(name='test.exported', version='0.0.0'))
 
     # TODO(John Sirois): This hacks around a direct but undeclared dependency
     # `pants.java.distribution.distribution.Distribution` gained in
@@ -354,7 +356,7 @@ class TestSetupPy(PythonTaskTestBase):
     # Remove this once proper Subsystem dependency chains are re-established.
     with subsystem_instance(JVM):
       with self.run_execute(target) as created:
-        self.assertEqual([target], created)
+        self.assertEqual([target], created.keys())
 
   def test_exported_thrift(self):
     SourceRoot.register('src/thrift', PythonThriftLibrary)
@@ -366,13 +368,82 @@ class TestSetupPy(PythonTaskTestBase):
     target = self.make_target(spec='src/thrift/exported',
                               target_type=PythonThriftLibrary,
                               sources=['exported.thrift'],
-                              provides=PythonArtifact(name='test.exported', version='0.0.0.'))
-    # TODO(John Sirois): Find a way to get easy access to pants option defaults.
-    self.set_options_for_scope('binaries',
-                               baseurls=['https://dl.bintray.com/pantsbuild/bin/build-support'],
-                               fetch_timeout_secs=30)
+                              provides=PythonArtifact(name='test.exported', version='0.0.0'))
     with self.run_execute(target) as created:
-      self.assertEqual([target], created)
+      self.assertEqual([target], created.keys())
+
+  def test_exported_thrift_issues_2005(self):
+    # Issue #2005 highlighted the fact the PythonThriftBuilder was building both a given
+    # PythonThriftLibrary's thrift files as well as its transitive dependencies thrift files.
+    # We test here to ensure that independently published PythonThriftLibraries each only own their
+    # own thrift stubs and the proper dependency links exist between the distributions.
+
+    SourceRoot.register('src/thrift', PythonThriftLibrary)
+    self.create_file(relpath='src/thrift/exported/exported.thrift', contents=dedent("""
+      namespace py exported
+
+      const set<string> VALID_IDENTIFIERS = ["Hello", "World", "!"]
+    """))
+    target1 = self.make_target(spec='src/thrift/exported',
+                               target_type=PythonThriftLibrary,
+                               sources=['exported.thrift'],
+                               provides=PythonArtifact(name='test.exported', version='0.0.0'))
+
+    self.create_file(relpath='src/thrift/exported_dependee/exported_dependee.thrift',
+                     contents=dedent("""
+                       namespace py exported_dependee
+
+                       include "exported/exported.thrift"
+
+                       const set<string> ALIASED_IDENTIFIERS = exported.VALID_IDENTIFIERS
+                     """))
+    target2 = self.make_target(spec='src/thrift/exported_dependee',
+                               target_type=PythonThriftLibrary,
+                               sources=['exported_dependee.thrift'],
+                               dependencies=[target1],
+                               provides=PythonArtifact(name='test.exported_dependee',
+                                                       version='0.0.0'))
+
+    with self.run_execute(target2, recursive=True) as created:
+      self.assertEqual({target2, target1}, set(created.keys()))
+
+      @contextmanager
+      def extracted_sdist(target, expected_prefix):
+        sdist = created[target]
+        with temporary_dir() as chroot:
+          TGZ.extract(sdist, chroot)
+
+          all_py_files = set()
+          for root, _, files in os.walk(chroot):
+            all_py_files.update(os.path.join(root, f) for f in files if f.endswith('.py'))
+
+          def as_full_path(p):
+            return os.path.join(chroot, expected_prefix, p)
+
+          yield all_py_files, as_full_path
+
+      with extracted_sdist(target1, 'test.exported-0.0.0') as (py_files, path):
+        self.assertEqual({path('setup.py'),
+                          path('src/__init__.py'),
+                          path('src/exported/__init__.py'),
+                          path('src/exported/constants.py'),
+                          path('src/exported/ttypes.py')},
+                         py_files)
+
+        self.assertFalse(os.path.exists(path('src/test.exported.egg-info/requires.txt')))
+
+      with extracted_sdist(target2, 'test.exported_dependee-0.0.0') as (py_files, path):
+        self.assertEqual({path('setup.py'),
+                          path('src/__init__.py'),
+                          path('src/exported_dependee/__init__.py'),
+                          path('src/exported_dependee/constants.py'),
+                          path('src/exported_dependee/ttypes.py')},
+                         py_files)
+
+        requirements = path('src/test.exported_dependee.egg-info/requires.txt')
+        self.assertTrue(os.path.exists(requirements))
+        with open(requirements) as fp:
+          self.assertEqual('test.exported==0.0.0', fp.read().strip())
 
 
 def test_detect_namespace_packages():

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import subprocess
 from contextlib import contextmanager
 from textwrap import dedent
@@ -143,31 +144,46 @@ class PythonChrootTest(BaseTest):
         self.assertEqual(['Hello', ' ', 'World!'], stdout.splitlines())
 
   @contextmanager
-  def do_test_thrift(self):
+  def do_test_thrift(self, inspect_chroot=None):
     SourceRoot.register('src/thrift', PythonThriftLibrary)
+
+    self.create_file(relpath='src/thrift/core/identifiers.thrift', contents=dedent("""
+      namespace py core
+
+      const string HELLO = "Hello"
+      const string WORLD = "World!"
+    """))
+    core_const = self.make_target(spec='src/thrift/core',
+                                  target_type=PythonThriftLibrary,
+                                  sources=['identifiers.thrift'])
+
     self.create_file(relpath='src/thrift/test/const.thrift', contents=dedent("""
       namespace py test
 
-      const list<string> VALID_IDENTIFIERS = ["Hello", "World!"]
+      include "core/identifiers.thrift"
+
+      const list<string> MESSAGE = [identifiers.HELLO, identifiers.WORLD]
     """))
-    thrift_target = self.make_target(spec='src/thrift/test',
-                                     target_type=PythonThriftLibrary,
-                                     sources=['const.thrift'])
+    test_const = self.make_target(spec='src/thrift/test',
+                                  target_type=PythonThriftLibrary,
+                                  sources=['const.thrift'],
+                                  dependencies=[core_const])
 
     SourceRoot.register('src/python', PythonBinary)
+
     self.create_file(relpath='src/python/test/main.py', contents=dedent("""
-      from test.constants import VALID_IDENTIFIERS
+      from test.constants import MESSAGE
 
 
       def say_hello():
-        print(' '.join(VALID_IDENTIFIERS))
+        print(' '.join(MESSAGE))
     """))
     binary = self.make_target(spec='src/python/test',
                               target_type=PythonBinary,
                               source='main.py',
-                              dependencies=[thrift_target])
+                              dependencies=[test_const])
 
-    yield binary, thrift_target
+    yield binary, test_const
 
     with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
       pex_builder.set_entry_point('test.main:say_hello')
@@ -179,6 +195,9 @@ class PythonChrootTest(BaseTest):
 
       self.assertEqual(0, process.returncode)
       self.assertEqual('Hello World!', stdout.strip())
+
+      if inspect_chroot:
+        inspect_chroot(python_chroot)
 
   def test_thrift(self):
     with self.do_test_thrift():
@@ -204,3 +223,20 @@ class PythonChrootTest(BaseTest):
                                                            sources=['__init__.py', 'constants.py'],
                                                            derived_from=thrift_target)
       binary.inject_dependency(synthetic_pythrift_codegen_target.address)
+
+  def test_thrift_issues_2005(self):
+    # Issue #2005 highlighted the fact the PythonThriftBuilder was building both a given
+    # PythonThriftLibrary's thrift files as well as its transitive dependencies thrift files.
+    # We test here that the generated chroot only contains 1 copy of each thrift stub in the face
+    # of transitive thrift deps.
+    def inspect_chroot(python_chroot):
+      all_constants_files = set()
+      for root, _, files in os.walk(python_chroot.path()):
+        all_constants_files.update(os.path.join(root, f) for f in files if f == 'constants.py')
+
+      # If core/constants.py was included in test/ we'd have 2 copies of core/constants.py plus
+      # test/constants.py for a total of 3 constants.py files.
+      self.assertEqual(2, len(all_constants_files))
+
+    with self.do_test_thrift(inspect_chroot=inspect_chroot):
+      pass  # Our test takes place in inspect_chroot above


### PR DESCRIPTION
Previously it operated on the closure of thrift files depended on by a
single PythonThriftLibrary and this trampled on work both PythonChroot
and SetupPy did to walk the closure and link together CodeGenerator
outputs.  This brings PythonThriftBuilder into line PythonAntlrBuilder
and fixes 2 bugs.

Tests are added that fail before the fix and pass after.

https://rbcommons.com/s/twitter/r/2696/