### PR TITLE
Prepare the 0.0.49 hotfix release.

### DIFF
--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -13,6 +13,9 @@ that use relative imports.
 Bugfixes
 ~~~~~~~~
 
+* Include resolved jar versions in compile fingerprints; ensure coordinates match artifacts.
+  `RB #2853 <https://rbcommons.com/s/twitter/r/2853>`_
+
 * Fixup GoFetch to handle relative imports.
   `RB #2854 <https://rbcommons.com/s/twitter/r/2854>`_
 

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -1,6 +1,27 @@
 RELEASE HISTORY
 ===============
 
+0.0.49 (9/21/2015)
+------------------
+
+Release Notes
+~~~~~~~~~~~~~
+
+This is a hotfix release that includes a fix for resolving remote go libraries
+that use relative imports.
+
+Bugfixes
+~~~~~~~~
+
+* Fixup GoFetch to handle relative imports.
+  `RB #2854 <https://rbcommons.com/s/twitter/r/2854>`_
+
+New Features
+~~~~~~~~~~~~
+
+* Enhancements to the dep-usage goal
+  `RB #2851 <https://rbcommons.com/s/twitter/r/2851>`_
+
 0.0.48 (9/18/2015)
 ------------------
 

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -113,7 +113,7 @@ class JarDependency(object):
     self.apidocs = apidocs
     self.mutable = mutable
 
-    @deprecated(removal_version='0.0.49',
+    @deprecated(removal_version='0.0.50',
                 hint_message='JarDependency now only specifies a single artifact, so the '
                              'artifacts argument will be removed.')
     def make_artifacts():
@@ -151,7 +151,7 @@ class JarDependency(object):
   def append_artifact(self, name, type_=None, ext=None, conf=None, url=None, classifier=None):
     """Append a new IvyArtifact to the list of artifacts for this jar."""
 
-    @deprecated(removal_version='0.0.49',
+    @deprecated(removal_version='0.0.50',
                 hint_message='JarDependency now only specifies a single artifact, {} defines more '
                              'than one.'.format(name))
     def add_more_artifacts():

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -161,7 +161,7 @@ class Address(AbstractClass):
     return ':{target_name}'.format(target_name=self._target_name)
 
   @property
-  @deprecated(removal_version='0.0.49',
+  @deprecated(removal_version='0.0.50',
               hint_message='Use `not isinstance(address, BuildFileAddress)` instead.')
   def is_synthetic(self):
     return False
@@ -226,7 +226,7 @@ class BuildFileAddress(Address):
 
 
 class SyntheticAddress(Address):
-  deprecate_me = functools.partial(deprecated, removal_version='0.0.49')
+  deprecate_me = functools.partial(deprecated, removal_version='0.0.50')
 
   @classmethod
   @deprecate_me(hint_message='Use `Address.parse(...)` instead.')

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -6,4 +6,4 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 
-VERSION = '0.0.48'
+VERSION = '0.0.49'


### PR DESCRIPTION
This release includes a hotfix for resolving remote go libraries that
use relative imports.