### PR TITLE
Kill 'ivy_resolve_symlink_map' and 'ivy_cache_dir' products.

### DIFF
--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -39,15 +39,15 @@ python_library(
   sources=['ivy_utils.py'],
   resources=globs('tasks/templates/ivy_resolve/*.mustache'),
   dependencies=[
-    ':jar_dependency_utils',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:six',
+    ':jar_dependency_utils',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/base:revision',
     'src/python/pants/base:target',
-    'src/python/pants/ivy',
     'src/python/pants/util:dirutil',
   ],
 )

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -15,6 +15,7 @@ from collections import OrderedDict, defaultdict, namedtuple
 from contextlib import contextmanager
 from copy import deepcopy
 
+import six
 from twitter.common.collections import OrderedSet, maybe_list
 
 from pants.backend.jvm.jar_dependency_utils import M2Coordinate, ResolvedJar
@@ -25,7 +26,6 @@ from pants.base.exceptions import TaskError
 from pants.base.generator import Generator, TemplateData
 from pants.base.revision import Revision
 from pants.base.target import Target
-from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.util.dirutil import safe_mkdir, safe_open
 
 
@@ -209,21 +209,7 @@ class IvyUtils(object):
         yield (path.strip() for path in cp.read().split(os.pathsep) if path.strip())
 
   @classmethod
-  def _find_new_symlinks(cls, existing_symlink_path, updated_symlink_path):
-    """Find the difference between the existing and updated symlink path.
-
-    :param existing_symlink_path: map from path : symlink
-    :param updated_symlink_path: map from path : symlink after new resolve
-    :return: the portion of updated_symlink_path that is not found in existing_symlink_path.
-    """
-    diff_map = OrderedDict()
-    for key, value in updated_symlink_path.iteritems():
-      if key not in existing_symlink_path:
-        diff_map[key] = value
-    return diff_map
-
-  @classmethod
-  def symlink_cachepath(cls, ivy_cache_dir, inpath, symlink_dir, outpath, existing_symlink_map):
+  def symlink_cachepath(cls, ivy_cache_dir, inpath, symlink_dir, outpath):
     """Symlinks all paths listed in inpath that are under ivy_cache_dir into symlink_dir.
 
     If there is an existing symlink for a file under inpath, it is used rather than creating
@@ -235,22 +221,20 @@ class IvyUtils(object):
     # reference the realpath of the .jar file after it is resolved in the cache dir. To handle
     # this case, add both the symlink'ed path and the realpath to the jar to the symlink map.
     real_ivy_cache_dir = os.path.realpath(ivy_cache_dir)
-    updated_symlink_map = OrderedDict()
+    symlink_map = OrderedDict()
     with safe_open(inpath, 'r') as infile:
       inpaths = filter(None, infile.read().strip().split(os.pathsep))
       paths = OrderedSet([os.path.realpath(path) for path in inpaths])
 
     for path in paths:
       if path.startswith(real_ivy_cache_dir):
-        updated_symlink_map[path] = os.path.join(symlink_dir, os.path.relpath(path, real_ivy_cache_dir))
+        symlink_map[path] = os.path.join(symlink_dir, os.path.relpath(path, real_ivy_cache_dir))
       else:
         # This path is outside the cache. We won't symlink it.
-        updated_symlink_map[path] = path
+        symlink_map[path] = path
 
-    # Create symlinks for paths in the ivy cache dir that we haven't seen before.
-    new_symlinks = cls._find_new_symlinks(existing_symlink_map, updated_symlink_map)
-
-    for path, symlink in new_symlinks.iteritems():
+    # Create symlinks for paths in the ivy cache dir.
+    for path, symlink in six.iteritems(symlink_map):
       if path == symlink:
         # Skip paths that aren't going to be symlinked.
         continue
@@ -264,9 +248,9 @@ class IvyUtils(object):
 
     # (re)create the classpath with all of the paths
     with safe_open(outpath, 'w') as outfile:
-      outfile.write(':'.join(OrderedSet(updated_symlink_map.values())))
+      outfile.write(':'.join(OrderedSet(symlink_map.values())))
 
-    return dict(updated_symlink_map)
+    return dict(symlink_map)
 
   @staticmethod
   def identify(targets):
@@ -277,30 +261,36 @@ class IvyUtils(object):
       return IvyUtils.INTERNAL_ORG_NAME, Target.maybe_readable_identify(targets)
 
   @classmethod
-  def xml_report_path(cls, resolve_hash_name, conf):
+  def xml_report_path(cls, cache_dir, resolve_hash_name, conf):
     """The path to the xml report ivy creates after a retrieve.
-    :param string resolve_hash_name: Hash from the Cache key from the VersionedTargetSet
-    used for resolution.
-    :param string conf: the ivy conf name (e.g. "default")
+
+    :param string cache_dir: The path of the ivy cache dir used for resolves.
+    :param string resolve_hash_name: Hash from the Cache key from the VersionedTargetSet used for
+                                     resolution.
+    :param string conf: The ivy conf name (e.g. "default").
+    :returns: The report path.
+    :rtype: string
     """
-    cachedir = IvySubsystem.global_instance().get_options().cache_dir
-    return os.path.join(cachedir, '{}-{}-{}.xml'.format(IvyUtils.INTERNAL_ORG_NAME,
-                                                        resolve_hash_name, conf))
+    return os.path.join(cache_dir, '{}-{}-{}.xml'.format(IvyUtils.INTERNAL_ORG_NAME,
+                                                         resolve_hash_name, conf))
 
   @classmethod
-  def parse_xml_report(cls, resolve_hash_name, conf):
+  def parse_xml_report(cls, cache_dir, resolve_hash_name, conf):
     """Parse the ivy xml report corresponding to the name passed to ivy.
 
-    :param string resolve_hash_name: Hash from the Cache key from the VersionedTargetSet
-    used for resolution.
+    :param string cache_dir: The path of the ivy cache dir used for resolves.
+    :param string resolve_hash_name: Hash from the Cache key from the VersionedTargetSet used for
+                                     resolution; if `None` returns `None` instead of attempting to
+                                     parse any report.
     :param string conf: the ivy conf name (e.g. "default")
-    :return: The info in the xml report or None if target is empty.
-    :rtype: IvyInfo
-    :raises: IvyResolveReportError if no report exists.
+    :returns: The info in the xml report or None if target is empty.
+    :rtype: :class:`IvyInfo`
+    :raises: :class:`IvyResolveMappingError` if no report exists.
     """
+    # TODO(John Sirois): Cleanup acceptance of None, this is IvyResolve's concern, not ours.
     if not resolve_hash_name:
       return None
-    path = cls.xml_report_path(resolve_hash_name, conf)
+    path = cls.xml_report_path(cache_dir, resolve_hash_name, conf)
     if not os.path.exists(path):
       raise cls.IvyResolveReportError('Missing expected ivy output file {}'.format(path))
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -172,11 +172,10 @@ python_library(
     'src/python/pants/backend/jvm:ivy_utils',
     'src/python/pants/backend/jvm:jar_dependency_utils',
     'src/python/pants/base:cache_manager',
+    'src/python/pants/base:exceptions',
     'src/python/pants/binaries:binary_util',
-    'src/python/pants/goal:products',
-    'src/python/pants/ivy',
-    'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:strutil',
   ],
 )
 
@@ -185,14 +184,15 @@ python_library(
   sources = ['ivy_task_mixin.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/backend/jvm:ivy_utils',
     'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/backend/jvm:ivy_utils',
     'src/python/pants/base:cache_manager',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/ivy',
     'src/python/pants/java:util',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -197,7 +197,7 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
 
   def _bootstrap_classpath(self, jvm_tool, targets):
     workunit_name = 'bootstrap-{}'.format(jvm_tool.key)
-    classpath, _ = self.ivy_resolve(targets, silent=True, workunit_name=workunit_name)
+    classpath, _, _ = self.ivy_resolve(targets, silent=True, workunit_name=workunit_name)
     return classpath
 
   @memoized_property

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -256,7 +256,7 @@ class IvyResolve(IvyTaskMixin, NailgunTask):
     css = os.path.join(self._outdir, 'ivy-report.css')
     if os.path.exists(css):
       os.unlink(css)
-    shutil.copy(os.path.join(self._cachedir, 'ivy-report.css'), self._outdir)
+    shutil.copy(os.path.join(self.ivy_cache_dir, 'ivy-report.css'), self._outdir)
 
     if self._open and report:
       binary_util.ui_open(report)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -72,11 +72,11 @@ python_library(
     'src/python/pants/backend/core/tasks:group_task',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/base:fingerprint_strategy',
+    'src/python/pants/base:workunit',
     'src/python/pants/goal:products',
     'src/python/pants/option',
     'src/python/pants/reporting',
-    'src/python/pants/util:dirutil',
-    'src/python/pants/base:fingerprint_strategy',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import itertools
-import os
 import sys
 from collections import defaultdict
 
@@ -87,7 +86,6 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     super(JvmCompile, cls).prepare(options, round_manager)
 
     round_manager.require_data('compile_classpath')
-    round_manager.require_data('ivy_resolve_symlink_map')
 
     # Require codegen we care about
     # TODO(John Sirois): roll this up in Task - if the list of labels we care about for a target

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -74,7 +74,6 @@ class IvyResolveTest(JvmToolTaskTestBase):
     symlink_map = {artifact_path('bogus0'): artifact_path('bogus0'),
                    artifact_path('bogus1'): artifact_path('bogus1'),
                    artifact_path('unused'): artifact_path('unused')}
-    context.products.safe_create_data('ivy_resolve_symlink_map', lambda: symlink_map)
     task = self.create_task(context, 'unused')
 
     def mock_ivy_resolve(targets, *args, **kw):
@@ -84,7 +83,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
         cache_key = vts.cache_key.hash
       else:
         cache_key = None
-      return ([], cache_key)
+      return [], symlink_map, cache_key
 
     task.ivy_resolve = mock_ivy_resolve
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -258,14 +258,6 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
   def assert_attributes(self, elem, **kwargs):
     self.assertEqual(dict(**kwargs), dict(elem.attrib))
 
-  def test_find_new_symlinks(self):
-    map1 = {'foo': 'bar'}
-    map2 = {}
-    diff_map = IvyUtils._find_new_symlinks(map1, map2)
-    self.assertEquals({}, diff_map)
-    diff_map = IvyUtils._find_new_symlinks(map2, map1)
-    self.assertEquals({'foo': 'bar'}, diff_map)
-
   def test_symlink_cachepath(self):
     self.maxDiff = None
     with temporary_dir() as mock_cache_dir:
@@ -273,7 +265,6 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
         with temporary_dir() as classpath_dir:
           input_path = os.path.join(classpath_dir, 'inpath')
           output_path = os.path.join(classpath_dir, 'classpath')
-          existing_symlink_map = {}
           foo_path = os.path.join(mock_cache_dir, 'foo.jar')
           with open(foo_path, 'w') as foo:
             foo.write("test jar contents")
@@ -281,7 +272,7 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
           with open(input_path, 'w') as inpath:
             inpath.write(foo_path)
           result_map = IvyUtils.symlink_cachepath(mock_cache_dir, input_path, symlink_dir,
-                                                  output_path, existing_symlink_map)
+                                                  output_path)
           symlink_foo_path = os.path.join(symlink_dir, 'foo.jar')
           self.assertEquals(
             {
@@ -299,9 +290,8 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
             bar.write("test jar contents2")
           with open(input_path, 'w') as inpath:
             inpath.write(os.pathsep.join([foo_path, bar_path]))
-          existing_symlink_map = result_map
           result_map = IvyUtils.symlink_cachepath(mock_cache_dir, input_path, symlink_dir,
-                                                  output_path, existing_symlink_map)
+                                                  output_path)
           symlink_bar_path = os.path.join(symlink_dir, 'bar.jar')
           self.assertEquals(
             {
@@ -319,19 +309,20 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
           # Reverse the ordering and make sure order is preserved in the output path
           with open(input_path, 'w') as inpath:
             inpath.write(os.pathsep.join([bar_path, foo_path]))
-          IvyUtils.symlink_cachepath(mock_cache_dir, input_path, symlink_dir,
-                                                  output_path, result_map)
+          IvyUtils.symlink_cachepath(mock_cache_dir, input_path, symlink_dir, output_path)
           with open(output_path, 'r') as outpath:
             self.assertEquals(symlink_bar_path + os.pathsep + symlink_foo_path, outpath.readline())
 
   def test_missing_ivy_report(self):
-    self.set_options_for_scope(IvySubsystem.options_scope, cache_dir='DOES_NOT_EXIST', use_nailgun=False)
+    self.set_options_for_scope(IvySubsystem.options_scope,
+                               cache_dir='DOES_NOT_EXIST',
+                               use_nailgun=False)
 
     # Hack to initialize Ivy subsystem
     self.context()
 
     with self.assertRaises(IvyUtils.IvyResolveReportError):
-      IvyUtils.parse_xml_report('INVALID_REPORT_UNIQUE_NAME', 'default')
+      IvyUtils.parse_xml_report('INVALID_CACHE_DIR', 'INVALID_REPORT_UNIQUE_NAME', 'default')
 
   def parse_ivy_report(self, path):
     ivy_info = IvyUtils._parse_xml_report(path)


### PR DESCRIPTION
The 'ivy_cache_dir' product was unused within pants and anyone in need
of this info can consult the IvySubsystem.

The 'ivy_resolve_symlink_map' product was unused except internally to
the `IvyTaskMixin`/`IvyResolve` - switch to a normal return parameter
and kill the one unused task dependency on the product.  As a result,
simplify symlink handling which no longer is multi-pass as is made clear
by the product collapse.

https://rbcommons.com/s/twitter/r/2819/