### PR TITLE
Add support for golang.org/x remote libs.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
@@ -280,12 +280,16 @@ class ArchiveFetcher(Fetcher, Subsystem):
   options_scope = 'archive-fetcher'
 
   _DEFAULT_MATCHERS = {
-    r'bitbucket.org/(?P<user>[^/]+)/(?P<repo>[^/]+)':
+    r'bitbucket\.org/(?P<user>[^/]+)/(?P<repo>[^/]+)':
       UrlInfo(url_format='https://bitbucket.org/\g<user>/\g<repo>/get/{rev}.tar.gz',
               default_rev='tip',
               strip_level=1),
-    r'github.com/(?P<user>[^/]+)/(?P<repo>[^/]+)':
+    r'github\.com/(?P<user>[^/]+)/(?P<repo>[^/]+)':
       UrlInfo(url_format='https://github.com/\g<user>/\g<repo>/archive/{rev}.tar.gz',
+              default_rev='master',
+              strip_level=1),
+    r'golang\.org/x/(?P<repo>[^/]+)':
+      UrlInfo(url_format='https://github.com/golang/\g<repo>/archive/{rev}.tar.gz',
               default_rev='master',
               strip_level=1),
   }
@@ -569,3 +573,4 @@ Fetchers._register_default(r'^gopkg\.in/.*$', GopkgInFetcher)
 Fetchers.advertise(ArchiveFetcher, namespace='')
 Fetchers._register_default(r'^bitbucket\.org/.*$', ArchiveFetcher)
 Fetchers._register_default(r'^github\.com/.*$', ArchiveFetcher)
+Fetchers._register_default(r'^golang\.org/x/.*$', ArchiveFetcher)

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
@@ -51,6 +51,12 @@ class FetchersTest(unittest.TestCase):
     self.check_default('github.com/docker/docker/daemon/events',
                        expected_root='github.com/docker/docker')
 
+  def test_default_golang(self):
+    self.check_default('golang.org/x/oauth2',
+                       expected_root='github.com/golang/oauth2')
+    self.check_default('golang.org/x/net/context',
+                       expected_root='github.com/golang/net')
+
   def test_default_gopkg(self):
     self.check_default('gopkg.in/check.v1', expected_root='gopkg.in/check.v1')
 

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
@@ -64,8 +64,6 @@ class FetchersTest(unittest.TestCase):
 class GolangOrgFetcherTest(unittest.TestCase):
 
   def do_fetch(self, import_path, expected_url, rev=None):
-    # Simulate a series of github api calls to list refs for the given import paths.
-    # Optionally asserts an expected fetch call to the underlying fetcher.
     with subsystem_instance(ArchiveFetcher) as fetcher:
       fetcher._fetch = mock.MagicMock(spec=fetcher._fetch)
       with temporary_dir() as dest:


### PR DESCRIPTION
Although golang.org/x supports the `go get` <meta> protocol, pants does
not have a `Fetcher` that supports that protocol yet, so just use the
standard `ArchiveFetcher` with a regex mapping that redirects directly
to github (this appears to be the consistent pattern of th golang.org/x
<meta> re-directs).

Add a test to cover this new default fetcher configuration.

https://rbcommons.com/s/twitter/r/2976/