### PR TITLE
Add support for config selectors in dep addresses.

### DIFF
--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -78,6 +78,7 @@ python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:six',
+    'src/python/pants/engine/exp:addressable',
     'src/python/pants/engine/exp:objects',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',

--- a/src/python/pants/engine/exp/addressable.py
+++ b/src/python/pants/engine/exp/addressable.py
@@ -12,6 +12,7 @@ from functools import update_wrapper
 
 import six
 
+from pants.build_graph.address import Address
 from pants.engine.exp.objects import Resolvable, Serializable
 from pants.util.meta import AbstractClass
 
@@ -379,3 +380,31 @@ def addressable_dict(type_constraint):
   :type type_constraint: :class:`TypeConstraint`
   """
   return _addressable_wrapper(AddressableDict, type_constraint)
+
+
+# TODO(John Sirois): Move config_selector into Address 1st class as part of merging the engine/exp
+# into the mainline if the config selectors survive.
+def strip_config_selector(address):
+  """Return a copy of the given address with the config selector (if any) stripped from the name.
+
+  :rtype: :class:`pants.build_graph.address.Address`
+  """
+  address, _ = _parse_config(address)
+  return address
+
+
+def extract_config_selector(address):
+  """Return a the config selector (if any) stripped from the given address' name.
+
+  :returns: The config selector or else `None` if there is none.
+  :rtype: string
+  """
+  _, config_specifier = _parse_config(address)
+  return config_specifier
+
+
+def _parse_config(address):
+  target_name, _, config_specifier = address.target_name.partition('@')
+  config_specifier = config_specifier or None
+  normalized_address = Address(spec_path=address.spec_path, target_name=target_name)
+  return normalized_address, config_specifier

--- a/src/python/pants/engine/exp/examples/planners.py
+++ b/src/python/pants/engine/exp/examples/planners.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import functools
 import sys
+from abc import abstractmethod, abstractproperty
 
 from twitter.common.collections import OrderedSet
 
@@ -18,7 +19,7 @@ from pants.engine.exp.parsers import parse_json
 from pants.engine.exp.scheduler import GlobalScheduler, Plan, Planners, Subject, Task, TaskPlanner
 from pants.engine.exp.targets import Sources as AddressableSources
 from pants.engine.exp.targets import Target
-from pants.util.memo import memoized
+from pants.util.memo import memoized, memoized_property
 
 
 class PrintingTask(Task):
@@ -50,7 +51,7 @@ class Classpath(object):
 class Jar(Configuration):
   """A java jar."""
 
-  def __init__(self, org, name, rev=None, **kwargs):
+  def __init__(self, org=None, name=None, rev=None, **kwargs):
     """
     :param string org: The Maven ``groupId`` of this dependency.
     :param string name: The Maven ``artifactId`` of this dependency; also serves as the name portion
@@ -69,7 +70,7 @@ class GlobalIvyResolvePlanner(TaskPlanner):
   def product_types(self):
     yield Classpath
 
-  def plan(self, scheduler, product_type, subject):
+  def plan(self, scheduler, product_type, subject, configuration=None):
     if isinstance(subject, Jar):
       # This plan is only used internally, the finalized plan will s/jar/jars/ for a single global
       # resolve.
@@ -120,17 +121,13 @@ class Sources(object):
     return 'Sources(ext={!r})'.format(self.ext)
 
 
-class ApacheThriftConfiguration(Configuration):
-  def __init__(self, rev, gen, strict=True, deps=None, **kwargs):
+class ThriftConfiguration(Configuration):
+  def __init__(self, deps=None, **kwargs):
     """
-    :param string rev: The version of the apache thrift compiler to use.
-    :param string gen: The thrift compiler `--gen` argument specifying the type of code to generate
-                       and any options to pass to the generator.
-    :param bool strict: `False` to turn strict compiler warnings off (not recommended).
     :param deps: An optional list of dependencies needed by the generated code.
     :type deps: list of jars
     """
-    super(ApacheThriftConfiguration, self).__init__(rev=rev, gen=gen, strict=strict, **kwargs)
+    super(ThriftConfiguration, self).__init__(**kwargs)
     self.deps = deps
 
   # Could be Jars, PythonRequirements, ... we simply don't know a-priori - depends on --gen lang.
@@ -139,16 +136,73 @@ class ApacheThriftConfiguration(Configuration):
     """Return a list of the dependencies needed by the generated code."""
 
 
-class ApacheThriftPlanner(TaskPlanner):
-
-  def __init__(self):
-    # This will come via an option default.
-    # TODO(John Sirois): once the options system is plumbed, make the languages configurable.
-    self._product_type_by_lang = {'java': Sources.of('.java'), 'py': Sources.of('.py')}
-
+class ThriftPlanner(TaskPlanner):
   @property
   def goal_name(self):
     return 'gen'
+
+  @abstractmethod
+  def extract_thrift_config(self, product_type, target, configuration=None):
+    """Return the configuration to be used to produce the given product type for the given target.
+
+    :rtype: :class:`ThriftConfiguration`
+    """
+
+  @abstractproperty
+  def gen_task_type(self):
+    """Return the type of the code gen task.
+
+    :rtype: type
+    """
+
+  @abstractmethod
+  def plan_parameters(self, config):
+    """Return a dict of any extra parameters besides sources needed to execute the code gen plan.
+
+    :rtype: dict
+    """
+
+  def plan(self, scheduler, product_type, subject, configuration=None):
+    if not isinstance(subject, Target):
+      return None
+
+    thrift_sources = list(subject.sources.iter_paths(base_path=subject.address.spec_path,
+                                                     ext='.thrift'))
+    if not thrift_sources:
+      return None
+
+    config = self.extract_thrift_config(product_type, subject, configuration=configuration)
+    if config is None:
+      return None
+
+    subject = Subject(subject, alternate=Target(dependencies=config.deps))
+    return Plan(task_type=self.gen_task_type,
+                subjects=(subject,),
+                sources=thrift_sources,
+                **self.plan_parameters(config))
+
+
+class ApacheThriftConfiguration(ThriftConfiguration):
+  def __init__(self, rev=None, gen=None, strict=True, **kwargs):
+    """
+    :param string rev: The version of the apache thrift compiler to use.
+    :param string gen: The thrift compiler `--gen` argument specifying the type of code to generate
+                       and any options to pass to the generator.
+    :param bool strict: `False` to turn strict compiler warnings off (not recommended).
+    """
+    super(ApacheThriftConfiguration, self).__init__(rev=rev, gen=gen, strict=strict, **kwargs)
+
+
+class ApacheThriftPlanner(ThriftPlanner):
+  @property
+  def gen_task_type(self):
+    return ApacheThrift
+
+  @memoized_property
+  def _product_type_by_lang(self):
+    # This will come via an option default.
+    # TODO(John Sirois): once the options system is plumbed, make the languages configurable.
+    return {'java': Sources.of('.java'), 'py': Sources.of('.py')}
 
   @property
   def product_types(self):
@@ -158,32 +212,23 @@ class ApacheThriftPlanner(TaskPlanner):
     lang = gen.partition(':')[0]
     return self._product_type_by_lang.get(lang)
 
-  def plan(self, scheduler, product_type, subject):
-    if not isinstance(subject, Target):
-      return None
-
-    thrift_sources = list(subject.sources.iter_paths(base_path=subject.address.spec_path,
-                                                     ext='.thrift'))
-    if not thrift_sources:
-      return None
-
-    configs = [config for config in subject.configurations
-               if product_type == self._product_type(config.gen)]
+  def extract_thrift_config(self, product_type, target, configuration=None):
+    configs = (configuration,) if configuration else target.configurations
+    configs = tuple(config for config in configs
+                    if (isinstance(config, ApacheThriftConfiguration) and
+                        product_type == self._product_type(config.gen)))
     if not configs:
       # We don't know how to generate these type of sources for this subject.
       return None
     if len(configs) > 1:
       raise self.Error('Found more than one configuration for generating {!r} from {!r}:\n\t{}'
-                       .format(product_type, subject, '\n\t'.join(repr(c) for c in configs)))
-    config = configs[0]
+                       .format(product_type, target, '\n\t'.join(repr(c) for c in configs)))
+    return configs[0]
 
-    subject = Subject(subject, alternate=Target(dependencies=config.deps))
-    return Plan(task_type=ApacheThrift,
-                subjects=(subject,),
-                sources=thrift_sources,
-                rev=config.rev,
-                gen=config.gen,
-                strict=config.strict)
+  def plan_parameters(self, apache_thrift_config):
+    return dict(rev=apache_thrift_config.rev,
+                gen=apache_thrift_config.gen,
+                strict=apache_thrift_config.strict)
 
 
 class ApacheThrift(PrintingTask):
@@ -191,10 +236,54 @@ class ApacheThrift(PrintingTask):
     return super(ApacheThrift, self).execute(sources=sources, rev=rev, gen=gen, strict=strict)
 
 
-class JavacPlanner(TaskPlanner):
-  # Product type
-  JavaSources = Sources.of('.java')
+class ScroogeConfiguration(ThriftConfiguration):
+  def __init__(self, rev=None, lang=None, strict=True, **kwargs):
+    """
+    :param string rev: The version of the scrooge compiler to use.
+    :param string lang: The language to target code generation to.
+    :param bool strict: `False` to turn strict compiler warnings off (not recommended).
+    """
+    super(ScroogeConfiguration, self).__init__(rev=rev, lang=lang, strict=strict, **kwargs)
 
+
+class ScroogePlanner(ThriftPlanner):
+  @property
+  def gen_task_type(self):
+    return Scrooge
+
+  @memoized_property
+  def _product_type_by_lang(self):
+    # This will come via an option default.
+    # TODO(John Sirois): once the options system is plumbed, make the languages configurable.
+    return {'scala': Sources.of('.scala'), 'java': Sources.of('.java')}
+
+  @property
+  def product_types(self):
+    return self._product_type_by_lang.values()
+
+  def extract_thrift_config(self, product_type, target, configuration=None):
+    configs = (configuration,) if configuration else target.configurations
+    configs = tuple(config for config in configs
+                    if (isinstance(config, ScroogeConfiguration) and
+                        product_type == self._product_type_by_lang.get(config.lang)))
+    if not configs:
+      # We don't know how to generate these type of sources for this subject.
+      return None
+    if len(configs) > 1:
+      raise self.Error('Found more than one configuration for generating {!r} from {!r}:\n\t{}'
+                       .format(product_type, target, '\n\t'.join(repr(c) for c in configs)))
+    return configs[0]
+
+  def plan_parameters(self, scrooge_config):
+    return dict(rev=scrooge_config.rev, lang=scrooge_config.lang, strict=scrooge_config.strict)
+
+
+class Scrooge(PrintingTask):
+  def execute(self, sources, rev, lang, strict):
+    return super(Scrooge, self).execute(sources=sources, rev=rev, lang=lang, strict=strict)
+
+
+class JvmCompilerPlanner(TaskPlanner):
   @property
   def goal_name(self):
     return 'compile'
@@ -203,11 +292,26 @@ class JavacPlanner(TaskPlanner):
   def product_types(self):
     yield Classpath
 
-  def plan(self, scheduler, product_type, subject):
+  @abstractproperty
+  def compile_task_type(self):
+    """Return the type of the jvm compiler task.
+
+    :rtype: type
+    """
+
+  @abstractproperty
+  def source_ext(self):
+    """Return the extension of the source code compiled by the jvm compiler.
+
+    :rtype: string
+    """
+
+  def plan(self, scheduler, product_type, subject, configuration=None):
     if not isinstance(subject, Target):
       return None
 
-    sources = list(subject.sources.iter_paths(base_path=subject.address.spec_path, ext='.java'))
+    sources = list(subject.sources.iter_paths(base_path=subject.address.spec_path,
+                                              ext=self.source_ext))
     if not sources:
       # TODO(John Sirois): Abstract a ~SourcesConsumerPlanner that can grab sources of given types
       # or else defer to a code generator like we do here.  As it stands, the planner must
@@ -216,9 +320,12 @@ class JavacPlanner(TaskPlanner):
       # introduced to any nesting depth, ie: code gen '.thrift' files.
 
       # This is a dep graph "hole", we depend on the thing but don't know what it is.  Either it
-      # could be something that gets transformed in to java or transformed into a `Classpath`
-      # by some other compiler targeting the jvm.
-      sources = scheduler.promise(subject, self.JavaSources, required=False)
+      # could be something that gets transformed in to our compile input source extension (codegen)
+      # or transformed into a `Classpath` product by some other compiler targeting the jvm.
+      sources = scheduler.promise(subject,
+                                  Sources.of(self.source_ext),
+                                  configuration=configuration,
+                                  required=False)
       if sources:
         subject = sources.subject
 
@@ -227,23 +334,47 @@ class JavacPlanner(TaskPlanner):
       return None
 
     classpath_promises = []
-    for derivation in Subject.as_subject(subject).iter_derivations:
-      for dep in derivation.dependencies:
-        # This could recurse to us (or be satisfied by IvyResolve, Scalac, etc. depending on the
-        # dep type).
-        internal_cp_promise = scheduler.promise(dep, Classpath)
-        if internal_cp_promise:
-          classpath_promises.append(internal_cp_promise)
+    for dep, dep_config in self.iter_configured_dependencies(subject):
+      # This could recurse to us (or be satisfied by IvyResolve, another jvm compiler, etc.
+      # depending on the dep type).
+      internal_cp_promise = scheduler.promise(dep, Classpath, configuration=dep_config)
+      if internal_cp_promise:
+        classpath_promises.append(internal_cp_promise)
 
-    return Plan(task_type=JavacTask,
+    return Plan(task_type=self.compile_task_type,
                 subjects=(subject,),
                 sources=sources,
                 classpath=classpath_promises)
 
 
-class JavacTask(PrintingTask):
+class JavacPlanner(JvmCompilerPlanner):
+  @property
+  def source_ext(self):
+    return '.java'
+
+  @property
+  def compile_task_type(self):
+    return Javac
+
+
+class Javac(PrintingTask):
   def execute(self, sources, classpath):
-    return super(JavacTask, self).execute(sources=sources, classpath=classpath)
+    return super(Javac, self).execute(sources=sources, classpath=classpath)
+
+
+class ScalacPlanner(JvmCompilerPlanner):
+  @property
+  def source_ext(self):
+    return '.scala'
+
+  @property
+  def compile_task_type(self):
+    return Scalac
+
+
+class Scalac(PrintingTask):
+  def execute(self, sources, classpath):
+    return super(Scalac, self).execute(sources=sources, classpath=classpath)
 
 
 def setup_json_scheduler(build_root):
@@ -255,6 +386,7 @@ def setup_json_scheduler(build_root):
   symbol_table = {'apache_thrift_configuration': ApacheThriftConfiguration,
                   'jar': Jar,
                   'requirement': Requirement,
+                  'scrooge_configuration': ScroogeConfiguration,
                   'sources': AddressableSources,
                   'target': Target}
   json_parser = functools.partial(parse_json, symbol_table=symbol_table)
@@ -262,6 +394,10 @@ def setup_json_scheduler(build_root):
                               build_pattern=r'^BLD.json$',
                               parser=json_parser))
 
-  planners = [ApacheThriftPlanner(), GlobalIvyResolvePlanner(), JavacPlanner()]
+  planners = [ApacheThriftPlanner(),
+              GlobalIvyResolvePlanner(),
+              JavacPlanner(),
+              ScalacPlanner(),
+              ScroogePlanner()]
   global_scheduler = GlobalScheduler(graph, Planners(planners))
   return graph, global_scheduler

--- a/src/python/pants/engine/exp/examples/visualizer.py
+++ b/src/python/pants/engine/exp/examples/visualizer.py
@@ -83,7 +83,7 @@ def visualize_execution_graph(execution_graph):
       fp.write('\n')
     fp.close()
     with temporary_file_path(cleanup=False) as image_file:
-      subprocess.check_call('dot -Tpng -o{} {}'.format(image_file, fp.name), shell=True)
+      subprocess.check_call('dot -Tsvg -o{} {}'.format(image_file, fp.name), shell=True)
       binary_util.ui_open(image_file)
 
 

--- a/src/python/pants/engine/exp/graph.py
+++ b/src/python/pants/engine/exp/graph.py
@@ -10,7 +10,8 @@ import collections
 import six
 
 from pants.build_graph.address import Address
-from pants.engine.exp.addressable import AddressableDescriptor, TypeConstraintError
+from pants.engine.exp.addressable import (AddressableDescriptor, TypeConstraintError,
+                                          strip_config_selector)
 from pants.engine.exp.mapper import MappingError
 from pants.engine.exp.objects import Resolvable, Serializable, SerializableFactory, Validatable
 
@@ -117,7 +118,7 @@ class Graph(object):
                                            for a in resolve_path + [address])))
     resolve_path.append(address)
 
-    obj = self._address_mapper.resolve(address)
+    obj = self._address_mapper.resolve(strip_config_selector(address))
 
     def parse_addr(a):
       return Address.parse(a, relative_to=address.spec_path)

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD
@@ -16,7 +16,7 @@ Target(
 # can always be built up via a sequence of objects extending or merging others.
 Target(
   name='java1',
-  merges=':production_thrift_configs',
+  merges=[':production_thrift_configs'],
   sources={},
   dependencies=[
     ':thrift2',

--- a/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
+++ b/tests/python/pants_test/engine/exp/examples/graph_test/self_contained.BUILD.json
@@ -99,7 +99,7 @@
 {
   "type_alias": "Target",
   "name": "indirect_cycle",
-  "merges": ":one"
+  "merges": [":one"]
 }
 
 {

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/selector/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/selector/BLD.json
@@ -1,0 +1,25 @@
+{
+  "type_alias": "sources",
+  "name": "sources",
+  "files": ["Selector.java"]
+}
+
+{
+  "type_alias": "target",
+  "name": "selected",
+  "sources": ":sources",
+  "dependencies": [
+    "3rdparty/jvm:guava",
+    "src/thrift/codegen/selector:selector@scrooge_scala_config"
+  ]
+}
+
+{
+  "type_alias": "target",
+  "name": "conflict",
+  "sources": ":sources",
+  "dependencies": [
+    "3rdparty/jvm:guava",
+    "src/thrift/codegen/selector"
+  ]
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/selector/Selector.java
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/selector/Selector.java
@@ -1,0 +1,1 @@
+// Placeholder file.

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
@@ -1,4 +1,18 @@
 {
+  "type_alias": "jar",
+  "abstract": true,
+  "org": "org.apache.thrift",
+  "name": "libthrift"
+}
+
+{
+  "type_alias": "jar",
+  "org": "org.slf4j",
+  "name": "slf4j-api",
+  "rev": "1.6.1"
+}
+
+{
   "type_alias": "target",
   "abstract": true,
   "name": "java_thrift_base",
@@ -11,8 +25,7 @@
       "deps": [
         {
           "type_alias": "jar",
-          "org": "org.apache.thrift",
-          "name": "libthrift",
+          "extends": ":libthrift",
           "rev": "0.9.2"
         },
         {
@@ -21,12 +34,67 @@
           "name": "commons-lang",
           "rev": "2.5"
         },
+        ":slf4j-api"
+      ]
+    }
+  ]
+}
+
+{
+  "type_alias": "scrooge_configuration",
+  "name": "scrooge_scala_config",
+  "rev": "3.20.0",
+  "strict": true,
+  "lang": "scala",
+  "deps": [
+    {
+      "type_alias": "jar",
+      "extends": ":libthrift",
+      "rev": "0.6.1"
+    },
+    {
+      "type_alias": "jar",
+      "org": "com.twitter",
+      "name": "scrooge-core_2.10",
+      "rev": "3.20.0"
+    },
+    {
+      "type_alias": "jar",
+      "org": "com.twitter",
+      "name": "finagle-thrift_2.10",
+      "rev": "6.28.0"
+    }
+  ]
+}
+
+{
+  "type_alias": "target",
+  "abstract": true,
+  "name": "scala_thrift_base",
+  "configurations": [
+    ":scrooge_scala_config"
+  ]
+}
+
+{
+  "type_alias": "target",
+  "abstract": true,
+  "name": "all_jvm_thrift_base",
+  "merges": [":java_thrift_base", ":scala_thrift_base"],
+  "configurations": [
+    {
+      "type_alias": "scrooge_configuration",
+      "merges": [":scrooge_scala_config"],
+      "name": "scrooge_java_config",
+      "lang": "java",
+      "deps": [
         {
           "type_alias": "jar",
-          "org": "org.slf4j",
-          "name": "slf4j-api",
-          "rev": "1.6.1"
-        }
+          "org": "org.scala-lang",
+          "name": "scala-library",
+          "rev": "2.10.6"
+        },
+        ":slf4j-api"
       ]
     }
   ]

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/selector/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/selector/BLD.json
@@ -1,0 +1,8 @@
+{
+  "type_alias": "target",
+  "extends": "src/thrift:all_jvm_thrift_base",
+  "name": "selector",
+  "sources": {
+    "files": ["selector.thrift"]
+  }
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/selector/selector.thrift
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/codegen/selector/selector.thrift
@@ -1,0 +1,1 @@
+// Placeholder file.

--- a/tests/python/pants_test/engine/exp/test_engine.py
+++ b/tests/python/pants_test/engine/exp/test_engine.py
@@ -11,7 +11,7 @@ from contextlib import closing
 
 from pants.build_graph.address import Address
 from pants.engine.exp.engine import LocalMultiprocessEngine, LocalSerialEngine
-from pants.engine.exp.examples.planners import Classpath, JavacTask, setup_json_scheduler
+from pants.engine.exp.examples.planners import Classpath, Javac, setup_json_scheduler
 from pants.engine.exp.scheduler import BuildRequest, Promise
 
 
@@ -25,7 +25,7 @@ class EngineTest(unittest.TestCase):
   def assert_engine(self, engine):
     build_request = BuildRequest(goals=['compile'], addressable_roots=[self.java.address])
     result = engine.execute(build_request)
-    self.assertEqual({Promise(Classpath, self.java): JavacTask.fake_product()},
+    self.assertEqual({Promise(Classpath, self.java): Javac.fake_product()},
                      result.root_products)
 
   def test_serial_engine(self):

--- a/tests/python/pants_test/engine/exp/test_scheduler.py
+++ b/tests/python/pants_test/engine/exp/test_scheduler.py
@@ -9,7 +9,7 @@ import os
 import unittest
 
 from pants.build_graph.address import Address
-from pants.engine.exp.examples.planners import (ApacheThrift, Classpath, IvyResolve, Jar, JavacTask,
+from pants.engine.exp.examples.planners import (ApacheThrift, Classpath, IvyResolve, Jar, Javac,
                                                 Sources, setup_json_scheduler)
 from pants.engine.exp.scheduler import BuildRequest, Plan, Promise
 
@@ -79,7 +79,7 @@ class SchedulerTest(unittest.TestCase):
 
     thrift_jars = [Jar(org='org.apache.thrift', name='libthrift', rev='0.9.2'),
                    Jar(org='commons-lang', name='commons-lang', rev='2.5'),
-                   Jar(org='org.slf4j', name='slf4j-api', rev='1.6.1')]
+                   self.graph.resolve(Address.parse('src/thrift:slf4j-api'))]
 
     jars = [self.guava] + thrift_jars
 
@@ -96,14 +96,14 @@ class SchedulerTest(unittest.TestCase):
 
     # The rest is linked.
     self.assertEqual((Classpath,
-                      Plan(task_type=JavacTask,
+                      Plan(task_type=Javac,
                            subjects=[self.thrift],
                            sources=Promise(Sources.of('.java'), self.thrift),
                            classpath=[Promise(Classpath, jar) for jar in thrift_jars])),
                      plans[2])
 
     self.assertEqual((Classpath,
-                      Plan(task_type=JavacTask,
+                      Plan(task_type=Javac,
                            subjects=[self.java],
                            sources=['src/java/codegen/simple/Simple.java'],
                            classpath=[Promise(Classpath, self.guava),


### PR DESCRIPTION
This allows for modelling many variants of a target through a single
target with many configurations.  When the set of applicable
configuratons for a dependee has more than one element, the required
configuration can be specified by "sub-addressing" into a target's
(named) configurations.

This change adds an example of this:
```
./pants run src/python/pants/engine/exp/examples:viz -- \
  tests/python/pants_test/engine/exp/examples/scheduler_inputs \
  compile \
  src/java/codegen/selector:selected
```

As well as an example of what happens when more than one configuration
applies (a failing example):
```
./pants run src/python/pants/engine/exp/examples:viz -- \
  tests/python/pants_test/engine/exp/examples/scheduler_inputs \
  compile \
  src/java/codegen/selector:conflict
...
pants.engine.exp.scheduler.ConflictingProducersError: Collected the
following plans for generating "Sources(u'.java')" from
Target(address=src/thrift/codegen/selector)
  ApacheThriftPlanner
  ScroogePlanner

FAILURE:
/home/jsirois/dev/3rdparty/jsirois-pants3/build-support/pants_dev_deps.venv/bin/python2.7
pants.engine.exp.examples.visualizer:main
tests/python/pants_test/engine/exp/examples/scheduler_inputs compile
src/java/codegen/selector:conflict ... exited non-zero (1)
```

https://rbcommons.com/s/twitter/r/3025/