### PR TITLE
Requiring explicit dependency on the DistributionLocator subsystem.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/BUILD
+++ b/src/python/pants/backend/codegen/tasks/BUILD
@@ -149,7 +149,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',
-    'src/python/pants/java:util',
+    'src/python/pants/java/distribution',
     'src/python/pants/option',
   ],
 )

--- a/src/python/pants/backend/codegen/tasks/antlr_gen.py
+++ b/src/python/pants/backend/codegen/tasks/antlr_gen.py
@@ -14,7 +14,6 @@ from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
-from pants.java import util
 
 
 logger = logging.getLogger(__name__)
@@ -76,8 +75,8 @@ class AntlrGen(SimpleCodegenTask, NailgunTask):
       antlr_classpath = self.tool_classpath(compiler)
       sources = self._calculate_sources([target])
       args.extend(sources)
-      result = util.execute_java(classpath=antlr_classpath, main=java_main,
-                                 args=args, workunit_name='antlr')
+      result = self.runjava(classpath=antlr_classpath, main=java_main, args=args,
+                            workunit_name='antlr')
       if result != 0:
         raise TaskError('java {} ... exited non-zero ({})'.format(java_main, result))
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -68,6 +68,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/ivy',
+    'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
     'src/python/pants/java:util',
     'src/python/pants/java/jar:shader',
@@ -312,6 +313,7 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/fs',
     'src/python/pants/java:executor',
+    'src/python/pants/java/distribution',
     'src/python/pants/java:util',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:strutil',
@@ -407,7 +409,7 @@ python_library(
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/base:workunit',
     'src/python/pants/console:stty_utils',
-    'src/python/pants/java:util',
+    'src/python/pants/java/distribution',
     'src/python/pants/util:strutil',
   ],
 )
@@ -419,6 +421,7 @@ python_library(
     ':jvmdoc_gen',
     'src/python/pants/backend/jvm/subsystems:scala_platform',
     'src/python/pants/java:executor',
+    'src/python/pants/java/distribution',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -9,7 +9,7 @@ from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.base.target import Target
 from pants.console.stty_utils import preserve_stty_settings
-from pants.java.util import execute_java
+from pants.java.distribution.distribution import DistributionLocator
 
 
 class ScalaRepl(JvmToolTaskMixin, JvmTask):
@@ -19,6 +19,10 @@ class ScalaRepl(JvmToolTaskMixin, JvmTask):
     register('--main', default='scala.tools.nsc.MainGenericRunner',
              help='The entry point for running the repl.')
     cls.register_jvm_tool(register, 'scala-repl', default=['//:scala-repl'])
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(ScalaRepl, cls).subsystem_dependencies() + (DistributionLocator,)
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -49,10 +53,10 @@ class ScalaRepl(JvmToolTaskMixin, JvmTask):
         print('')  # Start REPL output on a new line.
         try:
           # NOTE: We execute with no workunit, as capturing REPL output makes it very sluggish.
-          execute_java(classpath=classpath,
-                       main=self.get_options().main,
-                       jvm_options=jvm_options,
-                       args=self.args)
+          DistributionLocator.cached().execute_java(classpath=classpath,
+                                                    main=self.get_options().main,
+                                                    jvm_options=jvm_options,
+                                                    args=self.args)
         except KeyboardInterrupt:
           # TODO(John Sirois): Confirm with Steve Gury that finally does not work on mac and an
           # explicit catch of KeyboardInterrupt is required.

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.tasks.jvmdoc_gen import Jvmdoc, JvmdocGen
+from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.util.memo import memoized
 
@@ -20,6 +21,10 @@ class ScaladocGen(JvmdocGen):
   @classmethod
   def task_subsystems(cls):
     return super(ScaladocGen, cls).task_subsystems() + (ScalaPlatform,)
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JvmdocGen, cls).subsystem_dependencies() + (DistributionLocator,)
 
   def execute(self):
     def is_scala(target):
@@ -49,7 +54,7 @@ class ScaladocGen(JvmdocGen):
 
     args.extend(sources)
 
-    java_executor = SubprocessExecutor()
+    java_executor = SubprocessExecutor(DistributionLocator.cached())
     runner = java_executor.runner(jvm_options=self.jvm_options,
                                   classpath=tool_classpath,
                                   main='scala.tools.nsc.ScalaDoc',

--- a/src/python/pants/ivy/BUILD
+++ b/src/python/pants/ivy/BUILD
@@ -7,6 +7,7 @@ python_library(
   dependencies = [
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
     'src/python/pants/java:util',
     'src/python/pants/net',

--- a/src/python/pants/ivy/ivy_subsystem.py
+++ b/src/python/pants/ivy/ivy_subsystem.py
@@ -9,6 +9,7 @@ import os
 
 from six.moves import urllib
 
+from pants.java.distribution.distribution import DistributionLocator
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -38,6 +39,10 @@ class IvySubsystem(Subsystem):
              help='Directory to store artifacts retrieved by Ivy.')
     register('--ivy-settings', advanced=True,
              help='Location of XML configuration file for Ivy settings.')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(IvySubsystem, cls).subsystem_dependencies() + (DistributionLocator,)
 
   def http_proxy(self):
     """Set ivy to use an http proxy.

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -8,7 +8,6 @@ python_library(
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
-    'src/python/pants/java/distribution:distribution',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -8,6 +8,7 @@ python_library(
   dependencies = [
     '3rdparty/python:six',
     'src/python/pants/base:revision',
+    'src/python/pants/java:util',
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:osutil',

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from six import string_types
 
 from pants.base.revision import Revision
+from pants.java.util import execute_java
 from pants.option.custom_types import dict_option
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_dir
@@ -211,6 +212,9 @@ class Distribution(object):
     except self.Error:
       if self._jdk:
         raise
+
+  def execute_java(self, *args, **kwargs):
+    return execute_java(*args, distribution=self, **kwargs)
 
   def _get_version(self, java):
     if not self._version:

--- a/src/python/pants/java/jar/BUILD
+++ b/src/python/pants/java/jar/BUILD
@@ -13,7 +13,6 @@ python_library(
   name='shader',
   sources=['shader.py'],
   dependencies=[
-    'src/python/pants/java:executor',
     'src/python/pants/util:contextutil'
   ]
 )

--- a/src/python/pants/java/jar/shader.py
+++ b/src/python/pants/java/jar/shader.py
@@ -9,7 +9,6 @@ import os
 from collections import namedtuple
 from contextlib import contextmanager
 
-from pants.java.executor import SubprocessExecutor
 from pants.util.contextutil import open_zip, temporary_file
 
 
@@ -123,15 +122,14 @@ class Shader(object):
           paths.add(os.path.dirname(pathname))
       return cls._iter_packages(paths)
 
-  def __init__(self, jarjar, executor=None):
+  def __init__(self, jarjar, executor):
     """Creates a `Shader` the will use the given `jarjar` jar to create shaded jars.
 
     :param unicode jarjar: The path to the jarjar jar.
-    :param executor: An optional java `Executor` to use to create shaded jar files.  Defaults to a
-                    `SubprocessExecutor` that uses the default java distribution.
+    :param executor: A java `Executor` to use to create shaded jar files.
     """
     self._jarjar = jarjar
-    self._executor = executor or SubprocessExecutor()
+    self._executor = executor
     self._system_packages = None
 
   def _calculate_system_packages(self):

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -78,7 +78,7 @@ class NailgunExecutor(Executor, ProcessManager):
   _SELECT_WAIT = 1
   _PROCESS_NAME = b'java'
 
-  def __init__(self, identity, workdir, nailgun_classpath, distribution=None, ins=None,
+  def __init__(self, identity, workdir, nailgun_classpath, distribution, ins=None,
                connect_timeout=10, connect_attempts=5):
     Executor.__init__(self, distribution=distribution)
     ProcessManager.__init__(self, name=identity, process_name=self._PROCESS_NAME)

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -46,6 +46,7 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:bootstrap_jvm_tools',
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
+    'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
     'src/python/pants/java/jar:shader',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/java/jar/BUILD
+++ b/tests/python/pants_test/java/jar/BUILD
@@ -22,6 +22,8 @@ python_tests(
   sources = ['test_shader.py'],
   dependencies = [
     'src/python/pants/java/jar:shader',
+    'src/python/pants/java/distribution',
+    'src/python/pants/java:executor',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ]

--- a/tests/python/pants_test/java/jar/test_shader.py
+++ b/tests/python/pants_test/java/jar/test_shader.py
@@ -9,15 +9,20 @@ import os
 import tempfile
 import unittest
 
+from pants.java.distribution.distribution import DistributionLocator
+from pants.java.executor import SubprocessExecutor
 from pants.java.jar.shader import Shader
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_delete
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
 class ShaderTest(unittest.TestCase):
   def setUp(self):
     self.jarjar = '/not/really/jarjar.jar'
-    self.shader = Shader(jarjar=self.jarjar)
+    with subsystem_instance(DistributionLocator):
+      executor = SubprocessExecutor(DistributionLocator.cached())
+      self.shader = Shader(jarjar=self.jarjar, executor=executor)
     self.output_jar = '/not/really/shaded.jar'
 
   def populate_input_jar(self, *entries):

--- a/tests/python/pants_test/java/test_executor.py
+++ b/tests/python/pants_test/java/test_executor.py
@@ -12,7 +12,7 @@ import unittest
 from contextlib import contextmanager
 
 from pants.java.distribution.distribution import Distribution
-from pants.java.executor import SubprocessExecutor
+from pants.java.executor import Executor, SubprocessExecutor
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import chmod_plus_x, safe_open
 
@@ -73,3 +73,15 @@ class SubprocessExecutorTest(unittest.TestCase):
   def test_subprocess_classpath_relativize(self):
     with self.jre("FOO") as jre:
       self.do_test_executor_classpath_relativize(SubprocessExecutor(Distribution(bin_path=jre)))
+
+  def test_fails_with_bad_distribution(self):
+
+    class DefinitelyNotADistribution(object):
+      pass
+
+    with self.assertRaises(Executor.InvalidDistribution):
+      SubprocessExecutor(DefinitelyNotADistribution())
+
+  def test_fails_with_no_distribution(self):
+    with self.assertRaises(Executor.InvalidDistribution):
+      SubprocessExecutor(None)


### PR DESCRIPTION
This includes adding DistributionLocator as subsystem dependency of
IvySubsystem, and requiring a distribution input to execute_java in
pants.java.util.

The latter change is obviously the more disruptive, and due to how
the default parameters work, it is difficult to see that
distribution is necessary when trying to use that function, unless
you read the pydocs carefully.

To alleviate this, I've added an execute_java method to
Distribution, which just calls util.execute_java, passing itself
as the distribution.

This way, instead of importing pants.java.util, you just import
DistributionLocator, and use something like:

    DistributionLocator.cached().execute_java(...)

Which is more verbose, but requires one less import and makes it
obvious that you need a subsystem dependency on
DistributionLocator.

It makes sense to me that the Distribution should be able to invoke
its own java binary, and the actual meat-and-potatoes code is still
in pants.java.util, so I don't think this pollutes the primarily
information-holder functionality of Distribution too much. But I am
open to changing it if people find it offensive.

Regardless, this change also has the nice side-effect of making it
much more explicit that you're using an arbitrary cached version of
the jvm whenever you run java, which should make it easier and more
maintainable to use more constrained versions if necessary.