### PR TITLE
Reformatting the junit output to be consistent with pants.

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -473,7 +473,7 @@ public class ConsoleRunnerImpl {
         if (desc.isSuite()) {
           return true;
         }
-        String descString = desc.getDisplayName();
+        String descString = Util.getPantsFriendlyDisplayName(desc);
         // Note that currently even when parallelThreads is true, the first time this
         // is called in serial order, by our own iterator below.
         synchronized (this) {
@@ -498,7 +498,7 @@ public class ConsoleRunnerImpl {
     class AlphabeticComparator implements Comparator<Description> {
       @Override
       public int compare(Description o1, Description o2) {
-        return o1.getDisplayName().compareTo(o2.getDisplayName());
+        return Util.getPantsFriendlyDisplayName(o1).compareTo(Util.getPantsFriendlyDisplayName(o2));
       }
     }
 

--- a/src/java/org/pantsbuild/tools/junit/impl/PerTestConsoleListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/PerTestConsoleListener.java
@@ -22,7 +22,7 @@ class PerTestConsoleListener extends ConsoleListener {
 
   @Override
   public void testRunStarted(Description description) throws Exception {
-    String displayName = description.getDisplayName();
+    String displayName = Util.getPantsFriendlyDisplayName(description);
     if (displayName != "null") {
       out.println(displayName);
     }
@@ -30,7 +30,7 @@ class PerTestConsoleListener extends ConsoleListener {
 
   @Override
   public void testStarted(Description description) {
-    out.print("\t" + description.getDisplayName());
+    out.print("\t" + Util.getPantsFriendlyDisplayName(description));
   }
 
   @Override

--- a/src/java/org/pantsbuild/tools/junit/impl/Util.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Util.java
@@ -47,4 +47,31 @@ final class Util {
   static boolean isAssertionFailure(Failure failure) {
     return failure.getException() instanceof AssertionError;
   }
+
+  /**
+   * Returns a pants-friendly formatted description of the test-case.
+   *
+   * Pants likes test-cases formatted as org.foo.bar.TestClassName#testMethodName
+   *
+   * @param description The test description to produce a formatted name for.
+   * @return The formatted name of the test-case, if possible. If the Description does not have a
+   * class name or a method name, falls back on the description.getDisplayName().
+   */
+  static String getPantsFriendlyDisplayName(Description description) {
+    String className = description.getClassName();
+    String methodName = description.getMethodName();
+    String vanillaDisplayName = description.getDisplayName();
+    if (className.equals(vanillaDisplayName) || methodName.equals(vanillaDisplayName)) {
+      // This happens if the Description isn't actually describing a test method. We don't handle
+      // this, so just use the default formatting.
+      return vanillaDisplayName;
+    }
+
+    StringBuffer sb = new StringBuffer(className.length() + methodName.length() + 1);
+    sb.append(className);
+    sb.append("#");
+    sb.append(methodName);
+    return sb.toString();
+  }
+
 }


### PR DESCRIPTION
Now testcases are described as

  org.foo.bar.TestClass#testMethodName

Which is consistent with how tests are specified on the cli.