### PR TITLE
Move BuildFileAliases validation to BuildFileAliases.

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/register.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/register.py
@@ -17,7 +17,7 @@ from pants.contrib.cpp.tasks.cpp_run import CppRun
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       'cpp_library': CppLibrary,
       'cpp_binary': CppBinary,

--- a/contrib/go/src/python/pants/contrib/go/register.py
+++ b/contrib/go/src/python/pants/contrib/go/register.py
@@ -20,7 +20,7 @@ from pants.contrib.go.tasks.go_test import GoTest
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       GoBinary.alias(): TargetMacro.Factory.wrap(GoBinary.create, GoBinary),
       GoLibrary.alias(): TargetMacro.Factory.wrap(GoLibrary.create, GoLibrary),

--- a/contrib/node/src/python/pants/contrib/node/register.py
+++ b/contrib/node/src/python/pants/contrib/node/register.py
@@ -15,7 +15,7 @@ from pants.contrib.node.tasks.npm_resolve import NpmResolve
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       'node_module': NodeModule,
       'node_remote_module': NodeRemoteModule,

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -32,7 +32,7 @@ class ScroogeGenTest(TaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'java_thrift_library': JavaThriftLibrary})
+    return BuildFileAliases(targets={'java_thrift_library': JavaThriftLibrary})
 
   def setUp(self):
     super(ScroogeGenTest, self).setUp()

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -21,7 +21,7 @@ class ThriftLinterTest(TaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'java_thrift_library': JavaThriftLibrary,
       },

--- a/contrib/spindle/src/python/pants/contrib/spindle/register.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/register.py
@@ -13,7 +13,7 @@ from pants.contrib.spindle.tasks.spindle_gen import SpindleGen
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       'spindle_thrift_library': SpindleThriftLibrary,
     }

--- a/contrib/spindle/tests/python/pants_test/contrib/spindle/tasks/test_spindle_gen.py
+++ b/contrib/spindle/tests/python/pants_test/contrib/spindle/tasks/test_spindle_gen.py
@@ -24,7 +24,7 @@ class SpindleGenTest(JvmToolTaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'spindle_thrift_library': SpindleThriftLibrary,
         'jar_library': JarLibrary,

--- a/examples/src/java/org/pantsbuild/example/page.md
+++ b/examples/src/java/org/pantsbuild/example/page.md
@@ -179,7 +179,7 @@ have one. In the plugin, define a `Wiki` and register it:
 
     # in register.py:
     def build_file_aliases():
-      return BuildFileAliases.create(
+      return BuildFileAliases(
         # ...
         objects={
           # ...

--- a/pants-plugins/src/python/internal_backend/repositories/register.py
+++ b/pants-plugins/src/python/internal_backend/repositories/register.py
@@ -54,7 +54,7 @@ manual.builddict(suppress=True)(testing_repo)
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     objects={
       'public': public_repo,  # key 'public' must match name='public' above
       'testing': testing_repo,

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -159,7 +159,7 @@ class ContribPlugin(PantsPlugin):
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     objects={
       'pants_setup_py': pants_setup_py,
       'contrib_setup_py': contrib_setup_py

--- a/src/python/pants/backend/android/register.py
+++ b/src/python/pants/backend/android/register.py
@@ -20,7 +20,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       'android_binary': AndroidBinary,
       'android_dependency': AndroidDependency,

--- a/src/python/pants/backend/authentication/register.py
+++ b/src/python/pants/backend/authentication/register.py
@@ -10,7 +10,7 @@ from pants.base.build_file_aliases import BuildFileAliases
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     objects={
       'netrc': Netrc,
     },

--- a/src/python/pants/backend/codegen/register.py
+++ b/src/python/pants/backend/codegen/register.py
@@ -24,7 +24,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       'java_antlr_library': JavaAntlrLibrary,
       'java_protobuf_library': JavaProtobufLibrary,

--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -53,7 +53,7 @@ class BuildFilePath(object):
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       # NB: the 'dependencies' alias is deprecated in favor of the 'target' alias
       'dependencies': DeprecatedDependencies,

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -148,12 +148,11 @@ python_library(
   name = 'filter',
   sources = ['filter.py'],
   dependencies = [
-    ':common',
     ':console_task',
-    'src/python/pants/base:address',
+    'src/python/pants/base:address_lookup_error',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:cmd_line_spec_parser',
-    'src/python/pants/base:target',
+    'src/python/pants/base:exceptions',
     'src/python/pants/util:filtering',
   ],
 )

--- a/src/python/pants/backend/core/tasks/dependees.py
+++ b/src/python/pants/backend/core/tasks/dependees.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 from collections import defaultdict
+from textwrap import dedent
 
 from twitter.common.collections import OrderedSet
 
@@ -36,36 +37,49 @@ class ReverseDepmap(ConsoleTask):
 
     self._transitive = self.get_options().transitive
     self._closed = self.get_options().closed
-    self._dependees_type = self.get_options().type
+    self._dependees_types = self.get_options().type
     self._spec_excludes = self.get_options().spec_excludes
 
   def console_output(self, _):
     buildfiles = OrderedSet()
     address_mapper = self.context.address_mapper
-    if self._dependees_type:
+    if self._dependees_types:
       base_paths = OrderedSet()
-      for dependees_type in self._dependees_type:
-        target_aliases = self.context.build_file_parser.registered_aliases().targets
-        if dependees_type not in target_aliases:
-          raise TaskError('Invalid type name: {}'.format(dependees_type))
-        target_type = target_aliases[dependees_type]
-        # Try to find the SourceRoot for the given input type
-        try:
-          roots = SourceRoot.roots(target_type)
-          base_paths.update(roots)
-        except KeyError:
-          pass
+      for dependees_type in self._dependees_types:
+        registered_aliases = self.context.build_file_parser.registered_aliases()
+        target_types = registered_aliases.aliased_target_types(dependees_type)
+        if not target_types:
+          raise TaskError('No Targets with type name: {}'.format(dependees_type))
+        # Try to find the SourceRoots for the given input type alias
+        for target_type in target_types:
+          try:
+            roots = SourceRoot.roots(target_type)
+            base_paths.update(roots)
+          except KeyError:
+            pass
 
+      # TODO(John Sirois): BUG: This should not cause a failure, it should just force a slower full
+      # scan.
+      # TODO(John Sirois): BUG: The --type argument only limited the scn bases, it does no limit the
+      # types of targets found under those bases, ie: we may have just limited our scan to roots
+      # containing java_library, but those same roots likely also contain jvm_binary targets that
+      # we do not wish to have in the results.  So the --type filtering needs to apply to the final
+      # dependees_by_target map as well below.
       if not base_paths:
-        raise TaskError('No SourceRoot set for any target type in {}.'.format(self._dependees_type) +
-                        '\nPlease define a source root in BUILD file as:' +
-                        '\n\tsource_root(\'<src-folder>\', {})'.format(', '.join(self._dependees_type)))
+        raise TaskError(dedent("""\
+                        No SourceRoot set for any of these target types: {}.
+                        Please define a source root in BUILD file as:
+                          source_root('<src-folder>', {})
+                        """.format(' '.join(self._dependees_types),
+                                   ', '.join(self._dependees_types))).strip())
       for base_path in base_paths:
-        buildfiles.update(address_mapper.scan_buildfiles(get_buildroot(),
-                                                    os.path.join(get_buildroot(), base_path),
-                                                    spec_excludes=self._spec_excludes))
+        scanned = address_mapper.scan_buildfiles(get_buildroot(),
+                                                 os.path.join(get_buildroot(), base_path),
+                                                 spec_excludes=self._spec_excludes)
+        buildfiles.update(scanned)
     else:
-      buildfiles = address_mapper.scan_buildfiles(get_buildroot(), spec_excludes=self._spec_excludes)
+      buildfiles = address_mapper.scan_buildfiles(get_buildroot(),
+                                                  spec_excludes=self._spec_excludes)
 
     build_graph = self.context.build_graph
     build_file_parser = self.context.build_file_parser

--- a/src/python/pants/backend/core/tasks/dependees.py
+++ b/src/python/pants/backend/core/tasks/dependees.py
@@ -44,10 +44,10 @@ class ReverseDepmap(ConsoleTask):
     buildfiles = OrderedSet()
     address_mapper = self.context.address_mapper
     if self._dependees_types:
+      registered_aliases = self.context.build_file_parser.registered_aliases()
       base_paths = OrderedSet()
       for dependees_type in self._dependees_types:
-        registered_aliases = self.context.build_file_parser.registered_aliases()
-        target_types = registered_aliases.aliased_target_types(dependees_type)
+        target_types = registered_aliases.target_types_by_alias.get(dependees_type, None)
         if not target_types:
           raise TaskError('No Targets with type name: {}'.format(dependees_type))
         # Try to find the SourceRoots for the given input type alias

--- a/src/python/pants/backend/core/tasks/filter.py
+++ b/src/python/pants/backend/core/tasks/filter.py
@@ -12,7 +12,6 @@ from pants.base.address_lookup_error import AddressLookupError
 from pants.base.build_environment import get_buildroot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exceptions import TaskError
-from pants.base.target import Target
 from pants.util.filtering import create_filters, wrap_filters
 
 
@@ -70,22 +69,11 @@ class Filter(ConsoleTask):
     self._filters.extend(create_filters(self.get_options().target, filter_for_address))
 
     def filter_for_type(name):
-      # FIXME(pl): This should be a standard function provided by the plugin/BuildFileParser
-      # machinery
-      try:
-        # Try to do a fully qualified import 1st for filtering on custom types.
-        from_list, module, type_name = name.rsplit('.', 2)
-        module = __import__('{}.{}'.format(from_list, module), fromlist=[from_list])
-        target_type = getattr(module, type_name)
-      except (ImportError, ValueError):
-        # Fall back on pants provided target types.
-        registered_aliases = self.context.build_file_parser.registered_aliases()
-        if name not in registered_aliases.targets:
-          raise TaskError('Invalid type name: {}'.format(name))
-        target_type = registered_aliases.targets[name]
-      if not issubclass(target_type, Target):
-        raise TaskError('Not a Target type: {}'.format(name))
-      return lambda target: isinstance(target, target_type)
+      registered_aliases = self.context.build_file_parser.registered_aliases()
+      target_types = registered_aliases.aliased_target_types(name)
+      if not target_types:
+        raise TaskError('No Targets with type name: {}'.format(name))
+      return lambda target: isinstance(target, tuple(target_types))
     self._filters.extend(create_filters(self.get_options().type, filter_for_type))
 
     def filter_for_ancestor(spec):

--- a/src/python/pants/backend/core/tasks/filter.py
+++ b/src/python/pants/backend/core/tasks/filter.py
@@ -70,7 +70,7 @@ class Filter(ConsoleTask):
 
     def filter_for_type(name):
       registered_aliases = self.context.build_file_parser.registered_aliases()
-      target_types = registered_aliases.aliased_target_types(name)
+      target_types = registered_aliases.target_types_by_alias.get(name, None)
       if not target_types:
         raise TaskError('No Targets with type name: {}'.format(name))
       return lambda target: isinstance(target, tuple(target_types))

--- a/src/python/pants/backend/core/tasks/reflect.py
+++ b/src/python/pants/backend/core/tasks/reflect.py
@@ -420,7 +420,14 @@ def get_syms(build_file_parser):
         syms[sym] = item
 
   aliases = build_file_parser.registered_aliases()
-  map_symbols(aliases.targets)
+  map_symbols(aliases.target_types)
+
+  # TODO(John Sirois): Handle mapping the `Macro.expand` arguments - these are the real arguments
+  # to document and may be different than the set gathered from walking the Target hierarchy.
+  for alias, target_macro_factory in aliases.target_macro_factories.items():
+    for target_type in target_macro_factory.target_types:
+      map_symbols({alias: target_type})
+
   map_symbols(aliases.objects)
   map_symbols(aliases.context_aware_object_factories)
   return syms

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -56,7 +56,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       'annotation_processor': AnnotationProcessor,
       'benchmark': Benchmark,

--- a/src/python/pants/backend/maven_layout/register.py
+++ b/src/python/pants/backend/maven_layout/register.py
@@ -10,7 +10,7 @@ from pants.base.build_file_aliases import BuildFileAliases
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     context_aware_object_factories={
       'maven_layout': BuildFileAliases.curry_context(maven_layout)
     }

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -68,17 +68,21 @@ python_library(
   name = 'export',
   sources = ['export.py'],
   dependencies = [
-    ':projectutils',
-    '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:pex',
+    ':projectutils',
     'src/python/pants/backend/core/targets:all',
     'src/python/pants/backend/core/tasks:console_task',
+    'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm:ivy_utils',
+    'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
+    'src/python/pants/java/distribution',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -23,7 +23,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 
 def build_file_aliases():
-  return BuildFileAliases.create(
+  return BuildFileAliases(
     targets={
       'python_binary': PythonBinary,
       'python_library': PythonLibrary,

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -83,6 +83,9 @@ python_library(
   sources = ['build_file_aliases.py'],
   dependencies = [
     ':build_file_target_factory',
+    ':deprecated',
+    ':target',
+    'src/python/pants/util:memo',
   ]
 )
 

--- a/src/python/pants/base/build_file_aliases.py
+++ b/src/python/pants/base/build_file_aliases.py
@@ -300,8 +300,7 @@ class BuildFileAliases(object):
                             context_aware_object_factories=context_aware_object_factories)
 
   def _tuple(self):
-    def tuplize(map):
-      return tuple(sorted(map.items()))
+    tuplize = lambda d: tuple(sorted(d.items()))
     return (tuplize(self._target_types),
             tuplize(self._target_macro_factories),
             tuplize(self._objects),

--- a/src/python/pants/base/build_file_aliases.py
+++ b/src/python/pants/base/build_file_aliases.py
@@ -6,10 +6,16 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import functools
+import inspect
 from abc import abstractmethod
-from collections import namedtuple
+from collections import defaultdict
+
+import six
 
 from pants.base.build_file_target_factory import BuildFileTargetFactory
+from pants.base.deprecated import deprecated
+from pants.base.target import Target
+from pants.util.memo import memoized_property
 
 
 class TargetMacro(object):
@@ -87,10 +93,7 @@ class TargetMacro(object):
     """Expands the given BUILD file arguments in to one or more target addressable instances."""
 
 
-class BuildFileAliases(namedtuple('BuildFileAliases',
-                                  ['targets',
-                                   'objects',
-                                   'context_aware_object_factories'])):
+class BuildFileAliases(object):
   """A structure containing sets of symbols to be exposed in BUILD files.
 
   There are three types of symbols that can be directly exposed:
@@ -106,16 +109,16 @@ class BuildFileAliases(namedtuple('BuildFileAliases',
   """
 
   @classmethod
+  @deprecated(removal_version='0.0.50',
+              hint_message='Use the BuildFileAliases constructor instead.')
   def create(cls,
              targets=None,
              objects=None,
              context_aware_object_factories=None):
     """A convenience constructor that can accept zero to all alias types."""
-    def copy(orig):
-      return orig.copy() if orig else {}
-    return cls(targets=copy(targets),
-               objects=copy(objects),
-               context_aware_object_factories=copy(context_aware_object_factories))
+    return cls(targets=targets,
+               objects=objects,
+               context_aware_object_factories=context_aware_object_factories)
 
   @classmethod
   def curry_context(cls, wrappee):
@@ -137,6 +140,144 @@ class BuildFileAliases(namedtuple('BuildFileAliases',
                                      wrappee.__name__]))
     return wrapper
 
+  @staticmethod
+  def _is_target_type(obj):
+    return inspect.isclass(obj) and issubclass(obj, Target)
+
+  @staticmethod
+  def _is_target_macro_factory(obj):
+    return isinstance(obj, TargetMacro.Factory)
+
+  @classmethod
+  def _validate_alias(cls, category, alias, obj):
+    if not isinstance(alias, six.string_types):
+      raise TypeError('Aliases must be strings, given {category} entry {alias} of type {typ} as '
+                      'the alias of {obj}'
+                      .format(category=category, alias=alias, typ=type(alias).__name__, obj=obj))
+
+  @classmethod
+  def _validate_not_targets(cls, category, alias, obj):
+    if cls._is_target_type(obj):
+      raise TypeError('The {category} entry {alias!r} is a Target subclasss - these should be '
+                      'registered via the `targets` parameter'
+                      .format(category=category, alias=alias))
+    if cls._is_target_macro_factory(obj):
+      raise TypeError('The {category} entry {alias!r} is a TargetMacro.Factory instance - these '
+                      'should be registered via the `targets` parameter'
+                      .format(category=category, alias=alias))
+
+  @classmethod
+  def _validate_targets(cls, targets):
+    if not targets:
+      return {}, {}
+
+    target_types = {}
+    target_macro_factories = {}
+    for alias, obj in targets.items():
+      cls._validate_alias('targets', alias, obj)
+      if cls._is_target_type(obj):
+        target_types[alias] = obj
+      elif cls._is_target_macro_factory(obj):
+        target_macro_factories[alias] = obj
+      else:
+        raise TypeError('Only Target types and TargetMacro.Factory instances can be registered '
+                        'via the `targets` parameter, given item {alias!r} with value {value} of '
+                        'type {typ}'.format(alias=alias, value=obj, typ=type(obj).__name__))
+
+    return target_types, target_macro_factories
+
+  @classmethod
+  def _validate_objects(cls, objects):
+    if not objects:
+      return {}
+
+    for alias, obj in objects.items():
+      cls._validate_alias('objects', alias, obj)
+      cls._validate_not_targets('objects', alias, obj)
+    return objects.copy()
+
+  @classmethod
+  def _validate_context_aware_object_factories(cls, context_aware_object_factories):
+    if not context_aware_object_factories:
+      return {}
+
+    for alias, obj in context_aware_object_factories.items():
+      cls._validate_alias('context_aware_object_factories', alias, obj)
+      cls._validate_not_targets('context_aware_object_factories', alias, obj)
+      if not callable(obj):
+        raise TypeError('The given context aware object factory {alias!r} must be a callable.'
+                        .format(alias=alias))
+
+    return context_aware_object_factories.copy()
+
+  def __init__(self, targets=None, objects=None, context_aware_object_factories=None):
+    """
+    :param dict targets: A mapping from string aliases to Target subclasses or TargetMacro.Factory
+                         instances
+    :param dict objects: A mapping from string aliases to arbitrary objects.
+    :param dict context_aware_object_factories: A mapping from string aliases to context aware
+                                                object factory callables.
+    """
+    self._target_types, self._target_macro_factories = self._validate_targets(targets)
+    self._objects = self._validate_objects(objects)
+    self._context_aware_object_factories = self._validate_context_aware_object_factories(
+      context_aware_object_factories)
+
+  @property
+  def target_types(self):
+    """Returns a mapping from string aliases to Target subclasses.
+
+    :rtype: dict
+    """
+    return self._target_types
+
+  @property
+  def target_macro_factories(self):
+    """Returns a mapping from string aliases to TargetMacro.Factory instances.
+
+    :rtype: dict
+    """
+    return self._target_macro_factories
+
+  @property
+  def objects(self):
+    """Returns a mapping from string aliases arbitrary objects.
+
+    :rtype: dict
+    """
+    return self._objects
+
+  @property
+  def context_aware_object_factories(self):
+    """Returns a mapping from string aliases to context aware object factory callables.
+
+    :rtype: dict
+    """
+    return self._context_aware_object_factories
+
+  def aliased_target_types(self, alias):
+    """Returns all the target types that can be produced from the given alias.
+
+    :rtype: set
+    """
+    return self.target_types_by_alias.get(alias, set())
+
+  @memoized_property
+  def target_types_by_alias(self):
+    """Returns a mapping from target alias to the target types produced for that alias.
+
+    Normally there is 1 target type per alias, but macros can expand a single alias o several
+    target types.
+
+    :rtype: dict
+    """
+    target_types_by_alias = defaultdict(set)
+    for alias, target_type in self.target_types.items():
+      target_types_by_alias[alias].add(target_type)
+    for alias, target_macro_factory in self.target_macro_factories.items():
+      target_types_by_alias[alias].update(target_macro_factory.target_types)
+    return dict(target_types_by_alias)
+
   def merge(self, other):
     """Merges a set of build file aliases and returns a new set of aliases containing both.
 
@@ -149,8 +290,35 @@ class BuildFileAliases(namedtuple('BuildFileAliases',
     """
     if not isinstance(other, BuildFileAliases):
       raise TypeError('Can only merge other BuildFileAliases, given {0}'.format(other))
-    all_aliases = self._asdict()
-    other_aliases = other._asdict()
-    for alias_type, alias_map in all_aliases.items():
-      alias_map.update(other_aliases[alias_type])
-    return BuildFileAliases(**all_aliases)
+
+    def merge(*items):
+      merged = {}
+      for item in items:
+        merged.update(item)
+      return merged
+
+    targets = merge(self.target_types, self.target_macro_factories,
+                    other.target_types, other.target_macro_factories)
+    objects = merge(self.objects, other.objects)
+    context_aware_object_factories=merge(self.context_aware_object_factories,
+                                         other.context_aware_object_factories)
+    return BuildFileAliases(targets=targets,
+                            objects=objects,
+                            context_aware_object_factories=context_aware_object_factories)
+
+  def _tuple(self):
+    def tuplize(map):
+      return tuple(map.items())
+    return (tuplize(self._target_types),
+            tuplize(self._target_macro_factories),
+            tuplize(self._objects),
+            tuplize(self._context_aware_object_factories))
+
+  def __eq__(self, other):
+    return isinstance(other, BuildFileAliases) and self._tuple() == other._tuple()
+
+  def __ne__(self, other):
+    return not self == other
+
+  def __hash__(self):
+    return hash(self._tuple())

--- a/src/python/pants/base/build_file_aliases.py
+++ b/src/python/pants/base/build_file_aliases.py
@@ -255,13 +255,6 @@ class BuildFileAliases(object):
     """
     return self._context_aware_object_factories
 
-  def aliased_target_types(self, alias):
-    """Returns all the target types that can be produced from the given alias.
-
-    :rtype: set
-    """
-    return self.target_types_by_alias.get(alias, set())
-
   @memoized_property
   def target_types_by_alias(self):
     """Returns a mapping from target alias to the target types produced for that alias.
@@ -308,7 +301,7 @@ class BuildFileAliases(object):
 
   def _tuple(self):
     def tuplize(map):
-      return tuple(map.items())
+      return tuple(sorted(map.items()))
     return (tuplize(self._target_types),
             tuplize(self._target_macro_factories),
             tuplize(self._objects),

--- a/src/python/pants/docs/howto_plugin.md
+++ b/src/python/pants/docs/howto_plugin.md
@@ -80,7 +80,7 @@ exposed in build files, targets, tasks and goals:
         from ext_maven_layout.ext_maven_layout import ext_maven_layout
 
         def build_file_aliases():
-         return BuildFileAliases.create(
+         return BuildFileAliases(
            context_aware_object_factories={
             'ext_maven_layout': BuildFileAliases.curry_context(ext_maven_layout)
            }

--- a/tests/python/pants_test/android/tasks/test_unpack_libraries.py
+++ b/tests/python/pants_test/android/tasks/test_unpack_libraries.py
@@ -39,7 +39,7 @@ class UnpackLibrariesTest(TestAndroidBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'android_dependency': AndroidDependency,
         'android_library': AndroidLibrary,

--- a/tests/python/pants_test/backend/codegen/targets/test_java_antlr_library.py
+++ b/tests/python/pants_test/backend/codegen/targets/test_java_antlr_library.py
@@ -16,7 +16,7 @@ class JavaAntlrLibraryTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'java_antlr_library': JavaAntlrLibrary})
+    return BuildFileAliases(targets={'java_antlr_library': JavaAntlrLibrary})
 
   def test_empty(self):
     with self.assertRaisesRegexp(ValueError, "Missing required 'sources' parameter"):

--- a/tests/python/pants_test/backend/codegen/targets/test_java_protobuf_library.py
+++ b/tests/python/pants_test/backend/codegen/targets/test_java_protobuf_library.py
@@ -18,9 +18,9 @@ class JavaProtobufLibraryTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'java_protobuf_library': JavaProtobufLibrary,
-                                            'jar_library': JarLibrary},
-                                   objects={'jar': JarDependency})
+    return BuildFileAliases(targets={'java_protobuf_library': JavaProtobufLibrary,
+                                     'jar_library': JarLibrary},
+                            objects={'jar': JarDependency})
 
   def test_empty(self):
     self.add_to_build_file('BUILD', dedent('''

--- a/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_antlr_gen.py
@@ -29,7 +29,7 @@ class AntlrGenTest(NailgunTaskTestBase):
 
   @property
   def alias_groups(self):
-    return super(AntlrGenTest, self).alias_groups.merge(BuildFileAliases.create(
+    return super(AntlrGenTest, self).alias_groups.merge(BuildFileAliases(
       targets={
         'java_antlr_library': JavaAntlrLibrary,
       },

--- a/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_simple_codegen_task.py
@@ -26,7 +26,7 @@ class SimpleCodegenTaskTest(TaskTestBase):
 
   @property
   def alias_groups(self):
-    return register_core().merge(register_codegen()).merge(BuildFileAliases.create({
+    return register_core().merge(register_codegen()).merge(BuildFileAliases({
       'dummy_library': SimpleCodegenTaskTest.DummyLibrary
     }))
 

--- a/tests/python/pants_test/backend/core/test_prep.py
+++ b/tests/python/pants_test/backend/core/test_prep.py
@@ -25,7 +25,7 @@ class PrepTest(TaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'prep_command': PrepCommand,
       },

--- a/tests/python/pants_test/backend/core/test_wrapped_globs.py
+++ b/tests/python/pants_test/backend/core/test_wrapped_globs.py
@@ -18,7 +18,7 @@ class FilesetRelPathWrapperTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'java_library': JavaLibrary,
       },

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_library.py
@@ -24,8 +24,8 @@ class JarLibraryTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'jar_library': JarLibrary},
-                                   objects={'jar': JarDependency})
+    return BuildFileAliases(targets={'jar_library': JarLibrary},
+                            objects={'jar': JarDependency})
 
   def test_validation(self):
     target = Target(name='mybird', address=Address.parse('//:mybird'),

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_imports.py
@@ -28,7 +28,7 @@ class IvyImportsTest(NailgunTaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'unpacked_jars': UnpackedJars,
         'jar_library': JarLibrary,

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -34,7 +34,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
 
   @property
   def alias_groups(self):
-    return super(JUnitRunnerTest, self).alias_groups.merge(BuildFileAliases.create(
+    return super(JUnitRunnerTest, self).alias_groups.merge(BuildFileAliases(
       targets={
         'java_tests': JavaTests,
         'python_tests': PythonTests,

--- a/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_unpack_jars.py
@@ -30,7 +30,7 @@ class UnpackJarsTest(TaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'unpacked_jars': UnpackedJars,
         'jar_library': JarLibrary,

--- a/tests/python/pants_test/backend/python/tasks/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_repl.py
@@ -35,7 +35,7 @@ class PythonReplTest(PythonTaskTestBase):
   @property
   def alias_groups(self):
     return super(PythonReplTest, self).alias_groups.merge(
-        BuildFileAliases.create(targets={'jvm_target': self.JvmTarget}))
+        BuildFileAliases(targets={'jvm_target': self.JvmTarget}))
 
   def create_non_python_target(self, relpath, name):
     self.create_file(relpath=self.build_path(relpath), contents=dedent("""

--- a/tests/python/pants_test/backend/python/test_python_requirement_list.py
+++ b/tests/python/pants_test/backend/python/test_python_requirement_list.py
@@ -16,7 +16,7 @@ from pants_test.base_test import BaseTest
 class PythonRequirementListTest(BaseTest):
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
         targets={
             'python_requirement_library': PythonRequirementLibrary,
         },

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -75,11 +75,9 @@ python_tests(
   name = 'build_configuration',
   sources = ['test_build_configuration.py'],
   dependencies = [
-    'src/python/pants/base:address',
     'src/python/pants/base:build_configuration',
     'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_aliases',
-    'src/python/pants/base:build_graph',
     'src/python/pants/base:target',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
@@ -164,7 +162,9 @@ python_tests(
   name = 'build_file_aliases',
   sources = ['test_build_file_aliases.py'],
   dependencies = [
+    'src/python/pants/base:address',
     'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:build_graph',
     'src/python/pants/base:target',
   ]
 )

--- a/tests/python/pants_test/base/test_build_configuration.py
+++ b/tests/python/pants_test/base/test_build_configuration.py
@@ -9,10 +9,9 @@ import os
 import unittest
 from contextlib import contextmanager
 
-from pants.base.address import Address
 from pants.base.build_configuration import BuildConfiguration
 from pants.base.build_file import FilesystemBuildFile
-from pants.base.build_graph import BuildGraph
+from pants.base.build_file_aliases import BuildFileAliases, TargetMacro
 from pants.base.target import Target
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import touch
@@ -22,15 +21,23 @@ class BuildConfigurationTest(unittest.TestCase):
   def setUp(self):
     self.build_configuration = BuildConfiguration()
 
+  def _register_aliases(self, **kwargs):
+    self.build_configuration.register_aliases(BuildFileAliases(**kwargs))
+
+  def test_register_bad(self):
+    with self.assertRaises(TypeError):
+      self.build_configuration.register_aliases(42)
+
   def test_register_target_alias(self):
     class Fred(Target):
       pass
 
-    self.build_configuration._register_target_alias('fred', Fred)
+    self._register_aliases(targets={'fred': Fred})
     aliases = self.build_configuration.registered_aliases()
+    self.assertEqual({}, aliases.target_macro_factories)
     self.assertEqual({}, aliases.objects)
     self.assertEqual({}, aliases.context_aware_object_factories)
-    self.assertEqual(dict(fred=Fred), aliases.targets)
+    self.assertEqual(dict(fred=Fred), aliases.target_types)
 
     build_file = FilesystemBuildFile('/tmp', 'fred', must_exist=False)
     parse_state = self.build_configuration.initialize_parse_state(build_file)
@@ -45,19 +52,54 @@ class BuildConfigurationTest(unittest.TestCase):
     self.assertEqual('jake', target_proxy.addressed_name)
     self.assertEqual(Fred, target_proxy.addressed_type)
 
-  def test_register_bad_target_alias(self):
-    with self.assertRaises(TypeError):
-      self.build_configuration._register_target_alias('fred', object())
+  def test_register_target_macro_facory(self):
+    class Fred(Target):
+      pass
 
-    target = Target('fred', Address.parse('a:b'), BuildGraph(address_mapper=None))
-    with self.assertRaises(TypeError):
-      self.build_configuration._register_target_alias('fred', target)
+    class FredMacro(TargetMacro):
+      def __init__(self, parse_context):
+        self._parse_context = parse_context
+
+      def expand(self, *args, **kwargs):
+        return self._parse_context.create_object(Fred, name='frog', dependencies=[kwargs['name']])
+
+    class FredFactory(TargetMacro.Factory):
+      @property
+      def target_types(self):
+        return {Fred}
+
+      def macro(self, parse_context):
+        return FredMacro(parse_context)
+
+    factory = FredFactory()
+
+    self._register_aliases(targets={'fred': factory})
+    aliases = self.build_configuration.registered_aliases()
+    self.assertEqual({}, aliases.target_types)
+    self.assertEqual({}, aliases.objects)
+    self.assertEqual({}, aliases.context_aware_object_factories)
+    self.assertEqual(dict(fred=factory), aliases.target_macro_factories)
+
+    build_file = FilesystemBuildFile('/tmp', 'fred', must_exist=False)
+    parse_state = self.build_configuration.initialize_parse_state(build_file)
+
+    self.assertEqual(0, len(parse_state.registered_addressable_instances))
+    self.assertEqual(1, len(parse_state.parse_globals))
+
+    target_call_proxy = parse_state.parse_globals['fred']
+    target_call_proxy(name='jake')
+    self.assertEqual(1, len(parse_state.registered_addressable_instances))
+    name, target_proxy = parse_state.registered_addressable_instances.pop()
+    self.assertEqual('frog', target_proxy.addressed_name)
+    self.assertEqual(Fred, target_proxy.addressed_type)
+    self.assertEqual(['jake'], target_proxy.dependency_specs)
 
   def test_register_exposed_object(self):
-    self.build_configuration._register_exposed_object('jane', 42)
+    self._register_aliases(objects={'jane': 42})
 
     aliases = self.build_configuration.registered_aliases()
-    self.assertEqual({}, aliases.targets)
+    self.assertEqual({}, aliases.target_types)
+    self.assertEqual({}, aliases.target_macro_factories)
     self.assertEqual({}, aliases.context_aware_object_factories)
     self.assertEqual(dict(jane=42), aliases.objects)
 
@@ -67,10 +109,6 @@ class BuildConfigurationTest(unittest.TestCase):
     self.assertEqual(0, len(parse_state.registered_addressable_instances))
     self.assertEqual(1, len(parse_state.parse_globals))
     self.assertEqual(42, parse_state.parse_globals['jane'])
-
-  def test_register_bad_exposed_object(self):
-    with self.assertRaises(TypeError):
-      self.build_configuration._register_exposed_object('jane', Target)
 
   def test_register_exposed_context_aware_function(self):
     self.do_test_exposed_context_aware_function(lambda context: lambda: context.rel_path)
@@ -113,11 +151,11 @@ class BuildConfigurationTest(unittest.TestCase):
 
   @contextmanager
   def do_test_exposed_context_aware_object(self, context_aware_object_factory):
-    self.build_configuration._register_exposed_context_aware_object_factory(
-        'george', context_aware_object_factory)
+    self._register_aliases(context_aware_object_factories={'george': context_aware_object_factory})
 
     aliases = self.build_configuration.registered_aliases()
-    self.assertEqual({}, aliases.targets)
+    self.assertEqual({}, aliases.target_types)
+    self.assertEqual({}, aliases.target_macro_factories)
     self.assertEqual({}, aliases.objects)
     self.assertEqual(dict(george=context_aware_object_factory),
                      aliases.context_aware_object_factories)
@@ -131,7 +169,3 @@ class BuildConfigurationTest(unittest.TestCase):
       self.assertEqual(0, len(parse_state.registered_addressable_instances))
       self.assertEqual(1, len(parse_state.parse_globals))
       yield parse_state.parse_globals['george']
-
-  def test_register_bad_exposed_context_aware_object(self):
-    with self.assertRaises(TypeError):
-      self.build_configuration._register_exposed_context_aware_object_factory('george', 1)

--- a/tests/python/pants_test/base/test_build_file_aliases.py
+++ b/tests/python/pants_test/base/test_build_file_aliases.py
@@ -8,63 +8,67 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import unittest
 
+from pants.base.address import Address
 from pants.base.build_file_aliases import BuildFileAliases, TargetMacro
+from pants.base.build_graph import BuildGraph
 from pants.base.target import Target
 
 
 class BuildFileAliasesTest(unittest.TestCase):
+
+  target_macro_factory = TargetMacro.Factory.wrap(
+    lambda ctx: ctx.create_object(Target,
+                                  type_alias='jill',
+                                  name=os.path.basename(ctx.rel_path)),
+    Target)
+
   def test_create(self):
     self.assertEqual(BuildFileAliases(targets={},
                                       objects={},
                                       context_aware_object_factories={}),
-                     BuildFileAliases.create())
+                     BuildFileAliases())
 
-    target_macro_factory = TargetMacro.Factory.wrap(
-      lambda ctx: ctx.create_object(Target,
-                                    type_alias='jill',
-                                    name=os.path.basename(ctx.rel_path)),
-      Target)
-    targets = {'jake': Target, 'jill': target_macro_factory}
+    targets = {'jake': Target, 'jill': self.target_macro_factory}
     self.assertEqual(BuildFileAliases(targets=targets,
                                       objects={},
                                       context_aware_object_factories={}),
-                     BuildFileAliases.create(targets=targets))
+                     BuildFileAliases(targets=targets))
 
     objects = {'jane': 42}
     self.assertEqual(BuildFileAliases(targets={},
                                       objects=objects,
                                       context_aware_object_factories={}),
-                     BuildFileAliases.create(objects=objects))
+                     BuildFileAliases(objects=objects))
 
     factories = {'jim': lambda ctx: 'bob'}
     self.assertEqual(BuildFileAliases(targets={},
                                       objects={},
                                       context_aware_object_factories=factories),
-                     BuildFileAliases.create(context_aware_object_factories=factories))
+                     BuildFileAliases(context_aware_object_factories=factories))
 
     self.assertEqual(BuildFileAliases(targets=targets,
                                       objects=objects,
                                       context_aware_object_factories={}),
-                     BuildFileAliases.create(targets=targets, objects=objects))
+                     BuildFileAliases(targets=targets, objects=objects))
 
     self.assertEqual(BuildFileAliases(targets=targets,
                                       objects={},
                                       context_aware_object_factories=factories),
-                     BuildFileAliases.create(targets=targets,
-                                             context_aware_object_factories=factories))
+                     BuildFileAliases(targets=targets,
+                                      context_aware_object_factories=factories))
 
     self.assertEqual(BuildFileAliases(targets={},
                                       objects=objects,
                                       context_aware_object_factories=factories),
-                     BuildFileAliases.create(objects=objects,
-                                             context_aware_object_factories=factories))
+                     BuildFileAliases(objects=objects,
+                                      context_aware_object_factories=factories))
 
     self.assertEqual(BuildFileAliases(targets=targets,
                                       objects=objects,
                                       context_aware_object_factories=factories),
-                     BuildFileAliases.create(targets=targets,
-                                             objects=objects,
-                                             context_aware_object_factories=factories))
+                     BuildFileAliases(targets=targets,
+                                      objects=objects,
+                                      context_aware_object_factories=factories))
 
   def test_curry_context(self):
     def curry_me(ctx, bob):
@@ -79,26 +83,40 @@ class BuildFileAliasesTest(unittest.TestCase):
                     'Unhelpful __name__: ' + curried.__name__)
     self.assertEqual((42, 'fred'), func('fred'))
 
+  def test_create_bad_targets(self):
+    with self.assertRaises(TypeError):
+      BuildFileAliases(targets={'fred': object()})
+
+    target = Target('fred', Address.parse('a:b'), BuildGraph(address_mapper=None))
+    with self.assertRaises(TypeError):
+      BuildFileAliases(targets={'fred': target})
+
+  def test_create_bad_objects(self):
+    with self.assertRaises(TypeError):
+      BuildFileAliases(objects={'jane': Target})
+
+    with self.assertRaises(TypeError):
+      BuildFileAliases(objects={'jane': self.target_macro_factory})
+
+  def test_bad_context_aware_object_factories(self):
+    with self.assertRaises(TypeError):
+      BuildFileAliases(context_aware_object_factories={'george': 1})
+
   def test_merge(self):
     e_factory = lambda ctx: 'e'
     f_factory = lambda ctx: 'f'
-    target_macro_factory = TargetMacro.Factory.wrap(
-      lambda ctx: ctx.create_object(Target,
-                                    type_alias='jill',
-                                    name=os.path.basename(ctx.rel_path)),
-      Target)
 
     first = BuildFileAliases(targets={'a': Target},
                              objects={'d': 2},
                              context_aware_object_factories={'e': e_factory})
 
-    second = BuildFileAliases(targets={'b': target_macro_factory},
+    second = BuildFileAliases(targets={'b': self.target_macro_factory},
                               objects={'c': 1, 'd': 42},
                               context_aware_object_factories={'f': f_factory})
 
     expected = BuildFileAliases(
         # nothing to merge
-        targets={'a': Target, 'b': target_macro_factory},
+        targets={'a': Target, 'b': self.target_macro_factory},
         # second overrides first
         objects={'c': 1, 'd': 42},
         # combine

--- a/tests/python/pants_test/base/test_build_file_parser.py
+++ b/tests/python/pants_test/base/test_build_file_parser.py
@@ -64,7 +64,7 @@ class BuildFileParserTargetTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'fake': ErrorTarget})
+    return BuildFileAliases(targets={'fake': ErrorTarget})
 
   def test_trivial_target(self):
     self.add_to_build_file('BUILD', 'fake(name="foozle")')
@@ -151,7 +151,7 @@ class BuildFileParserExposedObjectTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(objects={'fake_object': object()})
+    return BuildFileAliases(objects={'fake_object': object()})
 
   def test_exposed_object(self):
     self.add_to_build_file('BUILD', """fake_object""")
@@ -231,7 +231,7 @@ class BuildFileParserExposedContextAwareObjectFactoryTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'jar_library': self.JarLibrary,
         'java_library': self.JavaLibrary,

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -19,7 +19,7 @@ class CmdLineSpecParserTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'generic': Target
       }

--- a/tests/python/pants_test/base/test_extension_loader.py
+++ b/tests/python/pants_test/base/test_extension_loader.py
@@ -113,7 +113,8 @@ class LoaderTest(unittest.TestCase):
 
   def assert_empty_aliases(self):
     registered_aliases = self.build_configuration.registered_aliases()
-    self.assertEqual(0, len(registered_aliases.targets))
+    self.assertEqual(0, len(registered_aliases.target_types))
+    self.assertEqual(0, len(registered_aliases.target_macro_factories))
     self.assertEqual(0, len(registered_aliases.objects))
     self.assertEqual(0, len(registered_aliases.context_aware_object_factories))
     self.assertEqual(self.build_configuration.subsystems(), set())
@@ -124,13 +125,13 @@ class LoaderTest(unittest.TestCase):
       self.assert_empty_aliases()
 
   def test_load_valid_partial_aliases(self):
-    aliases = BuildFileAliases.create(targets={'bob': DummyTarget},
-                                      objects={'obj1': DummyObject1,
-                                               'obj2': DummyObject2})
+    aliases = BuildFileAliases(targets={'bob': DummyTarget},
+                               objects={'obj1': DummyObject1,
+                                        'obj2': DummyObject2})
     with self.create_register(build_file_aliases=lambda: aliases) as backend_package:
       load_backend(self.build_configuration, backend_package)
       registered_aliases = self.build_configuration.registered_aliases()
-      self.assertEqual(DummyTarget, registered_aliases.targets['bob'])
+      self.assertEqual(DummyTarget, registered_aliases.target_types['bob'])
       self.assertEqual(DummyObject1, registered_aliases.objects['obj1'])
       self.assertEqual(DummyObject2, registered_aliases.objects['obj2'])
       self.assertEqual(self.build_configuration.subsystems(), {DummySubsystem1, DummySubsystem2})
@@ -155,7 +156,7 @@ class LoaderTest(unittest.TestCase):
 
   def test_load_invalid_entrypoint(self):
     def build_file_aliases(bad_arg):
-      return BuildFileAliases.create()
+      return BuildFileAliases()
 
     with self.create_register(build_file_aliases=build_file_aliases) as backend_package:
       with self.assertRaises(BuildConfigurationError):
@@ -258,9 +259,9 @@ class LoaderTest(unittest.TestCase):
 
   def test_plugin_installs_alias(self):
     def reg_alias():
-      return BuildFileAliases.create(targets={'pluginalias': DummyTarget},
-                                     objects={'FROMPLUGIN1': DummyObject1,
-                                              'FROMPLUGIN2': DummyObject2})
+      return BuildFileAliases(targets={'pluginalias': DummyTarget},
+                              objects={'FROMPLUGIN1': DummyObject1,
+                                       'FROMPLUGIN2': DummyObject2})
     self.working_set.add(self.get_mock_plugin('aliasdemo', '0.0.1', alias=reg_alias))
 
     # Start with no aliases.
@@ -271,7 +272,7 @@ class LoaderTest(unittest.TestCase):
 
     # Aliases now exist.
     registered_aliases = self.build_configuration.registered_aliases()
-    self.assertEqual(DummyTarget, registered_aliases.targets['pluginalias'])
+    self.assertEqual(DummyTarget, registered_aliases.target_types['pluginalias'])
     self.assertEqual(DummyObject1, registered_aliases.objects['FROMPLUGIN1'])
     self.assertEqual(DummyObject2, registered_aliases.objects['FROMPLUGIN2'])
     self.assertEqual(self.build_configuration.subsystems(), {DummySubsystem1, DummySubsystem2})

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -17,7 +17,7 @@ class PayloadTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'java_library': JavaLibrary,
       },

--- a/tests/python/pants_test/base/test_source_mapper.py
+++ b/tests/python/pants_test/base/test_source_mapper.py
@@ -21,7 +21,7 @@ class SourceMapperTest(object):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'java_library': JavaLibrary,
       },

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -125,7 +125,7 @@ class BaseTest(unittest.TestCase):
     # backend here since the `BaseTest` is used by lower level tests in base and since the
     # `Dependencies` type itself is nothing more than an alias for Target that carries along a
     # pydoc for the BUILD dictionary.
-    return BuildFileAliases.create(targets={'target': Target})
+    return BuildFileAliases(targets={'target': Target})
 
   def setUp(self):
     super(BaseTest, self).setUp()

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -24,7 +24,7 @@ class JvmToolTaskTestBase(TaskTestBase):
   @property
   def alias_groups(self):
     # Aliases appearing in our real BUILD.tools.
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'jar_library': JarLibrary,
       },

--- a/tests/python/pants_test/targets/test_java_agent.py
+++ b/tests/python/pants_test/targets/test_java_agent.py
@@ -14,7 +14,7 @@ from pants_test.base_test import BaseTest
 class JavaAgentTest(BaseTest):
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'java_agent': JavaAgent,
       },

--- a/tests/python/pants_test/targets/test_scala_library.py
+++ b/tests/python/pants_test/targets/test_scala_library.py
@@ -18,7 +18,7 @@ from pants_test.base_test import BaseTest
 class ScalaLibraryTest(BaseTest):
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'scala_library': ScalaLibrary,
         'java_library': JavaLibrary,

--- a/tests/python/pants_test/targets/test_wiki_page.py
+++ b/tests/python/pants_test/targets/test_wiki_page.py
@@ -18,7 +18,7 @@ class WikiPageTest(BaseTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'page': Page,
       },

--- a/tests/python/pants_test/tasks/test_check_published_deps.py
+++ b/tests/python/pants_test/tasks/test_check_published_deps.py
@@ -23,7 +23,7 @@ class CheckPublishedDepsTest(ConsoleTaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'target': Dependencies,
         'jar_library': JarLibrary,

--- a/tests/python/pants_test/tasks/test_dependees.py
+++ b/tests/python/pants_test/tasks/test_dependees.py
@@ -47,7 +47,7 @@ class ReverseDepmapTest(BaseReverseDepmapTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'target': Dependencies,
         'jar_library': JarLibrary,

--- a/tests/python/pants_test/tasks/test_filemap.py
+++ b/tests/python/pants_test/tasks/test_filemap.py
@@ -18,7 +18,7 @@ from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 class FilemapTest(ConsoleTaskTestBase):
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'python_library': PythonLibrary,
       },

--- a/tests/python/pants_test/tasks/test_filter.py
+++ b/tests/python/pants_test/tasks/test_filter.py
@@ -22,7 +22,7 @@ class BaseFilterTest(ConsoleTaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'target': Dependencies,
         'java_library': JavaLibrary,
@@ -146,16 +146,14 @@ class FilterTest(BaseFilterTest):
       'overlaps:foo',
       targets=self.targets('::'),
       # Note that the comma is inside the string, so these are ORed.
-      options={'type': ['python_requirement_library,'
-                        'pants.backend.python.targets.python_library.PythonLibrary']}
+      options={'type': ['python_requirement_library,python_library']}
     )
 
   def test_filter_multiple_types(self):
     # A target can only have one type, so the output should be empty.
     self.assert_console_output(
       targets=self.targets('::'),
-      options={'type': ['python_requirement_library',
-                        'pants.backend.python.targets.python_library.PythonLibrary']}
+      options={'type': ['python_requirement_library', 'python_library']}
     )
 
   def test_filter_target(self):

--- a/tests/python/pants_test/tasks/test_jar_create.py
+++ b/tests/python/pants_test/tasks/test_jar_create.py
@@ -30,7 +30,7 @@ class JarCreateTestBase(JarTaskTestBase):
 
   @property
   def alias_groups(self):
-    return super(JarCreateTestBase, self).alias_groups.merge(BuildFileAliases.create(
+    return super(JarCreateTestBase, self).alias_groups.merge(BuildFileAliases(
       targets={
         'java_library': JavaLibrary,
         'java_thrift_library': JavaThriftLibrary,

--- a/tests/python/pants_test/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/tasks/test_jar_publish.py
@@ -46,7 +46,7 @@ class JarPublishTest(TaskTestBase):
     self.push_db_basedir = os.path.join(self.build_root, "pushdb")
     safe_mkdir(self.push_db_basedir)
 
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'jar_library': JarLibrary,
         'java_library': JavaLibrary,

--- a/tests/python/pants_test/tasks/test_jar_task.py
+++ b/tests/python/pants_test/tasks/test_jar_task.py
@@ -37,7 +37,7 @@ class BaseJarTaskTest(JarTaskTestBase):
 
   @property
   def alias_groups(self):
-    return super(BaseJarTaskTest, self).alias_groups.merge(BuildFileAliases.create(
+    return super(BaseJarTaskTest, self).alias_groups.merge(BuildFileAliases(
       targets={
         'java_agent': JavaAgent,
         'jvm_binary': JvmBinary,

--- a/tests/python/pants_test/tasks/test_listtargets.py
+++ b/tests/python/pants_test/tasks/test_listtargets.py
@@ -36,7 +36,7 @@ class ListTargetsTest(BaseListTargetsTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'target': Dependencies,
         'java_library': JavaLibrary,

--- a/tests/python/pants_test/tasks/test_minimal_cover.py
+++ b/tests/python/pants_test/tasks/test_minimal_cover.py
@@ -27,7 +27,7 @@ class MinimalCoverEmptyTest(BaseMinimalCovertTest):
 class MinimalCoverTest(BaseMinimalCovertTest):
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'python_library': PythonLibrary})
+    return BuildFileAliases(targets={'python_library': PythonLibrary})
 
   def setUp(self):
     super(MinimalCoverTest, self).setUp()

--- a/tests/python/pants_test/tasks/test_sorttargets.py
+++ b/tests/python/pants_test/tasks/test_sorttargets.py
@@ -30,7 +30,7 @@ class SortTargetsTest(BaseSortTargetsTest):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'python_library': PythonLibrary})
+    return BuildFileAliases(targets={'python_library': PythonLibrary})
 
   def setUp(self):
     super(SortTargetsTest, self).setUp()

--- a/tests/python/pants_test/tasks/test_what_changed.py
+++ b/tests/python/pants_test/tasks/test_what_changed.py
@@ -29,7 +29,7 @@ class BaseWhatChangedTest(ConsoleTaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'java_library': JavaLibrary,
         'python_library': PythonLibrary,

--- a/tests/python/pants_test/test_maven_layout.py
+++ b/tests/python/pants_test/test_maven_layout.py
@@ -15,7 +15,7 @@ from pants_test.base_test import BaseTest
 class MavenLayoutTest(BaseTest):
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(
+    return BuildFileAliases(
       targets={
         'java_library': JavaLibrary,
         'junit_tests': JavaTests,


### PR DESCRIPTION
Previously, alias mappings were validated by BuildConfiguration.  Doing
the validation in BuildConfiguration ensure only valid objects are
constructed and never float around in an invalid state and it
centralizes the mostly internal detail that "targets" contains a mix of
types, allowing the mix to be split and presented via seperate
properties.

This adds TargetMacro.Factory coverage to BuildConfigurationTest while
moving its validation tests over to BuilfFileAliasesTest.

https://rbcommons.com/s/twitter/r/2789/