### PR TITLE
resource dir use target.id hash to prevent filename being too long

### DIFF
--- a/src/python/pants/backend/jvm/tasks/resources_task.py
+++ b/src/python/pants/backend/jvm/tasks/resources_task.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import hashlib
 import os
 from abc import abstractmethod
 from collections import defaultdict
@@ -40,7 +41,8 @@ class ResourcesTask(Task):
   def compute_target_dir(self, target):
     # Sources are all relative to their roots: relativize directories as well to avoid
     # breaking filesystem path length limits.
-    return relativize_path(os.path.join(self.workdir, target.id), get_buildroot())
+    target_id_hash = hashlib.sha1(target.id).hexdigest()
+    return relativize_path(os.path.join(self.workdir, target_id_hash), get_buildroot())
 
   def execute(self):
     # Tracked and returned for use in tests.


### PR DESCRIPTION
migrating ScroogeGen into SimpleCodegenTask (https://github.com/pantsbuild/pants/pull/2217) will result longer target.id, thus causing resouce task to generate super long filename that exceeds OS limit. This intends to be patched before the migration.

10:28:29 00:14   [resources]
10:28:30 00:15     [prepare]
                   Invalidated 326 targets.
               Waiting for background workers to finish.
10:28:30 00:15   [complete]
               FAILURE

Exception message: [Errno 63] File name too long: '.pants.d/resources/prepare/.pants.d.compile.library-buildprops..pants.d.gen.scrooge.isolated.science.src.thrift.com.twitter.ads.internal.serving.user_text_profile.user_text_profile-java.science.src.thrift.com.twitter.ads.internal.serving.user_text_profile.user_text_profile-java.build-props'