### PR TITLE
Introduce the 1st cut at the new engine frontend.

### DIFF
--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -57,6 +57,7 @@ python_library(
   dependencies=[
     '3rdparty/python:six',
     ':objects',
+    'src/python/pants/build_graph',
     'src/python/pants/util:memo',
   ]
 )

--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -63,6 +63,17 @@ python_library(
 )
 
 python_library(
+  name='scheduler',
+  sources=['scheduler.py'],
+  dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:six',
+    'src/python/pants/engine/exp:objects',
+    'src/python/pants/util:meta',
+  ]
+)
+
+python_library(
   name='targets',
   sources=['targets.py'],
   dependencies=[

--- a/src/python/pants/engine/exp/scheduler.py
+++ b/src/python/pants/engine/exp/scheduler.py
@@ -1,0 +1,570 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import collections
+from abc import abstractmethod, abstractproperty
+from collections import defaultdict
+
+import six
+from twitter.common.collections import OrderedSet
+
+from pants.engine.exp.objects import Serializable
+from pants.util.meta import AbstractClass
+
+
+class Subject(object):
+  """The subject of a production plan."""
+
+  @classmethod
+  def as_subject(cls, item):
+    """Return the given item as the primary of a subject if its not already a subject.
+
+    :rtype: :class:`Subject`
+    """
+    return item if isinstance(item, Subject) else cls(primary=item)
+
+  def __init__(self, primary, alternate=None):
+    """
+    :param primary: The primary subject of a production plan.
+    :param alternate: An alternate subject as suggested by some other plan.
+    """
+    self._primary = primary
+    self._alternate = alternate
+
+  @property
+  def primary(self):
+    """Return the primary subject."""
+    return self._primary
+
+  @property
+  def iter_derivations(self):
+    """Iterates over all subjects.
+
+    The primary subject will always be returned as the 1st item from the iterator and if there is
+    an alternate, it will be returned next.
+
+    :rtype: :class:`collection.Iterator`
+    """
+    yield self._primary
+    if self._alternate:
+      yield self._alternate
+
+  def __hash__(self):
+    return hash(self._primary)
+
+  def __eq__(self, other):
+    return isinstance(other, Subject) and self._primary == other._primary
+
+  def __ne__(self, other):
+    return not (self == other)
+
+  def __repr__(self):
+    return 'Subject(primary={!r}, alternate={!r})'.format(self._primary, self._alternate)
+
+
+class Plan(Serializable):
+  """Represents an production plan that will yield a given product type for one or more subjects.
+
+  A plan can be serialized and executed wherever its task type and and source inputs it needs are
+  available.
+  """
+  # TODO(John Sirois): Sources are currently serialized as paths relative to the build root, but
+  # they could also be serialized a a path + blob.  Talks about distributed backend solutions will
+  # shake out if we need this in the near term.  Even if we only need paths for remote execution,
+  # it probably makes sense to ship a path + hash pair so a remote build can fail fast if its source
+  # inputs don't match local expectations.
+  # NB: We don't ship around toolchains, just requirements of them as specified in plan inputs, like
+  # the apache thrift compiler version.  There may need to be a protocol as a result that
+  # pre-screens remote nodes for the capability to execute a given plan in-general (some nodes may
+  # have a required toolchain but some may not and pants may have no intrinsic to fetch the
+  # toolchain).  For example, pants can intrinsically fetch the Go toolchain in a Task today but it
+  # cannot do the same for the jdk and instead only asserts its presence.
+
+  def __init__(self, task_type, subjects, **inputs):
+    """
+    :param type task_type: The type of :class:`Task` that will execute this plan.
+    :param subjects: The subjects the plan will generate products for.
+    :type subjects: :class:`collections.Iterable` of :class:`Subject` or else objects that will
+                    be converted to the primary of a `Subject`.
+    """
+    # TODO(John Sirois): There's no reason this couldn't also just be a function.
+    self._task_type = task_type
+
+    self._subjects = frozenset(Subject.as_subject(subject) for subject in subjects)
+    self._inputs = inputs
+
+  @property
+  def subjects(self):
+    """Return the subjects of this plan.
+
+    When the plan is executed, its results will be associated with each one of these subjects.
+
+    :rtype: frozenset of :class:`Subject`
+    """
+    return self._subjects
+
+  def __getattr__(self, item):
+    return self._inputs[item]
+
+  @staticmethod
+  def _is_mapping(value):
+    return isinstance(value, collections.Mapping)
+
+  @staticmethod
+  def _is_iterable(value):
+    return isinstance(value, collections.Iterable) and not isinstance(value, six.string_types)
+
+  def iter_promises(self):
+    """Return an iterator over the unique promises in this plan's inputs.
+
+    A plan's promises indicate its dependency edges on other plans.
+
+    :rtype: :class:`collections.Iterator` of :class:`Promise`
+    """
+    # TODO(John Sirois): Ask other if this is sane.  The idea of **inputs is to allow for natural
+    # Task.execute functions with standard parameter lists.  In fact s/Task/function/ will work
+    # just fine.  The engine backend just needs to replace plan **inputs promises with resolved
+    # products and then splat inputs to the Task execution function.
+    promises = set()
+
+    def _iter_promises(item):
+      if isinstance(item, Promise) and item not in promises:
+        promises.add(item)
+        yield item
+      elif self._is_mapping(item):
+        for _, v in item.items():
+          for p in _iter_promises(v):
+            yield p
+      elif self._is_iterable(item):
+        for i in item:
+          for p in _iter_promises(i):
+            yield p
+
+    for _, value in self._inputs.items():
+      for promise in _iter_promises(value):
+        yield promise
+
+  def _asdict(self):
+    d = self._inputs.copy()
+    d.update(task_type=self._task_type, subjects=tuple(self._subjects))
+    return d
+
+  def _key(self):
+    def hashable(value):
+      if self._is_mapping(value):
+        return tuple(sorted((k, hashable(v)) for k, v in value.items()))
+      elif self._is_iterable(value):
+        return tuple(hashable(v) for v in value)
+      else:
+        return value
+    return self._task_type, self._subjects, hashable(self._inputs)
+
+  def __hash__(self):
+    return hash(self._key())
+
+  def __eq__(self, other):
+    return isinstance(other, Plan) and self._key() == other._key()
+
+  def __ne__(self, other):
+    return not (self == other)
+
+  def __repr__(self):
+    return ('Plan(task_type={!r}, subjects={!r}, inputs={!r})'
+            .format(self._task_type, self._subjects, self._inputs))
+
+
+class SchedulingError(Exception):
+  """Indicates inability to make a required scheduling promise."""
+
+
+class Scheduler(object):
+  """Schedule the creation of products."""
+
+  def promise(self, subject, product_type, required=True):
+    """Return an promise for a product of the given `product_type` for the given `subject`.
+
+    If the promise is required and no production plans can be made a
+    :class:`Scheduler.SchedulingError` is raised.
+
+    :param subject: The subject that the product type should be created for.
+    :param product_type: The type of product to promise production of for the given subject.
+    :param bool required: `False` if the product is not required; `True` by default.
+    :returns: A promise to make the given product type available for subject at task execution time
+              or None if the promise was not required and no production plans could be made.
+    :rtype: :class:`Promise`
+    :raises: :class:`SchedulerError` if the promise was required and no production plans could be
+             made.
+    """
+    # TODO(John Sirois): Get to the bottom of this when using an AbstractClass base and
+    # @abstractmethod:
+    #  ERROR collecting tests/python/pants_test/engine/exp/test_scheduler.py
+    # tests/python/pants_test/engine/exp/test_scheduler.py:20: in <module>
+    #     from pants.engine.exp.scheduler import (BuildRequest, GlobalScheduler, Plan, Planners, Promise,
+    #                                             src/python/pants/engine/exp/scheduler.py:418: in <module>
+    #     class LocalScheduler(Scheduler):
+    #   ../jsirois-pants3/build-support/pants_dev_deps.venv/lib/python2.7/abc.py:90: in __new__
+    #   for name, value in namespace.items()
+    # ../jsirois-pants3/build-support/pants_dev_deps.venv/lib/python2.7/abc.py:91: in <genexpr>
+    # if getattr(value, "__isabstractmethod__", False))
+    # src/python/pants/engine/exp/scheduler.py:111: in __getattr__
+    # return self._inputs[item]
+    # E   KeyError: '__isabstractmethod__'
+    raise NotImplementedError()
+
+
+class TaskPlanner(AbstractClass):
+  """Produces plans to control execution of a paired task."""
+
+  class Error(Exception):
+    """Indicates an error creating a product plan for a subject."""
+
+  @abstractproperty
+  def goal_name(self):
+    """Return the name of the goal this planner's task should run from.
+
+    :rtype: string
+    """
+
+  # TODO(John Sirois): This method is only needed to short-circuit asking every planner for every
+  # promise request, perhaps kill this and/or do a perf compare and drop if negligible.  Right now
+  # it's boilerplate that can be done wrong.
+  @abstractproperty
+  def product_types(self):
+    """Return an iterator over the product types this planner's task can produce."""
+
+  @abstractmethod
+  def plan(self, scheduler, product_type, subject):
+    """
+    :param scheduler: A scheduler that can supply promises for any inputs needed that the planner
+                      cannot supply on its own to its associated task.
+    :type scheduler: :class:`Scheduler`
+    :param type product_type: The type of product this plan should produce given subject when
+                              executed.
+    :param object subject: The subject of the plan.  Any products produced will be for the subject.
+    """
+
+  def finalize_plans(self, plans):
+    """Subclasses can override to finalize the plans they created.
+
+    :param plans: All the plans emitted by this planner for the current planning session.
+    :type plans: :class:`collections.Iterable` of :class:`Plan`
+    :returns: A possibly different iterable of plans.
+    :rtype: :class:`collections.Iterable` of :class:`Plan`
+    """
+    return plans
+
+
+class Task(object):
+  """An executable task.
+
+  Tasks form the atoms of work done by pants and when executed generally produce artifacts as a
+  side effect whether these be files on disk (for example compilation outputs) or characters output
+  to the terminal (for example dependency graph metadata).  These outputs are always represented
+  by a product type - sometimes `None`.  The product type instaces the task returns can often be
+  used to access the contents side-effect outputs.
+  """
+
+  def execute(self, **inputs):
+    """Executes this task."""
+
+
+class Planners(object):
+  def __init__(self, planners):
+    self._planners_by_goal_name = defaultdict(set)
+    self._planners_by_product_type = defaultdict(set)
+    for planner in planners:
+      self._planners_by_goal_name[planner.goal_name].add(planner)
+      for product_type in planner.product_types:
+        self._planners_by_product_type[product_type].add(planner)
+
+  def for_goal(self, goal_name):
+    return self._planners_by_goal_name[goal_name]
+
+  def for_product_type(self, product_type):
+    return self._planners_by_product_type[product_type]
+
+
+class BuildRequest(object):
+  def __init__(self, goals, addressable_roots):
+    self._goals = goals
+    self._addressable_roots = addressable_roots
+
+  @property
+  def goals(self):
+    return self._goals
+
+  @property
+  def addressable_roots(self):
+    return self._addressable_roots
+
+  def __repr__(self):
+    return ('BuildRequest(goals={!r}, addressable_roots={!r})'
+            .format(self._goals, self._addressable_roots))
+
+
+class ExecutionGraph(object):
+  """A DAG of execution plans where edges represent data dependencies between plans."""
+
+  def __init__(self, root_promises, product_mapper):
+    """
+    :param root_promises: The root promises in the graph; these represent the final products
+                          requested.
+    :type root_promises: :class:`collections.Iterable` of :class:`Promise`
+    :param product_mapper: A registry of all plans in the execution graph that will be used to
+                           traverse from one plan's promises to the plans that will fulfill them
+                           when executed.
+    :type product_mapper: :class:`ProductMapper`
+    """
+    self._root_promises = root_promises
+    self._product_mapper = product_mapper
+
+  def walk(self):
+    """Performs a depth first post-order walk of the graph of execution plans.
+
+    All plans are visited exactly once.
+    """
+    plans = set()
+    for promise in self._root_promises:
+      for plan in self._walk_plan(promise, plans):
+        yield plan
+
+  def _walk_plan(self, pr, plans):
+    plan = self._product_mapper.promised(pr)
+    if plan not in plans:
+      plans.add(plan)
+      for pr in plan.iter_promises():
+        for pl in self._walk_plan(pr, plans):
+          yield pl
+      yield plan
+
+
+class Promise(object):
+  """Represents a promise to produce a given product type for a given subject."""
+
+  def __init__(self, product_type, subject):
+    """
+    :param type product_type: The type of product promised.
+    :param subject: The subject the product will be produced for; ie: a java library would be a
+                    natural subject for a request for classfile products.
+    :type subject: :class:`Subject` or else any object that will be the primary of the stored
+                   `Subject`.
+    """
+    self._product_type = product_type
+    self._subject = Subject.as_subject(subject)
+
+  @property
+  def subject(self):
+    """Return the subject of this promise.
+
+    :rtype: :class:`Subject`
+    """
+    return self._subject
+
+  def _key(self):
+    # We promise the product_type for the primary subject, the alternate does not affect consume
+    # side identity.
+    return self._product_type, self._subject.primary
+
+  def __hash__(self):
+    return hash(self._key())
+
+  def __eq__(self, other):
+    return isinstance(other, Promise) and self._key() == other._key()
+
+  def __ne__(self, other):
+    return not (self == other)
+
+  def __repr__(self):
+    return 'Promise(product_type={!r}, subject={!r})'.format(self._product_type, self._subject)
+
+
+class ProductMapper(object):
+  """Stores the mapping from promises to the plans whose execution will satisfy them."""
+
+  class InvalidRegistrationError(Exception):
+    """Indicates registration of a plan that does not cover the expected subject."""
+
+  def __init__(self):
+    self._promises = {}
+
+  def register_promises(self, product_type, plan, primary_subject=None):
+    """Registers the promises the given plan will satisfy when executed.
+
+    :param type product_type: The product type the plan will produce when executed.
+    :param plan: The plan to register promises for.
+    :type plan: :class:`Plan`
+    :param primary_subject: An optional primary subject.  If supplied, the registered promise for
+                            this subject will be returned.
+    :returns: The promise for the primary subject of one was supplied.
+    :rtype: :class:`Promise`
+    :raises:
+    """
+    # Index by all subjects.  This allows dependencies on products from "chunking" tasks, even
+    # products from tasks that act globally in the extreme.
+    primary_promise = None
+    for subject in plan.subjects:
+      promise = Promise(product_type, subject)
+      if primary_subject == subject.primary:
+        primary_promise = promise
+      self._promises[promise] = plan
+
+    if primary_subject and not primary_promise:
+      raise self.InvalidRegistrationError('The subject {} is not part of the final plan!: {}'
+                                          .format(primary_subject, plan))
+    return primary_promise
+
+  def promised(self, promise):
+    """Return the plan that was promised.
+
+    :param promise: The promise to lookup a registered plan for.
+    :type promise: :class:`Promise`
+    :returns: The plan registered for the given promise; or `None`.
+    :rtype: :class:`Plan`
+    """
+    return self._promises.get(promise)
+
+
+class LocalScheduler(Scheduler):
+  """A scheduler that formulates an execution graph locally.
+
+  This implementation is synchronous in addition to being local.
+  """
+
+  class NoProducersError(SchedulingError):
+    """Indicates no planners were able to promise a required product for a given subject."""
+
+    def __init__(self, product_type, subject=None):
+      msg = ('No plans to generate {!r}{} could be made.'
+             .format(product_type.__name__, ' {!r}'.format(subject) if subject else ''))
+      super(LocalScheduler.NoProducersError, self).__init__(msg)
+
+  class ConflictingProducersError(SchedulingError):
+    """Indicates more than one planner was able to promise a product for a given subject."""
+
+    def __init__(self, product_type, subject, planners):
+      msg = ('Collected the following plans for generating {!r} from {!r}\n\t{}'
+             .format(product_type.__name__,
+                     subject,
+                     '\n\t'.join(type(p).__name__ for p in planners)))
+      super(LocalScheduler.ConflictingProducersError, self).__init__(msg)
+
+  def __init__(self, planners):
+    """
+    :param planners: All the planners installed in the system.
+    :type planners: :class:`Planners`
+    """
+    self._planners = planners
+    self._product_mapper = ProductMapper()
+    self._plans_by_product_type_by_planner = defaultdict(lambda: defaultdict(OrderedSet))
+    self._planner_stack = []
+
+  def formulate_graph(self, goals, subjects):
+    """Formulate the execution graph that satisfies the given `build_request`.
+
+    :param goals: The names of the goals to achieve.
+    :type goals: :class:`collections.Iterable` of string
+    :param list subjects: The subjects to attempt the given goals for.
+    :returns: An execution graph of plans, that when reduced
+    :returns: An execution graph of plans that, when reduced, can satisfy the given build request.
+    :raises: :class:`LocalScheduler.SchedulingError` if no execution graph solution could be found.
+    """
+    root_promises = []
+    for goal in goals:
+      for planner in self._planners.for_goal(goal):
+        for product_type in planner.product_types:
+          # TODO(John Sirois): Allow for subject-less (target-less) goals.  Examples are clean-all,
+          # ng-killall, and buildgen.go.
+          for subject in subjects:
+            promise = self.promise(subject, product_type, required=False)
+            if promise:
+              root_promises.append(promise)
+
+    # Give aggregating planners a chance to aggregate plans.
+    for planner, plans_by_product_type in self._plans_by_product_type_by_planner.items():
+      for product_type, plans in plans_by_product_type.items():
+        finalized_plans = planner.finalize_plans(plans)
+        if finalized_plans is not plans:
+          for finalized_plan in finalized_plans:
+            self._product_mapper.register_promises(product_type, finalized_plan)
+
+    return ExecutionGraph(root_promises, self._product_mapper)
+
+  # A sentinel that denotes a `None` planning result that was accepted.  This can happen for
+  # promise requests that are not required.
+  NO_PLAN = Plan(task_type=None, subjects=())
+
+  def promise(self, subject, product_type, required=True):
+    promise = Promise(product_type, subject)
+    plan = self._product_mapper.promised(promise)
+    if plan is not None:
+      # The `NO_PLAN` plan may have been decided in a non-required round.
+      if required and promise is self.NO_PLAN:
+        raise self.NoProducersError(product_type, subject)
+      return None
+
+    planners = self._planners.for_product_type(product_type)
+    if required and not planners:
+      raise self.NoProducersError(product_type)
+
+    plans = []
+    for planner in planners:
+      self._planner_stack.append(planner)
+      plan = planner.plan(self, product_type, subject)
+      if plan:
+        plans.append((planner, plan))
+      self._planner_stack.pop(-1)
+
+    if len(plans) > 1:
+      planners = [planner for planner, plan in plans]
+      raise self.ConflictingProducersError(product_type, subject, planners)
+    elif not plans:
+      if required:
+        raise self.NoProducersError(product_type, subject)
+      self._product_mapper.register_promises(product_type, self.NO_PLAN)
+      return None
+
+    planner, plan = plans[0]
+    try:
+      primary_promise = self._product_mapper.register_promises(product_type, plan,
+                                                               primary_subject=subject)
+      self._plans_by_product_type_by_planner[planner][product_type].add(plan)
+      return primary_promise
+    except ProductMapper.InvalidRegistrationError:
+      raise SchedulingError('The plan produced for {subject!r} by {planner!r} does not cover '
+                            '{subject!r}:\n\t{plan!r}'.format(subject=subject,
+                                                              planner=type(planner).__name__,
+                                                              plan=plan))
+
+
+class GlobalScheduler(object):
+  """Generates execution graphs for build requests.
+
+  This is the front-end of the new pants execution engine.
+  """
+
+  def __init__(self, graph, planners):
+    """
+    :param graph: The BUILD graph build requests will execute against.
+    :type graph: :class:`pants.engine.exp.graph.Graph`
+    :param planners: All the task planners known to the system.
+    :type planners: :class:`Planners`
+    """
+    self._graph = graph
+    self._planners = planners
+
+  def execution_graph(self, build_request):
+    """Create an execution graph that can satisfy the given build request.
+
+    :param build_request: The description of the goals to achieve.
+    :type build_request: :class:`BuildRequest`
+    :returns: An execution graph of plans that, when reduced, can satisfy the given build request.
+    :rtype: :class:`ExecutionGraph`
+    """
+    scheduler = LocalScheduler(planners=self._planners)
+    goals = build_request.goals
+    subjects = [self._graph.resolve(a) for a in build_request.addressable_roots]
+    return scheduler.formulate_graph(goals, subjects)

--- a/src/python/pants/engine/exp/targets.py
+++ b/src/python/pants/engine/exp/targets.py
@@ -114,7 +114,7 @@ class Target(Configuration):
     :rtype list of :class:`pants.engine.exp.configuration.Configuration`
     """
 
-  @property
+  @addressable_list(SubclassesOf(Configuration))
   def dependencies(self):
     """The direct dependencies of this target.
 
@@ -150,7 +150,3 @@ class Target(Configuration):
 
     :rtype: :class:`Sources`
     """
-
-# Since Target.dependencies is recursive on the Target type, we need to post-class-definition
-# re-define dependencies in this way.
-Target.dependencies = addressable_list(SubclassesOf(Configuration))(Target.dependencies)

--- a/src/python/pants/engine/exp/targets.py
+++ b/src/python/pants/engine/exp/targets.py
@@ -5,74 +5,152 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.engine.exp.addressable import (Exactly, SubclassesOf, addressable, addressable_dict,
-                                          addressable_list)
+import itertools
+import os
+
+from pants.backend.core.wrapped_globs import Globs, RGlobs, ZGlobs
+from pants.engine.exp.addressable import Exactly, SubclassesOf, addressable, addressable_list
 from pants.engine.exp.configuration import Configuration
 
 
-# TODO(John Sirois): document as the contract for targets fleshes out; especially the role of
-# configurations.
-class Target(Configuration):
-  # An example of an addressable (is Serializable + has a name) that can cause graph walks.  The
-  # only magic here are the fields wrapped with `addressables` which allow for mixed addresses and
-  # embedded objects.  The addresses are tagged by being wrapped in the Addressed type which allows
-  # a lazy resolution of the addressed and re-construction of this object with the fully resolved
-  # properties later.
+class Sources(Configuration):
+  """Represents a collection of source files."""
 
-  def __init__(self, name=None, configurations=None, dependencies=None, **kwargs):
+  def __init__(self,
+               name=None,
+               files=None,
+               globs=None,
+               rglobs=None,
+               zglobs=None,
+               excludes=None,
+               **kwargs):
+    """
+    :param string name: An optional name of this set of sources if the set is top-level for sharing.
+    :param files: A list of relative file paths to include.
+    :type files: list of string.
+    :param string globs: A relative glob pattern of files to include.
+    :param string rglobs: A relative recursive glob pattern of files to include.
+    :param string zglobs: A relative zsh-style glob pattern of files to include.
+    :param zglobs: A relative zsh-style glob pattern of files to include.
+    :param excludes: A set of sources to exclude from the sources gathered via files, globs, rglobs
+                     and zglobs.
+    :type excludes: :class:`Sources`
+    """
+    super(Sources, self).__init__(name=name, files=files, globs=globs, rglobs=rglobs, zglobs=zglobs,
+                                  **kwargs)
+    self.excludes = excludes
+
+  @property
+  def excludes(self):
+    """The sources to exclude.
+
+    :rtype: :class:`Sources`
+    """
+
+  def iter_paths(self, base_path=None, ext=None):
+    """Return an iterator over this collection of sources file paths.
+
+    If these sources are addressable, the paths returned will have a base path of the address
+    `spec_path`; otherwise a `base_path` must be explicitly supplied.
+
+    :param string base_path: If this collection of sources is not addressed, the base path in the
+                             repo the sources are relative to.
+    :param string ext: An optional file extension filter to restrict returned file paths with.
+    :returns: An iterator over the source paths that match the given file extension (if any) and are
+              not excluded by `excludes`.  Paths are of the form
+              `os.path.join(base_path, rel_path)`.
+    :rtype: :class:`collections.Iterator` of string
+    """
+    base_path = self.address.spec_path if self.address else base_path
+    if not base_path:
+      raise ValueError('A `base_path` must be supplied to iterate paths for {!r}'.format(self))
+
+    def select(file_name):
+      return file_name.endswith(ext) if ext else True
+
+    excluded_files = frozenset(self.excludes.iter_paths(base_path)) if self.excludes else ()
+
+    def file_sources():
+      if self.files:
+        yield self.files
+      for spec, fileset_wrapper_type in ((self.globs, Globs),
+                                         (self.rglobs, RGlobs),
+                                         (self.zglobs, ZGlobs)):
+        if spec:
+          fileset = fileset_wrapper_type(base_path)(spec)
+          yield fileset
+
+    for rel_path in itertools.chain.from_iterable(file_sources()):
+      if select(rel_path):
+        file_path = os.path.join(base_path, rel_path)
+        if file_path not in excluded_files:
+          yield file_path
+
+# Since Sources.excludes is recursive on the Sources type, we need to post-class-definition
+# re-define excludes in this way.
+Sources.excludes = addressable(Exactly(Sources))(Sources.excludes)
+
+
+class Target(Configuration):
+  """TODO(John Sirois): XXX DOCME"""
+
+  def __init__(self, name=None, sources=None, configurations=None, dependencies=None, **kwargs):
+    """
+    :param string name: The name of this target which forms its address in its namespace.
+    :param sources: The relative source file paths of sources this target owns.
+    :type sources: :class:`Sources`
+    :param list configurations: The configurations that apply to this target in various contexts.
+    :param list dependencies: The direct dependencies of this target.
+    """
     super(Target, self).__init__(name=name, **kwargs)
     self.configurations = configurations
     self.dependencies = dependencies
+    self.sources = sources
 
   @addressable_list(SubclassesOf(Configuration))
   def configurations(self):
-    """"""
+    """The configurations that apply to this target in various contexts.
+
+    :rtype list of :class:`pants.engine.exp.configuration.Configuration`
+    """
 
   @property
   def dependencies(self):
-    """"""
+    """The direct dependencies of this target.
+
+    :rtype: list
+    """
+
+  def walk_targets(self, postorder=True):
+    """Performs a depth first walk of this target, visiting all reachable targets exactly once.
+
+    :param bool postorder: When ``True``, the traversal order is postorder (children before
+                           parents), else it is preorder (parents before children).
+    """
+    visited = set()
+
+    def walk(target):
+      if target not in visited:
+        visited.add(target)
+        if not postorder:
+          yield target
+        for dep in self.dependencies:
+          if isinstance(dep, Target):
+            for t in walk(dep):
+              yield t
+        if postorder:
+          yield target
+
+    for target in walk(self):
+      yield target
+
+  @addressable(Exactly(Sources))
+  def sources(self):
+    """Return the sources this target owns.
+
+    :rtype: :class:`Sources`
+    """
 
 # Since Target.dependencies is recursive on the Target type, we need to post-class-definition
 # re-define dependencies in this way.
-Target.dependencies = addressable_list(SubclassesOf(Target))(Target.dependencies)
-
-
-class ApacheThriftConfiguration(Configuration):
-  # An example of a mixed-mode object - can be directly embedded without a name or else referenced
-  # via address if both top-level and carrying a name.
-  #
-  # Also an example of a more constrained config object that has an explicit set of allowed fields
-  # and that can have pydoc hung directly off the constructor to convey a fully accurate BUILD
-  # dictionary entry.
-
-  def __init__(self, name=None, version=None, strict=None, lang=None, options=None, **kwargs):
-    super(ApacheThriftConfiguration, self).__init__(name=name,
-                                                    version=version,
-                                                    strict=strict,
-                                                    lang=lang,
-                                                    options=options,
-                                                    **kwargs)
-
-  # An example of a validatable bit of config.
-  def validate_concrete(self):
-    if not self.version:
-      self.report_validation_error('A thrift `version` is required.')
-    if not self.lang:
-      self.report_validation_error('A thrift gen `lang` is required.')
-
-
-class PublishConfiguration(Configuration):
-  # An example of addressable and addressable_mapping field wrappers.
-
-  def __init__(self, default_repo, repos, name=None, **kwargs):
-    super(PublishConfiguration, self).__init__(name=name, **kwargs)
-    self.default_repo = default_repo
-    self.repos = repos
-
-  @addressable(Exactly(Configuration))
-  def default_repo(self):
-    """"""
-
-  @addressable_dict(Exactly(Configuration))
-  def repos(self):
-    """"""
+Target.dependencies = addressable_list(SubclassesOf(Configuration))(Target.dependencies)

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -11,6 +11,16 @@ python_tests(
 
 
 python_tests(
+  name='configuration',
+  sources=['test_configuration.py'],
+  dependencies=[
+    'src/python/pants/build_graph',
+    'src/python/pants/engine/exp:configuration',
+    'src/python/pants/engine/exp:objects',
+  ]
+)
+
+python_tests(
   name='graph',
   sources=['test_graph.py'],
   dependencies=[
@@ -47,11 +57,15 @@ python_tests(
 )
 
 python_tests(
-  name='configuration',
-  sources=['test_configuration.py'],
+  name='scheduler',
+  sources=['test_scheduler.py'],
   dependencies=[
     'src/python/pants/build_graph',
+    'src/python/pants/engine/exp:addressable',
     'src/python/pants/engine/exp:configuration',
-    'src/python/pants/engine/exp:objects',
+    'src/python/pants/engine/exp:graph',
+    'src/python/pants/engine/exp:mapper',
+    'src/python/pants/engine/exp:parsers',
+    'src/python/pants/engine/exp:targets',
   ]
 )

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -66,6 +66,8 @@ python_tests(
     'src/python/pants/engine/exp:graph',
     'src/python/pants/engine/exp:mapper',
     'src/python/pants/engine/exp:parsers',
+    'src/python/pants/engine/exp:scheduler',
     'src/python/pants/engine/exp:targets',
+    'src/python/pants/util:memo',
   ]
 )

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
@@ -3,12 +3,10 @@
 
 Target(
   name='thrift1',
-  sources=[]
 )
 
 Target(
   name='thrift2',
-  sources=[],
   dependencies=[
     ':thrift1',
   ]
@@ -19,7 +17,7 @@ Target(
 Target(
   name='java1',
   merges=':production_thrift_configs',
-  sources=[],
+  sources={},
   dependencies=[
     ':thrift2',
   ],

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -4,13 +4,12 @@
 {
   "type_alias": "Target",
   "name": "thrift1",
-  "sources": []
+  "sources": null
 }
 
 {
   "type_alias": "Target",
   "name": "thrift2",
-  "sources": [],
   "dependencies": [
     ":thrift1"
   ]
@@ -19,7 +18,7 @@
 {
   "type_alias": "Target",
   "name": "java1",
-  "sources": [],
+  "sources": {},
   "dependencies": [
     ":thrift2"
   ],

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.python
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.python
@@ -2,18 +2,17 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 thrift1 = Target(
-  sources=[]
+  sources=None,
 )
 
 thrift2 = Target(
-  sources=[],
+  sources={},
   dependencies=[
     ':thrift1',
   ]
 )
 
 java1 = Target(
-  sources=[],
   dependencies=[
     ':thrift2',
   ],

--- a/tests/python/pants_test/engine/exp/examples/mapper_test/a/b/b.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/mapper_test/a/b/b.BUILD.json
@@ -5,7 +5,6 @@
   "configurations": [
     "//a",
     {
-      "type_alias": "configuration",
       "embedded": "yes"
     }
   ]

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/3rdparty/jvm/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/3rdparty/jvm/BLD.json
@@ -1,0 +1,6 @@
+{
+  "type_alias": "jar",
+  "org": "com.google.guava",
+  "name": "guava",
+  "rev": "18.0"
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/simple/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/simple/BLD.json
@@ -1,0 +1,11 @@
+{
+  "type_alias": "target",
+  "name": "simple",
+  "sources": {
+    "files": ["Simple.java"]
+  },
+  "dependencies": [
+    "3rdparty/jvm:guava",
+    "src/thrift/codegen/simple"
+  ]
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/simple/Simple.java
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/simple/Simple.java
@@ -1,0 +1,1 @@
+// Placeholder file.

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
@@ -1,0 +1,33 @@
+{
+  "type_alias": "target",
+  "abstract": true,
+  "name": "java_thrift_base",
+  "configurations": [
+    {
+      "type_alias": "apache_thrift_configuration",
+      "rev": "0.9.2",
+      "strict": true,
+      "gen": "java",
+      "deps": [
+        {
+          "type_alias": "jar",
+          "org": "org.apache.thrift",
+          "name": "libthrift",
+          "rev": "0.9.2"
+        },
+        {
+          "type_alias": "jar",
+          "org": "commons-lang",
+          "name": "commons-lang",
+          "rev": "2.5"
+        },
+        {
+          "type_alias": "jar",
+          "org": "org.slf4j",
+          "name": "slf4j-api",
+          "rev": "1.6.1"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/simple/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/simple/BLD.json
@@ -1,0 +1,8 @@
+{
+  "type_alias": "target",
+  "extends": "src/thrift:java_thrift_base",
+  "name": "simple",
+  "sources": {
+    "files": ["simple.thrift"]
+  }
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/simple/simple.thrift
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/simple/simple.thrift
@@ -1,0 +1,1 @@
+// Placeholder file.

--- a/tests/python/pants_test/engine/exp/test_addressable.py
+++ b/tests/python/pants_test/engine/exp/test_addressable.py
@@ -33,16 +33,20 @@ class SuperclassesOfTest(TypeConstraintTestBase):
       SubclassesOf()
 
   def test_single(self):
-    self.assertTrue(SuperclassesOf(self.B).satisfied_by(self.A()))
-    self.assertTrue(SuperclassesOf(self.B).satisfied_by(self.B()))
-    self.assertFalse(SuperclassesOf(self.B).satisfied_by(self.BPrime()))
-    self.assertFalse(SuperclassesOf(self.B).satisfied_by(self.C()))
+    superclasses_of_b = SuperclassesOf(self.B)
+    self.assertEqual((self.B,), superclasses_of_b.types)
+    self.assertTrue(superclasses_of_b.satisfied_by(self.A()))
+    self.assertTrue(superclasses_of_b.satisfied_by(self.B()))
+    self.assertFalse(superclasses_of_b.satisfied_by(self.BPrime()))
+    self.assertFalse(superclasses_of_b.satisfied_by(self.C()))
 
   def test_multiple(self):
-    self.assertTrue(SuperclassesOf(self.A, self.B).satisfied_by(self.A()))
-    self.assertTrue(SuperclassesOf(self.A, self.B).satisfied_by(self.B()))
-    self.assertFalse(SuperclassesOf(self.A, self.B).satisfied_by(self.BPrime()))
-    self.assertFalse(SuperclassesOf(self.A, self.B).satisfied_by(self.C()))
+    superclasses_of_a_or_b = SuperclassesOf(self.A, self.B)
+    self.assertEqual((self.A, self.B), superclasses_of_a_or_b.types)
+    self.assertTrue(superclasses_of_a_or_b.satisfied_by(self.A()))
+    self.assertTrue(superclasses_of_a_or_b.satisfied_by(self.B()))
+    self.assertFalse(superclasses_of_a_or_b.satisfied_by(self.BPrime()))
+    self.assertFalse(superclasses_of_a_or_b.satisfied_by(self.C()))
 
 
 class ExactlyTest(TypeConstraintTestBase):
@@ -51,16 +55,20 @@ class ExactlyTest(TypeConstraintTestBase):
       Exactly()
 
   def test_single(self):
-    self.assertFalse(Exactly(self.B).satisfied_by(self.A()))
-    self.assertTrue(Exactly(self.B).satisfied_by(self.B()))
-    self.assertFalse(Exactly(self.B).satisfied_by(self.BPrime()))
-    self.assertFalse(Exactly(self.B).satisfied_by(self.C()))
+    exactly_b = Exactly(self.B)
+    self.assertEqual((self.B,), exactly_b.types)
+    self.assertFalse(exactly_b.satisfied_by(self.A()))
+    self.assertTrue(exactly_b.satisfied_by(self.B()))
+    self.assertFalse(exactly_b.satisfied_by(self.BPrime()))
+    self.assertFalse(exactly_b.satisfied_by(self.C()))
 
   def test_multiple(self):
-    self.assertTrue(Exactly(self.A, self.B).satisfied_by(self.A()))
-    self.assertTrue(Exactly(self.A, self.B).satisfied_by(self.B()))
-    self.assertFalse(Exactly(self.A, self.B).satisfied_by(self.BPrime()))
-    self.assertFalse(Exactly(self.A, self.B).satisfied_by(self.C()))
+    exactly_a_or_b = Exactly(self.A, self.B)
+    self.assertEqual((self.A, self.B), exactly_a_or_b.types)
+    self.assertTrue(exactly_a_or_b.satisfied_by(self.A()))
+    self.assertTrue(exactly_a_or_b.satisfied_by(self.B()))
+    self.assertFalse(exactly_a_or_b.satisfied_by(self.BPrime()))
+    self.assertFalse(exactly_a_or_b.satisfied_by(self.C()))
 
 
 class SubclassesOfTest(TypeConstraintTestBase):
@@ -69,16 +77,20 @@ class SubclassesOfTest(TypeConstraintTestBase):
       SubclassesOf()
 
   def test_single(self):
-    self.assertFalse(SubclassesOf(self.B).satisfied_by(self.A()))
-    self.assertTrue(SubclassesOf(self.B).satisfied_by(self.B()))
-    self.assertFalse(SubclassesOf(self.B).satisfied_by(self.BPrime()))
-    self.assertTrue(SubclassesOf(self.B).satisfied_by(self.C()))
+    subclasses_of_b = SubclassesOf(self.B)
+    self.assertEqual((self.B,), subclasses_of_b.types)
+    self.assertFalse(subclasses_of_b.satisfied_by(self.A()))
+    self.assertTrue(subclasses_of_b.satisfied_by(self.B()))
+    self.assertFalse(subclasses_of_b.satisfied_by(self.BPrime()))
+    self.assertTrue(subclasses_of_b.satisfied_by(self.C()))
 
   def test_multiple(self):
-    self.assertTrue(SubclassesOf(self.B, self.C).satisfied_by(self.B()))
-    self.assertTrue(SubclassesOf(self.B, self.C).satisfied_by(self.C()))
-    self.assertFalse(SubclassesOf(self.B, self.C).satisfied_by(self.BPrime()))
-    self.assertFalse(SubclassesOf(self.B, self.C).satisfied_by(self.A()))
+    subclasses_of_b_or_c = SubclassesOf(self.B, self.C)
+    self.assertEqual((self.B, self.C), subclasses_of_b_or_c.types)
+    self.assertTrue(subclasses_of_b_or_c.satisfied_by(self.B()))
+    self.assertTrue(subclasses_of_b_or_c.satisfied_by(self.C()))
+    self.assertFalse(subclasses_of_b_or_c.satisfied_by(self.BPrime()))
+    self.assertFalse(subclasses_of_b_or_c.satisfied_by(self.A()))
 
 
 class SimpleSerializable(Serializable):

--- a/tests/python/pants_test/engine/exp/test_scheduler.py
+++ b/tests/python/pants_test/engine/exp/test_scheduler.py
@@ -1,0 +1,123 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import functools
+import os
+import unittest
+
+from pants.build_graph.address import Address
+from pants.engine.exp.addressable import SubclassesOf, addressable_list
+from pants.engine.exp.configuration import Configuration
+from pants.engine.exp.graph import Graph
+from pants.engine.exp.mapper import AddressMapper
+from pants.engine.exp.parsers import encode_json, parse_json
+from pants.engine.exp.targets import Target
+
+
+class Jar(Configuration):
+  """A pre-built Maven repository dependency."""
+
+  def __init__(self, org, name, rev=None, **kwargs):
+    """
+    :param string org: The Maven ``groupId`` of this dependency.
+    :param string name: The Maven ``artifactId`` of this dependency; also serves as the name portion
+                        of the address of this jar if defined at the top level of a BUILD file.
+    :param string rev: The Maven ``version`` of this dependency.
+    """
+    super(Jar, self).__init__(org=org, name=name, rev=rev, **kwargs)
+
+
+class ApacheThriftConfiguration(Configuration):
+  def __init__(self, rev, gen, strict=True, deps=None, **kwargs):
+    """
+    :param string rev: The version of the apache thrift compiler to use.
+    :param string gen: The thrift compiler `--gen` argument specifying the type of code to generate
+                       and any options to pass to the generator.
+    :param bool strict: `False` to turn strict compiler warnings off (not recommended).
+    :param deps: An optional list of dependencies needed by the generated code.
+    :type deps: list of jars
+    """
+    super(ApacheThriftConfiguration, self).__init__(rev=rev, gen=gen, strict=strict, **kwargs)
+    self.deps = deps
+
+  # Could be Jars, PythonRequirements, ... we simply don't know a-priori - depends on --gen lang.
+  @addressable_list(SubclassesOf(Configuration))
+  def deps(self):
+    """Return a list of the dependencies needed by the generated code."""
+
+
+class SchedulerTest(unittest.TestCase):
+  def setUp(self):
+    build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
+    symbol_table = {'jar': Jar,
+                    'apache_thrift_configuration': ApacheThriftConfiguration,
+                    'target': Target}
+    json_parser = functools.partial(parse_json, symbol_table=symbol_table)
+    self.graph = Graph(AddressMapper(build_root=build_root,
+                                     build_pattern=r'^BLD.json$',
+                                     parser=json_parser))
+
+  def test_codegen_simple(self):
+    # {
+    #   "address": "src/java/codegen/simple",
+    #   "dependencies": [
+    #     {
+    #       "address": "3rdparty/jvm:guava",
+    #       "name": "guava",
+    #       "org": "com.google.guava",
+    #       "rev": "18.0",
+    #       "type_alias": "jar"
+    #     },
+    #     {
+    #       "address": "src/thrift/codegen/simple",
+    #       "configurations": [
+    #         {
+    #           "deps": [
+    #             {
+    #               "name": "libthrift",
+    #               "org": "org.apache.thrift",
+    #               "rev": "0.9.2",
+    #               "type_alias": "jar"
+    #             },
+    #             {
+    #               "name": "commons-lang",
+    #               "org": "commons-lang",
+    #               "rev": "2.5",
+    #               "type_alias": "jar"
+    #             },
+    #             {
+    #               "name": "slf4j-api",
+    #               "org": "org.slf4j",
+    #               "rev": "1.6.1",
+    #               "type_alias": "jar"
+    #             }
+    #           ],
+    #           "gen": "java",
+    #           "rev": "0.9.2",
+    #           "strict": true,
+    #           "type_alias": "apache_thrift_configuration"
+    #         }
+    #       ],
+    #       "name": "simple",
+    #       "sources": {
+    #         "files": [
+    #           "simple.thrift"
+    #         ]
+    #       },
+    #       "type_alias": "pants.engine.exp.targets.Target"
+    #     }
+    #   ],
+    #   "name": "simple",
+    #   "sources": {
+    #     "files": [
+    #       "Java.java"
+    #     ]
+    #   },
+    #   "type_alias": "target"
+    # }
+    simple_java = self.graph.resolve(Address.parse('src/java/codegen/simple'))
+    print(encode_json(simple_java, inline=True, sort_keys=True, indent=2))

--- a/tests/python/pants_test/engine/exp/test_scheduler.py
+++ b/tests/python/pants_test/engine/exp/test_scheduler.py
@@ -183,11 +183,11 @@ class JavacPlanner(TaskPlanner):
 
     sources = list(subject.sources.iter_paths(base_path=subject.address.spec_path, ext='.java'))
     if not sources:
-      # TODO(John Sirois): Abstract ~SourcesConsumerPlanner that can grab sources of given types
+      # TODO(John Sirois): Abstract a ~SourcesConsumerPlanner that can grab sources of given types
       # or else defer to a code generator like we do here.  As it stands, the planner must
-      # explicitly allow for code generators like we do here and this repeated code / foresight can
-      # easily be missed in new compilers, and other source using tasks.  Once done though, code gen
-      # can be introduced to any nesting depth, ie: code gen '.thrift' files.
+      # explicitly allow for code generators and this repeated code / foresight can easily be
+      # missed in new compilers, and other source-using tasks.  Once done though, code gen can be
+      # introduced to any nesting depth, ie: code gen '.thrift' files.
 
       # This is a dep graph "hole", we depend on the thing but don't know what it is.  Either it
       # could be something that gets transformed in to java or transformed into a `Classpath`

--- a/tests/python/pants_test/engine/exp/test_scheduler.py
+++ b/tests/python/pants_test/engine/exp/test_scheduler.py
@@ -9,17 +9,39 @@ import functools
 import os
 import unittest
 
+from twitter.common.collections.orderedset import OrderedSet
+
 from pants.build_graph.address import Address
 from pants.engine.exp.addressable import SubclassesOf, addressable_list
 from pants.engine.exp.configuration import Configuration
 from pants.engine.exp.graph import Graph
 from pants.engine.exp.mapper import AddressMapper
-from pants.engine.exp.parsers import encode_json, parse_json
+from pants.engine.exp.parsers import parse_json
+from pants.engine.exp.scheduler import (BuildRequest, GlobalScheduler, Plan, Planners, Promise,
+                                        Subject, Task, TaskPlanner)
+from pants.engine.exp.targets import Sources as AddressableSources
 from pants.engine.exp.targets import Target
+from pants.util.memo import memoized
+
+
+class Requirement(Configuration):
+  """A setuptools requirement."""
+
+  def __init__(self, req, repo=None, **kwargs):
+    """
+    :param string req: A setuptools compatible requirement specifier; eg: `pantsbuild.pants>0.0.42`.
+    :param string repo: An optional custom find-links repo URL.
+    """
+    super(Requirement, self).__init__(req=req, repo=repo, **kwargs)
+
+
+class Classpath(object):
+  # Placeholder product.
+  pass
 
 
 class Jar(Configuration):
-  """A pre-built Maven repository dependency."""
+  """A java jar."""
 
   def __init__(self, org, name, rev=None, **kwargs):
     """
@@ -29,6 +51,47 @@ class Jar(Configuration):
     :param string rev: The Maven ``version`` of this dependency.
     """
     super(Jar, self).__init__(org=org, name=name, rev=rev, **kwargs)
+
+
+class GlobalIvyResolvePlanner(TaskPlanner):
+  @property
+  def goal_name(self):
+    return 'resolve'
+
+  @property
+  def product_types(self):
+    yield Classpath
+
+  def plan(self, scheduler, product_type, subject):
+    if isinstance(subject, Jar):
+      # This plan is only used internally, the finalized plan will s/jar/jars/ for a single global
+      # resolve.
+      return Plan(task_type=IvyResolve, subjects=(subject,), jar=subject)
+
+  def finalize_plans(self, plans):
+    subjects = set()
+    jars = OrderedSet()
+    for plan in plans:
+      subjects.update(plan.subjects)
+      jars.add(plan.jar)
+    global_plan = Plan(task_type=IvyResolve, subjects=subjects, jars=list(jars))
+    return [global_plan]
+
+
+class IvyResolve(Task):
+  def execute(self, jars):
+    pass
+
+
+class Sources(object):
+  @staticmethod
+  @memoized
+  def of(ext):
+    return type(b'Sources({!r})'.format(ext), (Sources,), dict(ext=ext))
+
+  @classmethod
+  def ext(cls):
+    raise NotImplementedError()
 
 
 class ApacheThriftConfiguration(Configuration):
@@ -50,74 +113,211 @@ class ApacheThriftConfiguration(Configuration):
     """Return a list of the dependencies needed by the generated code."""
 
 
+class ApacheThriftPlanner(TaskPlanner):
+
+  def __init__(self):
+    # This will come via an option default.
+    # TODO(John Sirois): once the options system is plumbed, make the languages configurable.
+    self._product_type_by_lang = {'java': Sources.of('.java'), 'py': Sources.of('.py')}
+
+  @property
+  def goal_name(self):
+    return 'gen'
+
+  @property
+  def product_types(self):
+    return self._product_type_by_lang.values()
+
+  def _product_type(self, gen):
+    lang = gen.partition(':')[0]
+    return self._product_type_by_lang.get(lang)
+
+  def plan(self, scheduler, product_type, subject):
+    if not isinstance(subject, Target):
+      return None
+
+    thrift_sources = list(subject.sources.iter_paths(base_path=subject.address.spec_path,
+                                                     ext='.thrift'))
+    if not thrift_sources:
+      return None
+
+    configs = [config for config in subject.configurations
+               if product_type == self._product_type(config.gen)]
+    if not configs:
+      # We don't know how to generate these type of sources for this subject.
+      return None
+    if len(configs) > 1:
+      raise self.Error('Found more than one configuration for generating {!r} from {!r}:\n\t{}'
+                       .format(product_type, subject, '\n\t'.join(repr(c) for c in configs)))
+    config = configs[0]
+
+    subject = Subject(subject, alternate=Target(dependencies=config.deps))
+    return Plan(task_type=ApacheThrift,
+                subjects=(subject,),
+                sources=thrift_sources,
+                rev=config.rev,
+                gen=config.gen,
+                strict=config.strict)
+
+
+class ApacheThrift(Task):
+  def execute(self, sources, rev, gen, strict):
+    pass
+
+
+class JavacPlanner(TaskPlanner):
+  # Product type
+  JavaSources = Sources.of('.java')
+
+  @property
+  def goal_name(self):
+    return 'compile'
+
+  @property
+  def product_types(self):
+    yield Classpath
+
+  def plan(self, scheduler, product_type, subject):
+    if not isinstance(subject, Target):
+      return None
+
+    sources = list(subject.sources.iter_paths(base_path=subject.address.spec_path, ext='.java'))
+    if not sources:
+      # TODO(John Sirois): Abstract ~SourcesConsumerPlanner that can grab sources of given types
+      # or else defer to a code generator like we do here.  As it stands, the planner must
+      # explicitly allow for code generators like we do here and this repeated code / foresight can
+      # easily be missed in new compilers, and other source using tasks.  Once done though, code gen
+      # can be introduced to any nesting depth, ie: code gen '.thrift' files.
+
+      # This is a dep graph "hole", we depend on the thing but don't know what it is.  Either it
+      # could be something that gets transformed in to java or transformed into a `Classpath`
+      # by some other compiler targeting the jvm.
+      sources = scheduler.promise(subject, self.JavaSources, required=False)
+      if sources:
+        subject = sources.subject
+
+    if not sources:
+      # We don't know how to compile this subject, someone else may (Scalac, Groovyc, ...)
+      return None
+
+    classpath_promises = []
+    for derivation in Subject.as_subject(subject).iter_derivations:
+      for dep in derivation.dependencies:
+        # This could recurse to us (or be satisfied by IvyResolve, Scalac, etc. depending on the
+        # dep type).
+        internal_cp_promise = scheduler.promise(dep, Classpath)
+        if internal_cp_promise:
+          classpath_promises.append(internal_cp_promise)
+
+    return Plan(task_type=JavacTask,
+                subjects=(subject,),
+                sources=sources,
+                classpath=classpath_promises)
+
+
+class JavacTask(Task):
+  def execute(self, sources, classpath):
+    pass
+
+
 class SchedulerTest(unittest.TestCase):
   def setUp(self):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
-    symbol_table = {'jar': Jar,
-                    'apache_thrift_configuration': ApacheThriftConfiguration,
+    symbol_table = {'apache_thrift_configuration': ApacheThriftConfiguration,
+                    'jar': Jar,
+                    'requirement': Requirement,
+                    'sources': AddressableSources,
                     'target': Target}
     json_parser = functools.partial(parse_json, symbol_table=symbol_table)
     self.graph = Graph(AddressMapper(build_root=build_root,
                                      build_pattern=r'^BLD.json$',
                                      parser=json_parser))
 
+    self.guava = self.graph.resolve(Address.parse('3rdparty/jvm:guava'))
+    self.thrift = self.graph.resolve(Address.parse('src/thrift/codegen/simple'))
+    self.java = self.graph.resolve(Address.parse('src/java/codegen/simple'))
+
+    planners = [ApacheThriftPlanner(), GlobalIvyResolvePlanner(), JavacPlanner()]
+    self.global_scheduler = GlobalScheduler(self.graph, Planners(planners))
+
+  def assert_resolve_only(self, goals, root_specs, jars):
+    build_request = BuildRequest(goals=goals,
+                                 addressable_roots=[Address.parse(spec) for spec in root_specs])
+    execution_graph = self.global_scheduler.execution_graph(build_request)
+
+    plans = list(execution_graph.walk())
+    self.assertEqual(1, len(plans))
+    self.assertEqual(Plan(task_type=IvyResolve, subjects=jars, jars=list(jars)), plans[0])
+
+  def test_resolve(self):
+    self.assert_resolve_only(goals=['resolve'],
+                             root_specs=['3rdparty/jvm:guava'],
+                             jars=[self.guava])
+
+  def test_compile_only_3rdaprty(self):
+    self.assert_resolve_only(goals=['compile'],
+                             root_specs=['3rdparty/jvm:guava'],
+                             jars=[self.guava])
+
+  def test_gen_noop(self):
+    # TODO(John Sirois): Ask around - is this OK?
+    # This is different than today.  There is a gen'able target reachable from the java target, but
+    # the scheduler 'pull-seeding' has ApacheThriftPlanner stopping short since the subject it's
+    # handed is not thrift.
+    build_request = BuildRequest(goals=['gen'], addressable_roots=[self.java.address])
+    execution_graph = self.global_scheduler.execution_graph(build_request)
+
+    plans = list(execution_graph.walk())
+    self.assertEqual(0, len(plans))
+
+  def test_gen(self):
+    build_request = BuildRequest(goals=['gen'], addressable_roots=[self.thrift.address])
+    execution_graph = self.global_scheduler.execution_graph(build_request)
+
+    plans = list(execution_graph.walk())
+    self.assertEqual(1, len(plans))
+
+    self.assertEqual(Plan(task_type=ApacheThrift,
+                          subjects=[self.thrift],
+                          strict=True,
+                          rev='0.9.2',
+                          gen='java',
+                          sources=['src/thrift/codegen/simple/simple.thrift']),
+                     plans[0])
+
   def test_codegen_simple(self):
-    # {
-    #   "address": "src/java/codegen/simple",
-    #   "dependencies": [
-    #     {
-    #       "address": "3rdparty/jvm:guava",
-    #       "name": "guava",
-    #       "org": "com.google.guava",
-    #       "rev": "18.0",
-    #       "type_alias": "jar"
-    #     },
-    #     {
-    #       "address": "src/thrift/codegen/simple",
-    #       "configurations": [
-    #         {
-    #           "deps": [
-    #             {
-    #               "name": "libthrift",
-    #               "org": "org.apache.thrift",
-    #               "rev": "0.9.2",
-    #               "type_alias": "jar"
-    #             },
-    #             {
-    #               "name": "commons-lang",
-    #               "org": "commons-lang",
-    #               "rev": "2.5",
-    #               "type_alias": "jar"
-    #             },
-    #             {
-    #               "name": "slf4j-api",
-    #               "org": "org.slf4j",
-    #               "rev": "1.6.1",
-    #               "type_alias": "jar"
-    #             }
-    #           ],
-    #           "gen": "java",
-    #           "rev": "0.9.2",
-    #           "strict": true,
-    #           "type_alias": "apache_thrift_configuration"
-    #         }
-    #       ],
-    #       "name": "simple",
-    #       "sources": {
-    #         "files": [
-    #           "simple.thrift"
-    #         ]
-    #       },
-    #       "type_alias": "pants.engine.exp.targets.Target"
-    #     }
-    #   ],
-    #   "name": "simple",
-    #   "sources": {
-    #     "files": [
-    #       "Java.java"
-    #     ]
-    #   },
-    #   "type_alias": "target"
-    # }
-    simple_java = self.graph.resolve(Address.parse('src/java/codegen/simple'))
-    print(encode_json(simple_java, inline=True, sort_keys=True, indent=2))
+    build_request = BuildRequest(goals=['compile'], addressable_roots=[self.java.address])
+    execution_graph = self.global_scheduler.execution_graph(build_request)
+
+    plans = list(execution_graph.walk())
+    self.assertEqual(4, len(plans))
+
+    thrift_jars = [Jar(org='org.apache.thrift', name='libthrift', rev='0.9.2'),
+                   Jar(org='commons-lang', name='commons-lang', rev='2.5'),
+                   Jar(org='org.slf4j', name='slf4j-api', rev='1.6.1')]
+
+    jars = [self.guava] + thrift_jars
+
+    # Independent leaves 1st
+    self.assertEqual({Plan(task_type=ApacheThrift,
+                           subjects=[self.thrift],
+                           strict=True,
+                           rev='0.9.2',
+                           gen='java',
+                           sources=['src/thrift/codegen/simple/simple.thrift']),
+                      Plan(task_type=IvyResolve, subjects=jars, jars=jars)},
+                     set(plans[0:2]))
+
+    # The rest is linked.
+    self.assertEqual(Plan(task_type=JavacTask,
+                          subjects=[self.thrift],
+                          sources=Promise(Sources.of('.java'), self.thrift),
+                          classpath=[Promise(Classpath, jar) for jar in thrift_jars]),
+                     plans[2])
+
+    self.assertEqual(Plan(task_type=JavacTask,
+                          subjects=[self.java],
+                          sources=['src/java/codegen/simple/Simple.java'],
+                          classpath=[Promise(Classpath, self.guava),
+                                     Promise(Classpath, self.thrift)]),
+                     plans[3])


### PR DESCRIPTION
Introduce the 1st cut at the new engine frontend.

The new `LocalScheduler` implements a means of extracting an
`ExecutionGraph` from `TaskPlanner`'s.  This graph can later be used by
a new engine backend to schedule maximally parallel execution as well as
distributing that execution.

A test is added to exercise the nominal simple codegen case as well as a
few other cases convenient to the example codegen graph.

https://rbcommons.com/s/twitter/r/2989/