### PR TITLE
Add support for @fromfile option values.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
@@ -183,11 +183,8 @@ class GoBuildgen(GoTask):
              help='Instead of just auto-generating missing go_binary and go_library targets in '
                   'memory, (re-)generate them on disk using the installed Go BUILD file template.')
 
-    # TODO(John Sirois): Support loading the template from disk and add docs for the template
-    # parameters.
-    # This disk loading will come for free when the options system supports argfile syntax, ie:
-    #   --template=@argfile
-    register('--template', metavar='<template>',
+    # TODO(John Sirois): Add docs for the template parameters.
+    register('--template', metavar='<template>', fromfile=True,
              default=cls._default_template(),
              advanced=True, fingerprint=True,
              help='A Go BUILD file mustache template to use with --materialize.')

--- a/src/python/pants/backend/core/tasks/reflect.py
+++ b/src/python/pants/backend/core/tasks/reflect.py
@@ -454,9 +454,10 @@ def oref_template_data_from_help_info(oschi):
       hlp = indent_docstring_by_n(sub_buildroot(ohi.help), 6)
     option_l.append(TemplateData(
       st=st,
+      fromfile=ohi.fromfile,
       default=sub_buildroot(ohi.default),
       hlp=hlp,
-      typ=ohi.type.__name__))
+      typ=ohi.typ.__name__))
   return TemplateData(
     title=title,
     options=option_l,

--- a/src/python/pants/backend/core/tasks/templates/builddictionary/options_reference.mustache
+++ b/src/python/pants/backend/core/tasks/templates/builddictionary/options_reference.mustache
@@ -23,7 +23,7 @@ and is installed in the ``compile`` goal.
 -----------------------------------------------------------------------------
 
 {{#goal.description}}
-{{goal.description}}
+{{.}}
 {{/goal.description}}
 
 {{#tasks}}
@@ -33,7 +33,7 @@ and is installed in the ``compile`` goal.
 
 *
 {{#ogroup.title}}
-  **{{{ogroup.title}}}**
+  **{{{.}}}**
 {{/ogroup.title}}
   Implemented by ``{{impl}}``
 {{/ogroup}}
@@ -43,17 +43,20 @@ and is installed in the ``compile`` goal.
 
 
 {{#doc_rst}}
-{{{doc_rst}}}
+{{{.}}}
 {{/doc_rst}}
 
 {{#ogroup}}
 {{#options}}
   * | ``{{st}}``
 {{#typ}}
-      ``{{typ}}``
+      ``{{.}}``
 {{/typ}}
+{{#fromfile}}
+      (@fromfile value supported)
+{{/fromfile}}
 {{#default}}
-      (Default: ``{{default}}``)
+      (Default: ``{{.}}``)
 {{/default}}
     |
 {{{hlp}}}
@@ -84,10 +87,13 @@ These command-line flags are available with all Pants goals.
 {{#options}}
   * | ``{{st}}``
 {{#typ}}
-      ``{{typ}}``
+      ``{{.}}``
 {{/typ}}
+{{#fromfile}}
+      (@fromfile value supported)
+{{/fromfile}}
 {{#default}}
-      (Default: ``{{default}}``)
+      (Default: ``{{.}}``)
 {{/default}}
     |
 {{{hlp}}}

--- a/src/python/pants/backend/core/tasks/templates/builddictionary/oref_html.mustache
+++ b/src/python/pants/backend/core/tasks/templates/builddictionary/oref_html.mustache
@@ -7,13 +7,13 @@
 <h1>Options Reference</h1>
 
 <p>
-This page documents Pants options: command-line options, options in a <tt>pants.ini</tt> file.
+This page documents Pants options: command-line options, options in a <code>pants.ini</code> file.
 These options are organized by <em>goal</em>. Goals are actions that can be taken on build targets.
 A goal identifies some high-level goal that you wish to accomplish, such as compiling your code.
 
 <p>
-Some goals have sub-goals, or <em>tasks</em>. For example, the <tt>compile.jvm</tt> task compiles
-Java code, and is installed in the <tt>compile</tt> goal.
+Some goals have sub-goals, or <em>tasks</em>. For example, the <code>compile.jvm</code> task compiles
+Java code, and is installed in the <code>compile</code> goal.
 
 <p><b>Goals and Tasks summary</b>
 
@@ -48,7 +48,7 @@ div.oref_ogroup_section h3 {
 <h2 id="{{goal.name}}">{{goal.name}}</h2>
 
 {{#goal.description}}
-<p>{{goal.description}}
+<p>{{.}}
 {{/goal.description}}
 
 {{#tasks}}
@@ -64,7 +64,7 @@ div.oref_ogroup_section h3 {
 
 {{#doc_html}}
 <div>
-{{{doc_html}}}
+{{{.}}}
 </div>
 {{/doc_html}}
 
@@ -73,10 +73,13 @@ div.oref_ogroup_section h3 {
 {{#options}}
 <li><code>{{st}}</code>
 {{#typ}}
-    <code>{{typ}}</code>
+    <code>{{.}}</code>
 {{/typ}}
+{{#fromfile}}
+      (@fromfile value supported)
+{{/fromfile}}
 {{#default}}
-      (Default: <code>{{default}}</code>)
+      (Default: <pre style="display: inline">{{.}}</pre>)
 {{/default}}
 
 {{hlp}}
@@ -109,10 +112,13 @@ These command-line flags are available with all Pants goals.
 {{#options}}
 <li><code>{{st}}</code>
 {{#typ}}
-    <code>{{typ}}</code>
+    <code>{{.}}</code>
 {{/typ}}
+{{#fromfile}}
+      (@fromfile value supported)
+{{/fromfile}}
 {{#default}}
-      (Default: <code>{{default}}</code>)
+      (Default: <pre style="display: inline">{{.}}</pre>)
 {{/default}}
 
 {{hlp}}

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -63,8 +63,11 @@ class HelpFormatter(object):
 
   def format_option(self, ohi):
     lines = []
-    arg_line = '{args} {dflt}'.format(args=self._maybe_cyan(', '.join(ohi.display_args)),
-                                      dflt=self._maybe_green('(default: {})'.format(ohi.default)))
+    arg_line = ('{args} {fromfile}{dflt}'
+                .format(args=self._maybe_cyan(', '.join(ohi.display_args)),
+                        dflt=self._maybe_green('(default: {})'.format(ohi.default)),
+                        fromfile=self._maybe_green('(@fromfile value supported) ' if ohi.fromfile
+                                                   else '')))
     lines.append(arg_line)
 
     indent = '    '

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -13,17 +13,19 @@ from pants.option.option_util import is_boolean_flag
 
 class OptionHelpInfo(namedtuple('_OptionHelpInfo',
     ['registering_class', 'display_args', 'scoped_cmd_line_args', 'unscoped_cmd_line_args',
-     'type', 'default', 'help', 'deprecated_version', 'deprecated_message', 'deprecated_hint'])):
+     'typ', 'fromfile', 'default', 'help', 'deprecated_version', 'deprecated_message',
+     'deprecated_hint'])):
   """A container for help information for a single option.
 
   registering_class: The type that registered the option.
-  display args: Arg strings suitable for display in help text, including value examples
+  display_args: Arg strings suitable for display in help text, including value examples
                 (e.g., [-f, --[no]-foo-bar, --baz=<metavar>].)
   scoped_cmd_line_args: The explicitly scoped raw flag names allowed anywhere on the cmd line,
                         (e.g., [--scope-baz, --no-scope-baz, --scope-qux])
   unscoped_cmd_line_args: The unscoped raw flag names allowed on the cmd line in this option's
                           scope context (e.g., [--baz, --no-baz, --qux])
-  type: The type of the option.
+  typ: The type of the option.
+  fromfile: `True` if the option supports @fromfile value loading.
   default: The value of this option if no flags are specified (derived from config and env vars).
   help: The help message registered for this option.
   deprecated_version: The version at which this option is to be removed, if any (None otherwise).
@@ -89,7 +91,7 @@ class HelpInfoExtracter(object):
       if typ == list_option or action == 'append':
         metavar = '"[\'str1\',\'str2\',...]"'
       elif typ == dict_option:
-        metavar = '"{ \'key1\': val1,\'key2\': val2,...}"'
+        metavar = '"{\'key1\':val1,\'key2\':val2,...}"'
       else:
         metavar = '<{}>'.format(typ.__name__)
     return metavar
@@ -160,7 +162,8 @@ class HelpInfoExtracter(object):
                          display_args=display_args,
                          scoped_cmd_line_args=scoped_cmd_line_args,
                          unscoped_cmd_line_args=unscoped_cmd_line_args,
-                         type=typ,
+                         typ=typ,
+                         fromfile=kwargs.get('fromfile', False),
                          default=default,
                          help=help_msg,
                          deprecated_version=deprecated_version,

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -375,7 +375,7 @@ class Parser(object):
           break
 
     def expand(val_str):
-      if is_fromfile and val_str and val_str.startswith('@'):
+      if is_fromfile and val_str and val_str.startswith('@') and not val_str.startswith('@@'):
         fromfile = val_str[1:]
         try:
           with open(fromfile) as fp:
@@ -383,7 +383,8 @@ class Parser(object):
         except IOError as e:
           raise self.FromfileError('Failed to read {} from file {}: {}'.format(dest, fromfile, e))
       else:
-        return val_str
+        # Support a literal @ for fromfile values via @@.
+        return val_str[1:] if is_fromfile and val_str.startswith('@@') else val_str
 
     if is_fromfile:
       kwargs['type'] = lambda flag_val_str: value_type(expand(flag_val_str))  # Expand flag values.

--- a/tests/python/pants_test/option/test_help_formatter.py
+++ b/tests/python/pants_test/option/test_help_formatter.py
@@ -12,17 +12,25 @@ from pants.help.help_info_extracter import OptionHelpInfo
 
 
 class OptionHelpFormatterTest(unittest.TestCase):
-  def test_format_help(self):
+  def format_help_for_foo(self, **kwargs):
     ohi = OptionHelpInfo(registering_class=type(None), display_args=['--foo'],
                          scoped_cmd_line_args=['--foo'], unscoped_cmd_line_args=['--foo'],
-                         type=bool, default='MYDEFAULT', help='help for foo',
+                         typ=bool, fromfile=False, default=None, help='help for foo',
                          deprecated_version=None, deprecated_message=None, deprecated_hint=None)
-
+    ohi = ohi._replace(**kwargs)
     lines = HelpFormatter(scope='', show_recursive=False, show_advanced=False,
                           color=False).format_option(ohi)
     self.assertEquals(len(lines), 2)
-    self.assertEquals('--foo (default: MYDEFAULT)', lines[0])
     self.assertIn('help for foo', lines[1])
+    return lines[0]
+
+  def test_format_help(self):
+    line = self.format_help_for_foo(default='MYDEFAULT')
+    self.assertEquals('--foo (default: MYDEFAULT)', line)
+
+  def test_format_help_fromfile(self):
+    line = self.format_help_for_foo(fromfile=True)
+    self.assertEquals('--foo (@fromfile value supported) (default: None)', line)
 
   def test_suppress_advanced(self):
     args = ['--foo']

--- a/tests/python/pants_test/option/test_help_info_extracter.py
+++ b/tests/python/pants_test/option/test_help_info_extracter.py
@@ -33,7 +33,7 @@ class HelpInfoExtracterTest(unittest.TestCase):
     do_test(['--foo'], {'metavar': 'xx'}, ['--foo=xx'], ['--foo'])
     do_test(['--foo'], {'type': int}, ['--foo=<int>'], ['--foo'])
     do_test(['--foo'], {'type': list_option}, ['--foo="[\'str1\',\'str2\',...]"'], ['--foo'])
-    do_test(['--foo'], {'type': dict_option}, ['--foo="{ \'key1\': val1,\'key2\': val2,...}"'],
+    do_test(['--foo'], {'type': dict_option}, ['--foo="{\'key1\':val1,\'key2\':val2,...}"'],
                                             ['--foo'])
     do_test(['--foo'], {'action': 'append'},
             ['--foo="[\'str1\',\'str2\',...]" (--foo="[\'str1\',\'str2\',...]") ...'], ['--foo'])
@@ -78,6 +78,18 @@ class HelpInfoExtracterTest(unittest.TestCase):
     self.assertEquals('999.99.9', ohi.deprecated_version)
     self.assertEquals('do not use this', ohi.deprecated_hint)
     self.assertIsNotNone(ohi.deprecated_message)
+
+  def test_fromfile(self):
+    ohi = HelpInfoExtracter('').get_option_help_info([], {})
+    self.assertFalse(ohi.fromfile)
+
+    kwargs = {'fromfile': False}
+    ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
+    self.assertFalse(ohi.fromfile)
+
+    kwargs = {'fromfile': True}
+    ohi = HelpInfoExtracter('').get_option_help_info([], kwargs)
+    self.assertTrue(ohi.fromfile)
 
   def test_grouping(self):
     def do_test(kwargs, expected_basic=False, expected_recursive=False, expected_advanced=False):

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -679,3 +679,7 @@ class OptionsTest(unittest.TestCase):
     options = self._parse('./pants fromfile --string=@/does/not/exist')
     with self.assertRaises(Parser.FromfileError):
       options.for_scope('fromfile')
+
+  def test_fromfile_escape(self):
+    options = self._parse(r'./pants fromfile --string=@@/does/not/exist')
+    self.assertEqual('@/does/not/exist', options.for_scope('fromfile').string)


### PR DESCRIPTION
Options can now be registered as supporting fromfiles by passing
`fromfile=True`.  When so registered, if the option value starts with
the '@' character, the rest of the value is interpreted as a file path
and the option value is read from that file.

This will open up support for large configuration values being stored
outside of `pants.ini` and in dedicated configuration files on disk. This
facility will make most sense for large string messages, long lists, and
big dictionaries.