### PR TITLE
Set 'pants-reviews' as the default group.

### DIFF
--- a/.reviewboardrc
+++ b/.reviewboardrc
@@ -1,4 +1,5 @@
 REVIEWBOARD_URL = 'https://rbcommons.com/s/twitter/'
 REPOSITORY = 'pants'
+TARGET_GROUPS = 'pants-reviews'
 LAND_DEST_BRANCH = 'master'
 LAND_SQUASH = True

--- a/rbt-create
+++ b/rbt-create
@@ -7,7 +7,7 @@
 # will create a review with the specified names as reviewers, with pants-reviews as a group,
 # and with the other flags passed through to rbt.
 
-NAME_REGEX="[a-z].+"
+NAME_REGEX="^[a-zA-Z][a-zA-Z_.-]+$"
 REVIEWERS=""
 
 while [[ $1 ]] && [[ $1 =~ ${NAME_REGEX} ]]; do
@@ -21,4 +21,4 @@ if [[ ${REVIEWERS} ]]; then
   REVIEWERS_FLAG="--target-people=${REVIEWERS}"
 fi
 
-./rbt post -o -g --target-groups=pants-reviews ${REVIEWERS_FLAG} "$@"
+./rbt post -o -g ${REVIEWERS_FLAG} "$@"


### PR DESCRIPTION
This is one less thing to remember or script around.  Folks who
like to do a private review before adding in the group can always
remove the group before clicking publish.