### PR TITLE
Adding a console task to explain where options came from.

### DIFF
--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -20,6 +20,7 @@ from pants.backend.core.tasks.clean import Cleaner, Invalidator
 from pants.backend.core.tasks.confluence_publish import ConfluencePublish
 from pants.backend.core.tasks.deferred_sources_mapper import DeferredSourcesMapper
 from pants.backend.core.tasks.dependees import ReverseDepmap
+from pants.backend.core.tasks.explain_options_task import ExplainOptionsTask
 from pants.backend.core.tasks.filemap import Filemap
 from pants.backend.core.tasks.filter import Filter
 from pants.backend.core.tasks.list_goals import ListGoals
@@ -172,3 +173,6 @@ def register_goals():
 
   task(name='bash-completion', action=BashCompletionTask).install().with_description(
     'Dump bash shell script for autocompletion of pants command lines.')
+
+  task(name='options', action=ExplainOptionsTask).install().with_description(
+    'List what options pants has set.')

--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -13,6 +13,7 @@ target(
     ':console_task',
     ':deferred_sources_mapper',
     ':dependees',
+    ':explain_options',
     ':filemap',
     ':filter',
     ':group_task',
@@ -149,6 +150,16 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:target',
     'src/python/pants/backend/core/targets:common',
+  ],
+)
+
+python_library(
+  name = 'explain_options',
+  sources = ['explain_options_task.py'],
+  dependencies = [
+    '3rdparty/python:ansicolors',
+    ':console_task',
+    'src/python/pants/option',
   ],
 )
 

--- a/src/python/pants/backend/core/tasks/explain_options_task.py
+++ b/src/python/pants/backend/core/tasks/explain_options_task.py
@@ -1,0 +1,103 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from colors import black, blue, cyan, green, magenta, red, white
+
+from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.option.ranked_value import RankedValue
+
+
+class ExplainOptionsTask(ConsoleTask):
+  """Console task to display meta-information about options.
+
+  This "meta-information" includes what values options have, and what values they *used* to have
+  before they were overridden by a higher-rank value (eg, a HARDCODED value overridden by a CONFIG
+  value and then a cli FLAG value).
+  """
+
+  @classmethod
+  def register_options(cls, register):
+    super(ExplainOptionsTask, cls).register_options(register)
+    register('--scope', help='Only show options in this scope.')
+    register('--name', help='Only show options with this name.')
+    register('--rank', choices=RankedValue.get_names(),
+             help='Only show options with at least this importance.')
+    register('--show-history', action='store_true', default=False,
+             help='Show the previous values options had before being overridden.')
+    register('--only-overridden', action='store_true', default=False,
+             help='Only show values that overrode defaults.')
+
+  def _scope_filter(self, scope):
+    pattern = self.get_options().scope
+    return not pattern or scope.startswith(pattern)
+
+  def _option_filter(self, option):
+    pattern = self.get_options().name
+    if not pattern:
+      return True
+    pattern = pattern.replace('-', '_')
+    return option == pattern
+
+  def _rank_filter(self, rank):
+    pattern = self.get_options().rank
+    if not pattern:
+      return True
+    return rank >= RankedValue.get_rank_value(pattern)
+
+  def _rank_color(self, rank):
+    if not self.get_options().colors:
+      return lambda x: x
+    if rank == RankedValue.NONE: return white
+    if rank == RankedValue.HARDCODED: return white
+    if rank == RankedValue.ENVIRONMENT: return red
+    if rank == RankedValue.CONFIG: return blue
+    if rank == RankedValue.FLAG: return magenta
+    return black
+
+  def _format_scope(self, scope, option):
+    scope_color = cyan if self.get_options().colors else lambda x: x
+    option_color = blue if self.get_options().colors else lambda x: x
+    return '{scope}{option}'.format(
+      scope=scope_color('{}.'.format(scope) if scope else ''),
+      option=option_color(option),
+    )
+
+  def _format_record(self, record):
+    value_color = green if self.get_options().colors else lambda x: x
+    rank_color = self._rank_color(record.rank)
+    return '{value} {rank}'.format(
+      value=value_color(str(record.value)),
+      rank=rank_color('(from {rank}{details})'.format(
+        rank=RankedValue.get_rank_name(record.rank),
+        details=' {}'.format(record.details) if record.details else '',
+      )),
+    )
+
+  def _show_history(self, history):
+    for record in reversed(list(history)[:-1]):
+      if record.rank > RankedValue.NONE:
+        yield '  overrode {}'.format(self._format_record(record))
+
+  def _force_option_parsing(self):
+    scopes = list(self.context.options.tracker.option_history_by_scope.keys())
+    for scope in scopes:
+      self.context.options.for_scope(scope)
+
+  def console_output(self, targets):
+    self._force_option_parsing()
+    for scope, options in sorted(self.context.options.tracker.option_history_by_scope.items()):
+      if not self._scope_filter(scope): continue
+      for option, history in sorted(options.items()):
+        if not self._option_filter(option): continue
+        if not self._rank_filter(history.latest.rank): continue
+        if self.get_options().only_overridden and not history.was_overridden:
+          continue
+        yield '{} = {}'.format(self._format_scope(scope, option),
+                               self._format_record(history.latest))
+        if self.get_options().show_history:
+          for line in self._show_history(history):
+            yield line

--- a/src/python/pants/base/config.py
+++ b/src/python/pants/base/config.py
@@ -183,6 +183,16 @@ class Config(object):
     """Return the value of the option in this config, as a string, or None if no value specified."""
     raise NotImplementedError()
 
+  def get_source_for_option(self, section, option):
+    """Returns the path to the source file the given option was defined in.
+
+    :param string section: the scope of the option.
+    :param string option: the name of the option.
+    :returns: the path to the config file, or None if the option was not defined by a config file.
+    :rtype: string
+    """
+    raise NotImplementedError
+
 
 class SingleFileConfig(Config):
   """Config read from a single file."""
@@ -207,6 +217,11 @@ class SingleFileConfig(Config):
       return self.configparser.get(section, option)
     else:
       return self.configparser.get(self.DEFAULT_SECTION, option)
+
+  def get_source_for_option(self, section, option):
+    if self.has_option(section, option):
+      return self.sources()[0]
+    return None
 
 
 class ChainedConfig(Config):
@@ -244,3 +259,9 @@ class ChainedConfig(Config):
     if not self.has_section(section):
       raise ConfigParser.NoSectionError(section)
     raise ConfigParser.NoOptionError(option, section)
+
+  def get_source_for_option(self, section, option):
+    for cfg in self.configs:
+      if cfg.has_option(section, option):
+        return cfg.get_source_for_option(section, option)
+    return None

--- a/src/python/pants/option/option_tracker.py
+++ b/src/python/pants/option/option_tracker.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import defaultdict, namedtuple
+
+from pants.option.ranked_value import RankedValue
+
+
+class OptionTracker(object):
+  """Records a history of what options are set and where they came from."""
+
+  OptionHistoryRecord = namedtuple('OptionHistoryRecord', ['value', 'rank', 'details'])
+
+  class OptionHistory(object):
+    """Tracks the history of an individual option."""
+
+    def __init__(self):
+      self.values = []
+
+    def record_value(self, value, rank, details=None):
+      """Record that the option was set to the given value at the given rank.
+
+      :param value: the value the option was set to.
+      :param int rank: the rank of the option when it was set to this value.
+      :param string details: optional elaboration of where the option came from (eg, a particular
+        config file).
+      """
+      if self.values:
+        if self.latest.rank > rank:
+          return
+        if self.latest.value == value:
+          return # No change.
+      self.values.append(OptionTracker.OptionHistoryRecord(value, rank, details))
+
+    @property
+    def was_overridden(self):
+      """A value was overridden if it has rank greater than 'HARDCODED'."""
+      if len(self.values) < 2:
+        return False
+      return self.latest.rank > RankedValue.HARDCODED and self.values[-2].rank > RankedValue.NONE
+
+    @property
+    def latest(self):
+      """The most recent value this option was set to, or None if it was never set."""
+      return self.values[-1] if self.values else None
+
+    def __iter__(self):
+      for record in self.values:
+        yield record
+
+    def __len__(self):
+      return len(self.values)
+
+  def __init__(self):
+    self.option_history_by_scope = defaultdict(dict)
+
+  def record_option(self, scope, option, value, rank, details=None):
+    """Records that the given option was set to the given value.
+
+    :param string scope: scope of the option.
+    :param string option: name of the option.
+    :param string value: value the option was set to.
+    :param int rank: the rank of the option (Eg, RankedValue.HARDCODED), to keep track of where the
+      option came from.
+    :param string details: optional additional details about how the option was set (eg, the name of a
+      particular config file, if the rank is RankedValue.CONFIG).
+    """
+    scoped_options = self.option_history_by_scope[scope]
+    if option not in scoped_options:
+      scoped_options[option] = self.OptionHistory()
+    scoped_options[option].record_value(value, rank, details)

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -12,6 +12,7 @@ import sys
 from pants.base.config import Config
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.global_options import GlobalOptionsRegistrar
+from pants.option.option_tracker import OptionTracker
 from pants.option.option_util import is_boolean_flag
 from pants.option.options import Options
 
@@ -26,6 +27,7 @@ class OptionsBootstrapper(object):
     self._args = sys.argv if args is None else args
     self._bootstrap_options = None  # We memoize the bootstrap options here.
     self._full_options = {}  # We memoize the full options here.
+    self._option_tracker = OptionTracker()
 
   def get_bootstrap_options(self):
     """:returns: an Options instance that only knows about the bootstrap options.
@@ -64,7 +66,8 @@ class OptionsBootstrapper(object):
 
       def bootstrap_options_from_config(config):
         bootstrap_options = Options.create(env=self._env, config=config,
-            known_scope_infos=[GlobalOptionsRegistrar.get_scope_info()], args=bargs)
+            known_scope_infos=[GlobalOptionsRegistrar.get_scope_info()], args=bargs,
+            option_tracker=self._option_tracker)
 
         def register_global(*args, **kwargs):
           bootstrap_options.register(GLOBAL_SCOPE, *args, **kwargs)
@@ -111,5 +114,6 @@ class OptionsBootstrapper(object):
                                                self._post_bootstrap_config,
                                                known_scope_infos,
                                                args=self._args,
-                                               bootstrap_option_values=bootstrap_option_values)
+                                               bootstrap_option_values=bootstrap_option_values,
+                                               option_tracker=self._option_tracker)
     return self._full_options[key]

--- a/src/python/pants/option/parser_hierarchy.py
+++ b/src/python/pants/option/parser_hierarchy.py
@@ -23,7 +23,7 @@ class ParserHierarchy(object):
   empty string.)
   """
 
-  def __init__(self, env, config, scope_infos):
+  def __init__(self, env, config, scope_infos, option_tracker):
     # Sorting ensures that ancestors precede descendants.
     scope_infos = sorted(set(list(scope_infos)), key=lambda si: si.scope)
     self._parser_by_scope = {}
@@ -31,7 +31,8 @@ class ParserHierarchy(object):
       scope = scope_info.scope
       parent_parser = (None if scope == GLOBAL_SCOPE else
                        self._parser_by_scope[enclosing_scope(scope)])
-      self._parser_by_scope[scope] = Parser(env, config, scope_info, parent_parser)
+      self._parser_by_scope[scope] = Parser(env, config, scope_info, parent_parser,
+                                            option_tracker=option_tracker)
 
   def get_parser_by_scope(self, scope):
     try:

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -2,16 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name = 'option',
-  dependencies = [
+  name='option',
+  dependencies=[
     ':testing'
   ],
 )
 
 python_tests(
-  name = 'testing',
-  sources = globs('*.py', exclude=[globs('*_integration.py')]),
-  dependencies = [
+  name='testing',
+  sources=globs('*.py', exclude=[globs('*_integration.py')]),
+  dependencies=[
     '3rdparty/python:mock',
     '3rdparty/python:pytest',
     'src/python/pants/base:build_environment',
@@ -24,10 +24,21 @@ python_tests(
 
 python_tests(
   name='help_integration',
-  sources = [
+  sources=[
     'test_help_integration.py',
   ],
-  dependencies = [
+  dependencies=[
+    'tests/python/pants_test:int-test',
+  ],
+)
+
+python_tests(
+  name='options_integration',
+  sources=[
+    'test_options_integration.py',
+  ],
+  dependencies=[
+    'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
 )

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+from textwrap import dedent
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class TestOptionsIntegration(PantsRunIntegrationTest):
+
+  def test_options_works_at_all(self):
+    self.assert_success(self.run_pants(['options']))
+
+  def test_options_scope(self):
+    pants_run = self.run_pants(['options', '--no-colors', '--scope=options'])
+    self.assert_success(pants_run)
+    self.assertIn('options.colors = False', pants_run.stdout_data)
+    self.assertIn('options.scope = options', pants_run.stdout_data)
+    self.assertIn('options.name = None', pants_run.stdout_data)
+    self.assertNotIn('publish.jar.scm_push_attempts = ', pants_run.stdout_data)
+
+    pants_run = self.run_pants(['options', '--no-colors', '--scope=publish.jar'])
+    self.assert_success(pants_run)
+    self.assertNotIn('options.colors = False', pants_run.stdout_data)
+    self.assertNotIn('options.scope = options', pants_run.stdout_data)
+    self.assertNotIn('options.name = None', pants_run.stdout_data)
+    self.assertIn('publish.jar.scm_push_attempts = ', pants_run.stdout_data)
+
+  def test_options_option(self):
+    pants_run = self.run_pants(['options', '--no-colors', '--name=colors'])
+    self.assert_success(pants_run)
+    self.assertIn('options.colors = ', pants_run.stdout_data)
+    self.assertIn('unpack-jars.colors = ', pants_run.stdout_data)
+    self.assertNotIn('options.scope = ', pants_run.stdout_data)
+
+  def test_options_only_overridden(self):
+    pants_run = self.run_pants(['options', '--no-colors', '--only-overridden'])
+    self.assert_success(pants_run)
+    self.assertIn('options.only_overridden = True', pants_run.stdout_data)
+    self.assertIn('options.colors = False', pants_run.stdout_data)
+    self.assertNotIn('options.scope =', pants_run.stdout_data)
+    self.assertNotIn('from HARDCODED', pants_run.stdout_data)
+    self.assertNotIn('from NONE', pants_run.stdout_data)
+
+  def test_options_rank(self):
+    pants_run = self.run_pants(['options', '--no-colors', '--rank=FLAG'])
+    self.assert_success(pants_run)
+    self.assertIn('options.rank = ', pants_run.stdout_data)
+    self.assertIn('(from FLAG)', pants_run.stdout_data)
+    self.assertNotIn('(from CONFIG', pants_run.stdout_data)
+    self.assertNotIn('(from HARDCODED', pants_run.stdout_data)
+    self.assertNotIn('(from NONE', pants_run.stdout_data)
+
+  def test_options_show_history(self):
+    pants_run = self.run_pants(['options', '--no-colors', '--only-overridden', '--show-history'])
+    self.assert_success(pants_run)
+    self.assertIn('options.only_overridden = True', pants_run.stdout_data)
+    self.assertIn('overrode False (from HARDCODED', pants_run.stdout_data)
+
+  def test_from_config(self):
+    with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
+      config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
+      with open(config_path, 'w+') as f:
+        f.write(dedent('''
+          [options]
+          colors: False
+          scope: options
+          only_overridden: True
+          show_history: True
+        '''))
+      pants_run = self.run_pants(['--config-override={}'.format(config_path), 'options'])
+      self.assert_success(pants_run)
+      self.assertIn('options.only_overridden = True', pants_run.stdout_data)
+      self.assertIn('(from CONFIG in {})'.format(config_path), pants_run.stdout_data)


### PR DESCRIPTION
Since pants allows options in config files that haven't been
registered, it's easy to accidentally typo an option and have
pants silently ignore your config.

It can also be tricky to know what options end up getting used when
you might have flags set via multiple config files, through env
variables, and by flags set in wrapper scripts.

This makes it easy to verify if options you set in pants.ini or
elsewhere are actually sticking/not getting overriden by something
else.

It might also be cool to plumb this information through to the
pants server UI at some point.