### PR TITLE
Upgrade the default Go distribution to 1.5.1.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -32,7 +32,7 @@ class GoDistribution(object):
       register('--supportdir', advanced=True, default='bin/go',
                help='Find the go distributions under this dir.  Used as part of the path to lookup '
                     'the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', advanced=True, default='1.5',
+      register('--version', advanced=True, default='1.5.1',
                help='Go distribution version.  Used as part of the path to lookup the distribution '
                     'with --binary-util-baseurls and --pants-bootstrapdir')
 


### PR DESCRIPTION
The changelog is here:
  https://golang.org/doc/devel/release.html#go1.5.minor

https://rbcommons.com/s/twitter/r/2936/