### PR TITLE
Define local variable in finally block of nailgun_executor

### DIFF
--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -188,7 +188,8 @@ class NailgunClient(object):
 
   def try_connect(self):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    return sock if sock.connect_ex((self._host, self._port)) == 0 else None
+    # The sock.close() call returns None.
+    return sock if sock.connect_ex((self._host, self._port)) == 0 else sock.close()
 
   def __call__(self, main_class, cwd=None, *args, **environment):
     """Executes the given main_class with any supplied args in the given environment.

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -188,8 +188,7 @@ class NailgunClient(object):
 
   def try_connect(self):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    # The sock.close() call returns None.
-    return sock if sock.connect_ex((self._host, self._port)) == 0 else sock.close()
+    return sock if sock.connect_ex((self._host, self._port)) == 0 else None
 
   def __call__(self, main_class, cwd=None, *args, **environment):
     """Executes the given main_class with any supplied args in the given environment.

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -217,14 +217,11 @@ class NailgunExecutor(Executor, ProcessManager):
                      .format(count=self._connect_attempts))
         raise NailgunClient.NailgunError('Failed to connect to ng server.')
 
-      try:
-        sock = nailgun.try_connect()
-        if sock:
-          logger.debug('Connected to ng server {server!r}'.format(server=self))
-          return
-      finally:
-        if sock:
-          sock.close()
+      sock = nailgun.try_connect()
+      if sock:
+        logger.debug('Connected to ng server {server!r}'.format(server=self))
+        sock.close()
+        return()
 
       attempt_count += 1
       time.sleep(self.WAIT_INTERVAL_SEC)

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -223,7 +223,8 @@ class NailgunExecutor(Executor, ProcessManager):
           logger.debug('Connected to ng server {server!r}'.format(server=self))
           return
       finally:
-        sock.close()
+        if sock:
+          sock.close()
 
       attempt_count += 1
       time.sleep(self.WAIT_INTERVAL_SEC)

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -221,7 +221,7 @@ class NailgunExecutor(Executor, ProcessManager):
       if sock:
         logger.debug('Connected to ng server {server!r}'.format(server=self))
         sock.close()
-        return()
+        return
 
       attempt_count += 1
       time.sleep(self.WAIT_INTERVAL_SEC)

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -219,8 +219,8 @@ class NailgunExecutor(Executor, ProcessManager):
 
       sock = nailgun.try_connect()
       if sock:
-        logger.debug('Connected to ng server {server!r}'.format(server=self))
         sock.close()
+        logger.debug('Connected to ng server {server!r}'.format(server=self))
         return
 
       attempt_count += 1


### PR DESCRIPTION
The sock variable was not defined upon failure. This had the
chance of causing zombie nialguns as the socket could be created
but never handled if sock_connect_ex returned non-zero.

The output was non-helpful:

```
                           ==== stdout ====
              compile(.pants.d/gen/spindle/scala_record:src.thrift.com.foursquare.thriftexample.thriftexample-scala) failed: local variable 'sock' referenced before assignment
FAILURE: Compilation failure: Failed jobs: compile(.pants.d/gen/spindle/scala_record:src.thrift.com.foursquare.thriftexample.thriftexample-scala)
```

The else block in nailgun_client.try_connect was changed to return
sock.close() which closes the socket upin failure while still
returning None to nailgun_executor.

This is intended to maintain the async connects.