### PR TITLE
[CI] Ability to capture a 'repro' of pants state, for debugging.

### DIFF
--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -36,7 +36,7 @@ class BuildRoot(Singleton):
           buildroot = os.path.dirname(buildroot)
         else:
           raise self.NotFoundError('Could not find pants.ini!')
-      self._root_dir = buildroot
+      self._root_dir = os.path.realpath(buildroot)
     return self._root_dir
 
   @path.setter

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -29,6 +29,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/reporting',
     'src/python/pants/subsystem',
+    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:filtering',
     'src/python/pants/util:memo',

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -21,6 +21,7 @@ from pants.base.extension_loader import load_plugins_and_backends
 from pants.base.scm_build_file import ScmBuildFile
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.bin.plugin_resolver import PluginResolver
+from pants.bin.repro import Reproducer
 from pants.engine.round_engine import RoundEngine
 from pants.goal.context import Context
 from pants.goal.goal import Goal
@@ -316,7 +317,7 @@ class GoalRunner(object):
   @classmethod
   def subsystems(cls):
     # Subsystems used outside of any task.
-    return {SourceRootBootstrapper, Reporting, RunTracker}
+    return {SourceRootBootstrapper, Reporting, Reproducer, RunTracker}
 
   def _execute_engine(self):
     unknown_goals = [goal.name for goal in self._goals if not goal.ordered_task_names()]

--- a/src/python/pants/bin/repro.py
+++ b/src/python/pants/bin/repro.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+import os
+import sys
+
+from pants.base.build_environment import get_buildroot
+from pants.subsystem.subsystem import Subsystem
+from pants.util.contextutil import open_tar, temporary_file
+from pants.util.dirutil import chmod_plus_x
+
+
+logger = logging.getLogger(__name__)
+
+
+class ReproError(Exception):
+  pass
+
+
+class Reproducer(Subsystem):
+  options_scope = 'repro'
+
+  @classmethod
+  def register_options(cls, register):
+    register('--capture', metavar='<repro_path>', default=None,
+             help='Capture information about this pants run (including the entire workspace) '
+                  'into a tar.gz file that can be used to help debug build problems.')
+
+  def create_repro(self):
+    """Return a Repro instance for capturing a repro of the current workspace state.
+
+    :return: a Repro instance, or None if no repro was requested.
+    :rtype: `pants.bin.repro.Repro`
+    """
+    path = self.get_options().capture
+    if path is None:
+      return None
+    buildroot = get_buildroot()
+    # Ignore a couple of common cases. Note: If we support SCMs other than git in the future,
+    # add their (top-level only) metadata dirs here if relevant.
+    ignore = ['.git', os.path.relpath(self.get_options().pants_distdir, buildroot)]
+    return Repro(path, buildroot, ignore)
+
+
+class Repro(object):
+  def __init__(self, path, buildroot, ignore):
+    """Create a Repro instance.
+
+    :param string path: Write the captured repro data to this path.
+    :param string buildroot: Capture the workspace at this buildroot.
+    :param ignore: Ignore these top-level files/dirs under buildroot.
+    """
+    if os.path.realpath(os.path.expanduser(path)).startswith(buildroot):
+      raise ReproError('Repro capture file location must be outside the build root.')
+    if not path.endswith('tar.gz') and not path.endswith('.tgz'):
+      path += '.tar.gz'
+    if os.path.exists(path):
+      raise ReproError('Repro capture file already exists: {}'.format(path))
+    self._path = path
+    self._buildroot = buildroot
+    self._ignore = ignore
+
+  def capture(self, run_info_dict):
+    # Force the scm discovery logging messages to appear before ours, so the startup delay
+    # is properly associated in the user's mind with us and not with scm.
+    logger.info('Capturing repro information to {}'.format(self._path))
+    with open_tar(self._path, 'w:gz', dereference=True, compresslevel=6) as tarout:
+      for relpath in os.listdir(self._buildroot):
+        if relpath not in self._ignore:
+          tarout.add(os.path.join(self._buildroot, relpath), relpath)
+
+      with temporary_file() as tmpfile:
+        tmpfile.write('# Pants repro captured for the following build:\n')
+        for k, v in sorted(run_info_dict.items()):
+          tmpfile.write('#  {}: {}\n'.format(k, v))
+        cmd_line = list(sys.argv)
+        # Use 'pants' instead of whatever the full executable path was on the user's system.
+        cmd_line[0] = 'pants'
+        # Remove any repro-related flags. The repro-ing user won't want to call those.
+        cmd_line = [x for x in cmd_line if not x.startswith('--repro-')]
+        tmpfile.write("'" +"' '".join(cmd_line) + "'\n")
+        tmpfile.flush()
+        chmod_plus_x(tmpfile.name)
+        tarout.add(tmpfile.name, 'repro.sh')
+
+  def log_location_of_repro_file(self):
+    if not self._path:
+      return  # No repro requested.
+    logger.info('Captured repro information to {}'.format(self._path))

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -32,3 +32,14 @@ python_tests(
     'src/python/pants/util:dirutil',
   ]
 )
+
+
+python_tests(
+  name='repro',
+  sources=['test_repro.py'],
+  dependencies=[
+    'src/python/pants/bin',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+  ]
+)

--- a/tests/python/pants_test/bin/test_repro.py
+++ b/tests/python/pants_test/bin/test_repro.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import unittest
+
+from pants.bin.repro import Repro
+from pants.util.contextutil import open_tar, temporary_dir
+from pants.util.dirutil import safe_mkdir_for
+
+
+class ReproTest(unittest.TestCase):
+  def test_repro(self):
+    with temporary_dir() as tmpdir:
+      fake_buildroot = os.path.join(tmpdir, 'buildroot')
+      def add_file(path, content):
+        fullpath = os.path.join(fake_buildroot, path)
+        safe_mkdir_for(fullpath)
+        with open(fullpath, 'w') as outfile:
+          outfile.write(content)
+
+      add_file('.git/foo', 'foo')
+      add_file('dist/bar', 'bar')
+      add_file('baz.txt', 'baz')
+      add_file('qux/quux.txt', 'quux')
+
+      repro_file = os.path.join(tmpdir, 'repro.tar.gz')
+      repro = Repro(repro_file, fake_buildroot, ['.git', 'dist'])
+      repro.capture(run_info_dict={'foo': 'bar', 'baz': 'qux'})
+
+      extract_dir = os.path.join(tmpdir, 'extract')
+      with open_tar(repro_file, 'r:gz') as tar:
+        tar.extractall(extract_dir)
+
+      def assert_not_exists(relpath):
+        fullpath = os.path.join(extract_dir, relpath)
+        self.assertFalse(os.path.exists(fullpath))
+
+      def assert_file(relpath, expected_content=None):
+        fullpath = os.path.join(extract_dir, relpath)
+        self.assertTrue(os.path.isfile(fullpath))
+        if expected_content:
+          with open(fullpath, 'r') as infile:
+            content = infile.read()
+          self.assertEquals(expected_content, content)
+
+      assert_file('baz.txt', 'baz')
+      assert_file('qux/quux.txt', 'quux')
+      assert_file('repro.sh')
+
+      assert_not_exists('.git')
+      assert_not_exists('dist')


### PR DESCRIPTION
When people complain about a problem with pants we can tell them to
run the same command with --repro-capture=<path> and send us the
resulting file.