### PR TITLE
Fix javadocs and add jvm doc gen to CI.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -162,7 +162,7 @@ fi
 if [[ "${skip_jvm:-false}" == "false" ]]; then
   banner "Running core jvm tests"
   (
-    ./pants.pex ${PANTS_ARGS[@]} test {src,tests}/{java,scala}:: zinc::
+    ./pants.pex ${PANTS_ARGS[@]} doc test {src,tests}/{java,scala}:: zinc::
   ) || die "Core jvm test failure"
 fi
 

--- a/src/java/org/pantsbuild/tools/jar/JarBuilder.java
+++ b/src/java/org/pantsbuild/tools/jar/JarBuilder.java
@@ -214,8 +214,9 @@ public class JarBuilder implements Closeable {
 
     /**
      * Creates a handler that merges well-known mergeable resources and otherwise skips duplicates.
-     * <p/>
+     * <p>
      * Merged resources include META-INF/services/ files.
+     * </p>
      */
     public static DuplicateHandler skipDuplicatesConcatWellKnownMetadata() {
       DuplicatePolicy concatServices =

--- a/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/scaladoc_gen.py
@@ -42,8 +42,10 @@ class ScaladocGen(JvmdocGen):
     for target in targets:
       sources.extend(target.sources_relative_to_buildroot())
       # TODO(Tejal Desai): pantsbuild/pants/65: Remove java_sources attribute for ScalaLibrary
-      for java_target in target.java_sources:
-        sources.extend(java_target.sources_relative_to_buildroot())
+      # A '.scala' owning target may not have java_sources, eg: junit_tests
+      if hasattr(target, 'java_sources'):
+        for java_target in target.java_sources:
+          sources.extend(java_target.sources_relative_to_buildroot())
 
     if not sources:
       return None


### PR DESCRIPTION
Previously we could have invalid javadoc ond/or scaladoc on master,
now CI checks there are no jvm doc errors.

An existing javadoc error is fixed so CI passes.  Also `ScaladocGen` is
fixed to only grab java_sources when it actually can.  No test is added
for the latter, but without the fix, CI goes red on `junit_tests` owning
scala code, but not exporting a `java_sources` attribute.  This issue
tracks a proper solution to `java_sources` attribute tests:
  https://github.com/pantsbuild/pants/issues/65

https://rbcommons.com/s/twitter/r/2877/