### PR TITLE
Add support for address subjects.

### DIFF
--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -78,6 +78,7 @@ python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:six',
+    'src/python/pants/build_graph',
     'src/python/pants/engine/exp:addressable',
     'src/python/pants/engine/exp:objects',
     'src/python/pants/util:memo',

--- a/src/python/pants/engine/exp/examples/BUILD
+++ b/src/python/pants/engine/exp/examples/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources=['planners.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/build_graph',
     'src/python/pants/engine/exp:addressable',
     'src/python/pants/engine/exp:configuration',
     'src/python/pants/engine/exp:graph',

--- a/src/python/pants/engine/exp/examples/visualizer.py
+++ b/src/python/pants/engine/exp/examples/visualizer.py
@@ -35,7 +35,8 @@ def create_digraph(execution_graph):
 
   yield 'digraph plans {'
   yield '  node[colorscheme={}];'.format(colorscheme)
-  yield '  rankdir=LR;'
+  yield '  concentrate=true;'
+  yield '  splines=polyline;'
 
   for product_type, plan in execution_graph.walk():
     label = format_label(product_type, plan)
@@ -88,8 +89,8 @@ def visualize_execution_graph(execution_graph):
 
 
 def visualize_build_request(build_root, build_request):
-  _, global_scheduler = setup_json_scheduler(build_root)
-  execution_graph = global_scheduler.execution_graph(build_request)
+  _, scheduler = setup_json_scheduler(build_root)
+  execution_graph = scheduler.execution_graph(build_request)
   visualize_execution_graph(execution_graph)
 
 

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/3rdparty/jvm/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/3rdparty/jvm/BLD.json
@@ -4,3 +4,10 @@
   "name": "guava",
   "rev": "18.0"
 }
+
+{
+  "type_alias": "jar",
+  "org": "org.scala-lang",
+  "name": "scala-library",
+  "rev": "2.10.6"
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/scala/scrooge/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/scala/scrooge/BLD.json
@@ -1,0 +1,10 @@
+{
+  "type_alias": "target",
+  "name": "scrooge",
+  "sources": {
+    "files": ["Scrooge.scala"]
+  },
+  "dependencies": [
+    "3rdparty/jvm:scala-library"
+  ]
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/scala/scrooge/Scrooge.scala
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/scala/scrooge/Scrooge.scala
@@ -1,0 +1,1 @@
+// Placeholder file.

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
@@ -63,7 +63,8 @@
       "org": "com.twitter",
       "name": "finagle-thrift_2.10",
       "rev": "6.28.0"
-    }
+    },
+    "3rdparty/jvm:scala-library"
   ]
 }
 
@@ -88,12 +89,7 @@
       "name": "scrooge_java_config",
       "lang": "java",
       "deps": [
-        {
-          "type_alias": "jar",
-          "org": "org.scala-lang",
-          "name": "scala-library",
-          "rev": "2.10.6"
-        },
+        "3rdparty/jvm:scala-library",
         ":slf4j-api"
       ]
     }

--- a/tests/python/pants_test/engine/exp/test_engine.py
+++ b/tests/python/pants_test/engine/exp/test_engine.py
@@ -18,7 +18,7 @@ from pants.engine.exp.scheduler import BuildRequest, Promise
 class EngineTest(unittest.TestCase):
   def setUp(self):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
-    self.graph, self.global_scheduler = setup_json_scheduler(build_root)
+    self.graph, self.scheduler = setup_json_scheduler(build_root)
 
     self.java = self.graph.resolve(Address.parse('src/java/codegen/simple'))
 
@@ -29,9 +29,9 @@ class EngineTest(unittest.TestCase):
                      result.root_products)
 
   def test_serial_engine(self):
-    engine = LocalSerialEngine(self.global_scheduler)
+    engine = LocalSerialEngine(self.scheduler)
     self.assert_engine(engine)
 
   def test_multiprocess_engine(self):
-    with closing(LocalMultiprocessEngine(self.global_scheduler)) as engine:
+    with closing(LocalMultiprocessEngine(self.scheduler)) as engine:
       self.assert_engine(engine)

--- a/tests/python/pants_test/engine/exp/test_scheduler.py
+++ b/tests/python/pants_test/engine/exp/test_scheduler.py
@@ -17,7 +17,7 @@ from pants.engine.exp.scheduler import BuildRequest, Plan, Promise
 class SchedulerTest(unittest.TestCase):
   def setUp(self):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
-    self.graph, self.global_scheduler = setup_json_scheduler(build_root)
+    self.graph, self.scheduler = setup_json_scheduler(build_root)
 
     self.guava = self.graph.resolve(Address.parse('3rdparty/jvm:guava'))
     self.thrift = self.graph.resolve(Address.parse('src/thrift/codegen/simple'))
@@ -26,7 +26,7 @@ class SchedulerTest(unittest.TestCase):
   def assert_resolve_only(self, goals, root_specs, jars):
     build_request = BuildRequest(goals=goals,
                                  addressable_roots=[Address.parse(spec) for spec in root_specs])
-    execution_graph = self.global_scheduler.execution_graph(build_request)
+    execution_graph = self.scheduler.execution_graph(build_request)
 
     plans = list(execution_graph.walk())
     self.assertEqual(1, len(plans))
@@ -49,14 +49,14 @@ class SchedulerTest(unittest.TestCase):
     # the scheduler 'pull-seeding' has ApacheThriftPlanner stopping short since the subject it's
     # handed is not thrift.
     build_request = BuildRequest(goals=['gen'], addressable_roots=[self.java.address])
-    execution_graph = self.global_scheduler.execution_graph(build_request)
+    execution_graph = self.scheduler.execution_graph(build_request)
 
     plans = list(execution_graph.walk())
     self.assertEqual(0, len(plans))
 
   def test_gen(self):
     build_request = BuildRequest(goals=['gen'], addressable_roots=[self.thrift.address])
-    execution_graph = self.global_scheduler.execution_graph(build_request)
+    execution_graph = self.scheduler.execution_graph(build_request)
 
     plans = list(execution_graph.walk())
     self.assertEqual(1, len(plans))
@@ -72,7 +72,7 @@ class SchedulerTest(unittest.TestCase):
 
   def test_codegen_simple(self):
     build_request = BuildRequest(goals=['compile'], addressable_roots=[self.java.address])
-    execution_graph = self.global_scheduler.execution_graph(build_request)
+    execution_graph = self.scheduler.execution_graph(build_request)
 
     plans = list(execution_graph.walk())
     self.assertEqual(4, len(plans))


### PR DESCRIPTION
This allows for tool bootstrapping in particular.  A planner can ask for
a promise for a given local tool target and incorporate that local tool
promise into its plans.

Modify the `src/java/codegen/selected:select` example by having the
`ScroogePlanner` require its local tool target.

https://rbcommons.com/s/twitter/r/3029/