### PR TITLE
Kill deprecated `BuildFileAliases.create` method.

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -83,7 +83,6 @@ python_library(
   sources = ['build_file_aliases.py'],
   dependencies = [
     ':build_file_target_factory',
-    ':deprecated',
     ':target',
     'src/python/pants/util:memo',
   ]

--- a/src/python/pants/base/build_file_aliases.py
+++ b/src/python/pants/base/build_file_aliases.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 import six
 
 from pants.base.build_file_target_factory import BuildFileTargetFactory
-from pants.base.deprecated import deprecated
 from pants.base.target import Target
 from pants.util.memo import memoized_property
 
@@ -107,18 +106,6 @@ class BuildFileAliases(object):
     BUILD file path or functions that need to be able to create targets or objects from within the
     BUILD file parse.
   """
-
-  @classmethod
-  @deprecated(removal_version='0.0.50',
-              hint_message='Use the BuildFileAliases constructor instead.')
-  def create(cls,
-             targets=None,
-             objects=None,
-             context_aware_object_factories=None):
-    """A convenience constructor that can accept zero to all alias types."""
-    return cls(targets=targets,
-               objects=objects,
-               context_aware_object_factories=context_aware_object_factories)
 
   @classmethod
   def curry_context(cls, wrappee):

--- a/tests/python/pants_test/tasks/test_list_owners.py
+++ b/tests/python/pants_test/tasks/test_list_owners.py
@@ -22,7 +22,7 @@ class ListOwnersTest(ConsoleTaskTestBase):
 
   @property
   def alias_groups(self):
-    return BuildFileAliases.create(targets={'python_library': PythonLibrary})
+    return BuildFileAliases(targets={'python_library': PythonLibrary})
 
   def setUp(self):
     super(ListOwnersTest, self).setUp()


### PR DESCRIPTION
BuildFileAliases now has a constructor with all defaulted parameters
which serves the same purpose as the old `create` factory method.

https://rbcommons.com/s/twitter/r/2888/