### PR TITLE
Make 'changed' faster by not instantiating already injected targets

### DIFF
--- a/src/python/pants/build_graph/source_mapper.py
+++ b/src/python/pants/build_graph/source_mapper.py
@@ -60,7 +60,7 @@ class SpecSourceMapper(SourceMapper):
       address_map = self._address_mapper._address_map_from_spec_path(build_file.spec_path)
       for address, addressable in address_map.values():
         self._build_graph.inject_address_closure(address)
-        target = self._build_graph._target_addressable_to_target(address, addressable)
+        target = self._build_graph.get_target(address)
         sources = target.payload.get_field('sources')
         if sources and not isinstance(sources, DeferredSourcesField) and sources.matches(source):
           yield address


### PR DESCRIPTION
A profiling of a long-running (10 minutes) './pants changed --changed-parent=master --changed-include-dependees=transitive' on a change with ~400 files from master reveals performance issue when many files are changed within a tree where there is an expensive rglobs at the root of the tree's BUILD file. The current logic goes like this:

- for each changed file (434x calls to source_mapper:41:target_addresses_for_source):
- all the BUILD files in its ancestor folders are parsed (2173x calls to source_mapper:58:_find_targets_for_source), inside each:
- each address is injected_address_closure(_)'d, but it was instantiated again at source_mapper:62:_target_addressable_to_target (51735x calls)

The instantiation is not necessary because inject_address_closure already instantiated it and added to build_graph, we only need to get_target.

![changed_profile_10min](https://cloud.githubusercontent.com/assets/3837256/10470817/bced8882-71c4-11e5-8314-48e645f82042.png)