### PR TITLE
Eliminated duplicate jar entries caused by consecutive slashes.

### DIFF
--- a/tests/java/org/pantsbuild/tools/jar/JarBuilderTest.java
+++ b/tests/java/org/pantsbuild/tools/jar/JarBuilderTest.java
@@ -6,6 +6,7 @@ package org.pantsbuild.tools.jar;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.String;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +40,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.pantsbuild.testing.EasyMockTest;
 import org.pantsbuild.testing.TearDownTestCase;
+import org.pantsbuild.tools.jar.JarBuilder;
 import org.pantsbuild.tools.jar.JarBuilder.DuplicateAction;
 import org.pantsbuild.tools.jar.JarBuilder.DuplicateEntryException;
 import org.pantsbuild.tools.jar.JarBuilder.DuplicateHandler;
@@ -787,6 +789,25 @@ public class JarBuilderTest {
       assertRelpath(new File("a/b/c"), new File("a/b/d"), "..", "c");
       assertRelpath(new File("a/b/c"), new File("a/d/e"), "..", "..", "b", "c");
       assertRelpath(new File("a/b/c"), new File("d/e/f"), "..", "..", "..", "a", "b", "c");
+    }
+  }
+
+  public static class PathJoinTest {
+
+    private static void assertJoinPath(String expected, String... components) {
+      assertEquals(expected, JarBuilder.joinJarPath(ImmutableList.copyOf(components)));
+    }
+
+    @Test
+    public void testJoin() {
+      assertJoinPath("a/b/c", "a", "b", "c");
+      assertJoinPath("a/b/c", "a/", "b", "c");
+      assertJoinPath("a/b/c", "a", "b/", "c");
+      assertJoinPath("a/b/c/", "a", "b", "c/");
+      assertJoinPath("a/b/c", "a", "b//", "c");
+      assertJoinPath("a/b/c/", "a", "b", "c/");
+      assertJoinPath("/a/b/c/", "/a", "b", "c/");
+      assertJoinPath("/a/b/c/", "//a", "b", "c/");
     }
   }
 }


### PR DESCRIPTION
We noticed this duplication in some of our internal jar builds. It
mostly doesn't cause any problems, but was breaking jarjar when it
tried to shade them (for rb 2754).

Despite only having one version of the class most of the way
through the jar building pipeline, duplicate classes were
artificially created due to a bug in the path calculation for the
jar entry.

Specifically, we create the final jar entry path by calling 'join'
on the path separator ('/') over an iterable of path components,
however it appears there are some cases where the path components
may contain trailing slashes.

Internally, this resulted in .jar files with entries that looked
like:

    com/squareup/foo/bar/app/package/File.class
    com//squareup/foo/bar/app/package/File.class
    com/squareup//foo/bar/app/package/File.class
    com/squareup/foo//bar/app/package/File.class
    com/squareup/foo/bar//app/package/File.class
    com/squareup/foo/bar/app//package/File.class
    com/squareup/foo/bar/app/package//File.class

This is a very simple (but subtle) bug, and the fix is similarly
simple.