### PR TITLE
Add transitive flag to ClasspathProduct.get_for_target[s]

### DIFF
--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -45,20 +45,24 @@ class ClasspathProducts(object):
     """Removes the given entries for the target"""
     self._classpaths.remove_for_target(target, classpath_elements)
 
-  def get_for_target(self, target):
+  def get_for_target(self, target, transitive=True):
     """Gets the transitive classpath products for the given target, in order, respecting target
        excludes."""
-    return self.get_for_targets([target])
+    return self.get_for_targets([target], transitive=transitive)
 
-  def get_for_targets(self, targets):
+  def get_for_targets(self, targets, transitive=True):
     """Gets the transitive classpath products for the given targets, in order, respecting target
        excludes."""
-    classpath_tuples = self._classpaths.get_for_targets(targets)
-    filtered_classpath_tuples = self._filter_by_excludes(classpath_tuples, targets)
+    classpath_tuples = self._classpaths.get_for_targets(targets, transitive=transitive)
+    filtered_classpath_tuples = self._filter_by_excludes(
+      classpath_tuples,
+      targets,
+      transitive=transitive,
+    )
     return filtered_classpath_tuples
 
-  def _filter_by_excludes(self, classpath_tuples, root_targets):
-    exclude_patterns = self._exclude_patterns.get_for_targets(root_targets)
+  def _filter_by_excludes(self, classpath_tuples, root_targets, transitive):
+    exclude_patterns = self._exclude_patterns.get_for_targets(root_targets, transitive=transitive)
     filtered_classpath_tuples = filter(_not_excluded_filter(exclude_patterns),
                                        classpath_tuples)
     return filtered_classpath_tuples

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -60,8 +60,19 @@ class ClasspathProductsTest(BaseTest):
     classpath_product.add_excludes_for_targets([a, b])
 
     classpath = classpath_product.get_for_target(a)
-
     self.assertEqual([], classpath)
+
+  def test_intransitive_dependencies_excluded_classpath_element(self):
+    b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
+    a = self.make_target('a', JvmTarget, dependencies=[b])
+
+    classpath_product = ClasspathProducts()
+    example_jar_path = self._example_jar_path()
+    classpath_product.add_for_target(a, [('default', example_jar_path)])
+    classpath_product.add_excludes_for_targets([a, b])
+
+    intransitive_classpath = classpath_product.get_for_target(a, transitive=False)
+    self.assertEqual([('default', example_jar_path)], intransitive_classpath)
 
   def test_parent_exclude_excludes_dependency_jar(self):
     b = self.make_target('b', JvmTarget)


### PR DESCRIPTION
* When transitive=False, excludes on transitive dependencies are
  also not considered.