### PR TITLE
Define a lifecycle for Config objects.

### DIFF
--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -94,7 +94,7 @@ class Addresses(namedtuple('Addresses', ['addresses', 'rel_path'])):
   """
 
 
-class Address(AbstractClass):
+class Address(object):
   """A target address.
 
   An address is a unique name representing a

--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources=['addressable.py'],
   dependencies=[
     '3rdparty/python:six',
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -16,7 +17,7 @@ python_library(
     '3rdparty/python:six',
     ':addressable',
     ':mapper',
-    ':serializable',
+    ':objects',
     'src/python/pants/base:address',
     'src/python/pants/util:memo',
   ]
@@ -26,10 +27,18 @@ python_library(
   name='mapper',
   sources=['mapper.py'],
   dependencies=[
+    ':objects',
     ':parsers',
-    ':serializable',
     'src/python/pants/base:address',
     'src/python/pants/util:memo',
+  ]
+)
+
+python_library(
+  name='objects',
+  sources=['objects.py'],
+  dependencies=[
+    'src/python/pants/util:meta',
   ]
 )
 
@@ -38,16 +47,8 @@ python_library(
   sources=['parsers.py'],
   dependencies=[
     '3rdparty/python:six',
-    ':serializable',
+    ':objects',
     'src/python/pants/util:memo',
-  ]
-)
-
-python_library(
-  name='serializable',
-  sources=['serializable.py'],
-  dependencies=[
-    'src/python/pants/util:meta',
   ]
 )
 
@@ -56,6 +57,6 @@ python_library(
   sources=['targets.py'],
   dependencies=[
     ':addressable',
-    ':serializable',
+    ':objects',
   ]
 )

--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -1,0 +1,61 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name='addressable',
+  sources=['addressable.py'],
+  dependencies=[
+    '3rdparty/python:six',
+  ]
+)
+
+python_library(
+  name='graph',
+  sources=['graph.py'],
+  dependencies=[
+    '3rdparty/python:six',
+    ':addressable',
+    ':mapper',
+    ':serializable',
+    'src/python/pants/base:address',
+    'src/python/pants/util:memo',
+  ]
+)
+
+python_library(
+  name='mapper',
+  sources=['mapper.py'],
+  dependencies=[
+    ':parsers',
+    ':serializable',
+    'src/python/pants/base:address',
+    'src/python/pants/util:memo',
+  ]
+)
+
+python_library(
+  name='parsers',
+  sources=['parsers.py'],
+  dependencies=[
+    '3rdparty/python:six',
+    ':serializable',
+    'src/python/pants/util:memo',
+  ]
+)
+
+python_library(
+  name='serializable',
+  sources=['serializable.py'],
+  dependencies=[
+    'src/python/pants/util:meta',
+  ]
+)
+
+python_library(
+  name='targets',
+  sources=['targets.py'],
+  dependencies=[
+    ':addressable',
+    ':serializable',
+  ]
+)

--- a/src/python/pants/engine/exp/addressable.py
+++ b/src/python/pants/engine/exp/addressable.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import six
+
+
+class AddressError(Exception):
+  """Indicates an error assigning or resolving an address."""
+
+
+class Addressed(object):
+  """Describes an addressed item of a given type."""
+
+  def __init__(self, addressed_type, address):
+    self._addressed_type = addressed_type
+    self._address = address
+
+  @property
+  def addressed_type(self):
+    return self._addressed_type
+
+  @property
+  def address(self):
+    return self._address
+
+  def __repr__(self):
+    return 'Addressed(addressed_type={!r}, address={!r})'.format(self._addressed_type,
+                                                                 self._address)
+
+
+def addressable(addressed_types, value):
+  """Marks a value as accepting a given type, possibly lazily resolved via address."""
+  if value is None:
+    return None
+  elif isinstance(value, addressed_types):
+    return value
+  elif isinstance(value, Addressed) and value.addressed_type == addressed_types:
+    return value
+  elif isinstance(value, six.string_types):
+    return Addressed(addressed_types, value)
+  else:
+    raise AddressError('The given value is not an address or an {!r}: {!r}'
+                       .format(addressed_types, value))
+
+
+def addressables(addressed_types, values):
+  """Marks a list as containing a given type, some elements of which are resolved via address."""
+  # TODO(John Sirois): Instead of re-traversing all lists later to hydrate any potentially contained
+  # Addressed objects, this could return a (marker) type.  The hydration could then avoid deep
+  # introspection and just look for a - say - `Resolvable` value, and only resolve those.  Only if
+  # perf is being tweaked might this need to be addressed.
+  return [addressable(addressed_types, v) for v in values] if values else []
+
+
+def addressable_mapping(addressed_types, mapping):
+  """Marks a dict as containing values of a given type, some elements of which are resolved."""
+  return {k: addressable(addressed_types, v) for k, v in mapping.items()} if mapping else {}

--- a/src/python/pants/engine/exp/addressable.py
+++ b/src/python/pants/engine/exp/addressable.py
@@ -5,7 +5,74 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from abc import abstractmethod
+
 import six
+
+from pants.util.meta import AbstractClass
+
+
+class TypeConstraint(AbstractClass):
+  """Represents a type constraint.
+
+  Not intended for direct use, instead use one of :class:`SuperclassesOf`, :class:`Exact` or
+  :class:`SubclassesOf`.
+  """
+
+  def __init__(self, type_):
+    """Creates a type constraint centered around the given type.
+
+    :param type type_: The focus of this type constraint.
+    """
+    self._type = type_
+
+  @abstractmethod
+  def satisfied_by(self, obj):
+    """Return `True` if the given object satisfies this type constraint.
+
+    :rtype: bool
+    """
+
+  def __hash__(self):
+    return hash((type(self), self._type))
+
+  def __eq__(self, other):
+    return type(self) == type(other) and self._type == other._type
+
+  def __str__(self):
+    return '{variance_symbol}{constrained_type}'.format(variance_symbol=self._variance_symbol,
+                                                        constrained_type=self._type.__name__)
+
+  def __repr__(self):
+    return ('{type_constraint_type}({constrained_type})'
+            .format(type_constraint_type=type(self).__name__, constrained_type=self._type.__name__))
+
+
+class SuperclassesOf(TypeConstraint):
+  """Objects of the exact type as well as any super types are allowed."""
+
+  _variance_symbol = '-'
+
+  def satisfied_by(self, obj):
+    return issubclass(self._type, type(obj))
+
+
+class Exactly(TypeConstraint):
+  """Only objects of the exact type are allowed."""
+
+  _variance_symbol = '='
+
+  def satisfied_by(self, obj):
+    return self._type == type(obj)
+
+
+class SubclassesOf(TypeConstraint):
+  """Objects of the exact type as well as any sub types are allowed."""
+
+  _variance_symbol = '+'
+
+  def satisfied_by(self, obj):
+    return issubclass(type(obj), self._type)
 
 
 class AddressError(Exception):
@@ -13,49 +80,97 @@ class AddressError(Exception):
 
 
 class Addressed(object):
-  """Describes an addressed item of a given type."""
+  """Describes an addressed item that meets a given type constraint."""
 
-  def __init__(self, addressed_type, address):
-    self._addressed_type = addressed_type
-    self._address = address
-
-  @property
-  def addressed_type(self):
-    return self._addressed_type
+  def __init__(self, type_constraint, address_spec):
+    self._type_constraint = type_constraint
+    self._address_spec = address_spec
 
   @property
-  def address(self):
-    return self._address
+  def type_constraint(self):
+    """The type constraint the addressed item must satisfy.
+
+    :rtype: :class:`TypeConstraint`
+    """
+    return self._type_constraint
+
+  @property
+  def address_spec(self):
+    """The address of the object that, when resolved, should meet the type constraint specified.
+
+    :returns: The serialized form of the address; aka. an address 'spec'.
+    :rtype: string
+    """
+    return self._address_spec
 
   def __repr__(self):
-    return 'Addressed(addressed_type={!r}, address={!r})'.format(self._addressed_type,
-                                                                 self._address)
+    return 'Addressed(type_constraint={!r}, address={!r})'.format(self._type_constraint,
+                                                                  self._address_spec)
 
 
-def addressable(addressed_types, value):
-  """Marks a value as accepting a given type, possibly lazily resolved via address."""
+def addressable(type_constraint, value):
+  """Marks a value as conforming to a given type constraint.
+
+  The value may be a 'pointer', aka. an :class:`Addressed` instance that is lazily resolved via
+  address and checked against the type constraint at resolve time.
+
+  :param type_constraint: The type constraint the value must satisfy.
+  :type type_constraint: :class:`TypeConstraint`
+  :param value: An object satisfying the type constraint or else a string encoding the address such
+                an object should be resolved from; aka. a 'pointer'.
+  :returns: The `value` if it satisfies the type constraint directly or else an :class:`Addressed`
+            pointer to a value to resolve later.
+  """
   if value is None:
     return None
-  elif isinstance(value, addressed_types):
+  elif type_constraint.satisfied_by(value):
     return value
-  elif isinstance(value, Addressed) and value.addressed_type == addressed_types:
+  # TODO(John Sirois): This case is only here to support the `parse_python_assignments` parsing
+  # scheme which is the only parsing scheme that doubly constructs it objects (the second
+  # construction that injects a `name` parameter discovered in the 1st construction triggers this
+  # case).  Consider removing this case if the `parse_python_assignments` parsing scheme is dropped.
+  elif isinstance(value, Addressed) and type_constraint == value.type_constraint:
     return value
   elif isinstance(value, six.string_types):
-    return Addressed(addressed_types, value)
+    return Addressed(type_constraint, value)
   else:
     raise AddressError('The given value is not an address or an {!r}: {!r}'
-                       .format(addressed_types, value))
+                       .format(type_constraint, value))
 
 
-def addressables(addressed_types, values):
-  """Marks a list as containing a given type, some elements of which are resolved via address."""
+def addressables(type_constraint, values):
+  """Marks a list's values as satisfying a given type constraint.
+
+  Some (or all) elements of the list may be :class:`Addressed` elements to resolve later.
+
+  :param type_constraint: The type constraint the list's values must all satisfy.
+  :type type_constraint: :class:`TypeConstraint`
+  :param values: An iterable of objects satisfying the type constraint or else strings encoding the
+                 address such objects should be resolved from; aka. 'pointers'.
+  :type values: :class:`collections.Iterable`
+  :returns: A list whose elements are values satisfying the type constraint directly or else are
+            :class:`Addressed` pointers to values to resolve later.
+  :rtype: list
+  """
   # TODO(John Sirois): Instead of re-traversing all lists later to hydrate any potentially contained
   # Addressed objects, this could return a (marker) type.  The hydration could then avoid deep
   # introspection and just look for a - say - `Resolvable` value, and only resolve those.  Only if
   # perf is being tweaked might this need to be addressed.
-  return [addressable(addressed_types, v) for v in values] if values else []
+  return [addressable(type_constraint, v) for v in values] if values else []
 
 
-def addressable_mapping(addressed_types, mapping):
-  """Marks a dict as containing values of a given type, some elements of which are resolved."""
-  return {k: addressable(addressed_types, v) for k, v in mapping.items()} if mapping else {}
+def addressable_mapping(type_constraint, mapping):
+  """Marks a dicts's values as satisfying a given type constraint.
+
+  Some (or all) values in the dict may be :class:`Addressed` values to resolve later.
+
+  :param type_constraint: The type constraint the dict's values must all satisfy.
+  :type type_constraint: :class:`TypeConstraint`
+  :param mapping: A mapping from keys to values satisfying the type constraint or else strings
+                  encoding the address such values should be resolved from; aka. 'pointers'.
+  :type mapping: :class:`collections.Mapping`
+  :returns: A dict whose values satisfy the type constraint directly or else are :class:`Addressed`
+            pointers to values to resolve later.
+  :rtype: dict
+  """
+  return {k: addressable(type_constraint, v) for k, v in mapping.items()} if mapping else {}

--- a/src/python/pants/engine/exp/graph.py
+++ b/src/python/pants/engine/exp/graph.py
@@ -14,12 +14,20 @@ import six
 from pants.base.address import Address
 from pants.engine.exp.addressable import Addressed
 from pants.engine.exp.mapper import AddressFamily, AddressMap
-from pants.engine.exp.serializable import Serializable
+from pants.engine.exp.objects import Serializable, SerializableFactory, Validatable
 from pants.util.memo import memoized_method
 
 
 class ResolveError(Exception):
   """Indicates an error resolving an address to an object."""
+
+
+class CycleError(ResolveError):
+  """Indicates a cycle was detected during object resolution."""
+
+
+class ResolvedTypeMismatchError(ResolveError):
+  """Indicates a resolved object was not of the expected type."""
 
 
 # TODO(John Sirois): Support in-memory injection of fully-hydrated (synthetic) addressables.
@@ -41,26 +49,55 @@ class Graph(object):
     self._build_root = os.path.realpath(build_root)
     self._build_pattern = re.compile(build_pattern or r'^BUILD(\.[a-zA-Z0-9_-]+)?$')
     self._parser = parser
+    self._resolved_by_address = {}
 
-  @memoized_method
   def resolve(self, address):
     """Resolves the object pointed at by the given `address`.
 
     The object will be hydrated from the BUILD graph along with any objects it points to.
 
+    The following lifecycle for resolved objects is observed:
+    1. The object's containing BUILD file family is parsed if not already parsed.  This is a 'thin'
+       parse that just hydrates immediate fields of objects defined in the BUILD file family.
+    2. The object's addressed values are all first resolved completely if not already resolved.
+    3. The object is reconstructed using the fully resolved values from step 2.
+    4. If the reconstructed object is a :class:`pants.engine.exp.objects.SerializableFactory`, its
+       `create` method is called to allow for a replacement object to be supplied.
+    5. The reconstructed object from step 3 (or replacement object from step 4) is validated if
+       it's an instance of :class:`pants.engine.exp.objects.Validatable`.
+    6. The fully resolved and validated object is cached and returned.
+
     :param address: The BUILD graph address to resolve.
     :type address: :class:`pants.base.address.Address`
     :returns: The object pointed at by the given `address`.
     :raises: :class:`ResolveError` if no object was found at the given `address`.
+    :raises: :class:`pants.engine.exp.objects.ValidationError` if the object was resolvable but
+             invalid.
     """
+    resolved = self._resolved_by_address.get(address)
+    if not resolved:
+      resolved = self._resolve_recursively(address, resolve_path=[])
+      self._resolved_by_address[address] = resolved
+    return resolved
+
+  def _resolve_recursively(self, address, resolve_path):
+    if address in resolve_path:
+      raise CycleError('Cycle detected along path:\n\t{}'
+                       .format('\n\t'.join('* {}'.format(a) if a == address else str(a)
+                                           for a in resolve_path + [address])))
+    resolve_path.append(address)
+
     address_family = self._address_family(address.spec_path)
     obj = address_family.addressables.get(address)
     if not obj:
       raise ResolveError('Object with address {} was not found'.format(address))
 
-    def resolve_item(item):
+    def resolve_item(item, addr=None):
       if Serializable.is_serializable(item):
-        hydrated_args = {}
+        hydrated_args = {'address': addr} if addr else {}
+
+        # Recurse on the Serializable's values and hydrate any `Addressed` found.  This unwinds from
+        # the leaves thus hydrating item's closure.
         for key, value in item._asdict().items():
           if isinstance(value, collections.MutableMapping):
             container_type = type(value)
@@ -73,17 +110,39 @@ class Graph(object):
           else:
             hydrated_args[key] = resolve_item(value)
 
+        # Re-build the thin Serializable with fully hydrated objects substituted for all Addressed
+        # values; ie: Only ever expose full resolved closures for requested addresses.
         item_type = type(item)
         hydrated_item = item_type(**hydrated_args)
+
+        # Let factories replace the hydrated object.
+        if isinstance(hydrated_item, SerializableFactory):
+          hydrated_item = hydrated_item.create()
+
+        # Finally make sure objects that can self-validate get a chance to do so before we cache
+        # them as the pointee of address.
+        if isinstance(hydrated_item, Validatable):
+          hydrated_item.validate()
+
         return hydrated_item
       elif isinstance(item, Addressed):
-        return self._resolve_item(context_address=address, addressed=item)
+        referenced_address = Address.parse(spec=item.address_spec, relative_to=address.spec_path)
+        referenced_item = self._resolve_recursively(referenced_address, resolve_path)
+        if not item.type_constraint.satisfied_by(referenced_item):
+          raise ResolvedTypeMismatchError('Found a {} when resolving {} for {}, expected a {!r}'
+                                          .format(type(referenced_item).__name__,
+                                                  referenced_address,
+                                                  address,
+                                                  item.type_constraint))
+        return referenced_item
       else:
         return item
 
-    return resolve_item(obj)
+    resolved = resolve_item(obj, addr=address)
+    resolve_path.pop(-1)
+    return resolved
 
-  def _find_sources(self, path):
+  def _find_build_file_sources(self, path):
     abspath = os.path.realpath(os.path.join(self._build_root, path))
     if not os.path.isdir(abspath):
       raise ResolveError('Expected {} to be a directory containing build files.'.format(path))
@@ -96,17 +155,6 @@ class Graph(object):
   @memoized_method
   def _address_family(self, spec_path):
     address_maps = []
-    for source in self._find_sources(spec_path):
+    for source in self._find_build_file_sources(spec_path):
       address_maps.append(AddressMap.parse(source, parse=self._parser))
     return AddressFamily.create(self._build_root, address_maps)
-
-  def _resolve_item(self, context_address, addressed):
-    address = Address.parse(addressed.address, relative_to=context_address.spec_path)
-    obj = self.resolve(address)
-    if not isinstance(obj, addressed.addressed_type):
-      raise ResolveError('Found a {} when resolving {} for {}, expected a {}'
-                         .format(type(obj).__name__,
-                                 address,
-                                 context_address,
-                                 addressed.addressed_type.__name__))
-    return obj

--- a/src/python/pants/engine/exp/graph.py
+++ b/src/python/pants/engine/exp/graph.py
@@ -1,0 +1,112 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import collections
+import os
+import re
+
+import six
+
+from pants.base.address import Address
+from pants.engine.exp.addressable import Addressed
+from pants.engine.exp.mapper import AddressFamily, AddressMap
+from pants.engine.exp.serializable import Serializable
+from pants.util.memo import memoized_method
+
+
+class ResolveError(Exception):
+  """Indicates an error resolving an address to an object."""
+
+
+# TODO(John Sirois): Support in-memory injection of fully-hydrated (synthetic) addressables.
+class Graph(object):
+  """A lazy, directed acyclic graph of objects. Not necessarily connected."""
+
+  def __init__(self, build_root, build_pattern=None, parser=None):
+    """Creates a build graph rooted at the given `build_root`.
+
+    Both the set of files that define a BUILD graph and the parser used to parse those files can be
+    customized.  See the `pants.engine.exp.parsers` module for example parsers.
+
+    :param string build_pattern: A regular expression for identifying BUILD files used to resolve
+                                 addresses; by default looks for `BUILD*` files.
+    :param parser: The BUILD file parser to use; by default a JSON BUILD file format parser.
+    :type parser: A :class:`collections.Callable` that takes a byte string and produces a list of
+                  parsed addressable Serializable objects found in the byte string.
+    """
+    self._build_root = os.path.realpath(build_root)
+    self._build_pattern = re.compile(build_pattern or r'^BUILD(\.[a-zA-Z0-9_-]+)?$')
+    self._parser = parser
+
+  @memoized_method
+  def resolve(self, address):
+    """Resolves the object pointed at by the given `address`.
+
+    The object will be hydrated from the BUILD graph along with any objects it points to.
+
+    :param address: The BUILD graph address to resolve.
+    :type address: :class:`pants.base.address.Address`
+    :returns: The object pointed at by the given `address`.
+    :raises: :class:`ResolveError` if no object was found at the given `address`.
+    """
+    address_family = self._address_family(address.spec_path)
+    obj = address_family.addressables.get(address)
+    if not obj:
+      raise ResolveError('Object with address {} was not found'.format(address))
+
+    def resolve_item(item):
+      if Serializable.is_serializable(item):
+        hydrated_args = {}
+        for key, value in item._asdict().items():
+          if isinstance(value, collections.MutableMapping):
+            container_type = type(value)
+            container = container_type()
+            container.update((k, resolve_item(v)) for k, v in value.items())
+            hydrated_args[key] = container
+          elif isinstance(value, collections.Iterable) and not isinstance(value, six.string_types):
+            container_type = type(value)
+            hydrated_args[key] = container_type(resolve_item(v) for v in value)
+          else:
+            hydrated_args[key] = resolve_item(value)
+
+        item_type = type(item)
+        hydrated_item = item_type(**hydrated_args)
+        return hydrated_item
+      elif isinstance(item, Addressed):
+        return self._resolve_item(context_address=address, addressed=item)
+      else:
+        return item
+
+    return resolve_item(obj)
+
+  def _find_sources(self, path):
+    abspath = os.path.realpath(os.path.join(self._build_root, path))
+    if not os.path.isdir(abspath):
+      raise ResolveError('Expected {} to be a directory containing build files.'.format(path))
+    for f in os.listdir(abspath):
+      if self._build_pattern.match(f):
+        absfile = os.path.join(abspath, f)
+        if os.path.isfile(absfile):
+          yield absfile
+
+  @memoized_method
+  def _address_family(self, spec_path):
+    address_maps = []
+    for source in self._find_sources(spec_path):
+      address_maps.append(AddressMap.parse(source, parse=self._parser))
+    return AddressFamily.create(self._build_root, address_maps)
+
+  def _resolve_item(self, context_address, addressed):
+    address = Address.parse(addressed.address, relative_to=context_address.spec_path)
+    obj = self.resolve(address)
+    if not isinstance(obj, addressed.addressed_type):
+      raise ResolveError('Found a {} when resolving {} for {}, expected a {}'
+                         .format(type(obj).__name__,
+                                 address,
+                                 context_address,
+                                 addressed.addressed_type.__name__))
+    return obj

--- a/src/python/pants/engine/exp/mapper.py
+++ b/src/python/pants/engine/exp/mapper.py
@@ -17,6 +17,14 @@ class MappingError(Exception):
   """Indicates an error mapping addressable objects."""
 
 
+class UnaddressableObjectError(MappingError):
+  """Indicates an un-addressable object was found at the top level."""
+
+
+class DuplicateNameError(MappingError):
+  """Indicates more than one top-level object was found with the same name."""
+
+
 class AddressMap(object):
   """Maps addressable Serializable objects from a byte source."""
 
@@ -43,12 +51,12 @@ class AddressMap(object):
       objects_by_name = {}
       for obj in objects:
         if not Serializable.is_serializable(obj) or not obj._asdict().get('name'):
-          raise MappingError('Parsed a non-addressable object: {!r}'.format(obj))
+          raise UnaddressableObjectError('Parsed a non-addressable object: {!r}'.format(obj))
         attributes = obj._asdict()
         name = attributes['name']
         if name in objects_by_name:
-          raise MappingError('An object already exists at {!r} with name {!r}: {!r}.  Cannot map '
-                             '{!r}'.format(path, name, objects_by_name[name], obj))
+          raise DuplicateNameError('An object already exists at {!r} with name {!r}: {!r}.  Cannot '
+                                   'map {!r}'.format(path, name, objects_by_name[name], obj))
         objects_by_name[name] = obj
       return cls(path, objects_by_name)
 
@@ -77,6 +85,10 @@ class AddressMap(object):
     return 'AddressMap(path={!r}, objects_by_name={!r})'.format(self._path, self._objects_by_name)
 
 
+class DifferingFamiliesError(MappingError):
+  """Indicates an attempt was made to merge address maps from different families together."""
+
+
 class AddressFamily(object):
   """Represents the family of addressed objects in a namespace.
 
@@ -101,10 +113,12 @@ class AddressFamily(object):
 
     spec_paths = {os.path.dirname(address_map.path) for address_map in address_maps}
     if len(spec_paths) > 1:
-      raise MappingError('Expected all AddressMaps to share the same parent directory but given '
-                         'a mix of parent directories:\n\t{}'
-                         .format('\n\t'.join(sorted(spec_paths))))
+      raise DifferingFamiliesError('Expected all AddressMaps to share the same parent directory '
+                                   'but given a mix of parent directories:\n\t{}'
+                                   .format('\n\t'.join(sorted(spec_paths))))
     spec_path = os.path.relpath(spec_paths.pop(), build_root)
+    if spec_path == '.':
+      spec_path = ''
 
     objects_by_name = {}
     for address_map in address_maps:
@@ -113,13 +127,13 @@ class AddressFamily(object):
         previous = objects_by_name.get(name)
         if previous:
           previous_path, _ = previous
-          raise MappingError('An object with name {name!r} is already defined in '
-                             '{previous_path!r}, will not overwrite with {obj!r} from '
-                             '{current_path!r}.'
-                             .format(name=name,
-                                     previous_path=previous_path,
-                                     obj=obj,
-                                     current_path=current_path))
+          raise DuplicateNameError('An object with name {name!r} is already defined in '
+                                   '{previous_path!r}, will not overwrite with {obj!r} from '
+                                   '{current_path!r}.'
+                                   .format(name=name,
+                                           previous_path=previous_path,
+                                           obj=obj,
+                                           current_path=current_path))
         objects_by_name[name] = (current_path, obj)
     return AddressFamily(namespace=spec_path,
                          objects_by_name={name: obj for name, (_, obj) in objects_by_name.items()})

--- a/src/python/pants/engine/exp/mapper.py
+++ b/src/python/pants/engine/exp/mapper.py
@@ -1,0 +1,155 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.base.address import Address
+from pants.engine.exp import parsers
+from pants.engine.exp.serializable import Serializable
+from pants.util.memo import memoized_property
+
+
+class MappingError(Exception):
+  """Indicates an error mapping addressable objects."""
+
+
+class AddressMap(object):
+  """Maps addressable Serializable objects from a byte source."""
+
+  @classmethod
+  def parse(cls, path, parse=None):
+    """Parses a source for addressable Serializable objects.
+
+    By default an enhanced JSON parser is used.  The parser admits extra blank lines, comment lines
+    and more than one top-level JSON object.  See :`pants.engine.exp.parsers.parse_json` for more
+    details on the modified JSON format and the schema for Serializable json objects.
+
+    No matter the parser used, the parsed and mapped addressable objects are all 'thin'; ie: any
+    objects they point to in other namespaces or even in the same namespace but from a seperate
+    source are left as unresolved pointers.
+
+    :param string path: The path to the byte source containing serialized objects.
+    :param parse: The parse function to use; by default a json parser.
+    :type parse: :class:`collection.Callable` that accepts a byte source and returns a list of all
+                 addressable Serializable objects parsed from it.
+    """
+    parse = parse or parsers.parse_json
+    with open(path, 'r') as fp:
+      objects = parse(fp.read())
+      objects_by_name = {}
+      for obj in objects:
+        if not Serializable.is_serializable(obj) or not obj._asdict().get('name'):
+          raise MappingError('Parsed a non-addressable object: {!r}'.format(obj))
+        attributes = obj._asdict()
+        name = attributes['name']
+        if name in objects_by_name:
+          raise MappingError('An object already exists at {!r} with name {!r}: {!r}.  Cannot map '
+                             '{!r}'.format(path, name, objects_by_name[name], obj))
+        objects_by_name[name] = obj
+      return cls(path, objects_by_name)
+
+  def __init__(self, path, objects_by_name):
+    """Not intended for direct use, instead see `parse`."""
+    self._path = path
+    self._objects_by_name = objects_by_name
+
+  @property
+  def path(self):
+    """Return the path to the byte source this address map's objects were pased from.
+
+    :rtype: string
+    """
+    return self._path
+
+  @property
+  def objects_by_name(self):
+    """Return a mapping from object name to the parsed 'thin' addressable object.
+
+    :rtype: dict from string to thin addressable objects.
+    """
+    return self._objects_by_name
+
+  def __repr__(self):
+    return 'AddressMap(path={!r}, objects_by_name={!r})'.format(self._path, self._objects_by_name)
+
+
+class AddressFamily(object):
+  """Represents the family of addressed objects in a namespace.
+
+  An address family can be composed of the addressed objects from one or more underlying address
+  sources.
+  """
+
+  @classmethod
+  def create(cls, build_root, address_maps):
+    """Creates an address family from the given set of address maps.
+
+    :param string build_root: The absolute path of the root of the namespace. All address maps must
+                              be hydrated from child paths of the build root.
+    :param address_maps: The family of maps that form this namespace.
+    :type address_maps: :class:`collections.Iterable` of :class:`AddressMap`
+    :returns: a new address family.
+    :rtype: :class:`AddressFamily`
+    :raises: :class:`MappingError` if the given address maps do not form a family.
+    """
+    if not address_maps:
+      raise TypeError('Handed an empty set of AddressMaps - must be given at least one.')
+
+    spec_paths = {os.path.dirname(address_map.path) for address_map in address_maps}
+    if len(spec_paths) > 1:
+      raise MappingError('Expected all AddressMaps to share the same parent directory but given '
+                         'a mix of parent directories:\n\t{}'
+                         .format('\n\t'.join(sorted(spec_paths))))
+    spec_path = os.path.relpath(spec_paths.pop(), build_root)
+
+    objects_by_name = {}
+    for address_map in address_maps:
+      current_path = address_map.path
+      for name, obj in address_map.objects_by_name.items():
+        previous = objects_by_name.get(name)
+        if previous:
+          previous_path, _ = previous
+          raise MappingError('An object with name {name!r} is already defined in '
+                             '{previous_path!r}, will not overwrite with {obj!r} from '
+                             '{current_path!r}.'
+                             .format(name=name,
+                                     previous_path=previous_path,
+                                     obj=obj,
+                                     current_path=current_path))
+        objects_by_name[name] = (current_path, obj)
+    return AddressFamily(namespace=spec_path,
+                         objects_by_name={name: obj for name, (_, obj) in objects_by_name.items()})
+
+  def __init__(self, namespace, objects_by_name):
+    """Not intended for direct use, instead see `create`."""
+    self._namespace = namespace
+    self._objects_by_name = objects_by_name
+
+  @property
+  def namespace(self):
+    """Return the namespace path of this address family.
+
+    :rtype: string
+    """
+    return self._namespace
+
+  # TODO(John Sirois): Support in-memory injection of fully-hydrated (synthetic) addressables in
+  # this family's namespace (spec_path).  It would be appealing to support this by
+  # expanding/re-defining the family and growing it to include an in-memory AddressMap sibling that
+  # would carry the injection(s).
+  @memoized_property
+  def addressables(self):
+    """Return a mapping from address to thin addressable objects in this namespace.
+
+    :rtype: dict from :class:`pants.base.address.Address` to thin addressable objects.
+    """
+    return {Address(spec_path=self._namespace, target_name=name): obj
+            for name, obj in self._objects_by_name.items()}
+
+  def __repr__(self):
+    return 'AddressFamily(namespace={!r}, objects_by_name={!r})'.format(self._namespace,
+                                                                        self._objects_by_name)

--- a/src/python/pants/engine/exp/mapper.py
+++ b/src/python/pants/engine/exp/mapper.py
@@ -9,7 +9,7 @@ import os
 
 from pants.base.address import Address
 from pants.engine.exp import parsers
-from pants.engine.exp.serializable import Serializable
+from pants.engine.exp.objects import Serializable
 from pants.util.memo import memoized_property
 
 

--- a/src/python/pants/engine/exp/objects.py
+++ b/src/python/pants/engine/exp/objects.py
@@ -34,3 +34,39 @@ class Serializable(AbstractClass):
     Any :class:`collections.namedtuple` satisfies the Serializable contract automatically via duck
     typing if it is composed of only primitive python values or Serializable values.
     """
+
+
+class SerializableFactory(AbstractClass):
+  """Creates :class:`Serializable` objects."""
+
+  @abstractmethod
+  def create(self):
+    """Return a serializable object.
+
+    :rtype: :class:`Serializable`
+    """
+
+
+class ValidationError(Exception):
+  """Indicates an invalid configuration was provided."""
+
+  def __init__(self, identifier, message):
+    """Creates a validation error pertaining to the identified invalid object.
+
+    :param object identifier: Any object whose string representation identifies the invalid object
+                              that led to this validation error.
+    :param string message: A message describing the invalid configuration.
+    """
+    super(ValidationError, self).__init__('Failed to validate {id}: {msg}'
+                                          .format(id=identifier, msg=message))
+
+
+class Validatable(AbstractClass):
+  """Marks a class whose instances should validated post-construction."""
+
+  @abstractmethod
+  def validate(self):
+    """Check this object's configuration is valid.
+
+    :raises: :class:`ValidationError` if this object is invalid.
+    """

--- a/src/python/pants/engine/exp/parsers.py
+++ b/src/python/pants/engine/exp/parsers.py
@@ -13,7 +13,7 @@ from json.encoder import JSONEncoder
 
 import six
 
-from pants.engine.exp.serializable import Serializable
+from pants.engine.exp.objects import Serializable
 from pants.util.memo import memoized
 
 

--- a/src/python/pants/engine/exp/parsers.py
+++ b/src/python/pants/engine/exp/parsers.py
@@ -1,0 +1,248 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import functools
+import importlib
+import inspect
+from json.decoder import JSONDecoder
+from json.encoder import JSONEncoder
+
+import six
+
+from pants.engine.exp.serializable import Serializable
+from pants.util.memo import memoized
+
+
+@memoized
+def _import(typename):
+  modulename, _, symbolname = typename.rpartition('.')
+  if not modulename:
+    raise ParseError('Expected a fully qualified type name, given {}'.format(typename))
+  try:
+    mod = importlib.import_module(modulename)
+    try:
+      return getattr(mod, symbolname)
+    except AttributeError:
+      raise ParseError('The symbol {} was not found in module {} when attempting to convert '
+                       'type name {}'.format(symbolname, modulename, typename))
+  except ImportError as e:
+    raise ParseError('Failed to import type name {} from module {}: {}'
+                     .format(typename, modulename, e))
+
+
+def _as_type(type_or_name):
+  return _import(type_or_name) if isinstance(type_or_name, six.string_types) else type_or_name
+
+
+class ParseError(Exception):
+  """Indicates an error parsing BUILD configuration."""
+
+
+def _object_decoder(obj, symbol_table=None):
+  # A magic field will indicate type and this can be used to wrap the object in a type.
+  typename = obj.get('typename', None)
+  if not typename:
+    return obj
+  else:
+    symbol = symbol_table(typename)
+    return symbol(**obj)
+
+
+@memoized(key_factory=lambda t: tuple(sorted(t.items())) if t is not None else None)
+def _get_decoder(symbol_table=None):
+  return functools.partial(_object_decoder,
+                           symbol_table=symbol_table.__getitem__ if symbol_table else _as_type)
+
+
+def _object_encoder(o):
+  if not Serializable.is_serializable(o):
+    raise ParseError('Can only encode Serializable objects in JSON, given {!r} of type {}'
+                     .format(o, type(o).__name__))
+  encoded = o._asdict()
+  if 'typename' not in encoded:
+    encoded['typename'] = '{}.{}'.format(inspect.getmodule(o).__name__, type(o).__name__)
+  return encoded
+
+
+encoder = JSONEncoder(encoding='UTF-8', default=_object_encoder, sort_keys=True, indent=True)
+
+
+def parse_json(json, symbol_table=None):
+  """Parses the given json encoded string into a list of top-level objects found.
+
+  The parser accepts both blank lines and comment lines (those beginning with optional whitespace
+  followed by the '#' character) as well as more than one top-level JSON object.
+
+  The parse also supports a simple protocol for serialized types that have an `_asdict` method.
+  This includes `namedtuple` subtypes as well as any custom class with an `_asdict` method defined;
+  see :class:`pants.engine.exp.serializable.Serializable`.
+
+  :param string json: A json encoded document with extra support for blank lines, comments and
+                      multiple top-level objects.
+  :returns: A list of decoded json data.
+  :rtype: list
+  :raises: :class:`ParseError` if there were any problems encountered parsing the given `json`.
+  """
+
+  decoder = JSONDecoder(encoding='UTF-8', object_hook=_get_decoder(symbol_table), strict=True)
+
+  # Strip comment lines and blank lines, which we allow, but preserve enough information about the
+  # stripping to constitute a reasonable error message that can be used to find the portion of the
+  # JSON document containing the error.
+
+  def non_comment_line(l):
+    stripped = l.lstrip()
+    return stripped if (stripped and not stripped.startswith('#')) else None
+
+  offset = 0
+  objects = []
+  while True:
+    lines = json[offset:].splitlines()
+    if not lines:
+      break
+
+    # Strip whitespace and comment lines preceding the next JSON object.
+    while True:
+      line = non_comment_line(lines[0])
+      if not line:
+        comment_line = lines.pop(0)
+        offset += len(comment_line) + 1
+      elif line.startswith('{') or line.startswith('['):
+        # Account for leading space in this line that starts off the JSON object.
+        offset += len(lines[0]) - len(line)
+        break
+      else:
+        raise ParseError('Unexpected json line:\n{}'.format(lines[0]))
+
+    lines = json[offset:].splitlines()
+    if not lines:
+      break
+
+    # Prepare the JSON blob for parsing - strip blank and comment lines recording enough information
+    # To reconstitute original offsets after the parse.
+    comment_lines = []
+    non_comment_lines = []
+    for line_number, line in enumerate(lines):
+      if non_comment_line(line):
+        non_comment_lines.append(line)
+      else:
+        comment_lines.append((line_number, line))
+
+    data = '\n'.join(non_comment_lines)
+    try:
+      obj, idx = decoder.raw_decode(data)
+      objects.append(obj)
+      if idx >= len(data):
+        break
+      offset += idx
+
+      # Add back in any parsed blank or comment line offsets.
+      parsed_line_count = len(data[:idx].splitlines())
+      for line_number, line in comment_lines:
+        if line_number >= parsed_line_count:
+          break
+        offset += len(line) + 1
+        parsed_line_count += 1
+    except ValueError as e:
+      json_lines = data.splitlines()
+      col_width = len(str(len(json_lines)))
+
+      col_padding = ' ' * col_width
+
+      def format_line(line):
+        return '{col_padding}  {line}'.format(col_padding=col_padding, line=line)
+
+      header_lines = [format_line(line) for line in json[:offset].splitlines()]
+
+      formatted_json_lines = [('{line_number:{col_width}}: {line}'
+                               .format(col_width=col_width, line_number=line_number, line=line))
+                              for line_number, line in enumerate(json_lines, start=1)]
+
+      for line_number, line in comment_lines:
+        formatted_json_lines.insert(line_number, format_line(line))
+
+      raise ParseError('{error}\nIn document:\n{json_data}'
+                       .format(error=e, json_data='\n'.join(header_lines + formatted_json_lines)))
+
+  return objects
+
+
+def encode_json(obj):
+  """Encodes the given object as json.
+
+  Supports objects that follow the `_asdict` protocol.  See `parse_json` for more information.
+
+  :param obj: A serializable object.
+  :returns: A json encoded blob representing the object.
+  :rtype: string
+  :raises: :class:`ParseError` if there were any problems encoding the given `obj` in json.
+  """
+  # TODO(John Sirois): Support an alias map from type (or from fqcn) -> typename.
+  return encoder.encode(obj)
+
+
+def parse_python_assignments(python, symbol_table=None):
+  """Parses the given python code into a list of top-level addressable Serializable objects found.
+
+  Only Serializable objects assigned to top-level variables will be collected and returned.  These
+  objects will be addressable via their top-level variable names in the parsed namespace.
+
+  :param string python: A python build file blob.
+  :returns: A list of decoded addressable, Serializable objects.
+  :rtype: list
+  :raises: :class:`ParseError` if there were any problems encountered parsing the given `python`.
+  """
+  def aliased(type_name, object_type, **kwargs):
+    return object_type(typename=type_name, **kwargs)
+
+  parse_globals = {}
+  for alias, symbol in (symbol_table or {}).items():
+    parse_globals[alias] = functools.partial(aliased, alias, symbol)
+
+  symbols = {}
+  six.exec_(python, parse_globals, symbols)
+  objects = []
+  for name, obj in symbols.items():
+    if Serializable.is_serializable(obj):
+      attributes = obj._asdict()
+      redundant_name = attributes.pop('name', name)
+      if redundant_name and redundant_name != name:
+        raise ParseError('The object named {!r} is assigned to a mismatching name {!r}'
+                         .format(redundant_name, name))
+      obj_type = type(obj)
+      named_obj = obj_type(name=name, **attributes)
+      objects.append(named_obj)
+  return objects
+
+
+def parse_python_callbacks(python, symbol_table):
+  """Parses the given python code into a list of top-level addressable Serializable objects found.
+
+  Only Serializable objects with `name`s will be collected and returned.  These objects will be
+  addressable via their name in the parsed namespace.
+
+  :param string python: A python build file blob.
+  :returns: A list of decoded addressable, Serializable objects.
+  :rtype: list
+  :raises: :class:`ParseError` if there were any problems encountered parsing the given `python`.
+  """
+  objects = []
+
+  def registered(type_name, object_type, name=None, **kwargs):
+    if name:
+      obj = object_type(name=name, typename=type_name, **kwargs)
+      if Serializable.is_serializable(obj):
+        objects.append(obj)
+      return obj
+    else:
+      return object_type(typename=type_name, **kwargs)
+
+  parse_globals = {}
+  for alias, symbol in symbol_table.items():
+    parse_globals[alias] = functools.partial(registered, alias, symbol)
+  six.exec_(python, parse_globals, {})
+  return objects

--- a/src/python/pants/engine/exp/serializable.py
+++ b/src/python/pants/engine/exp/serializable.py
@@ -1,0 +1,36 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import inspect
+from abc import abstractmethod
+
+from pants.util.meta import AbstractClass
+
+
+class Serializable(AbstractClass):
+  """Marks a class that can be serialized into and reconstituted from python builtin values."""
+
+  @staticmethod
+  def is_serializable(obj):
+    return isinstance(obj, Serializable) or (not inspect.isclass(obj) and hasattr(obj, '_asdict'))
+
+  @abstractmethod
+  def _asdict(self):
+    """Return a dict mapping this class' properties.
+
+    To meet the contract of a serializable the constructor must accept all the properties returned
+    here as constructor parameters; ie the following must be true::
+
+    >>> s = Serializable(...)
+    >>> Serializable(**s._asdict()) == s
+
+    Additionally the dict must also contain nothing except python primitive values, ie: dicts,
+    lists, strings, numbers, bool values, etc.
+
+    Any :class:`collections.namedtuple` satisfies the Serializable contract automatically via duck
+    typing if it is composed of only primitive python values or Serializable values.
+    """

--- a/src/python/pants/engine/exp/targets.py
+++ b/src/python/pants/engine/exp/targets.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.engine.exp.addressable import addressable, addressable_mapping, addressables
+from pants.engine.exp.serializable import Serializable
+
+
+# TODO(John Sirois): Find a better - non-overloaded - name for this.
+class Config(Serializable):
+  """A serializable object describing some bit of build configuration.
+
+  All build configuration data is composed of basic python builtin types and higher-level config
+  objects that aggregate configuration data.  Config objects can carry a name in which case they
+  become addressable and can be reused.
+  """
+
+  def __init__(self, **kwargs):
+    """Creates a new configuration data blob.
+
+    :param **kwargs: The configuration parameters.
+    """
+    self._kwargs = kwargs
+    self._hashable_key = None
+
+  @property
+  def name(self):
+    """Return the name of this object if any.
+
+    In general config objects need not be named, in which case they are generally embedded objects;
+    ie: attributes values of enclosing named config objects.  Any top-level config object though
+    will carry a unique name (in the config object's enclosing namespace) that can be used to
+    address it.
+    """
+    return self._kwargs.get('name')
+
+  @property
+  def typename(self):
+    """Returns the type name this target was constructed via.
+
+    For a target read from a BUILD file, this will be target alias, like 'java_library'.
+    For a target constructed in memory, this will be the simple class name, like 'JavaLibrary'.
+
+    The end result is that the type alias should be the most natural way to refer to this target's
+    type to the author of the target instance.
+
+    :rtype: string
+    """
+    return self._kwargs.get('typename', type(self).__name__)
+
+  def _asdict(self):
+    return self._kwargs.copy()
+
+  def _key(self):
+    if self._hashable_key is None:
+      self._hashable_key = sorted((k, v) for k, v in self._kwargs.items() if k != 'typename')
+    return self._hashable_key
+
+  def __hash__(self):
+    return hash(self._key())
+
+  def __eq__(self, other):
+    return isinstance(other, Config) and self._key() == other._key()
+
+  def __repr__(self):
+    # TODO(John Sirois): Do something else here.  This is recursive and so printing a Node prints
+    # its whole closure and will be too expensive and bewildering past simple example debugging.
+    return '{classname}({args})'.format(classname=type(self).__name__,
+                                        args=', '.join(sorted('{}={!r}'.format(k, v)
+                                                              for k, v in self._kwargs.items())))
+
+
+# TODO(John Sirois): document as the contract for targets fleshes out; especially the role of
+# configurations.
+class Target(Config):
+  # An example of an addressable (is Serializable + has a name) that can cause graph walks.  The
+  # only magic here are the fields wrapped with `addressables` which allow for mixed addresses and
+  # embedded objects.  The addresses are tagged by being wrapped in the Addressed type which allows
+  # a lazy resolution of the addressed and re-construction of this object with the fully resolved
+  # properties later.
+
+  def __init__(self, name=None, configurations=None, dependencies=None, **kwargs):
+    super(Target, self).__init__(name=name,
+                                 configurations=addressables(Config, configurations),
+                                 dependencies=addressables(Target, dependencies),
+                                 **kwargs)
+
+  # Some convenience properties to give the class more form, but also not strictly needed.
+  @property
+  def configurations(self):
+    return self._kwargs['configurations']
+
+  @property
+  def dependencies(self):
+    return self._kwargs['dependencies']
+
+
+class ApacheThriftConfig(Config):
+  # An example of a mixed-mode object - can be directly embedded without a name or else referenced
+  # via address if both top-level and carrying a name.
+  #
+  # Also an example of a more constrained config object that has an explicit set of allowed fields
+  # and that can have pydoc hung directly off the constructor to convey a fully accurate BUILD
+  # dictionary entry with no hierarchy walking or ignoring of "special" fields - there are no
+  # special fields.
+
+  def __init__(self, name=None, version=None, strict=None, lang=None, options=None, **kwargs):
+    super(ApacheThriftConfig, self).__init__(name=name,
+                                             version=version,
+                                             strict=strict,
+                                             lang=lang,
+                                             options=options,
+                                             **kwargs)
+
+
+class PublishConfig(Config):
+  # An example of addressable and addressable_mapping.
+
+  def __init__(self, default_repo, repos, name=None, **kwargs):
+    super(PublishConfig, self).__init__(name=name,
+                                        default_repo=addressable(Config, default_repo),
+                                        repos=addressable_mapping(Config, repos),
+                                        **kwargs)

--- a/src/python/pants/engine/exp/targets.py
+++ b/src/python/pants/engine/exp/targets.py
@@ -5,12 +5,16 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.engine.exp.addressable import addressable, addressable_mapping, addressables
-from pants.engine.exp.serializable import Serializable
+from collections import MutableMapping, MutableSequence
+
+import six
+
+from pants.engine.exp.addressable import (Exactly, SubclassesOf, SuperclassesOf, addressable,
+                                          addressable_mapping, addressables)
+from pants.engine.exp.objects import Serializable, SerializableFactory, Validatable, ValidationError
 
 
-# TODO(John Sirois): Find a better - non-overloaded - name for this.
-class Config(Serializable):
+class Config(Serializable, SerializableFactory, Validatable):
   """A serializable object describing some bit of build configuration.
 
   All build configuration data is composed of basic python builtin types and higher-level config
@@ -18,28 +22,88 @@ class Config(Serializable):
   become addressable and can be reused.
   """
 
-  def __init__(self, **kwargs):
+  # Internal book-keeping fields to exclude from hash codes/equality checks.
+  _SPECIAL_FIELDS = ('extends', 'merges', 'typename')
+
+  def __init__(self, abstract=False, extends=None, merges=None, **kwargs):
     """Creates a new configuration data blob.
 
+    By default configurations are anonymous (un-named), concrete (not `abstract`), and they neither
+    inherit nor merge another configuration.
+
+    Inheritance is only allowed via one of the `extends` or `merges` channels, it is an error to
+    specify both.  A configuration can be semantically abstract without setting `abstract=True`.
+    The `abstract` value can serve as documentation, or, for subclasses that provide an
+    implementation for `validate_concrete`, it allows skipping validation for abstract instances.
+
+    :param bool abstract: `True` to mark this configuration item as abstract, in which case no
+                          validation is performed (see `validate_concrete`); `False` by default.
+    :param extends: The configuration instance to inherit field values from.  Any shared fields are
+                    over-written with this instances values.
+    :type extends: An addressed or concrete configuration instance that is a type compatible with
+                   this configuration or this configurations superclasses.
+    :param merges: The configuration instance to merge this instances field values with.  Merging is
+                   like extension except for containers, which are extended instead of replaced; ie:
+                   any `dict` values are updated with this instances items and any `list` values are
+                   extended with this instances items.
+    :type merges: An addressed or concrete configuration instance that is a type compatible with
+                  this configuration or this configurations superclasses.
     :param **kwargs: The configuration parameters.
     """
     self._kwargs = kwargs
+
+    self._kwargs['abstract'] = abstract
+
+    # It only makes sense to inherit a subset of our own fields (we should not inherit new fields!),
+    # our superclasses logically provide fields within this constrained set.
+    # NB: Since Config is at base an ~unconstrained struct, a superclass does allow for arbitrary
+    # and thus more fields to be defined than a subclass might logically support.  We accept this
+    # hole in a trade for generally expected behavior when Config is subclassed in the style of
+    # constructors with named parameters representing the full complete set of expected parameters
+    # leaving **kwargs only for use by 'the system'; ie for `typename` and `address` plumbing for
+    # example.
+    self._kwargs['extends'] = addressable(SuperclassesOf(type(self)), extends)
+    self._kwargs['merges'] = addressable(SuperclassesOf(type(self)), merges)
+
+    # Allow for configuration items that are directly constructed in memory.  These can have an
+    # address directly assigned (vs. inferred from name + source file location) and we only require
+    # that if they do, their name - if also assigned, matches the address.
+    if self.address:
+      if self.name and self.name != self.address.target_name:
+        self.report_validation_error('Address and name do not match! address: {}, name: {}'
+                                     .format(self.address, self.name))
+      self._kwargs['name'] = self.address.target_name
+
     self._hashable_key = None
 
   @property
   def name(self):
-    """Return the name of this object if any.
+    """Return the name of this object, if any.
 
     In general config objects need not be named, in which case they are generally embedded objects;
     ie: attributes values of enclosing named config objects.  Any top-level config object though
     will carry a unique name (in the config object's enclosing namespace) that can be used to
     address it.
+
+    :rtype: string
     """
     return self._kwargs.get('name')
 
   @property
+  def address(self):
+    """Return the address of this object, if any.
+
+    In general config objects need not be identified by an address, in which case they are generally
+    embedded objects; ie: attributes values of enclosing named config objects.  Any top-level config
+    object though will be identifiable via a unique address.
+
+    :rtype: :class:`pants.base.address.Address`
+    """
+    return self._kwargs.get('address')
+
+  @property
   def typename(self):
-    """Returns the type name this target was constructed via.
+    """Return the type name this target was constructed via.
 
     For a target read from a BUILD file, this will be target alias, like 'java_library'.
     For a target constructed in memory, this will be the simple class name, like 'JavaLibrary'.
@@ -51,12 +115,99 @@ class Config(Serializable):
     """
     return self._kwargs.get('typename', type(self).__name__)
 
+  @property
+  def abstract(self):
+    """Return `True` if this object has been marked as abstract.
+
+    Abstract objects are not validated. See: `validate_concrete`.
+
+    :rtype: bool
+    """
+    return self._kwargs['abstract']
+
+  @property
+  def extends(self):
+    """Return the object this object extends, if any.
+
+    :rtype: Serializable
+    """
+    return self._kwargs['extends']
+
+  @property
+  def merges(self):
+    """Return the object this object merges in, if any.
+
+    :rtype: Serializable
+    """
+    return self._kwargs['merges']
+
   def _asdict(self):
     return self._kwargs.copy()
 
+  def _extract_inheritable_attributes(self, serializable):
+    attributes = serializable._asdict()
+    # Allow for un-named (embedded) objects inheriting from named objects
+    attributes.pop('name', None)
+    attributes.pop('address', None)
+    return attributes
+
+  def create(self):
+    if self.extends and self.merges:
+      self.report_validation_error('Can only inherit from one object.  Both extension of {} and '
+                                   'merging with {} were requested.'
+                                   .format(self.extends.address, self.merges.address))
+
+    if self.extends:
+      attributes = self._extract_inheritable_attributes(self.extends)
+      attributes.update((k, v) for k, v in self._asdict().items()
+                        if k not in self._SPECIAL_FIELDS and v is not None)
+      config_type = type(self)
+      return config_type(**attributes)
+    elif self.merges:
+      attributes = self._extract_inheritable_attributes(self.merges)
+      for k, v in self._asdict().items():
+        if k not in self._SPECIAL_FIELDS:
+          if isinstance(v, MutableMapping):
+            attributes.setdefault(k, {}).update(v)
+          elif isinstance(v, MutableSequence) and not isinstance(v, six.string_types):
+            prior = attributes.setdefault(k, [])
+            prior.extend(v)
+          elif v is not None:
+            attributes[k] = v
+      config_type = type(self)
+      return config_type(**attributes)
+    else:
+      return self
+
+  def validate(self):
+    if not self.abstract:
+      self.validate_concrete()
+
+  def report_validation_error(self, message):
+    """Raises a properly identified validation error.
+
+    :param string message: An error message describing the validation error.
+    :raises: :class:`pants.engine.exp.objects.ValidationError`
+    """
+    raise ValidationError(self.address, message)
+
+  def validate_concrete(self):
+    """Subclasses can override to implement validation logic.
+
+    The object will be fully hydrated state and it's guaranteed the object will be concrete, aka.
+    not `abstract`.  If an error is found in the object's configuration, a validation error should
+    be raised by calling `report_validation_error`.
+
+    :raises: :class:`pants.engine.exp.objects.ValidationError`
+    """
+
+  def __getattr__(self, item):
+    return self._kwargs[item]
+
   def _key(self):
     if self._hashable_key is None:
-      self._hashable_key = sorted((k, v) for k, v in self._kwargs.items() if k != 'typename')
+      self._hashable_key = sorted((k, v) for k, v in self._kwargs.items()
+                                  if k not in self._SPECIAL_FIELDS)
     return self._hashable_key
 
   def __hash__(self):
@@ -84,8 +235,8 @@ class Target(Config):
 
   def __init__(self, name=None, configurations=None, dependencies=None, **kwargs):
     super(Target, self).__init__(name=name,
-                                 configurations=addressables(Config, configurations),
-                                 dependencies=addressables(Target, dependencies),
+                                 configurations=addressables(SubclassesOf(Config), configurations),
+                                 dependencies=addressables(SubclassesOf(Target), dependencies),
                                  **kwargs)
 
   # Some convenience properties to give the class more form, but also not strictly needed.
@@ -98,7 +249,7 @@ class Target(Config):
     return self._kwargs['dependencies']
 
 
-class ApacheThriftConfig(Config):
+class ApacheThriftConfig(Config, Validatable):
   # An example of a mixed-mode object - can be directly embedded without a name or else referenced
   # via address if both top-level and carrying a name.
   #
@@ -115,12 +266,19 @@ class ApacheThriftConfig(Config):
                                              options=options,
                                              **kwargs)
 
+  # An example of a validatable bit of config.
+  def validate_concrete(self):
+    if not self.version:
+      self.report_validation_error('A thrift `version` is required.')
+    if not self.lang:
+      self.report_validation_error('A thrift gen `lang` is required.')
+
 
 class PublishConfig(Config):
-  # An example of addressable and addressable_mapping.
+  # An example of addressable and addressable_mapping field wrappers.
 
   def __init__(self, default_repo, repos, name=None, **kwargs):
     super(PublishConfig, self).__init__(name=name,
-                                        default_repo=addressable(Config, default_repo),
-                                        repos=addressable_mapping(Config, repos),
+                                        default_repo=addressable(Exactly(Config), default_repo),
+                                        repos=addressable_mapping(Exactly(Config), repos),
                                         **kwargs)

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -2,6 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
+  name='addressable',
+  sources=['test_addressable.py'],
+  dependencies=[
+    'src/python/pants/engine/exp:addressable',
+  ]
+)
+
+
+python_tests(
   name='graph',
   sources=['test_graph.py'],
   dependencies=[
@@ -13,9 +22,30 @@ python_tests(
 )
 
 python_tests(
+  name='mapper',
+  sources=['test_mapper.py'],
+  dependencies=[
+    'src/python/pants/base:address',
+    'src/python/pants/engine/exp:mapper',
+    'src/python/pants/engine/exp:parsers',
+    'src/python/pants/util:contextutil',
+  ]
+)
+
+python_tests(
   name='parsers',
   sources=['test_parsers.py'],
   dependencies=[
     'src/python/pants/engine/exp:parsers',
+  ]
+)
+
+python_tests(
+  name='targets',
+  sources=['test_targets.py'],
+  dependencies=[
+    'src/python/pants/base:address',
+    'src/python/pants/engine/exp:objects',
+    'src/python/pants/engine/exp:targets',
   ]
 )

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -1,0 +1,21 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_tests(
+  name='graph',
+  sources=['test_graph.py'],
+  dependencies=[
+    'src/python/pants/base:address',
+    'src/python/pants/engine/exp:graph',
+    'src/python/pants/engine/exp:parsers',
+    'src/python/pants/engine/exp:targets',
+  ]
+)
+
+python_tests(
+  name='parsers',
+  sources=['test_parsers.py'],
+  dependencies=[
+    'src/python/pants/engine/exp:parsers',
+  ]
+)

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
@@ -1,0 +1,51 @@
+Target(
+  name='thrift1',
+  sources=[]
+)
+
+Target(
+  name='thrift2',
+  sources=[],
+  dependencies=[
+    ':thrift1',
+  ]
+)
+
+Target(
+  name='java1',
+  sources=[],
+  dependencies=[
+    ':thrift2',
+  ],
+  configurations=[
+    # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
+    # off / prove the capabilities of the new BUILD graph parser.
+    ApacheThriftConfig(
+      version='0.9.2',
+      strict=True,
+      lang='java',
+    ),
+    ':nonstrict',
+    PublishConfig(
+      default_repo=':public',
+      repos={
+        'jake': Config(
+          url='https://dl.bintray.com/pantsbuild/maven'
+        ),
+        'jane': ':public'
+      }
+    )
+  ]
+)
+
+ApacheThriftConfig(
+  name='nonstrict',
+  version='0.9.2',
+  strict=False,
+  lang='java'
+)
+
+Config(
+  name='public',
+  url='https://oss.sonatype.org/#stagingRepositories'
+)

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
@@ -13,7 +13,7 @@ Target(
     ':thrift1',
   ]
 )
-ApacheThriftConfig
+
 # Right now the base Config class only allows either `extends` or `merges`, but more complex chains
 # can always be built up via a sequence of objects extending or merging others.
 Target(

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
@@ -1,3 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 Target(
   name='thrift1',
   sources=[]
@@ -10,22 +13,17 @@ Target(
     ':thrift1',
   ]
 )
-
+ApacheThriftConfig
+# Right now the base Config class only allows either `extends` or `merges`, but more complex chains
+# can always be built up via a sequence of objects extending or merging others.
 Target(
   name='java1',
+  merges=':production_thrift_configs',
   sources=[],
   dependencies=[
     ':thrift2',
   ],
   configurations=[
-    # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
-    # off / prove the capabilities of the new BUILD graph parser.
-    ApacheThriftConfig(
-      version='0.9.2',
-      strict=True,
-      lang='java',
-    ),
-    ':nonstrict',
     PublishConfig(
       default_repo=':public',
       repos={
@@ -40,7 +38,7 @@ Target(
 
 ApacheThriftConfig(
   name='nonstrict',
-  version='0.9.2',
+  extends=':production_thrift_config',
   strict=False,
   lang='java'
 )
@@ -48,4 +46,43 @@ ApacheThriftConfig(
 Config(
   name='public',
   url='https://oss.sonatype.org/#stagingRepositories'
+)
+
+# ~ABCs defined in a BUILD - no plugin needed for extending target types.
+#
+# This also solves the extracted constant version for jar libraries for example:
+# Jar(org='org.apache.lucene', name='production_lucene_jar', rev='5.3.1')
+#
+# Jar(extends=':production_lucene_jar', name='lucene-core')
+# Jar(extends=':production_lucene_jar', name='lucene-codecs')
+# Jar(extends=':production_lucene_jar', name='lucene-classification')
+#
+# Note also that the ancient pants support for inline jar dependencies can be resurrected.  No
+# longer must a dependency by thing with dependencies itself (JarLibrary) - it can be an addressable
+# leaf.  This allows for much more natural very small project setups with pants.  You have 1 small
+# target with all configuration inline.
+
+ApacheThriftConfig(
+  name='production_thrift_config',
+  abstract=True,  # ApacheThriftConfig validates, so we avoid validation for this abstract template.
+  version='0.9.2',
+  strict=True
+
+  # NB: This abstract template has no `lang` - which is required (validated).
+)
+
+# Since this abstract target declares a list, it can be usefully extended via `merges` such that
+# additional configurations defined by the merger are appended.
+Target(
+  name='production_thrift_configs',
+  configurations=[
+    # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
+    # off / prove the capabilities of the new BUILD graph parser.
+    ApacheThriftConfig(
+      version='0.9.2',
+      strict=True,
+      lang='java',
+    ),
+    ':nonstrict'
+  ]
 )

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -60,3 +60,67 @@
   "name": "public",
   "url": "https://oss.sonatype.org/#stagingRepositories"
 }
+
+{
+  "typename": "Config",
+  "name": "type_mismatch",
+
+  # This should trigger a type mismatch when resolved since ApacheThriftConfig is not a superclass
+  # of Config
+  "extends": ":nonstrict"
+}
+
+{
+  "typename": "Config",
+  "name": "self_cycle",
+
+  # This should trigger a cycle error when resolved since we're trying to depend on ourselves for
+  # inheritance purposes.
+  "extends": ":self_cycle"
+}
+
+# A single-hop direct cycle - though through different types of dependency edges.
+{
+  "typename": "Target",
+  "name": "direct_cycle",
+  "dependencies": [
+    ":direct_cycle_dep"
+  ]
+}
+
+{
+  "typename": "Target",
+  "name": "direct_cycle_dep",
+  "configurations": [
+    ":direct_cycle"
+  ]
+}
+
+# A multi-hop cycle
+{
+  "typename": "Target",
+  "name": "indirect_cycle",
+  "merges": ":one"
+}
+
+{
+  "typename": "Target",
+  "name": "one",
+  "dependencies": [
+    ":two"
+  ]
+}
+
+{
+  "typename": "Target",
+  "name": "two",
+  "extends": ":three"
+}
+
+{
+  "typename": "Target",
+  "name": "three",
+  "configurations": [
+    ":one"
+  ]
+}

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -1,3 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 {
   "typename": "Target",
   "name": "thrift1",

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -1,0 +1,59 @@
+{
+  "typename": "Target",
+  "name": "thrift1",
+  "sources": []
+}
+
+{
+  "typename": "Target",
+  "name": "thrift2",
+  "sources": [],
+  "dependencies": [
+    ":thrift1"
+  ]
+}
+
+{
+  "typename": "Target",
+  "name": "java1",
+  "sources": [],
+  "dependencies": [
+    ":thrift2"
+  ],
+  "configurations": [
+    # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
+    # off / prove the capabilities of the new BUILD graph parser.
+    {
+      "typename": "ApacheThriftConfig",
+      "version": "0.9.2",
+      "strict": true,
+      "lang": "java"
+    },
+    ":nonstrict",
+    {
+      "typename": "PublishConfig",
+      "default_repo": ":public",
+      "repos": {
+        "jake": {
+          "typename": "Config",
+          "url": "https://dl.bintray.com/pantsbuild/maven"
+        },
+        "jane": ":public"
+      }
+    }
+  ]
+}
+
+{
+  "typename": "ApacheThriftConfig",
+  "name": "nonstrict",
+  "version": "0.9.2",
+  "strict": false,
+  "lang": "java"
+}
+
+{
+  "typename": "Config",
+  "name": "public",
+  "url": "https://oss.sonatype.org/#stagingRepositories"
+}

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.python
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.python
@@ -1,0 +1,46 @@
+thrift1 = Target(
+  sources=[]
+)
+
+thrift2 = Target(
+  sources=[],
+  dependencies=[
+    ':thrift1',
+  ]
+)
+
+java1 = Target(
+  sources=[],
+  dependencies=[
+    ':thrift2',
+  ],
+  configurations=[
+    # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
+    # off / prove the capabilities of the new BUILD graph parser.
+    ApacheThriftConfig(
+      version='0.9.2',
+      strict=True,
+      lang='java',
+    ),
+    ':nonstrict',
+    PublishConfig(
+      default_repo=':public',
+      repos={
+        'jake': Config(
+          url='https://dl.bintray.com/pantsbuild/maven'
+        ),
+        'jane': ':public'
+      }
+    )
+  ]
+)
+
+nonstrict = ApacheThriftConfig(
+  version='0.9.2',
+  strict=False,
+  lang='java'
+)
+
+public = Config(
+  url='https://oss.sonatype.org/#stagingRepositories'
+)

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.python
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.python
@@ -1,3 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 thrift1 = Target(
   sources=[]
 )

--- a/tests/python/pants_test/engine/exp/test_addressable.py
+++ b/tests/python/pants_test/engine/exp/test_addressable.py
@@ -1,0 +1,112 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.engine.exp.addressable import (Addressed, AddressedError, Exactly, SubclassesOf,
+                                          SuperclassesOf, addressable, addressable_mapping,
+                                          addressables)
+
+
+class TypeConstraintTestBase(unittest.TestCase):
+  class A(object):
+    pass
+
+  class B(A):
+    pass
+
+  class C(B):
+    pass
+
+  class BPrime(A):
+    pass
+
+
+class SuperclassesOfTest(TypeConstraintTestBase):
+  def test(self):
+    self.assertTrue(SuperclassesOf(self.B).satisfied_by(self.A()))
+    self.assertTrue(SuperclassesOf(self.B).satisfied_by(self.B()))
+    self.assertFalse(SuperclassesOf(self.B).satisfied_by(self.BPrime()))
+    self.assertFalse(SuperclassesOf(self.B).satisfied_by(self.C()))
+
+
+class ExactlyTest(TypeConstraintTestBase):
+  def test(self):
+    self.assertFalse(Exactly(self.B).satisfied_by(self.A()))
+    self.assertTrue(Exactly(self.B).satisfied_by(self.B()))
+    self.assertFalse(Exactly(self.B).satisfied_by(self.BPrime()))
+    self.assertFalse(Exactly(self.B).satisfied_by(self.C()))
+
+
+class SubclassesOfTest(TypeConstraintTestBase):
+  def test(self):
+    self.assertFalse(SubclassesOf(self.B).satisfied_by(self.A()))
+    self.assertTrue(SubclassesOf(self.B).satisfied_by(self.B()))
+    self.assertFalse(SubclassesOf(self.B).satisfied_by(self.BPrime()))
+    self.assertTrue(SubclassesOf(self.B).satisfied_by(self.C()))
+
+
+class AddressableTest(unittest.TestCase):
+  def test_none(self):
+    self.assertIsNone(addressable(Exactly(int), None))
+
+  def test_value(self):
+    self.assertEqual(42, addressable(Exactly(int), 42))
+
+  def test_pointer(self):
+    self.assertEqual(Addressed(Exactly(int), '//:meaning-of-life'),
+                     addressable(Exactly(int), '//:meaning-of-life'))
+
+  def test_type_mismatch(self):
+    with self.assertRaises(AddressedError):
+      addressable(Exactly(int), 42.0)
+
+
+class AddressablesTest(unittest.TestCase):
+  def test_none(self):
+    self.assertEqual([], addressables(Exactly(int), None))
+
+  def test_values(self):
+    self.assertEqual([42, 1 / 137.0], addressables(SubclassesOf((int, float)), (42, 1 / 137.0)))
+
+  def test_pointers(self):
+    self.assertEqual([Addressed(Exactly(int), '//:meaning-of-life')],
+                     addressables(Exactly(int), ['//:meaning-of-life']))
+
+  def test_mixed(self):
+    self.assertEqual([42, Addressed(Exactly(int), '//:meaning-of-life')],
+                     addressables(Exactly(int), [42, '//:meaning-of-life']))
+
+  def test_type_mismatch(self):
+    with self.assertRaises(AddressedError):
+      addressables(Exactly(int), [42, 1 / 137.0])
+
+
+class AddressableMappingTest(unittest.TestCase):
+  def test_none(self):
+    self.assertEqual({}, addressable_mapping(Exactly(int), None))
+
+  def test_values(self):
+    self.assertEqual(dict(meaning_of_life=42, fine_structure_constant=1 / 137.0),
+                     addressable_mapping(SubclassesOf((int, float)),
+                                         dict(meaning_of_life=42,
+                                              fine_structure_constant=1 / 137.0)))
+
+  def test_pointers(self):
+    self.assertEqual(dict(meaning_of_life=Addressed(Exactly(int), '//:meaning-of-life')),
+                     addressable_mapping(Exactly(int), dict(meaning_of_life='//:meaning-of-life')))
+
+  def test_mixed(self):
+    self.assertEqual(dict(meaning_of_life=42,
+                          fine_structure_constant=Addressed(SubclassesOf((int, float)), '//:fsc')),
+                     addressable_mapping(SubclassesOf((int, float)),
+                                         dict(meaning_of_life=42,
+                                              fine_structure_constant='//:fsc')))
+
+  def test_type_mismatch(self):
+    with self.assertRaises(AddressedError):
+      addressable_mapping(Exactly(int), dict(meaning_of_life=42, fine_structure_constant=1 / 137.0))

--- a/tests/python/pants_test/engine/exp/test_graph.py
+++ b/tests/python/pants_test/engine/exp/test_graph.py
@@ -10,7 +10,7 @@ import unittest
 from functools import partial
 
 from pants.base.address import Address
-from pants.engine.exp.graph import Graph
+from pants.engine.exp.graph import CycleError, Graph, ResolvedTypeMismatchError, ResolveError
 from pants.engine.exp.parsers import parse_json, parse_python_assignments, parse_python_callbacks
 from pants.engine.exp.targets import ApacheThriftConfig, Config, PublishConfig, Target
 
@@ -22,6 +22,10 @@ class GraphTest(unittest.TestCase):
 
   def create_graph(self, build_pattern=None, parser=None):
     return Graph(build_root=os.path.dirname(__file__), build_pattern=build_pattern, parser=parser)
+
+  def create_json_graph(self):
+    return self.create_graph(build_pattern=r'.+\.BUILD.json$',
+                             parser=partial(parse_json, symbol_table=self.symbol_table))
 
   def do_test_codegen_simple(self, graph):
     def address(name):
@@ -54,8 +58,7 @@ class GraphTest(unittest.TestCase):
     self.assertEqual(expected_java1, resolved_java1)
 
   def test_json(self):
-    graph = self.create_graph(build_pattern=r'.+\.BUILD.json$',
-                              parser=partial(parse_json, symbol_table=self.symbol_table))
+    graph = self.create_json_graph()
     self.do_test_codegen_simple(graph)
 
   def test_python(self):
@@ -69,3 +72,63 @@ class GraphTest(unittest.TestCase):
                               parser=partial(parse_python_callbacks,
                                              symbol_table=self.symbol_table))
     self.do_test_codegen_simple(graph)
+
+  def test_resolve_cache(self):
+    graph = self.create_json_graph()
+
+    nonstrict_address = Address.parse('examples/graph_test:nonstrict')
+    nonstrict = graph.resolve(nonstrict_address)
+    self.assertIs(nonstrict, graph.resolve(nonstrict_address))
+
+    # The already resolved `nonstrict` interior node should be re-used by `java1`.
+    java1_address = Address.parse('examples/graph_test:java1')
+    java1 = graph.resolve(java1_address)
+    self.assertIs(nonstrict, java1.configurations[1])
+
+    self.assertIs(java1, graph.resolve(java1_address))
+
+  def extract_path_tail(self, cycle_exception, line_count):
+    return [l.lstrip() for l in str(cycle_exception).splitlines()[-line_count:]]
+
+  def test_cycle_self(self):
+    graph = self.create_json_graph()
+    with self.assertRaises(CycleError) as exc:
+      graph.resolve(Address.parse('examples/graph_test:self_cycle'))
+    self.assertEqual(['* examples/graph_test:self_cycle',
+                      '* examples/graph_test:self_cycle'],
+                     self.extract_path_tail(exc.exception, 2))
+
+  def test_cycle_direct(self):
+    graph = self.create_json_graph()
+    with self.assertRaises(CycleError) as exc:
+      graph.resolve(Address.parse('examples/graph_test:direct_cycle'))
+    self.assertEqual(['* examples/graph_test:direct_cycle',
+                      'examples/graph_test:direct_cycle_dep',
+                      '* examples/graph_test:direct_cycle'],
+                     self.extract_path_tail(exc.exception, 3))
+
+  def test_cycle_indirect(self):
+    graph = self.create_json_graph()
+    with self.assertRaises(CycleError) as exc:
+      graph.resolve(Address.parse('examples/graph_test:indirect_cycle'))
+    self.assertEqual(['examples/graph_test:indirect_cycle',
+                      '* examples/graph_test:one',
+                      'examples/graph_test:two',
+                      'examples/graph_test:three',
+                      '* examples/graph_test:one'],
+                     self.extract_path_tail(exc.exception, 5))
+
+  def test_type_mismatch_error(self):
+    graph = self.create_json_graph()
+    with self.assertRaises(ResolvedTypeMismatchError):
+      graph.resolve(Address.parse('examples/graph_test:type_mismatch'))
+
+  def test_not_found_but_family_exists(self):
+    graph = self.create_json_graph()
+    with self.assertRaises(ResolveError):
+      graph.resolve(Address.parse('examples/graph_test:this_addressable_does_not_exist'))
+
+  def test_not_found_and_family_does_not_exist(self):
+    graph = self.create_json_graph()
+    with self.assertRaises(ResolveError):
+      graph.resolve(Address.parse('this/dir/does/not/exist'))

--- a/tests/python/pants_test/engine/exp/test_graph.py
+++ b/tests/python/pants_test/engine/exp/test_graph.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import unittest
+from functools import partial
+
+from pants.base.address import Address
+from pants.engine.exp.graph import Graph
+from pants.engine.exp.parsers import parse_json, parse_python_assignments, parse_python_callbacks
+from pants.engine.exp.targets import ApacheThriftConfig, Config, PublishConfig, Target
+
+
+class GraphTest(unittest.TestCase):
+  def setUp(self):
+    self.symbol_table = {type_.__name__: type_
+                         for type_ in (ApacheThriftConfig, Config, Target, PublishConfig)}
+
+  def create_graph(self, build_pattern=None, parser=None):
+    return Graph(build_root=os.path.dirname(__file__), build_pattern=build_pattern, parser=parser)
+
+  def do_test_codegen_simple(self, graph):
+    resolved_java1 = graph.resolve(Address.parse('examples/graph_test:java1'))
+
+    nonstrict = ApacheThriftConfig(name='nonstrict',
+                                   version='0.9.2',
+                                   strict=False,
+                                   lang='java')
+    public = Config(name='public', url='https://oss.sonatype.org/#stagingRepositories')
+    thrift1 = Target(name='thrift1', sources=[])
+    thrift2 = Target(name='thrift2', sources=[], dependencies=[thrift1])
+    expected_java1 = Target(name='java1',
+                            sources=[],
+                            configurations=[
+                              ApacheThriftConfig(version='0.9.2', strict=True, lang='java'),
+                              nonstrict,
+                              PublishConfig(
+                                default_repo=public,
+                                repos={
+                                  'jake': Config(url='https://dl.bintray.com/pantsbuild/maven'),
+                                  'jane': public
+                                }
+                              )
+                            ],
+                            dependencies=[thrift2])
+
+    self.assertEqual(expected_java1, resolved_java1)
+
+  def test_json(self):
+    graph = self.create_graph(build_pattern=r'.+\.BUILD.json$',
+                              parser=partial(parse_json, symbol_table=self.symbol_table))
+    self.do_test_codegen_simple(graph)
+
+  def test_python(self):
+    graph = self.create_graph(build_pattern=r'.+\.BUILD.python$',
+                              parser=partial(parse_python_assignments,
+                                             symbol_table=self.symbol_table))
+    self.do_test_codegen_simple(graph)
+
+  def test_python_classic(self):
+    graph = self.create_graph(build_pattern=r'.+\.BUILD$',
+                              parser=partial(parse_python_callbacks,
+                                             symbol_table=self.symbol_table))
+    self.do_test_codegen_simple(graph)

--- a/tests/python/pants_test/engine/exp/test_graph.py
+++ b/tests/python/pants_test/engine/exp/test_graph.py
@@ -24,16 +24,19 @@ class GraphTest(unittest.TestCase):
     return Graph(build_root=os.path.dirname(__file__), build_pattern=build_pattern, parser=parser)
 
   def do_test_codegen_simple(self, graph):
-    resolved_java1 = graph.resolve(Address.parse('examples/graph_test:java1'))
+    def address(name):
+      return Address(spec_path='examples/graph_test', target_name=name)
 
-    nonstrict = ApacheThriftConfig(name='nonstrict',
+    resolved_java1 = graph.resolve(address('java1'))
+
+    nonstrict = ApacheThriftConfig(address=address('nonstrict'),
                                    version='0.9.2',
                                    strict=False,
                                    lang='java')
-    public = Config(name='public', url='https://oss.sonatype.org/#stagingRepositories')
-    thrift1 = Target(name='thrift1', sources=[])
-    thrift2 = Target(name='thrift2', sources=[], dependencies=[thrift1])
-    expected_java1 = Target(name='java1',
+    public = Config(address=address('public'), url='https://oss.sonatype.org/#stagingRepositories')
+    thrift1 = Target(address=address('thrift1'), sources=[])
+    thrift2 = Target(address=address('thrift2'), sources=[], dependencies=[thrift1])
+    expected_java1 = Target(address=address('java1'),
                             sources=[],
                             configurations=[
                               ApacheThriftConfig(version='0.9.2', strict=True, lang='java'),

--- a/tests/python/pants_test/engine/exp/test_mapper.py
+++ b/tests/python/pants_test/engine/exp/test_mapper.py
@@ -1,0 +1,114 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import functools
+import unittest
+from contextlib import contextmanager
+from textwrap import dedent
+
+from pants.base.address import Address
+from pants.engine.exp import parsers
+from pants.engine.exp.mapper import (AddressFamily, AddressMap, DifferingFamiliesError,
+                                     DuplicateNameError, UnaddressableObjectError)
+from pants.util.contextutil import temporary_file
+
+
+class Thing(object):
+  def __init__(self, **kwargs):
+    self._kwargs = kwargs
+
+  def _asdict(self):
+    return self._kwargs.copy()
+
+  def _key(self):
+    return {k: v for k, v in self._kwargs.items() if k != 'typename'}
+
+  def __eq__(self, other):
+    return isinstance(other, Thing) and self._key() == other._key()
+
+
+class AddressMapTest(unittest.TestCase):
+  _parse = functools.partial(parsers.parse_json, symbol_table={'thing': Thing})
+
+  @contextmanager
+  def parse_address_map(self, json):
+    with temporary_file() as fp:
+      fp.write(json)
+      fp.close()
+      address_map = AddressMap.parse(fp.name, parse=self._parse)
+      self.assertEqual(fp.name, address_map.path)
+      yield address_map
+
+  def test_parse(self):
+    with self.parse_address_map(dedent("""
+      {
+        "typename": "thing",
+        "name": "one",
+        "age": 42
+      }
+      {
+        "typename": "thing",
+        "name": "two",
+        "age": 37
+      }
+      """)) as address_map:
+
+      self.assertEqual({'one': Thing(name='one', age=42), 'two': Thing(name='two', age=37)},
+                       address_map.objects_by_name)
+
+  def test_not_serializable(self):
+    with self.assertRaises(UnaddressableObjectError):
+      with self.parse_address_map('{}'):
+        self.fail()
+
+  def test_not_named(self):
+    with self.assertRaises(UnaddressableObjectError):
+      with self.parse_address_map('{"typename": "thing"}'):
+        self.fail()
+
+  def test_duplicate_names(self):
+    with self.assertRaises(DuplicateNameError):
+      with self.parse_address_map('{"typename": "thing", "name": "one"}'
+                                  '{"typename": "thing", "name": "one"}'):
+        self.fail()
+
+
+class AddressFamilyTest(unittest.TestCase):
+  def test_create_single(self):
+    address_family = AddressFamily.create('/dev/null',
+                                          [AddressMap('/dev/null/0', {
+                                            'one': Thing(name='one', age=42),
+                                            'two': Thing(name='two', age=37)
+                                          })])
+    self.assertEqual('', address_family.namespace)
+    self.assertEqual({Address.parse('//:one'): Thing(name='one', age=42),
+                      Address.parse('//:two'): Thing(name='two', age=37)},
+                     address_family.addressables)
+
+  def test_create_multiple(self):
+    address_family = AddressFamily.create('/dev/null',
+                                          [AddressMap('/dev/null/name/space/0',
+                                                      {'one': Thing(name='one', age=42)}),
+                                           AddressMap('/dev/null/name/space/1',
+                                                      {'two': Thing(name='two', age=37)})])
+
+    self.assertEqual('name/space', address_family.namespace)
+    self.assertEqual({Address.parse('name/space:one'): Thing(name='one', age=42),
+                      Address.parse('name/space:two'): Thing(name='two', age=37)},
+                     address_family.addressables)
+
+  def test_mismatching_paths(self):
+    with self.assertRaises(DifferingFamiliesError):
+      AddressFamily.create('/dev/null', [AddressMap('/dev/null/one/0', {}),
+                                         AddressMap('/dev/null/two/0', {})])
+
+  def test_duplicate_names(self):
+    with self.assertRaises(DuplicateNameError):
+      AddressFamily.create('/dev/null', [AddressMap('/dev/null/name/space/0',
+                                                    {'one': Thing(name='one', age=42)}),
+                                         AddressMap('/dev/null/name/space/1',
+                                                    {'one': Thing(name='one', age=37)})])

--- a/tests/python/pants_test/engine/exp/test_parsers.py
+++ b/tests/python/pants_test/engine/exp/test_parsers.py
@@ -1,0 +1,280 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+from textwrap import dedent
+
+from pants.engine.exp import parsers
+from pants.engine.exp.parsers import ParseError
+
+
+# A duck-typed Serializable with an `==` suitable for ease of testing.
+class Bob(object):
+  def __init__(self, **kwargs):
+    self._kwargs = kwargs
+
+  def _asdict(self):
+    return self._kwargs.copy()
+
+  def _key(self):
+    return {k: v for k, v in self._kwargs.items() if k != 'typename'}
+
+  def __eq__(self, other):
+    return isinstance(other, Bob) and self._key() == other._key()
+
+
+class JsonParserTest(unittest.TestCase):
+  def test_comments(self):
+    document = dedent("""
+    # Top level comment.
+    {
+      # Nested comment
+      "hobbies": [1, 2, 3]
+    }
+    """)
+    results = parsers.parse_json(document)
+    self.assertEqual(1, len(results))
+    self.assertEqual([dict(hobbies=[1, 2, 3])],
+                     parsers.parse_json(parsers.encode_json(results[0])))
+
+  def test_single(self):
+    document = dedent("""
+    # An simple example with a single Bob.
+    {
+      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "hobbies": [1, 2, 3]
+    }
+    """)
+    results = parsers.parse_json(document)
+    self.assertEqual(1, len(results))
+    self.assertEqual([Bob(hobbies=[1, 2, 3])],
+                     parsers.parse_json(parsers.encode_json(results[0])))
+    self.assertEqual('pants_test.engine.exp.test_parsers.Bob', results[0]._asdict()['typename'])
+
+  def test_symbol_table(self):
+    symbol_table = {'bob': Bob}
+    document = dedent("""
+    # An simple example with a single Bob.
+    {
+      "typename": "bob",
+      "hobbies": [1, 2, 3]
+    }
+    """)
+    results = parsers.parse_json(document, symbol_table=symbol_table)
+    self.assertEqual(1, len(results))
+    self.assertEqual([Bob(hobbies=[1, 2, 3])],
+                     parsers.parse_json(parsers.encode_json(results[0]), symbol_table=symbol_table))
+    self.assertEqual('bob', results[0]._asdict()['typename'])
+
+  def test_nested_single(self):
+    document = dedent("""
+    # An example with nested Bobs.
+    {
+      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "uncle": {
+        "typename": "pants_test.engine.exp.test_parsers.Bob",
+        "age": 42
+      },
+      "hobbies": [1, 2, 3]
+    }
+    """)
+    results = parsers.parse_json(document)
+    self.assertEqual(1, len(results))
+    self.assertEqual([Bob(uncle=Bob(age=42), hobbies=[1, 2, 3])],
+                     parsers.parse_json(parsers.encode_json(results[0])))
+
+  def test_nested_deep(self):
+    document = dedent("""
+    # An example with deeply nested Bobs.
+    {
+      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "configs": [
+        {
+          "mappings": {
+            "uncle": {
+              "typename": "pants_test.engine.exp.test_parsers.Bob",
+              "age": 42
+            }
+          }
+        }
+      ]
+    }
+    """)
+    results = parsers.parse_json(document)
+    self.assertEqual(1, len(results))
+    self.assertEqual([Bob(configs=[dict(mappings=dict(uncle=Bob(age=42)))])],
+                     parsers.parse_json(parsers.encode_json(results[0])))
+
+  def test_nested_many(self):
+    document = dedent("""
+    # An example with many nested Bobs.
+    {
+      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "cousins": [
+        {
+          "typename": "pants_test.engine.exp.test_parsers.Bob",
+          "name": "Jake",
+          "age": 42
+        },
+        {
+          "typename": "pants_test.engine.exp.test_parsers.Bob",
+          "name": "Jane",
+          "age": 37
+        }
+      ]
+    }
+    """)
+    results = parsers.parse_json(document)
+    self.assertEqual(1, len(results))
+    self.assertEqual([Bob(cousins=[Bob(name='Jake', age=42), Bob(name='Jane', age=37)])],
+                     parsers.parse_json(parsers.encode_json(results[0])))
+
+  def test_multiple(self):
+    document = dedent("""
+    # An example with several Bobs.
+
+    # One with hobbies.
+    {
+      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "hobbies": [1, 2, 3]
+    }
+
+    # Another that is aged.
+    {
+      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "age": 42
+    }
+    """)
+    results = parsers.parse_json(document)
+    self.assertEqual([Bob(hobbies=[1, 2, 3]), Bob(age=42)], results)
+
+  def test_tricky_spacing(self):
+    document = dedent("""
+    # An example with several Bobs.
+
+    # One with hobbies.
+      {
+        "typename": "pants_test.engine.exp.test_parsers.Bob",
+
+        # And internal comment and blank lines.
+
+        "hobbies": [1, 2, 3]} {
+      # This comment is inside an empty object that started on the prior line!
+    }
+
+    # Another that is aged.
+    {"typename": "pants_test.engine.exp.test_parsers.Bob","age": 42}
+    """).strip()
+    results = parsers.parse_json(document)
+    self.assertEqual([Bob(hobbies=[1, 2, 3]), {}, Bob(age=42)], results)
+
+  def test_error_presentation(self):
+    document = dedent("""
+    # An example with several Bobs.
+
+    # One with hobbies.
+      {
+        "typename": "pants_test.engine.exp.test_parsers.Bob",
+
+        # And internal comment and blank lines.
+
+        "hobbies": [1, 2, 3]} {
+      # This comment is inside an empty object that started on the prior line!
+    }
+
+    # Another that is imaginary aged.
+    {
+      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "age": 42i,
+
+      "four": 1,
+      "five": 1,
+      "six": 1,
+      "seven": 1,
+      "eight": 1,
+      "nine": 1
+    }
+    """).strip()
+    with self.assertRaises(ParseError) as exc:
+      parsers.parse_json(document)
+
+    # Strip trailing whitespace from the message since our expected literal below will have
+    # trailing ws stripped via editors and code reviews calling for it.
+    actual_lines = [line.rstrip() for line in str(exc.exception).splitlines()]
+
+    # This message from the json stdlib varies between python releases, so fuzz the match a bit.
+    self.assertRegexpMatches(actual_lines[0],
+                             r"""Expecting (?:,|','|",") delimiter: line 3 column 12 \(char 69\)""")
+
+    self.assertEqual(dedent("""
+      In document:
+          # An example with several Bobs.
+
+          # One with hobbies.
+            {
+              "typename": "pants_test.engine.exp.test_parsers.Bob",
+
+              # And internal comment and blank lines.
+
+              "hobbies": [1, 2, 3]} {
+            # This comment is inside an empty object that started on the prior line!
+          }
+
+          # Another that is imaginary aged.
+       1: {
+       2:   "typename": "pants_test.engine.exp.test_parsers.Bob",
+       3:   "age": 42i,
+
+       4:   "four": 1,
+       5:   "five": 1,
+       6:   "six": 1,
+       7:   "seven": 1,
+       8:   "eight": 1,
+       9:   "nine": 1
+      10: }
+      """).strip(), '\n'.join(actual_lines[1:]))
+
+
+class PythonAssignmentsParserTest(unittest.TestCase):
+  def test_no_symbol_table(self):
+    document = dedent("""
+    from pants_test.engine.exp.test_parsers import Bob
+
+    nancy = Bob(
+      hobbies=[1, 2, 3]
+    )
+    """)
+    results = parsers.parse_python_assignments(document)
+    self.assertEqual([Bob(name='nancy', hobbies=[1, 2, 3])], results)
+
+    # No symbol table was used so no `typename` plumbing can be expected.
+    self.assertNotIn('typename', results[0]._asdict())
+
+  def test_symbol_table(self):
+    symbol_table = {'nancy': Bob}
+    document = dedent("""
+    bill = nancy(
+      hobbies=[1, 2, 3]
+    )
+    """)
+    results = parsers.parse_python_assignments(document, symbol_table=symbol_table)
+    self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
+    self.assertEqual('nancy', results[0]._asdict()['typename'])
+
+
+class PythonCallbacksParserTest(unittest.TestCase):
+  def test(self):
+    symbol_table = {'nancy': Bob}
+    document = dedent("""
+    nancy(
+      name='bill',
+      hobbies=[1, 2, 3]
+    )
+    """)
+    results = parsers.parse_python_callbacks(document, symbol_table)
+    self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
+    self.assertEqual('nancy', results[0]._asdict()['typename'])

--- a/tests/python/pants_test/engine/exp/test_targets.py
+++ b/tests/python/pants_test/engine/exp/test_targets.py
@@ -1,0 +1,81 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.base.address import Address
+from pants.engine.exp.objects import ValidationError
+from pants.engine.exp.targets import Config
+
+
+class ConfigTest(unittest.TestCase):
+  def test_address_no_name(self):
+    config = Config(address=Address.parse('a:b'))
+    self.assertEqual('b', config.name)
+
+  def test_address_name_conflict(self):
+    with self.assertRaises(ValidationError):
+      Config(name='a', address=Address.parse('a:b'))
+
+  def test_typename(self):
+    self.assertEqual('Config', Config().typename)
+    self.assertEqual('aliased', Config(typename='aliased').typename)
+
+    class Subclass(Config):
+      pass
+
+    self.assertEqual('Subclass', Subclass().typename)
+    self.assertEqual('aliased_subclass', Subclass(typename='aliased_subclass').typename)
+
+  def test_extend_and_merge(self):
+    # Resolution should be lazy, so - although its invalid to both extend and merge, we should be
+    # able to create the config.
+    config = Config(extends=Config(), merges=Config())
+    with self.assertRaises(ValidationError):
+      # But we should fail when we go to actually inherit.
+      config.create()
+
+  def test_extend(self):
+    extends = Config(age=32, label='green', items=[],
+                     extends=Config(age=42, other=True, items=[1, 2]))
+
+    # Extension is lazy, so we don't pick up the other field yet.
+    self.assertNotEqual(Config(age=32, label='green', items=[], other=True), extends)
+
+    # But we do pick it up now.
+    self.assertEqual(Config(age=32, label='green', items=[], other=True), extends.create())
+
+  def test_merge(self):
+    merges = Config(age=32, items=[3], knobs={'b': False},
+                    merges=Config(age=42, other=True, items=[1, 2], knobs={'a': True, 'b': True}))
+
+    # Merging is lazy, so we don't pick up the other field yet.
+    self.assertNotEqual(Config(age=32, items=[1, 2, 3], knobs={'a': True, 'b': False}, other=True),
+                        merges)
+
+    # But we do pick it up now.
+    self.assertEqual(Config(age=32, items=[1, 2, 3], knobs={'a': True, 'b': False}, other=True),
+                     merges.create())
+
+  def test_validate_concrete(self):
+    class Subclass(Config):
+      def validate_concrete(self):
+        if self.name != 'jake':
+          self.report_validation_error('There is only one true good name.')
+
+    # A valid name.
+    jake = Subclass(name='jake')
+    jake.validate()
+
+    # An invalid name, but we're abstract, so don't validate yet.
+    jack = Subclass(name='jack', abstract=True)
+    jack.validate()
+
+    # An invalid name in a concrete instance, this should raise.
+    jeb = Subclass(name='jeb')
+    with self.assertRaises(ValidationError):
+      jeb.validate()


### PR DESCRIPTION
The lifecycle is enforced by `Graph` and includes new support for:
1. Resolved object replacement:
   This is used to implement 2 forms of value inheritance, aka.
   templating.
2. Resolved object validation:
   This gives a first class home for validation logic and ensures the
   full hydrated object closure is available to run that logic against.

Additionally, `Graph` gains support for cycle detection at resolve time
and it now plumbs resolved objects addresses into their `address` field.

https://rbcommons.com/s/twitter/r/2920/