### PR TITLE
Upgrade to jarjar 1.6.0.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/shader.py
+++ b/src/python/pants/backend/jvm/subsystems/shader.py
@@ -189,7 +189,7 @@ class Shader(object):
       cls.register_jvm_tool(register,
                             'jarjar',
                             classpath=[
-                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.5.2')
+                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.6.0')
                             ])
 
     @classmethod


### PR DESCRIPTION
This picks up fixes for handling rogue classfile packaging and support
for java 1.8.

https://rbcommons.com/s/twitter/r/2880/