### PR TITLE
[ExecutionGraph] Introduce job prioritization

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -9,7 +9,6 @@ import Queue as queue
 import time
 import traceback
 from collections import defaultdict
-from heapq import heappop, heappush
 
 from pants.base.worker_pool import Work
 
@@ -272,12 +271,11 @@ class ExecutionGraph(object):
             raise ExecutionFailure("Error in on_success for {}".format(finished_key), e)
 
           print("before computing ready_deps: {}".format(time.time() - finish_time[finished_key]))
+          ready_dependees = []
           for dependee in direct_dependees:
             completed_dependencies[dependee] += 1
-
-          ready_dependees = [dependee for dependee in direct_dependees
-                             # if status_table.are_all_successful(self._jobs[dependee].dependencies)]
-                             if completed_dependencies[dependee] == len(self._jobs[dependee].dependencies)]
+            if completed_dependencies[dependee] == len(self._jobs[dependee].dependencies):
+              ready_dependees.append(dependee)
 
           print("before submit: {}".format(time.time() - finish_time[finished_key]))
           submit_jobs(ready_dependees)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -125,7 +125,7 @@ class ExecutionGraph(object):
   global execution graph.
   """
 
-  def __init__(self, job_list, job_sizes):
+  def __init__(self, job_list, job_sizes=None):
     """
 
     :param job_list Job: list of Jobs to schedule and run.
@@ -144,6 +144,9 @@ class ExecutionGraph(object):
 
     if len(self._job_keys_with_no_dependencies) == 0:
       raise NoRootJobError()
+
+    if job_sizes is None:
+      job_sizes = [1] * len(job_list)
 
     self._job_size = {}
     for (job, job_size) in zip(job_list, job_sizes):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -9,6 +9,7 @@ import Queue as queue
 import threading
 import traceback
 from collections import defaultdict, deque
+from heapq import heappop, heappush
 
 from pants.base.worker_pool import Work
 
@@ -20,12 +21,13 @@ class Job(object):
   keys of its dependent jobs.
   """
 
-  def __init__(self, key, fn, dependencies, on_success=None, on_failure=None):
+  def __init__(self, key, fn, dependencies, size=0, on_success=None, on_failure=None):
     """
 
     :param key: Key used to reference and look up jobs
     :param fn callable: The work to perform
-    :param dependency_keys: List of keys for dependent jobs
+    :param dependencies: List of keys for dependent jobs
+    :param size: Estimated job size used for prioritization
     :param on_success: Zero parameter callback to run if job completes successfully. Run on main
                        thread.
     :param on_failure: Zero parameter callback to run if job completes successfully. Run on main
@@ -33,6 +35,7 @@ class Job(object):
     self.key = key
     self.fn = fn
     self.dependencies = dependencies
+    self.size = size
     self.on_success = on_success
     self.on_failure = on_failure
 
@@ -58,8 +61,9 @@ CANCELED = 'Canceled'
 class StatusTable(object):
   DONE_STATES = {SUCCESSFUL, FAILED, CANCELED}
 
-  def __init__(self, keys):
+  def __init__(self, keys, pending_dependencies_count):
     self._statuses = {key: UNSTARTED for key in keys}
+    self._pending_dependencies_count = pending_dependencies_count
 
   def mark_as(self, state, key):
     self._statuses[key] = state
@@ -74,11 +78,14 @@ class StatusTable(object):
   def get(self, key):
     return self._statuses.get(key)
 
+  def mark_one_successful_dependency(self, key):
+    self._pending_dependencies_count[key] -= 1
+
+  def is_ready_to_submit(self, key):
+    return self._pending_dependencies_count[key] == 0
+
   def are_all_done(self):
     return all(s in self.DONE_STATES for s in self._statuses.values())
-
-  def are_all_successful(self, keys):
-    return all(stat is SUCCESSFUL for stat in [self._statuses[k] for k in keys])
 
   def has_failures(self):
     return any(stat is FAILED for stat in self._statuses.values())
@@ -143,11 +150,10 @@ class ExecutionGraph(object):
   global execution graph.
   """
 
-  def __init__(self, job_list, job_sizes=None):
+  def __init__(self, job_list):
     """
 
     :param job_list Job: list of Jobs to schedule and run.
-    :param job_sizes: list of estimated job sizes used for prioritization.
     """
     self._dependencies = defaultdict(list)
     self._dependees = defaultdict(list)
@@ -165,15 +171,7 @@ class ExecutionGraph(object):
     if len(self._job_keys_with_no_dependencies) == 0:
       raise NoRootJobError()
 
-    if job_sizes is None:
-      job_sizes = [1] * len(job_list)
-    else:
-      assert len(job_sizes) == len(job_list)
-
-    self._job_size = {job.key: job_size for job, job_size in zip(job_list, job_sizes)}
-
-    self._job_priority = defaultdict(int)
-    self._compute_job_priorities(job_list)
+    self._job_priority = self._compute_job_priorities(job_list)
 
   def format_dependee_graph(self):
     return "\n".join([
@@ -199,24 +197,28 @@ class ExecutionGraph(object):
   def _compute_job_priorities(self, job_list):
     """Walks the dependency graph breadth-first, starting from the most dependent tasks,
      and computes the job priority as the sum of the jobs sizes along the critical path."""
-    queue = deque()
+
+    job_size = {job.key: job.size for job in job_list}
+    job_priority = defaultdict(int)
+
+    bfs_queue = deque()
     for job in job_list:
       if len(self._dependees[job.key]) == 0:
-        self._job_priority[job.key] = self._job_size[job.key]
-        queue.append(job.key)
+        job_priority[job.key] = job_size[job.key]
+        bfs_queue.append(job.key)
 
     satisfied_dependees_count = defaultdict(int)
-
-    while len(queue) > 0:
-      job_key = queue.popleft()
+    while len(bfs_queue) > 0:
+      job_key = bfs_queue.popleft()
       for dependency_key in self._dependencies[job_key]:
-        self._job_priority[dependency_key] = \
-          max(self._job_priority[dependency_key],
-              self._job_size[dependency_key] + self._job_priority[job_key])
+        job_priority[dependency_key] = \
+          max(job_priority[dependency_key],
+              job_size[dependency_key] + job_priority[job_key])
         satisfied_dependees_count[dependency_key] += 1
         if satisfied_dependees_count[dependency_key] == len(self._dependees[dependency_key]):
-          queue.append(dependency_key)
+          bfs_queue.append(dependency_key)
 
+    return job_priority
 
   def execute(self, pool, log):
     """Runs scheduled work, ensuring all dependencies for each element are done before execution.
@@ -241,14 +243,19 @@ class ExecutionGraph(object):
     """
     log.debug(self.format_dependee_graph())
 
-    status_table = StatusTable(self._job_keys_as_scheduled)
+    status_table = StatusTable(self._job_keys_as_scheduled,
+                               {key: len(self._jobs[key].dependencies) for key in self._job_keys_as_scheduled})
     finished_queue = queue.Queue()
-    completed_dependencies = defaultdict(int)
 
-    heap = queue.PriorityQueue()
+    heap = []
     jobs_in_flight = ThreadSafeCounter()
 
-    def submit_jobs(job_keys):
+    def put_jobs_into_heap(job_keys):
+      for job_key in job_keys:
+        # minus because jobs with larger priority should go first
+        heappush(heap, (-self._job_priority[job_key], job_key))
+
+    def try_to_submit_jobs_from_heap():
       def worker(worker_key, work):
         try:
           work()
@@ -258,15 +265,15 @@ class ExecutionGraph(object):
         finished_queue.put(result)
         jobs_in_flight.decrement()
 
-      for job_key in job_keys:
-        # minus because jobs with larger priority should go first
-        heap.put((-self._job_priority[job_key], job_key))
-
-      while heap.qsize() > 0 and jobs_in_flight.get() < pool.num_workers:
-        priority, job_key = heap.get()
+      while len(heap) > 0 and jobs_in_flight.get() < pool.num_workers:
+        priority, job_key = heappop(heap)
         jobs_in_flight.increment()
         status_table.mark_as(QUEUED, job_key)
         pool.submit_async_work(Work(worker, [(job_key, (self._jobs[job_key]))]))
+
+    def submit_jobs(job_keys):
+      put_jobs_into_heap(job_keys)
+      try_to_submit_jobs_from_heap()
 
     try:
       submit_jobs(self._job_keys_with_no_dependencies)
@@ -277,6 +284,7 @@ class ExecutionGraph(object):
         except queue.Empty:
           log.debug("Waiting on \n  {}\n".format("\n  ".join(
             "{}: {}".format(key, state) for key, state in status_table.unfinished_items())))
+          try_to_submit_jobs_from_heap()
           continue
 
         finished_job = self._jobs[finished_key]
@@ -293,8 +301,8 @@ class ExecutionGraph(object):
 
           ready_dependees = []
           for dependee in direct_dependees:
-            completed_dependencies[dependee] += 1
-            if completed_dependencies[dependee] == len(self._jobs[dependee].dependencies):
+            status_table.mark_one_successful_dependency(dependee)
+            if status_table.is_ready_to_submit(dependee):
               ready_dependees.append(dependee)
 
           submit_jobs(ready_dependees)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
@@ -275,7 +275,6 @@ class JvmCompileIsolatedStrategy(JvmCompileStrategy):
                       # Otherwise, fail it.
                       on_success=vts.update,
                       on_failure=vts.force_invalidate))
-
     return jobs
 
   def compile_chunk(self,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
@@ -254,15 +254,17 @@ class JvmCompileIsolatedStrategy(JvmCompileStrategy):
                       on_failure=vts.force_invalidate))
 
       def file_line_count(source_file_name):
-        with open(source_file_name) as file_handle:
-          line_count = len(file_handle.readlines())
-        return line_count
+        with open(source_file_name, 'rb') as fh:
+          return sum(1 for line in fh)
 
       # job size is the total line count in the target:
       job_sizes.append(sum([file_line_count(filepath) for filepath in compile_context.sources]))
 
       # job size is the number of files in the target:
       # job_sizes.append(len(compile_context.sources))
+
+      # job size is the total byte size of files in the target:
+      # job_sizes.append(sum([os.path.getsize(filepath) for filepath in compile_context.sources]))
 
     return jobs, job_sizes
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile_isolated_strategy.py
@@ -7,8 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import shutil
-import time
-import threading
 import zipfile
 from collections import OrderedDict, defaultdict
 from hashlib import sha1
@@ -255,13 +253,17 @@ class JvmCompileIsolatedStrategy(JvmCompileStrategy):
                       on_success=vts.update,
                       on_failure=vts.force_invalidate))
 
-      def file_line_count(fname):
-        with open(fname) as f:
-          x = len(f.readlines())
-        return x
+      def file_line_count(source_file_name):
+        with open(source_file_name) as file_handle:
+          line_count = len(file_handle.readlines())
+        return line_count
 
-      # job_sizes.append(sum([file_line_count(filepath) for filepath in compile_context.sources]))
-      job_sizes.append(len(compile_context.sources))
+      # job size is the total line count in the target:
+      job_sizes.append(sum([file_line_count(filepath) for filepath in compile_context.sources]))
+
+      # job size is the number of files in the target:
+      # job_sizes.append(len(compile_context.sources))
+
     return jobs, job_sizes
 
   def compile_chunk(self,

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -50,6 +50,8 @@ class WorkerPool(object):
 
     self._shutdown_hooks = []
 
+    self.num_workers = num_workers
+
   def add_shutdown_hook(self, hook):
     self._shutdown_hooks.append(hook)
 

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -13,6 +13,7 @@ from pants.backend.jvm.tasks.jvm_compile.execution_graph import (ExecutionFailur
 
 
 class ImmediatelyExecutingPool(object):
+  num_workers = 4
 
   def submit_async_work(self, work):
     work.func(*work.args_tuples[0])
@@ -144,7 +145,7 @@ class ExecutionGraphTest(unittest.TestCase):
     with self.assertRaises(ExecutionFailure) as cm:
       self.execute(exec_graph)
 
-    self.assertEqual(["B", "F", "A"], self.jobs_run)
+    self.assertTrue(self.jobs_run == ["B", "F", "A"] or self.jobs_run == ["B", "A", "F"])
     self.assertEqual("Failed jobs: F", str(cm.exception))
 
   def test_failure_of_disconnected_job_does_not_cancel_non_dependents(self):

--- a/tests/python/pants_test/tasks/test_execution_graph.py
+++ b/tests/python/pants_test/tasks/test_execution_graph.py
@@ -13,7 +13,7 @@ from pants.backend.jvm.tasks.jvm_compile.execution_graph import (ExecutionFailur
 
 
 class ImmediatelyExecutingPool(object):
-  num_workers = 4
+  num_workers = 1
 
   def submit_async_work(self, work):
     work.func(*work.args_tuples[0])
@@ -44,12 +44,12 @@ class ExecutionGraphTest(unittest.TestCase):
   def execute(self, exec_graph):
     exec_graph.execute(ImmediatelyExecutingPool(), PrintLogger())
 
-  def job(self, name, fn, dependencies, on_success=None, on_failure=None):
+  def job(self, name, fn, dependencies, size=0, on_success=None, on_failure=None):
     def recording_fn():
       self.jobs_run.append(name)
       fn()
 
-    return Job(name, recording_fn, dependencies, on_success, on_failure)
+    return Job(name, recording_fn, dependencies, size, on_success, on_failure)
 
   def test_single_job(self):
     exec_graph = ExecutionGraph([self.job("A", passing_fn, [])])
@@ -195,3 +195,56 @@ class ExecutionGraphTest(unittest.TestCase):
                       self.job("Same", passing_fn, [])])
 
     self.assertEqual("Unexecutable graph: Job already scheduled u'Same'", str(cm.exception))
+
+  def test_priorities_for_chain_of_jobs(self):
+    exec_graph = ExecutionGraph([self.job("A", passing_fn, [], 8),
+                                 self.job("B", passing_fn, ["A"], 4),
+                                 self.job("C", passing_fn, ["B"], 2),
+                                 self.job("D", passing_fn, ["C"], 1)])
+    self.assertEqual(exec_graph._job_priority, {"A": 15, "B": 7, "C": 3, "D": 1})
+    self.execute(exec_graph)
+    self.assertEqual(self.jobs_run, ["A", "B", "C", "D"])
+
+  def test_priorities_for_fork(self):
+    exec_graph = ExecutionGraph([self.job("A", passing_fn, [], 4),
+                                 self.job("B", passing_fn, ["A"], 2),
+                                 self.job("C", passing_fn, ["A"], 1)])
+    self.assertEqual(exec_graph._job_priority, {"A": 6, "B": 2, "C": 1})
+    self.execute(exec_graph)
+    self.assertEqual(self.jobs_run, ["A", "B", "C"])
+
+  def test_priorities_for_mirrored_fork(self):
+    exec_graph = ExecutionGraph([self.job("A", passing_fn, [], 4),
+                                 self.job("B", passing_fn, ["A"], 1),
+                                 self.job("C", passing_fn, ["A"], 2)])
+    self.assertEqual(exec_graph._job_priority, {"A": 6, "B": 1, "C": 2})
+    self.execute(exec_graph)
+    self.assertEqual(self.jobs_run, ["A", "C", "B"])
+
+  def test_priorities_for_diamond(self):
+    exec_graph = ExecutionGraph([self.job("A", passing_fn, [], 8),
+                                 self.job("B", passing_fn, ["A"], 4),
+                                 self.job("C", passing_fn, ["A"], 2),
+                                 self.job("D", passing_fn, ["B", "C"], 1)])
+    self.assertEqual(exec_graph._job_priority, {"A": 13, "B": 5, "C": 3, "D": 1})
+    self.execute(exec_graph)
+    self.assertEqual(self.jobs_run, ["A", "B", "C", "D"])
+
+  def test_priorities_for_mirrored_diamond(self):
+    exec_graph = ExecutionGraph([self.job("A", passing_fn, [], 8),
+                                 self.job("B", passing_fn, ["A"], 2),
+                                 self.job("C", passing_fn, ["A"], 4),
+                                 self.job("D", passing_fn, ["B", "C"], 1)])
+    self.assertEqual(exec_graph._job_priority, {"A": 13, "B": 3, "C": 5, "D": 1})
+    self.execute(exec_graph)
+    self.assertEqual(self.jobs_run, ["A", "C", "B", "D"])
+
+  def test_priorities_for_skewed_diamond(self):
+    exec_graph = ExecutionGraph([self.job("A", passing_fn, [], 1),
+                                 self.job("B", passing_fn, ["A"], 2),
+                                 self.job("C", passing_fn, ["B"], 4),
+                                 self.job("D", passing_fn, ["A"], 8),
+                                 self.job("E", passing_fn, ["C", "D"], 16)])
+    self.assertEqual(exec_graph._job_priority, {"A": 25, "B": 22, "C": 20, "D": 24, "E": 16})
+    self.execute(exec_graph)
+    self.assertEqual(self.jobs_run, ["A", "D", "B", "C", "E"])


### PR DESCRIPTION
See googledoc for details: https://docs.google.com/a/twitter.com/document/d/1BGVAR_AdGXsf08MT0nBLh8s-lYenx7NK7Kk7keD_gwg/edit?usp=sharing

PROBLEM:
The jobs are submitted to the worker pool in a sort of insertion order. If the submission order was based on the “size” or “importance” of the job, it could result in less total execution time.

SOLUTION:
Introduce a priority queue where ready-to-be-submitted jobs are waiting for the moment when a worker becomes available, being sorted by “importance”. When a job finishes, its unblocked dependees is not submitted to the worker pool, but rather put in the priority queue. When a worker becomes available (i.e. when any job is finished), the most “important” job is taken from the priority queue. There is an additional latency (before, ready jobs are submitted to the worker pool immediately; after, they are all first put in the priority queue, and only then the most prioritized ones are chosen and submitted).

Additionally, make tracking of ready-to-be-submitted jobs smarter with a counter in status table which is decremented with every finished dependency.