### PR TITLE
[trigger ci] Fix buildcache doc typos, use err param rather than ignoring it in UnreadableArtifact

### DIFF
--- a/src/python/pants/base/build_invalidator.py
+++ b/src/python/pants/base/build_invalidator.py
@@ -103,7 +103,7 @@ class BuildInvalidator(object):
   def needs_update(self, cache_key):
     """Check if the given cached item is invalid.
 
-    :param cache_key: A CacheKey object (as returned by BuildInvalidator.key_for().
+    :param cache_key: A CacheKey object (as returned by CacheKeyGenerator.key_for().
     :returns: True if the cached version of the item is out of date.
     """
     return self._read_sha(cache_key) != cache_key.hash
@@ -111,7 +111,7 @@ class BuildInvalidator(object):
   def update(self, cache_key):
     """Makes cache_key the valid version of the corresponding target set.
 
-    :param cache_key: A CacheKey object (typically returned by BuildInvalidator.key_for()).
+    :param cache_key: A CacheKey object (typically returned by CacheKeyGenerator.key_for()).
     """
     self._write_sha(cache_key)
 

--- a/src/python/pants/base/build_invalidator.py
+++ b/src/python/pants/base/build_invalidator.py
@@ -103,7 +103,7 @@ class BuildInvalidator(object):
   def needs_update(self, cache_key):
     """Check if the given cached item is invalid.
 
-    :param cache_key: A CacheKey object (as returned by CacheKeyGenerator.key_for().
+    :param cache_key: A CacheKey object (as returned by CacheKeyGenerator.key_for_target().
     :returns: True if the cached version of the item is out of date.
     """
     return self._read_sha(cache_key) != cache_key.hash
@@ -111,7 +111,7 @@ class BuildInvalidator(object):
   def update(self, cache_key):
     """Makes cache_key the valid version of the corresponding target set.
 
-    :param cache_key: A CacheKey object (typically returned by CacheKeyGenerator.key_for()).
+    :param cache_key: A CacheKey object (typically returned by CacheKeyGenerator.key_for_target()).
     """
     self._write_sha(cache_key)
 

--- a/src/python/pants/cache/artifact_cache.py
+++ b/src/python/pants/cache/artifact_cache.py
@@ -37,7 +37,7 @@ class UnreadableArtifact(object):
     :param err: Any additional information on the nature of the read error.
     """
     self.key = key
-    self.err = None
+    self.err = err
 
   # For python 3
   def __bool__(self):
@@ -124,7 +124,7 @@ class ArtifactCache(object):
 
     Implementations may choose to return an UnreadableArtifact instance instead
     of `False` to indicate an artifact was in the cache but could not be read,
-    due to anerror or corruption. UnreadableArtifact evaluates as False-y, so
+    due to an error or corruption. UnreadableArtifact evaluates as False-y, so
     callers can treat the result as a boolean if they are only concerned with
     whether or not an artifact was read.
 


### PR DESCRIPTION
While looking at buildcache behavior, I noticed a few small things.