### PR TITLE
Collapse SyntheticAddress up into Address.

### DIFF
--- a/contrib/buildgen/src/python/pants/contrib/buildgen/build_file_manipulator.py
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/build_file_manipulator.py
@@ -11,7 +11,7 @@ import re
 import sys
 from difflib import unified_diff
 
-from pants.base.address import BuildFileAddress, SyntheticAddress
+from pants.base.address import Address, BuildFileAddress
 
 
 logger = logging.getLogger(__name__)
@@ -338,7 +338,7 @@ class BuildFileManipulator(object):
     self._dependencies_by_address = {}
 
     for dep in dependencies:
-      dep_address = SyntheticAddress.parse(dep.spec, relative_to=build_file.spec_path)
+      dep_address = Address.parse(dep.spec, relative_to=build_file.spec_path)
       if dep_address in self._dependencies_by_address:
         raise BuildTargetParseError('The address {dep_address} occurred multiple times in the '
                                     'dependency specs for target {name} in {build_file}. '

--- a/contrib/buildgen/tests/python/pants_test/contrib/buildgen/test_build_file_manipulator.py
+++ b/contrib/buildgen/tests/python/pants_test/contrib/buildgen/test_build_file_manipulator.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from textwrap import dedent
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants_test.base_test import BaseTest
 
 from pants.contrib.buildgen.build_file_manipulator import (BuildFileManipulator,
@@ -154,15 +154,15 @@ class BuildFileManipulatorTest(BaseTest):
     build_file = self.add_to_build_file('BUILD', simple_targets)
 
     for no_deps_name in ['no_deps', 'empty_deps', 'empty_deps_inline']:
-      no_deps = BuildFileManipulator.load(build_file, no_deps_name, set(['target_type']))
+      no_deps = BuildFileManipulator.load(build_file, no_deps_name, {'target_type'})
       self.assertEqual(tuple(no_deps.dependency_lines()), tuple())
-      no_deps.add_dependency(SyntheticAddress.parse(':fake_dep'))
+      no_deps.add_dependency(Address.parse(':fake_dep'))
       self.assertEqual(tuple(no_deps.dependency_lines()),
                        tuple(['  dependencies = [',
                               "    ':fake_dep',",
                               '  ],']))
-      no_deps.add_dependency(SyntheticAddress.parse(':b_fake_dep'))
-      no_deps.add_dependency(SyntheticAddress.parse(':a_fake_dep'))
+      no_deps.add_dependency(Address.parse(':b_fake_dep'))
+      no_deps.add_dependency(Address.parse(':a_fake_dep'))
       self.assertEqual(tuple(no_deps.dependency_lines()),
                        tuple(['  dependencies = [',
                               "    ':a_fake_dep',",
@@ -267,8 +267,8 @@ class BuildFileManipulatorTest(BaseTest):
 
     build_file = self.add_to_build_file('BUILD', self.multi_target_build_string)
 
-    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_bottom', set(['target_type']))
-    multi_targ_bfm.add_dependency(SyntheticAddress.parse(':new_dep'))
+    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_bottom', {'target_type'})
+    multi_targ_bfm.add_dependency(Address.parse(':new_dep'))
     build_file_str = '\n'.join(multi_targ_bfm.build_file_lines())
     self.assertEqual(build_file_str, expected_build_string)
 
@@ -301,8 +301,8 @@ class BuildFileManipulatorTest(BaseTest):
 
     build_file = self.add_to_build_file('BUILD', self.multi_target_build_string)
 
-    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_top', set(['target_type']))
-    multi_targ_bfm.add_dependency(SyntheticAddress.parse(':new_dep'))
+    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_top', {'target_type'})
+    multi_targ_bfm.add_dependency(Address.parse(':new_dep'))
     build_file_str = '\n'.join(multi_targ_bfm.build_file_lines())
     self.assertEqual(build_file_str, expected_build_string)
 
@@ -335,8 +335,8 @@ class BuildFileManipulatorTest(BaseTest):
 
     build_file = self.add_to_build_file('BUILD', self.multi_target_build_string)
 
-    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_middle', set(['target_type']))
-    multi_targ_bfm.add_dependency(SyntheticAddress.parse(':new_dep'))
+    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_middle', {'target_type'})
+    multi_targ_bfm.add_dependency(Address.parse(':new_dep'))
     build_file_str = '\n'.join(multi_targ_bfm.build_file_lines())
     self.assertEqual(build_file_str, expected_build_string)
 
@@ -370,8 +370,8 @@ class BuildFileManipulatorTest(BaseTest):
 
     build_file = self.add_to_build_file('BUILD', self.multi_target_build_string + '\n')
 
-    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_middle', set(['target_type']))
-    multi_targ_bfm.add_dependency(SyntheticAddress.parse(':new_dep'))
+    multi_targ_bfm = BuildFileManipulator.load(build_file, 'target_middle', {'target_type'})
+    multi_targ_bfm.add_dependency(Address.parse(':new_dep'))
     multi_targ_bfm.write(dry_run=False)
 
     with open(build_file.full_path, 'r') as bf:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
@@ -11,7 +11,7 @@ import subprocess
 from collections import defaultdict, namedtuple
 from textwrap import dedent
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator, TemplateData
@@ -84,7 +84,7 @@ class GoTargetGenerator(object):
             remote_root = fetcher.root(import_path)
             remote_pkg_path = GoRemoteLibrary.remote_package_path(remote_root, import_path)
             name = remote_pkg_path or os.path.basename(import_path)
-            address = SyntheticAddress(os.path.join(self._remote_source_root, remote_root), name)
+            address = Address(os.path.join(self._remote_source_root, remote_root), name)
             found = self._build_graph.get_target(address)
             if not found:
               if not self._generate_remotes:
@@ -95,8 +95,8 @@ class GoTargetGenerator(object):
                                                         pkg=remote_pkg_path)
           else:
             # Recurse on local targets.
-            address = SyntheticAddress(os.path.join(self._local_source_root, import_path),
-                                       os.path.basename(import_path))
+            address = Address(os.path.join(self._local_source_root, import_path),
+                              os.path.basename(import_path))
             name, import_paths = self._list_deps(gopath, address)
             self._generate_missing(gopath, address, name, import_paths, visited)
           visited[import_path] = address

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
@@ -10,7 +10,7 @@ import os
 import shutil
 from collections import defaultdict
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.exceptions import TaskError
 from pants.util.contextutil import temporary_dir
@@ -134,7 +134,7 @@ class GoFetch(GoTask):
           package_path = GoRemoteLibrary.remote_package_path(remote_root, remote_import_path)
           target_name = package_path or os.path.basename(remote_root)
 
-          address = SyntheticAddress(spec_path, target_name)
+          address = Address(spec_path, target_name)
           if address not in all_known_addresses:
             try:
               # If we've already resolved a package from this remote root, its ok to define an

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -9,7 +9,7 @@ import os
 import shutil
 from collections import defaultdict
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.source_root import SourceRoot
 from pants.util.contextutil import temporary_dir
 from pants_test.tasks.task_test_base import TaskTestBase
@@ -21,7 +21,7 @@ from pants.contrib.go.tasks.go_fetch import GoFetch
 
 class GoFetchTest(TaskTestBase):
 
-  address = SyntheticAddress.parse
+  address = Address.parse
 
   @classmethod
   def task_type(cls):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -16,7 +16,7 @@ from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
@@ -234,7 +234,7 @@ class ScroogeGen(NailgunTask):
 
     def create_target(files, deps, target_type):
       spec = '{spec_path}:{name}'.format(spec_path=outdir, name=gentarget.id)
-      address = SyntheticAddress.parse(spec=spec)
+      address = Address.parse(spec=spec)
       return self.context.add_new_target(address,
                                          target_type,
                                          sources=files,

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -12,7 +12,7 @@ from mock import MagicMock
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
@@ -134,7 +134,7 @@ class ScroogeGenTest(TaskTestBase):
       task.execute()
       relative_task_outdir = os.path.relpath(self.task_outdir, get_buildroot())
       spec = '{spec_path}:{name}'.format(spec_path=relative_task_outdir, name='test_smoke.a')
-      address = SyntheticAddress.parse(spec=spec)
+      address = Address.parse(spec=spec)
       Context.add_new_target.assert_called_once_with(address,
                                                      library_type,
                                                      sources=sources,

--- a/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
@@ -121,7 +121,7 @@ class SpindleGen(NailgunTask):
         java_synthetic_name = '{0}-{1}'.format(target.id, 'java')
         java_sources_rel_path = os.path.relpath(self.namespace_out, get_buildroot())
         java_spec_path = java_sources_rel_path
-        java_synthetic_address = SyntheticAddress(java_spec_path, java_synthetic_name)
+        java_synthetic_address = Address(java_spec_path, java_synthetic_name)
         java_generated_sources = [
           os.path.join(os.path.dirname(source), 'java_{0}.java'.format(os.path.basename(source)))
           for source in self.sources_generated_by_target(target)
@@ -162,7 +162,7 @@ class SpindleGen(NailgunTask):
         synthetic_name = '{0}-{1}'.format(target.id, 'scala')
         sources_rel_path = os.path.relpath(self.namespace_out, get_buildroot())
         spec_path = sources_rel_path
-        synthetic_address = SyntheticAddress(spec_path, synthetic_name)
+        synthetic_address = Address(spec_path, synthetic_name)
         generated_sources = [
           '{0}.{1}'.format(source, 'scala')
           for source in self.sources_generated_by_target(target)

--- a/src/python/pants/backend/android/tasks/aapt_gen.py
+++ b/src/python/pants/backend/android/tasks/aapt_gen.py
@@ -15,7 +15,7 @@ from pants.backend.android.tasks.aapt_task import AaptTask
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
@@ -70,7 +70,7 @@ class AaptGen(AaptTask):
       if sdk not in self._jar_library_by_sdk:
         jar_url = 'file://{0}'.format(self.android_jar(binary))
         jar = JarDependency(org='com.google', name='android', rev=sdk, url=jar_url)
-        address = SyntheticAddress(self.workdir, 'android-{0}.jar'.format(sdk))
+        address = Address(self.workdir, 'android-{0}.jar'.format(sdk))
         self._jar_library_by_sdk[sdk] = self.context.add_new_target(address, JarLibrary, jars=[jar])
 
   def _render_args(self, binary, manifest, resource_dirs):
@@ -150,13 +150,13 @@ class AaptGen(AaptTask):
     :rtype::class:`pants.backend.jvm.targets.java_library.JavaLibrary`
     """
     spec_path = os.path.join(os.path.relpath(self.aapt_out(binary), get_buildroot()))
-    address = SyntheticAddress(spec_path=spec_path, target_name=gentarget.id)
+    address = Address(spec_path=spec_path, target_name=gentarget.id)
     deps = [self._jar_library_by_sdk[binary.target_sdk]]
     new_target = self.context.add_new_target(address,
-                                      JavaLibrary,
-                                      derived_from=gentarget,
-                                      sources=[self._relative_genfile(gentarget)],
-                                      dependencies=deps)
+                                             JavaLibrary,
+                                             derived_from=gentarget,
+                                             sources=[self._relative_genfile(gentarget)],
+                                             dependencies=deps)
     return new_target
 
   def aapt_out(self, binary):

--- a/src/python/pants/backend/android/tasks/unpack_libraries.py
+++ b/src/python/pants/backend/android/tasks/unpack_libraries.py
@@ -13,7 +13,7 @@ from pants.backend.android.targets.android_resources import AndroidResources
 from pants.backend.core.tasks.task import Task
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
 from pants.fs.archive import ZIP
@@ -92,7 +92,7 @@ class UnpackLibraries(Task):
     archive_version = os.path.splitext(archive)[0].rpartition('-')[-1]
     jar_url = 'file://{0}'.format(jar_file)
     jar_dep = JarDependency(org=target.id, name=archive, rev=archive_version, url=jar_url)
-    address = SyntheticAddress(self.workdir, '{}-classes.jar'.format(archive))
+    address = Address(self.workdir, '{}-classes.jar'.format(archive))
     new_target = self.context.add_new_target(address, JarLibrary, jars=[jar_dep],
                                              derived_from=target)
     return new_target
@@ -107,7 +107,7 @@ class UnpackLibraries(Task):
     :rtype::class:`pants.backend.android.targets.AndroidResources`
     """
 
-    address = SyntheticAddress(self.workdir, '{}-resources'.format(archive))
+    address = Address(self.workdir, '{}-resources'.format(archive))
     new_target = self.context.add_new_target(address, AndroidResources,
                                              manifest=manifest, resource_dir=resource_dir,
                                              derived_from=target)
@@ -143,7 +143,7 @@ class UnpackLibraries(Task):
     if os.path.isfile(jar_file):
       deps.append(self.create_classes_jar_target(target, archive, jar_file))
 
-    address = SyntheticAddress(self.workdir, '{}-android_library'.format(archive))
+    address = Address(self.workdir, '{}-android_library'.format(archive))
     new_target = self.context.add_new_target(address, AndroidLibrary,
                                              manifest=manifest,
                                              include_patterns=target.include_patterns,

--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -18,7 +18,7 @@ from pants.backend.codegen.tasks.protobuf_parse import ProtobufParse
 from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
@@ -100,9 +100,8 @@ class ProtobufGen(SimpleCodegenTask):
     deps = OrderedSet()
     if target.imported_jars:
       # We need to add in the proto imports jars.
-      jars_address = SyntheticAddress(
-          os.path.relpath(self.codegen_workdir(target), get_buildroot()),
-          target.id + '-rjars')
+      jars_address = Address(os.path.relpath(self.codegen_workdir(target), get_buildroot()),
+                             target.id + '-rjars')
       jars_target = self.context.add_new_target(jars_address,
                                                 JarLibrary,
                                                 jars=target.imported_jars,

--- a/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
+++ b/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
@@ -12,7 +12,7 @@ from abc import abstractmethod
 from twitter.common.collections import OrderedSet
 
 from pants.backend.core.tasks.task import Task
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.build_graph import sort_targets
@@ -222,7 +222,7 @@ class SimpleCodegenTask(Task):
         target_workdir = self.codegen_workdir(target)
         synthetic_name = target.id
         sources_rel_path = os.path.relpath(target_workdir, get_buildroot())
-        synthetic_address = SyntheticAddress(sources_rel_path, synthetic_name)
+        synthetic_address = Address(sources_rel_path, synthetic_name)
         raw_generated_sources = list(self.codegen_strategy.find_sources(target))
         # Make the sources robust regardless of whether subclasses return relative paths, or
         # absolute paths that are subclasses of the workdir.

--- a/src/python/pants/backend/core/tasks/markdown_to_html.py
+++ b/src/python/pants/backend/core/tasks/markdown_to_html.py
@@ -22,7 +22,7 @@ from six.moves import range
 
 from pants.backend.core.targets.doc import Page
 from pants.backend.core.tasks.task import Task
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
@@ -332,7 +332,7 @@ class MarkdownToHtml(Task):
     def parse_url(spec):
       match = self.PANTS_LINK.match(spec)
       if match:
-        address = SyntheticAddress.parse(match.group(1), relative_to=get_buildroot())
+        address = Address.parse(match.group(1), relative_to=get_buildroot())
         page = self.context.build_graph.get_target(address)
         anchor = match.group(2) or ''
         if not page:

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import six
 
 from pants.backend.jvm.targets.jar_dependency import JarDependency
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import ExcludesField, JarsField
@@ -72,7 +72,7 @@ class JarLibrary(Target):
           .format(address=relative_to.spec,
                   found_class=type(spec).__name__))
 
-      lookup = SyntheticAddress.parse(spec, relative_to=relative_to.spec_path)
+      lookup = Address.parse(spec, relative_to=relative_to.spec_path)
       target = build_graph.get_target(lookup)
       if not isinstance(target, JarLibrary):
         raise JarLibrary.WrongTargetTypeError(

--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.exceptions import TargetDefinitionException
 
 
@@ -68,7 +68,7 @@ class ScalaLibrary(ExportableJvmLibrary):
   @property
   def java_sources(self):
     for spec in self._java_sources_specs:
-      address = SyntheticAddress.parse(spec, relative_to=self.address.spec_path)
+      address = Address.parse(spec, relative_to=self.address.spec_path)
       target = self._build_graph.get_target(address)
       if target is None:
         raise TargetDefinitionException(self, 'No such java target: {}'.format(spec))

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -98,10 +98,12 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':projectutils',
+    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
+    'src/python/pants/base:address',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:source_root',

--- a/src/python/pants/backend/project_info/tasks/depmap.py
+++ b/src/python/pants/backend/project_info/tasks/depmap.py
@@ -23,20 +23,6 @@ class Depmap(ConsoleTask):
     RESOURCE = 'RESOURCE'  # Resource belonging to Source Target
     TEST_RESOURCE = 'TEST_RESOURCE'  # Resource belonging to Test Target
 
-  @staticmethod
-  def _jar_id(jar):
-    if jar.rev:
-      return '{0}:{1}:{2}'.format(jar.org, jar.name, jar.rev)
-    else:
-      return '{0}:{1}'.format(jar.org, jar.name)
-
-  @staticmethod
-  def _address(address):
-    """
-    :type address: pants.base.address.SyntheticAddress
-    """
-    return '{0}:{1}'.format(address.spec_path, address.target_name)
-
   @classmethod
   def register_options(cls, register):
     super(Depmap, cls).register_options(register)
@@ -104,8 +90,6 @@ class Depmap(ConsoleTask):
             '{org}{sep}{name}').format(**params), is_internal_dep
 
   def _enumerate_visible_deps(self, dep, predicate):
-    dep_id, internal = self._dep_id(dep)
-
     dependencies = sorted([x for x in getattr(dep, 'dependencies', [])]) + sorted(
       [x for x in getattr(dep, 'jar_dependencies', [])] if not self.is_internal_only else [])
 

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -76,13 +76,6 @@ class Export(ConsoleTask):
     """
     return '{0}:{1}'.format(jar.org, jar.name) if jar.name else jar.org
 
-  @staticmethod
-  def _address(address):
-    """
-    :type address: pants.base.address.SyntheticAddress
-    """
-    return '{0}:{1}'.format(address.spec_path, address.target_name)
-
   @classmethod
   def register_options(cls, register):
     super(Export, cls).register_options(register)
@@ -179,7 +172,7 @@ class Export(ConsoleTask):
       if isinstance(current_target, JarLibrary):
         target_libraries = get_transitive_jars(current_target)
       for dep in current_target.dependencies:
-        info['targets'].append(self._address(dep.address))
+        info['targets'].append(dep.address.spec)
         if isinstance(dep, JarLibrary):
           for jar in dep.jar_dependencies:
             target_libraries.add(IvyModuleRef(jar.org, jar.name, jar.rev))
@@ -190,7 +183,7 @@ class Export(ConsoleTask):
 
       if isinstance(current_target, ScalaLibrary):
         for dep in current_target.java_sources:
-          info['targets'].append(self._address(dep.address))
+          info['targets'].append(dep.address.spec)
           process_target(dep)
 
       if isinstance(current_target, JvmTarget):
@@ -203,7 +196,7 @@ class Export(ConsoleTask):
 
       if self.get_options().libraries:
         info['libraries'] = [self._jar_id(lib) for lib in target_libraries]
-      targets_map[self._address(current_target.address)] = info
+      targets_map[current_target.address.spec] = info
 
     for target in targets:
       process_target(target)

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -18,6 +18,7 @@ from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.project_info.tasks.projectutils import get_jar_infos
+from pants.base.address import BuildFileAddress
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
@@ -575,7 +576,7 @@ class Project(object):
         # this target globs children as well.  Gather all these candidate BUILD files to test for
         # sources they own that live in the directories this targets sources live in.
         target_dirset = find_source_basedirs(target)
-        if target.address.is_synthetic:
+        if not isinstance(target.address, BuildFileAddress):
           return []  # Siblings don't make sense for synthetic addresses.
         candidates = self.target_util.get_all_addresses(target.address.build_file)
         for ancestor in target.address.build_file.ancestors():

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -577,7 +577,7 @@ class Project(object):
         # sources they own that live in the directories this targets sources live in.
         target_dirset = find_source_basedirs(target)
         if not isinstance(target.address, BuildFileAddress):
-          return []  # Siblings don't make sense for synthetic addresses.
+          return []  # Siblings only make sense for BUILD files.
         candidates = self.target_util.get_all_addresses(target.address.build_file)
         for ancestor in target.address.build_file.ancestors():
           candidates.update(self.target_util.get_all_addresses(ancestor))

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -10,7 +10,7 @@ from twitter.common.collections import maybe_list
 
 from pants.backend.core.targets.resources import Resources
 from pants.backend.python.python_artifact import PythonArtifact
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
@@ -90,7 +90,7 @@ class PythonTarget(Target):
       yield spec
     if self._provides:
       for spec in self._provides._binaries.values():
-        address = SyntheticAddress.parse(spec, relative_to=self.address.spec_path)
+        address = Address.parse(spec, relative_to=self.address.spec_path)
         yield address.spec
 
   @property
@@ -102,7 +102,7 @@ class PythonTarget(Target):
     def binary_iter():
       if self.payload.provides:
         for key, binary_spec in self.payload.provides.binaries.items():
-          address = SyntheticAddress.parse(binary_spec, relative_to=self.address.spec_path)
+          address = Address.parse(binary_spec, relative_to=self.address.spec_path)
           yield (key, self._build_graph.get_target(address))
     return dict(binary_iter())
 
@@ -138,11 +138,11 @@ class PythonTarget(Target):
   def _synthesize_resources_target(self):
     # Create an address for the synthetic target.
     spec = self.address.spec + '_synthetic_resources'
-    synthetic_address = SyntheticAddress.parse(spec=spec)
+    synthetic_address = Address.parse(spec=spec)
     # For safety, ensure an address that's not used already, even though that's highly unlikely.
     while self._build_graph.contains_address(synthetic_address):
       spec += '_'
-      synthetic_address = SyntheticAddress.parse(spec=spec)
+      synthetic_address = Address.parse(spec=spec)
 
     self._build_graph.inject_synthetic_target(synthetic_address, Resources,
                                               sources=self.payload.resources.source_paths,

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources = ['address.py'],
   dependencies = [
     ':build_file',
+    'src/python/pants/base:deprecated',
     'src/python/pants/util:meta',
   ]
 )

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -5,9 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import functools
 import os
 from collections import namedtuple
 
+from pants.base.deprecated import deprecated
 from pants.util.meta import AbstractClass
 
 
@@ -113,14 +115,24 @@ class Address(AbstractClass):
   Where ``path/to/buildfile:targetname`` is the dependent target address.
   """
 
+  @classmethod
+  def parse(cls, spec, relative_to=''):
+    """Parses an address from its serialized form.
+
+    :param string spec: An address in string form <path>:<name>.
+    :param string relative_to: For sibling specs, ie: ':another_in_same_build_family', interprets
+                               the missing spec_path part as `relative_to`.
+    :returns: A new address.
+    :rtype: :class:`pants.base.address.Address`
+    """
+    spec_path, target_name = parse_spec(spec, relative_to=relative_to)
+    return cls(spec_path, target_name)
+
   def __init__(self, spec_path, target_name):
     """
     :param string spec_path: The path from the root of the repo to this Target.
     :param string target_name: The name of a target this Address refers to.
     """
-    # TODO(John Sirois): AbstractClass / Interface should probably have this feature built in.
-    if type(self) == Address:
-      raise TypeError('Cannot instantiate abstract class Address')
     norm_path = os.path.normpath(spec_path)
     self._spec_path = norm_path if norm_path != '.' else ''
     self._target_name = target_name
@@ -149,6 +161,8 @@ class Address(AbstractClass):
     return ':{target_name}'.format(target_name=self._target_name)
 
   @property
+  @deprecated(removal_version='0.0.49',
+              hint_message='Use `not isinstance(address, BuildFileAddress)` instead.')
   def is_synthetic(self):
     return False
 
@@ -197,20 +211,18 @@ class BuildFileAddress(Address):
 
 
 class SyntheticAddress(Address):
-  @classmethod
-  def parse(cls, spec, relative_to=''):
-    """
-    :param string spec: an address in string form <path>:<name>
-    :param string relative_to: For sibling specs, ie: ':another_in_same_build_family', interprets
-    the missing spec_path part as `relative_to`.
-    :return:
-    """
-    spec_path, target_name = parse_spec(spec, relative_to=relative_to)
-    return cls(spec_path, target_name)
+  deprecate_me = functools.partial(deprecated, removal_version='0.0.49')
 
-  def __repr__(self):
-    return "SyntheticAddress({spec})".format(spec=self.spec)
+  @classmethod
+  @deprecate_me(hint_message='Use `Address.parse(...)` instead.')
+  def parse(cls, *args, **kwargs):
+    return super(SyntheticAddress, cls).parse(*args, **kwargs)
+
+  @deprecate_me(hint_message='Use `Address(...)` instead.')
+  def __init__(self, *args, **kwargs):
+    super(SyntheticAddress, self).__init__(*args, **kwargs)
 
   @property
+  @deprecate_me(hint_message='Use `not isinstance(address, BuildFileAddress)` instead.')
   def is_synthetic(self):
     return True

--- a/src/python/pants/base/build_file_address_mapper.py
+++ b/src/python/pants/base/build_file_address_mapper.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.address import BuildFileAddress, SyntheticAddress, parse_spec
+from pants.base.address import Address, BuildFileAddress, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
@@ -125,7 +125,7 @@ class BuildFileAddressMapper(object):
   def resolve_spec(self, spec):
     """Converts a spec to an address and maps it using `resolve`"""
     try:
-      address = SyntheticAddress.parse(spec)
+      address = Address.parse(spec)
     except ValueError as e:
       raise self.InvalidAddressError(e)
     _, addressable = self.resolve(address)

--- a/src/python/pants/base/build_graph.py
+++ b/src/python/pants/base/build_graph.py
@@ -49,7 +49,7 @@ class BuildGraph(object):
     return address in self._target_by_address
 
   def get_target_from_spec(self, spec, relative_to=''):
-    """Converts `spec` into a SyntheticAddress and returns the result of `get_target`"""
+    """Converts `spec` into an address and returns the result of `get_target`"""
     return self.get_target(Address.parse(spec, relative_to=relative_to))
 
   def get_target(self, address):

--- a/src/python/pants/base/build_graph.py
+++ b/src/python/pants/base/build_graph.py
@@ -11,7 +11,7 @@ from collections import OrderedDict, defaultdict, deque
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.address_lookup_error import AddressLookupError
 
 
@@ -50,7 +50,7 @@ class BuildGraph(object):
 
   def get_target_from_spec(self, spec, relative_to=''):
     """Converts `spec` into a SyntheticAddress and returns the result of `get_target`"""
-    return self.get_target(SyntheticAddress.parse(spec, relative_to=relative_to))
+    return self.get_target(Address.parse(spec, relative_to=relative_to))
 
   def get_target(self, address):
     """Returns the Target at `address` if it has been injected into the BuildGraph, otherwise None.
@@ -403,7 +403,7 @@ class BuildGraph(object):
 
   def resolve(self, spec):
     """Returns an iterator over the target(s) the given address points to."""
-    address = SyntheticAddress.parse(spec)
+    address = Address.parse(spec)
     # NB: This is an idempotent, short-circuiting call.
     self.inject_address_closure(address)
     return self.transitive_subgraph_of_addresses([address])

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -12,7 +12,7 @@ from hashlib import sha1
 from six import string_types
 
 from pants.backend.core.wrapped_globs import FilesetWithSpec
-from pants.base.address import Addresses, SyntheticAddress
+from pants.base.address import Address, Addresses
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
@@ -534,8 +534,7 @@ class Target(AbstractTarget):
         raise self.WrongNumberOfAddresses(
           "Expected a single address to from_target() as argument to {spec}"
           .format(spec=address.spec))
-      referenced_address = SyntheticAddress.parse(sources.addresses[0],
-                                                  relative_to=sources.rel_path)
+      referenced_address = Address.parse(sources.addresses[0], relative_to=sources.rel_path)
       return DeferredSourcesField(ref_address=referenced_address)
     elif isinstance(sources, FilesetWithSpec):
       filespec = sources.filespec

--- a/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
@@ -14,7 +14,7 @@ from twitter.common.dirutil.fileset import Fileset
 
 from pants.backend.codegen.targets.java_antlr_library import JavaAntlrLibrary
 from pants.backend.codegen.tasks.antlr_gen import AntlrGen
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
@@ -73,7 +73,7 @@ class AntlrGenTest(NailgunTaskTestBase):
   def get_antlr_syn_target(self, task):
     target = self.get_antlr_target()
     target_workdir = task.codegen_workdir(target)
-    syn_address = SyntheticAddress(os.path.relpath(target_workdir, get_buildroot()), target.id)
+    syn_address = Address(os.path.relpath(target_workdir, get_buildroot()), target.id)
     return task.context.build_graph.get_target(syn_address)
 
   def execute_antlr_test(self, expected_package):

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.target import Target
@@ -27,14 +27,14 @@ class JarLibraryTest(BaseTest):
                                    objects={'jar': JarDependency})
 
   def test_validation(self):
-    target = Target(name='mybird', address=SyntheticAddress.parse('//:mybird'),
+    target = Target(name='mybird', address=Address.parse('//:mybird'),
                     build_graph=self.build_graph)
     # jars attribute must contain only JarLibrary instances
     with self.assertRaises(TargetDefinitionException):
       JarLibrary(name="test", jars=[target])
 
   def test_jar_dependencies(self):
-    lib = JarLibrary(name='foo', address=SyntheticAddress.parse('//:foo'),
+    lib = JarLibrary(name='foo', address=Address.parse('//:foo'),
                      build_graph=self.build_graph,
                      jars=[jar1, jar2])
     self.assertEquals((jar1, jar2), lib.jar_dependencies)
@@ -46,7 +46,7 @@ class JarLibraryTest(BaseTest):
 
   def test_excludes(self):
     # TODO(Eric Ayers) There doesn't seem to be any way to set this field at the moment.
-    lib = JarLibrary(name='foo', address=SyntheticAddress.parse('//:foo'),
+    lib = JarLibrary(name='foo', address=Address.parse('//:foo'),
                      build_graph=self.build_graph, jars=[jar1])
     self.assertEquals([], lib.excludes)
 

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_target.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_target.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 from pants.backend.core.register import build_file_aliases as register_core
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.base.address import BuildFileAddress, SyntheticAddress
+from pants.base.address import Address, BuildFileAddress
 from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
 
@@ -36,6 +36,6 @@ class JvmTargetTest(BaseTest):
     '''))
 
     self.build_graph.inject_address_closure(BuildFileAddress(build_file, 'foo'))
-    target = self.build_graph.get_target(SyntheticAddress.parse('//:foo'))
+    target = self.build_graph.get_target(Address.parse('//:foo'))
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':resource_target'], list(target.traversable_dependency_specs))

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -9,7 +9,7 @@ import os
 from textwrap import dedent
 
 from pants.backend.python.register import build_file_aliases as register_python
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
@@ -52,7 +52,7 @@ class PythonTaskTestBase(TaskTestBase):
       self.create_file(relpath=os.path.join(relpath, '__init__.py'))
       for source, contents in source_contents_map.items():
         self.create_file(relpath=os.path.join(relpath, source), contents=contents)
-    return self.target(SyntheticAddress(relpath, name).spec)
+    return self.target(Address(relpath, name).spec)
 
   def create_python_binary(self, relpath, name, entry_point, dependencies=(), provides=None):
     self.create_file(relpath=self.build_path(relpath), contents=dedent("""
@@ -66,7 +66,7 @@ class PythonTaskTestBase(TaskTestBase):
     )
     """).format(name=name, entry_point=entry_point, dependencies=','.join(map(repr, dependencies)),
                 provides_clause='provides={0},'.format(provides) if provides else ''))
-    return self.target(SyntheticAddress(relpath, name).spec)
+    return self.target(Address(relpath, name).spec)
 
   def create_python_requirement_library(self, relpath, name, requirements):
     def make_requirement(req):
@@ -80,4 +80,4 @@ class PythonTaskTestBase(TaskTestBase):
       ]
     )
     """).format(name=name, requirements=','.join(map(make_requirement, requirements))))
-    return self.target(SyntheticAddress(relpath, name).spec)
+    return self.target(Address(relpath, name).spec)

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -14,7 +14,7 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.tasks.python_repl import PythonRepl
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.exceptions import TaskError
 from pants.base.source_root import SourceRoot
@@ -45,7 +45,7 @@ class PythonReplTest(PythonTaskTestBase):
     )
     """).format(name=name))
 
-    return self.target(SyntheticAddress(relpath, name).spec)
+    return self.target(Address(relpath, name).spec)
 
   def setUp(self):
     super(PythonReplTest, self).setUp()

--- a/tests/python/pants_test/base/test_address.py
+++ b/tests/python/pants_test/base/test_address.py
@@ -9,7 +9,7 @@ import os
 import unittest
 from contextlib import contextmanager
 
-from pants.base.address import BuildFileAddress, SyntheticAddress, parse_spec
+from pants.base.address import Address, BuildFileAddress, parse_spec
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.build_root import BuildRoot
 from pants.util.contextutil import pushd, temporary_dir
@@ -106,16 +106,21 @@ class BaseAddressTest(unittest.TestCase):
     self.assertEqual(target_name, address.target_name)
 
 
-class SyntheticAddressTest(BaseAddressTest):
-  def test_synthetic_forms(self):
-    self.assert_address('a/b', 'target', SyntheticAddress.parse('a/b:target'))
-    self.assert_address('a/b', 'target', SyntheticAddress.parse('//a/b:target'))
-    self.assert_address('a/b', 'b', SyntheticAddress.parse('a/b'))
-    self.assert_address('a/b', 'b', SyntheticAddress.parse('//a/b'))
-    self.assert_address('a/b', 'target', SyntheticAddress.parse(':target', relative_to='a/b'))
-    self.assert_address('', 'target', SyntheticAddress.parse('//:target', relative_to='a/b'))
-    self.assert_address('', 'target', SyntheticAddress.parse(':target'))
-    self.assert_address('a/b', 'target', SyntheticAddress.parse(':target', relative_to='a/b'))
+class AddressTest(BaseAddressTest):
+  def test_equivalence(self):
+    self.assertEqual(Address('a/b', 'c'), Address('a/b', 'c'))
+    self.assertEqual(Address('a/b', 'c'), Address.parse('a/b:c'))
+    self.assertEqual(Address.parse('a/b:c'), Address.parse('a/b:c'))
+
+  def test_parse(self):
+    self.assert_address('a/b', 'target', Address.parse('a/b:target'))
+    self.assert_address('a/b', 'target', Address.parse('//a/b:target'))
+    self.assert_address('a/b', 'b', Address.parse('a/b'))
+    self.assert_address('a/b', 'b', Address.parse('//a/b'))
+    self.assert_address('a/b', 'target', Address.parse(':target', relative_to='a/b'))
+    self.assert_address('', 'target', Address.parse('//:target', relative_to='a/b'))
+    self.assert_address('', 'target', Address.parse(':target'))
+    self.assert_address('a/b', 'target', Address.parse(':target', relative_to='a/b'))
 
 
 class BuildFileAddressTest(BaseAddressTest):

--- a/tests/python/pants_test/base/test_build_configuration.py
+++ b/tests/python/pants_test/base/test_build_configuration.py
@@ -9,7 +9,7 @@ import os
 import unittest
 from contextlib import contextmanager
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_configuration import BuildConfiguration
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.build_graph import BuildGraph
@@ -49,7 +49,7 @@ class BuildConfigurationTest(unittest.TestCase):
     with self.assertRaises(TypeError):
       self.build_configuration.register_target_alias('fred', object())
 
-    target = Target('fred', SyntheticAddress.parse('a:b'), BuildGraph(address_mapper=None))
+    target = Target('fred', Address.parse('a:b'), BuildGraph(address_mapper=None))
     with self.assertRaises(TypeError):
       self.build_configuration.register_target_alias('fred', target)
 

--- a/tests/python/pants_test/base/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/base/test_build_file_address_mapper.py
@@ -9,7 +9,7 @@ import os
 from textwrap import dedent
 
 from pants.backend.core.targets.dependencies import Dependencies
-from pants.base.address import BuildFileAddress, SyntheticAddress
+from pants.base.address import Address, BuildFileAddress
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_file_address_mapper import BuildFileAddressMapper
 from pants_test.base_test import BaseTest
@@ -31,7 +31,7 @@ class BuildFileAddressMapperTest(BaseTest):
       '''
     ))
 
-    address, addressable = self.address_mapper.resolve(SyntheticAddress.parse('//:foo'))
+    address, addressable = self.address_mapper.resolve(Address.parse('//:foo'))
     self.assertIsInstance(address, BuildFileAddress)
     self.assertEqual(build_file, address.build_file)
     self.assertEqual('foo', address.target_name)

--- a/tests/python/pants_test/base/test_build_graph.py
+++ b/tests/python/pants_test/base/test_build_graph.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.address import SyntheticAddress, parse_spec
+from pants.base.address import Address, parse_spec
 from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_graph import BuildGraph
 from pants.base.target import Target
@@ -36,20 +36,20 @@ class BuildGraphTest(BaseTest):
             "'{}'".format("','".join(targets)) if targets else ''
           )
       )
-    root_address = SyntheticAddress.parse(root_spec)
+    root_address = Address.parse(root_spec)
     self.build_graph.inject_address_closure(root_address)
     return root_address
 
   def test_target_invalid(self):
     self.add_to_build_file('a/BUILD', 'target(name="a")')
     with self.assertRaises(AddressLookupError):
-      self.build_graph.inject_address_closure(SyntheticAddress.parse('a:nope'))
+      self.build_graph.inject_address_closure(Address.parse('a:nope'))
 
     self.add_to_build_file('b/BUILD', 'target(name="a")')
     with self.assertRaises(AddressLookupError):
-      self.build_graph.inject_address_closure(SyntheticAddress.parse('b'))
+      self.build_graph.inject_address_closure(Address.parse('b'))
     with self.assertRaises(AddressLookupError):
-      self.build_graph.inject_address_closure(SyntheticAddress.parse('b:b'))
+      self.build_graph.inject_address_closure(Address.parse('b:b'))
 
   def test_transitive_closure_address(self):
     root_address = self.inject_graph('//:foo', {
@@ -63,12 +63,12 @@ class BuildGraphTest(BaseTest):
   def test_no_targets(self):
     self.add_to_build_file('empty/BUILD', 'pass')
     with self.assertRaises(AddressLookupError):
-      self.build_graph.inject_address_closure(SyntheticAddress.parse('empty'))
+      self.build_graph.inject_address_closure(Address.parse('empty'))
     with self.assertRaises(AddressLookupError):
-      self.build_graph.inject_address_closure(SyntheticAddress.parse('empty:foo'))
+      self.build_graph.inject_address_closure(Address.parse('empty:foo'))
 
   def test_contains_address(self):
-    a = SyntheticAddress.parse('a')
+    a = Address.parse('a')
     self.assertFalse(self.build_graph.contains_address(a))
     target = Target(name='a',
                     address=a,
@@ -201,7 +201,7 @@ class BuildGraphTest(BaseTest):
     self.assertIsInstance(BuildGraph.TransitiveLookupError(), AddressLookupError)
 
   def inject_address_closure(self, spec):
-    self.build_graph.inject_address_closure(SyntheticAddress.parse(spec))
+    self.build_graph.inject_address_closure(Address.parse(spec))
 
   def test_invalid_address(self):
     with self.assertRaisesRegexp(AddressLookupError,

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.target import Target
@@ -119,14 +119,14 @@ class CmdLineSpecParserTest(BaseTest):
     def sort(addresses):
       return sorted(addresses, key=lambda address: address.spec)
 
-    self.assertEqual(sort(SyntheticAddress.parse(addr) for addr in expected),
+    self.assertEqual(sort(Address.parse(addr) for addr in expected),
                      sort(self.spec_parser.parse_addresses(cmdline_spec)))
 
   def assert_parsed_list(self, cmdline_spec_list, expected):
     def sort(addresses):
       return sorted(addresses, key=lambda address: address.spec)
 
-    self.assertEqual(sort(SyntheticAddress.parse(addr) for addr in expected),
+    self.assertEqual(sort(Address.parse(addr) for addr in expected),
                      sort(self.spec_parser.parse_addresses(cmdline_spec_list)))
 
   def test_pants_dot_d_excluded(self):

--- a/tests/python/pants_test/base/test_source_root.py
+++ b/tests/python/pants_test/base/test_source_root.py
@@ -10,7 +10,7 @@ import unittest
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.address import SyntheticAddress, parse_spec
+from pants.base.address import Address, parse_spec
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.source_root import SourceRoot, SourceRootTree
 from pants.base.target import Target
@@ -20,21 +20,21 @@ class TestTarget(Target):
 
   def __init__(self, spec):
     spec_path, target_name = parse_spec(spec)
-    super(TestTarget, self).__init__(target_name, SyntheticAddress.parse(spec), None)
+    super(TestTarget, self).__init__(target_name, Address.parse(spec), None)
 
 
 class NotTestTarget(Target):
 
   def __init__(self, spec):
     spec_path, target_name = parse_spec(spec)
-    super(NotTestTarget, self).__init__(target_name, SyntheticAddress.parse(spec), None)
+    super(NotTestTarget, self).__init__(target_name, Address.parse(spec), None)
 
 
 class AnotherTarget(Target):
 
   def __init__(self, spec):
     spec_path, target_name = parse_spec(spec)
-    super(AnotherTarget, self).__init__(target_name, SyntheticAddress.parse(spec), None)
+    super(AnotherTarget, self).__init__(target_name, Address.parse(spec), None)
 
 
 class SourceRootTest(unittest.TestCase):

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.payload import Payload
 from pants.base.payload_field import DeferredSourcesField
 from pants.base.target import Target
@@ -44,7 +44,7 @@ class TargetTest(BaseTest):
   def test_deferred_sources_payload_field(self):
     target = self.make_target(':bar',
                               TestDeferredSourcesTarget,
-                              deferred_sources_address=SyntheticAddress.parse('//:foo'))
+                              deferred_sources_address=Address.parse('//:foo'))
     self.assertSequenceEqual([], list(target.traversable_specs))
     self.assertSequenceEqual([':foo'], list(target.traversable_dependency_specs))
 

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -13,7 +13,7 @@ from tempfile import mkdtemp
 from textwrap import dedent
 
 from pants.backend.core.targets.dependencies import Dependencies
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_configuration import BuildConfiguration
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.build_file_address_mapper import BuildFileAddressMapper
@@ -84,7 +84,7 @@ class BaseTest(unittest.TestCase):
                   resources=None,
                   derived_from=None,
                   **kwargs):
-    address = SyntheticAddress.parse(spec)
+    address = Address.parse(spec)
     target = target_type(name=address.target_name,
                          address=address,
                          build_graph=self.build_graph,
@@ -211,7 +211,7 @@ class BaseTest(unittest.TestCase):
 
     Returns the corresponding Target or else None if the address does not point to a defined Target.
     """
-    address = SyntheticAddress.parse(spec)
+    address = Address.parse(spec)
     self.build_graph.inject_address_closure(address)
     return self.build_graph.get_target(address)
 

--- a/tests/python/pants_test/goal/test_context.py
+++ b/tests/python/pants_test/goal/test_context.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.target import Target
 from pants_test.base_test import BaseTest
 
@@ -64,8 +64,8 @@ class ContextTest(BaseTest):
     context = self.context(target_roots=[c])
     self.assertEquals([c, b, a], context.targets())
 
-    syn_b = context.add_new_target(SyntheticAddress.parse('syn_b'), Target, derived_from=b)
-    context.add_new_target(SyntheticAddress.parse('syn_d'), Target, derived_from=d)
+    syn_b = context.add_new_target(Address.parse('syn_b'), Target, derived_from=b)
+    context.add_new_target(Address.parse('syn_d'), Target, derived_from=d)
     # We expect syn_b to be included now since it has been synthesized during this run from an
     # in-play target.
     self.assertEquals([c, b, a, syn_b], context.targets())
@@ -80,7 +80,7 @@ class ContextTest(BaseTest):
     context = self.context(target_roots=[b])
     self.assertEquals([b], context.targets())
 
-    syn_with_deps = context.add_new_target(SyntheticAddress.parse('syn_with_deps'),
+    syn_with_deps = context.add_new_target(Address.parse('syn_with_deps'),
                                            Target,
                                            derived_from=b,
                                            dependencies=[a])
@@ -93,10 +93,7 @@ class ContextTest(BaseTest):
     context = self.context(target_roots=[b])
     self.assertEquals([b], context.targets())
 
-    syn_with_deps = context.add_new_target(SyntheticAddress.parse('syn_with_deps'),
-                                           Target,
-                                           dependencies=[a])
-
+    context.add_new_target(Address.parse('syn_with_deps'), Target, dependencies=[a])
     self.assertEquals([b], context.targets())
 
   def test_targets_include_synthetics_with_no_derived_from_injected_into_graph(self):
@@ -105,9 +102,7 @@ class ContextTest(BaseTest):
     context = self.context(target_roots=[b])
     self.assertEquals([b], context.targets())
 
-    syn_with_deps = context.add_new_target(SyntheticAddress.parse('syn_with_deps'),
-                                           Target,
-                                           dependencies=[a])
+    syn_with_deps = context.add_new_target(Address.parse('syn_with_deps'), Target, dependencies=[a])
     b.inject_dependency(syn_with_deps.address)
 
     self.assertEquals([b, syn_with_deps, a], context.targets())

--- a/tests/python/pants_test/targets/test_wiki_page.py
+++ b/tests/python/pants_test/targets/test_wiki_page.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from textwrap import dedent
 
 from pants.backend.core.targets.doc import Page, Wiki, WikiArtifact
-from pants.base.address import SyntheticAddress
+from pants.base.address import Address
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file_aliases import BuildFileAliases
 from pants_test.base_test import BaseTest
@@ -95,5 +95,5 @@ This is the second readme file! Isn't it exciting?
 
     # Check to make sure the 'readme2' target has been loaded into the build graph (via parsing of
     # the 'README.md' page)
-    address = SyntheticAddress.parse('junk/docs:readme2', relative_to=get_buildroot())
+    address = Address.parse('junk/docs:readme2', relative_to=get_buildroot())
     self.assertEquals(p._build_graph.get_target(address), self.target('junk/docs:readme2'))


### PR DESCRIPTION
This makes Address concrete with only a single BuildFileAddress subclass
that may be removed later.  SyntheticAddress use is removed from the
pants codebase but the class is kept around for a deprecation cycle for
plugin writers with forwardings set up to Address.

https://rbcommons.com/s/twitter/r/2730/