### PR TITLE
Kill PANTS_VERBOSE and PANTS_BUILD_ROOT.

### DIFF
--- a/examples/src/python/example/readme.md
+++ b/examples/src/python/example/readme.md
@@ -190,7 +190,7 @@ To drop into our example library target `examples/src/python/example/hello/greet
 turn on to see what's going on in the background:
 
     :::bash
-    $ PANTS_VERBOSE=1 ./pants repl examples/src/python/example/hello/greet
+    $ ./pants -ldebug repl examples/src/python/example/hello/greet
     
     15:11:41 00:00 [main]
                    (To run a reporting server: ./pants server)

--- a/examples/src/python/example/readme.md
+++ b/examples/src/python/example/readme.md
@@ -191,7 +191,7 @@ turn on to see what's going on in the background:
 
     :::bash
     $ ./pants -ldebug repl examples/src/python/example/hello/greet
-    
+
     15:11:41 00:00 [main]
                    (To run a reporting server: ./pants server)
       ...lots of build output...

--- a/src/docs/first_tutorial.md
+++ b/src/docs/first_tutorial.md
@@ -211,7 +211,7 @@ For help with things that aren't goals (global options, other kinds of help), us
 
 If you want help diagnosing some strange Pants behavior, you might want verbose output.
 To get this, instead of just invoking `./pants`, set some environment variables and request
-more logging: `PEX_VERBOSE=1 PANTS_VERBOSE=1 ./pants -ldebug`.
+more logging: `PEX_VERBOSE=5 ./pants -ldebug`.
 
 BUILD Files
 -----------

--- a/src/docs/invoking.md
+++ b/src/docs/invoking.md
@@ -35,7 +35,8 @@ Some goals are made up of tasks; to specify an option for that task, use the dot
 _goal.task_ notation:
 
     :::bash
-    ./pants compile.java --no-delete-scratch src:: # compile src, keeping Java compile's "scratch files"
+    # compile src, keeping Java compile's "scratch files"
+    ./pants compile.java --no-delete-scratch src::
 
 You can specify one or more targets to operate upon. Target specifications come after goals
 and goal options on the command line.
@@ -67,8 +68,8 @@ Instead of passing an option on the command line, you can set an environment var
 an option in an `.ini` file. Pants "looks" for an option value on the command line, environment
 variable, and `.ini` file; it uses the first it finds.
 For a complete, precedence-ordered list of places Pants looks for option values, see the
-`Options` docstring in
-[src/python/pants/option/options.py](https://github.com/pantsbuild/pants/blob/master/src/python/pants/option/options.py).
+`Options` docstring in [src/python/pants/option/options.py]
+(https://github.com/pantsbuild/pants/blob/master/src/python/pants/option/options.py).
 
 ### `PANTS_...` Environment Variables
 
@@ -83,16 +84,6 @@ commands opens a coverage report in your browser:
 Pants checks for an environment variable whose name is `PANTS` + the goal name (or goal+task name)
 + the option name; all of these in all-caps, joined by underscores (instead of dots or hyphens).
 
-Pants checks some environment variables that don't correspond to command-line options.
-E.g., though Pants uses the `PANTS_VERBOSE` environment variable, there's no `--verbose` flag
-to Pants.
-
-* `PANTS_BUILD_ROOT`
-* `PANTS_IVY_CACHE_DIR`
-* `PANTS_IVY_SETTINGS_XML`
-* `PANTS_LEAVE_CHROOT`
-* `PANTS_VERBOSE`
-
 ### `pants.ini` Settings File
 
 Pants can also read command-line options (and other options) from an `.ini` file. For example, if
@@ -104,10 +95,6 @@ your `pants.ini` file contains
 ...then whenever Pants carries out the `test.junit` task, it will behave as if you passed
 `test.junit --coverage-html-open`. If an environment variable and an `.ini` configuration both
 specify a value for some option, the environment variable "wins".
-
-Pants also checks some `.ini` settings that don't correspond to any command-line option.
-For example, though Pants uses the `PANTS_VERBOSE` environment variable, there's no `--verbose`
-flag to Pants.
 
 ### Overlay `.ini` Files with `--config-overrides`
 

--- a/src/docs/tshoot.md
+++ b/src/docs/tshoot.md
@@ -52,7 +52,7 @@ stdout, you can set some environment variables and pass the `-ldebug`
 flag (along with the parameters you meant to pass):
 
     :::bash
-    $ PEX_VERBOSE=1 PANTS_VERBOSE=1 ./pants -ldebug ...
+    $ PEX_VERBOSE=5 ./pants -ldebug ...
 
 This can be especially useful if you're trying to figure out what Pants
 was "looking at" when it crashed.

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -65,7 +65,8 @@ class PythonChroot(object):
                builder,
                targets,
                platforms,
-               extra_requirements=None):
+               extra_requirements=None,
+               log=None):
     self._python_setup = python_setup
     self._python_repos = python_repos
     self._ivy_bootstrapper = ivy_bootstrapper
@@ -76,6 +77,7 @@ class PythonChroot(object):
     self._targets = targets
     self._platforms = platforms
     self._extra_requirements = list(extra_requirements) if extra_requirements else []
+    self._logger = log or logger
 
     # Note: unrelated to the general pants artifact cache.
     self._artifact_cache_root = os.path.join(
@@ -87,9 +89,8 @@ class PythonChroot(object):
     """Deletes this chroot from disk if it has been dumped."""
     safe_rmtree(self.path())
 
-  def debug(self, msg, indent=0):
-    if os.getenv('PANTS_VERBOSE') is not None:
-      print('{}{}'.format(' ' * indent, msg))
+  def debug(self, msg):
+    self._logger.debug(msg)
 
   def path(self):
     return os.path.realpath(self._builder.path())

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -123,7 +123,8 @@ class PythonTask(Task):
                         builder=builder,
                         targets=targets,
                         platforms=platforms,
-                        extra_requirements=extra_requirements)
+                        extra_requirements=extra_requirements,
+                        log=self.context.log)
 
   @contextmanager
   def cached_chroot(self, interpreter, pex_info, targets, platforms,

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -16,8 +16,8 @@ class BuildRoot(Singleton):
   """Represents the global workspace build root.
 
   By default a pants workspace is defined by a root directory where the workspace configuration
-  file - 'pants.ini' - lives.  This can be overridden by exporting 'PANTS_BUILD_ROOT' in the
-  environment with the path to the build root or manipulated through this interface.
+  file - 'pants.ini' - lives.  This path can also be manipulated through this interface for
+  re-location of the build root in tests
   """
 
   class NotFoundError(Exception):
@@ -30,16 +30,13 @@ class BuildRoot(Singleton):
   def path(self):
     """Returns the build root for the current workspace."""
     if self._root_dir is None:
-      if 'PANTS_BUILD_ROOT' in os.environ:
-        self._root_dir = os.environ['PANTS_BUILD_ROOT']
-      else:
-        buildroot = os.path.abspath(os.getcwd())
-        while not os.path.exists(os.path.join(buildroot, 'pants.ini')):
-          if buildroot != os.path.dirname(buildroot):
-            buildroot = os.path.dirname(buildroot)
-          else:
-            raise self.NotFoundError('Could not find pants.ini!')
-        self._root_dir = buildroot
+      buildroot = os.path.abspath(os.getcwd())
+      while not os.path.exists(os.path.join(buildroot, 'pants.ini')):
+        if buildroot != os.path.dirname(buildroot):
+          buildroot = os.path.dirname(buildroot)
+        else:
+          raise self.NotFoundError('Could not find pants.ini!')
+      self._root_dir = buildroot
     return self._root_dir
 
   @path.setter

--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -17,7 +17,7 @@ class BuildRoot(Singleton):
 
   By default a pants workspace is defined by a root directory where the workspace configuration
   file - 'pants.ini' - lives.  This path can also be manipulated through this interface for
-  re-location of the build root in tests
+  re-location of the build root in tests.
   """
 
   class NotFoundError(Exception):

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -68,10 +68,8 @@ def _run(exiter):
   # Launch RunTracker as early as possible (just after Subsystem options are initialized).
   run_tracker, reporting = ReportingInitializer().setup()
 
-  # Determine and check validity of the buildroot.
+  # Determine the build root dir.
   root_dir = get_buildroot()
-  if not os.path.exists(root_dir):
-    exiter.exit_and_fail('PANTS_BUILD_ROOT does not point to a valid path: {}'.format(root_dir))
 
   # Setup and run GoalRunner.
   goal_runner = GoalRunner.Factory(root_dir, options, build_config, run_tracker, reporting).setup()

--- a/src/python/pants/docs/howto_develop.md
+++ b/src/python/pants/docs/howto_develop.md
@@ -17,9 +17,6 @@ As pants is implemented in python it can be run directly from sources.
     $ ./pants goals
     <remainder of output omitted for brevity>
 
-Notice this invocation specifies the `PANTS_DEV` environment variable.
-By defining `PANTS_DEV` pants will be run from sources.
-
 Building a Pants PEX for Production
 -----------------------------------
 

--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -9,7 +9,7 @@ import os
 import unittest
 
 from pants.base.build_root import BuildRoot
-from pants.util.contextutil import environment_as, pushd, temporary_dir
+from pants.util.contextutil import pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_mkdtemp, safe_rmtree, touch
 
 
@@ -23,10 +23,6 @@ class BuildRootTest(unittest.TestCase):
   def tearDown(self):
     BuildRoot().reset()
     safe_rmtree(self.new_root)
-
-  def test_via_env(self):
-    with environment_as(PANTS_BUILD_ROOT=self.new_root):
-      self.assertEqual(self.new_root, BuildRoot().path)
 
   def test_via_set(self):
     BuildRoot().path = self.new_root


### PR DESCRIPTION
The PANTS_VERBOSE env var was obsolete and just needed a logger plumbed
and the PANTS_BUILD_ROOT was unused and unuseable since code elsewhere
in Config does `os.path.join(get_buildroot(), 'pants.ini')` which
assumes no PANTS_BUILD_ROOT env var override took place (because the
default way to establish the build root is in fact the inverse of the
path join!).

Docs and messages are all updated to kill mention of these 2 dead env
vars and a few extra doc lies are removed or fixed.

https://rbcommons.com/s/twitter/r/2760/