### PR TITLE
Some optimizations and comparison support.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -13,6 +13,7 @@ print_exception_stacktrace: True
 
 # Enable our own custom loose-source plugins as well as contribs.
 pythonpath: [
+    "%(buildroot)s/src/python",
     "%(buildroot)s/contrib/cpp/src/python",
     "%(buildroot)s/contrib/go/src/python",
     "%(buildroot)s/contrib/node/src/python",

--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -57,6 +57,7 @@ python_library(
   dependencies=[
     '3rdparty/python:six',
     ':objects',
+    'src/python/pants/base:build_file_target_factory',
     'src/python/pants/util:memo',
   ]
 )

--- a/src/python/pants/engine/exp/commands/BUILD
+++ b/src/python/pants/engine/exp/commands/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_binary(
+  name='list',
+  source='commands.py',
+  entry_point='pants.engine.exp.commands.commands:list',
+  dependencies=[
+    '3rdparty/python:beautifulsoup4',  # This is needed to satisfy pants-plugins deps.
+    'src/python/pants/base:build_environment',
+    'src/python/pants/bin:pants',
+    'src/python/pants/engine/exp:mapper',
+    'src/python/pants/engine/exp:targets',
+  ]
+)

--- a/src/python/pants/engine/exp/commands/commands.py
+++ b/src/python/pants/engine/exp/commands/commands.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.base.build_environment import get_buildroot
+from pants.base.parse_context import ParseContext
+from pants.bin.goal_runner import OptionsInitializer
+from pants.engine.exp.mapper import walk_addressables
+from pants.engine.exp.parsers import python_callbacks_parser
+from pants.engine.exp.targets import Target
+
+
+def list():
+  build_root = get_buildroot()
+
+  options, build_config = OptionsInitializer().setup()
+  aliases = build_config.registered_aliases()
+
+  symbol_table = {alias: Target for alias in aliases.target_types}
+
+  object_table = aliases.objects
+
+  def per_path_symbol_factory(path, global_symbols):
+    per_path_symbols = {}
+
+    symbols = global_symbols.copy()
+    for alias, target_macro_factory in aliases.target_macro_factories.items():
+      for target_type in target_macro_factory.target_types:
+        symbols[target_type] = lambda *args, **kwargs: per_path_symbols[alias](*args, **kwargs)
+
+    parse_context = ParseContext(rel_path=os.path.relpath(os.path.dirname(path), build_root),
+                                 type_aliases=symbols)
+
+    for alias, object_factory in aliases.context_aware_object_factories.items():
+      per_path_symbols[alias] = object_factory(parse_context)
+
+    for alias, target_macro_factory in aliases.target_macro_factories.items():
+      target_macro = target_macro_factory.target_macro(parse_context)
+      per_path_symbols[alias] = target_macro
+      for target_type in target_macro_factory.target_types:
+        per_path_symbols[target_type] = target_macro
+
+    return per_path_symbols
+
+  parser = python_callbacks_parser(symbol_table,
+                                   object_table=object_table,
+                                   per_path_symbol_factory=per_path_symbol_factory)
+  spec_excludes = options.for_global_scope().spec_excludes
+  for address, obj in walk_addressables(parser, build_root, spec_excludes=spec_excludes):
+    print(address.spec)

--- a/src/python/pants/engine/exp/objects.py
+++ b/src/python/pants/engine/exp/objects.py
@@ -18,6 +18,10 @@ class Serializable(AbstractClass):
   def is_serializable(obj):
     return isinstance(obj, Serializable) or (not inspect.isclass(obj) and hasattr(obj, '_asdict'))
 
+  @staticmethod
+  def is_serializable_type(type_):
+    return issubclass(type_, Serializable) or (inspect.isclass(type_) and hasattr(type_, '_asdict'))
+
   @abstractmethod
   def _asdict(self):
     """Return a dict mapping this class' properties.

--- a/src/python/pants/engine/exp/parsers.py
+++ b/src/python/pants/engine/exp/parsers.py
@@ -8,13 +8,15 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import functools
 import importlib
 import inspect
+import threading
 from json.decoder import JSONDecoder
 from json.encoder import JSONEncoder
 
 import six
 
+from pants.base.build_file_target_factory import BuildFileTargetFactory
 from pants.engine.exp.objects import Serializable
-from pants.util.memo import memoized
+from pants.util.memo import memoized, memoized_property
 
 
 @memoized
@@ -44,18 +46,19 @@ class ParseError(Exception):
 
 def _object_decoder(obj, symbol_table=None):
   # A magic field will indicate type and this can be used to wrap the object in a type.
-  typename = obj.get('typename', None)
-  if not typename:
+  type_alias = obj.get('type_alias', None)
+  if not type_alias:
     return obj
   else:
-    symbol = symbol_table(typename)
+    symbol = symbol_table(type_alias)
     return symbol(**obj)
 
 
 @memoized(key_factory=lambda t: tuple(sorted(t.items())) if t is not None else None)
 def _get_decoder(symbol_table=None):
-  return functools.partial(_object_decoder,
-                           symbol_table=symbol_table.__getitem__ if symbol_table else _as_type)
+  decoder = functools.partial(_object_decoder,
+                              symbol_table=symbol_table.__getitem__ if symbol_table else _as_type)
+  return JSONDecoder(encoding='UTF-8', object_hook=decoder, strict=True)
 
 
 def _object_encoder(o):
@@ -63,15 +66,16 @@ def _object_encoder(o):
     raise ParseError('Can only encode Serializable objects in JSON, given {!r} of type {}'
                      .format(o, type(o).__name__))
   encoded = o._asdict()
-  if 'typename' not in encoded:
-    encoded['typename'] = '{}.{}'.format(inspect.getmodule(o).__name__, type(o).__name__)
+  if 'type_alias' not in encoded:
+    encoded = encoded.copy()
+    encoded['type_alias'] = '{}.{}'.format(inspect.getmodule(o).__name__, type(o).__name__)
   return encoded
 
 
 encoder = JSONEncoder(encoding='UTF-8', default=_object_encoder, sort_keys=True, indent=True)
 
 
-def parse_json(json, symbol_table=None):
+def parse_json(path, symbol_table=None):
   """Parses the given json encoded string into a list of top-level objects found.
 
   The parser accepts both blank lines and comment lines (those beginning with optional whitespace
@@ -81,14 +85,16 @@ def parse_json(json, symbol_table=None):
   This includes `namedtuple` subtypes as well as any custom class with an `_asdict` method defined;
   see :class:`pants.engine.exp.serializable.Serializable`.
 
-  :param string json: A json encoded document with extra support for blank lines, comments and
-                      multiple top-level objects.
+  :param string path: The path of a json encoded document with extra support for blank lines,
+                      comments and multiple top-level objects.
   :returns: A list of decoded json data.
   :rtype: list
   :raises: :class:`ParseError` if there were any problems encountered parsing the given `json`.
   """
+  with open(path) as fp:
+    json = fp.read()
 
-  decoder = JSONDecoder(encoding='UTF-8', object_hook=_get_decoder(symbol_table), strict=True)
+  decoder = _get_decoder(symbol_table)
 
   # Strip comment lines and blank lines, which we allow, but preserve enough information about the
   # stripping to constitute a reasonable error message that can be used to find the portion of the
@@ -181,68 +187,121 @@ def encode_json(obj):
   :rtype: string
   :raises: :class:`ParseError` if there were any problems encoding the given `obj` in json.
   """
-  # TODO(John Sirois): Support an alias map from type (or from fqcn) -> typename.
+  # TODO(John Sirois): Support an alias map from type (or from fqcn) -> type_alias.
   return encoder.encode(obj)
 
 
-def parse_python_assignments(python, symbol_table=None):
-  """Parses the given python code into a list of top-level addressable Serializable objects found.
+def python_assignments_parser(symbol_table=None):
+  """Returns a parser that parses the given python code into a list of top-level objects found.
 
   Only Serializable objects assigned to top-level variables will be collected and returned.  These
   objects will be addressable via their top-level variable names in the parsed namespace.
 
-  :param string python: A python build file blob.
-  :returns: A list of decoded addressable, Serializable objects.
-  :rtype: list
-  :raises: :class:`ParseError` if there were any problems encountered parsing the given `python`.
+  :param dict symbol_table: An optional symbol table to expose to the python file being parsed.
+  :returns: A callable that accepts a string path and returns a list of decoded addressable,
+            Serializable objects.  The callable will raise :class:`ParseError` if there were any
+            problems encountered parsing the python BUILD file at the given path.
+  :rtype: :class:`collections.Callable`
   """
-  def aliased(type_name, object_type, **kwargs):
-    return object_type(typename=type_name, **kwargs)
+  def aliased(type_alias, object_type, **kwargs):
+    return object_type(type_alias=type_alias, **kwargs)
 
   parse_globals = {}
   for alias, symbol in (symbol_table or {}).items():
     parse_globals[alias] = functools.partial(aliased, alias, symbol)
 
-  symbols = {}
-  six.exec_(python, parse_globals, symbols)
-  objects = []
-  for name, obj in symbols.items():
-    if Serializable.is_serializable(obj):
-      attributes = obj._asdict()
-      redundant_name = attributes.pop('name', name)
+  def parse(path):
+    symbols = {}
+    with open(path) as fp:
+      six.exec_(fp.read(), parse_globals, symbols)
+
+    objects = []
+    for name, obj in symbols.items():
+      if isinstance(obj, type):
+        # Allow type imports
+        continue
+
+      if not Serializable.is_serializable(obj):
+        raise ParseError('Found a non-serializable top-level object: {}'.format(obj))
+
+      attributes = obj._asdict().copy()
+      redundant_name = attributes.pop('name', None)
       if redundant_name and redundant_name != name:
         raise ParseError('The object named {!r} is assigned to a mismatching name {!r}'
                          .format(redundant_name, name))
       obj_type = type(obj)
       named_obj = obj_type(name=name, **attributes)
       objects.append(named_obj)
-  return objects
+    return objects
+
+  return parse
 
 
-def parse_python_callbacks(python, symbol_table):
-  """Parses the given python code into a list of top-level addressable Serializable objects found.
+def python_callbacks_parser(symbol_table, object_table=None, per_path_symbol_factory=None):
+  """Returns a parser that parses the given python code into a list of top-level objects.
 
   Only Serializable objects with `name`s will be collected and returned.  These objects will be
   addressable via their name in the parsed namespace.
 
-  :param string python: A python build file blob.
-  :returns: A list of decoded addressable, Serializable objects.
-  :rtype: list
-  :raises: :class:`ParseError` if there were any problems encountered parsing the given `python`.
+  :param dict symbol_table: An optional symbol table to expose to the python file being parsed.
+  :param dict object_table: An optional symbol table of plain python objects to expose.  This is
+                            intended to support compatibility with the legacy parsing system and
+                            its exposed objects.
+  :param per_path_symbol_factory: An optional factory for any symbols needing the current path;
+                                  called with (path, global_symbols), should return a dict of
+                                  per-path symbols.  This is intended to support compatibility with
+                                  the legacy parsing system and context aware symbols.
+  :type per_path_symbol_factory: :class:`collections.Callable`
+  :returns: A callable that accepts a string path and returns a list of decoded addressable,
+            Serializable objects.  The callable will raise :class:`ParseError` if there were any
+            problems encountered parsing the python BUILD file at the given path.
+  :rtype: :class:`collections.Callable`
   """
   objects = []
 
-  def registered(type_name, object_type, name=None, **kwargs):
-    if name:
-      obj = object_type(name=name, typename=type_name, **kwargs)
-      if Serializable.is_serializable(obj):
+  class Registrar(BuildFileTargetFactory):
+    def __init__(self, type_alias, object_type):
+      self._type_alias = type_alias
+      self._object_type = object_type
+      self._serializable = Serializable.is_serializable_type(self._object_type)
+
+    @memoized_property
+    def target_types(self):
+      return [self._object_type]
+
+    def __call__(self, *args, **kwargs):
+      name = kwargs.get('name')
+      if name and self._serializable:
+        obj = self._object_type(type_alias=self._type_alias, **kwargs)
         objects.append(obj)
-      return obj
-    else:
-      return object_type(typename=type_name, **kwargs)
+        return obj
+      else:
+        return self._object_type(*args, **kwargs)
 
   parse_globals = {}
   for alias, symbol in symbol_table.items():
-    parse_globals[alias] = functools.partial(registered, alias, symbol)
-  six.exec_(python, parse_globals, {})
-  return objects
+    registrar = Registrar(alias, symbol)
+    parse_globals[alias] = registrar
+    parse_globals[symbol] = registrar
+
+  if object_table:
+    parse_globals.update(object_table)
+
+  lock = threading.Lock()
+
+  def parse(path):
+    with open(path) as fp:
+      python = fp.read()
+
+    if per_path_symbol_factory:
+      symbols = per_path_symbol_factory(path, parse_globals)
+      symbols.update(parse_globals)
+    else:
+      symbols = parse_globals
+
+    with lock:
+      del objects[:]
+      six.exec_(python, symbols, {})
+      return list(objects)
+
+  return parse

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -38,6 +38,7 @@ python_tests(
   sources=['test_parsers.py'],
   dependencies=[
     'src/python/pants/engine/exp:parsers',
+    'src/python/pants/util:contextutil',
   ]
 )
 

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "thrift1",
   "sources": []
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "thrift2",
   "sources": [],
   "dependencies": [
@@ -17,7 +17,7 @@
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "java1",
   "sources": [],
   "dependencies": [
@@ -27,18 +27,18 @@
     # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
     # off / prove the capabilities of the new BUILD graph parser.
     {
-      "typename": "ApacheThriftConfig",
+      "type_alias": "ApacheThriftConfig",
       "version": "0.9.2",
       "strict": true,
       "lang": "java"
     },
     ":nonstrict",
     {
-      "typename": "PublishConfig",
+      "type_alias": "PublishConfig",
       "default_repo": ":public",
       "repos": {
         "jake": {
-          "typename": "Config",
+          "type_alias": "Config",
           "url": "https://dl.bintray.com/pantsbuild/maven"
         },
         "jane": ":public"
@@ -48,7 +48,7 @@
 }
 
 {
-  "typename": "ApacheThriftConfig",
+  "type_alias": "ApacheThriftConfig",
   "name": "nonstrict",
   "version": "0.9.2",
   "strict": false,
@@ -56,13 +56,13 @@
 }
 
 {
-  "typename": "Config",
+  "type_alias": "Config",
   "name": "public",
   "url": "https://oss.sonatype.org/#stagingRepositories"
 }
 
 {
-  "typename": "Config",
+  "type_alias": "Config",
   "name": "type_mismatch",
 
   # This should trigger a type mismatch when resolved since ApacheThriftConfig is not a superclass
@@ -71,7 +71,7 @@
 }
 
 {
-  "typename": "Config",
+  "type_alias": "Config",
   "name": "self_cycle",
 
   # This should trigger a cycle error when resolved since we're trying to depend on ourselves for
@@ -81,7 +81,7 @@
 
 # A single-hop direct cycle - though through different types of dependency edges.
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "direct_cycle",
   "dependencies": [
     ":direct_cycle_dep"
@@ -89,7 +89,7 @@
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "direct_cycle_dep",
   "configurations": [
     ":direct_cycle"
@@ -98,13 +98,13 @@
 
 # A multi-hop cycle
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "indirect_cycle",
   "merges": ":one"
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "one",
   "dependencies": [
     ":two"
@@ -112,13 +112,13 @@
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "two",
   "extends": ":three"
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "three",
   "configurations": [
     ":one"

--- a/tests/python/pants_test/engine/exp/test_configuration.py
+++ b/tests/python/pants_test/engine/exp/test_configuration.py
@@ -21,15 +21,15 @@ class ConfigurationTest(unittest.TestCase):
     with self.assertRaises(ValidationError):
       Configuration(name='a', address=Address.parse('a:b'))
 
-  def test_typename(self):
-    self.assertEqual('Configuration', Configuration().typename)
-    self.assertEqual('aliased', Configuration(typename='aliased').typename)
+  def test_type_alias(self):
+    self.assertEqual('Configuration', Configuration().type_alias)
+    self.assertEqual('aliased', Configuration(type_alias='aliased').type_alias)
 
     class Subclass(Configuration):
       pass
 
-    self.assertEqual('Subclass', Subclass().typename)
-    self.assertEqual('aliased_subclass', Subclass(typename='aliased_subclass').typename)
+    self.assertEqual('Subclass', Subclass().type_alias)
+    self.assertEqual('aliased_subclass', Subclass(type_alias='aliased_subclass').type_alias)
 
   def test_extend_and_merge(self):
     # Resolution should be lazy, so - although its invalid to both extend and merge, we should be

--- a/tests/python/pants_test/engine/exp/test_graph.py
+++ b/tests/python/pants_test/engine/exp/test_graph.py
@@ -12,7 +12,7 @@ from functools import partial
 from pants.base.address import Address
 from pants.engine.exp.configuration import Configuration
 from pants.engine.exp.graph import CycleError, Graph, ResolvedTypeMismatchError, ResolveError
-from pants.engine.exp.parsers import parse_json, parse_python_assignments, parse_python_callbacks
+from pants.engine.exp.parsers import parse_json, python_assignments_parser, python_callbacks_parser
 from pants.engine.exp.targets import ApacheThriftConfiguration, PublishConfiguration, Target
 
 
@@ -68,14 +68,12 @@ class GraphTest(unittest.TestCase):
 
   def test_python(self):
     graph = self.create_graph(build_pattern=r'.+\.BUILD.python$',
-                              parser=partial(parse_python_assignments,
-                                             symbol_table=self.symbol_table))
+                              parser=python_assignments_parser(self.symbol_table))
     self.do_test_codegen_simple(graph)
 
   def test_python_classic(self):
     graph = self.create_graph(build_pattern=r'.+\.BUILD$',
-                              parser=partial(parse_python_callbacks,
-                                             symbol_table=self.symbol_table))
+                              parser=python_callbacks_parser(self.symbol_table))
     self.do_test_codegen_simple(graph)
 
   def test_resolve_cache(self):

--- a/tests/python/pants_test/engine/exp/test_mapper.py
+++ b/tests/python/pants_test/engine/exp/test_mapper.py
@@ -22,10 +22,10 @@ class Thing(object):
     self._kwargs = kwargs
 
   def _asdict(self):
-    return self._kwargs.copy()
+    return self._kwargs
 
   def _key(self):
-    return {k: v for k, v in self._kwargs.items() if k != 'typename'}
+    return {k: v for k, v in self._kwargs.items() if k != 'type_alias'}
 
   def __eq__(self, other):
     return isinstance(other, Thing) and self._key() == other._key()
@@ -46,12 +46,12 @@ class AddressMapTest(unittest.TestCase):
   def test_parse(self):
     with self.parse_address_map(dedent("""
       {
-        "typename": "thing",
+        "type_alias": "thing",
         "name": "one",
         "age": 42
       }
       {
-        "typename": "thing",
+        "type_alias": "thing",
         "name": "two",
         "age": 37
       }
@@ -67,13 +67,13 @@ class AddressMapTest(unittest.TestCase):
 
   def test_not_named(self):
     with self.assertRaises(UnaddressableObjectError):
-      with self.parse_address_map('{"typename": "thing"}'):
+      with self.parse_address_map('{"type_alias": "thing"}'):
         self.fail()
 
   def test_duplicate_names(self):
     with self.assertRaises(DuplicateNameError):
-      with self.parse_address_map('{"typename": "thing", "name": "one"}'
-                                  '{"typename": "thing", "name": "one"}'):
+      with self.parse_address_map('{"type_alias": "thing", "name": "one"}'
+                                  '{"type_alias": "thing", "name": "one"}'):
         self.fail()
 
 

--- a/tests/python/pants_test/engine/exp/test_parsers.py
+++ b/tests/python/pants_test/engine/exp/test_parsers.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from pants.engine.exp import parsers
 from pants.engine.exp.parsers import ParseError
+from pants.util.contextutil import temporary_file
 
 
 # A duck-typed Serializable with an `==` suitable for ease of testing.
@@ -18,16 +19,26 @@ class Bob(object):
     self._kwargs = kwargs
 
   def _asdict(self):
-    return self._kwargs.copy()
+    return self._kwargs
 
   def _key(self):
-    return {k: v for k, v in self._kwargs.items() if k != 'typename'}
+    return {k: v for k, v in self._kwargs.items() if k != 'type_alias'}
 
   def __eq__(self, other):
     return isinstance(other, Bob) and self._key() == other._key()
 
 
+def parse(parser, document, **args):
+  with temporary_file() as fp:
+    fp.write(document)
+    fp.close()
+    return parser(fp.name, **args)
+
+
 class JsonParserTest(unittest.TestCase):
+  def parse(self, document, **kwargs):
+    return parse(parsers.parse_json, document, **kwargs)
+
   def test_comments(self):
     document = dedent("""
     # Top level comment.
@@ -36,67 +47,67 @@ class JsonParserTest(unittest.TestCase):
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([dict(hobbies=[1, 2, 3])],
-                     parsers.parse_json(parsers.encode_json(results[0])))
+                     self.parse(parsers.encode_json(results[0])))
 
   def test_single(self):
     document = dedent("""
     # An simple example with a single Bob.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(hobbies=[1, 2, 3])],
-                     parsers.parse_json(parsers.encode_json(results[0])))
-    self.assertEqual('pants_test.engine.exp.test_parsers.Bob', results[0]._asdict()['typename'])
+                     self.parse(parsers.encode_json(results[0])))
+    self.assertEqual('pants_test.engine.exp.test_parsers.Bob', results[0]._asdict()['type_alias'])
 
   def test_symbol_table(self):
     symbol_table = {'bob': Bob}
     document = dedent("""
     # An simple example with a single Bob.
     {
-      "typename": "bob",
+      "type_alias": "bob",
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document, symbol_table=symbol_table)
+    results = self.parse(document, symbol_table=symbol_table)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(hobbies=[1, 2, 3])],
-                     parsers.parse_json(parsers.encode_json(results[0]), symbol_table=symbol_table))
-    self.assertEqual('bob', results[0]._asdict()['typename'])
+                     self.parse(parsers.encode_json(results[0]), symbol_table=symbol_table))
+    self.assertEqual('bob', results[0]._asdict()['type_alias'])
 
   def test_nested_single(self):
     document = dedent("""
     # An example with nested Bobs.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "uncle": {
-        "typename": "pants_test.engine.exp.test_parsers.Bob",
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob",
         "age": 42
       },
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(uncle=Bob(age=42), hobbies=[1, 2, 3])],
-                     parsers.parse_json(parsers.encode_json(results[0])))
+                     self.parse(parsers.encode_json(results[0])))
 
   def test_nested_deep(self):
     document = dedent("""
     # An example with deeply nested Bobs.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "configs": [
         {
           "mappings": {
             "uncle": {
-              "typename": "pants_test.engine.exp.test_parsers.Bob",
+              "type_alias": "pants_test.engine.exp.test_parsers.Bob",
               "age": 42
             }
           }
@@ -104,34 +115,34 @@ class JsonParserTest(unittest.TestCase):
       ]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(configs=[dict(mappings=dict(uncle=Bob(age=42)))])],
-                     parsers.parse_json(parsers.encode_json(results[0])))
+                     self.parse(parsers.encode_json(results[0])))
 
   def test_nested_many(self):
     document = dedent("""
     # An example with many nested Bobs.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "cousins": [
         {
-          "typename": "pants_test.engine.exp.test_parsers.Bob",
+          "type_alias": "pants_test.engine.exp.test_parsers.Bob",
           "name": "Jake",
           "age": 42
         },
         {
-          "typename": "pants_test.engine.exp.test_parsers.Bob",
+          "type_alias": "pants_test.engine.exp.test_parsers.Bob",
           "name": "Jane",
           "age": 37
         }
       ]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(cousins=[Bob(name='Jake', age=42), Bob(name='Jane', age=37)])],
-                     parsers.parse_json(parsers.encode_json(results[0])))
+                     self.parse(parsers.encode_json(results[0])))
 
   def test_multiple(self):
     document = dedent("""
@@ -139,17 +150,17 @@ class JsonParserTest(unittest.TestCase):
 
     # One with hobbies.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "hobbies": [1, 2, 3]
     }
 
     # Another that is aged.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "age": 42
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual([Bob(hobbies=[1, 2, 3]), Bob(age=42)], results)
 
   def test_tricky_spacing(self):
@@ -158,7 +169,7 @@ class JsonParserTest(unittest.TestCase):
 
     # One with hobbies.
       {
-        "typename": "pants_test.engine.exp.test_parsers.Bob",
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob",
 
         # And internal comment and blank lines.
 
@@ -167,9 +178,9 @@ class JsonParserTest(unittest.TestCase):
     }
 
     # Another that is aged.
-    {"typename": "pants_test.engine.exp.test_parsers.Bob","age": 42}
+    {"type_alias": "pants_test.engine.exp.test_parsers.Bob","age": 42}
     """).strip()
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual([Bob(hobbies=[1, 2, 3]), {}, Bob(age=42)], results)
 
   def test_error_presentation(self):
@@ -178,7 +189,7 @@ class JsonParserTest(unittest.TestCase):
 
     # One with hobbies.
       {
-        "typename": "pants_test.engine.exp.test_parsers.Bob",
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob",
 
         # And internal comment and blank lines.
 
@@ -188,7 +199,7 @@ class JsonParserTest(unittest.TestCase):
 
     # Another that is imaginary aged.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "age": 42i,
 
       "four": 1,
@@ -200,7 +211,7 @@ class JsonParserTest(unittest.TestCase):
     }
     """).strip()
     with self.assertRaises(ParseError) as exc:
-      parsers.parse_json(document)
+      self.parse(document)
 
     # Strip trailing whitespace from the message since our expected literal below will have
     # trailing ws stripped via editors and code reviews calling for it.
@@ -208,7 +219,7 @@ class JsonParserTest(unittest.TestCase):
 
     # This message from the json stdlib varies between python releases, so fuzz the match a bit.
     self.assertRegexpMatches(actual_lines[0],
-                             r"""Expecting (?:,|','|",") delimiter: line 3 column 12 \(char 69\)""")
+                             r"""Expecting (?:,|','|",") delimiter: line 3 column 12 \(char 71\)""")
 
     self.assertEqual(dedent("""
       In document:
@@ -216,7 +227,7 @@ class JsonParserTest(unittest.TestCase):
 
           # One with hobbies.
             {
-              "typename": "pants_test.engine.exp.test_parsers.Bob",
+              "type_alias": "pants_test.engine.exp.test_parsers.Bob",
 
               # And internal comment and blank lines.
 
@@ -226,7 +237,7 @@ class JsonParserTest(unittest.TestCase):
 
           # Another that is imaginary aged.
        1: {
-       2:   "typename": "pants_test.engine.exp.test_parsers.Bob",
+       2:   "type_alias": "pants_test.engine.exp.test_parsers.Bob",
        3:   "age": 42i,
 
        4:   "four": 1,
@@ -248,11 +259,11 @@ class PythonAssignmentsParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parsers.parse_python_assignments(document)
+    results = parse(parsers.python_assignments_parser(), document)
     self.assertEqual([Bob(name='nancy', hobbies=[1, 2, 3])], results)
 
-    # No symbol table was used so no `typename` plumbing can be expected.
-    self.assertNotIn('typename', results[0]._asdict())
+    # No symbol table was used so no `type_alias` plumbing can be expected.
+    self.assertNotIn('type_alias', results[0]._asdict())
 
   def test_symbol_table(self):
     symbol_table = {'nancy': Bob}
@@ -261,9 +272,9 @@ class PythonAssignmentsParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parsers.parse_python_assignments(document, symbol_table=symbol_table)
+    results = parse(parsers.python_assignments_parser(symbol_table), document)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
-    self.assertEqual('nancy', results[0]._asdict()['typename'])
+    self.assertEqual('nancy', results[0]._asdict()['type_alias'])
 
 
 class PythonCallbacksParserTest(unittest.TestCase):
@@ -275,6 +286,6 @@ class PythonCallbacksParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parsers.parse_python_callbacks(document, symbol_table)
+    results = parse(parsers.python_callbacks_parser(symbol_table), document)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
-    self.assertEqual('nancy', results[0]._asdict()['typename'])
+    self.assertEqual('nancy', results[0]._asdict()['type_alias'])


### PR DESCRIPTION
Several changes to support testing parse speed against existing pants
BUILD trees:

1. Avoid dict un-needed copies and s/typename/type_alias/ for compat.
2. Move the parse interface to be path based and optimize python
   parses by capturing the symbol table just once for the life of the
   parser (json already did this via memoization).
3. Expand python_callbacks_parser API to allow for legacy BUILD
   parsing.

Add a list command to allow for ~reasonable speed comparsons of
shallow parses that leverages the above changes.