### PR TITLE
[CI] Slim down the API of the Config class and move it to options/.

### DIFF
--- a/migrations/options/src/python/BUILD
+++ b/migrations/options/src/python/BUILD
@@ -6,7 +6,6 @@ python_binary(
   source='migrate_config.py',
   dependencies=[
     '3rdparty/python:ansicolors',
-    'src/python/pants/base:config',
     'src/python/pants/option',
   ]
 )

--- a/migrations/options/src/python/migrate_config.py
+++ b/migrations/options/src/python/migrate_config.py
@@ -9,8 +9,8 @@ import sys
 
 from colors import cyan, green, red, yellow
 
-from pants.base.config import Config
 from pants.option import custom_types
+from pants.option.config import Config
 from pants.option.errors import ParseError
 
 
@@ -532,18 +532,15 @@ def check_option(cp, src, dst):
     # David tried to avoid poking into cp's guts in https://rbcommons.com/s/twitter/r/1451/ but
     # that approach fails for the important case of boolean options.  Since this is a ~short term
     # tool and its highly likely its lifetime will be shorter than the time the private
-    # ConfigParser_sections API we use here changes, its worth the risk.
+    # ConfigParser_sections API we use here changes, it's worth the risk.
     if section == 'DEFAULT':
       # NB: The 'DEFAULT' section is not tracked via `has_section` or `_sections`, so we use a
-      # different API to check for an explicit default.  The defaults are a combination of both
-      # 'DEFAULT' section values and defaults passed to the ConfigParser constructor, but we
-      # create the `cp` config parser below explicitly with no constructor defaults so this check
-      # works.
+      # different API to check for an explicit default.
       return key in cp.defaults()
     else:
       return cp.has_section(section) and (key in cp._sections[section])
 
-  def section(s):
+  def sect(s):
     return cyan('[{}]'.format(s))
 
   src_section, src_key = src
@@ -551,8 +548,8 @@ def check_option(cp, src, dst):
     if dst is not None:
       dst_section, dst_key = dst
       print('Found {src_key} in section {src_section}. Should be {dst_key} in section '
-            '{dst_section}.'.format(src_key=green(src_key), src_section=section(src_section),
-                                    dst_key=green(dst_key), dst_section=section(dst_section)),
+            '{dst_section}.'.format(src_key=green(src_key), src_section=sect(src_section),
+                                    dst_key=green(dst_key), dst_section=sect(dst_section)),
             file=sys.stderr)
     elif src not in notes:
       print('Found {src_key} in section {src_section} and there is no automated migration path'
@@ -562,12 +559,12 @@ def check_option(cp, src, dst):
     if (src_section, src_key) in notes:
       print('  Note for {src_key} in section {src_section}: {note}'
             .format(src_key=green(src_key),
-                    src_section=section(src_section),
+                    src_section=sect(src_section),
                     note=yellow(notes[(src_section, src_key)])))
 
 
 def check_config_file(path):
-  cp = Config.create_parser()
+  cp = Config._create_parser()
   with open(path, 'r') as ini:
     cp.readfp(ini)
 

--- a/src/docs/setup_repo.md
+++ b/src/docs/setup_repo.md
@@ -12,8 +12,8 @@ Configuring with `pants.ini`
 ----------------------------
 
 Pants Build is very configurable. Your source tree's top-level directory
-should contain a `pants.ini` file that sets many, many options. You can
-modify a broad range of settings here, including specific binaries to
+should contain a `pants.ini` file that sets various options. You can
+modify a broad range of options here, including specific binaries to
 use in your toolchain, arguments to pass to tools, etc.
 
 These files are formatted as [Python config
@@ -46,7 +46,7 @@ several contexts, as in these excerpts that define/use `thrift_workdir`:
 It's also handy for defining values that are used in several contexts,
 since these values will be available in all those contexts. The code
 that combines DEFAULT values with others is in Pants'
-[base/config.py](https://github.com/pantsbuild/pants/blob/master/src/python/pants/base/config.py).
+[option/config.py](https://github.com/pantsbuild/pants/blob/master/src/python/pants/option/config.py).
 
 Configure Pants' own Runtime Dependencies
 -----------------------------------------

--- a/src/python/pants/backend/android/BUILD
+++ b/src/python/pants/backend/android/BUILD
@@ -36,7 +36,7 @@ python_library(
   name='keystore_resolver',
   sources=['keystore/keystore_resolver.py'],
   dependencies=[
-    'src/python/pants/base:config',
+    'src/python/pants/option',
   ]
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -151,17 +151,6 @@ python_library(
 )
 
 python_library(
-  name = 'config',
-  sources = ['config.py'],
-  dependencies = [
-    '3rdparty/python:six',
-    ':build_environment',
-    'src/python/pants/util:eval',
-    'src/python/pants/util:strutil',
-  ]
-)
-
-python_library(
   name = 'dep_lookup_error',
   dependencies = [
     ':address_lookup_error',

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -9,10 +9,10 @@ python_library(
     '3rdparty/python:six',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
-    'src/python/pants/base:config',
     'src/python/pants/base:deprecated',
     'src/python/pants/util:eval',
     'src/python/pants/util:meta',
+    'src/python/pants/util:strutil',
   ]
 )
 

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -9,8 +9,8 @@ import itertools
 import os
 import sys
 
-from pants.base.config import Config
 from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.config import Config
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_tracker import OptionTracker
 from pants.option.option_util import is_boolean_flag

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -40,7 +40,6 @@ target(
     ':build_invalidator',
     ':build_root',
     ':cmd_line_spec_parser',
-    ':config',
     ':deprecated',
     ':extension_loader',
     ':filesystem_build_file',
@@ -211,15 +210,6 @@ python_tests(
     'src/python/pants/base:build_file_aliases',
     'src/python/pants/base:cmd_line_spec_parser',
     'tests/python/pants_test:base_test',
-  ]
-)
-
-python_tests(
-  name = 'config',
-  sources = ['test_config.py'],
-  dependencies = [
-    'src/python/pants/base:config',
-    'src/python/pants/util:contextutil',
   ]
 )
 

--- a/tests/python/pants_test/option/test_config.py
+++ b/tests/python/pants_test/option/test_config.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import textwrap
 import unittest
 
-from pants.base.config import Config
+from pants.option.config import Config
 from pants.util.contextutil import temporary_file
 
 
@@ -57,7 +57,6 @@ class ConfigTest(unittest.TestCase):
         self.config = Config.load(configpaths=[ini1.name, ini2.name])
 
   def test_getstring(self):
-    self.assertEquals('foo', self.config.getdefault('name'))
     self.assertEquals('/a/b/42', self.config.get('a', 'path'))
     self.assertEquals('/a/b/42::foo', self.config.get('a', 'embed'))
     self.assertEquals(
@@ -69,52 +68,12 @@ that.""",
     self._check_defaults(self.config.get, '')
     self._check_defaults(self.config.get, '42')
 
-  def test_getint(self):
-    self.assertEquals(42, self.config.getint('a', 'answer'))
-    self._check_defaults(self.config.get, 42)
-
-  def test_getfloat(self):
-    self.assertEquals(1.2, self.config.getfloat('b', 'scale'))
-    self._check_defaults(self.config.get, 42.0)
-
-  def test_getbool(self):
-    self.assertTrue(self.config.getbool('a', 'fast'))
-    self.assertFalse(self.config.getbool('b', 'preempt'))
-    self._check_defaults(self.config.get, True)
-
-  def test_getlist(self):
-    self.assertEquals([1, 2, 3, 42], self.config.getlist('a', 'list'))
-    self._check_defaults(self.config.get, [])
-    self._check_defaults(self.config.get, [42])
-
-  def test_getdict(self):
-    self.assertEquals(dict(a=1, b=42, c=['42', 42]), self.config.getdict('b', 'dict'))
-    self._check_defaults(self.config.get, {})
-    self._check_defaults(self.config.get, dict(a=42))
-
-  def test_get_required(self):
-    self.assertEquals('foo', self.config.get_required('a', 'name'))
-    self.assertEquals(42, self.config.get_required('a', 'answer', type=int))
-    with self.assertRaises(Config.ConfigError):
-      self.config.get_required('a', 'answer', type=dict)
-    with self.assertRaises(Config.ConfigError):
-      self.config.get_required('a', 'no_section')
-    with self.assertRaises(Config.ConfigError):
-      self.config.get_required('a', 'blank_section')
-
-  def test_getdefault(self):
-    self.assertEquals('foo', self.config.getdefault('name'))
-
-  def test_getdefault_explicit(self):
-    self.assertEquals('foo', self.config.getdefault('name', type=str))
-
-  def test_getdefault_not_found(self):
-    with self.assertRaises(Config.ConfigError):
-      self.config.getdefault('scale', type=int)
-
   def test_default_section_fallback(self):
     self.assertEquals('foo', self.config.get('defined_section', 'name'))
     self.assertEquals('foo', self.config.get('not_a_defined_section', 'name'))
+
+  def test_sections(self):
+    self.assertEquals(['a', 'b', 'defined_section'], self.config.sections())
 
   def _check_defaults(self, accessor, default):
     self.assertEquals(None, accessor('c', 'fast'))

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -13,9 +13,9 @@ import warnings
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pants.base.config import Config
 from pants.base.deprecated import PastRemovalVersionError
 from pants.option.arg_splitter import GLOBAL_SCOPE
+from pants.option.config import Config
 from pants.option.custom_types import dict_option, file_option, list_option, target_list_option
 from pants.option.errors import ParseError
 from pants.option.global_options import GlobalOptionsRegistrar


### PR DESCRIPTION
Remove/make private all methods that weren't used outside its test.

Move get_required into the only code that uses it. That code
(keystore_resolver.py) had to catch and re-throw all exceptions anyway,
so this didn't really add any net LoC there.