### PR TITLE
Record the BUILD target alias in BuildFileAddress.

### DIFF
--- a/contrib/buildgen/src/python/pants/contrib/buildgen/build_file_manipulator.py
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/build_file_manipulator.py
@@ -146,6 +146,8 @@ class BuildFileManipulator(object):
                                   .format(name=name, build_file=build_file))
 
     target_call = calls_by_name[name]
+    target_alias = target_call.func.id
+
     # lineno is 1-indexed
     target_interval_index = intervals.index(target_call.lineno - 1)
     target_start = intervals[target_interval_index]
@@ -312,6 +314,7 @@ class BuildFileManipulator(object):
       deps_end = -1
 
     return cls(name=name,
+               target_alias=target_alias,
                build_file=build_file,
                build_file_source_lines=source_lines,
                target_source_lines=target_source_lines,
@@ -321,6 +324,7 @@ class BuildFileManipulator(object):
 
   def __init__(self,
                name,
+               target_alias,
                build_file,
                build_file_source_lines,
                target_source_lines,
@@ -329,8 +333,9 @@ class BuildFileManipulator(object):
                dependencies_interval):
     """See BuildFileManipulator.load() for how to construct one as a user."""
     self.name = name
+    self.target_alias = target_alias
     self.build_file = build_file
-    self.target_address = BuildFileAddress(build_file, name)
+    self.target_address = BuildFileAddress(build_file, target_alias, name)
     self._build_file_source_lines = build_file_source_lines
     self._target_source_lines = target_source_lines
     self._target_interval = target_interval

--- a/migrations/options/src/python/migrate_config.py
+++ b/migrations/options/src/python/migrate_config.py
@@ -269,6 +269,8 @@ migrations = {
   ('compile.apt', 'jar'): None,
   ('compile.java', 'jar'): None,
   ('compile.zinc', 'jar'): None,
+
+  ('unknown-arguments', 'ignored'): None,
 }
 
 ng_daemons_note = ('The global "ng_daemons" option has been replaced by a "use_nailgun" option '
@@ -380,6 +382,11 @@ notes = {
   ('compile.apt', 'jar'): compile_jar_note,
   ('compile.java', 'jar'): compile_jar_note,
   ('compile.zinc', 'jar'): compile_jar_note,
+
+  ('unknown-arguments', 'ignored'): 'Target name keys are now expected to be the alias used in '
+                                    'BUILD files and not the target type\'s simple class name. '
+                                    'For example, if you had \'JavaLibrary\' key you\'d now use '
+                                    '\'java_library\' instead.'
 }
 
 

--- a/src/python/pants/backend/jvm/targets/jvm_app.py
+++ b/src/python/pants/backend/jvm/targets/jvm_app.py
@@ -183,7 +183,7 @@ class JvmApp(Target):
     super_globs = super(JvmApp, self).globs_relative_to_buildroot()
     if super_globs:
       globs += super_globs['globs']
-    return {'globs' : globs}
+    return {'globs': globs}
 
   @property
   def traversable_dependency_specs(self):

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -65,7 +65,7 @@ class Duplicate(JarRule):
     def __init__(self, path):
       """Creates a duplicate entry error for the given path.
 
-      :param str path: The path of the duplicate entry.
+      :param string path: The path of the duplicate entry.
       """
       assert path and isinstance(path, string_types), 'A non-empty path must be supplied.'
       super(Duplicate.Error, self).__init__('Duplicate entry encountered for path {}'.format(path))
@@ -107,7 +107,7 @@ class Duplicate(JarRule):
   def __init__(self, apply_pattern, action):
     """Creates a rule for handling duplicate jar entries.
 
-    :param str apply_pattern: A regular expression that matches duplicate jar entries this rule
+    :param string apply_pattern: A regular expression that matches duplicate jar entries this rule
       applies to.
     :param action: An action to take to handle one or more duplicate entries.  Must be one of:
       ``Duplicate.SKIP``, ``Duplicate.REPLACE``, ``Duplicate.CONCAT`` or ``Duplicate.FAIL``.

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -62,11 +62,13 @@ class JvmTarget(Target, Jarable):
     if sources_rel_path is None:
       sources_rel_path = address.spec_path
     payload = payload or Payload()
+    excludes = ExcludesField(self.assert_list(excludes, expected_type=Exclude, key_arg='excludes'))
+    configurations = ConfigurationsField(self.assert_list(configurations, key_arg='configurations'))
     payload.add_fields({
       'sources': self.create_sources_field(sources, sources_rel_path, address, key_arg='sources'),
       'provides': provides,
-      'excludes': ExcludesField(self.assert_list(excludes, expected_type=Exclude, key_arg='excludes')),
-      'configurations': ConfigurationsField(self.assert_list(configurations, key_arg='configurations')),
+      'excludes': excludes,
+      'configurations': configurations,
       'platform': PrimitiveField(platform),
     })
     self._resource_specs = self.assert_list(resources, key_arg='resources')

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -239,7 +239,8 @@ class Export(ConsoleTask):
     if pants_target_type in self.target_aliases_map:
       return self.target_aliases_map.get(pants_target_type)
     else:
-      raise TaskError('Unregistered target type {target_type}'.format(target_type=pants_target_type))
+      raise TaskError('Unregistered target type {target_type}'
+                      .format(target_type=pants_target_type))
 
   @staticmethod
   def _source_roots_for_target(target):

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -197,16 +197,25 @@ class Address(AbstractClass):
 
 
 class BuildFileAddress(Address):
-  def __init__(self, build_file, target_name=None):
-    self.build_file = build_file
+  def __init__(self, build_file, type_alias, target_name=None):
     spec_path = os.path.dirname(build_file.relpath)
-    default_target_name = os.path.basename(spec_path)
     super(BuildFileAddress, self).__init__(spec_path=spec_path,
-                                           target_name=target_name or default_target_name)
+                                           target_name=target_name or os.path.basename(spec_path))
+    self._build_file = build_file
+    self._type_alias = type_alias
+
+  @property
+  def build_file(self):
+    return self._build_file
+
+  @property
+  def type_alias(self):
+    return self._type_alias
 
   def __repr__(self):
-    return ("BuildFileAddress({build_file}, {target_name})"
+    return ("BuildFileAddress({build_file}, {type_alias}, {target_name})"
             .format(build_file=self.build_file,
+                    type_alias=self.type_alias,
                     target_name=self.target_name))
 
 

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -87,7 +87,7 @@ def parse_spec(spec, relative_to=None):
   return spec_path, target_name
 
 
-class Addresses (namedtuple('Addresses', ['addresses', 'rel_path'])):
+class Addresses(namedtuple('Addresses', ['addresses', 'rel_path'])):
   """ Used as a sentinel type for identifying a list of string specs.
 
   addresses: list of string specs

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -197,7 +197,16 @@ class Address(AbstractClass):
 
 
 class BuildFileAddress(Address):
+  """Represents the address of a type materialized from a BUILD file."""
+
   def __init__(self, build_file, type_alias, target_name=None):
+    """
+    :param build_file: The build file that contains the object this address points to.
+    :type build_file: :class:`pants.base.build_file.BuildFile`
+    :param string type_alias: The type alias this address points to; eg: 'java_library'.
+    :param string target_name: The name of the target within the BUILD file; defaults to the default
+                               target, aka the name of the BUILD file parent dir.
+    """
     spec_path = os.path.dirname(build_file.relpath)
     super(BuildFileAddress, self).__init__(spec_path=spec_path,
                                            target_name=target_name or os.path.basename(spec_path))
@@ -206,10 +215,18 @@ class BuildFileAddress(Address):
 
   @property
   def build_file(self):
+    """The build file that contains the object this address points to.
+
+    :rtype: :class:`pants.base.build_file.BuildFile`
+    """
     return self._build_file
 
   @property
   def type_alias(self):
+    """The type alias of the object this address points to; eg: 'java_library'.
+
+    :rtype: string
+    """
     return self._type_alias
 
   def __repr__(self):

--- a/src/python/pants/base/addressable.py
+++ b/src/python/pants/base/addressable.py
@@ -12,7 +12,8 @@ from pants.util.meta import AbstractClass
 class AddressableCallProxy(object):
   """A registration proxy for objects to be captured and addressed from BUILD files."""
 
-  def __init__(self, addressable_type, build_file, registration_callback):
+  def __init__(self, addressable_alias, addressable_type, build_file, registration_callback):
+    self._addressable_alias = addressable_alias
     self._addressable_type = addressable_type
     self._build_file = build_file
     self._registration_callback = registration_callback
@@ -21,7 +22,9 @@ class AddressableCallProxy(object):
     addressable = self._addressable_type(*args, **kwargs)
     addressable_name = addressable.addressable_name
     if addressable_name:
-      address = BuildFileAddress(self._build_file, addressable_name)
+      address = BuildFileAddress(build_file=self._build_file,
+                                 type_alias=self._addressable_alias,
+                                 target_name=addressable_name)
       self._registration_callback(address, addressable)
     return addressable
 

--- a/src/python/pants/base/build_configuration.py
+++ b/src/python/pants/base/build_configuration.py
@@ -146,7 +146,8 @@ class BuildConfiguration(object):
       registered_addressable_instances.append((address, addressable))
 
     for alias, addressable_type in self._addressable_alias_map.items():
-      call_proxy = AddressableCallProxy(addressable_type=addressable_type,
+      call_proxy = AddressableCallProxy(addressable_alias=alias,
+                                        addressable_type=addressable_type,
                                         build_file=build_file,
                                         registration_callback=registration_callback)
       type_aliases[alias] = call_proxy

--- a/src/python/pants/base/build_file_address_mapper.py
+++ b/src/python/pants/base/build_file_address_mapper.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.address import Address, BuildFileAddress, parse_spec
+from pants.base.address import Address, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
@@ -165,11 +165,14 @@ class BuildFileAddressMapper(object):
     return self._build_file_type.from_cache(*args, **kwargs)
 
   def spec_to_address(self, spec, relative_to=''):
-    """A helper method for mapping a spec to the correct BuildFileAddress.
-    :param spec: a spec to lookup in the map.
-    :param relative_to: path the spec might be relative to
-    :raises AddressLookupError: if the BUILD file cannot be found in the path specified by the spec
-    :returns a new Address instance
+    """A helper method for mapping a spec to the correct address.
+
+    :param string spec: A spec to lookup in the map.
+    :param string relative_to: Path the spec might be relative to
+    :raises :class:`pants.base.address_lookup_error.AddressLookupError` If the BUILD file cannot be
+            found in the path specified by the spec.
+    :returns: A new Address instance.
+    :rtype: :class:`pants.base.address.Address`
     """
     spec_path, name = parse_spec(spec, relative_to=relative_to)
     try:
@@ -177,7 +180,7 @@ class BuildFileAddressMapper(object):
     except BuildFile.BuildFileError as e:
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))
-    return SyntheticAddress(spec_path, name)
+    return Address(spec_path, name)
 
   def scan_buildfiles(self, root_dir, *args, **kwargs):
     """Looks for all BUILD files in root_dir or its descendant directories.

--- a/src/python/pants/base/build_file_address_mapper.py
+++ b/src/python/pants/base/build_file_address_mapper.py
@@ -169,15 +169,15 @@ class BuildFileAddressMapper(object):
     :param spec: a spec to lookup in the map.
     :param relative_to: path the spec might be relative to
     :raises AddressLookupError: if the BUILD file cannot be found in the path specified by the spec
-    :returns a new BuildFileAddress instanace
+    :returns a new Address instance
     """
     spec_path, name = parse_spec(spec, relative_to=relative_to)
     try:
-      build_file = self.from_cache(self.root_dir, spec_path)
+      self.from_cache(self.root_dir, spec_path)
     except BuildFile.BuildFileError as e:
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))
-    return BuildFileAddress(build_file, name)
+    return SyntheticAddress(spec_path, name)
 
   def scan_buildfiles(self, root_dir, *args, **kwargs):
     """Looks for all BUILD files in root_dir or its descendant directories.

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet, maybe_list
 
-from pants.base.address import BuildFileAddress, parse_spec
+from pants.base.address import BuildFileAddress, SyntheticAddress, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file import BuildFile
 
@@ -164,7 +164,7 @@ class CmdLineSpecParser(object):
       spec_parts[0] = normalize_spec_path(spec_parts[0])
       spec_path, target_name = parse_spec(':'.join(spec_parts))
       try:
-        build_file = self._address_mapper.from_cache(self._root_dir, spec_path)
-        return set([BuildFileAddress(build_file, target_name)])
+        self._address_mapper.from_cache(self._root_dir, spec_path)
       except BuildFile.BuildFileError as e:
         raise self.BadSpecError(e)
+      return {SyntheticAddress(spec_path, target_name)}

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 from twitter.common.collections import OrderedSet, maybe_list
 
-from pants.base.address import BuildFileAddress, SyntheticAddress, parse_spec
+from pants.base.address import Address, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file import BuildFile
 
@@ -167,4 +167,4 @@ class CmdLineSpecParser(object):
         self._address_mapper.from_cache(self._root_dir, spec_path)
       except BuildFile.BuildFileError as e:
         raise self.BadSpecError(e)
-      return {SyntheticAddress(spec_path, target_name)}
+      return {Address(spec_path, target_name)}

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -149,9 +149,7 @@ class Target(AbstractTarget):
       cls.global_instance().check_unknown(target, kwargs)
 
     def check_unknown(self, target, kwargs):
-      ignore_params = ()
-      if isinstance(target.address, BuildFileAddress):
-        ignore_params = set((self.get_options().ignored or {}).get(target.address.type_alias, ()))
+      ignore_params = set((self.get_options().ignored or {}).get(target.type_alias, ()))
       unknown_args = {arg: value for arg, value in kwargs.items() if arg not in ignore_params}
       ignored_args = {arg: value for arg, value in kwargs.items() if arg in ignore_params}
       if ignored_args:
@@ -257,6 +255,23 @@ class Target(AbstractTarget):
     self._cached_transitive_fingerprint_map = {}
     if kwargs:
       self.UnknownArguments.check(self, kwargs)
+
+  @property
+  def type_alias(self):
+    """Returns the type alias this target was constructed via.
+
+    For a target read from a BUILD file, this will be target alias, like 'java_library.
+    For a target constructed in memory, this will be the simple class name, like 'JavaLibrary'.
+
+    The end result is that the type alias should be the most natural way to refer to this target's
+    type to the author of the target instance.
+
+    :rtype: string
+    """
+    if isinstance(self.address, BuildFileAddress):
+      return self.address.type_alias
+    else:
+      return type(self).__name__
 
   @property
   def tags(self):

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -12,7 +12,7 @@ from hashlib import sha1
 from six import string_types
 
 from pants.backend.core.wrapped_globs import FilesetWithSpec
-from pants.base.address import Address, Addresses
+from pants.base.address import Address, Addresses, BuildFileAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
@@ -149,11 +149,11 @@ class Target(AbstractTarget):
       cls.global_instance().check_unknown(target, kwargs)
 
     def check_unknown(self, target, kwargs):
-      # NB(gmalmquist): Sure would be nice to be able to use the build-file-alias name here.
-      target_type_name = type(target).__name__
-      ignore_params = set((self.get_options().ignored or {}).get(target_type_name, ()))
-      unknown_args = { arg: value for arg, value in kwargs.items() if arg not in ignore_params }
-      ignored_args = { arg: value for arg, value in kwargs.items() if arg in ignore_params }
+      ignore_params = ()
+      if isinstance(target.address, BuildFileAddress):
+        ignore_params = set((self.get_options().ignored or {}).get(target.address.type_alias, ()))
+      unknown_args = {arg: value for arg, value in kwargs.items() if arg not in ignore_params}
+      ignored_args = {arg: value for arg, value in kwargs.items() if arg in ignore_params}
       if ignored_args:
         logger.debug('{target} ignoring the unimplemented arguments: {args}'
                      .format(target=target.address.spec,

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -260,7 +260,7 @@ class Target(AbstractTarget):
   def type_alias(self):
     """Returns the type alias this target was constructed via.
 
-    For a target read from a BUILD file, this will be target alias, like 'java_library.
+    For a target read from a BUILD file, this will be target alias, like 'java_library'.
     For a target constructed in memory, this will be the simple class name, like 'JavaLibrary'.
 
     The end result is that the type alias should be the most natural way to refer to this target's

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -25,7 +25,6 @@ python_library(
   name = 'base_test',
   sources = ['base_test.py'],
   dependencies = [
-    'src/python/pants/backend/core/targets:common',
     'src/python/pants/base:address',
     'src/python/pants/base:build_configuration',
     'src/python/pants/base:build_file',

--- a/tests/python/pants_test/backend/jvm/targets/BUILD
+++ b/tests/python/pants_test/backend/jvm/targets/BUILD
@@ -1,10 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 target(
-  name = 'targets',
-  dependencies = [
+  name='targets',
+  dependencies=[
     ':jar_dependency',
     ':jvm_app',
     ':jvm_binary',
@@ -14,21 +13,21 @@ target(
 )
 
 python_tests(
-  name = 'jar_dependency',
-  sources = ['test_jar_dependency.py'],
-  dependencies = [
+  name='jar_dependency',
+  sources=['test_jar_dependency.py'],
+  dependencies=[
     'src/python/pants/backend/core:plugin',
-    'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/backend/jvm:plugin',
     'src/python/pants/base:address',
     'tests/python/pants_test:base_test',
   ]
 )
 
 python_tests(
-  name = 'jar_library',
-  sources = ['test_jar_library.py'],
-  dependencies = [
+  name='jar_library',
+  sources=['test_jar_library.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:target',
     'tests/python/pants_test:base_test',
@@ -36,46 +35,45 @@ python_tests(
 )
 
 python_tests(
-  name = 'jvm_app',
-  sources = ['test_jvm_app.py'],
-  dependencies = [
-    'src/python/pants/backend/core:plugin',
-    'src/python/pants/backend/jvm:plugin',
+  name='jvm_app',
+  sources=['test_jvm_app.py'],
+  dependencies=[
+    'src/python/pants/backend/core:wrapped_globs',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:address',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:parse_context',
     'tests/python/pants_test:base_test',
   ]
 )
 
 python_tests(
-  name = 'jvm_binary',
-  sources = ['test_jvm_binary.py'],
-  dependencies = [
-    'src/python/pants/backend/jvm:plugin',
+  name='jvm_binary',
+  sources=['test_jvm_binary.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/base:address',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:payload_field',
+    'src/python/pants/base:target',
     'tests/python/pants_test:base_test',
   ]
 )
 
 python_tests(
-  name = 'jvm_target',
-  sources = ['test_jvm_target.py'],
-  dependencies = [
-    'src/python/pants/backend/core:plugin',
+  name='jvm_target',
+  sources=['test_jvm_target.py'],
+  dependencies=[
+    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/jvm/targets:jvm',
     'tests/python/pants_test:base_test',
   ]
 )
 
 python_tests(
-  name = 'unpacked_jars',
-  sources = ['test_unpacked_jars.py'],
-  dependencies = [
-    'src/python/pants/backend/core:plugin',
-    'src/python/pants/backend/jvm:plugin',
+  name='unpacked_jars',
+  sources=['test_unpacked_jars.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/base:address',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from pants.backend.core.wrapped_globs import Globs
 from pants.backend.jvm.targets.jvm_app import Bundle, DirectoryReMapper, JvmApp
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.parse_context import ParseContext
 from pants_test.base_test import BaseTest
@@ -45,7 +45,7 @@ class JvmAppTest(BundleTestBase):
 
   def create_app(self, rel_path, name=None, **kwargs):
     self.create_file(os.path.join(rel_path, 'config/densities.xml'))
-    return self.make_target(SyntheticAddress(rel_path, name or 'app').spec,
+    return self.make_target(Address(rel_path, name or 'app').spec,
                             JvmApp,
                             bundles=[self.create_bundle(rel_path, fileset='config/densities.xml')],
                             **kwargs)
@@ -105,7 +105,7 @@ class BundleTest(BundleTestBase):
   def test_bundle_filemap_dest_bypath(self):
     spec_path = 'src/java/org/archimedes/buoyancy'
     densities = self.create_file(os.path.join(spec_path, 'config/densities.xml'))
-    unused = self.make_target(SyntheticAddress(spec_path, 'unused').spec, JvmBinary)
+    unused = self.make_target(Address(spec_path, 'unused').spec, JvmBinary)
 
     app = self.make_target(spec_path,
                            JvmApp,
@@ -120,7 +120,7 @@ class BundleTest(BundleTestBase):
     spec_path = 'src/java/org/archimedes/tub'
     one = self.create_file(os.path.join(spec_path, 'config/one.xml'))
     two = self.create_file(os.path.join(spec_path, 'config/two.xml'))
-    unused = self.make_target(SyntheticAddress(spec_path, 'unused').spec, JvmBinary)
+    unused = self.make_target(Address(spec_path, 'unused').spec, JvmBinary)
 
     parse_context = self.create_parse_context(spec_path)
     globs = Globs(parse_context)
@@ -135,7 +135,7 @@ class BundleTest(BundleTestBase):
   def test_bundle_filemap_dest_relative(self):
     spec_path = 'src/java/org/archimedes/crown'
     five = self.create_file(os.path.join(spec_path, 'gold/config/five.xml'))
-    unused = self.make_target(SyntheticAddress(spec_path, 'unused').spec, JvmBinary)
+    unused = self.make_target(Address(spec_path, 'unused').spec, JvmBinary)
 
     app = self.make_target(spec_path,
                            JvmApp,
@@ -150,7 +150,7 @@ class BundleTest(BundleTestBase):
   def test_bundle_filemap_dest_remap(self):
     spec_path = 'src/java/org/archimedes/crown'
     one = self.create_file(os.path.join(spec_path, 'config/one.xml'))
-    unused = self.make_target(SyntheticAddress(spec_path, 'unused').spec, JvmBinary)
+    unused = self.make_target(Address(spec_path, 'unused').spec, JvmBinary)
 
     mapper = DirectoryReMapper(os.path.join(spec_path, 'config'), 'gold/config')
     app = self.make_target(spec_path,
@@ -172,7 +172,7 @@ class BundleTest(BundleTestBase):
     spec_path = 'src/java/org/archimedes/volume'
     stone_dense = self.create_file(os.path.join(spec_path, 'config/stone/dense.xml'))
     metal_dense = self.create_file(os.path.join(spec_path, 'config/metal/dense.xml'))
-    unused = self.make_target(SyntheticAddress(spec_path, 'unused').spec, JvmBinary)
+    unused = self.make_target(Address(spec_path, 'unused').spec, JvmBinary)
 
     bundle = self.create_bundle(spec_path,
                                 relative_to='config',
@@ -187,7 +187,7 @@ class BundleTest(BundleTestBase):
     spec_path = 'src/java/org/archimedes/volume'
     stone_dense = self.create_file(os.path.join(spec_path, 'config/stone/dense.xml'))
     metal_dense = self.create_file(os.path.join(spec_path, 'config/metal/dense.xml'))
-    unused = self.make_target(SyntheticAddress(spec_path, 'unused').spec, JvmBinary)
+    unused = self.make_target(Address(spec_path, 'unused').spec, JvmBinary)
 
     self.add_to_build_file('src/java/org/archimedes/volume/BUILD', dedent('''
       jvm_app(name='volume',
@@ -205,14 +205,14 @@ class BundleTest(BundleTestBase):
       )
     '''))
 
-    app1 = self.make_target(SyntheticAddress(spec_path, 'app1').spec,
+    app1 = self.make_target(Address(spec_path, 'app1').spec,
                             JvmApp,
                             dependencies=[unused],
                             bundles=[self.create_bundle(spec_path,
                                                         relative_to='config',
                                                         fileset='config/stone/dense.xml')])
 
-    app2 = self.make_target(SyntheticAddress(spec_path, 'app2').spec,
+    app2 = self.make_target(Address(spec_path, 'app2').spec,
                             JvmApp,
                             dependencies=[unused],
                             bundles=[self.create_bundle(spec_path,

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_target.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_target.py
@@ -5,37 +5,15 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from textwrap import dedent
-
-from pants.backend.core.register import build_file_aliases as register_core
+from pants.backend.core.targets.resources import Resources
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.base.address import Address, BuildFileAddress
-from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
 
 
 class JvmTargetTest(BaseTest):
 
-  @property
-  def alias_groups(self):
-    return register_core().merge(BuildFileAliases.create(
-      targets={
-        # We don't usually have an alias for 'jvm_target' in BUILD files. It's being added here
-        # to make it easier to write a test.
-        'jvm_target': JvmTarget,
-        }))
-
   def test_traversable_dependency_specs(self):
-    build_file = self.add_to_build_file('BUILD', dedent('''
-    jvm_target(name='foo',
-      resources=[':resource_target'],
-    )
-    resources(name='resource_target',
-      sources=['foo.txt'],
-    )
-    '''))
-
-    self.build_graph.inject_address_closure(BuildFileAddress(build_file, 'foo'))
-    target = self.build_graph.get_target(Address.parse('//:foo'))
+    self.make_target(':resource_target', Resources)
+    target = self.make_target(':foo', JvmTarget, resources=[':resource_target'])
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':resource_target'], list(target.traversable_dependency_specs))

--- a/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_unpacked_jars.py
@@ -5,46 +5,23 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from textwrap import dedent
-
-from pants.backend.core.register import build_file_aliases as register_core
-from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.targets.import_jars_mixin import ImportJarsMixin
 from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
-from pants.base.address import BuildFileAddress
 from pants_test.base_test import BaseTest
 
 
 class UnpackedJarsTest(BaseTest):
 
-  @property
-  def alias_groups(self):
-    return register_core().merge(register_jvm())
-
   def test_empty_libraries(self):
-    build_file = self.add_to_build_file('BUILD', dedent('''
-    unpacked_jars(name='foo',
-    )'''))
     with self.assertRaises(UnpackedJars.ExpectedLibrariesError):
-      self.build_graph.inject_address_closure(BuildFileAddress(build_file, 'foo'))
+      self.make_target(':foo', UnpackedJars)
 
   def test_simple(self):
-    build_file = self.add_to_build_file('BUILD', dedent('''
-    unpacked_jars(name='foo',
-      libraries=[':import_jars'],
-    )
+    self.make_target(':import_jars', JarLibrary, jars=[JarDependency('foo', 'bar', '123')])
+    target = self.make_target(':foo', UnpackedJars, libraries=[':import_jars'])
 
-    jar_library(name='import_jars',
-      jars=[
-        jar(org='foo', name='bar', rev='123'),
-      ],
-    )
-   '''))
-
-    address = BuildFileAddress(build_file, 'foo')
-    self.build_graph.inject_address_closure(address)
-    target = self.build_graph.get_target(address)
     self.assertIsInstance(target, UnpackedJars)
     traversable_specs = [spec for spec in target.traversable_specs]
     self.assertSequenceEqual([':import_jars'], traversable_specs)
@@ -53,23 +30,8 @@ class UnpackedJarsTest(BaseTest):
     self.assertIsInstance(import_jar_dep, JarDependency)
 
   def test_bad_libraries_ref(self):
-    build_file = self.add_to_build_file('BUILD', dedent('''
-    unpacked_jars(name='foo',
-      libraries=[':wrong-type'],
-    )
-
-    unpacked_jars(name='wrong-type',
-      libraries=[':right-type'],
-    )
-
-    jar_library(name='right-type',
-      jars=[
-        jar(org='foo', name='bar', rev='123'),
-      ],
-    )
-   '''))
-    address = BuildFileAddress(build_file, 'foo')
-    self.build_graph.inject_address_closure(address)
-    target = self.build_graph.get_target(address)
+    self.make_target(':right-type', JarLibrary, jars=[JarDependency('foo', 'bar', '123')])
+    self.make_target(':wrong-type', UnpackedJars, libraries=[':right-type'])
+    target = self.make_target(':foo', UnpackedJars, libraries=[':wrong-type'])
     with self.assertRaises(ImportJarsMixin.ExpectedJarLibraryError):
       target.imported_jar_libraries

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -83,7 +83,6 @@ python_tests(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:checkstyle',
     'src/python/pants/base:address',
-    'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
     'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/tasks:task_test_base',
@@ -141,11 +140,13 @@ python_tests(
   sources = ['test_ivy_resolve.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/tasks:ivy_resolve',
+    'src/python/pants/backend/jvm:ivy_utils',
+    'src/python/pants/base:cache_manager',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/jvm:nailgun_task_test_base',
+    'tests/python/pants_test/jvm:jvm_tool_task_test_base',
   ]
 )
 
@@ -263,10 +264,11 @@ python_tests(
   name = 'prepare_resources',
   sources = ['test_prepare_resources.py'],
   dependencies = [
+    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/tasks:prepare_resources',
+    'src/python/pants/base:target',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/tasks:task_test_base',
   ]
@@ -278,7 +280,6 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/tasks:prepare_services',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/tasks:task_test_base',
@@ -289,13 +290,14 @@ python_tests(
   name = 'scalastyle',
   sources = ['test_scalastyle.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/subsystems:scala_platform',
     'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/tasks:scalastyle',
-    'src/python/pants/base:address',
-    'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:exceptions',
     'tests/python/pants_test/jvm:nailgun_task_test_base',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.checkstyle import Checkstyle
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.exceptions import TaskError
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants_test.tasks.task_test_base import ensure_cached
@@ -90,7 +90,7 @@ class CheckstyleTest(NailgunTaskTestBase):
     self.create_file(relpath=os.path.join(rel_dir, '{name}.java'.format(name=name)),
                      contents=test_java_source)
 
-    return self.make_target(SyntheticAddress(spec_path=rel_dir, target_name=name).spec,
+    return self.make_target(Address(spec_path=rel_dir, target_name=name).spec,
                             JavaLibrary,
                             sources=['{}.java'.format(name)])
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle.py
@@ -10,8 +10,7 @@ from textwrap import dedent
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.checkstyle import Checkstyle
-from pants.base.address import BuildFileAddress
-from pants.base.build_file_aliases import BuildFileAliases
+from pants.base.address import SyntheticAddress
 from pants.base.exceptions import TaskError
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from pants_test.tasks.task_test_base import ensure_cached
@@ -49,14 +48,6 @@ class CheckstyleTest(NailgunTaskTestBase):
   @classmethod
   def task_type(cls):
     return Checkstyle
-
-  @property
-  def alias_groups(self):
-    return super(CheckstyleTest, self).alias_groups.merge(BuildFileAliases.create(
-      targets={
-        'java_library': JavaLibrary,
-      },
-    ))
 
   def _create_context(self, rules_xml=(), properties=None, target_roots=None):
     return self.context(
@@ -99,16 +90,9 @@ class CheckstyleTest(NailgunTaskTestBase):
     self.create_file(relpath=os.path.join(rel_dir, '{name}.java'.format(name=name)),
                      contents=test_java_source)
 
-    build_file = self.add_to_build_file(rel_dir, dedent("""
-      java_library(
-        name="{name}",
-        sources=["{name}.java"]
-      )
-    """.format(name=name)))
-
-    java_target_address = BuildFileAddress(build_file, name)
-    self.build_graph.inject_address_closure(java_target_address)
-    return self.build_graph.get_target(java_target_address)
+    return self.make_target(SyntheticAddress(spec_path=rel_dir, target_name=name).spec,
+                            JavaLibrary,
+                            sources=['{}.java'.format(name)])
 
   #
   # Test section

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -16,7 +16,6 @@ from pants.backend.jvm.targets.jar_dependency import IvyArtifact, JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
-from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.ivy_resolve import IvyResolve
 from pants.base.cache_manager import VersionedTargetSet
 from pants.util.contextutil import temporary_dir
@@ -51,7 +50,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
     # Create a jar_library with a single dep, and another library with no deps.
     dep = JarDependency('commons-lang', 'commons-lang', '2.5')
     jar_lib = self.make_target('//:a', JarLibrary, jars=[dep])
-    scala_lib = self.make_target('//:b', ScalaLibrary)
+    scala_lib = self.make_target('//:b', JavaLibrary)
     # Confirm that the deps were added to the appropriate targets.
     compile_classpath = self.resolve([jar_lib, scala_lib])
     self.assertEquals(1, len(compile_classpath.get_for_target(jar_lib)))
@@ -146,12 +145,15 @@ class IvyResolveTest(JvmToolTaskTestBase):
                                                  artifacts=[IvyArtifact('junit')])
 
     no_classifier_lib = self.make_target('//:a', JarLibrary, jars=[no_classifier])
-    classifier_and_no_classifier_lib = self.make_target('//:b', JarLibrary, jars=[classifier_and_no_classifier])
+    classifier_and_no_classifier_lib = self.make_target('//:b',
+                                                        JarLibrary,
+                                                        jars=[classifier_and_no_classifier])
 
     compile_classpath = self.resolve([no_classifier_lib, classifier_and_no_classifier_lib])
 
     no_classifier_cp = compile_classpath.get_for_target(no_classifier_lib)
-    classifier_and_no_classifier_cp = compile_classpath.get_for_target(classifier_and_no_classifier_lib)
+    classifier_and_no_classifier_cp = compile_classpath.get_for_target(
+        classifier_and_no_classifier_lib)
 
     sources_jar = 'junit-4.12-sources.jar'
     regular_jar = 'junit-4.12.jar'
@@ -210,7 +212,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
 
   def test_resolve_no_deps(self):
     # Resolve a library with no deps, and confirm that the empty product is created.
-    target = self.make_target('//:a', ScalaLibrary)
+    target = self.make_target('//:a', JavaLibrary)
     self.assertTrue(self.resolve([target]))
 
   def test_resolve_symlinked_cache(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_prepare_resources.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_prepare_resources.py
@@ -10,7 +10,6 @@ import os
 from pants.backend.core.targets.resources import Resources
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.prepare_resources import PrepareResources
 from pants.base.target import Target
 from pants.util.contextutil import temporary_dir
@@ -42,19 +41,19 @@ class PrepareResourcesTest(TaskTestBase):
     resources4 = self.make_target('resources:target4', target_type=Resources)
     jvm_target = self.make_target('jvm:target',
                                   target_type=JvmTarget,
-                                  resources=[resources1])
+                                  resources=[resources1.address.spec])
     java_library = self.make_target('java:target', target_type=JavaLibrary)
-    scala_library = self.make_target('scala:target',
-                                     target_type=ScalaLibrary,
-                                     resources=[resources4])
+    java_library2 = self.make_target('java:target2',
+                                     target_type=JavaLibrary,
+                                     resources=[resources4.address.spec])
     other_target = self.make_target('other:target',
                                     target_type=self.NonJvmResourcesUsingTarget,
-                                    resources=[resources3])
+                                    resources=[resources3.address.spec])
 
     task = self.create_task(self.context(target_roots=[resources2,
                                                        jvm_target,
                                                        java_library,
-                                                       scala_library,
+                                                       java_library2,
                                                        other_target]))
     relevant_resources_targets = task.find_all_relevant_resources_targets()
     self.assertEqual(sorted([self.target('resources:target1'), self.target('resources:target4')]),

--- a/tests/python/pants_test/backend/jvm/tasks/test_prepare_services.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_prepare_services.py
@@ -10,7 +10,6 @@ import os
 from pants.backend.jvm.targets.exclude import Exclude
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.prepare_services import PrepareServices
 from pants.util.contextutil import temporary_dir
 from pants_test.tasks.task_test_base import TaskTestBase
@@ -24,20 +23,20 @@ class PrepareServicesTest(TaskTestBase):
   def test_find_all_relevant_resources_targets(self):
     jvm_target = self.make_target('jvm:target', target_type=JvmTarget)
     java_library = self.make_target('java:target', target_type=JavaLibrary)
-    scala_library = self.make_target('scala:target',
-                                     target_type=ScalaLibrary,
+    java_library2 = self.make_target('java:target2',
+                                     target_type=JavaLibrary,
                                      services={'com.foo.bars.Baz': ['com.spam.bars.BaxImpl']})
     non_services_target = self.make_target('other:target')
 
     task = self.create_task(self.context(target_roots=[jvm_target,
                                                        java_library,
                                                        non_services_target,
-                                                       scala_library]))
+                                                       java_library2]))
     relevant_resources_targets = task.find_all_relevant_resources_targets()
 
     # Just the JvmTargets are relevant, and they're relevant whether they have defined services or
     # not.
-    self.assertEqual(sorted([jvm_target, java_library, scala_library]),
+    self.assertEqual(sorted([jvm_target, java_library, java_library2]),
                      sorted(relevant_resources_targets))
 
   def test_create_invalidation_strategy(self):
@@ -85,8 +84,8 @@ class PrepareServicesTest(TaskTestBase):
         self.assertEqual([], os.listdir(chroot))
 
     assert_no_resources_prepared(self.make_target('java:target', target_type=JavaLibrary))
-    assert_no_resources_prepared(self.make_target('scala:target',
-                                                  target_type=ScalaLibrary,
+    assert_no_resources_prepared(self.make_target('java:target2',
+                                                  target_type=JavaLibrary,
                                                   services={}))
     assert_no_resources_prepared(self.make_target('jvm:target',
                                                   target_type=JvmTarget,

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -6,15 +6,18 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
+from contextlib import contextmanager
 from textwrap import dedent
 
+from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
+from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.scalastyle import FileExcluder, Scalastyle
-from pants.base.address import BuildFileAddress
-from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
+from pants_test.subsystem.subsystem_util import subsystem_instance
 from pants_test.tasks.task_test_base import ensure_cached
 
 
@@ -28,14 +31,6 @@ class ScalastyleTest(NailgunTaskTestBase):
   def task_type(cls):
     return Scalastyle
 
-  @property
-  def alias_groups(self):
-    return super(ScalastyleTest, self).alias_groups.merge(BuildFileAliases.create(
-      targets={
-        'java_library': JavaLibrary,
-        'scala_library': ScalaLibrary,
-      },
-    ))
   #
   # Internal test helper section
   #
@@ -65,25 +60,11 @@ class ScalastyleTest(NailgunTaskTestBase):
   def _create_context(self, scalastyle_config=None, excludes=None, target_roots=None):
     # If config is not specified, then we override pants.ini scalastyle such that
     # we have a default scalastyle config xml but with empty excludes.
-    options = {
-      'skip': False,
-    }
-    if scalastyle_config:
-      options['config'] = scalastyle_config
-    if excludes:
-      options['excludes'] = excludes
-
-    return self.context(
-      options={
-        self.options_scope: options
-      },
-      target_roots=target_roots)
+    self.set_options(skip=False, config=scalastyle_config, excludes=excludes)
+    return self.context(target_roots=target_roots)
 
   def _create_scalastyle_task(self, scalastyle_config):
-    return self.create_task(self._create_context(scalastyle_config), self.build_root)
-
-  def _create_scalastyle_task_from_context(self, context):
-    return self.create_task(context, self.build_root)
+    return self.prepare_execute(self._create_context(scalastyle_config))
 
   def setUp(self):
     super(ScalastyleTest, self).setUp()
@@ -115,152 +96,123 @@ class ScalastyleTest(NailgunTaskTestBase):
     self.assertFalse(excluder.should_include('com/some/org/y.cpp'))
     self.assertFalse(excluder.should_include('z.py'))
 
+  @contextmanager
+  def scala_platform_setup(self):
+    with subsystem_instance(ScalaPlatform):
+      self.make_target(':scala-compiler',
+                       JarLibrary,
+                       jars=[JarDependency('org.scala-lang', 'scala-compiler', '2.10.5')])
+      self.make_target(':scala-library',
+                       JarLibrary,
+                       jars=[JarDependency('org.scala-lang', 'scala-library', '2.10.5')])
+      self.set_options_for_scope(ScalaPlatform.options_scope, scalac=':scala-compiler')
+      yield
+
   def test_get_non_synthetic_scala_targets(self):
-    # scala_library - should remain.
-    scala_target_address = BuildFileAddress(
-      self.add_to_build_file(
-        'a/scala/BUILD', 'scala_library(name="s", sources=["Source.scala"])'),
-      's')
-    self.build_graph.inject_address_closure(scala_target_address)
-    scala_target = self.build_graph.get_target(scala_target_address)
+    with self.scala_platform_setup():
+      # scala_library - should remain.
+      scala_target = self.make_target('a/scala:s', ScalaLibrary, sources=['Source.scala'])
 
-    # scala_library but with java sources - should be filtered
-    scala_target_java_source_address = BuildFileAddress(
-      self.add_to_build_file(
-        'a/scala_java/BUILD', 'scala_library(name="sj", sources=["Source.java"])'),
-      'sj')
-    self.build_graph.inject_address_closure(scala_target_java_source_address)
-    scala_target_with_java_source = self.build_graph.get_target(
-      scala_target_java_source_address)
+      # scala_library but with java sources - should be filtered
+      scala_target_with_java_source = self.make_target('a/scala_java:sj',
+                                                       ScalaLibrary,
+                                                       sources=['Source.java'])
 
-    # java_library - should be filtered
-    java_target_address = BuildFileAddress(
-      self.add_to_build_file(
-        'a/java/BUILD', 'java_library(name="j", sources=["Source.java"])'),
-      'j')
-    self.build_graph.inject_address_closure(java_target_address)
-    java_target = self.build_graph.get_target(java_target_address)
+      # java_library - should be filtered
+      java_target = self.make_target('a/java:j', JavaLibrary, sources=['Source.java'])
 
-    # synthetic scala_library - should be filtered
-    synthetic_scala_target = self.make_target('a/synthetic_scala:ss', ScalaLibrary)
+      # synthetic scala_library - should be filtered
+      synthetic_scala_target = self.make_target('a/synthetic_scala:ss',
+                                                ScalaLibrary,
+                                                sources=['SourceGenerated.scala'],
+                                                derived_from=scala_target)
 
-    # Create a custom context so we can manually inject multiple targets of different source types
-    # and synthetic vs non-synthetic to test the target filtering logic.
-    context = self._create_context(
-      target_roots=[
-        java_target,
-        scala_target,
-        scala_target_with_java_source,
-        synthetic_scala_target
-      ])
+      result_targets = Scalastyle.get_non_synthetic_scala_targets([java_target,
+                                                                   scala_target,
+                                                                   scala_target_with_java_source,
+                                                                   synthetic_scala_target])
 
-    # scala_library would bring in 'scala-library defined in BUILD.tools
-    # so we have an extra target here.
-    self.assertEqual(5, len(context.targets()))
-
-    # Now create the task and run the non_synthetic scala-only filtering.
-    task = self._create_scalastyle_task_from_context(context)
-    result_targets = task.get_non_synthetic_scala_targets(context.targets())
-
-    # Only the scala target should remain
-    self.assertEquals(1, len(result_targets))
-    self.assertEqual(scala_target, result_targets[0])
+      # Only the scala target should remain
+      self.assertEquals(1, len(result_targets))
+      self.assertEqual(scala_target, result_targets[0])
 
   def test_get_non_excluded_scala_sources(self):
-    # this scala target has mixed *.scala and *.java sources.
-    # the *.java source should be filtered out.
-    scala_target_address_1 = BuildFileAddress(
-      self.add_to_build_file(
-        'a/scala_1/BUILD',
-        'scala_library(name="s1", sources=["Source1.java", "Source1.scala"])'),
-      's1')
-    self.build_graph.inject_address_closure(scala_target_address_1)
-    scala_target_1 = self.build_graph.get_target(scala_target_address_1)
+    with self.scala_platform_setup():
+      # this scala target has mixed *.scala and *.java sources.
+      # the *.java source should be filtered out.
+      scala_target_1 = self.make_target('a/scala_1:s1',
+                                        ScalaLibrary,
+                                        sources=['Source1.java', 'Source1.scala'])
 
-    # this scala target has single *.scala source but will be excluded out
-    # by the [scalastyle].[excludes] setting.
-    scala_target_address_2 = BuildFileAddress(
-      self.add_to_build_file(
-        'a/scala_2/BUILD', 'scala_library(name="s2", sources=["Source2.scala"])'),
-      's2')
-    self.build_graph.inject_address_closure(scala_target_address_2)
-    scala_target_2 = self.build_graph.get_target(scala_target_address_2)
+      # this scala target has single *.scala source but will be excluded out
+      # by the [scalastyle].[excludes] setting.
+      scala_target_2 = self.make_target('a/scala_2:s2', ScalaLibrary, sources=['Source2.scala'])
 
-    # Create a custom context so we can manually inject scala targets
-    # with mixed sources in them to test the source filtering logic.
-    context = self._create_context(
-      scalastyle_config=self._create_scalastyle_config_file(),
-      excludes=self._create_scalastyle_excludes_file(['a/scala_2/Source2.scala']),
-      target_roots=[
-        scala_target_1,
-        scala_target_2
-      ]
-    )
+      # Create a custom context so we can manually inject scala targets
+      # with mixed sources in them to test the source filtering logic.
+      context = self._create_context(
+        scalastyle_config=self._create_scalastyle_config_file(),
+        excludes=self._create_scalastyle_excludes_file(['a/scala_2/Source2.scala']),
+        target_roots=[
+          scala_target_1,
+          scala_target_2
+        ]
+      )
 
-    # Remember, we have the extra 'scala-library-2.9.3' dep target.
-    self.assertEqual(3, len(context.targets()))
+      # Remember, we have the extra 'scala-library' dep target.
+      self.assertEqual(3, len(context.targets()))
 
-    # Now create the task and run the scala source and exclusion filtering.
-    task = self._create_scalastyle_task_from_context(context)
+      # Now create the task and run the scala source and exclusion filtering.
+      task = self.prepare_execute(context)
 
-    result_sources = task.get_non_excluded_scala_sources(
-      task.create_file_excluder(),
-      task.get_non_synthetic_scala_targets(context.targets()))
+      result_sources = task.get_non_excluded_scala_sources(
+        task.create_file_excluder(),
+        task.get_non_synthetic_scala_targets(context.targets()))
 
-    # Only the scala source from target 1 should remain
-    self.assertEquals(1, len(result_sources))
-    self.assertEqual('a/scala_1/Source1.scala', result_sources[0])
+      # Only the scala source from target 1 should remain
+      self.assertEquals(1, len(result_sources))
+      self.assertEqual('a/scala_1/Source1.scala', result_sources[0])
 
   @ensure_cached(Scalastyle, expected_num_artifacts=1)
   def test_end_to_end_pass(self):
     # Default scalastyle config (import grouping rule) and no excludes.
+    with self.scala_platform_setup():
+      # Create a scala source that would PASS ImportGroupingChecker rule.
+      self.create_file(
+        relpath='a/scala/pass.scala',
+        contents=dedent("""
+          import java.util
+          object HelloWorld {
+             def main(args: Array[String]) {
+                println("Hello, world!")
+             }
+          }
+        """))
+      scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
 
-    # Create a scala source that would PASS ImportGroupingChecker rule.
-    self.create_file(
-      relpath='a/scala/pass.scala',
-      contents=dedent("""
-        import java.util
-        object HelloWorld {
-           def main(args: Array[String]) {
-              println("Hello, world!")
-           }
-        }
-      """))
-    scala_target_address = BuildFileAddress(
-      self.add_to_build_file(
-        'a/scala/BUILD', 'scala_library(name="pass", sources=["pass.scala"])'),
-      'pass')
-    self.build_graph.inject_address_closure(scala_target_address)
-    scala_target = self.build_graph.get_target(scala_target_address)
+      context = self._create_context(scalastyle_config=self._create_scalastyle_config_file(),
+                                     target_roots=[scala_target])
 
-    context = self._create_context(scalastyle_config=self._create_scalastyle_config_file(),
-                                   target_roots=[scala_target])
-
-    self.execute(context)
+      self.execute(context)
 
   def test_fail(self):
     # Default scalastyle config (import grouping rule) and no excludes.
+    with self.scala_platform_setup():
+      # Create a scala source that would FAIL ImportGroupingChecker rule.
+      self.create_file(
+        relpath='a/scala/fail.scala',
+        contents=dedent("""
+          import java.io._
+          object HelloWorld {
+             def main(args: Array[String]) {
+                println("Hello, world!")
+             }
+          }
+          import java.util._
+        """))
+      scala_target = self.make_target('a/scala:fail', ScalaLibrary, sources=['fail.scala'])
 
-    # Create a scala source that would FAIL ImportGroupingChecker rule.
-    self.create_file(
-      relpath='a/scala/fail.scala',
-      contents=dedent("""
-        import java.io._
-        object HelloWorld {
-           def main(args: Array[String]) {
-              println("Hello, world!")
-           }
-        }
-        import java.util._
-      """))
-    scala_target_address = BuildFileAddress(
-      self.add_to_build_file(
-        'a/scala/BUILD', 'scala_library(name="fail", sources=["fail.scala"])'),
-      'fail')
-    self.build_graph.inject_address_closure(scala_target_address)
-    scala_target = self.build_graph.get_target(scala_target_address)
+      context = self._create_context(target_roots=[scala_target])
 
-    context = self._create_context(target_roots=[scala_target])
-
-    with self.assertRaises(TaskError):
-      self.execute(context)
+      with self.assertRaises(TaskError):
+        self.execute(context)

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -18,12 +18,11 @@ python_tests(
   sources = ['test_dependencies.py'],
   dependencies = [
     'src/python/pants/backend/core/targets:common',
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/project_info/tasks:dependencies',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:python_requirement',
-    'src/python/pants/base:exceptions',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )
@@ -63,15 +62,21 @@ python_tests(
   name = 'export',
   sources = ['test_export.py'],
   dependencies = [
-    'src/python/pants/backend/core:plugin',
     'src/python/pants/backend/core/targets:common',
-    'src/python/pants/backend/jvm:plugin',
+    'src/python/pants/backend/core:plugin',
+    'src/python/pants/backend/core:wrapped_globs',
+    'src/python/pants/backend/jvm/subsystems:scala_platform',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
+    'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/project_info/tasks:export',
+    'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:parse_context',
+    'src/python/pants/base:source_root',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )

--- a/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.backend.core.targets.dependencies import Dependencies as DepBag
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.scala_library import ScalaLibrary
+from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.project_info.tasks.dependencies import Dependencies
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -35,12 +35,12 @@ class NonPythonDependenciesTest(ConsoleTaskTestBase):
 
     third = self.make_target(
       'dependencies:third',
-      target_type=ScalaLibrary,
+      target_type=JavaLibrary,
     )
 
     first = self.make_target(
       'dependencies:first',
-      target_type=ScalaLibrary,
+      target_type=JavaLibrary,
       dependencies=[
         third,
       ],
@@ -56,7 +56,7 @@ class NonPythonDependenciesTest(ConsoleTaskTestBase):
 
     project = self.make_target(
       'project:project',
-      target_type=ScalaLibrary,
+      target_type=JavaLibrary,
       dependencies=[
         first,
         second,

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -63,6 +63,7 @@ python_tests(
   sources = ['test_address.py'],
   dependencies = [
     'src/python/pants/base:address',
+    'src/python/pants/base:build_file',
     'src/python/pants/base:build_root',
     'tests/python/pants_test:base_test',
     'src/python/pants/util:contextutil',
@@ -119,6 +120,10 @@ python_tests(
   name = 'build_file_address_mapper',
   sources = ['test_build_file_address_mapper.py'],
   dependencies = [
+    'src/python/pants/base:address',
+    'src/python/pants/base:address_lookup_error',
+    'src/python/pants/base:build_file_address_mapper',
+    'src/python/pants/base:target',
     'tests/python/pants_test:base_test',
   ]
 )
@@ -164,21 +169,15 @@ python_tests(
   ]
 )
 
-
 python_tests(
   name = 'build_file_parser',
   sources = ['test_build_file_parser.py'],
   dependencies = [
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/backend/jvm/targets:java',
-    'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/targets:scala',
-    'src/python/pants/backend/jvm:artifact',
-    'src/python/pants/backend/jvm:repository',
+    'src/python/pants/base:address',
     'src/python/pants/base:build_file',
+    'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:build_file_parser',
     'src/python/pants/base:target',
-    'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',
   ]
 )
@@ -296,10 +295,11 @@ python_tests(
   name = 'target',
   sources = ['test_target.py'],
   dependencies = [
-    'src/python/pants/backend/core',
-    'src/python/pants/base:address',
-    'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:payload',
+    'src/python/pants/base:payload_field',
+    'src/python/pants/base:target',
     'tests/python/pants_test:base_test',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
 

--- a/tests/python/pants_test/base/test_address.py
+++ b/tests/python/pants_test/base/test_address.py
@@ -127,11 +127,11 @@ class BuildFileAddressTest(BaseAddressTest):
   def test_build_file_forms(self):
     with self.workspace('a/b/c/BUILD') as root_dir:
       build_file = FilesystemBuildFile(root_dir, relpath='a/b/c')
-      self.assert_address('a/b/c', 'c', BuildFileAddress(build_file))
-      self.assert_address('a/b/c', 'foo', BuildFileAddress(build_file, target_name='foo'))
-      self.assertEqual('a/b/c:foo', BuildFileAddress(build_file, target_name='foo').spec)
+      self.assert_address('a/b/c', 'c', BuildFileAddress(build_file, 'target'))
+      self.assert_address('a/b/c', 'foo', BuildFileAddress(build_file, 'target', target_name='foo'))
+      self.assertEqual('a/b/c:foo', BuildFileAddress(build_file, 'target', target_name='foo').spec)
 
     with self.workspace('BUILD') as root_dir:
       build_file = FilesystemBuildFile(root_dir, relpath='')
-      self.assert_address('', 'foo', BuildFileAddress(build_file, target_name='foo'))
-      self.assertEqual(':foo', BuildFileAddress(build_file, target_name='foo').spec)
+      self.assert_address('', 'foo', BuildFileAddress(build_file, 'target', target_name='foo'))
+      self.assertEqual(':foo', BuildFileAddress(build_file, 'target', target_name='foo').spec)

--- a/tests/python/pants_test/base/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/base/test_build_file_address_mapper.py
@@ -8,10 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from textwrap import dedent
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.base.address import Address, BuildFileAddress
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file_address_mapper import BuildFileAddressMapper
+from pants.base.target import Target
 from pants_test.base_test import BaseTest
 
 
@@ -20,42 +20,26 @@ from pants_test.base_test import BaseTest
 
 class BuildFileAddressMapperTest(BaseTest):
 
-  def setUp(self):
-    super(BuildFileAddressMapperTest, self).setUp()
-
   def test_resolve(self):
-    build_file = self.add_to_build_file('BUILD', dedent(
-      ''' target(
-        name = 'foo'
-      )
-      '''
-    ))
-
+    build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
     address, addressable = self.address_mapper.resolve(Address.parse('//:foo'))
     self.assertIsInstance(address, BuildFileAddress)
     self.assertEqual(build_file, address.build_file)
     self.assertEqual('foo', address.target_name)
     self.assertEqual(address.target_name, addressable.addressable_name)
-    self.assertEqual(addressable.target_type, Dependencies)
+    self.assertEqual(addressable.target_type, Target)
 
   def test_resolve_spec(self):
-    self.add_to_build_file('BUILD', dedent(
-      '''
-      target(
-        name = 'foozle'
-      )
-
-      target(
-        name = 'baz',
-      )
-      '''
-    ))
+    self.add_to_build_file('BUILD', dedent("""
+      target(name='foozle')
+      target(name='baz')
+      """))
 
     with self.assertRaises(AddressLookupError):
       self.address_mapper.resolve_spec('//:bad_spec')
 
     dependencies_addressable = self.address_mapper.resolve_spec('//:foozle')
-    self.assertEqual(dependencies_addressable.target_type, Dependencies)
+    self.assertEqual(dependencies_addressable.target_type, Target)
 
   def test_scan_addresses(self):
     root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
@@ -63,17 +47,18 @@ class BuildFileAddressMapperTest(BaseTest):
     subdir_suffix_build_file = self.add_to_build_file('subdir/BUILD.suffix', 'target(name="baz")')
     with open(os.path.join(self.build_root, 'BUILD.invalid.suffix'), 'w') as invalid_build_file:
       invalid_build_file.write('target(name="foobar")')
-    self.assertEquals(set([BuildFileAddress(root_build_file, 'foo'),
-                           BuildFileAddress(subdir_build_file, 'bar'),
-                           BuildFileAddress(subdir_suffix_build_file, 'baz')]),
+    self.assertEquals({BuildFileAddress(root_build_file, 'target', 'foo'),
+                       BuildFileAddress(subdir_build_file, 'target', 'bar'),
+                       BuildFileAddress(subdir_suffix_build_file, 'target', 'baz')},
                       self.address_mapper.scan_addresses(root=self.build_root))
 
   def test_scan_addresses_with_excludes(self):
     root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
-    subdir_build_file = self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
+    self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
     spec_excludes = [os.path.join(self.build_root, 'subdir')]
-    self.assertEquals(set([BuildFileAddress(root_build_file, 'foo')]),
-                      self.address_mapper.scan_addresses(root=self.build_root, spec_excludes=spec_excludes))
+    self.assertEquals({BuildFileAddress(root_build_file, 'target', 'foo')},
+                      self.address_mapper.scan_addresses(root=self.build_root,
+                                                         spec_excludes=spec_excludes))
 
   def test_raises_invalid_build_file_reference(self):
     # reference a BUILD file that doesn't exist
@@ -83,16 +68,10 @@ class BuildFileAddressMapperTest(BaseTest):
       self.address_mapper.spec_to_address('//non-existent-path:a')
 
   def test_raises_address_not_in_build_file(self):
-    build_file = self.add_to_build_file('BUILD', dedent(
-      '''
-      target(
-        name = 'foo'
-      )
-      '''
-    ))
+    self.add_to_build_file('BUILD', 'target(name="foo")')
 
     # Create an address that doesn't exist in an existing BUILD file
-    address = BuildFileAddress(build_file, 'bar')
+    address = Address.parse(':bar')
     with self.assertRaises(BuildFileAddressMapper.AddressNotInBuildFile):
       self.address_mapper.resolve(address)
 

--- a/tests/python/pants_test/base/test_build_file_parser.py
+++ b/tests/python/pants_test/base/test_build_file_parser.py
@@ -212,11 +212,11 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
                                            repo=jvm_repo)
 
       parse_context.create_object('java_library',
-                                  name='%s-java' % base_name,
+                                  name='{}-java'.format(base_name),
                                   provides=provides_artifact(provides_java_name))
 
       parse_context.create_object('scala_library',
-                                  name='%s-scala' % base_name,
+                                  name='{}-scala'.format(base_name),
                                   provides=provides_artifact(provides_scala_name))
 
     return real_create_java_libraries

--- a/tests/python/pants_test/base/test_build_file_parser.py
+++ b/tests/python/pants_test/base/test_build_file_parser.py
@@ -6,16 +6,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from collections import namedtuple
 from textwrap import dedent
 
-import pytest
-
-from pants.backend.jvm.artifact import Artifact
-from pants.backend.jvm.repository import Repository
-from pants.backend.jvm.targets.jar_dependency import JarDependency
-from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.address import BuildFileAddress
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.build_file_aliases import BuildFileAliases
@@ -39,26 +32,26 @@ class BuildFileParserBasicsTest(BaseTest):
     self.add_to_build_file('a/BUILD', 'target()')
     build_file_a = FilesystemBuildFile(self.build_root, 'a/BUILD')
 
-    with pytest.raises(BuildFileParser.ExecuteError):
+    with self.assertRaises(BuildFileParser.ExecuteError):
       self.build_file_parser.parse_build_file(build_file_a)
 
     self.add_to_build_file('b/BUILD', 'target(name="foo", "bad_arg")')
     build_file_b = FilesystemBuildFile(self.build_root, 'b/BUILD')
-    with pytest.raises(BuildFileParser.BuildFileParserError):
+    with self.assertRaises(BuildFileParser.BuildFileParserError):
       self.build_file_parser.parse_build_file(build_file_b)
 
     self.add_to_build_file('d/BUILD', dedent(
-      '''
+      """
       target(
         name="foo",
         dependencies=[
           object(),
         ]
       )
-      '''
+      """
     ))
     build_file_d = FilesystemBuildFile(self.build_root, 'd/BUILD')
-    with pytest.raises(BuildFileParser.BuildFileParserError):
+    with self.assertRaises(BuildFileParser.BuildFileParserError):
       self.build_file_parser.parse_build_file(build_file_d)
 
   def test_noop_parse(self):
@@ -75,47 +68,37 @@ class BuildFileParserTargetTest(BaseTest):
     return BuildFileAliases.create(targets={'fake': ErrorTarget})
 
   def test_trivial_target(self):
-    self.add_to_build_file('BUILD', '''fake(name='foozle')''')
+    self.add_to_build_file('BUILD', 'fake(name="foozle")')
     build_file = FilesystemBuildFile(self.build_root, 'BUILD')
     address_map = self.build_file_parser.parse_build_file(build_file)
 
     self.assertEqual(len(address_map), 1)
     address, proxy = address_map.popitem()
-    self.assertEqual(address, BuildFileAddress(build_file, 'foozle'))
+    self.assertEqual(address, BuildFileAddress(build_file, 'fake', 'foozle'))
     self.assertEqual(proxy.name, 'foozle')
     self.assertEqual(proxy.target_type, ErrorTarget)
 
-  def test_trivial_target(self):
-    self.add_to_build_file('BUILD', '''fake(name='foozle')''')
-    build_file = FilesystemBuildFile(self.build_root, 'BUILD')
-    address_map = self.build_file_parser.parse_build_file(build_file)
-    self.assertEqual(len(address_map), 1)
-    address, addressable = address_map.popitem()
-    self.assertEqual(address, BuildFileAddress(build_file, 'foozle'))
-    self.assertEqual(addressable.name, 'foozle')
-    self.assertEqual(addressable.target_type, ErrorTarget)
-
   def test_sibling_build_files(self):
     self.add_to_build_file('BUILD', dedent(
-      '''
+      """
       fake(name="base",
            dependencies=[
              ':foo',
            ])
-      '''))
+      """))
 
     self.add_to_build_file('BUILD.foo', dedent(
-      '''
+      """
       fake(name="foo",
            dependencies=[
              ':bat',
            ])
-      '''))
+      """))
 
     self.add_to_build_file('./BUILD.bar', dedent(
-      '''
+      """
       fake(name="bat")
-      '''))
+      """))
 
     bar_build_file = FilesystemBuildFile(self.build_root, 'BUILD.bar')
     base_build_file = FilesystemBuildFile(self.build_root, 'BUILD')
@@ -123,9 +106,9 @@ class BuildFileParserTargetTest(BaseTest):
 
     address_map = self.build_file_parser.address_map_from_build_file(bar_build_file)
     addresses = address_map.keys()
-    self.assertEqual(set([bar_build_file, base_build_file, foo_build_file]),
+    self.assertEqual({bar_build_file, base_build_file, foo_build_file},
                      set([address.build_file for address in addresses]))
-    self.assertEqual(set([':base', ':foo', ':bat']),
+    self.assertEqual({':base', ':foo', ':bat'},
                      set([address.spec for address in addresses]))
 
   def test_build_file_duplicates(self):
@@ -133,36 +116,35 @@ class BuildFileParserTargetTest(BaseTest):
     self.add_to_build_file('BUILD', 'fake(name="foo")\n')
     self.add_to_build_file('BUILD', 'fake(name="foo")\n')
 
-    with pytest.raises(BuildFileParser.AddressableConflictException):
+    with self.assertRaises(BuildFileParser.AddressableConflictException):
       base_build_file = FilesystemBuildFile(self.build_root, 'BUILD')
       self.build_file_parser.parse_build_file(base_build_file)
 
   def test_sibling_build_files_duplicates(self):
     # This workspace is malformed, you can't shadow a name in a sibling BUILD file
     self.add_to_build_file('BUILD', dedent(
-      '''
+      """
       fake(name="base",
            dependencies=[
              ':foo',
            ])
-      '''))
+      """))
 
     self.add_to_build_file('BUILD.foo', dedent(
-      '''
+      """
       fake(name="foo",
            dependencies=[
              ':bat',
            ])
-      '''))
+      """))
 
     self.add_to_build_file('./BUILD.bar', dedent(
-      '''
+      """
       fake(name="base")
-      '''))
+      """))
 
-    with pytest.raises(BuildFileParser.SiblingConflictException):
+    with self.assertRaises(BuildFileParser.SiblingConflictException):
       base_build_file = FilesystemBuildFile(self.build_root, 'BUILD')
-      bf_address = BuildFileAddress(base_build_file, 'base')
       self.build_file_parser.address_map_from_build_file(base_build_file)
 
 
@@ -173,7 +155,7 @@ class BuildFileParserExposedObjectTest(BaseTest):
     return BuildFileAliases.create(objects={'fake_object': object()})
 
   def test_exposed_object(self):
-    self.add_to_build_file('BUILD', '''fake_object''')
+    self.add_to_build_file('BUILD', """fake_object""")
     build_file = FilesystemBuildFile(self.build_root, 'BUILD')
     address_map = self.build_file_parser.parse_build_file(build_file)
     self.assertEqual(len(address_map), 0)
@@ -181,15 +163,35 @@ class BuildFileParserExposedObjectTest(BaseTest):
 
 class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
 
-  @staticmethod
-  def make_lib(parse_context):
+  Jar = namedtuple('Jar', ['org', 'name', 'rev'])
+  Repository = namedtuple('Repository', ['name', 'url', 'push_db_basedir'])
+  Artifact = namedtuple('Artifact', ['org', 'name', 'repo'])
+
+  class JarLibrary(Target):
+    def __init__(self, jars=None, **kwargs):
+      super(BuildFileParserExposedContextAwareObjectFactoryTest.JarLibrary, self).__init__(**kwargs)
+      self.jars = jars or []
+
+  class JvmLibrary(Target):
+    def __init__(self, provides=None, **kwargs):
+      super(BuildFileParserExposedContextAwareObjectFactoryTest.JvmLibrary, self).__init__(**kwargs)
+      self.provides = provides
+
+  class JavaLibrary(JvmLibrary):
+    pass
+
+  class ScalaLibrary(JvmLibrary):
+    pass
+
+  @classmethod
+  def make_lib(cls, parse_context):
     def real_make_lib(org, name, rev):
       dep = parse_context.create_object('jar', org=org, name=name, rev=rev)
       parse_context.create_object('jar_library', name=name, jars=[dep])
     return real_make_lib
 
-  @staticmethod
-  def create_java_libraries(parse_context):
+  @classmethod
+  def create_java_libraries(cls, parse_context):
 
     def real_create_java_libraries(base_name,
                                    org='com.twitter',
@@ -199,7 +201,7 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
       def provides_artifact(provides_name):
         if provides_name is None:
           return None
-        jvm_repo = Repository(
+        jvm_repo = cls.Repository(
           name='maven-central',
           url='http://maven.example.com',
           push_db_basedir=os.path.join('build-support', 'ivy', 'pushdb'),
@@ -211,14 +213,10 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
 
       parse_context.create_object('java_library',
                                   name='%s-java' % base_name,
-                                  sources=[],
-                                  dependencies=[],
                                   provides=provides_artifact(provides_java_name))
 
       parse_context.create_object('scala_library',
                                   name='%s-scala' % base_name,
-                                  sources=[],
-                                  dependencies=[],
                                   provides=provides_artifact(provides_scala_name))
 
     return real_create_java_libraries
@@ -236,9 +234,9 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
   def alias_groups(self):
     return BuildFileAliases.create(
       targets={
-        'jar_library': JarLibrary,
-        'java_library': JavaLibrary,
-        'scala_library': ScalaLibrary,
+        'jar_library': self.JarLibrary,
+        'java_library': self.JavaLibrary,
+        'scala_library': self.ScalaLibrary,
       },
       context_aware_object_factories={
         'make_lib': self.make_lib,
@@ -246,19 +244,19 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
         'path_util': self.path_relative_util,
       },
       objects={
-        'artifact': Artifact,
-        'jar': JarDependency,
+        'artifact': self.Artifact,
+        'jar': self.Jar,
       }
     )
 
   def test_context_aware_object_factories(self):
-    contents = dedent('''
+    contents = dedent("""
                  create_java_libraries(base_name="create-java-libraries",
                                        provides_java_name="test-java",
                                        provides_scala_name="test-scala")
                  make_lib("com.foo.test", "does_not_exists", "1.0")
                  path_util("baz")
-               ''')
+               """)
     self.create_file('3rdparty/BUILD', contents)
 
     build_file = FilesystemBuildFile(self.build_root, '3rdparty/BUILD')
@@ -270,15 +268,15 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
     for target_proxy in registered_proxies:
       targets_created[target_proxy.name] = target_proxy.target_type
 
-    self.assertEqual(set(['does_not_exists',
-                          'create-java-libraries-scala',
-                          'create-java-libraries-java']),
+    self.assertEqual({'does_not_exists',
+                      'create-java-libraries-scala',
+                      'create-java-libraries-java'},
                      set(targets_created.keys()))
-    self.assertEqual(targets_created['does_not_exists'], JarLibrary)
-    self.assertEqual(targets_created['create-java-libraries-java'], JavaLibrary)
-    self.assertEqual(targets_created['create-java-libraries-scala'], ScalaLibrary)
+    self.assertEqual(targets_created['does_not_exists'], self.JarLibrary)
+    self.assertEqual(targets_created['create-java-libraries-java'], self.JavaLibrary)
+    self.assertEqual(targets_created['create-java-libraries-scala'], self.ScalaLibrary)
 
-    self.assertEqual(set(['3rdparty/baz']), self._paths)
+    self.assertEqual({'3rdparty/baz'}, self._paths)
 
   def test_raises_parse_error(self):
     self.add_to_build_file('BUILD', 'foo(name = = "baz")')
@@ -289,7 +287,7 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
     # Test some corner cases for the context printing
 
     # Error at beginning of BUILD file
-    build_file = self.add_to_build_file('begin/BUILD', dedent('''
+    build_file = self.add_to_build_file('begin/BUILD', dedent("""
       *?&INVALID! = 'foo'
       target(
         name='bar',
@@ -297,12 +295,12 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
           ':baz',
         ],
       )
-      '''))
+      """))
     with self.assertRaises(BuildFileParser.ParseError):
       self.build_file_parser.parse_build_file(build_file)
 
     # Error at end of BUILD file
-    build_file = self.add_to_build_file('end/BUILD', dedent('''
+    build_file = self.add_to_build_file('end/BUILD', dedent("""
       target(
         name='bar',
         dependencies= [
@@ -310,12 +308,12 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
         ],
       )
       *?&INVALID! = 'foo'
-      '''))
+      """))
     with self.assertRaises(BuildFileParser.ParseError):
       self.build_file_parser.parse_build_file(build_file)
 
     # Error in the middle of BUILD file > 6 lines
-    build_file = self.add_to_build_file('middle/BUILD', dedent('''
+    build_file = self.add_to_build_file('middle/BUILD', dedent("""
       target(
         name='bar',
 
@@ -325,14 +323,14 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
           ':baz',
         ],
       )
-      '''))
+      """))
     with self.assertRaises(BuildFileParser.ParseError):
       self.build_file_parser.parse_build_file(build_file)
 
     # Error in very short build file.
-    build_file = self.add_to_build_file('short/BUILD', dedent('''
+    build_file = self.add_to_build_file('short/BUILD', dedent("""
       target(name='bar', dependencies = [':baz'],) *?&INVALID! = 'foo'
-      '''))
+      """))
     with self.assertRaises(BuildFileParser.ParseError):
       self.build_file_parser.parse_build_file(build_file)
 
@@ -343,11 +341,14 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
       self.build_file_parser.parse_build_file(build_file)
 
   def test_build_file_parser_error_hierarcy(self):
-    """Exception handling code depends on the fact that all explicit exceptions from BuildFileParser are
-   subclassed from the BuildFileParserError base class.
-   """
-    self.assertIsInstance(BuildFileParser.BuildFileScanError(), BuildFileParser.BuildFileParserError)
-    self.assertIsInstance(BuildFileParser.AddressableConflictException(), BuildFileParser.BuildFileParserError)
-    self.assertIsInstance(BuildFileParser.SiblingConflictException(), BuildFileParser.BuildFileParserError)
-    self.assertIsInstance(BuildFileParser.ParseError(), BuildFileParser.BuildFileParserError)
-    self.assertIsInstance(BuildFileParser.ExecuteError(), BuildFileParser.BuildFileParserError)
+    """Exception handling code depends on the fact that all explicit exceptions from BuildFileParser
+    are subclassed from the BuildFileParserError base class.
+    """
+    def assert_build_file_parser_error(e):
+      self.assertIsInstance(e, BuildFileParser.BuildFileParserError)
+
+    assert_build_file_parser_error(BuildFileParser.BuildFileScanError())
+    assert_build_file_parser_error(BuildFileParser.AddressableConflictException())
+    assert_build_file_parser_error(BuildFileParser.SiblingConflictException())
+    assert_build_file_parser_error(BuildFileParser.ParseError())
+    assert_build_file_parser_error(BuildFileParser.ExecuteError())

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.address import Address
 from pants.base.payload import Payload
 from pants.base.payload_field import DeferredSourcesField
 from pants.base.target import Target
@@ -21,8 +20,8 @@ class TestDeferredSourcesTarget(Target):
     })
     super(TestDeferredSourcesTarget, self).__init__(payload=payload, *args, **kwargs)
 
-
 class TargetTest(BaseTest):
+
   def test_derived_from_chain(self):
     # add concrete target
     concrete = self.make_target('y:concrete', Target)
@@ -42,9 +41,10 @@ class TargetTest(BaseTest):
     self.assertSequenceEqual([], list(target.traversable_dependency_specs))
 
   def test_deferred_sources_payload_field(self):
+    foo = self.make_target(':foo', Target)
     target = self.make_target(':bar',
                               TestDeferredSourcesTarget,
-                              deferred_sources_address=Address.parse('//:foo'))
+                              deferred_sources_address=foo.address)
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':foo'], list(target.traversable_dependency_specs))
 

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -82,6 +82,14 @@ class BaseTest(unittest.TestCase):
                   dependencies=None,
                   derived_from=None,
                   **kwargs):
+    """Creates a target and injects it into the test's build graph.
+
+    :param string spec: The target address spec that locates this target.
+    :param type target_type: The concrete target subclass to create this new target from.
+    :param list dependencies: A list of target instances this new target depends on.
+    :param derived_from: The target this new target was derived from.
+    :type derived_from: :class:`pants.base.target.Target`
+    """
     address = Address.parse(spec)
     target = target_type(name=address.target_name,
                          address=address,

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -104,8 +104,8 @@ class BaseTest(unittest.TestCase):
     # TODO(John Sirois): This re-creates a little bit too much work done by the BuildGraph.
     # Fixup the BuildGraph to deal with non BuildFileAddresses better and just leverage it.
     for traversable_dependency_spec in target.traversable_dependency_specs:
-      traversable_dependency_address = SyntheticAddress.parse(traversable_dependency_spec,
-                                                              relative_to=address.spec_path)
+      traversable_dependency_address = Address.parse(traversable_dependency_spec,
+                                                     relative_to=address.spec_path)
       traversable_dependency_target = self.build_graph.get_target(traversable_dependency_address)
       if not traversable_dependency_target:
         raise ValueError('Tests must make targets for traversable dependency specs ahead of them '
@@ -232,7 +232,7 @@ class BaseTest(unittest.TestCase):
 
     Returns the corresponding Target or else None if the address does not point to a defined Target.
     """
-    address = SyntheticAddress.parse(spec)
+    address = Address.parse(spec)
     self.build_graph.inject_address_closure(address)
     return self.build_graph.get_target(address)
 

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -120,6 +120,11 @@ class BaseTest(unittest.TestCase):
 
   @property
   def alias_groups(self):
+    # NB: In a normal pants deployment, 'target' is an alias for
+    # `pants.backend.core.targets.dependencies.Dependencies`.  We avoid that dependency on the core
+    # backend here since the `BaseTest` is used by lower level tests in base and since the
+    # `Dependencies` type itself is nothing more than an alias for Target that carries along a
+    # pydoc for the BUILD dictionary.
     return BuildFileAliases.create(targets={'target': Target})
 
   def setUp(self):

--- a/tests/python/pants_test/targets/test_unknown_arguments_integration.py
+++ b/tests/python/pants_test/targets/test_unknown_arguments_integration.py
@@ -31,7 +31,7 @@ class TestUnknownArgumentsIntegration(PantsRunIntegrationTest):
   def test_future_params(self):
     param = 'nonexistant_parameter'
     with self.temp_target_spec(**{param: 'value'}) as spec:
-      run = self.run_pants(['--unknown-arguments-ignored={{"JavaLibrary": ["{}"]}}'.format(param),
+      run = self.run_pants(['--unknown-arguments-ignored={{"java_library": ["{}"]}}'.format(param),
                             '-ldebug',
                             'clean-all', spec])
       self.assert_success(run)
@@ -42,7 +42,7 @@ class TestUnknownArgumentsIntegration(PantsRunIntegrationTest):
     future = 'nonexistant_parameter'
     unknown = 'unexpected_nonexistant_parameter'
     with self.temp_target_spec(**{future: 'value', unknown: 'other value'}) as spec:
-      run = self.run_pants(['--unknown-arguments-ignored={{"JavaLibrary": ["{}"]}}'.format(future),
+      run = self.run_pants(['--unknown-arguments-ignored={{"java_library": ["{}"]}}'.format(future),
                             'clean-all', spec])
       self.assert_failure(run)
       self.assertIn('Invalid target {}'.format(spec), run.stderr_data)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -429,10 +429,8 @@ python_tests(
   name = 'group_task',
   sources = ['test_group_task.py'],
   dependencies = [
+    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/core/tasks:group_task',
-    'src/python/pants/backend/jvm/targets:java',
-    'src/python/pants/backend/jvm/targets:scala',
-    'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:target',
     'src/python/pants/engine:engine',
     'tests/python/pants_test:base_test',


### PR DESCRIPTION
This change supports acting on the target alias a BUILD file author
knows instead of target class names they likely don't.

Fallout includes eliminating BuildFileAddress use from most tests
and secondary fallout is modernizing those tests to use make_target.
In order to support targets that utilize traversable_dependency_specs,
make_target is beefed up to emulate more of the standard BuildGraph
behavior parsing in a target from a BUILD file.

https://rbcommons.com/s/twitter/r/2726/