### PR TITLE
Stop the execution_graph from infinitely adding downstream failures.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/execution_graph.py
@@ -314,9 +314,10 @@ class ExecutionGraph(object):
             log.debug(traceback.format_exc())
             raise ExecutionFailure("Error in on_failure for {}".format(finished_key), e)
 
-          # Propagate failures downstream.
+          # Propagate failures downstream without adding repeated jobs.
           for dependee in direct_dependees:
-            finished_queue.put((dependee, CANCELED, None))
+            if status_table.get(dependee) not in status_table.DONE_STATES:
+              finished_queue.put((dependee, CANCELED, None))
 
         # Log success or failure for this job.
         if result_status is FAILED:


### PR DESCRIPTION
We discovered that certain large build graphs were stalling
and paging all available memory into a python process. Upon
dumping the python heap we discovered that there the execution
graph was unboundedly adding failed jobs tuples to the
finished_queue.

This patch merely checks to see if the job is already marked
as done before inserting it into the finished_queue. The
root cause of this behavior is likely undiscovered. One guess
was a cycle in the build graph but the execution_graph tests
supposedly test for that, and pants itself should detect a cycle
in the build graph.