### PR TITLE
[Trigger CI] Include resolved jar versions in compile fingerprints; ensure coordin…

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -102,6 +102,10 @@ class IvyInfo(object):
     self._artifacts_by_ref = defaultdict(OrderedSet)
 
   def add_module(self, module):
+    if not module.artifact:
+      # Module was evicted, so do not record information about it
+      return
+
     ref_unversioned = module.ref.unversioned
     if ref_unversioned in self.refs_by_unversioned_refs:
       raise IvyResolveMappingError('Already defined module {}, as rev {}!'
@@ -111,9 +115,7 @@ class IvyInfo(object):
                                    .format(module.ref))
     self.refs_by_unversioned_refs[ref_unversioned] = module.ref
     self.modules_by_ref[module.ref] = module
-    if not module.artifact: #TODO maybe move above symbol table entry
-      # Module was evicted, so do not record information about it
-      return
+
     for caller in module.callers:
       self._deps_by_caller[caller.caller_key].add(module.ref)
     self._artifacts_by_ref[ref_unversioned].add(module.artifact)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -26,7 +26,7 @@ from pants.reporting.reporting_utils import items_to_report_element
 
 
 class ResolvedJarAwareTaskIdentityFingerprintStrategy(TaskIdentityFingerprintStrategy):
-  """Fingerprint strategy which includes the current task fingerprint when fingerprinting target."""
+  """Task fingerprint strategy that also includes the resolved coordinates of dependent jars."""
 
   def __init__(self, task, compile_classpath):
     super(ResolvedJarAwareTaskIdentityFingerprintStrategy, self).__init__(task)

--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -63,10 +63,14 @@ class TaskIdentityFingerprintStrategy(FingerprintStrategy):
   def __init__(self, task):
     self._task = task
 
-  def compute_fingerprint(self, target):
+  def _build_hasher(self, target):
     hasher = hashlib.sha1()
     hasher.update(target.payload.fingerprint() or '')
     hasher.update(self._task.fingerprint or '')
+    return hasher
+
+  def compute_fingerprint(self, target):
+    hasher = self._build_hasher(target)
     return hasher.hexdigest()
 
   def __hash__(self):

--- a/testprojects/src/java/org/pantsbuild/testproject/jarversionincompatibility/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/jarversionincompatibility/BUILD
@@ -1,0 +1,19 @@
+target(name='only-15-directly',
+       dependencies=[':jarversionincompatibility'])
+
+target(name='alongside-16',
+       dependencies=[':jarversionincompatibility',
+                     ':guava-16',
+                    ])
+
+
+java_library(name='jarversionincompatibility',
+             sources=['DependsOnRateLimiter.java'],
+             dependencies=[':guava-15'])
+
+
+jar_library(name='guava-15',
+            jars=[jar('com.google.guava', 'guava', '15.0')])
+
+jar_library(name='guava-16',
+            jars=[jar('com.google.guava', 'guava', '16.0')])

--- a/testprojects/src/java/org/pantsbuild/testproject/jarversionincompatibility/DependsOnRateLimiter.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/jarversionincompatibility/DependsOnRateLimiter.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.jarversionincompatibility;
+
+import com.google.common.util.concurrent.RateLimiter;
+
+public class DependsOnRateLimiter {
+    public static void main(String[] args) {
+        RateLimiter rateLimiter = RateLimiter.create(10000.0); // 10k permits per second
+        rateLimiter.acquire();
+    }
+}

--- a/tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources/report_with_resolve_to_other_version.xml
+++ b/tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources/report_with_resolve_to_other_version.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="ivy-report.xsl"?>
+<ivy-report version="1.0">
+    <info organisation="toplevel" module="toplevelmodule" revision="latest" />
+    <dependencies>
+        <module organisation="org1" name="name1">
+            <revision name="0.0.2">
+                <caller organisation="toplevel" name="toplevelmodule" callerrev="latest"/>
+                <artifacts>
+                    <artifact location="ivy2cache_path/org1/name1.jar" extra-classifier="tests"/>
+                </artifacts>
+            </revision>
+        </module>
+    </dependencies>
+</ivy-report>

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -207,21 +207,24 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
     self.assertEqual(expected, coordinate_by_path)
 
   def test_resolved_jars_with_different_version(self):
+    # If a jar is resolved as a different version than the requested one, the coordinates of
+    # the resolved jar should match the artifact, not the requested coordinates.
     lib = self.make_target(spec=':org1-name1',
                            target_type=JarLibrary,
-                           jars=[JarDependency(org='org1', name='name1', rev='0.0.1',
-                                               classifier='tests')])
+                           jars=[
+                             JarDependency(org='org1', name='name1',
+                                           rev='0.0.1',
+                                           classifier='tests')])
 
     ivy_info = self.parse_ivy_report('ivy_utils_resources/report_with_resolve_to_other_version.xml')
 
     resolved_jars = ivy_info.get_resolved_jars_for_jar_library(lib)
 
-    expected = {'ivy2cache_path/org1/name1.jar': coord(org='org1', name='name1',
-                                                       classifier='tests',
-                                                       rev='0.0.2')}
     self.maxDiff = None
-    coordinate_by_path = {rj.cache_path: rj.coordinate for rj in resolved_jars}
-    self.assertEqual(expected, coordinate_by_path)
+    self.assertEqual([coord(org='org1', name='name1',
+                           classifier='tests',
+                           rev='0.0.2')],
+                     [jar.coordinate for jar in resolved_jars])
 
   def test_does_not_visit_diamond_dep_twice(self):
     ivy_info = self.parse_ivy_report('ivy_utils_resources/report_with_diamond.xml')


### PR DESCRIPTION
…ates match artifacts.

We've run into issues recently where a different jar version resolution can result in different compiled outputs. This adds the resolved coordinates into the fingerprint for JVM compile artifacts. By doing that we can ensure that cache entries for compile artifacts will be invalidated if the resolved jar versions change.

Additionally, while working on this I discovered that the revision assigned to a particular classpath artifact is the requested one and not the final one. I added a unversioned -> versioned table to IvyInfo to ensure that the resolved versions are used in all cases.