### PR TITLE
Prepare for the 0.0.48 release.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -90,6 +90,7 @@ Created by running `./build-support/bin/contributors.sh`.
 + Sergey Serebryakov
 + Simeon Franklin
 + Stu Hood
++ Tansy Arron-Walker
 + Ted Dziuba
 + Tejal Desai
 + Tianshuo Deng

--- a/build-support/bin/release-changelog-helper.sh
+++ b/build-support/bin/release-changelog-helper.sh
@@ -37,15 +37,14 @@ else
 fi
 
 change_count=$(git rev-list HEAD ^${LAST_RELEASE_SHA} | wc -l)
-git log --format="format:%H %aE %s" HEAD ^${LAST_RELEASE_SHA} | {
+git log --format="format:%H %s" HEAD ^${LAST_RELEASE_SHA} | {
 
   echo
   echo "There have been ${change_count} changes since the last release."
   echo
 
-  while read sha user subject
+  while read sha subject
   do
-    date=$(git log -1 ${sha} --format="format:%cd")
     urls=()
     urls=(
       ${urls}
@@ -58,9 +57,6 @@ git log --format="format:%H %aE %s" HEAD ^${LAST_RELEASE_SHA} | {
       )
     )
 
-    echo ${date} ${user}
-    echo "https://github.com/pantsbuild/pants/commit/${sha}"
-    echo "=="
     echo "* ${subject}"
 
     for url in ${urls[@]}

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
@@ -8,7 +8,7 @@ java_thrift_library(
   provides=artifact(
     org='org.archimedes',
     name='android_generator',
-    repo=Repository(name='test',
+    repo=repository(name='test',
       url='https://dl.bintray.com/somerandom/url',
       push_db_basedir='/tmp')
   )

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -1,6 +1,147 @@
 RELEASE HISTORY
 ===============
 
+0.0.48 (9/18/2015)
+------------------
+
+Release Notes
+~~~~~~~~~~~~~
+
+There is a new UI in the `./pants server` web interface that shows 'Timing Stats' graphs.  These
+graphs show where time is spent on a daily-aggregation basis in various tasks.  You can drill down
+into a task to see which sub-steps are most expensive.  Try it out!
+
+We also have a few new metadata goals to help figure out what's going on with file ownership and
+options.
+
+If you want to find out where options are comping from, the `options` goal can help you out::
+
+    $ ./pants -q options --only-overridden --scope=compile
+    compile.apt.jvm_options = ['-Xmx1g', '-XX:MaxPermSize=256m'] (from CONFIG in pants.ini)
+    compile.java.jvm_options = ['-Xmx2G'] (from CONFIG in pants.ini)
+    compile.java.partition_size_hint = 1000000000 (from CONFIG in pants.ini)
+    compile.zinc.jvm_options = ['-Xmx2g', '-XX:MaxPermSize=256m', '-Dzinc.analysis.cache.limit=0'] (from CONFIG in pants.ini)
+
+If you're not sure which target(s) own a given file::
+
+    $ ./pants -q list-owners -- src/python/pants/base/target.py
+    src/python/pants/base:target
+
+The latter comes from new contributor Tansy Arron-Walker.
+
+API Changes
+~~~~~~~~~~~
+
+* Kill 'ivy_jar_products'.
+  `RB #2823 <https://rbcommons.com/s/twitter/r/2823>`_
+
+* Kill 'ivy_resolve_symlink_map' and 'ivy_cache_dir' products.
+  `RB #2819 <https://rbcommons.com/s/twitter/r/2819>`_
+
+Bugfixes
+~~~~~~~~
+
+* Upgrade to jarjar 1.5.2.
+  `RB #2847 <https://rbcommons.com/s/twitter/r/2847>`_
+
+* Don't modify globs excludes argument value.
+  `RB #2841 <https://rbcommons.com/s/twitter/r/2841>`_
+
+* Whitelist the appropriate filter option name for zinc
+  `RB #2839 <https://rbcommons.com/s/twitter/r/2839>`_
+
+* Ensure stale classes are removed during isolated compile by cleaning classes directory prior to handling invalid targets
+  `RB #2805 <https://rbcommons.com/s/twitter/r/2805>`_
+
+* Fix `linecount` estimator for `dep-usage` goal
+  `RB #2828 <https://rbcommons.com/s/twitter/r/2828>`_
+
+* Fix resource handling for the python backend.
+  `RB #2817 <https://rbcommons.com/s/twitter/r/2817>`_
+
+* Fix coordinates of resolved jars in IvyInfo.
+  `RB #2818 <https://rbcommons.com/s/twitter/r/2818>`_
+
+* Fix `NailgunExecutor` to support more than one connect attempt
+  `RB #2822 <https://rbcommons.com/s/twitter/r/2822>`_
+
+* Fixup AndroidIntegrationTest broken by Distribution refactor.
+  `RB #2811 <https://rbcommons.com/s/twitter/r/2811>`_
+
+* Backport sbt java output fixes into zinc
+  `RB #2810 <https://rbcommons.com/s/twitter/r/2810>`_
+
+* Align ivy excludes and ClasspathProducts excludes.
+  `RB #2807 <https://rbcommons.com/s/twitter/r/2807>`_
+
+New Features
+~~~~~~~~~~~~
+
+* A nice timing stats report.
+  `RB #2825 <https://rbcommons.com/s/twitter/r/2825>`_
+
+* Add new console task ListOwners to determine the targets that own a source
+  `RB #2755 <https://rbcommons.com/s/twitter/r/2755>`_
+
+* Adding a console task to explain where options came from.
+  `RB #2816 <https://rbcommons.com/s/twitter/r/2816>`_
+
+Small improvements, Refactoring and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Deprecate 'Repository' alias in favor of 'repo'.
+  `RB #2845 <https://rbcommons.com/s/twitter/r/2845>`_
+
+* Fix indents (checkstyle)
+  `RB #2844 <https://rbcommons.com/s/twitter/r/2844>`_
+
+* Use list comprehension in jvm_compile to calculate valid targets
+  `RB #2843 <https://rbcommons.com/s/twitter/r/2843>`_
+
+* Transition `IvyImports` to 'compile_classpath'.
+  `RB #2840 <https://rbcommons.com/s/twitter/r/2840>`_
+
+* Migrate `JvmBinaryTask` to 'compile_classpath'.
+  `RB #2832 <https://rbcommons.com/s/twitter/r/2832>`_
+
+* Add support for snapshotting `ClasspathProducts`.
+  `RB #2837 <https://rbcommons.com/s/twitter/r/2837>`_
+
+* Bump to zinc 1.0.11
+  `RB #2827 <https://rbcommons.com/s/twitter/r/2827>`_
+  `RB #2836 <https://rbcommons.com/s/twitter/r/2836>`_
+  `RB #2812 <https://rbcommons.com/s/twitter/r/2812>`_
+
+* Lazily load zinc analysis
+  `RB #2827 <https://rbcommons.com/s/twitter/r/2827>`_
+
+* Add support for whitelisting of zinc options
+  `RB #2835 <https://rbcommons.com/s/twitter/r/2835>`_
+
+* Kill the unused `JvmTarget.configurations` field.
+  `RB #2834 <https://rbcommons.com/s/twitter/r/2834>`_
+
+* Kill 'jvm_build_tools_classpath_callbacks' deps.
+  `RB #2831 <https://rbcommons.com/s/twitter/r/2831>`_
+
+* Add `:scalastyle_integration` test to `:integration` test target
+  `RB #2830 <https://rbcommons.com/s/twitter/r/2830>`_
+
+* Use fast_relpath in JvmCompileIsolatedStrategy.compute_classes_by_source
+  `RB #2826 <https://rbcommons.com/s/twitter/r/2826>`_
+
+* Enable New Style class check
+  `RB #2820 <https://rbcommons.com/s/twitter/r/2820>`_
+
+* Remove `--quiet` flag from `pip`
+  `RB #2809 <https://rbcommons.com/s/twitter/r/2809>`_
+
+* Move AptCompile to zinc
+  `RB #2806 <https://rbcommons.com/s/twitter/r/2806>`_
+
+* Add a just-in-time check of the artifact cache to the isolated compile strategy
+  `RB #2690 <https://rbcommons.com/s/twitter/r/2690>`_
+
 0.0.47 (9/11/2015)
 ------------------
 

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -14,7 +14,7 @@ into a task to see which sub-steps are most expensive.  Try it out!
 We also have a few new metadata goals to help figure out what's going on with file ownership and
 options.
 
-If you want to find out where options are comping from, the `options` goal can help you out::
+If you want to find out where options are coming from, the `options` goal can help you out::
 
     $ ./pants -q options --only-overridden --scope=compile
     compile.apt.jvm_options = ['-Xmx1g', '-XX:MaxPermSize=256m'] (from CONFIG in pants.ini)

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -113,8 +113,9 @@ class JarDependency(object):
     self.apidocs = apidocs
     self.mutable = mutable
 
-    @deprecated('0.0.48',
-                hint_message='JarDependency now only specifies a single artifact, so the artifacts argument will be removed.')
+    @deprecated(removal_version='0.0.49',
+                hint_message='JarDependency now only specifies a single artifact, so the '
+                             'artifacts argument will be removed.')
     def make_artifacts():
       return tuple(assert_list(artifacts, expected_type=IvyArtifact, key_arg='artifacts'))
 
@@ -150,8 +151,9 @@ class JarDependency(object):
   def append_artifact(self, name, type_=None, ext=None, conf=None, url=None, classifier=None):
     """Append a new IvyArtifact to the list of artifacts for this jar."""
 
-    @deprecated('0.0.48',
-                hint_message='JarDependency now only specifies a single artifact, {} defines more than one.'.format(name))
+    @deprecated(removal_version='0.0.49',
+                hint_message='JarDependency now only specifies a single artifact, {} defines more '
+                             'than one.'.format(name))
     def add_more_artifacts():
       return self.artifacts + (IvyArtifact(name, type_=type_, ext=ext, conf=conf, url=url, classifier=classifier), )
     if self.artifacts:

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -6,4 +6,4 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 
-VERSION = '0.0.47'
+VERSION = '0.0.48'


### PR DESCRIPTION
I pushed back the `JarDependency` artifacts deprecations - this needs a
bit more time to remove nicely.

I also updated the `release-changelog-helper.sh` script to just output
the changelog bullets, folks have been solid at using `rbt patch` for a
while now, obviating the need for timestamps, sha and users info to
track down RBs/PRs.

https://rbcommons.com/s/twitter/r/2849/