### PR TITLE
Seperate out AddressMapper from Graph.

### DIFF
--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -28,7 +28,6 @@ python_library(
     ':mapper',
     ':objects',
     'src/python/pants/base:address',
-    'src/python/pants/util:memo',
   ]
 )
 

--- a/src/python/pants/engine/exp/graph.py
+++ b/src/python/pants/engine/exp/graph.py
@@ -6,16 +6,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import collections
-import os
-import re
 
 import six
 
 from pants.base.address import Address
 from pants.engine.exp.addressable import Addressed
-from pants.engine.exp.mapper import AddressFamily, AddressMap
+from pants.engine.exp.mapper import MappingError
 from pants.engine.exp.objects import Serializable, SerializableFactory, Validatable
-from pants.util.memo import memoized_method
 
 
 class ResolveError(Exception):
@@ -30,25 +27,16 @@ class ResolvedTypeMismatchError(ResolveError):
   """Indicates a resolved object was not of the expected type."""
 
 
-# TODO(John Sirois): Support in-memory injection of fully-hydrated (synthetic) addressables.
 class Graph(object):
   """A lazy, directed acyclic graph of objects. Not necessarily connected."""
 
-  def __init__(self, build_root, build_pattern=None, parser=None):
-    """Creates a build graph rooted at the given `build_root`.
+  def __init__(self, address_mapper):
+    """Creates a build graph composed of addresses resolvable by an address mapper.
 
-    Both the set of files that define a BUILD graph and the parser used to parse those files can be
-    customized.  See the `pants.engine.exp.parsers` module for example parsers.
-
-    :param string build_pattern: A regular expression for identifying BUILD files used to resolve
-                                 addresses; by default looks for `BUILD*` files.
-    :param parser: The BUILD file parser to use; by default a JSON BUILD file format parser.
-    :type parser: A :class:`collections.Callable` that takes a byte string and produces a list of
-                  parsed addressable Serializable objects found in the byte string.
+    :param address_mapper: An address mapper that can resolve the objects addresses point to.
+    :type address_mapper: :class:`pants.engine.exp.mapper.AddressMapper`.
     """
-    self._build_root = os.path.realpath(build_root)
-    self._build_pattern = re.compile(build_pattern or r'^BUILD(\.[a-zA-Z0-9_-]+)?$')
-    self._parser = parser
+    self._address_mapper = address_mapper
 
     # Our resolution cache.
     self._resolved_by_address = {}
@@ -76,7 +64,10 @@ class Graph(object):
     :raises: :class:`pants.engine.exp.objects.ValidationError` if the object was resolvable but
              invalid.
     """
-    return self._resolve_recursively(address)
+    try:
+      return self._resolve_recursively(address)
+    except MappingError as e:
+      raise ResolveError('Failed to resolve {}: {}'.format(address, e))
 
   def _resolve_recursively(self, address, resolve_path=None):
     resolved = self._resolved_by_address.get(address)
@@ -90,10 +81,7 @@ class Graph(object):
                                            for a in resolve_path + [address])))
     resolve_path.append(address)
 
-    address_family = self._address_family(address.spec_path)
-    obj = address_family.addressables.get(address)
-    if not obj:
-      raise ResolveError('Object with address {} was not found'.format(address))
+    obj = self._address_mapper.resolve(address)
 
     def resolve_item(item, addr=None):
       if Serializable.is_serializable(item):
@@ -145,20 +133,3 @@ class Graph(object):
     resolve_path.pop(-1)
     self._resolved_by_address[address] = resolved
     return resolved
-
-  def _find_build_file_sources(self, path):
-    abspath = os.path.realpath(os.path.join(self._build_root, path))
-    if not os.path.isdir(abspath):
-      raise ResolveError('Expected {} to be a directory containing build files.'.format(path))
-    for f in os.listdir(abspath):
-      if self._build_pattern.match(f):
-        absfile = os.path.join(abspath, f)
-        if os.path.isfile(absfile):
-          yield absfile
-
-  @memoized_method
-  def _address_family(self, spec_path):
-    address_maps = []
-    for source in self._find_build_file_sources(spec_path):
-      address_maps.append(AddressMap.parse(source, parse=self._parser))
-    return AddressFamily.create(self._build_root, address_maps)

--- a/src/python/pants/engine/exp/mapper.py
+++ b/src/python/pants/engine/exp/mapper.py
@@ -6,11 +6,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import re
 
 from pants.base.address import Address
 from pants.engine.exp import parsers
 from pants.engine.exp.objects import Serializable
-from pants.util.memo import memoized_property
+from pants.util.memo import memoized_method, memoized_property
 
 
 class MappingError(Exception):
@@ -167,3 +168,97 @@ class AddressFamily(object):
   def __repr__(self):
     return 'AddressFamily(namespace={!r}, objects_by_name={!r})'.format(self._namespace,
                                                                         self._objects_by_name)
+
+
+class ResolveError(MappingError):
+  """Indicates an error resolving targets."""
+
+
+# TODO(John Sirois): Support in-memory injection of (synthetic) addressables to support conversion
+# of the legacy system.
+class AddressMapper(object):
+  """Maps addresses to the objects they point to.
+
+  An address mapper serves as its own cache of the BUILD files it has parsed.  Although it has no
+  knowledge of BUILD file contents, it does expose an `invalidate_build_file` for external agents
+  aware of file changes to mark the corresponding address namespaces as being in-need of re-parsing.
+  """
+
+  def __init__(self, build_root, build_pattern=None, parser=None):
+    """Creates an address mapper rooted at the given `build_root`.
+
+    Both the set of files that define a mappable BUILD files and the parser used to parse those
+    files can be customized.  See the `pants.engine.exp.parsers` module for example parsers.
+
+    :param string build_root: The root of the BUILD files; typically the code repository root
+                              directory.
+    :param string build_pattern: A regular expression for identifying BUILD files used to resolve
+                                 addresses; by default looks for `BUILD*` files.
+    :param parser: The BUILD file parser to use; by default a JSON BUILD file format parser.
+    :type parser: A :class:`collections.Callable` that takes a byte string and produces a list of
+                  parsed addressable Serializable objects found in the byte string.
+    """
+    self._build_root = os.path.realpath(build_root)
+    self._build_pattern = re.compile(build_pattern or r'^BUILD(\.[a-zA-Z0-9_-]+)?$')
+    self._parser = parser
+
+  def _find_build_files(self, dir_path):
+    abs_dir_path = os.path.realpath(os.path.join(self._build_root, dir_path))
+    if not os.path.isdir(abs_dir_path):
+      raise ResolveError('Expected {} to be a directory containing build files.'.format(dir_path))
+    for f in os.listdir(abs_dir_path):
+      if self._build_pattern.match(f):
+        abs_build_file = os.path.join(abs_dir_path, f)
+        if os.path.isfile(abs_build_file):
+          yield abs_build_file
+
+  @memoized_method
+  def _parse(self, path):
+    return AddressMap.parse(path, parse=self._parser)
+
+  @memoized_method
+  def family(self, namespace):
+    """Load the address family in the given namespace.
+
+    :param string namespace: The namespace of the address family to load.
+    :returns: The address family at the given namespace.
+    :rtype: :class:`AddressFamily`
+    :raises: :class:`ResolveError` if the address family could not be found.
+    """
+    address_maps = []
+    for path in self._find_build_files(namespace):
+      address_maps.append(self._parse(path))
+    if not address_maps:
+      raise ResolveError('No addresses registered in namespace {}'.format(namespace))
+    return AddressFamily.create(self._build_root, address_maps)
+
+  def resolve(self, address):
+    """Resolve the given address to a named Serializable object.
+
+    :param address: The address to resolve to an named Serializable object.
+    :type address: :class:`pants.base.address.Address`
+    :returns: The resolved object.
+    :raises: :class:`ResolveError` if the object could not be resolved.
+    """
+    family = self.family(address.spec_path)
+    obj = family.addressables.get(address)
+    if not obj:
+      raise ResolveError('Object with address {} was not found'.format(address))
+    return obj
+
+  def invalidate_build_file(self, path):
+    """Force the given build file path to be re-parsed on next access of its namespace.
+
+    The namespace containing BUILD file is also invalidated such that the enclosing family is
+    completely recalculated.  This allows for adding new paths to a BUILD file family, modifying
+    existing paths or marking paths as having been deleted.
+
+    :param string path: The path of the build file; either absolute or relative to the build root.
+    """
+    # TODO(John Sirois): replace @memoized caches with hand-build local caches if needed when
+    # considering concurrency implications of a seperate thread calling invalidate while other
+    # threads access the cache.
+    path = path if os.path.isabs(path) else os.path.join(self._build_root, path)
+    self._parse.forget(self, path)
+    namespace = os.path.relpath(os.path.dirname(path), self._build_root)
+    self.family.forget(self, namespace)

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -17,6 +17,7 @@ python_tests(
     'src/python/pants/base:address',
     'src/python/pants/engine/exp:configuration',
     'src/python/pants/engine/exp:graph',
+    'src/python/pants/engine/exp:mapper',
     'src/python/pants/engine/exp:parsers',
     'src/python/pants/engine/exp:targets',
   ]
@@ -27,9 +28,12 @@ python_tests(
   sources=['test_mapper.py'],
   dependencies=[
     'src/python/pants/base:address',
+    'src/python/pants/engine/exp:configuration',
     'src/python/pants/engine/exp:mapper',
     'src/python/pants/engine/exp:parsers',
+    'src/python/pants/engine/exp:targets',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
   ]
 )
 

--- a/tests/python/pants_test/engine/exp/examples/mapper_test/a/b/b.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/mapper_test/a/b/b.BUILD.json
@@ -1,0 +1,12 @@
+{
+  "typename": "target",
+  "name": "b",
+  "dependencies": ["//d:e"],
+  "configurations": [
+    "//a",
+    {
+      "typename": "configuration",
+      "embedded": "yes"
+    }
+  ]
+}

--- a/tests/python/pants_test/engine/exp/examples/mapper_test/a/c/README
+++ b/tests/python/pants_test/engine/exp/examples/mapper_test/a/c/README
@@ -1,0 +1,2 @@
+There are no build files in this dir, this README just place-holds to allow for tests of dirs with
+no BUILD files.

--- a/tests/python/pants_test/engine/exp/test_graph.py
+++ b/tests/python/pants_test/engine/exp/test_graph.py
@@ -12,6 +12,7 @@ from functools import partial
 from pants.base.address import Address
 from pants.engine.exp.configuration import Configuration
 from pants.engine.exp.graph import CycleError, Graph, ResolvedTypeMismatchError, ResolveError
+from pants.engine.exp.mapper import AddressMapper
 from pants.engine.exp.parsers import parse_json, parse_python_assignments, parse_python_callbacks
 from pants.engine.exp.targets import ApacheThriftConfiguration, PublishConfiguration, Target
 
@@ -24,7 +25,10 @@ class GraphTest(unittest.TestCase):
                          'PublishConfig': PublishConfiguration}
 
   def create_graph(self, build_pattern=None, parser=None):
-    return Graph(build_root=os.path.dirname(__file__), build_pattern=build_pattern, parser=parser)
+    mapper = AddressMapper(build_root=os.path.dirname(__file__),
+                           build_pattern=build_pattern,
+                           parser=parser)
+    return Graph(mapper)
 
   def create_json_graph(self):
     return self.create_graph(build_pattern=r'.+\.BUILD.json$',


### PR DESCRIPTION
This restricts responsibility of Graph to just linking addressables.
Currently Graph links via inlining fully hydrated objects, but it or an
alternative could also traverse to addressables on demand.

With AddressMapper extracted, an interface for BUILD file invalidation
comes to the fore and allows straight-forward integration of in
invalidation system that watches the build root for BUILD file
additions, removals and modifications.

https://rbcommons.com/s/twitter/r/2931/