### PR TITLE
Align ivy excludes and ClasspathProducts excludes.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
+++ b/src/python/pants/backend/jvm/tasks/templates/ivy_resolve/ivy.mustache
@@ -76,14 +76,14 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
       />
       {{/artifacts}}
       {{#excludes}}
-      {{#name}}<exclude matcher="exactOrRegexp" org="{{org}}" module="{{name}}"/>{{/name}}
-      {{^name}}<exclude matcher="exactOrRegexp" org="{{org}}"/>{{/name}}
+      {{#name}}<exclude matcher="exact" org="{{org}}" module="{{name}}"/>{{/name}}
+      {{^name}}<exclude matcher="exact" org="{{org}}"/>{{/name}}
       {{/excludes}}
     </dependency>
     {{/lib.dependencies}}
     {{#lib.excludes}}
-    {{#name}}<exclude matcher="exactOrRegexp" org="{{org}}" module="{{name}}"/>{{/name}}
-    {{^name}}<exclude matcher="exactOrRegexp" org="{{org}}"/>{{/name}}
+    {{#name}}<exclude matcher="exact" org="{{org}}" module="{{name}}"/>{{/name}}
+    {{^name}}<exclude matcher="exact" org="{{org}}"/>{{/name}}
     {{/lib.excludes}}
     {{#lib.overrides?}}
       {{#lib.overrides}}


### PR DESCRIPTION
Previously, ivy excludes supported regexes and ClasspathProducts did
not.  Since poms do not support regex and we're getting rid of our
ivyisms, pin the ivy.xml to use exact excludes as well.