### PR TITLE
Bump the default ivy bootstrap jar to 2.4.0.

### DIFF
--- a/src/python/pants/ivy/ivy_subsystem.py
+++ b/src/python/pants/ivy/ivy_subsystem.py
@@ -17,7 +17,7 @@ class IvySubsystem(Subsystem):
   """Common configuration items for ivy tasks."""
   options_scope = 'ivy'
 
-  _DEFAULT_VERSION = '2.3.0'
+  _DEFAULT_VERSION = '2.4.0'
   _DEFAULT_URL = ('https://repo1.maven.org/maven2/'
                   'org/apache/ivy/ivy/'
                   '{version}/ivy-{version}.jar'.format(version=_DEFAULT_VERSION))


### PR DESCRIPTION
This has been the stable release for almost a year and pantsbuild/pants
itself needs this version to properly handle the ANDROID_HOME env var
detection it uses in ivysetting.xml.

Previously, the bootstrap was 2.3.0 and the final used by
pantsbuild/pants was 2.4.0 + extras.  For any workspace with a cached
final, the ivysettings.xml would work, but for workspaces w/o an ivy
bootstrapped, the ivysettings.xml would fail.  This change gets
pantsbuild/pants ivysettings.xml working no matter the bootstrap phase.

https://rbcommons.com/s/twitter/r/2938/