### PR TITLE
Kill the checkstyle jvm tool override in pants.ini.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -107,7 +107,6 @@ deps: ["3rdparty:thrift-0.9.2"]
 
 
 [compile.checkstyle]
-bootstrap_tools: ["//:checkstyle"]
 configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 
 


### PR DESCRIPTION
It was both not needed and in the old list of specs format.

https://rbcommons.com/s/twitter/r/2941/