### PR TITLE
Upgrade to jarjar 1.5.1.

### DIFF
--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
@@ -22,7 +22,7 @@ class ShaderTest(unittest.TestCase):
     self.jarjar = '/not/really/jarjar.jar'
     with subsystem_instance(DistributionLocator):
       executor = SubprocessExecutor(DistributionLocator.cached())
-      self.shader = Shader(jarjar=self.jarjar, executor=executor)
+      self.shader = Shader(jarjar_classpath=[self.jarjar], executor=executor)
     self.output_jar = '/not/really/shaded.jar'
 
   def populate_input_jar(self, *entries):


### PR DESCRIPTION
This picks up a fix for jarjar failing, but exiting with 0:
  https://github.com/pantsbuild/jarjar/pull/5

It also removes `Shader`s requirement of a single jar classpath and
accepts a classpath list instead.

https://rbcommons.com/s/twitter/r/2846/