### PR TITLE
fix failure in test_global_pinger_memo

### DIFF
--- a/tests/python/pants_test/cache/test_pinger.py
+++ b/tests/python/pants_test/cache/test_pinger.py
@@ -60,7 +60,7 @@ class TestPinger(BaseTest):
     self.assertEqual(ping_results[self.slow_netloc], Pinger.UNREACHABLE)
 
   def test_global_pinger_memo(self):
-    fast_pinger = Pinger(timeout=self.slow_seconds, tries=2)
+    fast_pinger = Pinger(timeout=self.slow_seconds - .01, tries=2)
     slow_pinger = Pinger(timeout=self.timeout_seconds, tries=2)
     self.assertEqual(fast_pinger.pings([self.slow_netloc])[0][1], Pinger.UNREACHABLE)
     self.assertNotEqual(slow_pinger.pings([self.slow_netloc])[0][1], Pinger.UNREACHABLE)


### PR DESCRIPTION
test_global_pinger_memo tries to confirm that pinger does time out when the cache takes to long to respond. When the timeout value and the time the cache takes to respond are too close, the test fails. 

I increased difference between the cache response time and the timeout value by .01 seconds.

_______ TestPinger.test_global_pinger_memo _______

self = <test_pinger.TestPinger testMethod=test_global_pinger_memo>

   def test_global_pinger_memo(self):
     fast_pinger = Pinger(timeout=self.slow_seconds, tries=2)
     slow_pinger = Pinger(timeout=self.timeout_seconds, tries=2)
>     self.assertEqual(fast_pinger.pings([self.slow_netloc])[0][1], Pinger.UNREACHABLE)
E     AssertionError: 0.05421900749206543 != 999999

tests/python/pants_test/cache/test_pinger.py:65: AssertionError