### PR TITLE
Setup the node contrib for release.

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/BUILD
@@ -1,8 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# TODO(John Sirois): Tie this into the contrib/release_packages.sh the minute the plugin can do
-# one useful thing, for example `./pants test contrib/node/examples::`.
 contrib_plugin(
   name='plugin',
   dependencies=[

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -62,10 +62,28 @@ function pkg_go_install_test() {
       test.go contrib/go/examples::
 }
 
+PKG_NODE=(
+  "pantsbuild.pants.contrib.node"
+  "//contrib/node/src/python/pants/contrib/node:plugin"
+  "pkg_node_install_test"
+)
+function pkg_node_install_test() {
+  (cat << EOF
+var typ = require('typ');
+console.log("type of boolean is: " + typ.BOOLEAN);
+EOF
+  ) | \
+  execute_packaged_pants_with_internal_backends \
+    "extra_bootstrap_buildfiles='${ROOT}/contrib/node/BUILD'" \
+      --plugins="['pantsbuild.pants.contrib.node==$(local_version)']" \
+      repl.node contrib/node/examples::
+}
+
 # Once individual (new) package is declared above, insert it into the array below)
 CONTRIB_PACKAGES=(
   PKG_SCROOGE
   PKG_BUILDGEN
   PKG_SPINDLE
   PKG_GO
+  PKG_NODE
 )


### PR DESCRIPTION
This adds a simple exercise of the repl as a test.  Future releases
will instead run tests in contrib/node/examples::.

https://rbcommons.com/s/twitter/r/2768/