### PR TITLE
Support for scanning addresses, implement `list`.

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -4,10 +4,6 @@
 python_library(
   name = 'address',
   sources = ['address.py'],
-  dependencies = [
-    ':build_file',
-    'src/python/pants/util:meta',
-  ]
 )
 
 python_library(

--- a/src/python/pants/base/address.py
+++ b/src/python/pants/base/address.py
@@ -8,8 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from collections import namedtuple
 
-from pants.util.meta import AbstractClass
-
 
 def parse_spec(spec, relative_to=None):
   """Parses a target address spec and returns the path from the root of the repo to this Target

--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources=['addressable.py'],
   dependencies=[
     '3rdparty/python:six',
+    ':objects',
     'src/python/pants/util:meta',
   ]
 )

--- a/src/python/pants/engine/exp/addressable.py
+++ b/src/python/pants/engine/exp/addressable.py
@@ -6,10 +6,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import collections
+import inspect
 from abc import abstractmethod
+from functools import update_wrapper
 
 import six
 
+from pants.engine.exp.objects import Resolvable, Serializable
 from pants.util.meta import AbstractClass
 
 
@@ -20,12 +23,16 @@ class TypeConstraint(AbstractClass):
   :class:`SubclassesOf`.
   """
 
-  def __init__(self, type_):
-    """Creates a type constraint centered around the given type.
+  def __init__(self, *types):
+    """Creates a type constraint centered around the given types.
 
-    :param type type_: The focus of this type constraint.
+    The type constraint is satisfied as a whole if satisfied for at least one of the given types.
+
+    :param type *types: The focus of this type constraint.
     """
-    self._type = type_
+    if not types:
+      raise ValueError('Must supply at least one type')
+    self._types = types
 
   @abstractmethod
   def satisfied_by(self, obj):
@@ -35,21 +42,21 @@ class TypeConstraint(AbstractClass):
     """
 
   def __hash__(self):
-    return hash((type(self), self._type))
+    return hash((type(self), self._types))
 
   def __eq__(self, other):
-    return type(self) == type(other) and self._type == other._type
+    return type(self) == type(other) and self._types == other._types
 
   def __ne__(self, other):
     return not (self == other)
 
   def __str__(self):
     return '{variance_symbol}{constrained_type}'.format(variance_symbol=self._variance_symbol,
-                                                        constrained_type=self._type.__name__)
+                                                        constrained_type=self._types)
 
   def __repr__(self):
     return ('{type_constraint_type}({constrained_type})'
-            .format(type_constraint_type=type(self).__name__, constrained_type=self._type.__name__))
+            .format(type_constraint_type=type(self).__name__, constrained_type=self._types))
 
 
 class SuperclassesOf(TypeConstraint):
@@ -58,7 +65,11 @@ class SuperclassesOf(TypeConstraint):
   _variance_symbol = '-'
 
   def satisfied_by(self, obj):
-    return issubclass(self._type, type(obj))
+    obj_type = type(obj)
+    for type_ in self._types:
+      if issubclass(type_, obj_type):
+        return True
+    return False
 
 
 class Exactly(TypeConstraint):
@@ -67,7 +78,7 @@ class Exactly(TypeConstraint):
   _variance_symbol = '='
 
   def satisfied_by(self, obj):
-    return self._type == type(obj)
+    return type(obj) in self._types
 
 
 class SubclassesOf(TypeConstraint):
@@ -76,126 +87,263 @@ class SubclassesOf(TypeConstraint):
   _variance_symbol = '+'
 
   def satisfied_by(self, obj):
-    return issubclass(type(obj), self._type)
+    return issubclass(type(obj), self._types)
 
 
-class AddressedError(TypeError):
-  """Indicates an error assigning an addressed item."""
+class NotSerializableError(TypeError):
+  """Indicates an addressable descriptor is illegally installed in a non-Serializable type."""
 
 
-class Addressed(object):
-  """Describes an addressed item that meets a given type constraint."""
+class MutationError(AttributeError):
+  """Indicates an illegal attempt to mutate an addressable attribute that already has a value."""
 
-  def __init__(self, type_constraint, address_spec):
+
+class TypeConstraintError(TypeError):
+  """Indicates a :class:`TypeConstraint` violation."""
+
+
+class AddressableDescriptor(object):
+  """A data descriptor for fields containing one or more addressable items.
+
+  An addressable descriptor has lifecycle expectations tightly coupled with the contract of
+  Serializable objects and the 2-phase hydration of AddressMap.parse, Graph.resolve.
+
+  Decorated accessors are write-once, and then read-only.  They are intended to be written in a
+  constructor such that objects containing them have immutable semantics. In other words, the
+  descriptor is intended to be used like a type-checked `@property` with possibly lazily resolved
+  values.
+
+  The written value is type-checked against a :class:`TypeConstraint` and can only be one of 3
+  types:
+
+  1. An opaque string address.
+  2. A Resolvable for the address that, when resolved, will meet the type constraint.
+  3. A concrete value that meets the type constraint.
+
+  The 1st type, an opaque string address, is also the type associated with the 1st stage of the
+  2-stage lifecycle of Serializable objects containing addressable values.  In the second and final
+  stage, the Serializable object is re-constructed with addressable values of the second or third
+  types; ie: reconstructed with either resolvables or concrete values in place of the first stage
+  address.
+
+  Two affordances are made in type constraint handling:
+
+  1. Either a :class:`TypeConstraint` instance can be given if the type constraint is fully known or
+     else a type constraint class can be given if the type constraint should apply to the type of
+     the enclosing class.  This is useful for declaring an addressable property in a baseclass that
+     should be type-constrained based on the type of the derived class.
+  2. Decorators for addressables (see `addressable`, `addressable_list` and `addressable_dict`)
+     allow wrapping of either class functions - typical - or @property descriptors.  The property
+     descriptor case sets up an idiom for recursive addressables.  The idiom looks like:
+
+     >>> class Thing(Configuration):
+     ...   def __init__(self, thing):
+     ...     super(Thing, self).__init__()
+     ...     self.thing = thing
+     ...   @property
+     ...   def parent(self):
+     ...     '''Return this thing's parent.
+     ...
+     ...     :rtype: :class:`Thing`
+     ...     '''
+     ...
+     >>> Thing.parent = addressable(Exactly(Thing))(Thing.parent)
+
+     Here the `Thing.parent` property is re-assigned with a type-constrained addressable descriptor
+     after the class is defined so the class can be referred to in the type constraint.
+  """
+  _descriptors = set()
+
+  @classmethod
+  def is_addressable(cls, obj, key):
+    """Return `True` if the given attribute of `obj` is an addressable attribute.
+
+    :param obj: The object to inspect.
+    :param string key: The name of the property on `obj` to check.
+    """
+    return (type(obj), key) in cls._descriptors
+
+  @classmethod
+  def _register(cls, obj, descriptor):
+    cls._descriptors.add((type(obj), descriptor._name))
+
+  def __init__(self, name, type_constraint):
+    self._name = name
     self._type_constraint = type_constraint
-    self._address_spec = address_spec
 
-    self._key = (self._type_constraint, self._address_spec)
+  def __set__(self, instance, value):
+    if not Serializable.is_serializable(instance):
+      raise NotSerializableError('The addressable descriptor {} can only be applied to methods or '
+                                 'properties of Serializable objects, applied to method {} of '
+                                 'type {}'.format(type(self).__name__,
+                                                  self._name,
+                                                  type(instance).__name__))
 
-  @property
-  def type_constraint(self):
-    """The type constraint the addressed item must satisfy.
+    instance_dict = instance._asdict()
+    if self._name in instance_dict:
+      raise MutationError('Attribute {} of {} has already been set to {}, rejecting attempt to '
+                          're-set with {}'.format(self._name,
+                                                  instance,
+                                                  instance_dict[self._name],
+                                                  value))
 
-    :rtype: :class:`TypeConstraint`
-    """
-    return self._type_constraint
+    if value is not None:
+      self._check_value(instance, value)
 
-  @property
-  def address_spec(self):
-    """The address of the object that, when resolved, should meet the type constraint specified.
+    self._register(instance, self)
 
-    :returns: The serialized form of the address; aka. an address 'spec'.
-    :rtype: string
-    """
-    return self._address_spec
+    # We mutate the instance dict, which is only OK if used in the conventional idiom of setting
+    # the value via this data descriptor in the instance's constructor.
+    instance_dict[self._name] = value
 
-  def __hash__(self):
-    return hash(self._key)
+  def __get__(self, instance, unused_owner_type=None):
+    # We know instance is a Serializable from the type-checking done in set.
+    value = instance._asdict()[self._name]
+    return self._resolve_value(instance, value)
 
-  def __eq__(self, other):
-    return isinstance(other, Addressed) and self._key == other._key
+  def _get_type_constraint(self, instance):
+    if inspect.isclass(self._type_constraint):
+      return self._type_constraint(type(instance))
+    else:
+      return self._type_constraint
 
-  def __ne__(self, other):
-    return not (self == other)
+  def _check_value(self, instance, value):
+    # We allow three forms of value:
+    # 1. An opaque (to us) string address pointing to a value that can be resolved by external
+    #    means.
+    # 2. A `Resolvable` value that we can lazily resolve and type-check in `__get__`.
+    # 3. A concrete instance that meets our type constraint.
+    if isinstance(value, (six.string_types, Resolvable)):
+      return
 
-  def __repr__(self):
-    return 'Addressed(type_constraint={!r}, address={!r})'.format(self._type_constraint,
-                                                                  self._address_spec)
+    if not self._get_type_constraint(instance).satisfied_by(value):
+      raise TypeConstraintError('Got {} of type {} for {} attribute of {} but expected {!r}'
+                                .format(value,
+                                        type(value).__name__,
+                                        self._name,
+                                        instance,
+                                        self._type_constraint))
+
+  def _resolve_value(self, instance, value):
+    if not isinstance(value, Resolvable):
+      # The value is concrete which means we type-checked on set so no need to do so again, its a
+      # raw address string or an instance that satisfies our type constraint.
+      return value
+    else:
+      resolved_value = value.resolve()
+      type_constraint = self._get_type_constraint(instance)
+      if not type_constraint.satisfied_by(resolved_value):
+        raise TypeConstraintError('The value resolved from {} did not meet the type constraint of '
+                                  '{!r} for the {} property of {}: {}'
+                                  .format(value.address,
+                                          type_constraint,
+                                          self._name,
+                                          instance,
+                                          resolved_value))
+      return resolved_value
 
 
-def addressable(type_constraint, value):
-  """Marks a value as conforming to a given type constraint.
+def _addressable_wrapper(addressable_descriptor, type_constraint):
+  def wrapper(func):
+    # We allow for wrapping property objects to support the following idiom for defining recursive
+    # addressables:
+    #
+    # class Thing(Configuration):
+    #   def __init__(self, thing):
+    #      super(Thing, self).__init__()
+    #      self.thing = thing
+    #
+    #   @property
+    #   def parent(self):
+    #     """Return this thing's parent.
+    #
+    #     :rtype: :class:`Thing`
+    #     """"
+    #
+    # Thing.parent = addressable(Exactly(Thing))(Thing.parent)
+    func = func.fget if isinstance(func, property) else func
 
-  The value may be a 'pointer', aka. an :class:`Addressed` instance that is lazily resolved via
-  address and checked against the type constraint at resolve time.
+    addressable_accessor = addressable_descriptor(func.__name__, type_constraint)
+    return update_wrapper(addressable_accessor, func)
+  return wrapper
+
+
+def addressable(type_constraint):
+  """Return an addressable attribute for Serializable classes.
+
+  The attribute should have no implementation (it will be ignored), but can carry a docstring.
+  The implementation is provided by this wrapper.  Idiomatic use assigns the value, which can
+  either be an opaque address string or a resolved value that meets the type constraint, in the
+  constructor::
+
+  >>> class Employee(Serializable):
+  ...   def __init__(self, person):
+  ...     self.person = person
+  ...   @addressable(SubclassesOf(Person))
+  ...   def person(self):
+  ...     '''The person that is this employee.'''
+
+  Addressable attributes are only assignable once, so this pattern yields an immutable `Employee`
+  whose `person` attribute is either a `Person` instance or
+  :class:`pants.engine.exp.objects.Resolvable` person or else a string address pointing to one.
+
+  See :class:`AddressableDescriptor` for more details.
 
   :param type_constraint: The type constraint the value must satisfy.
   :type type_constraint: :class:`TypeConstraint`
-  :param value: An object satisfying the type constraint or else a string encoding the address such
-                an object should be resolved from; aka. a 'pointer'.
-  :returns: The `value` if it satisfies the type constraint directly or else an :class:`Addressed`
-            pointer to a value to resolve later.
-  :raises: :class:`AddressedError` if the given value is not a pointer or a value of the correct
-           type.
   """
-  if value is None:
-    return None
-  elif type_constraint.satisfied_by(value):
-    return value
-  # TODO(John Sirois): This case is only here to support the `parse_python_assignments` parsing
-  # scheme which is the only parsing scheme that doubly constructs it objects (the second
-  # construction that injects a `name` parameter discovered in the 1st construction triggers this
-  # case).  Consider removing this case if the `parse_python_assignments` parsing scheme is dropped.
-  elif isinstance(value, Addressed) and type_constraint == value.type_constraint:
-    return value
-  elif isinstance(value, six.string_types):
-    return Addressed(type_constraint, value)
-  else:
-    raise AddressedError('The given value is not an address or an {!r}: {!r}'
-                       .format(type_constraint, value))
+  return _addressable_wrapper(AddressableDescriptor, type_constraint)
 
 
-def addressables(type_constraint, values):
+class AddressableList(AddressableDescriptor):
+  def _check_value(self, instance, value):
+    if not isinstance(value, collections.MutableSequence):
+      raise TypeError('The {} property of {} must be a list, given {} of type {}'
+                      .format(self._name, instance, value, type(value).__name__))
+    for item in value:
+      super(AddressableList, self)._check_value(instance, item)
+
+  def _resolve_value(self, instance, value):
+    return [super(AddressableList, self)._resolve_value(instance, v)
+            for v in value] if value else []
+
+
+def addressable_list(type_constraint):
   """Marks a list's values as satisfying a given type constraint.
 
-  Some (or all) elements of the list may be :class:`Addressed` elements to resolve later.
+  Some (or all) elements of the list may be :class:`pants.engine.exp.objects.Resolvable` elements
+  to resolve later.
+
+  See :class:`AddressableDescriptor` for more details.
 
   :param type_constraint: The type constraint the list's values must all satisfy.
   :type type_constraint: :class:`TypeConstraint`
-  :param values: An iterable of objects satisfying the type constraint or else strings encoding the
-                 address such objects should be resolved from; aka. 'pointers'.
-  :type values: :class:`collections.Iterable`
-  :returns: A list whose elements are values satisfying the type constraint directly or else are
-            :class:`Addressed` pointers to values to resolve later.
-  :rtype: list
   """
-  if values and (not isinstance(values, collections.Iterable) or
-                 isinstance(values, six.string_types)):
-    raise AddressedError('Expected values to be an iterable of values, but given {} of type {}'
-                         .format(values, type(values).__name__))
-
-  # TODO(John Sirois): Instead of re-traversing all lists later to hydrate any potentially contained
-  # Addressed objects, this could return a (marker) type.  The hydration could then avoid deep
-  # introspection and just look for a - say - `Resolvable` value, and only resolve those.  Only if
-  # perf is being tweaked might this need to be addressed.
-  return [addressable(type_constraint, v) for v in values] if values else []
+  return _addressable_wrapper(AddressableList, type_constraint)
 
 
-def addressable_mapping(type_constraint, mapping):
+class AddressableDict(AddressableDescriptor):
+  def _check_value(self, instance, value):
+    if not isinstance(value, collections.MutableMapping):
+      raise TypeError('The {} property of {} must be a dict, given {} of type {}'
+                      .format(self._name, instance, value, type(value).__name__))
+    for item in value.values():
+      super(AddressableDict, self)._check_value(instance, item)
+
+  def _resolve_value(self, instance, value):
+    return {k: super(AddressableDict, self)._resolve_value(instance, v)
+            for k, v in value.items()} if value else {}
+
+
+def addressable_dict(type_constraint):
   """Marks a dicts's values as satisfying a given type constraint.
 
-  Some (or all) values in the dict may be :class:`Addressed` values to resolve later.
+  Some (or all) values in the dict may be :class:`pants.engine.exp.objects.Resolvable` values to
+  resolve later.
+
+  See :class:`AddressableDescriptor` for more details.
 
   :param type_constraint: The type constraint the dict's values must all satisfy.
   :type type_constraint: :class:`TypeConstraint`
-  :param mapping: A mapping from keys to values satisfying the type constraint or else strings
-                  encoding the address such values should be resolved from; aka. 'pointers'.
-  :type mapping: :class:`collections.Mapping`
-  :returns: A dict whose values satisfy the type constraint directly or else are :class:`Addressed`
-            pointers to values to resolve later.
-  :rtype: dict
   """
-  if mapping and not isinstance(mapping, collections.Mapping):
-    raise AddressedError('Expected mapping to be mapping object, but given {} of type {}'
-                         .format(mapping, type(mapping).__name__))
-  return {k: addressable(type_constraint, v) for k, v in mapping.items()} if mapping else {}
+  return _addressable_wrapper(AddressableDict, type_constraint)

--- a/src/python/pants/engine/exp/configuration.py
+++ b/src/python/pants/engine/exp/configuration.py
@@ -20,7 +20,7 @@ class Configuration(Serializable, SerializableFactory, Validatable):
   """
 
   # Internal book-keeping fields to exclude from hash codes/equality checks.
-  _SPECIAL_FIELDS = ('extends', 'merges', 'typename')
+  _SPECIAL_FIELDS = ('extends', 'merges', 'type_alias')
 
   def __init__(self, abstract=False, extends=None, merges=None, **kwargs):
     """Creates a new configuration data blob.
@@ -91,8 +91,8 @@ class Configuration(Serializable, SerializableFactory, Validatable):
     return self._kwargs.get('address')
 
   @property
-  def typename(self):
-    """Return the type name this target was constructed via.
+  def type_alias(self):
+    """Return the type alias this target was constructed via.
 
     For a target read from a BUILD file, this will be target alias, like 'java_library'.
     For a target constructed in memory, this will be the simple class name, like 'JavaLibrary'.
@@ -102,7 +102,7 @@ class Configuration(Serializable, SerializableFactory, Validatable):
 
     :rtype: string
     """
-    return self._kwargs.get('typename', type(self).__name__)
+    return self._kwargs.get('type_alias', type(self).__name__)
 
   @property
   def abstract(self):
@@ -120,7 +120,7 @@ class Configuration(Serializable, SerializableFactory, Validatable):
   # arbitrary and thus more fields to be defined than a subclass might logically support.  We
   # accept this hole in a trade for generally expected behavior when `Configuration` is subclassed
   # in the style of constructors with named parameters representing the full complete set of
-  # expected parameters leaving **kwargs only for use by 'the system'; ie for `typename` and
+  # expected parameters leaving **kwargs only for use by 'the system'; ie for `type_alias` and
   # `address` plumbing for example.
   #
   # Of note is the fact that we pass a constraint type and not a concrete constraint value.  This

--- a/src/python/pants/engine/exp/configuration.py
+++ b/src/python/pants/engine/exp/configuration.py
@@ -51,16 +51,8 @@ class Configuration(Serializable, SerializableFactory, Validatable):
 
     self._kwargs['abstract'] = abstract
 
-    # It only makes sense to inherit a subset of our own fields (we should not inherit new fields!),
-    # our superclasses logically provide fields within this constrained set.
-    # NB: Since Configuration is at base an ~unconstrained struct, a superclass does allow for
-    # arbitrary and thus more fields to be defined than a subclass might logically support.  We
-    # accept this hole in a trade for generally expected behavior when Configuration is subclassed
-    # in the style of constructors with named parameters representing the full complete set of
-    # expected parameters leaving **kwargs only for use by 'the system'; ie for `typename` and
-    # `address` plumbing for example.
-    self._kwargs['extends'] = addressable(SuperclassesOf(type(self)), extends)
-    self._kwargs['merges'] = addressable(SuperclassesOf(type(self)), merges)
+    self.extends = extends
+    self.merges = merges
 
     # Allow for configuration items that are directly constructed in memory.  These can have an
     # address directly assigned (vs. inferred from name + source file location) and we only require
@@ -122,27 +114,39 @@ class Configuration(Serializable, SerializableFactory, Validatable):
     """
     return self._kwargs['abstract']
 
-  @property
+  # It only makes sense to inherit a subset of our own fields (we should not inherit new fields!),
+  # our superclasses logically provide fields within this constrained set.
+  # NB: Since `Configuration` is at base an ~unconstrained struct, a superclass does allow for
+  # arbitrary and thus more fields to be defined than a subclass might logically support.  We
+  # accept this hole in a trade for generally expected behavior when `Configuration` is subclassed
+  # in the style of constructors with named parameters representing the full complete set of
+  # expected parameters leaving **kwargs only for use by 'the system'; ie for `typename` and
+  # `address` plumbing for example.
+  #
+  # Of note is the fact that we pass a constraint type and not a concrete constraint value.  This
+  # tells addressable to use `SuperclassesOf([Configuration instance's type])`, which is what we
+  # want.  Aka, for `ConfigurationSubclassA`, the constraint is
+  # `SuperclassesOf(ConfigurationSubclassA)`.
+  #
+  @addressable(SuperclassesOf)
   def extends(self):
     """Return the object this object extends, if any.
 
     :rtype: Serializable
     """
-    return self._kwargs['extends']
 
-  @property
+  @addressable(SuperclassesOf)
   def merges(self):
     """Return the object this object merges in, if any.
 
     :rtype: Serializable
     """
-    return self._kwargs['merges']
 
   def _asdict(self):
-    return self._kwargs.copy()
+    return self._kwargs
 
   def _extract_inheritable_attributes(self, serializable):
-    attributes = serializable._asdict()
+    attributes = serializable._asdict().copy()
 
     # Allow for un-named (embedded) objects inheriting from named objects
     attributes.pop('name', None)
@@ -171,9 +175,13 @@ class Configuration(Serializable, SerializableFactory, Validatable):
       for k, v in self._asdict().items():
         if k not in self._SPECIAL_FIELDS:
           if isinstance(v, MutableMapping):
-            attributes.setdefault(k, {}).update(v)
+            mapping = attributes.get(k) or {}
+            mapping.update(v)
+            attributes[k] = mapping
           elif isinstance(v, MutableSequence):
-            attributes.setdefault(k, []).extend(v)
+            sequence = attributes.get(k) or []
+            sequence.extend(v)
+            attributes[k] = sequence
           elif v is not None:
             attributes[k] = v
       configuration_type = type(self)
@@ -223,7 +231,8 @@ class Configuration(Serializable, SerializableFactory, Validatable):
 
   def __repr__(self):
     # TODO(John Sirois): Do something else here.  This is recursive and so printing a Node prints
-    # its whole closure and will be too expensive and bewildering past simple example debugging.
+    # its whole closure and will be too expensive for inlined objects and too bewildering past
+    # simple example debugging.
     return '{classname}({args})'.format(classname=type(self).__name__,
                                         args=', '.join(sorted('{}={!r}'.format(k, v)
                                                               for k, v in self._kwargs.items())))

--- a/src/python/pants/engine/exp/graph.py
+++ b/src/python/pants/engine/exp/graph.py
@@ -10,9 +10,9 @@ import collections
 import six
 
 from pants.base.address import Address
-from pants.engine.exp.addressable import Addressed
+from pants.engine.exp.addressable import AddressableDescriptor, TypeConstraintError
 from pants.engine.exp.mapper import MappingError
-from pants.engine.exp.objects import Serializable, SerializableFactory, Validatable
+from pants.engine.exp.objects import Resolvable, Serializable, SerializableFactory, Validatable
 
 
 class ResolveError(Exception):
@@ -27,19 +27,55 @@ class ResolvedTypeMismatchError(ResolveError):
   """Indicates a resolved object was not of the expected type."""
 
 
+class Resolver(Resolvable):
+  """Lazily resolves addressables using a graph."""
+
+  def __init__(self, graph, address):
+    self._graph = graph
+    self._address = address
+
+  def address(self):
+    return self._address.spec
+
+  def resolve(self):
+    return self._graph.resolve(self._address)
+
+  def __hash__(self):
+    return hash((self._graph, self._address))
+
+  def __eq__(self, other):
+    return (isinstance(other, Resolver) and
+            (self._graph, self._address) == (other._graph, other._address))
+
+  def __ne__(self, other):
+    return not (self == other)
+
+  def __repr__(self):
+    return 'Graph.Resolver(graph={}, address={!r})'.format(self._graph, self._address)
+
+
 class Graph(object):
   """A lazy, directed acyclic graph of objects. Not necessarily connected."""
 
-  def __init__(self, address_mapper):
+  def __init__(self, address_mapper, inline=False):
     """Creates a build graph composed of addresses resolvable by an address mapper.
 
     :param address_mapper: An address mapper that can resolve the objects addresses point to.
     :type address_mapper: :class:`pants.engine.exp.mapper.AddressMapper`.
+    :param bool inline: If `True`, resolved addressables are inlined in the containing object;
+                        otherwise a resolvable pointer is used that dynamically traverses to the
+                        addressable on every access.
     """
     self._address_mapper = address_mapper
 
+    # TODO(John Sirois): This will need to be eliminated in favor of just using the AddressMapper
+    # caching or else also expose an invalidation interface based on address.spec_path - aka
+    # AddressMapper.namespace.
+    #
     # Our resolution cache.
     self._resolved_by_address = {}
+
+    self._inline = inline
 
   def resolve(self, address):
     """Resolves the object pointed at by the given `address`.
@@ -83,49 +119,42 @@ class Graph(object):
 
     obj = self._address_mapper.resolve(address)
 
+    def parse_addr(a):
+      return Address.parse(a, relative_to=address.spec_path)
+
     def resolve_item(item, addr=None):
       if Serializable.is_serializable(item):
         hydrated_args = {'address': addr} if addr else {}
 
-        # Recurse on the Serializable's values and hydrate any `Addressed` found.  This unwinds from
-        # the leaves thus hydrating item's closure.
+        # Recurse on the Serializable's values and hydrates any addressables found.  This unwinds
+        # from the leaves thus hydrating item's closure in the inline case.
         for key, value in item._asdict().items():
+          is_addressable = AddressableDescriptor.is_addressable(item, key)
+
+          def maybe_addr(x):
+            return parse_addr(x) if is_addressable and isinstance(x, six.string_types) else x
+
           if isinstance(value, collections.MutableMapping):
             container_type = type(value)
             container = container_type()
-            container.update((k, resolve_item(v)) for k, v in value.items())
+            container.update((k, resolve_item(maybe_addr(v))) for k, v in value.items())
             hydrated_args[key] = container
-          elif isinstance(value, collections.Iterable) and not isinstance(value, six.string_types):
+          elif isinstance(value, collections.MutableSequence):
             container_type = type(value)
-            hydrated_args[key] = container_type(resolve_item(v) for v in value)
+            hydrated_args[key] = container_type(resolve_item(maybe_addr(v)) for v in value)
           else:
-            hydrated_args[key] = resolve_item(value)
+            hydrated_args[key] = resolve_item(maybe_addr(value))
 
-        # Re-build the thin Serializable with fully hydrated objects substituted for all Addressed
-        # values; ie: Only ever expose full resolved closures for requested addresses.
-        item_type = type(item)
-        hydrated_item = item_type(**hydrated_args)
-
-        # Let factories replace the hydrated object.
-        if isinstance(hydrated_item, SerializableFactory):
-          hydrated_item = hydrated_item.create()
-
-        # Finally make sure objects that can self-validate get a chance to do so before we cache
-        # them as the pointee of `hydrated_item.address`.
-        if isinstance(hydrated_item, Validatable):
-          hydrated_item.validate()
-
-        return hydrated_item
-      elif isinstance(item, Addressed):
-        referenced_address = Address.parse(spec=item.address_spec, relative_to=address.spec_path)
-        referenced_item = self._resolve_recursively(referenced_address, resolve_path)
-        if not item.type_constraint.satisfied_by(referenced_item):
-          raise ResolvedTypeMismatchError('Found a {} when resolving {} for {}, expected a {!r}'
-                                          .format(type(referenced_item).__name__,
-                                                  referenced_address,
-                                                  address,
-                                                  item.type_constraint))
-        return referenced_item
+        # Re-build the thin Serializable with either fully hydrated objects or Resolvables
+        # substituted for all Address values; ie: Only ever expose fully resolved or resolvable
+        # closures for requested addresses.
+        return self._hydrate(type(item), **hydrated_args)
+      elif isinstance(item, Address):
+        if self._inline:
+          return self._resolve_recursively(item, resolve_path)
+        else:
+          # TODO(John Sirois): Implement lazy cycle checks across Resolver chains.
+          return Resolver(self, address=item)
       else:
         return item
 
@@ -133,3 +162,21 @@ class Graph(object):
     resolve_path.pop(-1)
     self._resolved_by_address[address] = resolved
     return resolved
+
+  @staticmethod
+  def _hydrate(item_type, **kwargs):
+    try:
+      item = item_type(**kwargs)
+    except TypeConstraintError as e:
+      raise ResolvedTypeMismatchError(e)
+
+    # Let factories replace the hydrated object.
+    if isinstance(item, SerializableFactory):
+      item = item.create()
+
+    # Finally make sure objects that can self-validate get a chance to do so before we cache
+    # them as the pointee of `hydrated_item.address`.
+    if isinstance(item, Validatable):
+      item.validate()
+
+    return item

--- a/src/python/pants/engine/exp/legacy/BUILD
+++ b/src/python/pants/engine/exp/legacy/BUILD
@@ -1,0 +1,26 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name='legacy',
+  sources=globs('*.py'),
+  dependencies=[
+    '3rdparty/python:beautifulsoup4',  # This is needed to satisfy pants-plugins deps.
+    'src/python/pants/base:build_environment',
+    'src/python/pants/base:build_file_target_factory',
+    'src/python/pants/base:parse_context',
+    'src/python/pants/bin:pants',
+    'src/python/pants/engine/exp:mapper',
+    'src/python/pants/engine/exp:objects',
+    'src/python/pants/engine/exp:targets',
+    'src/python/pants/util:memo',
+  ]
+)
+
+python_binary(
+  name='list',
+  entry_point='pants.engine.exp.legacy.commands:list',
+  dependencies=[
+    ':legacy'
+  ]
+)

--- a/src/python/pants/engine/exp/legacy/commands.py
+++ b/src/python/pants/engine/exp/legacy/commands.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.base.build_environment import get_buildroot
+from pants.base.parse_context import ParseContext
+from pants.bin.goal_runner import OptionsInitializer
+from pants.engine.exp.legacy.parsers import legacy_python_callbacks_parser
+from pants.engine.exp.mapper import AddressMapper
+from pants.engine.exp.targets import Target
+
+
+def list():
+  """Lists all addresses under the current build root subject to `--spec-excludes` constraints."""
+  build_root = get_buildroot()
+
+  options, build_config = OptionsInitializer().setup()
+  aliases = build_config.registered_aliases()
+
+  symbol_table = {alias: Target for alias in aliases.target_types}
+
+  object_table = aliases.objects
+
+  def per_path_symbol_factory(path, global_symbols):
+    per_path_symbols = {}
+
+    symbols = global_symbols.copy()
+    for alias, target_macro_factory in aliases.target_macro_factories.items():
+      for target_type in target_macro_factory.target_types:
+        symbols[target_type] = lambda *args, **kwargs: per_path_symbols[alias](*args, **kwargs)
+
+    parse_context = ParseContext(rel_path=os.path.relpath(os.path.dirname(path), build_root),
+                                 type_aliases=symbols)
+
+    for alias, object_factory in aliases.context_aware_object_factories.items():
+      per_path_symbols[alias] = object_factory(parse_context)
+
+    for alias, target_macro_factory in aliases.target_macro_factories.items():
+      target_macro = target_macro_factory.target_macro(parse_context)
+      per_path_symbols[alias] = target_macro
+      for target_type in target_macro_factory.target_types:
+        per_path_symbols[target_type] = target_macro
+
+    return per_path_symbols
+
+  parser = legacy_python_callbacks_parser(symbol_table,
+                                          object_table=object_table,
+                                          per_path_symbol_factory=per_path_symbol_factory)
+  mapper = AddressMapper(build_root, parser=parser)
+
+  spec_excludes = options.for_global_scope().spec_excludes
+  for address, obj in mapper.walk_addressables(path_excludes=spec_excludes):
+    print(address.spec)

--- a/src/python/pants/engine/exp/legacy/parsers.py
+++ b/src/python/pants/engine/exp/legacy/parsers.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import threading
+
+import six
+
+from pants.base.build_file_target_factory import BuildFileTargetFactory
+from pants.engine.exp.objects import Serializable
+from pants.util.memo import memoized_property
+
+
+def legacy_python_callbacks_parser(symbol_table, object_table=None, per_path_symbol_factory=None):
+  """Return a parser that parses the given python code into a list of top-level objects.
+
+  Only Serializable objects with `name`s will be collected and returned.  These objects will be
+  addressable via their name in the parsed namespace.
+
+  This parser attempts to be compatible with existing legacy BUILD files and concepts including
+  macros and target factories.
+
+  :param dict symbol_table: An optional symbol table to expose to the python file being parsed.
+  :param dict object_table: An optional symbol table of plain python objects to expose.  This is
+                            intended to support compatibility with the legacy parsing system and
+                            its exposed objects.
+  :param per_path_symbol_factory: An optional factory for any symbols needing the current path;
+                                  called with (path, global_symbols), should return a dict of
+                                  per-path symbols.  This is intended to support compatibility with
+                                  the legacy parsing system and context aware symbols.
+  :type per_path_symbol_factory: :class:`collections.Callable`
+  :returns: A callable that accepts a string path and returns a list of decoded addressable,
+            Serializable objects.  The callable will raise :class:`ParseError` if there were any
+            problems encountered parsing the python BUILD file at the given path.
+  :rtype: :class:`collections.Callable`
+  """
+  objects = []
+
+  class Registrar(BuildFileTargetFactory):
+    def __init__(self, type_alias, object_type):
+      self._type_alias = type_alias
+      self._object_type = object_type
+      self._serializable = Serializable.is_serializable_type(self._object_type)
+
+    @memoized_property
+    def target_types(self):
+      return [self._object_type]
+
+    def __call__(self, *args, **kwargs):
+      name = kwargs.get('name')
+      if name and self._serializable:
+        obj = self._object_type(type_alias=self._type_alias, **kwargs)
+        objects.append(obj)
+        return obj
+      else:
+        return self._object_type(*args, **kwargs)
+
+  parse_globals = {}
+  for alias, symbol in symbol_table.items():
+    registrar = Registrar(alias, symbol)
+    parse_globals[alias] = registrar
+    parse_globals[symbol] = registrar
+
+  if object_table:
+    parse_globals.update(object_table)
+
+  lock = threading.Lock()
+
+  def parse(path):
+    with open(path) as fp:
+      python = fp.read()
+
+    if per_path_symbol_factory:
+      symbols = per_path_symbol_factory(path, parse_globals)
+      symbols.update(parse_globals)
+    else:
+      symbols = parse_globals
+
+    with lock:
+      del objects[:]
+      six.exec_(python, symbols, {})
+      return list(objects)
+
+  return parse

--- a/src/python/pants/engine/exp/mapper.py
+++ b/src/python/pants/engine/exp/mapper.py
@@ -30,7 +30,7 @@ class AddressMap(object):
   """Maps addressable Serializable objects from a byte source."""
 
   @classmethod
-  def parse(cls, path, parse=None):
+  def parse(cls, path, parser=None):
     """Parses a source for addressable Serializable objects.
 
     By default an enhanced JSON parser is used.  The parser admits extra blank lines, comment lines
@@ -42,24 +42,28 @@ class AddressMap(object):
     source are left as unresolved pointers.
 
     :param string path: The path to the byte source containing serialized objects.
-    :param parse: The parse function to use; by default a json parser.
-    :type parse: :class:`collection.Callable` that accepts a byte source and returns a list of all
-                 addressable Serializable objects parsed from it.
+    :param parser: The parser to use; by default a json parser.
+    :type parser: :class:`collection.Callable` that accepts a file path and returns a list of all
+                  addressable Serializable objects parsed from it.
     """
-    parse = parse or parsers.parse_json
-    with open(path, 'r') as fp:
-      objects = parse(fp.read())
-      objects_by_name = {}
-      for obj in objects:
-        if not Serializable.is_serializable(obj) or not obj._asdict().get('name'):
-          raise UnaddressableObjectError('Parsed a non-addressable object: {!r}'.format(obj))
-        attributes = obj._asdict()
-        name = attributes['name']
-        if name in objects_by_name:
-          raise DuplicateNameError('An object already exists at {!r} with name {!r}: {!r}.  Cannot '
-                                   'map {!r}'.format(path, name, objects_by_name[name], obj))
-        objects_by_name[name] = obj
-      return cls(path, objects_by_name)
+    parse = parser or parsers.parse_json
+    objects = parse(path)
+    objects_by_name = {}
+    for obj in objects:
+      if not Serializable.is_serializable(obj):
+        raise UnaddressableObjectError('Parsed a non-serilizable object: {!r}'.format(obj))
+      attributes = obj._asdict()
+
+      name = attributes.get('name')
+      if not name:
+        raise UnaddressableObjectError('Parsed a non-addressable object: {!r}'.format(obj))
+
+      if name in objects_by_name:
+        raise DuplicateNameError('An object already exists at {!r} with name {!r}: {!r}.  Cannot '
+                                 'map {!r}'.format(path, name, objects_by_name[name], obj))
+
+      objects_by_name[name] = obj
+    return cls(path, objects_by_name)
 
   def __init__(self, path, objects_by_name):
     """Not intended for direct use, instead see `parse`."""
@@ -218,7 +222,7 @@ class AddressMapper(object):
 
   @memoized_method
   def _parse(self, path):
-    return AddressMap.parse(path, parse=self._parser)
+    return AddressMap.parse(path, parser=self._parser)
 
   @memoized_method
   def family(self, namespace):

--- a/src/python/pants/engine/exp/objects.py
+++ b/src/python/pants/engine/exp/objects.py
@@ -28,7 +28,19 @@ class Serializable(AbstractClass):
 
   @staticmethod
   def is_serializable(obj):
+    """Return `True` if the given object conforms to the Serializable protocol.
+
+    :rtype: bool
+    """
     return isinstance(obj, Serializable) or (not inspect.isclass(obj) and hasattr(obj, '_asdict'))
+
+  @staticmethod
+  def is_serializable_type(type_):
+    """Return `True` if the given type's instances conform to the Serializable protocol.
+
+    :rtype: bool
+    """
+    return issubclass(type_, Serializable) or (inspect.isclass(type_) and hasattr(type_, '_asdict'))
 
   @abstractmethod
   def _asdict(self):

--- a/src/python/pants/engine/exp/objects.py
+++ b/src/python/pants/engine/exp/objects.py
@@ -6,9 +6,21 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import inspect
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
 
 from pants.util.meta import AbstractClass
+
+
+class Resolvable(AbstractClass):
+  """Represents a resolvable object."""
+
+  @abstractproperty
+  def address(self):
+    """Return the opaque address descriptor that this resolvable resolves."""
+
+  @abstractmethod
+  def resolve(self):
+    """Resolve and return the resolvable object."""
 
 
 class Serializable(AbstractClass):
@@ -28,8 +40,9 @@ class Serializable(AbstractClass):
     >>> s = Serializable(...)
     >>> Serializable(**s._asdict()) == s
 
-    Additionally the dict must also contain nothing except python primitive values, ie: dicts,
-    lists, strings, numbers, bool values, etc.
+    Additionally the dict must also contain nothing except Serializables, python primitive values,
+    ie: dicts, lists, strings, numbers, bool values, etc or Resolvables that resolve to Serilizables
+    or primitive values.
 
     Any :class:`collections.namedtuple` satisfies the Serializable contract automatically via duck
     typing if it is composed of only primitive python values or Serializable values.

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -41,6 +41,7 @@ python_tests(
   name='parsers',
   sources=['test_parsers.py'],
   dependencies=[
+    'src/python/pants/engine/exp:objects',
     'src/python/pants/engine/exp:parsers',
   ]
 )

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "thrift1",
   "sources": []
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "thrift2",
   "sources": [],
   "dependencies": [
@@ -17,7 +17,7 @@
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "java1",
   "sources": [],
   "dependencies": [
@@ -27,18 +27,18 @@
     # TODO(John Sirois): Just use 1 config - this mixed embedded and referenced items just show
     # off / prove the capabilities of the new BUILD graph parser.
     {
-      "typename": "ApacheThriftConfig",
+      "type_alias": "ApacheThriftConfig",
       "version": "0.9.2",
       "strict": true,
       "lang": "java"
     },
     ":nonstrict",
     {
-      "typename": "PublishConfig",
+      "type_alias": "PublishConfig",
       "default_repo": ":public",
       "repos": {
         "jake": {
-          "typename": "Config",
+          "type_alias": "Config",
           "url": "https://dl.bintray.com/pantsbuild/maven"
         },
         "jane": ":public"
@@ -48,7 +48,7 @@
 }
 
 {
-  "typename": "ApacheThriftConfig",
+  "type_alias": "ApacheThriftConfig",
   "name": "nonstrict",
   "version": "0.9.2",
   "strict": false,
@@ -56,13 +56,13 @@
 }
 
 {
-  "typename": "Config",
+  "type_alias": "Config",
   "name": "public",
   "url": "https://oss.sonatype.org/#stagingRepositories"
 }
 
 {
-  "typename": "Config",
+  "type_alias": "Config",
   "name": "type_mismatch",
 
   # This should trigger a type mismatch when resolved since ApacheThriftConfig is not a superclass
@@ -71,7 +71,7 @@
 }
 
 {
-  "typename": "Config",
+  "type_alias": "Config",
   "name": "self_cycle",
 
   # This should trigger a cycle error when resolved since we're trying to depend on ourselves for
@@ -81,7 +81,7 @@
 
 # A single-hop direct cycle - though through different types of dependency edges.
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "direct_cycle",
   "dependencies": [
     ":direct_cycle_dep"
@@ -89,7 +89,7 @@
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "direct_cycle_dep",
   "configurations": [
     ":direct_cycle"
@@ -98,13 +98,13 @@
 
 # A multi-hop cycle
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "indirect_cycle",
   "merges": ":one"
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "one",
   "dependencies": [
     ":two"
@@ -112,13 +112,13 @@
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "two",
   "extends": ":three"
 }
 
 {
-  "typename": "Target",
+  "type_alias": "Target",
   "name": "three",
   "configurations": [
     ":one"

--- a/tests/python/pants_test/engine/exp/examples/mapper_test/a/b/b.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/mapper_test/a/b/b.BUILD.json
@@ -1,11 +1,11 @@
 {
-  "typename": "target",
+  "type_alias": "target",
   "name": "b",
   "dependencies": ["//d:e"],
   "configurations": [
     "//a",
     {
-      "typename": "configuration",
+      "type_alias": "configuration",
       "embedded": "yes"
     }
   ]

--- a/tests/python/pants_test/engine/exp/examples/mapper_test/a/d/d.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/mapper_test/a/d/d.BUILD.json
@@ -1,0 +1,4 @@
+{
+  "type_alias": "target",
+  "name": "d"
+}

--- a/tests/python/pants_test/engine/exp/examples/mapper_test/a/d/e/e.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/mapper_test/a/d/e/e.BUILD.json
@@ -1,0 +1,9 @@
+{
+  "type_alias": "target",
+  "name": "e"
+}
+
+{
+  "type_alias": "configuration",
+  "name": "e-prime"
+}

--- a/tests/python/pants_test/engine/exp/examples/mapper_test/root.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/mapper_test/root.BUILD.json
@@ -1,0 +1,4 @@
+{
+  "type_alias": "configuration",
+  "name": "root"
+}

--- a/tests/python/pants_test/engine/exp/test_addressable.py
+++ b/tests/python/pants_test/engine/exp/test_addressable.py
@@ -7,9 +7,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-from pants.engine.exp.addressable import (Addressed, AddressedError, Exactly, SubclassesOf,
-                                          SuperclassesOf, addressable, addressable_mapping,
-                                          addressables)
+from pants.engine.exp.addressable import (Exactly, MutationError, NotSerializableError,
+                                          SubclassesOf, SuperclassesOf, TypeConstraintError,
+                                          addressable, addressable_dict, addressable_list)
+from pants.engine.exp.objects import Resolvable, Serializable
 
 
 class TypeConstraintTestBase(unittest.TestCase):
@@ -27,86 +28,302 @@ class TypeConstraintTestBase(unittest.TestCase):
 
 
 class SuperclassesOfTest(TypeConstraintTestBase):
-  def test(self):
+  def test_none(self):
+    with self.assertRaises(ValueError):
+      SubclassesOf()
+
+  def test_single(self):
     self.assertTrue(SuperclassesOf(self.B).satisfied_by(self.A()))
     self.assertTrue(SuperclassesOf(self.B).satisfied_by(self.B()))
     self.assertFalse(SuperclassesOf(self.B).satisfied_by(self.BPrime()))
     self.assertFalse(SuperclassesOf(self.B).satisfied_by(self.C()))
 
+  def test_multiple(self):
+    self.assertTrue(SuperclassesOf(self.A, self.B).satisfied_by(self.A()))
+    self.assertTrue(SuperclassesOf(self.A, self.B).satisfied_by(self.B()))
+    self.assertFalse(SuperclassesOf(self.A, self.B).satisfied_by(self.BPrime()))
+    self.assertFalse(SuperclassesOf(self.A, self.B).satisfied_by(self.C()))
+
 
 class ExactlyTest(TypeConstraintTestBase):
-  def test(self):
+  def test_none(self):
+    with self.assertRaises(ValueError):
+      Exactly()
+
+  def test_single(self):
     self.assertFalse(Exactly(self.B).satisfied_by(self.A()))
     self.assertTrue(Exactly(self.B).satisfied_by(self.B()))
     self.assertFalse(Exactly(self.B).satisfied_by(self.BPrime()))
     self.assertFalse(Exactly(self.B).satisfied_by(self.C()))
 
+  def test_multiple(self):
+    self.assertTrue(Exactly(self.A, self.B).satisfied_by(self.A()))
+    self.assertTrue(Exactly(self.A, self.B).satisfied_by(self.B()))
+    self.assertFalse(Exactly(self.A, self.B).satisfied_by(self.BPrime()))
+    self.assertFalse(Exactly(self.A, self.B).satisfied_by(self.C()))
+
 
 class SubclassesOfTest(TypeConstraintTestBase):
-  def test(self):
+  def test_none(self):
+    with self.assertRaises(ValueError):
+      SubclassesOf()
+
+  def test_single(self):
     self.assertFalse(SubclassesOf(self.B).satisfied_by(self.A()))
     self.assertTrue(SubclassesOf(self.B).satisfied_by(self.B()))
     self.assertFalse(SubclassesOf(self.B).satisfied_by(self.BPrime()))
     self.assertTrue(SubclassesOf(self.B).satisfied_by(self.C()))
 
+  def test_multiple(self):
+    self.assertTrue(SubclassesOf(self.B, self.C).satisfied_by(self.B()))
+    self.assertTrue(SubclassesOf(self.B, self.C).satisfied_by(self.C()))
+    self.assertFalse(SubclassesOf(self.B, self.C).satisfied_by(self.BPrime()))
+    self.assertFalse(SubclassesOf(self.B, self.C).satisfied_by(self.A()))
+
+
+class SimpleSerializable(Serializable):
+  def __init__(self, **kwargs):
+    self._kwargs = kwargs
+
+  def _asdict(self):
+    return self._kwargs
+
+
+class CountingResolvable(Resolvable):
+  def __init__(self, address, value):
+    self._address = address
+    self._value = value
+    self._resolutions = 0
+
+  @property
+  def address(self):
+    return self._address
+
+  def resolve(self):
+    try:
+      return self._value
+    finally:
+      self._resolutions += 1
+
+  @property
+  def resolutions(self):
+    return self._resolutions
+
+
+class AddressableDescriptorTest(unittest.TestCase):
+  def test_inappropriate_application(self):
+    class NotSerializable(object):
+      def __init__(self, count):
+        super(NotSerializable, self).__init__()
+        self.count = count
+
+      @addressable(Exactly(int))
+      def count(self):
+        pass
+
+    with self.assertRaises(NotSerializableError):
+      NotSerializable(42)
+
 
 class AddressableTest(unittest.TestCase):
+  class Person(SimpleSerializable):
+    def __init__(self, age):
+      super(AddressableTest.Person, self).__init__()
+      self.age = age
+
+    @addressable(Exactly(int))
+    def age(self):
+      """Return the person's age in years.
+
+      :rtype int
+      """
+
   def test_none(self):
-    self.assertIsNone(addressable(Exactly(int), None))
+    person = self.Person(None)
+
+    self.assertIsNone(person.age, None)
 
   def test_value(self):
-    self.assertEqual(42, addressable(Exactly(int), 42))
+    person = self.Person(42)
 
-  def test_pointer(self):
-    self.assertEqual(Addressed(Exactly(int), '//:meaning-of-life'),
-                     addressable(Exactly(int), '//:meaning-of-life'))
+    self.assertEqual(42, person.age)
 
-  def test_type_mismatch(self):
-    with self.assertRaises(AddressedError):
-      addressable(Exactly(int), 42.0)
+  def test_address(self):
+    person = self.Person('//:meaning-of-life')
+
+    self.assertEqual('//:meaning-of-life', person.age)
+
+  def test_resolvable(self):
+    resolvable_age = CountingResolvable('//:meaning-of-life', 42)
+    person = self.Person(resolvable_age)
+
+    self.assertEqual(0, resolvable_age.resolutions)
+
+    self.assertEqual(42, person.age)
+    self.assertEqual(1, resolvable_age.resolutions)
+
+    self.assertEqual(42, person.age)
+    self.assertEqual(2, resolvable_age.resolutions)
+
+  def test_type_mismatch_value(self):
+    with self.assertRaises(TypeConstraintError):
+      self.Person(42.0)
+
+  def test_type_mismatch_resolvable(self):
+    resolvable_age = CountingResolvable('//:meaning-of-life', 42.0)
+    person = self.Person(resolvable_age)
+
+    with self.assertRaises(TypeConstraintError):
+      person.age
+
+  def test_single_assignment(self):
+    person = self.Person(42)
+    with self.assertRaises(MutationError):
+      person.age = 37
 
 
-class AddressablesTest(unittest.TestCase):
+class AddressableListTest(unittest.TestCase):
+  class Series(SimpleSerializable):
+    def __init__(self, values):
+      super(AddressableListTest.Series, self).__init__()
+      self.values = values
+
+    @addressable_list(Exactly(int, float))
+    def values(self):
+      """Return this series' values.
+
+      :rtype list of int or float
+      """
+
   def test_none(self):
-    self.assertEqual([], addressables(Exactly(int), None))
+    series = self.Series(None)
+
+    self.assertEqual([], series.values)
 
   def test_values(self):
-    self.assertEqual([42, 1 / 137.0], addressables(SubclassesOf((int, float)), (42, 1 / 137.0)))
+    series = self.Series([42, 1 / 137.0])
 
-  def test_pointers(self):
-    self.assertEqual([Addressed(Exactly(int), '//:meaning-of-life')],
-                     addressables(Exactly(int), ['//:meaning-of-life']))
+    self.assertEqual([42, 1 / 137.0], series.values)
+
+  def test_addresses(self):
+    series = self.Series(['//:meaning-of-life'])
+
+    self.assertEqual(['//:meaning-of-life'], series.values)
+
+  def test_resolvables(self):
+    resolvable_value = CountingResolvable('//:fine-structure-constant', 1 / 137.0)
+    series = self.Series([resolvable_value])
+
+    self.assertEqual([1 / 137.0], series.values)
+    self.assertEqual(1, resolvable_value.resolutions)
+
+    self.assertEqual(1 / 137.0, series.values[0])
+    self.assertEqual(2, resolvable_value.resolutions)
 
   def test_mixed(self):
-    self.assertEqual([42, Addressed(Exactly(int), '//:meaning-of-life')],
-                     addressables(Exactly(int), [42, '//:meaning-of-life']))
+    resolvable_value = CountingResolvable('//:fine-structure-constant', 1 / 137.0)
+    series = self.Series([42, '//:meaning-of-life', resolvable_value])
 
-  def test_type_mismatch(self):
-    with self.assertRaises(AddressedError):
-      addressables(Exactly(int), [42, 1 / 137.0])
+    self.assertEqual(0, resolvable_value.resolutions)
+
+    self.assertEqual([42, '//:meaning-of-life', 1 / 137.0], series.values)
+    self.assertEqual(1, resolvable_value.resolutions)
+
+    self.assertEqual(1 / 137.0, series.values[2])
+    self.assertEqual(2, resolvable_value.resolutions)
+
+  def test_type_mismatch_container(self):
+    with self.assertRaises(TypeError):
+      self.Series({42, 1 / 137.0})
+
+  def test_type_mismatch_value(self):
+    with self.assertRaises(TypeConstraintError):
+      self.Series([42, False])
+
+  def test_type_mismatch_resolvable(self):
+    resolvable_value = CountingResolvable('//:meaning-of-life', True)
+    series = self.Series([42, resolvable_value])
+
+    with self.assertRaises(TypeConstraintError):
+      series.values
+
+  def test_single_assignment(self):
+    series = self.Series([42])
+    with self.assertRaises(MutationError):
+      series.values = [37]
 
 
-class AddressableMappingTest(unittest.TestCase):
+class AddressableDictTest(unittest.TestCase):
+  class Varz(SimpleSerializable):
+    def __init__(self, varz):
+      super(AddressableDictTest.Varz, self).__init__()
+      self.varz = varz
+
+    @addressable_dict(Exactly(int, float))
+    def varz(self):
+      """Return a snapshot of the current /varz.
+
+      :rtype dict of string -> int or float
+      """
+
   def test_none(self):
-    self.assertEqual({}, addressable_mapping(Exactly(int), None))
+    varz = self.Varz(None)
+
+    self.assertEqual({}, varz.varz)
 
   def test_values(self):
-    self.assertEqual(dict(meaning_of_life=42, fine_structure_constant=1 / 137.0),
-                     addressable_mapping(SubclassesOf((int, float)),
-                                         dict(meaning_of_life=42,
-                                              fine_structure_constant=1 / 137.0)))
+    varz = self.Varz({'meaning of life': 42, 'fine structure constant': 1 / 137.0})
 
-  def test_pointers(self):
-    self.assertEqual(dict(meaning_of_life=Addressed(Exactly(int), '//:meaning-of-life')),
-                     addressable_mapping(Exactly(int), dict(meaning_of_life='//:meaning-of-life')))
+    self.assertEqual({'meaning of life': 42, 'fine structure constant': 1 / 137.0}, varz.varz)
+
+  def test_addresses(self):
+    varz = self.Varz({'meaning of life': '//:meaning-of-life'})
+
+    self.assertEqual({'meaning of life': '//:meaning-of-life'}, varz.varz)
+
+  def test_resolvables(self):
+    resolvable_value = CountingResolvable('//:fine-structure-constant', 1 / 137.0)
+    varz = self.Varz({'fine structure constant': resolvable_value})
+
+    self.assertEqual({'fine structure constant': 1 / 137.0}, varz.varz)
+    self.assertEqual(1, resolvable_value.resolutions)
+
+    self.assertEqual(1 / 137.0, varz.varz['fine structure constant'])
+    self.assertEqual(2, resolvable_value.resolutions)
 
   def test_mixed(self):
-    self.assertEqual(dict(meaning_of_life=42,
-                          fine_structure_constant=Addressed(SubclassesOf((int, float)), '//:fsc')),
-                     addressable_mapping(SubclassesOf((int, float)),
-                                         dict(meaning_of_life=42,
-                                              fine_structure_constant='//:fsc')))
+    resolvable_value = CountingResolvable('//:fine-structure-constant', 1 / 137.0)
+    varz = self.Varz({'prime': 37,
+                      'meaning of life': '//:meaning-of-life',
+                      'fine structure constant': resolvable_value})
 
-  def test_type_mismatch(self):
-    with self.assertRaises(AddressedError):
-      addressable_mapping(Exactly(int), dict(meaning_of_life=42, fine_structure_constant=1 / 137.0))
+    self.assertEqual(0, resolvable_value.resolutions)
+
+    self.assertEqual({'prime': 37,
+                      'meaning of life': '//:meaning-of-life',
+                      'fine structure constant': 1 / 137.0},
+                     varz.varz)
+    self.assertEqual(1, resolvable_value.resolutions)
+
+    self.assertEqual(1 / 137.0, varz.varz['fine structure constant'])
+    self.assertEqual(2, resolvable_value.resolutions)
+
+  def test_type_mismatch_container(self):
+    with self.assertRaises(TypeError):
+      self.Varz([42, 1 / 137.0])
+
+  def test_type_mismatch_value(self):
+    with self.assertRaises(TypeConstraintError):
+      self.Varz({'meaning of life': 42, 'fine structure constant': False})
+
+  def test_type_mismatch_resolvable(self):
+    resolvable_item = CountingResolvable('//:fine-structure-constant', True)
+    varz = self.Varz({'meaning of life': 42, 'fine structure constant': resolvable_item})
+
+    with self.assertRaises(TypeConstraintError):
+      varz.varz
+
+  def test_single_assignment(self):
+    varz = self.Varz({'meaning of life': 42})
+    with self.assertRaises(MutationError):
+      varz.varz = {'fine structure constant': 1 / 137.0}

--- a/tests/python/pants_test/engine/exp/test_configuration.py
+++ b/tests/python/pants_test/engine/exp/test_configuration.py
@@ -21,15 +21,15 @@ class ConfigurationTest(unittest.TestCase):
     with self.assertRaises(ValidationError):
       Configuration(name='a', address=Address.parse('a:b'))
 
-  def test_typename(self):
-    self.assertEqual('Configuration', Configuration().typename)
-    self.assertEqual('aliased', Configuration(typename='aliased').typename)
+  def test_type_alias(self):
+    self.assertEqual('Configuration', Configuration().type_alias)
+    self.assertEqual('aliased', Configuration(type_alias='aliased').type_alias)
 
     class Subclass(Configuration):
       pass
 
-    self.assertEqual('Subclass', Subclass().typename)
-    self.assertEqual('aliased_subclass', Subclass(typename='aliased_subclass').typename)
+    self.assertEqual('Subclass', Subclass().type_alias)
+    self.assertEqual('aliased_subclass', Subclass(type_alias='aliased_subclass').type_alias)
 
   def test_extend_and_merge(self):
     # Resolution should be lazy, so - although its invalid to both extend and merge, we should be

--- a/tests/python/pants_test/engine/exp/test_graph.py
+++ b/tests/python/pants_test/engine/exp/test_graph.py
@@ -14,7 +14,7 @@ from pants.engine.exp.configuration import Configuration
 from pants.engine.exp.graph import (CycleError, Graph, ResolvedTypeMismatchError, ResolveError,
                                     Resolver)
 from pants.engine.exp.mapper import AddressMapper
-from pants.engine.exp.parsers import parse_json, parse_python_assignments, parse_python_callbacks
+from pants.engine.exp.parsers import parse_json, python_assignments_parser, python_callbacks_parser
 from pants.engine.exp.targets import ApacheThriftConfiguration, PublishConfiguration, Target
 
 
@@ -78,14 +78,12 @@ class InlinedGraphTest(GraphTestBase):
 
   def test_python(self):
     graph = self.create_graph(build_pattern=r'.+\.BUILD.python$',
-                              parser=partial(parse_python_assignments,
-                                             symbol_table=self.symbol_table))
+                              parser=python_assignments_parser(symbol_table=self.symbol_table))
     self.do_test_codegen_simple(graph)
 
   def test_python_classic(self):
     graph = self.create_graph(build_pattern=r'.+\.BUILD$',
-                              parser=partial(parse_python_callbacks,
-                                             symbol_table=self.symbol_table))
+                              parser=python_callbacks_parser(symbol_table=self.symbol_table))
     self.do_test_codegen_simple(graph)
 
   def test_resolve_cache(self):
@@ -220,12 +218,10 @@ class LazyResolvingGraphTest(GraphTestBase):
 
   def test_python(self):
     graph = self.create_graph(build_pattern=r'.+\.BUILD.python$',
-                              parser=partial(parse_python_assignments,
-                                             symbol_table=self.symbol_table))
+                              parser=python_assignments_parser(symbol_table=self.symbol_table))
     self.do_test_codegen_simple(graph)
 
   def test_python_classic(self):
     graph = self.create_graph(build_pattern=r'.+\.BUILD$',
-                              parser=partial(parse_python_callbacks,
-                                             symbol_table=self.symbol_table))
+                              parser=python_callbacks_parser(symbol_table=self.symbol_table))
     self.do_test_codegen_simple(graph)

--- a/tests/python/pants_test/engine/exp/test_mapper.py
+++ b/tests/python/pants_test/engine/exp/test_mapper.py
@@ -33,7 +33,7 @@ class Thing(object):
     return self._kwargs.copy()
 
   def _key(self):
-    return {k: v for k, v in self._kwargs.items() if k != 'typename'}
+    return {k: v for k, v in self._kwargs.items() if k != 'type_alias'}
 
   def __eq__(self, other):
     return isinstance(other, Thing) and self._key() == other._key()
@@ -54,12 +54,12 @@ class AddressMapTest(unittest.TestCase):
   def test_parse(self):
     with self.parse_address_map(dedent("""
       {
-        "typename": "thing",
+        "type_alias": "thing",
         "name": "one",
         "age": 42
       }
       {
-        "typename": "thing",
+        "type_alias": "thing",
         "name": "two",
         "age": 37
       }
@@ -75,13 +75,13 @@ class AddressMapTest(unittest.TestCase):
 
   def test_not_named(self):
     with self.assertRaises(UnaddressableObjectError):
-      with self.parse_address_map('{"typename": "thing"}'):
+      with self.parse_address_map('{"type_alias": "thing"}'):
         self.fail()
 
   def test_duplicate_names(self):
     with self.assertRaises(DuplicateNameError):
-      with self.parse_address_map('{"typename": "thing", "name": "one"}'
-                                  '{"typename": "thing", "name": "one"}'):
+      with self.parse_address_map('{"type_alias": "thing", "name": "one"}'
+                                  '{"type_alias": "thing", "name": "one"}'):
         self.fail()
 
 
@@ -161,7 +161,7 @@ class AddressMapperTest(unittest.TestCase):
 
     build_file = os.path.join(self.build_root, 'a/c/c.BUILD.json')
     with safe_open(build_file, 'w') as fp:
-      fp.write('{"typename": "configuration", "name": "c"}')
+      fp.write('{"type_alias": "configuration", "name": "c"}')
 
     resolved = self.address_mapper.resolve(Address.parse('a/c'))
     self.assertEqual(Configuration(name='c'), resolved)
@@ -186,7 +186,7 @@ class AddressMapperTest(unittest.TestCase):
                      address_family.addressables)
 
     with open(os.path.join(self.build_root, 'a/b/sibling.BUILD.json'), 'w') as fp:
-      fp.write('{"typename": "configuration", "name": "c"}')
+      fp.write('{"type_alias": "configuration", "name": "c"}')
 
     still_valid = self.address_mapper.family('a/b')
     self.assertIs(address_family, still_valid)
@@ -204,7 +204,7 @@ class AddressMapperTest(unittest.TestCase):
 
     build_file = os.path.join(self.build_root, 'a/b/b.BUILD.json')
     with safe_open(build_file, 'w+') as fp:
-      fp.write('{"typename": "configuration", "name": "c"}')
+      fp.write('{"type_alias": "configuration", "name": "c"}')
 
     with self.assertRaises(ResolveError):
       self.address_mapper.resolve(Address.parse('a/b:c'))

--- a/tests/python/pants_test/engine/exp/test_mapper.py
+++ b/tests/python/pants_test/engine/exp/test_mapper.py
@@ -30,7 +30,7 @@ class Thing(object):
     self._kwargs = kwargs
 
   def _asdict(self):
-    return self._kwargs.copy()
+    return self._kwargs
 
   def _key(self):
     return {k: v for k, v in self._kwargs.items() if k != 'type_alias'}
@@ -40,14 +40,14 @@ class Thing(object):
 
 
 class AddressMapTest(unittest.TestCase):
-  _parse = functools.partial(parsers.parse_json, symbol_table={'thing': Thing})
+  _parser = functools.partial(parsers.parse_json, symbol_table={'thing': Thing})
 
   @contextmanager
   def parse_address_map(self, json):
     with temporary_file() as fp:
       fp.write(json)
       fp.close()
-      address_map = AddressMap.parse(fp.name, parse=self._parse)
+      address_map = AddressMap.parse(fp.name, parser=self._parser)
       self.assertEqual(fp.name, address_map.path)
       yield address_map
 

--- a/tests/python/pants_test/engine/exp/test_parsers.py
+++ b/tests/python/pants_test/engine/exp/test_parsers.py
@@ -23,7 +23,7 @@ class Bob(object):
     return self._kwargs.copy()
 
   def _key(self):
-    return {k: v for k, v in self._kwargs.items() if k != 'typename'}
+    return {k: v for k, v in self._kwargs.items() if k != 'type_alias'}
 
   def __eq__(self, other):
     return isinstance(other, Bob) and self._key() == other._key()
@@ -49,21 +49,21 @@ class JsonParserTest(unittest.TestCase):
     document = dedent("""
     # An simple example with a single Bob.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "hobbies": [1, 2, 3]
     }
     """)
     results = parsers.parse_json(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(hobbies=[1, 2, 3])], self.round_trip(results[0]))
-    self.assertEqual('pants_test.engine.exp.test_parsers.Bob', results[0]._asdict()['typename'])
+    self.assertEqual('pants_test.engine.exp.test_parsers.Bob', results[0]._asdict()['type_alias'])
 
   def test_symbol_table(self):
     symbol_table = {'bob': Bob}
     document = dedent("""
     # An simple example with a single Bob.
     {
-      "typename": "bob",
+      "type_alias": "bob",
       "hobbies": [1, 2, 3]
     }
     """)
@@ -71,15 +71,15 @@ class JsonParserTest(unittest.TestCase):
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(hobbies=[1, 2, 3])],
                      self.round_trip(results[0], symbol_table=symbol_table))
-    self.assertEqual('bob', results[0]._asdict()['typename'])
+    self.assertEqual('bob', results[0]._asdict()['type_alias'])
 
   def test_nested_single(self):
     document = dedent("""
     # An example with nested Bobs.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "uncle": {
-        "typename": "pants_test.engine.exp.test_parsers.Bob",
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob",
         "age": 42
       },
       "hobbies": [1, 2, 3]
@@ -93,12 +93,12 @@ class JsonParserTest(unittest.TestCase):
     document = dedent("""
     # An example with deeply nested Bobs.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "configs": [
         {
           "mappings": {
             "uncle": {
-              "typename": "pants_test.engine.exp.test_parsers.Bob",
+              "type_alias": "pants_test.engine.exp.test_parsers.Bob",
               "age": 42
             }
           }
@@ -115,15 +115,15 @@ class JsonParserTest(unittest.TestCase):
     document = dedent("""
     # An example with many nested Bobs.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "cousins": [
         {
-          "typename": "pants_test.engine.exp.test_parsers.Bob",
+          "type_alias": "pants_test.engine.exp.test_parsers.Bob",
           "name": "Jake",
           "age": 42
         },
         {
-          "typename": "pants_test.engine.exp.test_parsers.Bob",
+          "type_alias": "pants_test.engine.exp.test_parsers.Bob",
           "name": "Jane",
           "age": 37
         }
@@ -141,13 +141,13 @@ class JsonParserTest(unittest.TestCase):
 
     # One with hobbies.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "hobbies": [1, 2, 3]
     }
 
     # Another that is aged.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "age": 42
     }
     """)
@@ -160,7 +160,7 @@ class JsonParserTest(unittest.TestCase):
 
     # One with hobbies.
       {
-        "typename": "pants_test.engine.exp.test_parsers.Bob",
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob",
 
         # And internal comment and blank lines.
 
@@ -169,7 +169,7 @@ class JsonParserTest(unittest.TestCase):
     }
 
     # Another that is aged.
-    {"typename": "pants_test.engine.exp.test_parsers.Bob","age": 42}
+    {"type_alias": "pants_test.engine.exp.test_parsers.Bob","age": 42}
     """).strip()
     results = parsers.parse_json(document)
     self.assertEqual([Bob(hobbies=[1, 2, 3]), {}, Bob(age=42)], results)
@@ -180,7 +180,7 @@ class JsonParserTest(unittest.TestCase):
 
     # One with hobbies.
       {
-        "typename": "pants_test.engine.exp.test_parsers.Bob",
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob",
 
         # And internal comment and blank lines.
 
@@ -190,7 +190,7 @@ class JsonParserTest(unittest.TestCase):
 
     # Another that is imaginary aged.
     {
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "age": 42i,
 
       "four": 1,
@@ -210,7 +210,7 @@ class JsonParserTest(unittest.TestCase):
 
     # This message from the json stdlib varies between python releases, so fuzz the match a bit.
     self.assertRegexpMatches(actual_lines[0],
-                             r"""Expecting (?:,|','|",") delimiter: line 3 column 12 \(char 69\)""")
+                             r"""Expecting (?:,|','|",") delimiter: line 3 column 12 \(char 71\)""")
 
     self.assertEqual(dedent("""
       In document:
@@ -218,7 +218,7 @@ class JsonParserTest(unittest.TestCase):
 
           # One with hobbies.
             {
-              "typename": "pants_test.engine.exp.test_parsers.Bob",
+              "type_alias": "pants_test.engine.exp.test_parsers.Bob",
 
               # And internal comment and blank lines.
 
@@ -228,7 +228,7 @@ class JsonParserTest(unittest.TestCase):
 
           # Another that is imaginary aged.
        1: {
-       2:   "typename": "pants_test.engine.exp.test_parsers.Bob",
+       2:   "type_alias": "pants_test.engine.exp.test_parsers.Bob",
        3:   "age": 42i,
 
        4:   "four": 1,
@@ -261,10 +261,10 @@ class JsonEncoderTest(unittest.TestCase):
     expected_json = dedent("""
     {
       "name": "bob",
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "friend": {
         "name": "bill",
-        "typename": "pants_test.engine.exp.test_parsers.Bob"
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob"
       },
       "relative": "::an opaque address::"
     }
@@ -276,14 +276,14 @@ class JsonEncoderTest(unittest.TestCase):
     expected_json = dedent("""
     {
       "name": "bob",
-      "typename": "pants_test.engine.exp.test_parsers.Bob",
+      "type_alias": "pants_test.engine.exp.test_parsers.Bob",
       "friend": {
         "name": "bill",
-        "typename": "pants_test.engine.exp.test_parsers.Bob"
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob"
       },
       "relative": {
         "name": "bill",
-        "typename": "pants_test.engine.exp.test_parsers.Bob"
+        "type_alias": "pants_test.engine.exp.test_parsers.Bob"
       }
     }
     """).strip()
@@ -303,8 +303,8 @@ class PythonAssignmentsParserTest(unittest.TestCase):
     results = parsers.parse_python_assignments(document)
     self.assertEqual([Bob(name='nancy', hobbies=[1, 2, 3])], results)
 
-    # No symbol table was used so no `typename` plumbing can be expected.
-    self.assertNotIn('typename', results[0]._asdict())
+    # No symbol table was used so no `type_alias` plumbing can be expected.
+    self.assertNotIn('type_alias', results[0]._asdict())
 
   def test_symbol_table(self):
     symbol_table = {'nancy': Bob}
@@ -315,7 +315,7 @@ class PythonAssignmentsParserTest(unittest.TestCase):
     """)
     results = parsers.parse_python_assignments(document, symbol_table=symbol_table)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
-    self.assertEqual('nancy', results[0]._asdict()['typename'])
+    self.assertEqual('nancy', results[0]._asdict()['type_alias'])
 
 
 class PythonCallbacksParserTest(unittest.TestCase):
@@ -329,4 +329,4 @@ class PythonCallbacksParserTest(unittest.TestCase):
     """)
     results = parsers.parse_python_callbacks(document, symbol_table)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
-    self.assertEqual('nancy', results[0]._asdict()['typename'])
+    self.assertEqual('nancy', results[0]._asdict()['type_alias'])

--- a/tests/python/pants_test/engine/exp/test_parsers.py
+++ b/tests/python/pants_test/engine/exp/test_parsers.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 from pants.engine.exp import parsers
 from pants.engine.exp.objects import Resolvable
 from pants.engine.exp.parsers import ParseError
+from pants.util.contextutil import temporary_file
 
 
 # A duck-typed Serializable with an `==` suitable for ease of testing.
@@ -20,7 +21,7 @@ class Bob(object):
     self._kwargs = kwargs
 
   def _asdict(self):
-    return self._kwargs.copy()
+    return self._kwargs
 
   def _key(self):
     return {k: v for k, v in self._kwargs.items() if k != 'type_alias'}
@@ -29,9 +30,20 @@ class Bob(object):
     return isinstance(other, Bob) and self._key() == other._key()
 
 
+def parse(parser, document, **args):
+  with temporary_file() as fp:
+    fp.write(document)
+    fp.close()
+    return parser(fp.name, **args)
+
+
 class JsonParserTest(unittest.TestCase):
+  def parse(self, document, **kwargs):
+    return parse(parsers.parse_json, document, **kwargs)
+
   def round_trip(self, obj, symbol_table=None):
-    return parsers.parse_json(parsers.encode_json(obj, inline=True), symbol_table=symbol_table)
+    document = parsers.encode_json(obj, inline=True)
+    return self.parse(document, symbol_table=symbol_table)
 
   def test_comments(self):
     document = dedent("""
@@ -41,7 +53,7 @@ class JsonParserTest(unittest.TestCase):
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([dict(hobbies=[1, 2, 3])], self.round_trip(results[0]))
 
@@ -53,7 +65,7 @@ class JsonParserTest(unittest.TestCase):
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(hobbies=[1, 2, 3])], self.round_trip(results[0]))
     self.assertEqual('pants_test.engine.exp.test_parsers.Bob', results[0]._asdict()['type_alias'])
@@ -67,7 +79,7 @@ class JsonParserTest(unittest.TestCase):
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document, symbol_table=symbol_table)
+    results = self.parse(document, symbol_table=symbol_table)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(hobbies=[1, 2, 3])],
                      self.round_trip(results[0], symbol_table=symbol_table))
@@ -85,7 +97,7 @@ class JsonParserTest(unittest.TestCase):
       "hobbies": [1, 2, 3]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(uncle=Bob(age=42), hobbies=[1, 2, 3])], self.round_trip(results[0]))
 
@@ -106,7 +118,7 @@ class JsonParserTest(unittest.TestCase):
       ]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(configs=[dict(mappings=dict(uncle=Bob(age=42)))])],
                      self.round_trip(results[0]))
@@ -130,7 +142,7 @@ class JsonParserTest(unittest.TestCase):
       ]
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual(1, len(results))
     self.assertEqual([Bob(cousins=[Bob(name='Jake', age=42), Bob(name='Jane', age=37)])],
                      self.round_trip(results[0]))
@@ -151,7 +163,7 @@ class JsonParserTest(unittest.TestCase):
       "age": 42
     }
     """)
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual([Bob(hobbies=[1, 2, 3]), Bob(age=42)], results)
 
   def test_tricky_spacing(self):
@@ -171,7 +183,7 @@ class JsonParserTest(unittest.TestCase):
     # Another that is aged.
     {"type_alias": "pants_test.engine.exp.test_parsers.Bob","age": 42}
     """).strip()
-    results = parsers.parse_json(document)
+    results = self.parse(document)
     self.assertEqual([Bob(hobbies=[1, 2, 3]), {}, Bob(age=42)], results)
 
   def test_error_presentation(self):
@@ -202,7 +214,7 @@ class JsonParserTest(unittest.TestCase):
     }
     """).strip()
     with self.assertRaises(ParseError) as exc:
-      parsers.parse_json(document)
+      self.parse(document)
 
     # Strip trailing whitespace from the message since our expected literal below will have
     # trailing ws stripped via editors and code reviews calling for it.
@@ -300,7 +312,7 @@ class PythonAssignmentsParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parsers.parse_python_assignments(document)
+    results = parse(parsers.python_assignments_parser(), document)
     self.assertEqual([Bob(name='nancy', hobbies=[1, 2, 3])], results)
 
     # No symbol table was used so no `type_alias` plumbing can be expected.
@@ -313,7 +325,7 @@ class PythonAssignmentsParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parsers.parse_python_assignments(document, symbol_table=symbol_table)
+    results = parse(parsers.python_assignments_parser(symbol_table), document)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
     self.assertEqual('nancy', results[0]._asdict()['type_alias'])
 
@@ -327,6 +339,6 @@ class PythonCallbacksParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parsers.parse_python_callbacks(document, symbol_table)
+    results = parse(parsers.python_callbacks_parser(symbol_table), document)
     self.assertEqual([Bob(name='bill', hobbies=[1, 2, 3])], results)
     self.assertEqual('nancy', results[0]._asdict()['type_alias'])


### PR DESCRIPTION
This also introduces a `legacy_python_callbacks_parser` that can work on
most legacy BuildFileAliases with proper configuration.  This is used to
create a self-contained list command that can be used in legacy BUILD
trees (possibly with some `--spec-excludes` to look past trick macros)
to start perf testing aspects of this experimental parsing system
against the 'legacy' (current) system.

https://rbcommons.com/s/twitter/r/2950/