### PR TITLE
Made shading rules accessible and configurable for jvm_binary.

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -122,6 +122,11 @@ jar_library(name='easymock',
               jar('org.easymock', 'easymock', '3.3.1')
             ])
 
+jar_library(name='gson',
+	    jars = [
+	      jar(org='com.google.code.gson', name='gson', rev='2.3.1')
+	    ])
+
 jar_library(name='guava-testlib',
             jars=[
               jar('com.google.guava', 'guava-testlib', '18.0')

--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -30,6 +30,7 @@ python_library(
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
+    'src/python/pants/java/jar:shader',
   ],
 )
 

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -52,6 +52,7 @@ from pants.backend.jvm.tasks.unpack_jars import UnpackJars
 from pants.base.build_file_aliases import BuildFileAliases
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
+from pants.java.jar.shader import Shading
 
 
 def build_file_aliases():
@@ -86,6 +87,10 @@ def build_file_aliases():
       'jar_rules': JarRules,
       'Repository': Repository,
       'Skip': Skip,
+      'shading_relocate': Shading.Relocate.new,
+      'shading_exclude': Shading.Exclude.new,
+      'shading_relocate_package': Shading.RelocatePackage.new,
+      'shading_exclude_package': Shading.ExcludePackage.new,
     },
     context_aware_object_factories={
       'bundle': Bundle.factory,

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -70,12 +70,12 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/ivy',
-    'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
     'src/python/pants/java:util',
     'src/python/pants/java/jar:shader',
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ],
 )
 
@@ -290,6 +290,11 @@ python_library(
     ':jar_task',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/java/jar:shader',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:fileutil',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -66,9 +66,9 @@ class BundleCreate(JvmBinaryTask):
     for target in self.context.target_roots:
       for app in map(self.App, filter(self.App.is_app, [target])):
         basedir = self.bundle(app)
-        # NB(Eric Ayers): Note that this product is not housed/controlled under .pants.d/  Since 
+        # NB(Eric Ayers): Note that this product is not housed/controlled under .pants.d/  Since
         # the bundle is re-created every time, this shouldn't cause a problem, but if we ever
-        # expect the product to be cached, a user running an 'rm' on the dist/ directory could 
+        # expect the product to be cached, a user running an 'rm' on the dist/ directory could
         # cause inconsistencies.
         jvm_bundles_product = self.context.products.get('jvm_bundles')
         jvm_bundles_product.add(target, os.path.dirname(basedir)).append(os.path.basename(basedir))
@@ -123,7 +123,11 @@ class BundleCreate(JvmBinaryTask):
       # Add external dependencies to the bundle.
       for basedir, external_jar in self.list_external_jar_dependencies(app.binary):
         path = os.path.join(basedir, external_jar)
-        verbose_symlink(path, os.path.join(lib_dir, external_jar))
+        destination = os.path.join(lib_dir, external_jar)
+        verbose_symlink(path, destination)
+        if app.binary.shading_rules:
+          self.shade_jar(binary=app.binary, jar_id=os.path.basename(external_jar),
+                         jar_path=destination)
         classpath.add(external_jar)
 
     bundle_jar = os.path.join(bundle_dir, '{}.jar'.format(app.binary.basename))

--- a/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
@@ -13,6 +13,12 @@ from twitter.common.collections.orderedset import OrderedSet
 
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jar_task import JarTask
+from pants.base.exceptions import TaskError
+from pants.java.jar.shader import Shader
+from pants.java.util import execute_runner
+from pants.util.contextutil import temporary_dir
+from pants.util.fileutil import atomic_copy
+from pants.util.memo import memoized_property
 
 
 class JvmBinaryTask(JarTask):
@@ -36,6 +42,10 @@ class JvmBinaryTask(JarTask):
     super(JvmBinaryTask, cls).prepare(options, round_manager)
     round_manager.require('jar_dependencies', predicate=cls.is_binary)
     cls.JarBuilder.prepare(round_manager)
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JvmBinaryTask, cls).subsystem_dependencies() + (Shader.Factory,)
 
   def list_external_jar_dependencies(self, binary, confs=None):
     """Returns the external jar dependencies of the given binary.
@@ -61,25 +71,60 @@ class JvmBinaryTask(JarTask):
     """
     # TODO(benjy): There's actually nothing here that requires 'binary' to be a jvm_binary.
     # It could be any target. And that might actually be useful.
-
     with self.context.new_workunit(name='create-monolithic-jar'):
       with self.open_jar(path,
                          jar_rules=binary.deploy_jar_rules,
                          overwrite=True,
-                         compressed=True) as jar:
+                         compressed=True) as monolithic_jar:
 
         with self.context.new_workunit(name='add-internal-classes'):
-          with self.create_jar_builder(jar) as jar_builder:
+          with self.create_jar_builder(monolithic_jar) as jar_builder:
             jar_builder.add_target(binary, recursive=True)
 
         if with_external_deps:
+          # NB(gmalmquist): Shading each jar dependency with its own prefix would be a nice feature,
+          # but is not currently possible with how things are set up. It may not be possible to do
+          # in general, at least efficiently.
           with self.context.new_workunit(name='add-dependency-jars'):
             for basedir, external_jar in self.list_external_jar_dependencies(binary):
-              external_jar_path = os.path.join(basedir, external_jar)
-              self.context.log.debug('  dumping {}'.format(external_jar_path))
-              jar.writejar(external_jar_path)
+              jar_path = os.path.join(basedir, external_jar)
+              self.context.log.debug('  dumping {}'.format(jar_path))
+              monolithic_jar.writejar(jar_path)
 
-        yield jar
+        yield monolithic_jar
+
+      if binary.shading_rules:
+        with self.context.new_workunit('shade-monolithic-jar'):
+          self.shade_jar(binary=binary, jar_id=binary.address.reference(), jar_path=path)
+
+  @memoized_property
+  def shader(self):
+    return Shader.Factory.create(self.context)
+
+  def shade_jar(self, binary, jar_id, jar_path):
+    """Shades a jar using the shading rules from the given jvm_binary.
+
+    This *overwrites* the existing jar file at ``jar_path``.
+
+    :param binary: The jvm_binary target the jar is being shaded for.
+    :param jar_id: The id of the jar being shaded (used for logging).
+    :param jar_path: The filepath to the jar that should be shaded.
+    """
+    self.context.log.debug('Shading {} at {}.'.format(jar_id, jar_path))
+    with temporary_dir() as tempdir:
+      output_jar = os.path.join(tempdir, os.path.basename(jar_path))
+      rules = [rule.rule() for rule in binary.shading_rules]
+      with self.shader.binary_shader_for_rules(output_jar, jar_path, rules) as shade_runner:
+        result = execute_runner(shade_runner, workunit_factory=self.context.new_workunit,
+                                workunit_name='jarjar')
+        if result != 0:
+          raise TaskError('Shading tool failed to shade {0} (error code {1})'.format(jar_path,
+                                                                                     result))
+        if not os.path.exists(output_jar):
+          raise TaskError('Shading tool returned success for {0}, but '
+                          'the output jar was not found at {1}'.format(jar_path, output_jar))
+        atomic_copy(output_jar, jar_path)
+        return jar_path
 
   def _mapped_dependencies(self, jardepmap, binary, confs):
     # TODO(John Sirois): rework product mapping towards well known types

--- a/src/python/pants/java/jar/BUILD
+++ b/src/python/pants/java/jar/BUILD
@@ -13,6 +13,8 @@ python_library(
   name='shader',
   sources=['shader.py'],
   dependencies=[
-    'src/python/pants/util:contextutil'
+    'src/python/pants/util:contextutil',
+    'src/python/pants/java/distribution',
+    'src/python/pants/subsystem',
   ]
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/shading/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shading/BUILD
@@ -1,0 +1,52 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='shading',
+  main='org.pantsbuild.testproject.shading.Main',
+  basename='shading',
+  dependencies=[
+    ':lib',
+    'testprojects/src/java/org/pantsbuild/testproject/shadingdep',
+    'testprojects/src/java/org/pantsbuild/testproject/shadingdep:other',
+  ],
+  shading_rules=[
+    shading_exclude('org.pantsbuild.testproject.shadingdep.PleaseDoNotShadeMe'),
+    shading_relocate('org.pantsbuild.testproject.shadingdep.otherpackage.ShadeWithTargetId'),
+    shading_relocate('org.pantsbuild.testproject.shadingdep.CompletelyRename',
+                     'org.pantsbuild.testproject.foo.bar.MyNameIsDifferentNow'),
+    shading_relocate_package('org.pantsbuild.testproject.shadingdep'),
+    shading_relocate('org.pantsbuild.testproject.shading.ShadeSelf')
+  ],
+)
+
+java_library(name='lib',
+  sources=[
+    'Main.java',
+    'ShadeSelf.java',
+  ],
+)
+
+java_library(name='third_lib',
+  sources=[
+    'Third.java',
+    'Second.java',
+  ],
+  platform='java7',
+  dependencies=[
+    '3rdparty:gson',
+  ],
+)
+
+jvm_binary(name='third',
+  basename='third',
+  main='org.pantsbuild.testproject.shading.Third',
+  platform='java7',
+  dependencies=[
+    ':third_lib',
+  ],
+  shading_rules=[
+    shading_exclude('org.pantsbuild.testproject.shading.Third'),
+    shading_relocate_package('org.pantsbuild', shade_prefix='hello.'),
+    shading_relocate('com.google.gson.**', shade_pattern='moc.elgoog.nosg.@1'),
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/shading/Main.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shading/Main.java
@@ -1,0 +1,19 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shading;
+
+import org.pantsbuild.testproject.shadingdep.PleaseDoNotShadeMe;
+import org.pantsbuild.testproject.shadingdep.otherpackage.ShadeWithTargetId;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class Main {
+  public static void main(String[] args) {
+    System.out.println("Hello, shady world!");
+    ShadeWithTargetId.main(args);
+    PleaseDoNotShadeMe.sayPlease();
+    ShadeSelf.sayHi();
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shading/Second.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shading/Second.java
@@ -1,0 +1,21 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shading;
+
+/**
+ * This is the not-main file in a tiny library made to test shading of 3rdparty libraries.
+ */
+public class Second {
+
+  private int writeOnlyInteger = 0;
+
+  /**
+   * The behavior of this function is irrelevant, we just want to make sure it can be called at all.
+   * @param i
+   */
+  public void write(int i) {
+    this.writeOnlyInteger = i;
+  }
+
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shading/ShadeSelf.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shading/ShadeSelf.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shading;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class ShadeSelf {
+  public static void sayHi() {
+    System.out.println("ShadeSelf says hi: " + ShadeSelf.class.getName());
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shading/Third.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shading/Third.java
@@ -1,0 +1,29 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shading;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * This is the main file in a tiny library just used to test 3rdparty dependency shading.
+ */
+public class Third {
+
+  public static void main(String[] args) {
+    Map<String, String> classNames = new HashMap<>();
+    classNames.put(Third.class.getSimpleName(), Third.class.getName());
+    classNames.put(Second.class.getSimpleName(), Second.class.getName());
+    classNames.put(Gson.class.getSimpleName(), Gson.class.getName());
+
+    new Second().write(42);
+
+    Gson gson = new GsonBuilder().create();
+    System.out.println(gson.toJson(classNames));
+  }
+
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/BUILD
@@ -1,0 +1,23 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jvm_binary(name='shadingdep',
+  main='org.pantsbuild.testproject.shadingdep.Dependency',
+  basename='shadingdep',
+  dependencies=[
+    ':lib',
+    'testprojects/src/java/org/pantsbuild/testproject/shadingdep/subpackage',
+  ],
+)
+
+jvm_binary(name='other',
+  main='org.pantsbuild.testproject.shadingdep.otherpackage.ShadeWithTargetId',
+  basename='other',
+  dependencies=[
+    'testprojects/src/java/org/pantsbuild/testproject/shadingdep/otherpackage',
+  ],
+)
+
+java_library(name='lib',
+  sources=globs('*.java'),
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/CompletelyRename.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/CompletelyRename.java
@@ -1,0 +1,16 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shadingdep;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class CompletelyRename {
+
+  public static void main(String[] args) {
+    System.out.println("CompletelyRename was completely renamed to "
+        + CompletelyRename.class.getName());
+  }
+
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/Dependency.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/Dependency.java
@@ -1,0 +1,11 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shadingdep;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class Dependency {
+  public static void main(String[] args) {}
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/PleaseDoNotShadeMe.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/PleaseDoNotShadeMe.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shadingdep;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class PleaseDoNotShadeMe {
+  public static void sayPlease() {
+    System.out.println("PleaseDoNotShadeMe: " + PleaseDoNotShadeMe.class.getName());
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/SomeClass.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/SomeClass.java
@@ -1,0 +1,9 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shadingdep;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class SomeClass {}

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/otherpackage/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/otherpackage/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='otherpackage',
+  sources=globs('*.java'),
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/otherpackage/ShadeWithTargetId.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/otherpackage/ShadeWithTargetId.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shadingdep.otherpackage;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class ShadeWithTargetId {
+  public static void main(String[] args) {
+    System.out.println("ShadeWithTargetId: " + ShadeWithTargetId.class.getName());
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/subpackage/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/subpackage/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='subpackage',
+  sources=globs('*.java'),
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/subpackage/Subpackaged.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/subpackage/Subpackaged.java
@@ -1,0 +1,10 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.shadingdep.subpackage;
+
+/**
+ * Used to test shading support in tests/python/pants_test/java/jar/test_shader_integration.py
+ */
+public class Subpackaged {
+}

--- a/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
@@ -14,7 +14,7 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
-from pants.java.jar.shader import Shader
+from pants.java.jar.shader import Shading
 from pants.util.contextutil import open_zip
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
 from pants_test.subsystem.subsystem_util import subsystem_instance
@@ -86,7 +86,7 @@ class BootstrapJvmToolsTest(JvmToolTaskTestBase):
     for excluded_class in excluded_classes:
       self.assertEqual('org/apache/tools/ant', os.path.dirname(excluded_class))
 
-    prefix_len = len(Shader.SHADE_PREFIX)
+    prefix_len = len(Shading.SHADE_PREFIX)
 
     def strip_prefix(shaded):
       return set(classfile[prefix_len:] for classfile in shaded)

--- a/tests/python/pants_test/java/jar/BUILD
+++ b/tests/python/pants_test/java/jar/BUILD
@@ -28,3 +28,15 @@ python_tests(
     'src/python/pants/util:dirutil',
   ]
 )
+
+python_tests(
+  name='shader_integration',
+  sources=['test_shader_integration.py'],
+  dependencies=[
+    'src/python/pants/fs',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/java/distribution',
+    'tests/python/pants_test:int-test',
+    'tests/python/pants_test/subsystem:subsystem_utils',
+  ],
+)

--- a/tests/python/pants_test/java/jar/test_shader_integration.py
+++ b/tests/python/pants_test/java/jar/test_shader_integration.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import json
+import os
+import subprocess
+from contextlib import contextmanager
+
+from pants.fs.archive import ZIP
+from pants.java.distribution.distribution import DistributionLocator
+from pants.java.executor import SubprocessExecutor
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.subsystem.subsystem_util import subsystem_instance
+
+
+class ShaderIntegrationTest(PantsRunIntegrationTest):
+
+  def test_shader_project(self):
+    """Test that the binary target at the ``shading_project`` can be built and run.
+
+    Explicitly checks that the classes end up with the correct shaded fully qualified classnames.
+    """
+    shading_project = 'testprojects/src/java/org/pantsbuild/testproject/shading'
+    self.assert_success(self.run_pants(['clean-all']))
+    self.assert_success(self.run_pants(['binary', shading_project]))
+
+    expected_classes = {
+      # Explicitly excluded by a shading_exclude() rule.
+      'org/pantsbuild/testproject/shadingdep/PleaseDoNotShadeMe.class',
+      # Not matched by any rule, so stays the same.
+      'org/pantsbuild/testproject/shading/Main.class',
+      # Shaded with the target_id prefix, along with the default pants prefix.
+      ('__shaded_by_pants__/org/pantsbuild/testproject/shadingdep/otherpackage/'
+       'ShadeWithTargetId.class'),
+      # Also shaded with the target_id prefix and default pants prefix, but for a different target
+      # (so the target_id is different).
+      ('__shaded_by_pants__/org/pantsbuild/testproject/shading/ShadeSelf.class'),
+      # All these are shaded by the same shading_relocate_package(), which is recursive by default.
+      '__shaded_by_pants__/org/pantsbuild/testproject/shadingdep/subpackage/Subpackaged.class',
+      '__shaded_by_pants__/org/pantsbuild/testproject/shadingdep/SomeClass.class',
+      '__shaded_by_pants__/org/pantsbuild/testproject/shadingdep/Dependency.class',
+      # Shaded by a shading_relocate() that completely renames the package and class name.
+      'org/pantsbuild/testproject/foo/bar/MyNameIsDifferentNow.class',
+    }
+
+    path = os.path.join('dist', 'shading.jar')
+    with subsystem_instance(DistributionLocator):
+      execute_java = DistributionLocator.cached(minimum_version='1.6').execute_java
+      self.assertEquals(0, execute_java(classpath=path,
+                                        main='org.pantsbuild.testproject.shading.Main'))
+      self.assertEquals(0, execute_java(classpath=path,
+                                        main='org.pantsbuild.testproject.foo.bar.MyNameIsDifferentNow'))
+
+    received_classes = set()
+    with temporary_dir() as tempdir:
+      ZIP.extract(path, tempdir, filter_func=lambda f: f.endswith('.class'))
+      for root, dirs, files in os.walk(tempdir):
+        for name in files:
+          received_classes.add(os.path.relpath(os.path.join(root, name), tempdir))
+
+    self.assertEqual(expected_classes, received_classes)
+
+  def _bundle_and_run(self, bundle_args, classpath):
+    self.assert_success(self.run_pants(['clean-all']))
+    pants_command = list(bundle_args)
+    pants_command.append('testprojects/src/java/org/pantsbuild/testproject/shading:third')
+    self.assert_success(self.run_pants(pants_command))
+
+    main_class = 'org.pantsbuild.testproject.shading.Third'
+    with subsystem_instance(DistributionLocator):
+      executor = SubprocessExecutor(DistributionLocator.cached(minimum_version='1.7'))
+      p = executor.spawn(classpath, main_class, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      out, err = p.communicate()
+      self.assertEqual(0, p.returncode, err)
+      class_names = json.loads(out.strip())
+      self.assertEqual({
+        'Gson': 'moc.elgoog.nosg.Gson',
+        'Third': 'org.pantsbuild.testproject.shading.Third',
+        'Second': 'hello.org.pantsbuild.testproject.shading.Second',
+      }, class_names)
+
+  @contextmanager
+  def _dist_dir(self):
+    with temporary_dir(root_dir=os.path.abspath('.')) as dist_dir:
+      yield os.path.relpath(dist_dir)
+
+  def test_no_deployjar_run(self):
+    with self._dist_dir() as dist_dir:
+      bundle_args = [
+        '--pants-distdir={}'.format(dist_dir), 'bundle', '--no-deployjar',
+      ]
+      classpath=[
+        os.path.join(dist_dir, 'third-bundle', 'third.jar'),
+        os.path.join(dist_dir, 'third-bundle', 'libs'),
+      ]
+      self._bundle_and_run(bundle_args, classpath)
+
+  def test_deployjar_run(self):
+    with self._dist_dir() as dist_dir:
+      bundle_args = [
+        '--pants-distdir={}'.format(dist_dir), 'bundle', '--deployjar',
+      ]
+      classpath=[
+        os.path.join(dist_dir, 'third-bundle', 'third.jar'),
+      ]
+      self._bundle_and_run(bundle_args, classpath)


### PR DESCRIPTION
jvm_binary() targets may now specify a shading_rules argument,
which accepts a list of shading rules, which can be any of:

    shading_relocate()
    shading_exclude()
    shading_relocate_package()
    shading_exclude_package()

The order of rules in the list matters, as typical of shading
logic in general.

These rules are powerful enough to take advantage of jarjar's more
advanced syntax, like using wildcards in the middle of package
names. E.g., this syntax will now work:

    # Destination pattern will be inferred to be
    # `__shaded_by_pants__.com.@1.foo.bar.@2`
    shading_relocate('com.*.foo.bar.**')

Which can also be done by:

   shading_relocate_package('com.*.foo.bar')

I also added the ability to change the default
`__shaded_by_pants__` prefix, and automatically append the target
id to the prefix (after sanitizing it to be a valid package name):

    # Assuming 'com.foo.bar' is from the jar 'group.name.rev.jar',
    # the shaded pattern will be something like:
    # `__my_prefix__.group.name.rev.jar.com.foo.bar.@1`
    shading_relocate_package('com.foo.bar', shade_prefix='__my_prefix__.',
                             shade_with_target_id=True)

The rules are implemented by `Shading.Relocate`, `Shading.Exclude`,
`Shading.RelocatePackage`, and `Shading.ExcludePackage`.

`Relocate` is the most generic, and acts as the base-class. It is
essentially a factory for the Rule nametuple that previously
existed in `Shader`.

Rather than build off of the pre-existing `shade_class`,
`shade_package`, `exclude_class`, and `exclude_package`, I made
`Relocate` and friends more powerful, extensible and (I hope)
intuitive concepts, and refactored the existing functions to use
the new classes instead.

They are classes rather than simple factory methods to make
for a clean inheritance structure, and to allow some fancy behavior
like shading with the binary target's id as a prefix. The actual
Rule objects are generated lazily, when the monolithic jar is
actually being generated by the JvmBinaryTask. Returning a lambda
would not be sufficient, because the rules need to be properly
fingerprinted in JvmBinary's payload.

They are wrapped in a Shading object rather than in the previous
Shader object to keep the objects that make it into BUILD file
aliases separate from those that do not. I also wistfully imagine
a day when we can register BUILD file aliases recursively,
which would let us use syntax like `Shading.Relocate` instead of
shading_relocate, which would both be more consistent with things
like `Duplicate` and `Skip` today, without polluting the global
namespace. Today this is not possible, because while you *can*
register `Shading`, and then access `Shading.*` in BUILD files,
they don't make it into the BUILD dictionary when we generate docs.