### PR TITLE
Kill the unused `JvmTarget.configurations` field.

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -13,7 +13,7 @@ from pants.backend.jvm.targets.exclude import Exclude
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jarable import Jarable
 from pants.base.payload import Payload
-from pants.base.payload_field import ConfigurationsField, ExcludesField, PrimitiveField
+from pants.base.payload_field import ExcludesField, PrimitiveField
 from pants.base.target import Target
 from pants.util.memo import memoized_property
 
@@ -32,15 +32,11 @@ class JvmTarget(Target, Jarable):
                provides=None,
                excludes=None,
                resources=None,
-               configurations=None,
                no_cache=False,
                services=None,
                platform=None,
                **kwargs):
     """
-    :param configurations: One or more ivy configurations to resolve for this target.
-      This parameter is not intended for general use.
-    :type configurations: tuple of strings
     :param excludes: List of `exclude <#exclude>`_\s to filter this target's
       transitive dependencies against.
     :param sources: Source code files to build. Paths are relative to the BUILD
@@ -62,12 +58,10 @@ class JvmTarget(Target, Jarable):
     self.address = address  # Set in case a TargetDefinitionException is thrown early
     payload = payload or Payload()
     excludes = ExcludesField(self.assert_list(excludes, expected_type=Exclude, key_arg='excludes'))
-    configurations = ConfigurationsField(self.assert_list(configurations, key_arg='configurations'))
     payload.add_fields({
       'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
       'provides': provides,
       'excludes': excludes,
-      'configurations': configurations,
       'platform': PrimitiveField(platform),
     })
     self._resource_specs = self.assert_list(resources, key_arg='resources')

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -44,8 +44,8 @@ class IvyResolveFingerprintStrategy(FingerprintStrategy):
       hasher.update(target.payload.fingerprint())
       return hasher.hexdigest()
     if isinstance(target, JvmTarget):
-      if target.payload.excludes or target.payload.configurations:
-        hasher.update(target.payload.fingerprint(field_keys=('excludes', 'configurations')))
+      if target.payload.excludes:
+        hasher.update(target.payload.fingerprint(field_keys=('excludes',)))
         return hasher.hexdigest()
 
     return None

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -264,16 +264,6 @@ class ExcludesField(OrderedSet, PayloadField):
     return stable_json_sha1(tuple(repr(exclude) for exclude in self))
 
 
-class ConfigurationsField(OrderedSet, PayloadField):
-  """An OrderedSet subclass that mixes in PayloadField.
-
-  Must be initialized with an iterable of strings.
-  """
-
-  def _compute_fingerprint(self):
-    return combine_hashes(sha1(s).hexdigest() for s in self)
-
-
 class JarsField(tuple, PayloadField):
   """A tuple subclass that mixes in PayloadField.
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -191,8 +191,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
 
     junit_jar_lib = self.make_target('//:junit_lib', JarLibrary, jars=[junit_dep])
     excluding_target = self.make_target('//:excluding_bin', JvmBinary, dependencies=[junit_jar_lib],
-                                        excludes=[Exclude('junit', 'junit')],
-                                        configurations=['default'])
+                                        excludes=[Exclude('junit', 'junit')])
 
     self.set_options(soft_excludes=True)
     context = self.context(target_roots=[junit_jar_lib, excluding_target])


### PR DESCRIPTION
A poll on the afternoon of 9/11/2015 in pantsbuild.slack.com#general
turned up no users of this field, and no objections to removing outright
so this change does just that to further trim the pants API exposure of
ivy configurations.

https://rbcommons.com/s/twitter/r/2834/