### PR TITLE
allow pants to bootstrap without git

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -46,4 +46,11 @@ function set_archflags() {
     export set ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
   fi
 }
+
+function echo_warning() { # $1 = string
+    COLOR='\033[1;33m'
+    NC='\033[0m'
+    printf "${COLOR}$1${NC}\n"
+}
+
 set_archflags

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -2,7 +2,17 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+git rev-parse --show-toplevel &> /dev/null
+if [ $? != 0 ]
+then
+  #Assuming pants source repo is one level up above location of this file
+  REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/..
+  source ${REPO_ROOT}/build-support/common.sh
+  echo_warning "Warning: Git repo root cannot be found, assuming current directory $REPO_ROOT is REPO_ROOT"
+else
+  REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+fi
+
 source ${REPO_ROOT}/build-support/common.sh
 
 REQUIREMENTS=(

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -4,9 +4,16 @@ set -e
 VIRTUALENV_VERSION=13.1.0
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.python.org/packages/source/v/virtualenv}
 
-REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
-source ${REPO_ROOT}/build-support/common.sh
 
+{
+  git rev-parse --show-toplevel &> /dev/null &&
+  REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
+} || {
+  REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/..
+  echo "Warning: Git repo root cannot be found, assuming current directory $REPO_ROOT is REPO_ROOT"
+}
+
+source ${REPO_ROOT}/build-support/common.sh
 
 if [[ -z "${PY}" ]]; then
   if which python2.7 >/dev/null; then


### PR DESCRIPTION
Pants currently cannot live without git. This change aims to allow it by assuming the location of pants invocation to be the repo root