### PR TITLE
Shorten too long target ids by adding a hash. test added. doc updated.

### DIFF
--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -450,22 +450,18 @@ class Target(AbstractTarget):
 
   @property
   def id(self):
-    """A unique identifier for the Target.
-
-    The generated id is safe for use as a path name on unix systems.
+    """A unique and unix safe identifier for the Target.
+    Since other classes use this id to generate new file names and unix system has 255 character
+    limitation on a file name, 200-character limit is chosen as a safe measure.
     """
     id_candidate = self.address.path_safe_spec
     if len(id_candidate) > 200:
-      return id_candidate[:80] + '.' + unicode(sha1(id_candidate).hexdigest()) + '.' + id_candidate[-80:]
+      #avoid cut half way of a word which creates confusion
+      heads = '.'.join(id_candidate[:80].split('.')[:-1])
+      tails = '.'.join(id_candidate[-80:].split('.')[1:])
+      hash_string = sha1(id_candidate).hexdigest()
+      return '{}.{}.{}'.format(heads, hash_string, tails)
     return id_candidate
-
-  @property
-  def identifier(self):
-    """A unique identifier for the Target.
-
-    The generated id is safe for use as a path name on unix systems.
-    """
-    return self.id
 
   def walk(self, work, predicate=None):
     """Walk of this target's dependency graph, DFS preorder traversal, visiting each node exactly

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -456,7 +456,7 @@ class Target(AbstractTarget):
     """
     id_candidate = self.address.path_safe_spec
     if len(id_candidate) > 200:
-        return id_candidate[:80] + '.' + unicode(sha1(id_candidate).hexdigest()) + '.' + id_candidate[-80:]
+      return id_candidate[:80] + '.' + unicode(sha1(id_candidate).hexdigest()) + '.' + id_candidate[-80:]
     return id_candidate
 
   @property

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -455,12 +455,9 @@ class Target(AbstractTarget):
     limitation on a file name, 200-character limit is chosen as a safe measure.
     """
     id_candidate = self.address.path_safe_spec
-    if len(id_candidate) > 200:
-      #avoid cut half way of a word which creates confusion
-      heads = '.'.join(id_candidate[:80].split('.')[:-1])
-      tails = '.'.join(id_candidate[-80:].split('.')[1:])
-      hash_string = sha1(id_candidate).hexdigest()
-      return '{}.{}.{}'.format(heads, hash_string, tails)
+    if len(id_candidate) >= 200:
+      # two dots + 79 char head + 79 char tail + 40 char sha1
+      return '{}.{}.{}'.format(id_candidate[:79], sha1(id_candidate).hexdigest(), id_candidate[-79:])
     return id_candidate
 
   @property

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -454,7 +454,10 @@ class Target(AbstractTarget):
 
     The generated id is safe for use as a path name on unix systems.
     """
-    return self.address.path_safe_spec
+    id_candidate = self.address.path_safe_spec
+    if len(id_candidate) > 200:
+        return id_candidate[:80] + '.' + unicode(sha1(id_candidate).hexdigest()) + '.' + id_candidate[-80:]
+    return id_candidate
 
   @property
   def identifier(self):

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -448,7 +448,7 @@ class Target(AbstractTarget):
     """Returns ``True`` if this target is derived from no other."""
     return self.derived_from == self
 
-  @property
+  @memoized_property
   def id(self):
     """A unique and unix safe identifier for the Target.
     Since other classes use this id to generate new file names and unix system has 255 character

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -463,6 +463,10 @@ class Target(AbstractTarget):
       return '{}.{}.{}'.format(heads, hash_string, tails)
     return id_candidate
 
+  @property
+  def identifier(self):
+    return self.id
+
   def walk(self, work, predicate=None):
     """Walk of this target's dependency graph, DFS preorder traversal, visiting each node exactly
     once.

--- a/src/python/pants/base/target.py
+++ b/src/python/pants/base/target.py
@@ -24,6 +24,7 @@ from pants.base.target_addressable import TargetAddressable
 from pants.base.validation import assert_list
 from pants.option.custom_types import dict_option
 from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_property
 
 
 logger = logging.getLogger(__name__)

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os.path
+
 from pants.base.payload import Payload
 from pants.base.payload_field import DeferredSourcesField
 from pants.base.target import Target
@@ -61,3 +63,23 @@ class TargetTest(BaseTest):
     with subsystem_instance(Target.UnknownArguments, options=options):
       target = self.make_target('foo:bar', Target, foobar='barfoo')
       self.assertFalse(hasattr(target, 'foobar'))
+
+  def test_target_id(self):
+
+    long_path = 'dummy'
+    for i in xrange(1,30):
+      long_path = os.path.join(long_path, 'dummy{}'.format(i))
+    long_target = self.make_target('{}:foo'.format(long_path), Target)
+    long_id = long_target.id
+    self.assertLessEqual(len(long_id), 200)
+    self.assertEqual(long_id,
+                     'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.dummy10.\
+c582ce0f60008b3dc8196ae9e6ff5e8c40096974.dummy21.dummy22.dummy23.dummy24.dummy25.dummy26.dummy27.dummy28.dummy29.foo')
+
+    short_path = 'dummy'
+    for i in xrange(1,10):
+      short_path = os.path.join(short_path, 'dummy{}'.format(i))
+    short_target = self.make_target('{}:foo'.format(short_path), Target)
+    short_id = short_target.id
+    self.assertLessEqual(len(short_id), 200)
+    self.assertEqual(short_id, 'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.foo')

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -64,21 +64,21 @@ class TargetTest(BaseTest):
       target = self.make_target('foo:bar', Target, foobar='barfoo')
       self.assertFalse(hasattr(target, 'foobar'))
 
-  def test_target_id(self):
-
+  def test_target_id_long(self):
     long_path = 'dummy'
     for i in xrange(1,30):
       long_path = os.path.join(long_path, 'dummy{}'.format(i))
     long_target = self.make_target('{}:foo'.format(long_path), Target)
     long_id = long_target.id
-    self.assertLessEqual(len(long_id), 200)
+    self.assertEqual(len(long_id), 200)
     self.assertEqual(long_id,
                      'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.dummy10.du.\
 c582ce0f60008b3dc8196ae9e6ff5e8c40096974.y20.dummy21.dummy22.dummy23.dummy24.dummy25.dummy26.dummy27.dummy28.dummy29.foo')
+
+  def test_target_id_short(self):
     short_path = 'dummy'
     for i in xrange(1,10):
       short_path = os.path.join(short_path, 'dummy{}'.format(i))
     short_target = self.make_target('{}:foo'.format(short_path), Target)
     short_id = short_target.id
-    self.assertLessEqual(len(short_id), 200)
     self.assertEqual(short_id, 'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.foo')

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -66,7 +66,7 @@ class TargetTest(BaseTest):
 
   def test_target_id_long(self):
     long_path = 'dummy'
-    for i in xrange(1,30):
+    for i in range(1,30):
       long_path = os.path.join(long_path, 'dummy{}'.format(i))
     long_target = self.make_target('{}:foo'.format(long_path), Target)
     long_id = long_target.id
@@ -77,7 +77,7 @@ c582ce0f60008b3dc8196ae9e6ff5e8c40096974.y20.dummy21.dummy22.dummy23.dummy24.dum
 
   def test_target_id_short(self):
     short_path = 'dummy'
-    for i in xrange(1,10):
+    for i in range(1,10):
       short_path = os.path.join(short_path, 'dummy{}'.format(i))
     short_target = self.make_target('{}:foo'.format(short_path), Target)
     short_id = short_target.id

--- a/tests/python/pants_test/base/test_target.py
+++ b/tests/python/pants_test/base/test_target.py
@@ -73,9 +73,8 @@ class TargetTest(BaseTest):
     long_id = long_target.id
     self.assertLessEqual(len(long_id), 200)
     self.assertEqual(long_id,
-                     'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.dummy10.\
-c582ce0f60008b3dc8196ae9e6ff5e8c40096974.dummy21.dummy22.dummy23.dummy24.dummy25.dummy26.dummy27.dummy28.dummy29.foo')
-
+                     'dummy.dummy1.dummy2.dummy3.dummy4.dummy5.dummy6.dummy7.dummy8.dummy9.dummy10.du.\
+c582ce0f60008b3dc8196ae9e6ff5e8c40096974.y20.dummy21.dummy22.dummy23.dummy24.dummy25.dummy26.dummy27.dummy28.dummy29.foo')
     short_path = 'dummy'
     for i in xrange(1,10):
       short_path = os.path.join(short_path, 'dummy{}'.format(i))


### PR DESCRIPTION
target id is used in many places to create a filename/path, so it is necessary to keep it under 255 characters for unix. 200 is used in this as a safe measure. 