### PR TITLE
Add `:scalastyle_integration` test to `:integration` test target

### DIFF
--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -55,6 +55,7 @@ target(
     ':jvm_bundle_integration',
     ':jvm_run_integration',
     ':protobuf_integration',
+    ':scalastyle_integration',
   ],
 )
 


### PR DESCRIPTION
This target seems to have been left out unintentionally so it's not currently
being exercised by the integration tests.