### PR TITLE
Fix `BuildFileAddressMapper.scan_addresses`.

### DIFF
--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
+
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.build_graph.address import Address, parse_spec
@@ -27,23 +29,22 @@ class BuildFileAddressMapper(object):
   """
 
   class AddressNotInBuildFile(AddressLookupError):
-    """ Raised when an address cannot be found in an existing BUILD file."""
-    pass
+    """Indicates an address cannot be found in an existing BUILD file."""
 
   class EmptyBuildFileError(AddressLookupError):
-    """Raised if no addresses are defined in a BUILD file."""
-    pass
+    """Indicates no addresses are defined in a BUILD file."""
 
   class InvalidBuildFileReference(AddressLookupError):
-    """ Raised when a BUILD file does not exist at the address referenced."""
-    pass
+    """Indicates no BUILD file exists at the address referenced."""
 
   class InvalidAddressError(AddressLookupError):
-    """ Raised when an address cannot be parsed."""
-    pass
+    """Indicates an address cannot be parsed."""
 
   class BuildFileScanError(AddressLookupError):
-    """ Raised when a problem was encountered scanning a tree of BUILD files."""
+    """Indicates a problem was encountered scanning a tree of BUILD files."""
+
+  class InvalidRootError(BuildFileScanError):
+    """Indicates an invalid scan root was supplied."""
 
   def __init__(self, build_file_parser, build_file_type):
     """Create a BuildFileAddressMapper.
@@ -199,13 +200,22 @@ class BuildFileAddressMapper(object):
 
   def scan_addresses(self, root=None, spec_excludes=None):
     """Recursively gathers all addresses visible under `root` of the virtual address space.
+
+    :param string root: The absolute path of the root to scan; defaults to the root directory of the
+                        pants project.
+    :rtype: set of :class:`pants.build_graph.address.Address`
     :raises AddressLookupError: if there is a problem parsing a BUILD file
-    :param path root: defaults to the root directory of the pants project.
     """
+    if root and os.path.commonprefix([get_buildroot(), root]) != get_buildroot():
+      raise self.InvalidRootError('The given root_dir is not an absolute sub-directory of the '
+                                  'build root: {}'.format(root))
+    base_path = os.path.relpath(root, get_buildroot()) if root else None
+
     addresses = set()
-    root = root or get_buildroot()
     try:
-      for build_file in self._build_file_type.scan_buildfiles(root, spec_excludes=spec_excludes):
+      for build_file in self._build_file_type.scan_buildfiles(root_dir=get_buildroot(),
+                                                              base_path=base_path,
+                                                              spec_excludes=spec_excludes):
         for address in self.addresses_in_spec_path(build_file.spec_path):
           addresses.add(address)
     except BuildFile.BuildFileError as e:

--- a/tests/python/pants_test/backend/core/test_wrapped_globs.py
+++ b/tests/python/pants_test/backend/core/test_wrapped_globs.py
@@ -38,15 +38,15 @@ class FilesetRelPathWrapperTest(BaseTest):
 
   def test_no_dir_glob(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*"))')
-    self.context().scan(self.build_root)
+    self.context().scan()
 
   def test_no_dir_glob_question(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("?"))')
-    self.context().scan(self.build_root)
+    self.context().scan()
 
   def _spec_test(self, spec, expected):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources={})'.format(spec))
-    graph = self.context().scan(self.build_root)
+    graph = self.context().scan()
     globs = graph.get_target_from_spec('y').globs_relative_to_buildroot()
     self.assertEquals(expected, globs)
 
@@ -101,18 +101,24 @@ class FilesetRelPathWrapperTest(BaseTest):
                                'y/a/*.java']})
 
   def test_glob_exclude(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*.java", exclude=[["fleem.java"]]))')
-    graph = self.context().scan(self.build_root)
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(name="y", sources=globs("*.java", exclude=[["fleem.java"]]))
+      """))
+    graph = self.context().scan()
     assert ['morx.java'] == list(graph.get_target_from_spec('y').sources_relative_to_source_root())
 
   def test_glob_exclude_not_string(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*.java", exclude="fleem.java"))')
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(name="y", sources=globs("*.java", exclude="fleem.java"))
+      """))
     with self.assertRaisesRegexp(AddressLookupError, 'Expected exclude parameter.*'):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_glob_exclude_string_in_list(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*.java", exclude=["fleem.java"]))')
-    self.context().scan(self.build_root)
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(name="y", sources=globs("*.java", exclude=["fleem.java"]))
+      """))
+    self.context().scan()
 
   def test_glob_exclude_doesnt_modify_exclude_array(self):
     self.add_to_build_file('y/BUILD', dedent("""
@@ -121,76 +127,89 @@ class FilesetRelPathWrapperTest(BaseTest):
       java_library(name="z", sources=list_of_files)
       """))
 
-    graph = self.context().scan(self.build_root)
+    graph = self.context().scan()
 
     self.assertEqual(['fleem.java'],
                      list(graph.get_target_from_spec('y:z').sources_relative_to_source_root()))
 
   def test_glob_invalid_keyword(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*.java", invalid_keyword=["fleem.java"]))')
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(name="y", sources=globs("*.java", invalid_keyword=["fleem.java"]))
+      """))
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_glob_invalid_keyword_along_with_valid_ones(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*.java", follow_links=True, invalid_keyword=["fleem.java"]))')
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(
+        name="y",
+        sources=globs("*.java", follow_links=True, invalid_keyword=["fleem.java"])
+      )
+      """))
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_subdir_glob(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("dir/*.scala"))')
-    self.context().scan(self.build_root)
+    self.context().scan()
 
   def test_subdir_glob_question(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("dir/?.scala"))')
-    self.context().scan(self.build_root)
+    self.context().scan()
 
   def test_subdir_bracket_glob(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("dir/[dir1, dir2]/*.scala"))')
-    self.context().scan(self.build_root)
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(name="y", sources=globs("dir/[dir1, dir2]/*.scala"))
+      """))
+    self.context().scan()
 
   def test_subdir_with_dir_glob(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("dir/**/*.scala"))')
-    self.context().scan(self.build_root)
+    self.context().scan()
 
   # This is no longer allowed.
   def test_parent_dir_glob(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../*.scala"))')
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_parent_dir_glob_question(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../?.scala"))')
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_parent_dir_bracket_glob_question(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../[dir1, dir2]/?.scala"))')
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(name="y", sources=globs("../[dir1, dir2]/?.scala"))
+      """))
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_parent_dir_bracket(self):
-    self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("../[dir1, dir2]/File.scala"))')
+    self.add_to_build_file('y/BUILD', dedent("""
+      java_library(name="y", sources=globs("../[dir1, dir2]/File.scala"))
+      """))
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_absolute_dir_glob(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("/root/*.scala"))')
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_absolute_dir_glob_question(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("/root/?.scala"))')
     with self.assertRaises(AddressLookupError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_rglob_follows_symlinked_dirs_by_default(self):
     self.add_to_build_file('z/w/BUILD', 'java_library(name="w", sources=rglobs("*.java"))')
-    graph = self.context().scan(self.build_root)
+    graph = self.context().scan()
     relative_sources = list(graph.get_target_from_spec('z/w').sources_relative_to_source_root())
     assert ['y/fleem.java', 'y/morx.java', 'foo.java'] == relative_sources
 
   def test_rglob_respects_follow_links_override(self):
     self.add_to_build_file('z/w/BUILD',
                            'java_library(name="w", sources=rglobs("*.java", follow_links=False))')
-    graph = self.context().scan(self.build_root)
+    graph = self.context().scan()
     assert ['foo.java'] == list(graph.get_target_from_spec('z/w').sources_relative_to_source_root())

--- a/tests/python/pants_test/base/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/base/test_build_file_address_mapper.py
@@ -49,15 +49,27 @@ class BuildFileAddressMapperTest(BaseTest):
     self.assertEquals({BuildFileAddress(root_build_file, 'foo'),
                        BuildFileAddress(subdir_build_file, 'bar'),
                        BuildFileAddress(subdir_suffix_build_file, 'baz')},
-                      self.address_mapper.scan_addresses(root=self.build_root))
+                      self.address_mapper.scan_addresses())
 
   def test_scan_addresses_with_excludes(self):
     root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
     self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
     spec_excludes = [os.path.join(self.build_root, 'subdir')]
     self.assertEquals({BuildFileAddress(root_build_file, 'foo')},
-                      self.address_mapper.scan_addresses(root=self.build_root,
-                                                         spec_excludes=spec_excludes))
+                      self.address_mapper.scan_addresses(spec_excludes=spec_excludes))
+
+  def test_scan_addresses_with_root(self):
+    self.add_to_build_file('BUILD', 'target(name="foo")')
+    subdir_build_file = self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
+    subdir_suffix_build_file = self.add_to_build_file('subdir/BUILD.suffix', 'target(name="baz")')
+    subdir = os.path.join(self.build_root, 'subdir')
+    self.assertEquals({BuildFileAddress(subdir_build_file, 'bar'),
+                       BuildFileAddress(subdir_suffix_build_file, 'baz')},
+                      self.address_mapper.scan_addresses(root=subdir))
+
+  def test_scan_addresses_with_invalid_root(self):
+    with self.assertRaises(BuildFileAddressMapper.InvalidRootError):
+      self.address_mapper.scan_addresses(root='subdir')
 
   def test_raises_invalid_build_file_reference(self):
     # reference a BUILD file that doesn't exist

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -75,16 +75,16 @@ class PayloadTest(BaseTest):
     # nesting no longer allowed
     self.add_to_build_file('z/BUILD', 'java_library(name="z", sources=[globs("*")])')
     with self.assertRaises(ValueError):
-      self.context().scan(self.build_root)
+      self.context().scan()
 
   def test_flat_globs_list(self):
     # flattened allowed
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=globs("*"))')
-    self.context().scan(self.build_root)
+    self.context().scan()
 
   def test_single_source(self):
     self.add_to_build_file('y/BUILD', 'java_library(name="y", sources=["Source.scala"])')
-    self.context().scan(self.build_root)
+    self.context().scan()
 
   def test_missing_payload_field(self):
     payload = Payload()


### PR DESCRIPTION
Previously passing an alternate `root` did not work, and by extension,
neither did passin a custom root to `Context.scan`

Add a failing test that this change fixes as well as a test of the new
root validity checking code.

https://rbcommons.com/s/twitter/r/2974/