### PR TITLE
Fixup release dry runs; use isolated plugin cache.

### DIFF
--- a/src/python/pants/bin/plugin_resolver.py
+++ b/src/python/pants/bin/plugin_resolver.py
@@ -35,6 +35,7 @@ class PluginResolver(object):
 
     bootstrap_options = self._options_bootstrapper.get_bootstrap_options().for_global_scope()
     self._plugin_requirements = bootstrap_options.plugins
+    self._plugin_cache_dir = bootstrap_options.plugin_cache_dir
 
   def resolve(self, working_set=None):
     """Resolves any configured plugins and adds them to the global working set.
@@ -94,7 +95,7 @@ class PluginResolver(object):
   @memoized_property
   def plugin_cache_dir(self):
     """The path of the directory pants plugins bdists are cached in."""
-    return os.path.join(self._options.for_global_scope().pants_bootstrapdir, 'plugins')
+    return self._plugin_cache_dir
 
   @memoized_property
   def _python_repos(self):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -65,6 +65,10 @@ class GlobalOptionsRegistrar(Optionable):
              help="Prints pants' version number and exits.")
 
     register('--plugins', advanced=True, type=list_option, help='Load these plugins.')
+    register('--plugin-cache-dir', advanced=True,
+             default=os.path.join(get_pants_cachedir(), 'plugins'),
+             help='Cache resolved plugin requirements here.')
+
     register('--backend-packages', advanced=True, type=list_option,
              help='Load backends from these packages that are already on the path.')
 


### PR DESCRIPTION
Previously release dry runs used the global plugin cache.  This was
problematic since pants versions are static in between releases, and so
installation and use of plugins in release dry run tests would use the
last released version of a plugin instead of the version just burned to
`dist/`.  Combined with API changes across plugin boundaries since the
last release, this could lead to spurious failures.

Fix this by adding an advanced `--plugin-cache-dir` option and use this
in the release dry run pointing to a new empty temporary directory.

https://rbcommons.com/s/twitter/r/2874/