### PR TITLE
Allow six to float a bit.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -17,7 +17,7 @@ pytest>=2.6,<2.7
 pywatchman==1.2.0
 requests>=2.5.0,<2.6
 setuptools==5.4.1
-six==1.9.0
+six>=1.9.0,<2
 thrift==0.9.1
 wheel==0.24.0
 zincutils==0.3.1


### PR DESCRIPTION
We use an extra unittest2 requirement in the \`test.pytest` task
and it floats six >=1.4.  Our pin conflicts with the float.  The
conflict appears to be a resolver bug in pants or pex that needs
to be investigated and fixed (see:
https://github.com/pantsbuild/pex/issues/167); this fix is just a
workaround to buy time for that fix.

https://rbcommons.com/s/twitter/r/2942/