### PR TITLE
Add support for snapshotting `ClasspathProducts`.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -162,16 +162,6 @@ class ClasspathProducts(object):
     for target in targets:
       self._add_elements_for_target(target, classpath_entries)
 
-  def add_excludes_for_target(self, target, excludes):
-    """Add excludes for the given target.
-
-    :param target: The target to add excludes for.
-    :type target: :class:`pants.base.target.Target`
-    :param excludes: The excludes to add for the target.
-    :type excludes: list of :class:`pants.backend.jvm.targets.exclude.Exclude`
-    """
-    self._excludes.add_for_target(target, excludes)
-
   def add_excludes_for_targets(self, targets):
     """Add excludes from the provided targets.
 
@@ -236,27 +226,6 @@ class ClasspathProducts(object):
       return self._filter_by_excludes(classpath_tuples, targets, transitive)
     else:
       return classpath_tuples
-
-  def get_artifact_classpath_entries_for_targets(self, targets, transitive=True,
-                                                 respect_excludes=True):
-    """Gets the transitive artifact classpath products for the given targets.
-
-    Products are returned in order, optionally respecting target excludes, and the products only
-    include external artifact classpath elements (ie: resolved jars).
-
-    :param targets: The targets to lookup classpath products for.
-    :param bool transitive: `True` to include the transitive classpath for all targets, `False` to
-                            just include the classpath formed by the direct dependencies of the
-                            targets.
-    :param bool respect_excludes: `True` to respect excludes; `False` to ignore them.
-    :returns: The ordered (conf, classpath entry) tuples.
-    :rtype: list of (string, :class:`ArtifactClasspathEntry`)
-    """
-    classpath_tuples = self.get_classpath_entries_for_targets(targets,
-                                                              transitive=transitive,
-                                                              respect_excludes=respect_excludes)
-    return [(conf, cp_entry) for conf, cp_entry in classpath_tuples
-            if isinstance(cp_entry, ArtifactClasspathEntry)]
 
   def _filter_by_excludes(self, classpath_tuples, root_targets, transitive):
     excludes = self._excludes.get_for_targets(root_targets, transitive=transitive)

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -19,9 +19,23 @@ class ProductError(Exception): pass
 class UnionProducts(object):
   """Here, products for a target are the ordered union of the products for its transitive deps."""
 
-  def __init__(self):
+  def __init__(self, products_by_target=None):
     # A map of target to OrderedSet of product members.
-    self._products_by_target = defaultdict(OrderedSet)
+    self._products_by_target = products_by_target or defaultdict(OrderedSet)
+
+  def copy(self):
+    """Returns a copy of this UnionProducts.
+
+    Edits to the copy's mappings will not affect the product mappings in the original.
+    The copy is shallow though, so edits to the the copy's product values will mutate the original's
+    product values.
+
+    :rtype: :class:`UnionProducts`
+    """
+    products_by_target = defaultdict(OrderedSet)
+    for key, value in self._products_by_target.items():
+      products_by_target[key] = OrderedSet(value)
+    return UnionProducts(products_by_target=products_by_target)
 
   def add_for_target(self, target, products):
     """Updates the products for a particular target, adding to existing entries."""

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -337,25 +337,6 @@ class ClasspathProductsTest(BaseTest):
                       ('default', ClasspathEntry(self.path('an/internally/generated.jar')))],
                      classpath)
 
-  def test_get_artifact_classpath_entries_for_targets(self):
-    b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
-    a = self.make_target('a', JvmTarget, dependencies=[b])
-
-    classpath_product = ClasspathProducts()
-    example_jar_path = self._example_jar_path()
-    resolved_jar = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path)
-
-    # These non-artifact classpath entries should be ignored.
-    classpath_product.add_for_target(b, [('default', self.path('b/loose/classes/dir'))])
-    classpath_product.add_for_target(a, [('default', self.path('a/loose/classes/dir')),
-                                         ('default', self.path('an/internally/generated.jar'))])
-
-    classpath = classpath_product.get_artifact_classpath_entries_for_targets([a])
-    self.assertEqual([('default', ArtifactClasspathEntry(example_jar_path,
-                                                         resolved_jar.coordinate,
-                                                         resolved_jar.cache_path))],
-                     classpath)
-
   def _example_jar_path(self):
     return self.path('ivy/jars/com.example/lib/jars/123.4.jar')
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -36,6 +36,34 @@ class ClasspathProductsTest(BaseTest):
 
     self.assertEqual([('default', path)], classpath_product.get_for_target(a))
 
+  def test_copy(self):
+    b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
+    a = self.make_target('a', JvmTarget, dependencies=[b])
+
+    classpath_product = ClasspathProducts()
+    resolved_jar = self.add_jar_classpath_element_for_path(classpath_product,
+                                                           a,
+                                                           self._example_jar_path())
+    classpath_product.add_for_target(a, [('default', self.path('a/path'))])
+
+    copied = classpath_product.copy()
+
+    self.assertEqual([('default', resolved_jar.pants_path),
+                      ('default', self.path('a/path'))], classpath_product.get_for_target(a))
+    self.assertEqual([('default', resolved_jar.pants_path),
+                      ('default', self.path('a/path'))], copied.get_for_target(a))
+
+    self.add_excludes_for_targets(copied, b, a)
+    self.assertEqual([('default', resolved_jar.pants_path),
+                      ('default', self.path('a/path'))], classpath_product.get_for_target(a))
+    self.assertEqual([('default', self.path('a/path'))], copied.get_for_target(a))
+
+    copied.add_for_target(b, [('default', self.path('b/path'))])
+    self.assertEqual([('default', resolved_jar.pants_path),
+                      ('default', self.path('a/path'))], classpath_product.get_for_target(a))
+    self.assertEqual([('default', self.path('a/path')),
+                      ('default', self.path('b/path'))], copied.get_for_target(a))
+
   def test_fails_if_paths_outside_buildroot(self):
     a = self.make_target('a', JvmTarget)
 
@@ -307,6 +335,25 @@ class ClasspathProductsTest(BaseTest):
                                                          resolved_jar.cache_path)),
                       ('default', ClasspathEntry(self.path('a/loose/classes/dir'))),
                       ('default', ClasspathEntry(self.path('an/internally/generated.jar')))],
+                     classpath)
+
+  def test_get_artifact_classpath_entries_for_targets(self):
+    b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
+    a = self.make_target('a', JvmTarget, dependencies=[b])
+
+    classpath_product = ClasspathProducts()
+    example_jar_path = self._example_jar_path()
+    resolved_jar = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path)
+
+    # These non-artifact classpath entries should be ignored.
+    classpath_product.add_for_target(b, [('default', self.path('b/loose/classes/dir'))])
+    classpath_product.add_for_target(a, [('default', self.path('a/loose/classes/dir')),
+                                         ('default', self.path('an/internally/generated.jar'))])
+
+    classpath = classpath_product.get_artifact_classpath_entries_for_targets([a])
+    self.assertEqual([('default', ArtifactClasspathEntry(example_jar_path,
+                                                         resolved_jar.coordinate,
+                                                         resolved_jar.cache_path))],
                      classpath)
 
   def _example_jar_path(self):

--- a/tests/python/pants_test/goal/test_union_products.py
+++ b/tests/python/pants_test/goal/test_union_products.py
@@ -31,6 +31,29 @@ class UnionProductsTest(BaseTest):
     self.assertEquals(self.products.get_for_target(b, transitive=False), OrderedSet([2]))
     self.assertEquals(self.products.get_for_target(c, transitive=False), OrderedSet([3]))
 
+  def test_copy(self):
+    c = self.make_target('c')
+    b = self.make_target('b', dependencies=[c])
+    a = self.make_target('a', dependencies=[b, c])
+    self.products.add_for_target(a, [1])
+    self.products.add_for_target(b, [2])
+
+    copied = self.products.copy()
+
+    self.assertEquals(self.products.get_for_target(a), OrderedSet([1, 2]))
+    self.assertEquals(self.products.get_for_target(b), OrderedSet([2]))
+    self.assertEquals(copied.get_for_target(a), OrderedSet([1, 2]))
+    self.assertEquals(copied.get_for_target(b), OrderedSet([2]))
+
+    copied.add_for_target(c, [3])
+
+    self.assertEquals(self.products.get_for_target(a), OrderedSet([1, 2]))
+    self.assertEquals(self.products.get_for_target(b), OrderedSet([2]))
+    self.assertEquals(self.products.get_for_target(c), OrderedSet())
+    self.assertEquals(copied.get_for_target(a), OrderedSet([1, 2, 3]))
+    self.assertEquals(copied.get_for_target(b), OrderedSet([2, 3]))
+    self.assertEquals(copied.get_for_target(c), OrderedSet([3]))
+
   def test_remove_for_target(self):
     c = self.make_target('c')
     b = self.make_target('b', dependencies=[c])


### PR DESCRIPTION
This is part of the story in supporting proper transitive
`JvmBinary.deploy_excludes` in `JvmBinaryTask` derived classes and
in-general sets up users of these products to take a snapshot and then
build upon the products without pollution.

Tests are added to verify the copies used in snapshotting are
sufficiently divorced from their originals.

https://rbcommons.com/s/twitter/r/2837/