### PR TITLE
[trigger ci] Use list comprehension in jvm_compile to calculate valid targets

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -267,7 +267,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
 
         # Register products for all the valid targets.
         # We register as we go, so dependency checking code can use this data.
-        valid_targets = list(set(relevant_targets) - set(invalid_targets))
+        valid_targets = [vt.target for vt in invalidation_check.all_vts if vt.valid]
         valid_compile_contexts = [self._strategy.compile_context(t) for t in valid_targets]
         self._register_vts(valid_compile_contexts)
 


### PR DESCRIPTION
While looking at vts usages when adjusting buildcache for adding the cache hit callback, I noticed that we are doing extra work here.

Instead of constructing two sets from relevant_targets which == [vt.target for vt in invalidation_check.all_vts] and invalid_targets, difing them, and converting the resulting set into a list, this just creates a list from the all_vts' targets, removing the invalid ones