### PR TITLE
Test-cases that passed are now properly omitted the junit summary.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -290,10 +290,13 @@ class _JUnitRunner(object):
 
           if target and (int_failures or int_errors):
             for testcase in xml.parsed.getElementsByTagName('testcase'):
-              failed_targets[target].add('{testclass}#{testname}'.format(
-                testclass=testcase.getAttribute('classname'),
-                testname=testcase.getAttribute('name'),
-              ))
+              test_failed = testcase.getElementsByTagName('failure')
+              test_errored = testcase.getElementsByTagName('error')
+              if test_failed or test_errored:
+                failed_targets[target].add('{testclass}#{testname}'.format(
+                  testclass=testcase.getAttribute('classname'),
+                  testname=testcase.getAttribute('name'),
+                ))
         except (XmlParser.XmlError, ValueError) as e:
           self._context.log.error('Error parsing test result file {0}: {1}'.format(filename, e))
 


### PR DESCRIPTION
I introduced a bug in https://rbcommons.com/s/twitter/r/2916/
wherein all test-cases in a class were printed if any of the
test-cases in the class had failed. This occurred due to my
incorrect assumption that only testcases that failed were listed
in the .xml report from the junit runner.

Now junit_run.py only prints a summary of those test-cases that
actually failed.

This fixes #2310.