### PR TITLE
Make BootstrapJvmTools fail fast on a bad user-specified address.

### DIFF
--- a/pants.ini.isolated
+++ b/pants.ini.isolated
@@ -13,7 +13,6 @@ use_jmake: False
 name_hashing: True
 strategy: isolated
 worker_count: 4
-zinc: //:zinc
 jvm_options: [
     '-Xmx4g', '-XX:MaxPermSize=512m', '-XX:+UseConcMarkSweepGC', '-XX:ParallelGCThreads=4',
     # bigger cache size for our big projects (default is just 5)

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -30,7 +30,7 @@ class JvmToolMixin(object):
     def dep_spec(self, options):
       """Returns the target address spec that points to this JVM tool's classpath dependencies.
 
-      :rtype string
+      :rtype: string
       """
       option = self.key.replace('-', '_')
       dep_spec = options.for_scope(self.scope)[option]
@@ -43,6 +43,13 @@ class JvmToolMixin(object):
           {key}: //tool/classpath:address
           """.format(scope=self.scope, key=self.key)))
       return dep_spec
+
+    def is_default(self, options):
+      """Return `True` if this option was not set by the user.
+
+      :rtype: bool
+      """
+      return options.for_scope(self.scope).is_default(self.key.replace('-', '_'))
 
   _jvm_tools = []  # List of JvmTool objects.
 

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -88,6 +88,17 @@ class OptionValueContainer(object):
     """
     return self.get_rank(key) == RankedValue.FLAG
 
+  def is_default(self, key):
+    """Returns `True` if the value for the specified key was not supplied by the user.
+
+    I.e. the option was NOT specified config files, on the cli, or in environment variables.
+
+    :param string key: The name of the option to check.
+    :returns: `True` if the user did not set the value for this option.
+    :rtype: bool
+    """
+    return self.get_rank(key) in (RankedValue.NONE, RankedValue.HARDCODED)
+
   def update(self, attrs):
     """Set attr values on this object from the data in the attrs dict."""
     for k, v in attrs.items():

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -55,6 +55,14 @@ python_tests(
 )
 
 python_tests(
+  name = 'bootstrap_jvm_tools_integration',
+  sources = ['test_bootstrap_jvm_tools_integration.py'],
+  dependencies = [
+    'tests/python/pants_test:int-test',
+  ]
+)
+
+python_tests(
   name = 'benchmark_run',
   sources = ['test_benchmark_run.py'],
   dependencies = [

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -60,4 +60,4 @@ class JvmExamplesCompileIntegrationTest(BaseCompileIT):
           ],
           clean_all=True,
         )
-        self.assertEqual(0, pants_run.returncode)
+        self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools_integration.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class BootstrapJvmToolsIntegrationTest(PantsRunIntegrationTest):
+
+  def test_bootstrap_jarjar_succeeds_normally(self):
+    # NB(gmalmquist): The choice of jarjar here is arbitrary; any jvm-tool that is integral to pants
+    # would suffice (eg, nailgun or jar-tool).
+    self.assert_success(self.run_pants(['clean-all']))
+    pants_run = self.run_pants(['bootstrap', '3rdparty:junit'])
+    self.assert_success(pants_run)
+
+  def test_bootstrap_jarjar_failure(self):
+    self.assert_success(self.run_pants(['clean-all']))
+    pants_run = self.run_pants(['bootstrap', '--shader-jarjar="fake-target"', '3rdparty:junit'])
+    self.assert_failure(pants_run)
+    self.assertIn('fake-target', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -86,12 +86,12 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
   @ensure_cached(expected_num_artifacts=2)
   def test_jvm_tool_changes_invalidate_targets(self, cache_args):
     with temporary_dir(root_dir=self.workdir_root()) as workdir:
-      # Ensure that only the second ':checkstyle' will not invalidate anything.
-      for checkstyle_jar in (':checkstyle', 'testprojects/3rdparty/checkstyle', ':checkstyle'):
+      # Ensure that only the second use of the default checkstyle will not invalidate anything.
+      for checkstyle_jar in (None, 'testprojects/3rdparty/checkstyle', None):
         args = [
             'compile.checkstyle',
             cache_args,
-            '--checkstyle="{}"'.format(checkstyle_jar),
+            '--checkstyle={}'.format(checkstyle_jar) if checkstyle_jar else '',
             'examples/src/java/org/pantsbuild/example/hello/simple'
           ]
         pants_run = self.run_pants_with_workdir(args, workdir)

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -36,6 +36,9 @@ class _FakeOptionValues(object):
   def is_flagged(self, key):
     return self.get_rank(key) == RankedValue.FLAG
 
+  def is_default(self, key):
+    return self.get_rank(key) in (RankedValue.NONE, RankedValue.HARDCODED)
+
 
 def create_option_values(option_values):
   """Create a fake OptionValueContainer object for testing.


### PR DESCRIPTION
Previously, if you specified a target for a jvm-tool that pants
failed to resolve, if the jvm-tool had a default classpath, pants
would simply inject a synthetic JarLibrary with the same name that
used the default classpath.

This resulted in pants pretending to use the user-specified target
that it couldn't find, but silently it was using the default.

This caused problems for square internally when we tried to specify
a different version of the wire-compiler with an (unwittingly)
malformatted spec. The build continued along merrily and subtly
pulled in the wrong version of wire, only blowing up when it tried
to compile a target that used features not available in pants's
default version of wire.

Example output after this change:

    ~/Src/Pants ./pants --gen-wire-wire-compiler="this-target-definitely-does-not-exist" clean-all compile examples/src/wire::
    INFO] Detected git repository at /Users/gmalmquist/Src/Pants on branch gmalmquist/missing-jvm-tool-options-fail-loudly

    17:41:55 00:00 [main]
                   (To run a reporting server: ./pants server)
    17:41:55 00:00   [bootstrap]
    17:41:55 00:00   [setup]
    17:41:55 00:00     [parse]
    FAILURE: Failed to resolve target for tool: this-target-definitely-does-not-exist. This target was obtained from
    option wire-compiler in scope gen.wire.

    Make sure you didn't make a typo in the tool's address. You specified that the
    tool should use the target found at "this-target-definitely-does-not-exist".

    This target has a default classpath configured, so you can simply remove:
      [gen.wire]
      wire-compiler: this-target-definitely-does-not-exist
    from pants.ini (or any other config file) to use the default tool.

    The default classpath is: com.squareup.wire-wire-compiler-1.6.0

    Note that tool target addresses in pants.ini should be specified *without* quotes.

    17:41:55 00:00   [complete]
                   FAILURE