### PR TITLE
 Fix `bench` goal to work for future benchmark `Task`s 

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -45,6 +45,7 @@ python_library(
   dependencies = [
     ':jvm_task',
     ':jvm_tool_task_mixin',
+    'src/python/pants/backend/core/tasks:mutex_task_mixin',
     'src/python/pants/backend/core/tasks:task',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:workunit',

--- a/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_benchmark_run.py
@@ -27,5 +27,4 @@ class BenchmarkRunTest(JvmToolTaskTestBase):
     context = self.context(target_roots=[self.target('foo:hello')])
     self.populate_compile_classpath(context)
 
-    with self.assertRaises(TaskError):
-      self.execute(context)
+    self.execute(context)


### PR DESCRIPTION
As part of implementing a Haskell plugin for `pants` I discovered that the
JVM `Benchmark` `Task` caused the `bench` goal to fail for newly added benchmark
`Task`s.

The `bench` goal fails on new benchmark `Task`s for two reasons:

* The `Benchmark` `Task` tries to parse JVM-specific command-line flags upon
  initialization.  In `pants`, all `Task`s are initialized (even if they are
  unused), which means that the `bench` goal currently demands these flags no
  matter what you are benchmarking.
* The `Benchmark` `Task` insists that at least one `Target` in the `Target`
  graph is a JVM `benchmark` `Target`.

To fix this I made two changes:

* I moved the flag parsing logic from `__init__` to the `execute` function, so
  that flags are only parsed if the `Benchmark` `Task` actually runs
* I guarded the `Benchmark` `Task` behind the new mutex system, ensuring that
  (A) it only runs if the user supplies a JVM `benchmark` `Target` and (B)
  it can be made mutually exclusive with future benchmark `Task`s.