### PR TITLE
Ensure GOPATH is always controlled by pants.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -79,9 +79,9 @@ class GoDistribution(object):
 
     @classmethod
     def _create(cls, goroot, cmd, gopath=None, args=None):
-      env = OrderedDict(GOROOT=goroot)
-      if gopath:
-        env.update(GOPATH=gopath)
+      # Forcibly nullify the GOPATH if the command does not need one - this can prevent bad user
+      # GOPATHs from erroring out commands; see: https://github.com/pantsbuild/pants/issues/2321.
+      env = OrderedDict(GOROOT=goroot, GOPATH=gopath or '')
       return cls([os.path.join(goroot, 'bin', 'go'), cmd] + (args or []), env=env)
 
     def spawn(self, env=None, **kwargs):

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -26,6 +26,7 @@ python_tests(
   sources=['test_go_distribution.py'],
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/subsystems:go_distribution',
+    'src/python/pants/util:contextutil',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
@@ -9,6 +9,7 @@ import os
 import unittest
 from contextlib import contextmanager
 
+from pants.util.contextutil import environment_as
 from pants_test.subsystem.subsystem_util import subsystem_instance
 
 from pants.contrib.go.subsystems.go_distribution import GoDistribution
@@ -27,14 +28,25 @@ class GoDistributionTest(unittest.TestCase):
       output = go_cmd.check_output()
       self.assertEqual(go_distribution.goroot, output.strip())
 
-  def test_go_command_no_gopath(self):
+  def assert_no_gopath(self):
     with self.distribution() as go_distribution:
-      go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOROOT'])
+      go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOPATH'])
 
-      self.assertEqual({'GOROOT': go_distribution.goroot}, go_cmd.env)
+      self.assertEqual({'GOROOT': go_distribution.goroot, 'GOPATH': ''}, go_cmd.env)
       self.assertEqual('go', os.path.basename(go_cmd.cmdline[0]))
-      self.assertEqual(['env', 'GOROOT'], go_cmd.cmdline[1:])
-      self.assertRegexpMatches(str(go_cmd), r'^GOROOT=[^ ]+ .*/go env GOROOT$')
+      self.assertEqual(['env', 'GOPATH'], go_cmd.cmdline[1:])
+      self.assertRegexpMatches(str(go_cmd), r'^GOROOT=[^ ]+ GOPATH= .*/go env GOPATH')
+      self.assertEqual('', go_cmd.check_output().strip())
+
+  def test_go_command_no_gopath(self):
+    self.assert_no_gopath()
+
+  def test_go_command_no_gopath_overrides_user_gopath_issue2321(self):
+    # Without proper GOPATH scrubbing, this bogus entry leads to a `go env` failure as explained
+    # here: https://github.com/pantsbuild/pants/issues/2321
+    # Before that fix, the `go env` command would raise.
+    with environment_as(GOPATH=':/bogus/first/entry'):
+      self.assert_no_gopath()
 
   def test_go_command_gopath(self):
     with self.distribution() as go_distribution:


### PR DESCRIPTION
Previously, commands that did not require a GOPATH allowed any GOPATH
set in the user's environment to leak through.  This could lead to
spurious failures when the GOPATH was invalid.  Fix GoDistribution to
instead forcibly nullify GOPATH when the go command does not set one.

https://rbcommons.com/s/twitter/r/2933/