### PR TITLE
Return cached_chroots instead of yielding them.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -405,19 +405,19 @@ class PytestRun(PythonTask):
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
 
-    with self.cached_chroot(interpreter=interpreter,
-                            pex_info=pex_info,
-                            targets=targets,
-                            platforms=('current',),
-                            extra_requirements=self._TESTING_TARGETS) as chroot:
-      pex = chroot.pex()
-      with self._maybe_shard() as shard_args:
-        with self._maybe_emit_junit_xml(targets) as junit_args:
-          with self._maybe_emit_coverage_data(targets,
-                                              chroot.path(),
-                                              pex,
-                                              workunit) as coverage_args:
-            yield pex, shard_args + junit_args + coverage_args
+    chroot = self.cached_chroot(interpreter=interpreter,
+                                pex_info=pex_info,
+                                targets=targets,
+                                platforms=('current',),
+                                extra_requirements=self._TESTING_TARGETS)
+    pex = chroot.pex()
+    with self._maybe_shard() as shard_args:
+      with self._maybe_emit_junit_xml(targets) as junit_args:
+        with self._maybe_emit_coverage_data(targets,
+                                            chroot.path(),
+                                            pex,
+                                            workunit) as coverage_args:
+          yield pex, shard_args + junit_args + coverage_args
 
   def _do_run_tests_with_args(self, pex, workunit, args):
     try:

--- a/src/python/pants/backend/python/tasks/python_eval.py
+++ b/src/python/pants/backend/python/tasks/python_eval.py
@@ -134,15 +134,18 @@ class PythonEval(PythonTask):
                             chroot_parent=self.chroot_cache_dir, modules=modules)
       executable_file_content = generator.render()
 
-      with self.cached_chroot(interpreter=interpreter, pex_info=pexinfo,
-                              targets=[target], platforms=platforms,
-                              executable_file_content=executable_file_content) as chroot:
-        pex = chroot.pex()
-        with self.context.new_workunit(name='eval',
-                                       labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.RUN, WorkUnitLabel.TOOL],
-                                       cmd=' '.join(pex.cmdline())) as workunit:
-          returncode = pex.run(stdout=workunit.output('stdout'), stderr=workunit.output('stderr'))
-          workunit.set_outcome(WorkUnit.SUCCESS if returncode == 0 else WorkUnit.FAILURE)
-          if returncode != 0:
-            self.context.log.error('Failed to eval {}'.format(target.address.spec))
-          return returncode
+      chroot = self.cached_chroot(interpreter=interpreter,
+                                  pex_info=pexinfo,
+                                  targets=[target],
+                                  platforms=platforms,
+                                  executable_file_content=executable_file_content)
+      pex = chroot.pex()
+      with self.context.new_workunit(name='eval',
+                                     labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.RUN,
+                                             WorkUnitLabel.TOOL],
+                                     cmd=' '.join(pex.cmdline())) as workunit:
+        returncode = pex.run(stdout=workunit.output('stdout'), stderr=workunit.output('stderr'))
+        workunit.set_outcome(WorkUnit.SUCCESS if returncode == 0 else WorkUnit.FAILURE)
+        if returncode != 0:
+          self.context.log.error('Failed to eval {}'.format(target.address.spec))
+        return returncode

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -46,17 +46,17 @@ class PythonRepl(PythonTask):
 
       pex_info = PexInfo.default()
       pex_info.entry_point = entry_point
-      with self.cached_chroot(interpreter=interpreter,
-                              pex_info=pex_info,
-                              targets=targets,
-                              platforms=None,
-                              extra_requirements=extra_requirements) as chroot:
-        pex = chroot.pex()
-        self.context.release_lock()
-        with stty_utils.preserve_stty_settings():
-          with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
-            po = pex.run(blocking=False, **pex_run_kwargs)
-            try:
-              return po.wait()
-            except KeyboardInterrupt:
-              pass
+      chroot = self.cached_chroot(interpreter=interpreter,
+                                  pex_info=pex_info,
+                                  targets=targets,
+                                  platforms=None,
+                                  extra_requirements=extra_requirements)
+      pex = chroot.pex()
+      self.context.release_lock()
+      with stty_utils.preserve_stty_settings():
+        with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
+          po = pex.run(blocking=False, **pex_run_kwargs)
+          try:
+            return po.wait()
+          except KeyboardInterrupt:
+            pass

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -34,25 +34,27 @@ class PythonRun(PythonTask):
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
       # TODO(benjy): Some more elegant way to coordinate how tasks claim targets.
       interpreter = self.select_interpreter_for_targets(binary.closure())
-      with self.cached_chroot(interpreter=interpreter, pex_info=binary.pexinfo,
-                              targets=[binary], platforms=binary.platforms) as chroot:
-        pex = chroot.pex()
-        self.context.release_lock()
-        with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
-          args = []
-          for arg in self.get_options().args:
-            args.extend(safe_shlex_split(arg))
-          args += self.get_passthru_args()
-          po = pex.run(blocking=False, args=args)
-          try:
-            result = po.wait()
-            if result != 0:
-              msg = '{interpreter} {entry_point} {args} ... exited non-zero ({code})'.format(
-                        interpreter=interpreter.binary,
-                        entry_point=binary.entry_point,
-                        args=' '.join(args),
-                        code=result)
-              raise TaskError(msg, exit_code=result)
-          except KeyboardInterrupt:
-            po.send_signal(signal.SIGINT)
-            raise
+      chroot = self.cached_chroot(interpreter=interpreter,
+                                  pex_info=binary.pexinfo,
+                                  targets=[binary],
+                                  platforms=binary.platforms)
+      pex = chroot.pex()
+      self.context.release_lock()
+      with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
+        args = []
+        for arg in self.get_options().args:
+          args.extend(safe_shlex_split(arg))
+        args += self.get_passthru_args()
+        po = pex.run(blocking=False, args=args)
+        try:
+          result = po.wait()
+          if result != 0:
+            msg = '{interpreter} {entry_point} {args} ... exited non-zero ({code})'.format(
+                      interpreter=interpreter.binary,
+                      entry_point=binary.entry_point,
+                      args=' '.join(args),
+                      code=result)
+            raise TaskError(msg, exit_code=result)
+        except KeyboardInterrupt:
+          po.send_signal(signal.SIGINT)
+          raise

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -126,7 +126,6 @@ class PythonTask(Task):
                         extra_requirements=extra_requirements,
                         log=self.context.log)
 
-  @contextmanager
   def cached_chroot(self, interpreter, pex_info, targets, platforms,
                     extra_requirements=None, executable_file_content=None):
     """Returns a cached PythonChroot created with the specified args.
@@ -155,16 +154,11 @@ class PythonTask(Task):
     pex_info = PexInfo.from_pex(path)
     # Now create a PythonChroot wrapper without dumping it.
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info, copy=True)
-    chroot = self.create_chroot(
-      interpreter=interpreter,
-      builder=builder,
-      targets=targets,
-      platforms=platforms,
-      extra_requirements=extra_requirements)
-    # TODO: Doesn't really need to be a contextmanager, but it's convenient to make it so
-    # while transitioning calls to temporary_chroot to calls to cached_chroot.
-    # We can revisit after that transition is complete.
-    yield chroot
+    return self.create_chroot(interpreter=interpreter,
+                              builder=builder,
+                              targets=targets,
+                              platforms=platforms,
+                              extra_requirements=extra_requirements)
 
   @contextmanager
   def temporary_chroot(self, interpreter, pex_info, targets, platforms,

--- a/tests/python/pants_test/backend/python/tasks/test_python_task.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_task.py
@@ -66,11 +66,11 @@ class PythonTaskTest(PythonTaskTestBase):
     pex_info = self.binary.pexinfo
     platforms = self.binary.platforms
 
-    with python_task.cached_chroot(interpreter, pex_info, [self.binary], platforms) as chroot:
-      with temporary_file_path() as pex:
-        chroot.dump()
-        chroot.package_pex(pex)
-        yield chroot, pex
+    chroot = python_task.cached_chroot(interpreter, pex_info, [self.binary], platforms)
+    with temporary_file_path() as pex:
+      chroot.dump()
+      chroot.package_pex(pex)
+      yield chroot, pex
 
   def test_cached_chroot_reuse(self):
     with self.cached_chroot() as (chroot1, pex1):


### PR DESCRIPTION
A forthcoming change to the `PythonRepl` and `ScalaRepl `tasks requires
this on the python side for sanity sake.  Although we still have one
`temporary_chroot` `@contextmanager` user in `PythonBinaryCreate`, the
transition wll be straightforward so cleaning this up now is not
disruptive.

https://rbcommons.com/s/twitter/r/2762/