### PR TITLE
Fix `NailgunExecutor` to support more than one connect attempt

### DIFF
--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -226,7 +226,7 @@ class NailgunExecutor(Executor, ProcessManager):
         sock.close()
 
       attempt_count += 1
-      time.sleep(self.WAIT_INTERVAL)
+      time.sleep(self.WAIT_INTERVAL_SEC)
 
   def _spawn_nailgun_server(self, fingerprint, jvm_options, classpath, stdout, stderr):
     """Synchronously spawn a new nailgun server."""


### PR DESCRIPTION
In 73e25e74, the `WAIT_INTERVAL` field of `ProcessManager` was renamed to
`WAIT_INTERVAL_SEC`, except for one location in `NailgunExecutor` which broke as
a result.  This causes the `try_connect` method to fail if one connection
attempt fails, regardless of what the user supplies as the
`--nailgun-connect-attempts` flag on the command line.