### PR TITLE
Fix `PythonTarget.resource_targets`.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -47,7 +47,9 @@ target(
 python_library(
   name = 'bash_completion',
   sources = ['bash_completion.py'],
-  resources = globs('templates/bash_completion/*.mustache'),
+  resource_targets = [
+    ':bash_completion_resources',
+  ],
   dependencies = [
     ':console_task',
     ':task',
@@ -56,13 +58,20 @@ python_library(
     'src/python/pants/goal',
     'src/python/pants/help',
     'src/python/pants/option',
-    ],
-  )
+  ],
+)
+
+resources(
+  name = 'bash_completion_resources',
+  sources = globs('templates/bash_completion/*.mustache'),
+)
 
 python_library(
   name = 'builddictionary',
   sources = ['builddictionary.py'],
-  resources = globs('templates/builddictionary/*.mustache'),
+  resource_targets = [
+    ':builddictionary_resources',
+  ],
   dependencies = [
     ':common',
     ':reflect',
@@ -82,6 +91,12 @@ python_library(
     'src/python/pants/util:dirutil',
   ],
 )
+
+resources(
+  name = 'builddictionary_resources',
+  sources = globs('templates/builddictionary/*.mustache'),
+)
+
 
 python_library(
   name = 'clean',
@@ -193,7 +208,9 @@ python_library(
 python_library(
   name = 'markdown_to_html',
   sources = ['markdown_to_html.py'],
-  resources = globs('templates/markdown/*.mustache'),
+  resource_targets = [
+    ':markdown_to_html_resources',
+  ],
   dependencies = [
     '3rdparty/python:Markdown',
     '3rdparty/python:Pygments',
@@ -209,6 +226,11 @@ python_library(
     'src/python/pants/binaries:binary_util',
     'src/python/pants/util:dirutil',
   ],
+)
+
+resources(
+  name = 'markdown_to_html_resources',
+  sources = globs('templates/markdown/*.mustache'),
 )
 
 python_library(
@@ -343,13 +365,20 @@ python_library(
 python_library(
   name = 'targets_help',
   sources = ['targets_help.py'],
-  resources = globs('templates/targets_help/*.mustache'),
+  resource_targets = [
+    ':targets_help_resources',
+  ],
   dependencies = [
     ':builddictionary',
     ':common',
     ':console_task',
     ':reflect',
   ],
+)
+
+resources(
+  name = 'targets_help_resources',
+  sources = globs('templates/targets_help/*.mustache'),
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -1,7 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 python_library(
   name='artifact',
   sources=['artifact.py'],
@@ -37,7 +36,9 @@ python_library(
 python_library(
   name='ivy_utils',
   sources=['ivy_utils.py'],
-  resources=globs('tasks/templates/ivy_resolve/*.mustache'),
+  resource_targets=[
+    ':ivy_utils_resources',
+  ],
   dependencies=[
     ':jar_dependency_utils',
     '3rdparty/python/twitter/commons:twitter.common.collections',
@@ -50,6 +51,11 @@ python_library(
     'src/python/pants/ivy',
     'src/python/pants/util:dirutil',
   ],
+)
+
+resources(
+  name='ivy_utils_resources',
+  sources=globs('tasks/templates/ivy_resolve/*.mustache'),
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -210,7 +210,9 @@ python_library(
 python_library(
   name = 'jar_publish',
   sources = ['jar_publish.py'],
-  resources = globs('templates/jar_publish/*.mustache', 'templates/ivy_resolve/*.mustache'),
+  resource_targets = [
+    ':jar_publish_resources',
+  ],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.config',
@@ -235,6 +237,11 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:strutil',
   ],
+)
+
+resources(
+  name = 'jar_publish_resources',
+  sources = globs('templates/jar_publish/*.mustache', 'templates/ivy_resolve/*.mustache'),
 )
 
 python_library(

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -41,7 +41,9 @@ python_library(
 python_library(
   name = 'eclipse_gen',
   sources = ['eclipse_gen.py'],
-  resources = globs('templates/eclipse/*.mustache', 'templates/eclipse/*.prefs'),
+  resource_targets = [
+    ':eclipse_gen_resources',
+  ],
   dependencies = [
     ':ide_gen',
     '3rdparty/python/twitter/commons:twitter.common.collections',
@@ -51,10 +53,17 @@ python_library(
   ],
 )
 
+resources(
+  name = 'eclipse_gen_resources',
+  sources = globs('templates/eclipse/*.mustache', 'templates/eclipse/*.prefs'),
+)
+
 python_library(
   name = 'ensime_gen',
   sources = ['ensime_gen.py'],
-  resources = globs('templates/ensime/*.mustache'),
+  resource_targets = [
+    ':ensime_gen_resources',
+  ],
   dependencies = [
     ':ide_gen',
     '3rdparty/python/twitter/commons:twitter.common.collections',
@@ -62,6 +71,11 @@ python_library(
     'src/python/pants/base:generator',
     'src/python/pants/util:dirutil',
   ],
+)
+
+resources(
+  name = 'ensime_gen_resources',
+  sources = globs('templates/ensime/*.mustache'),
 )
 
 python_library(
@@ -121,7 +135,9 @@ python_library(
 python_library(
   name = 'idea_gen',
   sources = ['idea_gen.py'],
-  resources = globs('templates/idea/*.mustache'),
+  resource_targets = [
+    ':idea_gen_resources',
+  ],
   dependencies = [
     ':ide_gen',
     'src/python/pants/base:build_environment',
@@ -132,6 +148,11 @@ python_library(
     'src/python/pants/scm:git',
     'src/python/pants/util:dirutil',
   ],
+)
+
+resources(
+  name = 'idea_gen_resources',
+  sources = globs('templates/idea/*.mustache'),
 )
 
 python_library(

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -95,13 +95,15 @@ python_library(
   name = 'python_chroot',
   sources = ['python_chroot.py'],
   dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:pex',
     ':antlr_builder',
     ':python_requirement',
     ':thrift_builder',
-    '3rdparty/python:pex',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/backend/codegen/targets:python',
+    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/python/targets:python',
-    'src/python/pants/base:target',
+    'src/python/pants/base:build_environment',
     'src/python/pants/base:build_invalidator',
     'src/python/pants/util:dirutil'
   ],

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -22,6 +22,7 @@ from pants.backend.codegen.targets.python_antlr_library import PythonAntlrLibrar
 from pants.backend.codegen.targets.python_thrift_library import PythonThriftLibrary
 from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.prep_command import PrepCommand
+from pants.backend.core.targets.resources import Resources
 from pants.backend.python.antlr_builder import PythonAntlrBuilder
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_binary import PythonBinary
@@ -45,7 +46,8 @@ class PythonChroot(object):
     PythonBinary: 'binaries',
     PythonThriftLibrary: 'thrifts',
     PythonAntlrLibrary: 'antlrs',
-    PythonTests: 'tests'
+    PythonTests: 'tests',
+    Resources: 'resources'
   }
 
   class InvalidDependencyException(Exception):

--- a/src/python/pants/backend/python/targets/BUILD
+++ b/src/python/pants/backend/python/targets/BUILD
@@ -1,3 +1,5 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
   name = 'python',
@@ -16,8 +18,11 @@ python_library(
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/python:python_artifact',
     'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/base:address',
+    'src/python/pants/base:exceptions',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/base:target',
+    'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -1,7 +1,12 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 python_library(
   name='python',
   sources=globs('*.py'),
-  resources=globs('templates/python_eval/*.mustache'),
+  resource_targets=[
+    ':resources'
+  ],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
@@ -12,6 +17,7 @@ python_library(
     '3rdparty/python:setuptools',
     '3rdparty/python:six',
     'src/python/pants/backend/codegen/targets:python',
+    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/core/tasks:repl_task_mixin',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/backend/python/tasks/checkstyle:all',
@@ -40,4 +46,9 @@ python_library(
     'src/python/pants/util:strutil',
     'src/python/pants/util:xml_parser',
   ]
+)
+
+resources(
+  name='resources',
+  sources=globs('templates/python_eval/*.mustache'),
 )

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -2,10 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'distribution',
-  sources = [ 'distribution.py' ],
-  resources = globs('*.class'),
-  dependencies = [
+  name='distribution',
+  sources=[ 'distribution.py' ],
+  resource_targets=[
+    ':resources',
+  ],
+  dependencies=[
     '3rdparty/python:six',
     'src/python/pants/base:revision',
     'src/python/pants/java:util',
@@ -13,4 +15,9 @@ python_library(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:osutil',
   ],
+)
+
+resources(
+  name='resources',
+  sources=globs('*.class'),
 )

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -2,10 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'reporting',
-  sources = globs('*.py', exclude=[['report.py']]),
-  resources = rglobs('assets/*', 'templates/*.mustache'),
-  dependencies = [
+  name='reporting',
+  sources=globs('*.py', exclude=[['report.py']]),
+  resource_targets=[
+    ':reporting_resources',
+  ],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.threading',
     '3rdparty/python:ansicolors',
     '3rdparty/python:pystache',
@@ -19,16 +21,21 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/option',
     'src/python/pants/pantsd:process_manager',
+    'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-    'src/python/pants/subsystem',
   ]
 )
 
+resources(
+  name='reporting_resources',
+  sources=rglobs('assets/*', 'templates/*.mustache')
+)
+
 python_library(
-  name = 'report',
-  sources = ['report.py'],
-  dependencies = [
+  name='report',
+  sources=['report.py'],
+  dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.threading',
   ],
 )

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -10,13 +10,12 @@ target(
 )
 
 python_tests(
-  name = 'resource_mapping',
-  sources = ['test_resource_mapping.py'],
-  dependencies = [
+  name='resource_mapping',
+  sources=['test_resource_mapping.py'],
+  dependencies=[
     'src/python/pants/backend/jvm/tasks/jvm_compile:resource_mapping',
     'tests/python/pants_test:base_test',
   ],
-  resources=rglobs('test-data/*'),
 )
 
 python_library(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_resource_mapping.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_resource_mapping.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
+
 from pants.backend.jvm.tasks.jvm_compile.resource_mapping import ResourceMapping
 from pants_test.base_test import BaseTest
 
@@ -12,35 +14,34 @@ from pants_test.base_test import BaseTest
 class ResourceMappingTest(BaseTest):
 
   def test_resource_mapping_ok(self):
-    rel_dir = 'tests/python/pants_test/backend/jvm/tasks/jvm_compile/test-data/resource_mapping'
-    resource_mapping = ResourceMapping(rel_dir)
+    resource_mapping = self._create_mapping('test-data/resource_mapping')
 
     self.assertEquals(2, len(resource_mapping.mappings))
 
   def test_resource_mapping_short(self):
-    rel_dir = 'tests/python/pants_test/backend/jvm/tasks/jvm_compile/test-data/resource_mapping-broken-short'
-    resource_mapping = ResourceMapping(rel_dir)
+    resource_mapping = self._create_mapping('test-data/resource_mapping-broken-short')
 
     with self.assertRaises(ResourceMapping.TruncatedFileException):
       resource_mapping.mappings
 
   def test_resource_mapping_long(self):
-    rel_dir = 'tests/python/pants_test/backend/jvm/tasks/jvm_compile/test-data/resource_mapping-broken-long'
-    resource_mapping = ResourceMapping(rel_dir)
+    resource_mapping = self._create_mapping('test-data/resource_mapping-broken-long')
 
     with self.assertRaises(ResourceMapping.TooLongFileException):
       resource_mapping.mappings
 
   def test_resource_mapping_mangled(self):
-    rel_dir = 'tests/python/pants_test/backend/jvm/tasks/jvm_compile/test-data/resource_mapping-broken-mangled'
-    resource_mapping = ResourceMapping(rel_dir)
+    resource_mapping = self._create_mapping('test-data/resource_mapping-broken-mangled')
 
     with self.assertRaises(ResourceMapping.UnparseableLineException):
       resource_mapping.mappings
 
   def test_resource_mapping_noitems(self):
-    rel_dir = 'tests/python/pants_test/backend/jvm/tasks/jvm_compile/test-data/resource_mapping-broken-missing-items'
-    resource_mapping = ResourceMapping(rel_dir)
+    resource_mapping = self._create_mapping('test-data/resource_mapping-broken-missing-items')
 
     with self.assertRaises(ResourceMapping.MissingItemsLineException):
       resource_mapping.mappings
+
+  def _create_mapping(self, rel_path):
+    path = os.path.join('tests/python/pants_test/backend/jvm/tasks/jvm_compile', rel_path)
+    return ResourceMapping(path)

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -87,12 +87,18 @@ python_tests(
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:mock',
     ':python_task_test_base',
+    'src/python/pants/backend/core/targets:common',
 
     # TODO(John Sirois): XXX this dep needs to be fixed.  All pants/java utility code needs to live
     # in pants java since non-jvm backends depend on it to run things.
     'src/python/pants/backend/jvm/subsystems:jvm',
 
+    'src/python/pants/backend/python:python_artifact',
+    'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/base:build_file_aliases',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:source_root',
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/targets/BUILD
+++ b/tests/python/pants_test/targets/BUILD
@@ -96,19 +96,17 @@ python_tests(
   ]
 )
 
-
 python_tests(
   name = 'python_target',
   sources = ['test_python_target.py'],
   dependencies = [
-    ':base',
+    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/jvm:artifact',
     'src/python/pants/backend/jvm:repository',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:python_artifact',
     'src/python/pants/base:exceptions',
-    'src/python/pants/base:source_root',
-    'src/python/pants/base:target',
+    'tests/python/pants_test:base_test'
   ]
 )
 


### PR DESCRIPTION
Previously resource handling was broken in a few ways:
1.  Resources targets in the same build file could not be addressed
    because relative_to was not passed to the build_graph.
2.  Since resource targets were not modelled as dependencies, they
    could not be found via the `resources` property since they never
    were loaded into the build graph.

This change fixes resources to be modelled as dependencies like they
are for `JvmTarget`, solving 2 above, and fixes resources target
resolution to use `relative_to`.

All existing python targets are updated to use `target_resources`
instead of `resources` as dogfood and a unit test is added to ensure
both modes of expressing resources work.

https://rbcommons.com/s/twitter/r/2817/