### PR TITLE
Implementing support for Wire 2.0 multiple proto paths.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/BUILD
+++ b/src/python/pants/backend/codegen/tasks/BUILD
@@ -148,8 +148,10 @@ python_library(
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:revision',
     'src/python/pants/base:source_root',
     'src/python/pants/java/distribution',
     'src/python/pants/option',
+    'src/python/pants/util:memo',
   ],
 )

--- a/tests/python/pants_test/backend/codegen/tasks/BUILD
+++ b/tests/python/pants_test/backend/codegen/tasks/BUILD
@@ -106,6 +106,8 @@ python_tests(
     'src/python/pants/backend/codegen/tasks:wire_gen',
     'src/python/pants/backend/codegen:plugin',
     'src/python/pants/backend/core:plugin',
+    'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',
     'src/python/pants/base:validation',
     'src/python/pants/util:contextutil',


### PR DESCRIPTION
Wire previously expected all protos, even the ones you were only
importing (not compiling), to be under the same --proto-path
directory. This is not always (read: usually isn't) a correct
assumption.

At Square, before we were internally hacking around the lack of
multiple --proto-paths for wire by doing symlink hacks. Now that
wire supports multiple proto paths, we can support the needed
behavior (java_wire_libraries with dependencies/imports being able
to compile properly) upstream without hacks.