### PR TITLE
Fixup AndroidIntegrationTest broken by Distribution refactor.

### DIFF
--- a/tests/python/pants_test/android/BUILD
+++ b/tests/python/pants_test/android/BUILD
@@ -28,6 +28,7 @@ python_tests(
   dependencies = [
     'src/python/pants/java/distribution:distribution',
     'tests/python/pants_test:int-test',
+    'tests/python/pants_test/subsystem:subsystem_utils',
   ],
 )
 

--- a/tests/python/pants_test/android/android_integration_test.py
+++ b/tests/python/pants_test/android/android_integration_test.py
@@ -7,8 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pants.java.distribution.distribution import Distribution
+from pants.java.distribution.distribution import Distribution, DistributionLocator
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
 class AndroidIntegrationTest(PantsRunIntegrationTest):
@@ -37,7 +38,8 @@ class AndroidIntegrationTest(PantsRunIntegrationTest):
     else:
       return False
     try:
-      Distribution.cached(minimum_version=cls.JAVA_MIN, maximum_version=cls.JAVA_MAX)
+      with subsystem_instance(DistributionLocator) as locator:
+        locator.cached(minimum_version=cls.JAVA_MIN, maximum_version=cls.JAVA_MAX)
     except Distribution.Error:
       return False
     return True


### PR DESCRIPTION
This base test was using the old pre-DistributionLocator api.