### PR TITLE
Support Configurations extending one, merging N.

### DIFF
--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
@@ -16,7 +16,7 @@ Target(
 # can always be built up via a sequence of objects extending or merging others.
 Target(
   name='java1',
-  merges=':production_thrift_configs',
+  merges=[':production_thrift_configs'],
   sources={},
   dependencies=[
     ':thrift2',

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -99,7 +99,7 @@
 {
   "type_alias": "Target",
   "name": "indirect_cycle",
-  "merges": ":one"
+  "merges": [":one"]
 }
 
 {


### PR DESCRIPTION
Previously a Configuration could only either extend one other or merge
one other, but not both.  This change allows for:
  `X extends A merges B, C, ...`.

A test is added for the new capability an semantics and BUILD files are
adjusted.

https://rbcommons.com/s/twitter/r/3023/