### PR TITLE
Eliminate travis-ci cache thrash.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 
 
 before_cache:
-  # Kill all `.pyc` in out cached venvs.  Some files appear to get
+  # Kill all `.pyc` in our cached venvs.  Some files appear to get
   # bytecode compiled in non-yet-understood circumstances leading to a
   # full cache re-pack due to new `.pyc` files.
   - find build-support -name "*.pyc" -print -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ sudo: false
 
 
 before_cache:
+  # Kill all `.pyc` in out cached venvs.  Some files appear to get
+  # bytecode compiled in non-yet-understood circumstances leading to a
+  # full cache re-pack due to new `.pyc` files.
+  - find build-support -name "*.pyc" -print -delete
   # The `ivydata-*.properties` & root level `*.{properties,xml}` files'
   # effect on resolution time is in the noise, but they are
   # re-timestamped in internal comments and fields on each run and this

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ sudo: false
 
 
 before_cache:
-  # Kill all `.pyc` in our cached venvs.  Some files appear to get
-  # bytecode compiled in non-yet-understood circumstances leading to a
-  # full cache re-pack due to new `.pyc` files.
-  - find build-support -name "*.pyc" -print -delete
+  # Kill all python bytecode in our cached venvs.  Some files appear to
+  # get bytecode compiled in non-yet-understood circumstances leading to
+  # a full cache re-pack due to new bytecode files.
+  - find build-support -name "*.py[co]" -print -delete
   # The `ivydata-*.properties` & root level `*.{properties,xml}` files'
   # effect on resolution time is in the noise, but they are
   # re-timestamped in internal comments and fields on each run and this


### PR DESCRIPTION
Noticed cache packs like this:
```
store build cache
change detected:
/home/travis/build/pantsbuild/pants/build-support/isort.venv/lib/python2.7/distutils/__init__.pyo
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2html.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2html.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2latex.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2latex.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2man.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2man.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2odt_prepstyles.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2odt_prepstyles.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2odt.pyc
/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/bin/rst2odt.pyc
/home/travis/bu
...
changes detected, packing new archive
```

https://rbcommons.com/s/twitter/r/2957/