### PR TITLE
Simplify fetcher regexes; doc the '^' assumption.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
@@ -184,9 +184,11 @@ class Fetchers(Subsystem):
     register('--mapping', metavar='<mapping>', type=dict_option, default=cls._DEFAULT_FETCHERS,
              advanced=True,
              help="A mapping from a remote import path matching regex to a fetcher type to use "
-                  "to fetch the remote sources.  Fetcher types are fully qualified class names "
-                  "or else an installed alias for a fetcher type; ie the builtin "
-                  "`contrib.go.subsystems.fetchers.ArchiveFetcher` is aliased as 'ArchiveFetcher'.")
+                  "to fetch the remote sources.  The regex must match the beginning of the remote "
+                  "import path; no '^' anchor is needed, it is assumed.  The Fetcher types are "
+                  "fully qualified class names or else an installed alias for a fetcher type; ie "
+                  "the builtin `contrib.go.subsystems.fetchers.ArchiveFetcher` is aliased as "
+                  "'ArchiveFetcher'.")
 
   class GetFetcherError(Exception):
     """Indicates an error finding an appropriate Fetcher."""
@@ -302,8 +304,9 @@ class ArchiveFetcher(Fetcher, Subsystem):
              # They're converted to a single space by the help formatting and the resulting long
              # line of help text is simply wrapped.
              help="A mapping from a remote import path matching regex to an UrlInfo struct "
-                  "describing how to fetch and unpack a remote import path.  The UrlInfo struct is "
-                  "a 3-tuple with the following slots:\n"
+                  "describing how to fetch and unpack a remote import path.  The regex must match "
+                  "the beginning of the remote import path; no '^' anchor is needed, it is "
+                  "assumed. The UrlInfo struct is a 3-tuple with the following slots:\n"
                   "0. An url format string that is supplied to the regex match\'s `.template` "
                   "method and then formatted with the remote import path\'s `rev` and `pkg`.\n"
                   "1. The default revision string to use when no `rev` is supplied; ie 'HEAD' or "
@@ -568,9 +571,9 @@ class GopkgInFetcher(Fetcher, Subsystem):
 # All builtin fetchers should be advertised and registered as defaults here, 1st advertise,
 # then register:
 Fetchers.advertise(GopkgInFetcher, namespace='')
-Fetchers._register_default(r'^gopkg\.in/.*$', GopkgInFetcher)
+Fetchers._register_default(r'gopkg\.in/.*', GopkgInFetcher)
 
 Fetchers.advertise(ArchiveFetcher, namespace='')
-Fetchers._register_default(r'^bitbucket\.org/.*$', ArchiveFetcher)
-Fetchers._register_default(r'^github\.com/.*$', ArchiveFetcher)
-Fetchers._register_default(r'^golang\.org/x/.*$', ArchiveFetcher)
+Fetchers._register_default(r'bitbucket\.org/.*', ArchiveFetcher)
+Fetchers._register_default(r'github\.com/.*', ArchiveFetcher)
+Fetchers._register_default(r'golang\.org/x/.*', ArchiveFetcher)


### PR DESCRIPTION
Both `Fetchers` and `ArchiveFetcher` employ regexes and both check that
matches start at the 0th slot; as such, no explicit anchors are needed.
Document this fact and remove anchors from the builtin default
configuration.

https://rbcommons.com/s/twitter/r/2980/