### PR TITLE
[CI] A new implementation of SourceRoots.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -331,7 +331,6 @@ python_library(
   sources = ['roots.py'],
   dependencies = [
     ':console_task',
-    'src/python/pants/backend/core/targets:common',
   ],
 )
 

--- a/src/python/pants/backend/core/tasks/roots.py
+++ b/src/python/pants/backend/core/tasks/roots.py
@@ -6,13 +6,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.core.tasks.console_task import ConsoleTask
-from pants.base.source_root import SourceRoot
 
 
 class ListRoots(ConsoleTask):
   """List the registered source roots of the repo."""
 
   def console_output(self, targets):
-    for src_root, targets in SourceRoot.all_roots().items():
-      all_targets = ','.join(sorted([tgt.__name__ for tgt in targets]))
-      yield '{}: {}'.format(src_root, all_targets or '*')
+    for src_root, langs in self.context.source_roots.all_roots():
+      all_langs = ','.join(sorted(langs))
+      yield '{}: {}'.format(src_root, all_langs or '*')

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -180,6 +180,9 @@ python_library(
     ':exceptions',
     ':parse_context',
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    # TEMPORARY dep during migration to new source roots mechanism.
+    # I've verified that this does not introduce a circular dep.
+    'src/python/pants/source',
   ],
 )
 

--- a/src/python/pants/base/source_root.py
+++ b/src/python/pants/base/source_root.py
@@ -13,6 +13,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.build_file_target_factory import BuildFileTargetFactory
 from pants.base.build_manual import manual
 from pants.base.exceptions import TargetDefinitionException
+from pants.source.source_root import SourceRoots as NewSourceRoots
 
 
 class SourceRootTree(object):

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -34,6 +34,7 @@ from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.report import Report
 from pants.reporting.reporting import Reporting
+from pants.source.source_root import SourceRootConfig
 from pants.subsystem.subsystem import Subsystem
 from pants.util.filtering import create_filters, wrap_filters
 
@@ -317,7 +318,7 @@ class GoalRunner(object):
   @classmethod
   def subsystems(cls):
     # Subsystems used outside of any task.
-    return {SourceRootBootstrapper, Reporting, Reproducer, RunTracker}
+    return {SourceRootBootstrapper, SourceRootConfig, Reporting, Reproducer, RunTracker}
 
   def _execute_engine(self):
     unknown_goals = [goal.name for goal in self._goals if not goal.ordered_task_names()]

--- a/src/python/pants/build_graph/README.md
+++ b/src/python/pants/build_graph/README.md
@@ -1,0 +1,3 @@
+/src/python/pants/build_graph/
+
+Code for modeling code as a DAG.

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -40,6 +40,7 @@ python_library(
     'src/python/pants/java/distribution:distribution',
     'src/python/pants/process',
     'src/python/pants/reporting:report',
+    'src/python/pants/source',
   ],
 )
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -22,6 +22,7 @@ from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.process.pidlock import OwnerPrintingPIDLockFile
 from pants.reporting.report import Report
+from pants.source.source_root import SourceRootConfig
 
 
 class Context(object):
@@ -70,6 +71,7 @@ class Context(object):
     self._target_base = target_base or Target
     self._products = Products()
     self._buildroot = get_buildroot()
+    self._source_roots = SourceRootConfig.global_instance().get_source_roots()
     self._lock = OwnerPrintingPIDLockFile(os.path.join(self._buildroot, '.pants.run'))
     self._java_sysprops = None  # Computed lazily.
     self.requested_goals = requested_goals or []
@@ -95,6 +97,11 @@ class Context(object):
   def products(self):
     """Returns the Products manager for the current run."""
     return self._products
+
+  @property
+  def source_roots(self):
+    """Returns the :class:`pants.source.source_root.SourceRoots` instance for the current run."""
+    return self._source_roots
 
   @property
   def target_roots(self):

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -22,7 +22,7 @@ from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
 from pants.process.pidlock import OwnerPrintingPIDLockFile
 from pants.reporting.report import Report
-from pants.source.source_root import SourceRootConfig
+from pants.source.source_root import SourceRoots
 
 
 class Context(object):
@@ -71,7 +71,7 @@ class Context(object):
     self._target_base = target_base or Target
     self._products = Products()
     self._buildroot = get_buildroot()
-    self._source_roots = SourceRootConfig.global_instance().get_source_roots()
+    self._source_roots = SourceRoots.instance()
     self._lock = OwnerPrintingPIDLockFile(os.path.join(self._buildroot, '.pants.run'))
     self._java_sysprops = None  # Computed lazily.
     self.requested_goals = requested_goals or []

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -1,0 +1,14 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name='source',
+  sources=globs('*.py'),
+  dependencies=[
+    '3rdparty/python:six',
+    'src/python/pants/base:build_environment',
+    'src/python/pants/option',
+    'src/python/pants/subsystem',
+    'src/python/pants/util:memo',
+  ]
+)

--- a/src/python/pants/source/README.md
+++ b/src/python/pants/source/README.md
@@ -1,0 +1,4 @@
+/src/python/pants/source/
+
+Code for modeling source code, in particular its filesystem representation (as opposed to 
+the dependency DAG).

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -154,12 +154,14 @@ class SourceRootConfig(Subsystem):
 
   _DEFAULT_SOURCE_ROOT_PARENTS = [
     'src',
+    'src/main',
     '3rdparty',
   ]
 
   _DEFAULT_TEST_ROOT_PARENTS = [
     'test',
     'tests',
+    'src/test',
   ]
 
   _DEFAULT_SOURCE_ROOT_PATTERNS = {

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -1,0 +1,315 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from six.moves import range
+
+from pants.base.build_environment import get_buildroot
+from pants.option.custom_types import dict_option, list_option
+from pants.subsystem.subsystem import Subsystem
+from pants.util.memo import memoized_method
+
+
+class SourceRoots(object):
+  """An interface for querying source roots."""
+
+  @classmethod
+  @memoized_method
+  def instance(cls):
+    """A singleton instance of SourceRoots.
+
+    Required temporarily, while migrating from the old source roots registry mechanism.
+    Tasks should be able to access a SourceRoots from context, so we may be able to get rid of
+    this explicit singleton.
+    """
+    return SourceRootConfig.global_instance().get_source_roots()
+
+  @classmethod
+  def reset(cls):
+    """Reset all source roots to empty. Only intended for testing."""
+    # TODO: Remove this after migration, when tests access source roots via context rather
+    # than from the singleton.
+    cls.instance.forget(cls)
+
+  def __init__(self, source_root_config):
+    """Create an object for querying source roots via patterns in a trie.
+
+    :param source_root_config: The SourceRootConfig for the source root patterns to query against.
+
+    Non-test code should not instantiate directly. See SourceRootConfig.get_source_roots().
+    """
+    self._trie = source_root_config.create_trie()
+    self._options = source_root_config.get_options()
+
+  def register(self, path, langs=tuple()):
+    """TEMPORARY registration method, during transition from old to new implementation."""
+    self._trie.add_fixed(path, langs)
+
+  def find(self, target):
+    """Find the source root for the given target.
+
+    :param target: Find the source root for this target.
+    :return: A (source root, list of langs) pair.
+    """
+    target_path = target.address.spec_path
+    # If no source root is found, use the target's path.
+    # TODO: Remove this logic. It should be an error to have no matching source root.
+    return self.find_by_path(target_path) or (target_path, [])
+
+  def find_by_path(self, path):
+    """Find the source root for the given path.
+
+    :param path: Find the source root for this path.
+    :return: A (source root, list of langs) pair, or None if no matching source root found.
+    """
+    # TODO: Is this normalization necessary? Shouldn't all paths here be relative already?
+    if os.path.isabs(path):
+      path = os.path.relpath(path, get_buildroot())
+    return self._trie.find(path)
+
+  def all_roots(self):
+    """Return all known source roots.
+
+    Returns a generator over (source root, list of langs) pairs.
+
+    Note: Requires a directory walk to match actual directories against patterns.
+    However we don't descend into source roots, once found, so this should be fast in practice.
+    Note: Does not follow symlinks.
+    """
+    buildroot = get_buildroot()
+    # Note: If we support other SCMs in the future, add their metadata dirs here if relevant.
+    ignore = {'.git'}.union({os.path.relpath(self._options[k], buildroot) for k in
+                            ['pants_workdir', 'pants_supportdir', 'pants_distdir']})
+
+    for dirpath, dirnames, _ in os.walk(buildroot, topdown=True):
+      relpath = os.path.relpath(dirpath, buildroot)
+      if relpath in ignore:
+        del dirnames[:]  # Don't descend into ignored dirs.
+      else:
+        match = self._trie.find(relpath)
+        if match:
+          yield match  # Found a source root.
+          del dirnames[:]  # Don't continue to walk into it.
+
+
+class SourceRootConfig(Subsystem):
+  """Configuration for roots of source trees.
+
+  We detect source roots based on a list of source root patterns.  E.g., if we have src/java
+  as a pattern then any directory that ends with src/java will be considered a source root:
+  src/java, my/project/src/java etc.
+
+  A source root may be associated with one or more 'languages'. E.g., src/java can be associated
+  with java, and src/jvm can be associated with java and scala. Note that this is a generalized
+  concept of 'language'. For example 'resources' is a language in this sense.
+
+  We specify source roots in three ways:
+
+  1. We autoconstruct patterns by appending language names to parent dirs. E.g., for languages
+     'java' and 'python', and parents 'src' and 'example/src', we construct the patterns
+     'src/java', 'src/python', 'example/src/java' and 'example/src/python'.  These are of course
+     associated with the appropriate language.
+
+  2. We can explicitly specify a mapping from source root pattern to language(s). E.g.,
+     {
+       'src/jvm': ['java', 'scala'],
+       'src/py': ['python']
+     }
+
+  3. We can also bypass the pattern mechanism altogether and specify a list of fixed source roots.
+     E.g., src/java will match just <buildroot>/src/java, and not <buildroot>/some/dir/src/java.
+
+  Note that we distinguish between 'source roots' and 'test roots'. All the above holds for both.
+  We don't currently use this distinction in a useful way, but we may in the future, and we don't
+  want to then require everyone to modify their source root declarations, so we implement the
+  distinction now.
+
+  Note also that there's no harm in specifying source root patterns that don't exist in your repo,
+  within reason.  This means that in most cases the defaults below will be sufficient and repo
+  owners will not need to explicitly specify source root patterns at all.
+  """
+
+  options_scope = 'source'
+
+  _DEFAULT_LANGS = [
+    'android',
+    'antlr',
+    'cpp',
+    'go',
+    'java',
+    'node',
+    'protobuf',
+    'py',
+    'python',
+    'resources',
+    'scala',
+    'thrift',
+    'wire',
+  ]
+
+  _DEFAULT_SOURCE_ROOT_PARENTS = [
+    'src',
+    '3rdparty',
+  ]
+
+  _DEFAULT_TEST_ROOT_PARENTS = [
+    'test',
+    'tests',
+  ]
+
+  _DEFAULT_SOURCE_ROOT_PATTERNS = {
+    'src/jvm': ['java', 'scala'],
+  }
+
+  _DEFAULT_TEST_ROOT_PATTERNS = {
+    'test/jvm': ['java', 'scala'],
+    'tests/jvm': ['java', 'scala'],
+  }
+
+  @classmethod
+  def register_options(cls, register):
+    super(SourceRootConfig, cls).register_options(register)
+    register('--langs', metavar='<list>', type=list_option,
+             default=cls._DEFAULT_LANGS, advanced=True,
+             help='A list of supported language names to autoconstruct source root patterns from.')
+
+    register('--source-root-parents', metavar='<list>', type=list_option,
+             default=cls._DEFAULT_SOURCE_ROOT_PARENTS, advanced=True,
+             help='A list of parent dirs to autoconstruct source root patterns from. '
+                  'The constructed roots are of the pattern <parent>/<lang>, where <lang> is one '
+                  'of the languages specified by the --langs option.')
+    register('--test-root-parents', metavar='<list>', type=list_option,
+             default=cls._DEFAULT_TEST_ROOT_PARENTS, advanced=True,
+             help='A list of parent dirs to autoconstruct test root patterns from. '
+                  'The constructed roots are of the pattern <parent>/<lang>, where <lang> is one '
+                  'of the languages specified by the --langs option.')
+
+    register('--source-root-patterns', metavar='<map>', type=dict_option,
+             default=cls._DEFAULT_SOURCE_ROOT_PATTERNS, advanced=True,
+             help='A mapping from source root pattern to list of languages of source code found '
+                  'under paths matching that pattern. Useful when the autoconstructed source root'
+                  'patterns are not sufficient.')
+    register('--test-root-patterns', metavar='<map>', type=dict_option,
+             default=cls._DEFAULT_TEST_ROOT_PATTERNS, advanced=True,
+             help='A mapping from test root pattern to list of languages of test code found '
+                  'under paths matching that pattern. Useful when the autoconstructed test root'
+                  'patterns are not sufficient.')
+
+    register('--source-roots', metavar='<map>', type=dict_option, advanced=True,
+             help='A map of source roots to list of languages.  Useful when you want to enumerate '
+                  'fixed source roots explicitly, instead of relying on patterns.')
+    register('--test-roots', metavar='<map>', type=dict_option, advanced=True,
+             help='A map of test roots to list of languages.  Useful when you want to enumerate '
+                  'fixed test roots explicitly, instead of relying on patterns.')
+
+  def get_source_roots(self):
+    return SourceRoots(self)
+
+  def generate_source_root_pattern_mappings(self):
+    """Generate source root patterns from options.
+
+    Does not currently distinguish between source (i.e., non-test) and test roots, and yields them
+    both as "source roots", which is correct for our current uses of source roots.
+    TODO: Put the distinction between test and non-test source roots to good use.
+    """
+    options = self.get_options()
+
+    def gen_from_options(prefix):
+      for parent in options[prefix + '_root_parents'] or []:
+        for lang in options.langs or []:
+          yield os.path.join(parent, lang), (lang,)
+      for pattern, langs in (options[prefix + '_root_patterns'] or {}).items():
+        yield pattern, tuple(langs)
+
+    for x in gen_from_options('source'):
+      yield x
+    for x in gen_from_options('test'):
+      yield x
+
+  def create_trie(self):
+    """Create a trie of source root patterns from options."""
+    trie = SourceRootTrie()
+
+    # First add all patterns.
+    for pattern, langs in self.generate_source_root_pattern_mappings():
+      trie.add_pattern(pattern, langs)
+
+    # Now add all fixed source roots.
+    def gen_fixed_from_options(prefix):
+      for path, langs in (self.get_options()[prefix + '_roots'] or {}).items():
+        trie.add_fixed(path, langs)
+
+    gen_fixed_from_options('source')
+    gen_fixed_from_options('test')
+
+    return trie
+
+
+class SourceRootTrie(object):
+  """A trie for efficiently finding the source root for a path.
+
+  Finds the first outermost pattern that matches. E.g., my/project/src/python/src/java/java.py
+  will match the pattern src/python, not src/java.
+
+  Implements fixed source roots by prepending a '^/' to them, and then prepending a '^' key to
+  the path we're matching. E.g., ^/src/java/foo/bar will match both the fixed root ^/src/java and
+  the pattern src/java, but ^/my/project/src/java/foo/bar will match only the pattern.
+  """
+  class Node(object):
+    def __init__(self):
+      self.children = {}
+      self.langs = tuple()  # Relevant only if this is a leaf node.
+
+    def get_child(self, key):
+      return self.children.get(key)
+
+    def new_child(self, key):
+      child = SourceRootTrie.Node()
+      self.children[key] = child
+      return child
+
+    def is_leaf(self):
+      return len(self.children) == 0
+
+  def __init__(self):
+    self._root = SourceRootTrie.Node()
+
+  def add_pattern(self, pattern, langs=None):
+    """Add a pattern to the trie."""
+    keys = pattern.split(os.path.sep)
+    node = self._root
+    for key in keys:
+      child = node.get_child(key)
+      if not child:
+        child = node.new_child(key)
+      node = child
+    node.langs = tuple(langs or [])
+
+  def add_fixed(self, path, langs=None):
+    """Add a fixed source root to the trie."""
+    self.add_pattern(os.path.join('^', path), tuple(langs))
+
+  def find(self, path):
+    """Find the source root for the given path."""
+    keys = ['^'] + path.split(os.path.sep)
+    for i in range(0, len(keys)):
+      # See if we have a match at position i.  We have such a match if following the path
+      # segments into the trie, from the root, leads us to a leaf.
+      node = self._root
+      for j in range(i, len(keys)):
+        child = node.get_child(keys[j])
+        if child is None:
+          break  # We can't continue.  Try the next value of i.
+        elif child.is_leaf():
+          # We found a leaf, so this source root pattern applies.  Return the entire prefix, up
+          # to the end of the pattern, as the source root.
+          # Note that the range starts from 1, to skip the '^' we added.
+          return os.path.join(*keys[1:j + 1]), child.langs
+        else:
+          node = child
+    return None

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -143,6 +143,7 @@ class SourceRootConfig(Subsystem):
     'go',
     'java',
     'node',
+    'proto',
     'protobuf',
     'py',
     'python',
@@ -165,12 +166,12 @@ class SourceRootConfig(Subsystem):
   ]
 
   _DEFAULT_SOURCE_ROOT_PATTERNS = {
-    'src/jvm': ['java', 'scala'],
+    'src/jvm': ('java', 'scala'),
   }
 
   _DEFAULT_TEST_ROOT_PATTERNS = {
-    'test/jvm': ['java', 'scala'],
-    'tests/jvm': ['java', 'scala'],
+    'test/jvm': ('java', 'scala'),
+    'tests/jvm': ('java', 'scala'),
   }
 
   @classmethod
@@ -222,10 +223,10 @@ class SourceRootConfig(Subsystem):
     options = self.get_options()
 
     def gen_from_options(prefix):
-      for parent in options[prefix + '_root_parents'] or []:
+      for parent in options['{}_root_parents'.format(prefix)] or []:
         for lang in options.langs or []:
           yield os.path.join(parent, lang), (lang,)
-      for pattern, langs in (options[prefix + '_root_patterns'] or {}).items():
+      for pattern, langs in (options['{}_root_patterns'.format(prefix)] or {}).items():
         yield pattern, tuple(langs)
 
     for x in gen_from_options('source'):
@@ -243,7 +244,7 @@ class SourceRootConfig(Subsystem):
 
     # Now add all fixed source roots.
     def gen_fixed_from_options(prefix):
-      for path, langs in (self.get_options()[prefix + '_roots'] or {}).items():
+      for path, langs in (self.get_options()['{}_roots'.format(prefix)] or {}).items():
         trie.add_fixed(path, langs)
 
     gen_fixed_from_options('source')
@@ -299,7 +300,7 @@ class SourceRootTrie(object):
   def find(self, path):
     """Find the source root for the given path."""
     keys = ['^'] + path.split(os.path.sep)
-    for i in range(0, len(keys)):
+    for i in range(len(keys)):
       # See if we have a match at position i.  We have such a match if following the path
       # segments into the trie, from the root, leads us to a leaf.
       node = self._root

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -32,6 +32,7 @@ python_library(
     'src/python/pants/base:source_root',
     'src/python/pants/build_graph',
     'src/python/pants/goal:goal',
+    'src/python/pants/source',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/base:context_utils',

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -30,7 +30,6 @@ python_tests(
     'src/python/pants/invalidation',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test:base_test',
   ]
 )
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -7,6 +7,7 @@ python_library(
   dependencies = [
     'src/python/pants/goal',
     'src/python/pants/goal:task_registrar',
+    'tests/python/pants_test:base_test',
   ]
 )
 

--- a/tests/python/pants_test/engine/base_engine_test.py
+++ b/tests/python/pants_test/engine/base_engine_test.py
@@ -5,13 +5,12 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import unittest
-
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar
+from pants_test.base_test import BaseTest
 
 
-class EngineTestBase(unittest.TestCase):
+class EngineTestBase(BaseTest):
 
   @classmethod
   def as_goal(cls, goal_name):

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.base.exceptions import TaskError
 from pants.engine.engine import Engine
-from pants_test.base.context_utils import create_context
 from pants_test.engine.base_engine_test import EngineTestBase
 
 
@@ -28,18 +27,19 @@ class EngineTest(EngineTestBase):
         self._action()
 
   def setUp(self):
-    self.context = create_context()
+    super(EngineTest, self).setUp()
+    self._context = self.context()
 
   def assert_attempt(self, engine, *goal_names):
     self.assertEqual(1, len(engine.attempts))
 
     context, goals = engine.attempts[0]
-    self.assertEqual(self.context, context)
+    self.assertEqual(self._context, context)
     self.assertEqual(self.as_goals(*goal_names), goals)
 
   def test_execute_success(self):
     engine = self.RecordingEngine()
-    result = engine.execute(self.context, self.as_goals('one', 'two'))
+    result = engine.execute(self._context, self.as_goals('one', 'two'))
     self.assertEqual(0, result)
     self.assert_attempt(engine, 'one', 'two')
 
@@ -50,12 +50,12 @@ class EngineTest(EngineTestBase):
 
   def test_execute_raise(self):
     engine = self.RecordingEngine(action=self._throw(TaskError()))
-    result = engine.execute(self.context, self.as_goals('three'))
+    result = engine.execute(self._context, self.as_goals('three'))
     self.assertEqual(1, result)
     self.assert_attempt(engine, 'three')
 
   def test_execute_code(self):
     engine = self.RecordingEngine(action=self._throw(TaskError(exit_code=42)))
-    result = engine.execute(self.context, self.as_goals('four', 'five', 'six'))
+    result = engine.execute(self._context, self.as_goals('four', 'five', 'six'))
     self.assertEqual(42, result)
     self.assert_attempt(engine, 'four', 'five', 'six')

--- a/tests/python/pants_test/source/BUILD
+++ b/tests/python/pants_test/source/BUILD
@@ -1,0 +1,19 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+target(
+  name = 'source',
+  dependencies = [
+    ':source_root',
+  ]
+)
+
+python_tests(
+  name = 'source_root',
+  sources = ['test_source_root.py'],
+  dependencies = [
+    'src/python/pants/source',
+    'tests/python/pants_test:base_test',
+    'tests/python/pants_test/subsystem:subsystem_utils'
+  ]
+)

--- a/tests/python/pants_test/source/test_source_root.py
+++ b/tests/python/pants_test/source/test_source_root.py
@@ -13,15 +13,15 @@ from pants_test.subsystem.subsystem_util import create_subsystem
 class SourceRootTest(BaseTest):
   def test_generate_source_root_patterns(self):
     def _do_test(langs=None,
-                 source_root_parents=None, source_roots=None,
-                 test_root_parents=None, test_roots=None,
+                 source_root_parents=None, source_root_patterns=None,
+                 test_root_parents=None, test_root_patterns=None,
                  expected=None):
       options = {
         'langs': langs or [],
         'source_root_parents': source_root_parents or [],
-        'source_root_patterns': source_roots or {},
+        'source_root_patterns': source_root_patterns or {},
         'test_root_parents': test_root_parents or [],
-        'test_root_patterns': test_roots or {},
+        'test_root_patterns': test_root_patterns or {},
       }
       source_root_config = create_subsystem(SourceRootConfig, **options)
       actual = dict(source_root_config.generate_source_root_pattern_mappings())
@@ -36,12 +36,12 @@ class SourceRootTest(BaseTest):
                'example/src/java': ('java',), 'example/src/python': ('python',)
              })
 
-    _do_test(source_roots={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
+    _do_test(source_root_patterns={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
              expected={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) })
 
     _do_test(langs=['java', 'python'],
              source_root_parents=['src', 'example/src'],
-             source_roots={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
+             source_root_patterns={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
              expected={
                'src/java': ('java',), 'src/python': ('python',),
                'example/src/java': ('java',), 'example/src/python': ('python',),
@@ -49,7 +49,7 @@ class SourceRootTest(BaseTest):
              })
 
     _do_test(langs=['java', 'python'], test_root_parents=['src', 'example/src'],
-             test_roots={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
+             test_root_patterns={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
              expected={
                'src/java': ('java',), 'src/python': ('python',),
                'example/src/java': ('java',), 'example/src/python': ('python',),

--- a/tests/python/pants_test/source/test_source_root.py
+++ b/tests/python/pants_test/source/test_source_root.py
@@ -1,0 +1,122 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.source.source_root import SourceRootConfig, SourceRootTrie
+from pants_test.base_test import BaseTest
+from pants_test.subsystem.subsystem_util import create_subsystem
+
+
+class SourceRootTest(BaseTest):
+  def test_generate_source_root_patterns(self):
+    def _do_test(langs=None,
+                 source_root_parents=None, source_roots=None,
+                 test_root_parents=None, test_roots=None,
+                 expected=None):
+      options = {
+        'langs': langs or [],
+        'source_root_parents': source_root_parents or [],
+        'source_root_patterns': source_roots or {},
+        'test_root_parents': test_root_parents or [],
+        'test_root_patterns': test_roots or {},
+      }
+      source_root_config = create_subsystem(SourceRootConfig, **options)
+      actual = dict(source_root_config.generate_source_root_pattern_mappings())
+      self.assertEqual(expected, actual)
+
+    _do_test(expected={})
+
+    _do_test(langs=['java', 'python'],
+             source_root_parents=['src', 'example/src'],
+             expected={
+               'src/java': ('java',), 'src/python': ('python',),
+               'example/src/java': ('java',), 'example/src/python': ('python',)
+             })
+
+    _do_test(source_roots={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
+             expected={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) })
+
+    _do_test(langs=['java', 'python'],
+             source_root_parents=['src', 'example/src'],
+             source_roots={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
+             expected={
+               'src/java': ('java',), 'src/python': ('python',),
+               'example/src/java': ('java',), 'example/src/python': ('python',),
+               'src/jvm': ('java', 'scala'), 'src/py': ('python',)
+             })
+
+    _do_test(langs=['java', 'python'], test_root_parents=['src', 'example/src'],
+             test_roots={ 'src/jvm': ('java', 'scala'), 'src/py': ('python',) },
+             expected={
+               'src/java': ('java',), 'src/python': ('python',),
+               'example/src/java': ('java',), 'example/src/python': ('python',),
+               'src/jvm': ('java', 'scala'), 'src/py': ('python',)
+             })
+
+  def test_source_root_trie(self):
+    trie = SourceRootTrie()
+    self.assertIsNone(trie.find('src/java/org/pantsbuild/foo/Foo.java'))
+
+    trie.add_pattern('src/java', ('java',))
+    self.assertEquals(('src/java', ('java',)),
+                      trie.find('src/java/org/pantsbuild/foo/Foo.java'))
+    self.assertEquals(('my/project/src/java', ('java',)),
+                      trie.find('my/project/src/java/org/pantsbuild/foo/Foo.java'))
+
+    trie.add_pattern('src/python', ('python',))
+    self.assertEquals(('src/java', ('java',)),
+                      trie.find('src/java/org/pantsbuild/foo/Foo.java'))
+    self.assertEquals(('my/project/src/java', ('java',)),
+                      trie.find('my/project/src/java/org/pantsbuild/foo/Foo.java'))
+    self.assertEquals(('src/python', ('python',)),
+                      trie.find('src/python/pantsbuild/foo/foo.py'))
+    self.assertEquals(('my/project/src/python', ('python',)),
+                      trie.find('my/project/src/python/org/pantsbuild/foo/foo.py'))
+
+    # Verify that we take the first matching prefix.
+    self.assertEquals(('src/java', ('java',)),
+                      trie.find('src/java/src/python/Foo.java'))
+
+    # Test fixed patterns.
+    trie.add_fixed('src/scala', ('scala',))
+    self.assertEquals(('src/scala', ('scala',)),
+                      trie.find('src/scala/org/pantsbuild/foo/Foo.scala'))
+    self.assertIsNone(trie.find('my/project/src/scala/org/pantsbuild/foo/Foo.scala'))
+
+    # Test multiple langs.
+    trie.add_pattern('src/jvm', ('java', 'scala'))
+
+    self.assertEquals(('src/jvm', ('java', 'scala')),
+                      trie.find('src/jvm/org/pantsbuild/foo/Foo.java'))
+    self.assertEquals(('src/jvm', ('java', 'scala')),
+                      trie.find('src/jvm/org/pantsbuild/foo/Foo.scala'))
+
+    # Test long pattern.
+    trie.add_pattern('src/main/long/path/java', ('java',))
+    self.assertEquals(('my/project/src/main/long/path/java', ('java',)),
+                      trie.find('my/project/src/main/long/path/java/org/pantsbuild/foo/Foo.java'))
+
+  def test_all_roots(self):
+    self.create_dir('src/java')
+    self.create_dir('src/python')
+    self.create_dir('src/example/java')
+    self.create_dir('src/example/python')
+    self.create_dir('my/project/src/java')
+    self.create_dir('not/a/srcroot/java')
+
+    options = {
+      'langs': ['java', 'python', 'nonexistent'],
+      'source_root_parents': ['src/', 'src/example'],
+    }
+    options.update(self.options[''])  # We need inherited values for pants_workdir etc.
+
+    source_roots = create_subsystem(SourceRootConfig, **options).get_source_roots()
+    self.assertEquals({('src/java', ('java',)),
+                       ('src/python', ('python',)),
+                       ('src/example/java', ('java',)),
+                       ('src/example/python', ('python',)),
+                       ('my/project/src/java', ('java',))},
+                      set(source_roots.all_roots()))

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -316,10 +316,9 @@ python_tests(
   sources = ['test_roots.py'],
   dependencies = [
     ':task_test_base',
-    'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/core/tasks:roots',
     'src/python/pants/base:build_environment',
-    'src/python/pants/build_graph',
+    'src/python/pants/source',
   ],
 )
 

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -147,7 +147,8 @@ class ConsoleTaskTestBase(TaskTestBase):
       task.execute()
       return output.getvalue()
 
-  def execute_console_task(self, targets=None, extra_targets=None, options=None, passthru_args=None, workspace=None):
+  def execute_console_task(self, targets=None, extra_targets=None, options=None,
+                           passthru_args=None, workspace=None):
     """Creates a new task and executes it with the given config, command line args and targets.
 
     :param options: option values.

--- a/tests/python/pants_test/tasks/test_roots.py
+++ b/tests/python/pants_test/tasks/test_roots.py
@@ -10,53 +10,56 @@ from contextlib import contextmanager
 
 from pants.backend.core.tasks.roots import ListRoots
 from pants.base.build_environment import get_buildroot
-from pants.base.source_root import SourceRoot
-from pants.build_graph.target import Target
+from pants.source.source_root import SourceRootConfig, SourceRoots
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
 @contextmanager
 def register_sourceroot():
   try:
-    yield SourceRoot.register
+    yield SourceRoots.register
   except (ValueError, IndexError) as e:
     print('SourceRoot Registration Failed.')
     raise e
   finally:
-    SourceRoot.reset()
+    SourceRoots.reset()
 
 
 class ListRootsTest(ConsoleTaskTestBase):
-
-  class TypeA(Target):
-    pass
-
-  class TypeB(Target):
-    pass
-
   @classmethod
   def task_type(cls):
     return ListRoots
 
+  def setUp(self):
+    super(ListRootsTest, self).setUp()
+    self.set_options_for_scope(SourceRootConfig.options_scope, langs=[],
+                               source_root_parents=[], test_root_parents=[],
+                               source_root_patterns={}, test_root_patterns={},
+                               source_roots={}, test_roots={})
+    self._context = self.context()
+
+  def _add_source_root(self, path, langs):
+    os.makedirs(os.path.join(get_buildroot(), path))
+    self._context.source_roots.register(path, langs)
+
+  def _assert_output(self, expected):
+    self.assertEqual(expected, self.execute_console_task_given_context(self._context))
+
   def test_roots_without_register(self):
     try:
-      self.assert_console_output()
+      self._assert_output([])
     except AssertionError:
       self.fail('./pants goal roots failed without any registered SourceRoot.')
 
-  def test_no_source_root(self):
-    with register_sourceroot() as sourceroot:
-      sourceroot(os.path.join(get_buildroot(), 'fakeroot'))
-      self.assert_console_output('fakeroot: *')
+  def test_no_langs(self):
+    self._add_source_root('fakeroot', tuple())
+    self._assert_output(['fakeroot: *'])
 
   def test_single_source_root(self):
-    with register_sourceroot() as sourceroot:
-      sourceroot(os.path.join(get_buildroot(), 'fakeroot'), ListRootsTest.TypeA,
-                                                            ListRootsTest.TypeB)
-      self.assert_console_output('fakeroot: TypeA,TypeB')
+    self._add_source_root('fakeroot', ('lang1', 'lang2'))
+    self._assert_output(['fakeroot: lang1,lang2'])
 
   def test_multiple_source_root(self):
-    with register_sourceroot() as sourceroot:
-      sourceroot(os.path.join(get_buildroot(), 'fakerootA'), ListRootsTest.TypeA)
-      sourceroot(os.path.join(get_buildroot(), 'fakerootB'), ListRootsTest.TypeB)
-      self.assert_console_output('fakerootA: TypeA', 'fakerootB: TypeB')
+    self._add_source_root('fakerootA', ('lang1',))
+    self._add_source_root('fakerootB', ('lang2',))
+    self._assert_output(['fakerootA: lang1', 'fakerootB: lang2'])


### PR DESCRIPTION
Takes source root information from options, instead of from
bootstrap BUILD files.

Does pattern-matching, with sensible defaults, so that in the
typical case the right thing "just happens".

Distinguishes between source and test roots, for cases where
that matters.

Gets rid of validation that source roots contain only the "right"
types of targets.  This was rather ad-hoc, and properly belongs
with any other per-repo validation rules.

Instead, introduces the concept of a 'language' (currently just
a string like 'java' or 'resources'), that source roots may be
associated with. What we do with that in the future is open.