### PR TITLE
Update developer docs to not mention `./pants test tests::`

### DIFF
--- a/src/python/pants/docs/howto_develop.md
+++ b/src/python/pants/docs/howto_develop.md
@@ -118,8 +118,6 @@ origin on `github.com/pantsbuild/pants`.
 Most test are runnable as regular Pants test targets. To find tests that work with a particular
 feature, you might explore `tests/python/pants_tests/.../BUILD`.
 
-Typically, you're not sure precisely which tests you need to run, so you run all of them.
-
 Before [[contributing a change to Pants|pants('src/python/pants/docs:howto_contribute')]],
 make sure it passes **all** of our continuous integration (CI) tests: everything builds,
 all tests pass. To try all the CI tests in a few configurations, you can run the same script
@@ -134,6 +132,12 @@ To run just Pants' *unit* tests (skipping the can-be-slow integration tests), us
 
     :::bash
     $ ./pants test tests/python/pants_test:all
+
+If you only want to run tests for changed targets, then you can use the
+`test-changed` goal:
+
+    :::bash
+    $ ./pants test-changed
 
 You can run your code through the Travis-CI before you submit a change. Travis-CI is integrated
 with the pull requests for the `pantsbuild/pants` repo. Travis-CI will test it soon after the pull

--- a/src/python/pants/docs/howto_develop.md
+++ b/src/python/pants/docs/howto_develop.md
@@ -120,17 +120,6 @@ feature, you might explore `tests/python/pants_tests/.../BUILD`.
 
 Typically, you're not sure precisely which tests you need to run, so you run all of them.
 
-To run all tests,
-
-    :::bash
-    $ ./pants test tests::
-
-To run just Pants' *unit* tests (skipping the can-be-slow integration tests), use the
-`tests/python/pants_test:all` target:
-
-    :::bash
-    $ ./pants test tests/python/pants_test:all
-
 Before [[contributing a change to Pants|pants('src/python/pants/docs:howto_contribute')]],
 make sure it passes **all** of our continuous integration (CI) tests: everything builds,
 all tests pass. To try all the CI tests in a few configurations, you can run the same script
@@ -139,6 +128,12 @@ contribute a change or merge it to master:
 
     :::bash
     $ ./build-support/bin/ci.sh
+
+To run just Pants' *unit* tests (skipping the can-be-slow integration tests), use the
+`tests/python/pants_test:all` target:
+
+    :::bash
+    $ ./pants test tests/python/pants_test:all
 
 You can run your code through the Travis-CI before you submit a change. Travis-CI is integrated
 with the pull requests for the `pantsbuild/pants` repo. Travis-CI will test it soon after the pull


### PR DESCRIPTION
According to @jsirois, many of the test targets are not meant to be run directly
by the user and are instead run indirectly via integration tests.  The correct
script to use is `build-support/bin/ci.sh`, so I updated the documentation to
only mention that script in order to avoid user confusion.

I also reordered two paragraphs so that the text after deletion still flowed
reasonably well.