### PR TITLE
Prepare the 0.0.52 hotfix release.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,7 @@ Created by running `./build-support/bin/contributors.sh`.
 + Peter Seibel
 + Qicheng Ma
 + Ryan Williams
++ Sameer Brenn
 + Sara Solano
 + Senthil Kumaran
 + Sergey Serebryakov

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -1,6 +1,82 @@
 RELEASE HISTORY
 ===============
 
+0.0.52 (10/7/2015)
+------------------
+
+Release Notes
+~~~~~~~~~~~~~
+
+This is a hotfix release that unpins pants own six requirement from `==1.9` to `>=1.9,<2` to allow
+folks depending on pantsbuild sdists in their own pants built/tested code to successfully resolve
+six.  The underlying issue is yet to be fixed, but is tracked
+`here <https://github.com/pantsbuild/pex/issues/167>`_.
+
+API Changes
+~~~~~~~~~~~
+
+* Bump the default ivy bootstrap jar to 2.4.0.
+  `RB #2938 <https://rbcommons.com/s/twitter/r/2938>`_
+
+* Remove the classes_by_target and resources_by_target products
+  `RB #2928 <https://rbcommons.com/s/twitter/r/2928>`_
+
+Bugfixes
+~~~~~~~~
+
+* Allow six to float a bit.
+  `RB #2942 <https://rbcommons.com/s/twitter/r/2942>`_
+
+* Add the include and exclude patterns to the payload so they will make it into the fingerprint
+  `RB #2927 <https://rbcommons.com/s/twitter/r/2927>`_
+
+* Ensure GOPATH is always controlled by pants.
+  `RB #2933 <https://rbcommons.com/s/twitter/r/2933>`_
+
+* Stopped ivy from failing if an artifact has a url specified.
+  `RB #2905 <https://rbcommons.com/s/twitter/r/2905>`_
+
+* Test-cases that passed are now properly omitted the junit summary.
+  `RB #2916 <https://rbcommons.com/s/twitter/r/2916>`_
+  `RB #2930 <https://rbcommons.com/s/twitter/r/2930>`_
+
+Small improvements, Refactoring and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Kill the checkstyle jvm tool override in pants.ini.
+  `RB #2941 <https://rbcommons.com/s/twitter/r/2941>`_
+
+* Only request the `classes_by_source` product if it is necessary
+  `RB #2939 <https://rbcommons.com/s/twitter/r/2939>`_
+
+* Fixup android local resolvers.
+  `RB #2934 <https://rbcommons.com/s/twitter/r/2934>`_
+
+* Simplify cobertura source paths for reporting
+  `RB #2918 <https://rbcommons.com/s/twitter/r/2918>`_
+
+* Upgrade the default Go distribution to 1.5.1.
+  `RB #2936 <https://rbcommons.com/s/twitter/r/2936>`_
+
+* Normalize AddressMapper paths for parse/forget.
+  `RB #2935 <https://rbcommons.com/s/twitter/r/2935>`_
+
+* Create test task mixin
+  `RB #2902 <https://rbcommons.com/s/twitter/r/2902>`_
+
+* Make sure tests/python/pants_test:all runs all the tests
+  `RB #2932 <https://rbcommons.com/s/twitter/r/2932>`_
+
+* Seperate out AddressMapper from Graph.
+  `RB #2931 <https://rbcommons.com/s/twitter/r/2931>`_
+
+* Add timeout configuration to Pinger and add unittest.
+  `RB #2912 <https://rbcommons.com/s/twitter/r/2912>`_
+
+* Adding Node examples
+  `RB #2900 <https://rbcommons.com/s/twitter/r/2900>`_
+
+
 0.0.51 (10/2/2015)
 ------------------
 

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -59,7 +59,7 @@ from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
 
 
-@deprecated(removal_version='0.0.52', hint_message="Replace 'Repository' with 'repository'.")
+@deprecated(removal_version='0.0.53', hint_message="Replace 'Repository' with 'repository'.")
 def Repository(*args, **kwargs):
   return repo(*args, **kwargs)
 

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -6,4 +6,4 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 
-VERSION = '0.0.51'
+VERSION = '0.0.52'


### PR DESCRIPTION
This is a hotfix release that unpins pants own six requirement from
`==1.9` to `>=1.9,<2` to allow folks depending on pantsbuild sdists
in their own pants built/tested code to successfully resolve six.
The underlying issue is yet to be fixed, but is tracked by:
  https://github.com/pantsbuild/pex/issues/167

A 'Repository' BUILD file alias deprecation is moved forward to
0.0.53.

https://rbcommons.com/s/twitter/r/2943/