### PR TITLE
Use Target.subsystems to expose UnknownArguments.

### DIFF
--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -39,7 +39,6 @@ from pants.backend.core.wrapped_globs import Globs, RGlobs, ZGlobs
 from pants.base.build_environment import get_buildroot, pants_version
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.source_root import SourceRoot
-from pants.base.target import Target
 from pants.goal.task_registrar import TaskRegistrar as task
 
 
@@ -187,7 +186,3 @@ def register_goals():
 
   task(name='bash-completion', action=BashCompletionTask).install().with_description(
     'Dump bash shell script for autocompletion of pants command lines.')
-
-
-def global_subsystems():
-  return (Target.UnknownArguments,)

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -166,6 +166,10 @@ class Target(AbstractTarget):
           args=''.join('\n  {} = {}'.format(key, value) for key, value in unknown_args.items())
         ))
 
+  @classmethod
+  def subsystems(cls):
+    return super(Target, cls).subsystems() + (cls.UnknownArguments,)
+
   LANG_DISCRIMINATORS = {
     'java': lambda t: t.is_jvm,
     'python': lambda t: t.is_python,

--- a/tests/python/pants_test/base/test_extension_loader.py
+++ b/tests/python/pants_test/base/test_extension_loader.py
@@ -53,7 +53,7 @@ class DummyTarget(Target):
 
   @classmethod
   def subsystems(cls):
-    return super(DummyTarget, cls).subsystems() + (DummySubsystem1, )
+    return (DummySubsystem1,)
 
 
 class DummyObject1(object):
@@ -65,7 +65,7 @@ class DummyObject2(object):
 
   @classmethod
   def subsystems(cls):
-    return (DummySubsystem2, )
+    return (DummySubsystem2,)
 
 
 class DummyTask(Task):
@@ -133,8 +133,7 @@ class LoaderTest(unittest.TestCase):
       self.assertEqual(DummyTarget, registered_aliases.targets['bob'])
       self.assertEqual(DummyObject1, registered_aliases.objects['obj1'])
       self.assertEqual(DummyObject2, registered_aliases.objects['obj2'])
-      self.assertEqual(self.build_configuration.subsystems(),
-                       set([DummySubsystem1, DummySubsystem2]))
+      self.assertEqual(self.build_configuration.subsystems(), {DummySubsystem1, DummySubsystem2})
 
   def test_load_valid_partial_goals(self):
     def register_goals():
@@ -182,8 +181,8 @@ class LoaderTest(unittest.TestCase):
     their name (foo/bar/baz in fake module) is added as the requested entry point to the mocked
     metadata added to the returned dist.
 
-    :param str name: project_name for distribution (see pkg_resources)
-    :param str version: version for distribution (see pkg_resources)
+    :param string name: project_name for distribution (see pkg_resources)
+    :param string version: version for distribution (see pkg_resources)
     :param callable reg: Optional callable for goal registration entry point
     :param callable alias: Optional callable for build_file_aliases entry point
     :param callable after: Optional callable for load_after list entry point
@@ -275,8 +274,7 @@ class LoaderTest(unittest.TestCase):
     self.assertEqual(DummyTarget, registered_aliases.targets['pluginalias'])
     self.assertEqual(DummyObject1, registered_aliases.objects['FROMPLUGIN1'])
     self.assertEqual(DummyObject2, registered_aliases.objects['FROMPLUGIN2'])
-    self.assertEqual(self.build_configuration.subsystems(),
-                     {DummySubsystem1, DummySubsystem2})
+    self.assertEqual(self.build_configuration.subsystems(), {DummySubsystem1, DummySubsystem2})
 
   def test_subsystems(self):
     def global_subsystems():

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -5,16 +5,12 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from textwrap import dedent
-
-from pants.backend.core.wrapped_globs import Globs
-from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.base.address import BuildFileAddress, SyntheticAddress
-from pants.base.build_file_aliases import BuildFileAliases
+from pants.base.address import SyntheticAddress
 from pants.base.payload import Payload
 from pants.base.payload_field import DeferredSourcesField
 from pants.base.target import Target
 from pants_test.base_test import BaseTest
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
 class TestDeferredSourcesTarget(Target):
@@ -25,41 +21,15 @@ class TestDeferredSourcesTarget(Target):
     })
     super(TestDeferredSourcesTarget, self).__init__(payload=payload, *args, **kwargs)
 
+
 class TargetTest(BaseTest):
-  @property
-  def alias_groups(self):
-    return BuildFileAliases.create(
-      targets={
-        'java_library': JavaLibrary,
-      },
-      context_aware_object_factories={
-        'globs': Globs,
-      },
-    )
-
   def test_derived_from_chain(self):
-    context = self.context()
-
     # add concrete target
-    build_file = self.add_to_build_file('y/BUILD', dedent('''
-    java_library(
-      name='concrete',
-      sources=['SourceA.scala'],
-    )
-    '''))
-    concrete_address = BuildFileAddress(build_file, 'concrete')
-    context.build_graph.inject_address_closure(concrete_address)
-    concrete = context.build_graph.get_target(concrete_address)
+    concrete = self.make_target('y:concrete', Target)
 
     # add synthetic targets
-    syn_one = context.add_new_target(SyntheticAddress('y', 'syn_one'),
-                                     JavaLibrary,
-                                     derived_from=concrete,
-                                     sources=["SourceB.scala"])
-    syn_two = context.add_new_target(SyntheticAddress('y', 'syn_two'),
-                                     JavaLibrary,
-                                     derived_from=syn_one,
-                                     sources=["SourceC.scala"])
+    syn_one = self.make_target('y:syn_one', Target, derived_from=concrete)
+    syn_two = self.make_target('y:syn_two', Target, derived_from=syn_one)
 
     # validate
     self.assertEquals(list(syn_two.derived_from_chain), [syn_one, concrete])
@@ -67,36 +37,26 @@ class TargetTest(BaseTest):
     self.assertEquals(list(concrete.derived_from_chain), [])
 
   def test_empty_traversable_properties(self):
-    build_file = self.add_to_build_file('BUILD', dedent('''
-    java_library(
-      name='foo',
-      sources=["foo.java"],
-    )
-    '''))
-    self.build_graph.inject_address_closure(BuildFileAddress(build_file, 'foo'))
-    target = self.build_graph.get_target(SyntheticAddress.parse('//:foo'))
+    target = self.make_target(':foo', Target)
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([], list(target.traversable_dependency_specs))
 
   def test_deferred_sources_payload_field(self):
-    target = TestDeferredSourcesTarget(name='bar', address=SyntheticAddress.parse('//:bar'),
-                                       build_graph=self.build_graph,
-                                       deferred_sources_address=SyntheticAddress.parse('//:foo'))
+    target = self.make_target(':bar',
+                              TestDeferredSourcesTarget,
+                              deferred_sources_address=SyntheticAddress.parse('//:foo'))
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':foo'], list(target.traversable_dependency_specs))
 
   def test_illegal_kwargs(self):
-    with self.assertRaises(Target.UnknownArguments.Error) as cm:
-      context = self.context(for_subsystems=[Target.UnknownArguments])
-      build_file = self.add_to_build_file('foo/BUILD', dedent('''
-      java_library(
-        name='bar',
-        sources=[],
-        foobar='barfoo',
-      )
-      '''))
-      address = BuildFileAddress(build_file, 'bar')
-      context.build_graph.inject_address_closure(address)
-      context.build_graph.get_target(address)
-    self.assertTrue('foobar = barfoo' in str(cm.exception))
-    self.assertTrue('foo:bar' in str(cm.exception))
+    with subsystem_instance(Target.UnknownArguments):
+      with self.assertRaises(Target.UnknownArguments.Error) as cm:
+        self.make_target('foo:bar', Target, foobar='barfoo')
+      self.assertTrue('foobar = barfoo' in str(cm.exception))
+      self.assertTrue('foo:bar' in str(cm.exception))
+
+  def test_unknown_kwargs(self):
+    options = {Target.UnknownArguments.options_scope: {'ignored': {'Target': ['foobar']}}}
+    with subsystem_instance(Target.UnknownArguments, options=options):
+      target = self.make_target('foo:bar', Target, foobar='barfoo')
+      self.assertFalse(hasattr(target, 'foobar'))

--- a/tests/python/pants_test/targets/test_unknown_arguments_integration.py
+++ b/tests/python/pants_test/targets/test_unknown_arguments_integration.py
@@ -28,11 +28,10 @@ class TestUnknownArgumentsIntegration(PantsRunIntegrationTest):
                                                   for key, val in kwargs.items())))
       yield spec
 
-
   def test_future_params(self):
     param = 'nonexistant_parameter'
     with self.temp_target_spec(**{param: 'value'}) as spec:
-      run = self.run_pants(['--unknown-arguments-ignored={"JavaLibrary": ["nonexistant_parameter"]}',
+      run = self.run_pants(['--unknown-arguments-ignored={{"JavaLibrary": ["{}"]}}'.format(param),
                             '-ldebug',
                             'clean-all', spec])
       self.assert_success(run)


### PR DESCRIPTION
Previously the UnknownArguments subsystem was exposed somewhat indirectly
by the core backend, but target types themselves are scanned for subsystems
in the pants boot-up stage.

This also modernizes and expands the Target unit test and cleans up
TestUnknownArgumentsIntegration.