### PR TITLE
Rid all targets of sources_rel_path parameters.

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_target.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_target.py
@@ -12,23 +12,16 @@ from pants.base.target import Target
 class CppTarget(Target):
   """A base class for all cpp targets."""
 
-  def __init__(self,
-               address=None,
-               payload=None,
-               sources_rel_path=None,
-               sources=None,
-               **kwargs):
+  def __init__(self, address=None, payload=None, sources=None, **kwargs):
     """
     :param sources: Source code files to build. Paths are relative to the BUILD
       file's directory.
     :type sources: ``Fileset`` (from globs or rglobs) or list of strings
     """
-    if sources_rel_path is None:
-      sources_rel_path = address.spec_path
     payload = payload or Payload()
     payload.add_fields({
       'sources': self.create_sources_field(sources=sources,
-                                           sources_rel_path=sources_rel_path,
+                                           sources_rel_path=address.spec_path,
                                            key_arg='sources'),
     })
     super(CppTarget, self).__init__(address=address, payload=payload, **kwargs)

--- a/contrib/go/src/python/pants/contrib/go/targets/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/targets/BUILD
@@ -28,7 +28,9 @@ python_library(
   name='go_local_source',
   sources=['go_local_source.py'],
   dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.dirutil',
     ':go_target',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:payload',
   ],
 )

--- a/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
@@ -120,8 +120,7 @@ class SpindleGen(NailgunTask):
       for target in targets:
         java_synthetic_name = '{0}-{1}'.format(target.id, 'java')
         java_sources_rel_path = os.path.relpath(self.namespace_out, get_buildroot())
-        java_spec_path = java_sources_rel_path
-        java_synthetic_address = Address(java_spec_path, java_synthetic_name)
+        java_synthetic_address = Address(java_sources_rel_path, java_synthetic_name)
         java_generated_sources = [
           os.path.join(os.path.dirname(source), 'java_{0}.java'.format(os.path.basename(source)))
           for source in self.sources_generated_by_target(target)
@@ -140,7 +139,6 @@ class SpindleGen(NailgunTask):
           target_type=JavaLibrary,
           dependencies=[dep.address for dep in self.synthetic_target_extra_dependencies],
           derived_from=target,
-          sources_rel_path=java_sources_rel_path,
           sources=java_relative_generated_sources,
         )
         java_synthetic_target = build_graph.get_target(java_synthetic_address)
@@ -161,8 +159,7 @@ class SpindleGen(NailgunTask):
 
         synthetic_name = '{0}-{1}'.format(target.id, 'scala')
         sources_rel_path = os.path.relpath(self.namespace_out, get_buildroot())
-        spec_path = sources_rel_path
-        synthetic_address = Address(spec_path, synthetic_name)
+        synthetic_address = Address(sources_rel_path, synthetic_name)
         generated_sources = [
           '{0}.{1}'.format(source, 'scala')
           for source in self.sources_generated_by_target(target)
@@ -173,7 +170,6 @@ class SpindleGen(NailgunTask):
           address=synthetic_address,
           target_type=ScalaLibrary,
           dependencies=self.synthetic_target_extra_dependencies,
-          sources_rel_path=sources_rel_path,
           sources=relative_generated_sources,
           derived_from=target,
           java_sources=[java_synthetic_target.address.spec],

--- a/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
+++ b/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
@@ -236,9 +236,14 @@ class SimpleCodegenTask(Task):
           address=synthetic_address,
           target_type=self.synthetic_target_type,
           dependencies=self.synthetic_target_extra_dependencies(target),
-          sources_rel_path=sources_rel_path,
           sources=relative_generated_sources,
           derived_from=target,
+
+          # TODO(John Sirois): This assumes - currently, a JvmTarget or PythonTarget which both
+          # happen to have this attribute for carrying publish metadata but share no interface
+          # that defines this canonical property.  Lift up an interface and check for it or else
+          # add a way for SimpleCodeGen subclasses to specify extra attribute names that should be
+          # copied over from the target to its derived target.
           provides=target.provides,
         )
         synthetic_target = self.target

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -26,7 +26,6 @@ class JvmTarget(Target, Jarable):
   def __init__(self,
                address=None,
                payload=None,
-               sources_rel_path=None,
                sources=None,
                provides=None,
                excludes=None,
@@ -59,13 +58,11 @@ class JvmTarget(Target, Jarable):
       by DistributionLocator.cached().version.
     """
     self.address = address  # Set in case a TargetDefinitionException is thrown early
-    if sources_rel_path is None:
-      sources_rel_path = address.spec_path
     payload = payload or Payload()
     excludes = ExcludesField(self.assert_list(excludes, expected_type=Exclude, key_arg='excludes'))
     configurations = ConfigurationsField(self.assert_list(configurations, key_arg='configurations'))
     payload.add_fields({
-      'sources': self.create_sources_field(sources, sources_rel_path, address, key_arg='sources'),
+      'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
       'provides': provides,
       'excludes': excludes,
       'configurations': configurations,

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -23,7 +23,6 @@ class PythonTarget(Target):
   def __init__(self,
                address=None,
                payload=None,
-               sources_rel_path=None,
                sources=None,
                resources=None,  # Old-style resources (file list, Fileset).
                resource_targets=None,  # New-style resources (Resources target specs).
@@ -53,11 +52,9 @@ class PythonTarget(Target):
       agnostic to interpreter class.
     """
     self.address = address
-    if sources_rel_path is None:
-      sources_rel_path = address.spec_path
     payload = payload or Payload()
     payload.add_fields({
-      'sources': self.create_sources_field(sources, sources_rel_path, address, key_arg='sources'),
+      'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
       'resources': self.create_sources_field(resources, address.spec_path, key_arg='resources'),
       'provides': provides,
       'compatibility': PrimitiveField(maybe_list(compatibility or ())),


### PR DESCRIPTION
These paramaters were largely unused or else redundantly used/
misused.  The existing external users of this parameter agreed
they can adjust during the next pants upgrade cycle they have
so this change kills the parameters outright.

https://rbcommons.com/s/twitter/r/2738/