### PR TITLE
Adding a summary list of failing testcases to junit_run.

### DIFF
--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -6,6 +6,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from contextlib import contextmanager
+from textwrap import dedent
 from xml.etree import ElementTree
 
 import pytest
@@ -181,3 +183,144 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       '--test-junit-cwd=testprojects/tests/java/org/pantsbuild/testproject/dummies'
     ])
     self.assert_success(pants_run)
+
+  @contextmanager
+  def _failing_test_cases(self):
+    with temporary_dir(root_dir=self.workdir_root()) as source_dir:
+      with open(os.path.join(source_dir, 'BUILD'), 'w+') as f:
+        f.write('source_root("{}/tests")\n'.format(os.path.basename(source_dir)))
+      tests_dir = os.path.join(source_dir, 'tests')
+      subpath = os.path.join('org', 'pantsbuild', 'tmp', 'tests')
+      tests_subdir = os.path.join(tests_dir, subpath)
+      os.makedirs(tests_subdir)
+      with open(os.path.join(tests_subdir, 'BUILD'), 'w+') as f:
+        f.write(dedent('''
+          target(name='tests',
+            dependencies=[
+              ':one',
+              ':two',
+              ':three',
+            ],
+          )
+
+          java_library(name='base',
+            dependencies=['3rdparty:junit'],
+          )
+
+          java_tests(name='one',
+            sources=['OneTest.java'],
+            dependencies=[':base'],
+          )
+
+          java_tests(name='two',
+            sources=['TwoTest.java'],
+            dependencies=[':base'],
+          )
+
+          java_tests(name='three',
+            sources=['subtest/ThreeTest.java'],
+            dependencies=[':base'],
+          )
+        '''))
+      with open(os.path.join(tests_subdir, 'OneTest.java'), 'w+') as f:
+        f.write(dedent('''
+          package org.pantsbuild.tmp.tests;
+
+          import org.junit.Test;
+          import static org.junit.Assert.*;
+
+          public class OneTest {
+            @Test
+            public void testSingle() {
+              assertTrue("Single is false.", false);
+            }
+          }
+        '''))
+      with open(os.path.join(tests_subdir, 'TwoTest.java'), 'w+') as f:
+        f.write(dedent('''
+          package org.pantsbuild.tmp.tests;
+
+          import org.junit.Test;
+          import static org.junit.Assert.*;
+
+          public class TwoTest {
+            @Test
+            public void testTupleFirst() {
+              assertTrue("First is false.", false);
+            }
+
+            @Test
+            public void testTupleSecond() {
+              assertTrue("Second is false.", false);
+            }
+          }
+        '''))
+      os.makedirs(os.path.join(tests_subdir, 'subtest'))
+      with open(os.path.join(tests_subdir, 'subtest', 'ThreeTest.java'), 'w+') as f:
+        f.write(dedent('''
+          package org.pantsbuild.tmp.tests.subtest;
+
+          import org.junit.Test;
+          import static org.junit.Assert.*;
+
+          public class ThreeTest {
+            @Test
+            public void testTripleFirst() {
+              assertTrue("First is false.", false);
+            }
+
+            @Test
+            public void testTripleSecond() {
+              assertTrue("Second is false.", false);
+            }
+
+            @Test
+            public void testTripleThird() {
+              assertTrue("Third is false.", false);
+            }
+          }
+        '''))
+      yield tests_subdir
+
+  def test_junit_test_failure_summary(self):
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with self._failing_test_cases() as tests_dir:
+        pants_run = self.run_pants_with_workdir([
+          'test',
+          '--test-junit-failure-summary',
+          os.path.relpath(tests_dir),
+        ], workdir)
+        self.assert_failure(pants_run)
+        expected_groups = []
+        expected_groups.append([
+          'org/pantsbuild/tmp/tests:one',
+          'org.pantsbuild.tmp.tests.OneTest#testSingle'
+        ])
+        expected_groups.append([
+          'org/pantsbuild/tmp/tests:two',
+          'org.pantsbuild.tmp.tests.TwoTest#testTupleFirst',
+          'org.pantsbuild.tmp.tests.TwoTest#testTupleSecond',
+        ])
+        expected_groups.append([
+          'org/pantsbuild/tmp/tests:three',
+          'org.pantsbuild.tmp.tests.subtest.ThreeTest#testTripleFirst',
+          'org.pantsbuild.tmp.tests.subtest.ThreeTest#testTripleSecond',
+          'org.pantsbuild.tmp.tests.subtest.ThreeTest#testTripleThird',
+        ])
+        output = '\n'.join(line.strip() for line in pants_run.stdout_data.split('\n'))
+        for group in expected_groups:
+          self.assertIn('\n'.join(group), output)
+
+  def test_junit_test_no_failure_summary(self):
+    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with self._failing_test_cases() as tests_dir:
+        pants_run = self.run_pants_with_workdir([
+          'test',
+          '--no-test-junit-failure-summary',
+          os.path.relpath(tests_dir)
+        ], workdir)
+        self.assert_failure(pants_run)
+        output = '\n'.join(line.strip() for line in pants_run.stdout_data.split('\n'))
+        self.assertNotIn('org/pantsbuild/tmp/tests:three\n'
+                         'org.pantsbuild.tmp.tests.subtest.ThreeTest#testTripleFirst',
+                         output)


### PR DESCRIPTION
Previously it was kind of a pain to scroll up through
pages of output to find which tests actually failed. This
organizes that information in one place clearly at the
bottom.

This output is controlled by the --failure-summary flag.