### PR TITLE
Add support for `repl.node`.

### DIFF
--- a/contrib/node/examples/3rdparty/node/BUILD
+++ b/contrib/node/examples/3rdparty/node/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+node_remote_module(
+  name='typ',
+  version='0.6.3',
+)

--- a/contrib/node/src/python/pants/contrib/node/register.py
+++ b/contrib/node/src/python/pants/contrib/node/register.py
@@ -10,6 +10,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.targets.node_remote_module import NodeRemoteModule
+from pants.contrib.node.tasks.node_repl import NodeRepl
 from pants.contrib.node.tasks.npm_resolve import NpmResolve
 
 
@@ -23,4 +24,5 @@ def build_file_aliases():
 
 
 def register_goals():
+  task(name='node', action=NodeRepl).install('repl')
   task(name='npm', action=NpmResolve).install('resolve')

--- a/contrib/node/src/python/pants/contrib/node/tasks/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/tasks/BUILD
@@ -4,7 +4,23 @@
 target(
   name='tasks',
   dependencies=[
+    ':node_repl',
     ':npm_resolve',
+  ]
+)
+
+python_library(
+  name='node_paths',
+  sources=['node_paths.py']
+)
+
+python_library(
+  name='node_repl',
+  sources=['node_repl.py'],
+  dependencies=[
+    ':node_paths',
+    ':node_task',
+    'src/python/pants/backend/core/tasks:repl_task_mixin',
   ]
 )
 
@@ -15,6 +31,7 @@ python_library(
     'contrib/node/src/python/pants/contrib/node/subsystems:node_distribution',
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_remote_module',
+    'contrib/node/src/python/pants/contrib/node/targets:npm_package',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/base:workunit',
     'src/python/pants/util:memo',
@@ -25,6 +42,7 @@ python_library(
   name='npm_resolve',
   sources=['npm_resolve.py'],
   dependencies=[
+    ':node_paths',
     ':node_task',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_paths.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_paths.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+
+# TODO(John Sirois): UnionProducts? That seems broken though for ranged version constraints,
+# which npm has and are widely used in the community.  For now stay dumb simple (and slow) and
+# resolve each node_module individually.
+class NodePaths(object):
+  """Maps NpmPackage targets to their resolved NODE_PATH chroot."""
+
+  def __init__(self):
+    self._paths_by_target = {}
+
+  def resolved(self, target, node_path):
+    """Identifies the given target as resolved to the given chroot path.
+
+    :param target: The target that was resolved to the `node_path` chroot.
+    :type target: :class:`pants.contrib.node.targets.npm_package.NpmPackage`
+    :param string node_path: The chroot path the given `target` was resolved to.
+    """
+    self._paths_by_target[target] = node_path
+
+  def node_path(self, target):
+    """Returns the path of the resolved chroot for the given NpmPackage.
+
+    Returns `None` if the target has not been resolved to a chroot.
+
+    :rtype string
+    """
+    return self._paths_by_target.get(target)

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_repl.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_repl.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.backend.core.tasks.repl_task_mixin import ReplTaskMixin
+
+from pants.contrib.node.tasks.node_paths import NodePaths
+from pants.contrib.node.tasks.node_task import NodeTask
+
+
+class NodeRepl(ReplTaskMixin, NodeTask):
+  """Launches a Node.js REPL session."""
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(NodeRepl, cls).prepare(options, round_manager)
+    round_manager.require_data(NodePaths)
+
+  @classmethod
+  def select_targets(cls, target):
+    return cls.is_npm_package(target)
+
+  @classmethod
+  def supports_passthru_args(cls):
+    return True
+
+  def setup_repl_session(self, targets):
+    node_paths = self.context.products.get_data(NodePaths)
+    return [node_paths.node_path(target) for target in targets]
+
+  def launch_repl(self, node_path):
+    args = self.get_passthru_args()
+    node_repl = self.node_distribution.node_command(args=args)
+
+    env = os.environ.copy()
+    env.update(NODE_PATH=os.pathsep.join(node_path))
+    repl_session = node_repl.run(env=env)
+
+    repl_session.wait()

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -28,7 +28,7 @@ class NodeTask(Task):
 
   @classmethod
   def is_npm_package(cls, target):
-    """Returns `True` if the given target is an `NopmPackage`."""
+    """Returns `True` if the given target is an `NpmPackage`."""
     return isinstance(target, NpmPackage)
 
   @classmethod

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -12,6 +12,7 @@ from pants.util.memo import memoized_property
 from pants.contrib.node.subsystems.node_distribution import NodeDistribution
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.targets.node_remote_module import NodeRemoteModule
+from pants.contrib.node.targets.npm_package import NpmPackage
 
 
 class NodeTask(Task):
@@ -24,6 +25,11 @@ class NodeTask(Task):
   def node_distribution(self):
     """A bootstrapped node distribution for use by node tasks."""
     return NodeDistribution.Factory.global_instance().create()
+
+  @classmethod
+  def is_npm_package(cls, target):
+    """Returns `True` if the given target is an `NopmPackage`."""
+    return isinstance(target, NpmPackage)
 
   @classmethod
   def is_node_module(cls, target):
@@ -46,8 +52,8 @@ class NodeTask(Task):
     :rtype: A tuple of (int,
             :class:`pants.contrib.node.subsystems.node_distribution.NodeDistribution.Command`)
     """
-    npm_command = self.node_distribution.node_command(args=args)
-    return self._execute_command(npm_command,
+    node_command = self.node_distribution.node_command(args=args)
+    return self._execute_command(node_command,
                                  workunit_name=workunit_name,
                                  workunit_labels=workunit_labels,
                                  **kwargs)

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/BUILD
@@ -10,6 +10,14 @@ target(
 )
 
 python_tests(
+  name='node_repl_integration',
+  sources=['test_node_repl_integration.py'],
+  dependencies=[
+    'tests/python/pants_test:int-test',
+  ]
+)
+
+python_tests(
   name='node_task',
   sources=['test_node_task.py'],
   dependencies=[
@@ -28,6 +36,7 @@ python_tests(
   dependencies=[
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'contrib/node/src/python/pants/contrib/node/targets:node_remote_module',
+    'contrib/node/src/python/pants/contrib/node/tasks:node_paths',
     'contrib/node/src/python/pants/contrib/node/tasks:npm_resolve',
     'src/python/pants/base:source_root',
     'src/python/pants/base:target',

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
@@ -21,6 +21,8 @@ class NodeReplIntegrationTest(PantsRunIntegrationTest):
         console.log("type of boolean is: " + typ.BOOLEAN);
       """)
     pants_run = self.run_pants(command=command, stdin_data=program)
+
+    self.assert_success(pants_run)
     self.assertEqual('type of boolean is: boolean', pants_run.stdout_data.strip())
 
   def test_run_repl_passthrough(self):
@@ -31,4 +33,6 @@ class NodeReplIntegrationTest(PantsRunIntegrationTest):
                '--eval',
                'var typ = require("typ"); console.log("type of boolean is: " + typ.BOOLEAN)']
     pants_run = self.run_pants(command=command)
+
+    self.assert_success(pants_run)
     self.assertEqual('type of boolean is: boolean', pants_run.stdout_data.strip())

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from textwrap import dedent
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class NodeReplIntegrationTest(PantsRunIntegrationTest):
+
+  def test_run_repl(self):
+    command = ['-q',
+               'repl',
+               'contrib/node/examples/3rdparty/node:typ']
+    program = dedent("""
+        var typ = require('typ');
+        console.log("type of boolean is: " + typ.BOOLEAN);
+      """)
+    pants_run = self.run_pants(command=command, stdin_data=program)
+    self.assertEqual('type of boolean is: boolean', pants_run.stdout_data.strip())
+
+  def test_run_repl_passthrough(self):
+    command = ['-q',
+               'repl',
+               'contrib/node/examples/3rdparty/node:typ',
+               '--',
+               '--eval',
+               'var typ = require("typ"); console.log("type of boolean is: " + typ.BOOLEAN)']
+    pants_run = self.run_pants(command=command)
+    self.assertEqual('type of boolean is: boolean', pants_run.stdout_data.strip())

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
@@ -29,6 +29,11 @@ class NodeTaskTest(TaskTestBase):
   def task_type(cls):
     return cls.TestNodeTask
 
+  def test_is_npm_package(self):
+    self.assertTrue(NodeTask.is_npm_package(self.make_target(':a', NodeRemoteModule)))
+    self.assertTrue(NodeTask.is_npm_package(self.make_target(':b', NodeModule)))
+    self.assertFalse(NodeTask.is_npm_package(self.make_target(':c', Target)))
+
   def test_is_node_module(self):
     self.assertTrue(NodeTask.is_node_module(self.make_target(':a', NodeModule)))
     self.assertFalse(NodeTask.is_node_module(self.make_target(':b', NodeRemoteModule)))

--- a/src/python/pants/backend/core/tasks/mutex_task_mixin.py
+++ b/src/python/pants/backend/core/tasks/mutex_task_mixin.py
@@ -123,7 +123,7 @@ class MutexTaskMixin(Task):
       # TODO: once https://github.com/pantsbuild/pants/issues/425 lands, we should add
       # language-specific flags that would resolve the ambiguity here
       def render_target(target):
-        return '{} a {}'.format(target.address.reference(), target.type_alias)
+        return '{} (a {})'.format(target.address.reference(), target.type_alias)
       raise self.IncompatibleActivationsError('Mutually incompatible targets specified: {} vs {} '
                                               '(and {} others)'
                                               .format(render_target(accepted[0]),

--- a/src/python/pants/backend/core/tasks/mutex_task_mixin.py
+++ b/src/python/pants/backend/core/tasks/mutex_task_mixin.py
@@ -122,8 +122,10 @@ class MutexTaskMixin(Task):
       # both accepted and rejected targets
       # TODO: once https://github.com/pantsbuild/pants/issues/425 lands, we should add
       # language-specific flags that would resolve the ambiguity here
+      def render_target(target):
+        return '{} a {}'.format(target.address.reference(), target.type_alias)
       raise self.IncompatibleActivationsError('Mutually incompatible targets specified: {} vs {} '
                                               '(and {} others)'
-                                              .format(accepted[0],
-                                                      rejected[0],
+                                              .format(render_target(accepted[0]),
+                                                      render_target(rejected[0]),
                                                       len(accepted) + len(rejected) - 2))


### PR DESCRIPTION
This builds off of the new ReplTaskMixin and NodeRepl itself is a small
task.

To support NodeRepl well, a few adjustments are made:

1. MutexTaskMixin is given better failure output when identifying
   mutually incompatible targets.
2. NpmResolve is updated to support resolving remote modules directly.
3. The NodePaths product if broken out of NpmResolve to present a more
   neutral data type and not explicitly couple NpmResolve to NodeRepl.

An example node 3rdparty dep is added to support some integration tests
and the existing NodeTask and NpmResolve tests are expanded to cover the
new functionality added to the respective classes.

https://rbcommons.com/s/twitter/r/2766/