### PR TITLE
Add `--verbose` and `--quiet` options to `compile.scalastyle`.  Fixes #1888

### DIFF
--- a/examples/src/scala/org/pantsbuild/example/styleissue/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/styleissue/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+scala_library(name = 'styleissue',
+  sources = ['StyleIssue.scala'],
+)

--- a/examples/src/scala/org/pantsbuild/example/styleissue/StyleIssue.scala
+++ b/examples/src/scala/org/pantsbuild/example/styleissue/StyleIssue.scala
@@ -1,0 +1,8 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.hello.styleissue;
+
+// A program designed to deliberately fail a scalastyle check
+	class StyleIssue {
+	}

--- a/examples/src/scala/org/pantsbuild/example/styleissue/style.xml
+++ b/examples/src/scala/org/pantsbuild/example/styleissue/style.xml
@@ -1,0 +1,3 @@
+<scalastyle>
+ <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true" />
+</scalastyle>

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -145,11 +145,14 @@ class Scalastyle(NailgunTask):
 
       if scala_sources:
         def call(srcs):
+          def to_java_boolean(x):
+            return str(x).lower()
+
           cp = self.tool_classpath('scalastyle')
           scalastyle_args = [
             '-c', scalastyle_config,
-            '-v', str(scalastyle_verbose).lower(),
-            '-q', str(scalastyle_quiet).lower(),
+            '-v', to_java_boolean(scalastyle_verbose),
+            '-q', to_java_boolean(scalastyle_quiet),
             ]
           return self.runjava(classpath=cp,
                               main=self._MAIN,

--- a/tests/python/pants_test/tasks/test_scalastyle_integration.py
+++ b/tests/python/pants_test/tasks/test_scalastyle_integration.py
@@ -39,7 +39,7 @@ class ScalastyleIntegrationTest(PantsRunIntegrationTest):
   def test_scalastyle_without_quiet(self):
     scalastyle_args = [
       'compile.scalastyle',
-      '--compile-scalastyle-config=examples/src/scala/org/pantsbuild/example/styleissue/style.xml',
+      '--config=examples/src/scala/org/pantsbuild/example/styleissue/style.xml',
       'examples/src/scala/org/pantsbuild/example/styleissue',
       ]
     pants_run = self.run_pants(scalastyle_args)
@@ -48,8 +48,8 @@ class ScalastyleIntegrationTest(PantsRunIntegrationTest):
   def test_scalastyle_with_quiet(self):
     scalastyle_args = [
       'compile.scalastyle',
-      '--compile-scalastyle-config=examples/src/scala/org/pantsbuild/example/styleissue/style.xml',
-      '--compile-scalastyle-quiet',
+      '--config=examples/src/scala/org/pantsbuild/example/styleissue/style.xml',
+      '--quiet',
       'examples/src/scala/org/pantsbuild/example/styleissue',
       ]
     pants_run = self.run_pants(scalastyle_args)

--- a/tests/python/pants_test/tasks/test_scalastyle_integration.py
+++ b/tests/python/pants_test/tasks/test_scalastyle_integration.py
@@ -35,3 +35,22 @@ class ScalastyleIntegrationTest(PantsRunIntegrationTest):
         # implying there was as a cache hit
         self.assertNotIn('abc_Scalastyle_compile_scalastyle will write to local artifact cache',
             pants_run.stdout_data)
+
+  def test_scalastyle_without_quiet(self):
+    scalastyle_args = [
+      'compile.scalastyle',
+      '--compile-scalastyle-config=examples/src/scala/org/pantsbuild/example/styleissue/style.xml',
+      'examples/src/scala/org/pantsbuild/example/styleissue',
+      ]
+    pants_run = self.run_pants(scalastyle_args)
+    self.assertIn('Found 2 errors', pants_run.stdout_data)
+
+  def test_scalastyle_with_quiet(self):
+    scalastyle_args = [
+      'compile.scalastyle',
+      '--compile-scalastyle-config=examples/src/scala/org/pantsbuild/example/styleissue/style.xml',
+      '--compile-scalastyle-quiet',
+      'examples/src/scala/org/pantsbuild/example/styleissue',
+      ]
+    pants_run = self.run_pants(scalastyle_args)
+    self.assertNotIn('Found 2 errors', pants_run.stdout_data)


### PR DESCRIPTION
This adds new `--verbose` and `--quiet` options to the `compile.scalastyle` goal, which get threaded directly to scalastyle, as requested in issue #1888.

Note: `scalastyle` currently accepts but ignores the `--verbose` option (See: https://github.com/scalastyle/scalastyle/issues/159).  However, I include it anyway for when that issue is eventually fixed.