### PR TITLE
Normalize AddressMapper paths for parse/forget.

### DIFF
--- a/src/python/pants/engine/exp/mapper.py
+++ b/src/python/pants/engine/exp/mapper.py
@@ -203,7 +203,7 @@ class AddressMapper(object):
     self._parser = parser
 
   def _find_build_files(self, dir_path):
-    abs_dir_path = os.path.realpath(os.path.join(self._build_root, dir_path))
+    abs_dir_path = os.path.join(self._build_root, dir_path)
     if not os.path.isdir(abs_dir_path):
       raise ResolveError('Expected {} to be a directory containing build files.'.format(dir_path))
     for f in os.listdir(abs_dir_path):
@@ -212,9 +212,13 @@ class AddressMapper(object):
         if os.path.isfile(abs_build_file):
           yield abs_build_file
 
+  @staticmethod
+  def _normalize_parse_path(path):
+    return os.path.realpath(path)
+
   @memoized_method
   def _parse(self, path):
-    return AddressMap.parse(path, parse=self._parser)
+    return AddressMap.parse(self._normalize_parse_path(path), parse=self._parser)
 
   @memoized_method
   def family(self, namespace):
@@ -258,7 +262,7 @@ class AddressMapper(object):
     # TODO(John Sirois): replace @memoized caches with hand-build local caches if needed when
     # considering concurrency implications of a seperate thread calling invalidate while other
     # threads access the cache.
-    path = path if os.path.isabs(path) else os.path.join(self._build_root, path)
-    self._parse.forget(self, path)
+    path = os.path.realpath(path if os.path.isabs(path) else os.path.join(self._build_root, path))
+    self._parse.forget(self, self._normalize_parse_path(path))
     namespace = os.path.relpath(os.path.dirname(path), self._build_root)
     self.family.forget(self, namespace)


### PR DESCRIPTION
Without proper normalization, errors were seen in OSX tests where the
build_root lay in the per-user tmp dir.

https://rbcommons.com/s/twitter/r/2935/