### PR TITLE
Kill the pants() pointer.

### DIFF
--- a/src/docs/build_files.md
+++ b/src/docs/build_files.md
@@ -394,24 +394,20 @@ What happened to the `pants()` wrapper around targets?
 ------------------------------------------------------
 
 If you have an existing project using Pants and have recently upgraded, you
-may encounter this warning:
+may encounter this exception:
 
-    *** pants() wrapper is obsolete and will be removed in a future release.
+    AddressLookupError: name 'pants' is not defined
 
-or the BUILD may fail an error.
-
-    NameError: name 'pants' is not defined
-
-In pre-release versions of Pants, targets declared in the `dependencies`
-attribute had to be wrapped in a call to the `pants()` method.
+In previous versions of Pants, targets declared in the `dependencies`
+attribute had to be wrapped in a call to the `pants()` method:
 
     :::python
     java_library(name='foo',
         dependencies=[pants('bar')])
 
-The `pants()` method has since been replaced with a noop and as of Pants
-0.0.24 is officially deprecated. The above snippet should be re-written
-to use the target as a plain string.
+The `pants()` method has since been replaced with a noop and as of Pants 0.0.24 is officially
+deprecated. As of pants 0.0.46, use of this method now triggers an exception. Thus, the above
+snippet should be re-written to use the target as a plain string:
 
     :::python
     java_library(name='foo',
@@ -423,41 +419,3 @@ references from your BUILD files with a regular expression.
     :::bash
     # Run this command from the root of your repo.
     $ sed -i "" -e 's/pants(\([^)]*\))/\1/g' `find . -name "BUILD*"`
-
-Using an older version of Pants?
---------------------------------
-
-If you are following along in these examples and are using a version of
-pants prior to the 2014 open source release you might see one of the
-following messages:
-
-From a `python_*` target dependencies attribute:
-
-    AttributeError: 'str' object has no attribute 'resolve'
-
-From a `java_library` dependencies attribute:
-
-    The following targets could not be loaded:
-      src/java/com/twitter/foo/bar/baz =>
-        TargetDefinitionException: Error with src/java/com/foo/bar/baz/BUILD:baz:
-           Expected elements of list to be (<class 'twitter.pants.targets.external_dependency.ExternalDependency'>, <class 'twitter.pants.targets.anonymous.AnonymousDeps'>,
-             <class 'twitter.pants.base.target.Target'>), got value 3rdparty:guava of type <type 'str'>
-
-From a `java_library` resources attribute:
-
-    IOError: [Errno 2] No such file or directory: '/Users/pantsaddict/workspace/src/resources/com/foo/bar'
-
-From a `junit_tests` resources attribute:
-
-    ValueError: Expected elements of list to be <class 'twitter.pants.base.target.Target'>, got value tests/scala/foo/bar/baz/resources of type <type 'str'>
-
-From a `provides` repo attribute:
-
-    ValueError: repo must be Repository or Pants but was foo/bar/baz:baz
-
-All of these errors likely mean that you need to wrap the strings
-mentioned in the error message with the `pants()` wrapper function in
-your BUILD files. The open source Pants release deprecated the use of
-this wrapper and thus examples in this documentation don't include it.
-For more information, see the
-<a pantsref="build_pants_wrapper_gone">`pants` wrapper</a> notes above.

--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -51,19 +51,6 @@ class BuildFilePath(object):
     return os.path.join(get_buildroot(), self.rel_path)
 
 
-class PantsObsolete(object):
-  _warning_emitted = False
-
-  @classmethod
-  def pants(cls, target):
-    if not cls._warning_emitted:
-      cls._warning_emitted = True
-      print('*** pants() wrapper is obsolete and will be removed in a future release. '
-            'See http://pantsbuild.github.io/build_files.html ***',
-            file=sys.stderr)
-    return target
-
-
 def build_file_aliases():
   return BuildFileAliases.create(
     targets={
@@ -78,8 +65,6 @@ def build_file_aliases():
       'ConfluencePublish': ConfluencePublish,
       'get_buildroot': get_buildroot,
       'pants_version': pants_version,
-      # TODO(Eric Ayers) pants() was officially deprecated in 0.0.24. Remove this function soon.
-      'pants': PantsObsolete.pants,
       'wiki_artifact': WikiArtifact,
       'Wiki': Wiki,
     },

--- a/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
@@ -37,7 +37,7 @@ class DepmapTest(BaseDepmapTest):
           """.format(
         type=type,
         name=name,
-        deps=','.join("pants('{0}')".format(dep) for dep in list(deps)),
+        deps=','.join("'{0}'".format(dep) for dep in list(deps)),
         extra=('' if not kwargs else ', '.join('{0}={1}'.format(k, v) for k, v in kwargs.items()))
       )))
 
@@ -51,13 +51,13 @@ class DepmapTest(BaseDepmapTest):
         type=type,
         entry_point=entry_point,
         name=name,
-        deps=','.join("pants('{0}')".format(dep) for dep in list(deps)))
+        deps=','.join("'{0}'".format(dep) for dep in list(deps)))
       ))
 
     def create_jvm_app(path, name, type, binary, deps=()):
       self.add_to_build_file(path, dedent("""
           {type}(name='{name}',
-            dependencies=[pants('{binary}')],
+            dependencies=['{binary}'],
             bundles={deps}
           )
           """.format(
@@ -87,7 +87,7 @@ class DepmapTest(BaseDepmapTest):
     add_to_build_file('overlaps', 'one', 'jvm_binary', deps=['common/h', 'common/i'])
     self.add_to_build_file('overlaps', dedent("""
       java_library(name='two',
-        dependencies=[pants('overlaps:one')],
+        dependencies=['overlaps:one'],
         sources=[],
       )
     """))
@@ -100,13 +100,13 @@ class DepmapTest(BaseDepmapTest):
     self.add_to_build_file('src/java/a', dedent("""
       java_library(
         name='a_java',
-        resources=[pants('resources/a:a_resources')]
+        resources=['resources/a:a_resources']
       )
     """))
     self.add_to_build_file('src/java/a', dedent("""
       target(
         name='a_dep',
-        dependencies=[pants(':a_java')]
+        dependencies=[':a_java']
       )
     """))
 


### PR DESCRIPTION
Kill the `pants()` pointer, per discussion in Slack: https://pantsbuild.slack.com/archives/general/p1440451305004760

Testing Done:
Added a `pants()` pointer, got this exception:

```
[drift pants (areitz/pants_pointer_fails)]$ ./pants list ::
WARN] While parsing FilesystemBuildFile(/Users/andyr/workspace/pants/testprojects/src/scala/org/pantsbuild/testproject/publish/classifiers/BUILD):

WARN] While parsing FilesystemBuildFile(/Users/andyr/workspace/pants/testprojects/src/scala/org/pantsbuild/testproject/publish/classifiers/BUILD):

Exception caught:
  File "/Users/andyr/workspace/pants/src/python/pants/bin/pants_exe.py", line 93, in <module>
    main()
  File "/Users/andyr/workspace/pants/src/python/pants/bin/pants_exe.py", line 88, in main
    _run(exiter)
  File "/Users/andyr/workspace/pants/src/python/pants/bin/pants_exe.py", line 79, in _run
    goal_runner.setup(options_bootstrapper, working_set)
  File "/Users/andyr/workspace/pants/src/python/pants/bin/goal_runner.py", line 158, in setup
    self._expand_goals_and_specs()
  File "/Users/andyr/workspace/pants/src/python/pants/bin/goal_runner.py", line 212, in _expand_goals_and_specs
    for address in spec_parser.parse_addresses(spec, fail_fast):
  File "/Users/andyr/workspace/pants/src/python/pants/base/cmd_line_spec_parser.py", line 85, in parse_addresses
    for address in self._parse_spec(spec, fail_fast):
  File "/Users/andyr/workspace/pants/src/python/pants/base/cmd_line_spec_parser.py", line 152, in _parse_spec
    raise self.BadSpecError(error_msg)

Exception message: --------------------
Traceback (most recent call last):
  File "/Users/andyr/workspace/pants/src/python/pants/base/cmd_line_spec_parser.py", line 142, in _parse_spec
    addresses.update(self._address_mapper.addresses_in_spec_path(build_file.spec_path))
  File "/Users/andyr/workspace/pants/src/python/pants/base/build_file_address_mapper.py", line 158, in addresses_in_spec_path
    return self._address_map_from_spec_path(spec_path).keys()
  File "/Users/andyr/workspace/pants/src/python/pants/base/build_file_address_mapper.py", line 150, in _address_map_from_spec_path
    .format(message=e, spec_path=spec_path))
AddressLookupError: name 'pants' is not defined
 while executing BUILD file FilesystemBuildFile(/Users/andyr/workspace/pants/tests/python/pants_test/python/BUILD)
 Loading addresses from 'tests/python/pants_test/python' failed.

Exception message: name 'pants' is not defined
 while executing BUILD file FilesystemBuildFile(/Users/andyr/workspace/pants/tests/python/pants_test/python/BUILD)
 Loading addresses from 'tests/python/pants_test/python' failed.
Invalid BUILD files for [::]
```

Reviewed at https://rbcommons.com/s/twitter/r/2650/