### PR TITLE
Make nailgun_client error when the client socket is closed.

### DIFF
--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -5,6 +5,7 @@ target(
   name = 'java',
   dependencies = [
     ':executor',
+    ':nailgun_client',
     'tests/python/pants_test/java/distribution',
     'tests/python/pants_test/java/jar',
   ]
@@ -18,5 +19,13 @@ python_tests(
     'src/python/pants/java:executor',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ]
+)
+
+python_tests(
+  name = 'nailgun_client',
+  sources = ['test_nailgun_client.py'],
+  dependencies = [
+    'src/python/pants/java:nailgun_client',
   ]
 )

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import socket
+import struct
+import unittest
+from contextlib import contextmanager
+
+from pants.java.nailgun_client import NailgunSession
+
+
+class FakeWritableFile(object):
+  def __init__(self):
+    self.content = b''
+
+  def write(self, val):
+    self.content += val
+
+  def flush(self):
+    pass
+
+
+class NailgunSessionTest(unittest.TestCase):
+  def setUp(self):
+    self.client_socket, self.ng_socket = socket.socketpair()
+    self.outfile = FakeWritableFile()
+    self.errfile = FakeWritableFile()
+    self.ng_session = NailgunSession(self.client_socket, None, self.outfile, self.errfile)
+
+  def test_socket_closed_before_header(self):
+    # Send some simple messages to exercise the loop first, to make
+    # sure we're not always erroring.
+    stdout_header = struct.pack(NailgunSession.HEADER_FMT, 6, b'1')
+    self.ng_socket.send(stdout_header)
+    self.ng_socket.send(b'foozle')
+    exit_header = struct.pack(NailgunSession.HEADER_FMT, 3, b'X')
+    self.ng_socket.send(exit_header)
+    self.ng_socket.send(b'123')
+    self.assertEquals(self.ng_session._read_response(), 123)
+    self.assertEquals(self.outfile.content, b'foozle')
+
+    self.ng_socket.close()
+    with self.assertRaises(NailgunSession.TruncatedHeaderError):
+      self.ng_session._read_response()
+
+  def test_socket_closed_during_header(self):
+    stdout_header = struct.pack(NailgunSession.HEADER_FMT, 6, b'1')
+    self.ng_socket.send(stdout_header[:2])
+
+    self.ng_socket.close()
+    with self.assertRaises(NailgunSession.TruncatedHeaderError):
+      self.ng_session._read_response()
+
+  def test_socket_closed_before_payload(self):
+    stdout_header = struct.pack(NailgunSession.HEADER_FMT, 6, b'1')
+    self.ng_socket.send(stdout_header)
+
+    self.ng_socket.close()
+    with self.assertRaises(NailgunSession.TruncatedPayloadError):
+      self.ng_session._read_response()
+
+  def test_socket_closed_during_payload(self):
+    stdout_header = struct.pack(NailgunSession.HEADER_FMT, 6, b'1')
+    self.ng_socket.send(stdout_header)
+    self.ng_socket.send(b'foo')
+
+    self.ng_socket.close()
+    with self.assertRaises(NailgunSession.TruncatedPayloadError):
+      self.ng_session._read_response()


### PR DESCRIPTION
* Previously, if the client socket was closed gracefully on
  the other side (by the nailgun) while at the start or middle
  of attempting to read a message from the socket, the client
  would go into a hard loop attempting to do a blocking read
  on the socket.  But when the socket has been closed, that
  blocking read returns immediately with no bytes to indicate
  that the socket is closed.
* Added tests to exercise the two new exception types and the
  various interesting points in the message byte stream where
  the server could terminate the socket.