### PR TITLE
[CI] Support arbitrary expressions in option values.

### DIFF
--- a/src/python/pants/base/config.py
+++ b/src/python/pants/base/config.py
@@ -12,7 +12,7 @@ import os
 import six
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir, get_pants_configdir
-from pants.util.eval import parse_literal
+from pants.util.eval import parse_expression
 from pants.util.strutil import is_text_or_binary
 
 
@@ -163,8 +163,8 @@ class Config(object):
       return raw_value
 
     key = '{}.{}'.format(section, option)
-    return parse_literal(name=key, val=raw_value, acceptable_types=type_,
-                         raise_type=self.ConfigError)
+    return parse_expression(name=key, val=raw_value, acceptable_types=type_,
+                            raise_type=self.ConfigError)
 
   # Subclasses must implement.
   def sources(self):

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.option.errors import ParseError
-from pants.util.eval import parse_literal
+from pants.util.eval import parse_expression
 
 
 def dict_option(s):
@@ -49,4 +49,4 @@ def _convert(val, acceptable_types):
   :raises :class:`pants.options.errors.ParseError`: if there was a problem parsing the val as an
                                                     acceptable type.
   """
-  return parse_literal(val, acceptable_types, raise_type=ParseError)
+  return parse_expression(val, acceptable_types, raise_type=ParseError)

--- a/src/python/pants/util/eval.py
+++ b/src/python/pants/util/eval.py
@@ -5,16 +5,15 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import ast
 from textwrap import dedent
 
 import six
 
 
-def parse_literal(val, acceptable_types, name=None, raise_type=ValueError):
-  """Attempts to parse the given `val` as a python literal of the specified `acceptable_types`.
+def parse_expression(val, acceptable_types, name=None, raise_type=ValueError):
+  """Attempts to parse the given `val` as a python expression of the specified `acceptable_types`.
 
-  :param string val: A string containing a python literal.
+  :param string val: A string containing a python expression.
   :param acceptable_types: The acceptable types of the parsed object.
   :type acceptable_types: type|tuple of types.  The tuple may be nested; ie anything `isinstance`
                           accepts.
@@ -44,7 +43,7 @@ def parse_literal(val, acceptable_types, name=None, raise_type=ValueError):
     return '\n'.join(lines)
 
   try:
-    parsed_value = ast.literal_eval(val)
+    parsed_value = eval(val)
   except ValueError as e:
     raise raise_type(dedent("""\
       The {name} cannot be evaluated as a literal expression: {error}

--- a/tests/python/pants_test/base/test_config.py
+++ b/tests/python/pants_test/base/test_config.py
@@ -110,7 +110,7 @@ that.""",
 
   def test_getdefault_not_found(self):
     with self.assertRaises(Config.ConfigError):
-      self.config.getdefault('name', type=int)
+      self.config.getdefault('scale', type=int)
 
   def test_default_section_fallback(self):
     self.assertEquals('foo', self.config.get('defined_section', 'name'))

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -36,6 +36,7 @@ class CustomTypesTest(unittest.TestCase):
     self._do_test({'a': 'b'}, '{ "a": "b" }')
     self._do_test({'a': 'b'}, "{ 'a': 'b' }")
     self._do_test({'a': [1, 2, 3]}, '{ "a": [1, 2, 3] }')
+    self._do_test({'a': [1, 2, 3, 4]}, '{ "a": [1, 2] + [3, 4] }')
     self._do_test_dict_error({})
     self._do_test_dict_error({'a': 'b'})
     self._do_test_dict_error({'a': [1, 2, 3]})
@@ -43,7 +44,6 @@ class CustomTypesTest(unittest.TestCase):
     self._do_test_dict_error('[1, 2, 3]')
     self._do_test_dict_error('1')
     self._do_test_dict_error('"a"')
-    self._do_test_dict_error('{ "a": [1, 2] + [3, 4] }')
 
   def test_list(self):
     self._do_test([], '[]')
@@ -51,6 +51,8 @@ class CustomTypesTest(unittest.TestCase):
     self._do_test((1, 2, 3), '1,2,3')
     self._do_test(['a', 'b', 'c'], '["a", "b", "c"]')
     self._do_test(['a', 'b', 'c'], "['a', 'b', 'c']")
+    self._do_test([1, 2, 3, 4], '[1, 2] + [3, 4]')
+    self._do_test((1, 2, 3, 4), '(1, 2) + (3, 4)')
     self._do_test_list_error([])
     self._do_test_list_error([1, 2, 3])
     self._do_test_list_error((1, 2, 3))
@@ -59,5 +61,3 @@ class CustomTypesTest(unittest.TestCase):
     self._do_test_list_error('{"a": "b"}')
     self._do_test_list_error('1')
     self._do_test_list_error('"a"')
-    self._do_test_list_error('[1, 2] + [3, 4]')
-    self._do_test_list_error('(1, 2) + (3, 4)')

--- a/tests/python/pants_test/util/test_eval.py
+++ b/tests/python/pants_test/util/test_eval.py
@@ -9,36 +9,38 @@ import unittest
 
 import six
 
-from pants.util.eval import parse_literal
+from pants.util.eval import parse_expression
 
 
 class ParseLiteralTest(unittest.TestCase):
 
   def test_success_simple(self):
-    literal = parse_literal("'42'", acceptable_types=six.string_types)
+    literal = parse_expression("'42'", acceptable_types=six.string_types)
     self.assertEqual('42', literal)
 
   def test_success_mixed(self):
-    literal = parse_literal('42', acceptable_types=(float, int))
+    literal = parse_expression('42', acceptable_types=(float, int))
     self.assertEqual(42, literal)
 
-  def test_failure_syntax(self):
-    with self.assertRaises(ValueError):
-      # Only literals are allowed!
-      parse_literal('1+2', acceptable_types=int)
+  def test_success_complex_syntax(self):
+    self.assertEqual(3, parse_expression('1+2', acceptable_types=int))
+
+  def test_success_list_concat(self):
+    # This is actually useful in config files.
+    self.assertEqual([1, 2, 3], parse_expression('[1, 2] + [3]', acceptable_types=list))
 
   def test_failure_type(self):
     # Prove there is no syntax error in the raw value.
-    literal = parse_literal('1.0', acceptable_types=float)
+    literal = parse_expression('1.0', acceptable_types=float)
     self.assertEqual(1.0, literal)
 
     # Now we can safely assume the ValueError is raise due to type checking.
     with self.assertRaises(ValueError):
-      parse_literal('1.0', acceptable_types=int)
+      parse_expression('1.0', acceptable_types=int)
 
   def test_custom_error_type(self):
     class CustomError(Exception):
       pass
 
     with self.assertRaises(CustomError):
-      parse_literal('1.0', acceptable_types=int, raise_type=CustomError)
+      parse_expression('1.0', acceptable_types=int, raise_type=CustomError)


### PR DESCRIPTION
Supporting only literals was too restrictive. E.g, it is
useful to be able to concatenate lists in config files.