### PR TITLE
Make Globs classes and Bundle stand on their own.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/targets/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/targets/BUILD
@@ -28,8 +28,8 @@ python_library(
   name='go_local_source',
   sources=['go_local_source.py'],
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.dirutil',
     ':go_target',
+    'src/python/pants/backend/core:wrapped_globs',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:payload',
   ],

--- a/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
@@ -7,9 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
+from pants.backend.core.wrapped_globs import Globs
 from pants.base.build_environment import get_buildroot
 from pants.base.payload import Payload
-from twitter.common.dirutil.fileset import Fileset
 
 from pants.contrib.go.targets.go_target import GoTarget
 
@@ -33,14 +33,8 @@ class GoLocalSource(GoTarget):
     return cls.package_path(source_root, address.spec_path)
 
   def __init__(self, address=None, payload=None, **kwargs):
-    # TODO(John Sirois): Make pants.backend.core.wrapped_globs.Globs in the core backend
-    # constructable with just a rel_path. Right now it violates the Law of Demeter and
-    # fundamentally takes a ParseContext, which it doesn't actually need and which other backend
-    # consumers should not need to know about or create.
-    # Here we depend on twitter/commons which is less than ideal in core pants and even worse in a
-    # plugin.  We depend on it here to ensure the globbing is lazy and skipped if the target is
-    # never fingerprinted (eg: when running `./pants list`).
-    sources = Fileset.globs('*.go', root=os.path.join(get_buildroot(), address.spec_path))
+    globs = Globs(rel_path=os.path.join(get_buildroot(), address.spec_path))
+    sources = globs('*.go')
 
     payload = payload or Payload()
     payload.add_fields({

--- a/src/python/pants/backend/core/BUILD
+++ b/src/python/pants/backend/core/BUILD
@@ -22,9 +22,10 @@ python_library(
     'wrapped_globs.py',
   ],
   dependencies = [
-    '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
+    '3rdparty/python:six',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:build_manual',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -85,11 +85,11 @@ def build_file_aliases():
     },
     context_aware_object_factories={
       'buildfile_path': BuildFilePath,
-      'globs': Globs,
+      'globs': Globs.factory,
       'from_target': FromTarget,
-      'rglobs': RGlobs,
+      'rglobs': RGlobs.factory,
       'source_root': SourceRoot.factory,
-      'zglobs': ZGlobs,
+      'zglobs': ZGlobs.factory,
     }
   )
 

--- a/src/python/pants/backend/core/wrapped_globs.py
+++ b/src/python/pants/backend/core/wrapped_globs.py
@@ -12,6 +12,7 @@ from six import string_types
 from twitter.common.dirutil.fileset import Fileset
 
 from pants.base.build_environment import get_buildroot
+from pants.base.build_manual import manual
 from pants.util.memo import memoized_property
 
 
@@ -52,11 +53,20 @@ class FilesetWithSpec(object):
 
 class FilesetRelPathWrapper(object):
 
-  def __init__(self, parse_context):
-    self.rel_path = parse_context.rel_path
+  @classmethod
+  @manual.builddict(factory=True)
+  def factory(cls, parse_context):
+    """A factory for using a `FilesetRelPathWrapper` as a context aware object factory."""
+    return cls(parse_context.rel_path)
+
+  def __init__(self, rel_path):
+    """
+    :param string rel_path: The path this file set will be relative to.
+    """
+    self._rel_path = rel_path
 
   def __call__(self, *args, **kwargs):
-    root = os.path.join(get_buildroot(), self.rel_path)
+    root = os.path.join(get_buildroot(), self._rel_path)
 
     excludes = kwargs.pop('exclude', [])
     if isinstance(excludes, string_types):

--- a/src/python/pants/backend/jvm/targets/jvm_app.py
+++ b/src/python/pants/backend/jvm/targets/jvm_app.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
+from six import string_types
 from twitter.common.dirutil import Fileset
 
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
@@ -91,11 +92,11 @@ class Bundle(object):
   def factory(cls, parse_context):
     """Return a factory method that can create bundles rooted at the parse context path."""
     def bundle(**kwargs):
-      return Bundle(parse_context, **kwargs)
+      return Bundle(parse_context.rel_path, **kwargs)
     bundle.__doc__ = Bundle.__init__.__doc__
     return bundle
 
-  def __init__(self, parse_context, rel_path=None, mapper=None, relative_to=None, fileset=None):
+  def __init__(self, target_rel_path, rel_path=None, mapper=None, relative_to=None, fileset=None):
     """
     :param rel_path: Base path of the "source" file paths. By default, path of the
       BUILD file. Useful for assets that don't live in the source code repo.
@@ -110,7 +111,7 @@ class Bundle(object):
     if mapper and relative_to:
       raise ValueError("Must specify exactly one of 'mapper' or 'relative_to'")
 
-    self._rel_path = rel_path or parse_context.rel_path
+    self._rel_path = rel_path or target_rel_path
     self.filemap = {}
 
     if relative_to:

--- a/src/python/pants/backend/jvm/targets/jvm_app.py
+++ b/src/python/pants/backend/jvm/targets/jvm_app.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from six import string_types
 from twitter.common.dirutil import Fileset
 
 from pants.backend.jvm.targets.jvm_binary import JvmBinary

--- a/tests/python/pants_test/backend/core/test_wrapped_globs.py
+++ b/tests/python/pants_test/backend/core/test_wrapped_globs.py
@@ -23,8 +23,8 @@ class FilesetRelPathWrapperTest(BaseTest):
         'java_library': JavaLibrary,
       },
       context_aware_object_factories={
-        'globs': Globs,
-        'rglobs': RGlobs,
+        'globs': Globs.factory,
+        'rglobs': RGlobs.factory,
       },
     )
 

--- a/tests/python/pants_test/backend/jvm/targets/BUILD
+++ b/tests/python/pants_test/backend/jvm/targets/BUILD
@@ -42,7 +42,6 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:address',
     'src/python/pants/base:exceptions',
-    'src/python/pants/base:parse_context',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -22,7 +22,7 @@ class PayloadTest(BaseTest):
         'java_library': JavaLibrary,
       },
       context_aware_object_factories={
-        'globs': Globs,
+        'globs': Globs.factory,
       },
     )
 

--- a/tests/python/pants_test/tasks/test_what_changed.py
+++ b/tests/python/pants_test/tasks/test_what_changed.py
@@ -42,7 +42,7 @@ class BaseWhatChangedTest(ConsoleTaskTestBase):
       },
       context_aware_object_factories={
         'source_root': SourceRoot.factory,
-        'rglobs': RGlobs,
+        'rglobs': RGlobs.factory,
         'from_target': FromTarget,
       },
       objects={


### PR DESCRIPTION
Previously a ParseConext was required to create these limiting use.
Fundamentally, each only needed a relative path to base its operations
from, so lift up a dedicated factory method for registration as a
context aware object factory leaving the fundamental constructor
unconstrained.

https://rbcommons.com/s/twitter/r/2740/