### PR TITLE
Fix Go targets to glob more than '.go' files.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
@@ -59,8 +59,16 @@ class GoLocalSource(GoTarget):
     raise NotImplementedError()
 
   def __init__(self, address=None, payload=None, **kwargs):
+    # We grab all files in the current directory except BUILD files for 2 reasons:
+    # 1. cgo: If a file imports "C" then it may rely on sibling .c, .cc, etc files that `go build`
+    #    will compile.
+    # 2. resources: Even though go does not support them; ie by providing a protocol to embed them
+    #    in binaries, it does allow them to be placed in a directory where a test might use them
+    #    for example via plain old filesystem access.
     globs = Globs(rel_path=os.path.join(get_buildroot(), address.spec_path))
-    sources = globs('*.go')
+    sources = globs('*', exclude=[globs('BUILD*'),
+                                  # This skips dirents.
+                                  globs('*/')])
 
     payload = payload or Payload()
     payload.add_fields({

--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -108,7 +108,6 @@ python_library(
   name='go_workspace_task',
   sources=['go_workspace_task.py'],
   dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_local_source',
     'contrib/go/src/python/pants/contrib/go/tasks:go_task',
     'src/python/pants/base:build_environment',
     'src/python/pants/util:dirutil',

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_workspace_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_workspace_task.py
@@ -11,7 +11,6 @@ from itertools import chain
 from pants.base.build_environment import get_buildroot
 from pants.util.dirutil import safe_mkdir
 
-from pants.contrib.go.targets.go_local_source import GoLocalSource
 from pants.contrib.go.tasks.go_task import GoTask
 
 
@@ -88,7 +87,9 @@ class GoWorkspaceTask(GoTask):
       remote_lib_source_dir = self.context.products.get_data('go_remote_lib_src')[go_remote_lib]
       for path in os.listdir(remote_lib_source_dir):
         remote_src = os.path.join(remote_lib_source_dir, path)
-        if GoLocalSource.is_go_source(remote_src):
+        # We grab any file since a go package might have .go, .c, .cc, etc files - all needed for
+        # installation.
+        if os.path.isfile(remote_src):
           yield remote_src
     return self._symlink_lib(gopath, go_remote_lib, source_iter(), required_links)
 

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
@@ -72,7 +72,7 @@ class GoLocalSourceTestBase(AbstractClass):
     # .c, .s, or .S .cc, .cpp, or .cxx .h, .hh, .hpp, or .hxx
     SourceRoot.register('src/go', self.target_type)
 
-    # We shouldn't grab theses - no BUILDs, no dirents, no subdir files.
+    # We shouldn't grab these - no BUILDs, no dirents, no subdir files.
     self.create_file('src/go/src/foo/BUILD')
     self.create_file('src/go/src/foo/subpackage/jane.go')
     self.create_file('src/go/src/foo/subpackage/jane.c')
@@ -107,7 +107,7 @@ class GoLocalSourceTestBase(AbstractClass):
   def test_globs_resources(self):
     SourceRoot.register('src/go', self.target_type)
 
-    # We shouldn't grab theses - no BUILDs, no dirents, no subdir files.
+    # We shouldn't grab these - no BUILDs, no dirents, no subdir files.
     self.create_file('src/go/src/foo/BUILD')
     self.create_file('src/go/src/foo/subpackage/jane.go')
     self.create_file('src/go/src/foo/subpackage/jane.png')

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
@@ -67,3 +67,42 @@ class GoLocalSourceTestBase(AbstractClass):
 
     with self.assertRaises(AddressLookupError):
       self.target('src/go/src/foo')
+
+  def test_globs_cgo(self):
+    # .c, .s, or .S .cc, .cpp, or .cxx .h, .hh, .hpp, or .hxx
+    SourceRoot.register('src/go', self.target_type)
+    self.create_file('src/go/src/foo/jake.go')
+    self.create_file('src/go/src/foo/jake.c')
+    self.create_file('src/go/src/foo/jake.s')
+    self.create_file('src/go/src/foo/jake.S')
+    self.create_file('src/go/src/foo/jake.cc')
+    self.create_file('src/go/src/foo/jake.cpp')
+    self.create_file('src/go/src/foo/jake.cxx')
+    self.create_file('src/go/src/foo/jake.h')
+    self.create_file('src/go/src/foo/jake.hh')
+    self.create_file('src/go/src/foo/jake.hpp')
+    self.create_file('src/go/src/foo/jake.hxx')
+    target = self.make_target(spec='src/go/src/foo', target_type=self.target_type)
+
+    self.assertEqual(sorted(['src/foo/jake.go',
+                             'src/foo/jake.c',
+                             'src/foo/jake.s',
+                             'src/foo/jake.S',
+                             'src/foo/jake.cc',
+                             'src/foo/jake.cpp',
+                             'src/foo/jake.cxx',
+                             'src/foo/jake.h',
+                             'src/foo/jake.hh',
+                             'src/foo/jake.hpp',
+                             'src/foo/jake.hxx']),
+                     sorted(target.sources_relative_to_source_root()))
+
+  def test_globs_resources(self):
+    SourceRoot.register('src/go', self.target_type)
+    self.create_file('src/go/src/foo/jake.go')
+    self.create_file('src/go/src/foo/jake.png')
+    target = self.make_target(spec='src/go/src/foo', target_type=self.target_type)
+
+    self.assertEqual(sorted(['src/foo/jake.go',
+                             'src/foo/jake.png']),
+                     sorted(target.sources_relative_to_source_root()))

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/go_local_source_test_base.py
@@ -71,6 +71,13 @@ class GoLocalSourceTestBase(AbstractClass):
   def test_globs_cgo(self):
     # .c, .s, or .S .cc, .cpp, or .cxx .h, .hh, .hpp, or .hxx
     SourceRoot.register('src/go', self.target_type)
+
+    # We shouldn't grab theses - no BUILDs, no dirents, no subdir files.
+    self.create_file('src/go/src/foo/BUILD')
+    self.create_file('src/go/src/foo/subpackage/jane.go')
+    self.create_file('src/go/src/foo/subpackage/jane.c')
+
+    # We should grab all of these though.
     self.create_file('src/go/src/foo/jake.go')
     self.create_file('src/go/src/foo/jake.c')
     self.create_file('src/go/src/foo/jake.s')
@@ -99,6 +106,13 @@ class GoLocalSourceTestBase(AbstractClass):
 
   def test_globs_resources(self):
     SourceRoot.register('src/go', self.target_type)
+
+    # We shouldn't grab theses - no BUILDs, no dirents, no subdir files.
+    self.create_file('src/go/src/foo/BUILD')
+    self.create_file('src/go/src/foo/subpackage/jane.go')
+    self.create_file('src/go/src/foo/subpackage/jane.png')
+
+    # We should grab all of these though.
     self.create_file('src/go/src/foo/jake.go')
     self.create_file('src/go/src/foo/jake.png')
     target = self.make_target(spec='src/go/src/foo', target_type=self.target_type)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_workspace_task.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_workspace_task.py
@@ -60,7 +60,7 @@ class GoWorkspaceTaskTest(TaskTestBase):
       SourceRoot.register('src/main/go')
       spec = 'src/main/go/foo/bar/mylib'
 
-      sources = ['x.go', 'y.go', 'z.go']
+      sources = ['x.go', 'y.go', 'z.go', 'z.c', 'z.h', 'w.png']
       for src in sources:
         self.create_file(os.path.join(spec, src))
 
@@ -101,7 +101,9 @@ class GoWorkspaceTaskTest(TaskTestBase):
         spec = '3rdparty/github.com/user/lib'
 
         remote_lib_src_dir = os.path.join(d, spec)
-        self.create_file(os.path.join(remote_lib_src_dir, 'file.go'))
+        remote_files = ['file.go', 'file.cc', 'file.hh']
+        for remote_file in remote_files:
+          self.create_file(os.path.join(remote_lib_src_dir, remote_file))
 
         go_remote_lib = self.make_target(spec=spec, target_type=GoRemoteLibrary)
 
@@ -117,5 +119,6 @@ class GoWorkspaceTaskTest(TaskTestBase):
         workspace_dir = os.path.join(gopath, 'src/github.com/user/lib')
         self.assertTrue(os.path.isdir(workspace_dir))
 
-        link = os.path.join(workspace_dir, 'file.go')
-        self.assertEqual(os.readlink(link), os.path.join(remote_lib_src_dir, 'file.go'))
+        for remote_file in remote_files:
+          link = os.path.join(workspace_dir, remote_file)
+          self.assertEqual(os.readlink(link), os.path.join(remote_lib_src_dir, remote_file))


### PR DESCRIPTION
Go packages can rely on local sibling '.c', '.cc' and other files to
build correctly and local tests might rely on loose resource files as
part of performin a test.

Allow for both of these cases by relaxing restrictions on files types
globbed by the go local source targets and by the GoWorkspaceTask when
setting up a local workspace for a remote lib.

Tests are updated to exercise these cases.

https://rbcommons.com/s/twitter/r/2873/