### PR TITLE
[Trigger CI] Don't modify globs excludes argument value.

### DIFF
--- a/tests/python/pants_test/backend/core/test_wrapped_globs.py
+++ b/tests/python/pants_test/backend/core/test_wrapped_globs.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from textwrap import dedent
 
 from pants.backend.core.wrapped_globs import Globs, RGlobs
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -111,6 +112,14 @@ class FilesetRelPathWrapperTest(BaseTest):
 
   def test_glob_exclude_string_in_list(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*.java", exclude=["fleem.java"]))')
+    self.context().scan(self.build_root)
+
+  def test_glob_exclude_doesnt_modify_exclude_array(self):
+    self.add_to_build_file('y/BUILD', dedent("""
+      list_of_files = ["fleem.java"]
+      java_library(name="y", sources=globs("*.java", exclude=list_of_files))
+      java_library(name="z", sources=list_of_files)
+      """))
     self.context().scan(self.build_root)
 
   def test_glob_invalid_keyword(self):

--- a/tests/python/pants_test/backend/core/test_wrapped_globs.py
+++ b/tests/python/pants_test/backend/core/test_wrapped_globs.py
@@ -120,7 +120,11 @@ class FilesetRelPathWrapperTest(BaseTest):
       java_library(name="y", sources=globs("*.java", exclude=list_of_files))
       java_library(name="z", sources=list_of_files)
       """))
-    self.context().scan(self.build_root)
+
+    graph = self.context().scan(self.build_root)
+
+    self.assertEqual(['fleem.java'],
+                     list(graph.get_target_from_spec('y:z').sources_relative_to_source_root()))
 
   def test_glob_invalid_keyword(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*.java", invalid_keyword=["fleem.java"]))')


### PR DESCRIPTION
Ideally, users shouldn't be using variables in BUILD files, but if they do, we shouldn't be modifying their values.