### PR TITLE
Tighten up the node target hierarchy.

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/targets/node_module.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_module.py
@@ -13,29 +13,21 @@ from pants.contrib.node.targets.npm_package import NpmPackage
 class NodeModule(NpmPackage):
   """Represents a Node module."""
 
-  def __init__(self,
-               sources=None,
-               sources_rel_path=None,
-               address=None,
-               payload=None,
-               **kwargs):
+  def __init__(self, sources=None, address=None, payload=None, **kwargs):
     """
     :param sources: Javascript and other source code files that make up this module; paths are
                     relative to the BUILD file's directory.
-    :type sources: `globs` , `rglobs` or a list of strings
+    :type sources: `globs`, `rglobs` or a list of strings
     """
     # TODO(John Sirois): Support devDependencies, etc.  The devDependencies case is not
     # clear-cut since pants controlled builds would provide devDependencies as needed to perform
     # tasks.  The reality is likely to be though that both pants will never cover all cases, and a
     # back door to execute new tools during development will be desirable and supporting conversion
     # of pre-existing package.json files as node_module targets will require this.
-
-    if sources_rel_path is None:
-      sources_rel_path = address.spec_path
     payload = payload or Payload()
     payload.add_fields({
       'sources': self.create_sources_field(sources=sources,
-                                           sources_rel_path=sources_rel_path,
+                                           sources_rel_path=address.spec_path,
                                            key_arg='sources'),
     })
     super(NodeModule, self).__init__(address=address, payload=payload, **kwargs)

--- a/contrib/node/src/python/pants/contrib/node/targets/npm_package.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/npm_package.py
@@ -11,7 +11,11 @@ from pants.base.target import Target
 
 
 class NpmPackage(Target):
-  """Represents an NPM package."""
+  """Represents an abstract NPM package.
+
+  All NPM packages have a package name whether they are local or remote so this serves as a base
+  class for all concrete manifestations of NPM packages.
+  """
 
   def __init__(self, package_name=None, address=None, payload=None, **kwargs):
     """


### PR DESCRIPTION
Add documentation to explain NpmTarget's role as an abc and kill
the gratuitous exposure of sources_rel_path in NodeModule.

https://rbcommons.com/s/twitter/r/2736/