### PR TITLE
Kill 'jvm_build_tools_classpath_callbacks' deps.

### DIFF
--- a/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
@@ -55,11 +55,6 @@ class SpindleGen(NailgunTask):
                                           rev='3.0.0-M7'),
                           ])
 
-  @classmethod
-  def prepare(cls, options, round_manager):
-    super(SpindleGen, cls).prepare(options, round_manager)
-    round_manager.require_data('jvm_build_tools_classpath_callbacks')
-
   @property
   def spindle_classpath(self):
     return self.tool_classpath('spindle-codegen')

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -117,6 +117,11 @@ class JvmToolMixin(object):
     jvm_tool = cls.JvmTool(register.scope, key, classpath, main, custom_rules)
     JvmToolMixin._jvm_tools.append(jvm_tool)
 
+  @classmethod
+  def prepare_tools(cls, round_manager):
+    """Subclasses must call this method to ensure jvm tool products are available."""
+    round_manager.require_data('jvm_build_tools_classpath_callbacks')
+
   @staticmethod
   def get_registered_tools():
     """Returns all registered jvm tools.

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -398,6 +398,7 @@ python_library(
   name = 'jvm_tool_task_mixin',
   sources = ['jvm_tool_task_mixin.py'],
   dependencies = [
+    'src/python/pants/backend/core/tasks:task',
     'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/base:exceptions',
   ],

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -87,6 +87,11 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
   def global_subsystems(cls):
     return super(BootstrapJvmTools, cls).global_subsystems() + (IvySubsystem, )
 
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(BootstrapJvmTools, cls).prepare(options, round_manager)
+    Shader.Factory.prepare_tools(round_manager)
+
   class ToolResolveError(TaskError):
     """Indicates an error resolving a required JVM tool classpath."""
 

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -32,11 +32,6 @@ class IvyImports(IvyTaskMixin, NailgunTask):
     return ['ivy_imports']  # Guaranteed to populate target => { builddir: [jar_filenames]}
   # TODO https://github.com/pantsbuild/pants/issues/604 product_types finish
 
-  @classmethod
-  def prepare(cls, options, round_manager):
-    super(IvyImports, cls).prepare(options, round_manager)
-    round_manager.require_data('jvm_build_tools_classpath_callbacks')
-
   def _str_jar(self, jar):
     return 'jar' + str((jar.org, jar.name, jar.rev))
 

--- a/src/python/pants/backend/jvm/tasks/jar_create.py
+++ b/src/python/pants/backend/jvm/tasks/jar_create.py
@@ -9,7 +9,7 @@ import os
 from contextlib import contextmanager
 
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
-from pants.backend.jvm.tasks.jar_task import JarTask
+from pants.backend.jvm.tasks.jar_task import JarBuilderTask
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 
@@ -32,7 +32,7 @@ def is_jvm_library(target):
           or (is_jvm_binary(target) and target.has_resources))
 
 
-class JarCreate(JarTask):
+class JarCreate(JarBuilderTask):
   """Jars jvm libraries and optionally their sources and their docs."""
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -219,7 +219,12 @@ class JarTask(NailgunTask):
 
   @classmethod
   def global_subsystems(cls):
-    return super(JarTask, cls).global_subsystems() + (JarTool, )
+    return super(JarTask, cls).global_subsystems() + (JarTool,)
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(JarTask, cls).prepare(options, round_manager)
+    JarTool.prepare_tools(round_manager)
 
   @staticmethod
   def _flag(bool_value):
@@ -291,6 +296,9 @@ class JarTask(NailgunTask):
 
         if JarTool.global_instance().run(context=self.context, runjava=self.runjava, args=args):
           raise TaskError('jar-tool failed')
+
+
+class JarBuilderTask(JarTask):
 
   class JarBuilder(AbstractClass):
     """A utility to aid in adding the classes and resources associated with targets to a jar."""
@@ -399,6 +407,11 @@ class JarTask(NailgunTask):
       """
       if not self._manifest.is_empty():
         jar.writestr(Manifest.PATH, self._manifest.contents())
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(JarBuilderTask, cls).prepare(options, round_manager)
+    cls.JarBuilder.prepare(round_manager)
 
   @contextmanager
   def create_jar_builder(self, jar):

--- a/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
@@ -13,7 +13,7 @@ from twitter.common.collections.orderedset import OrderedSet
 
 from pants.backend.jvm.subsystems.shader import Shader
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
-from pants.backend.jvm.tasks.jar_task import JarTask
+from pants.backend.jvm.tasks.jar_task import JarBuilderTask
 from pants.base.exceptions import TaskError
 from pants.java.util import execute_runner
 from pants.util.contextutil import temporary_dir
@@ -21,7 +21,7 @@ from pants.util.fileutil import atomic_copy
 from pants.util.memo import memoized_property
 
 
-class JvmBinaryTask(JarTask):
+class JvmBinaryTask(JarBuilderTask):
 
   @staticmethod
   def is_binary(target):
@@ -41,7 +41,7 @@ class JvmBinaryTask(JarTask):
   def prepare(cls, options, round_manager):
     super(JvmBinaryTask, cls).prepare(options, round_manager)
     round_manager.require('jar_dependencies', predicate=cls.is_binary)
-    cls.JarBuilder.prepare(round_manager)
+    Shader.Factory.prepare_tools(round_manager)
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -72,6 +72,7 @@ python_library(
     'src/python/pants/backend/core/tasks:group_task',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/base:exceptions',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/base:workunit',
     'src/python/pants/goal:products',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -15,6 +15,7 @@ from pants.backend.jvm.tasks.jvm_compile.jvm_compile_global_strategy import JvmC
 from pants.backend.jvm.tasks.jvm_compile.jvm_compile_isolated_strategy import \
   JvmCompileIsolatedStrategy
 from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
+from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import TaskIdentityFingerprintStrategy
 from pants.base.workunit import WorkUnitLabel
 from pants.goal.products import MultipleRootedProducts

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -120,6 +120,11 @@ class ZincCompile(JvmCompile):
     # empty classpath.
     cls.register_jvm_tool(register, 'plugin-jars', classpath=[])
 
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(ZincCompile, cls).prepare(options, round_manager)
+    ScalaPlatform.prepare_tools(round_manager)
+
   def select(self, target):
     return target.has_sources('.java') or target.has_sources('.scala')
 

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -5,11 +5,17 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.core.tasks.task import TaskBase
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 
 
-class JvmToolTaskMixin(JvmToolMixin):
+class JvmToolTaskMixin(JvmToolMixin, TaskBase):
   """A JvmToolMixin specialized for mixing in to Tasks."""
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(JvmToolTaskMixin, cls).prepare(options, round_manager)
+    cls.prepare_tools(round_manager)
 
   def tool_jar(self, key, scope=None):
     """Get the jar for the tool previously registered under key in the given scope.

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -26,6 +26,11 @@ class ScaladocGen(JvmdocGen):
   def subsystem_dependencies(cls):
     return super(JvmdocGen, cls).subsystem_dependencies() + (DistributionLocator,)
 
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(ScaladocGen, cls).prepare(options, round_manager)
+    ScalaPlatform.prepare_tools(round_manager)
+
   def execute(self):
     def is_scala(target):
       return target.has_sources('.scala')

--- a/src/python/pants/engine/round_engine.py
+++ b/src/python/pants/engine/round_engine.py
@@ -152,7 +152,11 @@ class RoundEngine(Engine):
         for producer_info in dependencies:
           producer_goal = producer_info.goal
           if producer_goal == goal:
-            if producer_info.task_type in visited_task_types:
+            if producer_info.task_type == task_type:
+              # We allow a task to produce products it itself needs.  We trust the Task writer
+              # to arrange for proper sequencing.
+              pass
+            elif producer_info.task_type in visited_task_types:
               ordering = '\n\t'.join("[{0}] '{1}' {2}".format(i, tn,
                                                               goal.task_type_by_name(tn).__name__)
                                      for i, tn in enumerate(goal.ordered_task_names()))

--- a/tests/python/pants_test/engine/test_round_engine.py
+++ b/tests/python/pants_test/engine/test_round_engine.py
@@ -123,11 +123,12 @@ class RoundEngineTest(EngineTestBase, BaseTest):
 
     self.assert_actions('task1', 'task2')
 
-  def test_inter_goal_dep_self_cycle(self):
+  def test_inter_goal_dep_self_cycle_ok(self):
     self.install_task('task1', goal='goal1', product_types=['1'], required_data=['1'])
 
-    with self.assertRaises(self.engine.TaskOrderError):
-      self.engine.attempt(self._context, self.as_goals('goal1'))
+    self.engine.attempt(self._context, self.as_goals('goal1'))
+
+    self.assert_actions('task1')
 
   def test_inter_goal_dep_downstream(self):
     self.install_task('task1', goal='goal1', required_data=['1'])


### PR DESCRIPTION
Only `JvmToolMixin` depends on this product, so isolate the product
dependency to it.  This necessitated some plumbing since `JvmToolMixin`
is not itself a task with a `prepare method`.  This also required
relaxing `RoundEngine` validation of product dep cycles.  It now trusts
you know what you're doing as the author of a task that produces
products it also depends on.

https://rbcommons.com/s/twitter/r/2831/