### PR TITLE
Unshade org.pantsbuild.junit.annotation so that @TestParallel works

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -105,7 +105,8 @@ class JUnitRun(TestTaskMixin, JvmToolTaskMixin, JvmTask):
                           # class and some subset of the @Rules, @Theories and @RunWith APIs.
                           custom_rules=[
                             Shader.exclude_package('org.junit', recursive=True),
-                            Shader.exclude_package('org.hamcrest', recursive=True)
+                            Shader.exclude_package('org.hamcrest', recursive=True),
+                            Shader.exclude_package('org.pantsbuild.junit.annotations', recursive=True),
                           ])
     # TODO: Yuck, but will improve once coverage steps are in their own tasks.
     for c in [Coverage, Emma, Cobertura]:


### PR DESCRIPTION
Currently @TestSerial and @TestSerial annotation does not work because its package org.pantsbuild.junit.annotation is shanded in the BUILD.tools:junit, causing ConsoleRunner to not recognized annotations in user's testing code which has the unshaded class name. This fixes #2425 