### PR TITLE
Upgrade to zinc 1.0.12 in order to support concurrent bootstraps

### DIFF
--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -3,7 +3,3 @@
 
 # Turn off all nailgun use.
 use_nailgun: False
-
-[compile.zinc]
-# In the absence of nailgun, zinc has concurrency issues with bootstrapping.
-worker_count: 1

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -113,7 +113,7 @@ class ZincCompile(JvmCompile):
     cls.register_jvm_tool(register,
                           'zinc',
                           classpath=[
-                            JarDependency('org.pantsbuild', 'zinc', '1.0.11')
+                            JarDependency('org.pantsbuild', 'zinc', '1.0.12')
                           ],
                           main=cls._ZINC_MAIN,
                           custom_rules=[


### PR DESCRIPTION
...and remove travis single-thread config.