### PR TITLE
Fix issue with trailing newline

### DIFF
--- a/src/python/pants/backend/python/tasks/checkstyle/common.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/common.py
@@ -79,7 +79,7 @@ class PythonFile(object):
     """
     # Remove the # coding=utf-8 to avoid AST erroneous parse errors
     #   https://bugs.python.org/issue22221
-    lines = [x.decode('utf-8', errors='replace') for x in blob.split('\n')]
+    lines = blob.split('\n')
     if lines and 'coding=utf-8' in lines[0]:
       lines[0] = '#remove coding'
     return '\n'.join(lines).encode('ascii', errors='replace')
@@ -103,7 +103,7 @@ class PythonFile(object):
 
   @classmethod
   def parse(cls, filename):
-    with codecs.open(filename) as fp:
+    with codecs.open(filename, encoding='utf-8') as fp:
       blob = fp.read()
     return cls(blob, filename)
 

--- a/src/python/pants/backend/python/tasks/checkstyle/common.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/common.py
@@ -79,7 +79,7 @@ class PythonFile(object):
     """
     # Remove the # coding=utf-8 to avoid AST erroneous parse errors
     #   https://bugs.python.org/issue22221
-    lines = [x.decode('utf-8', errors='replace') for x in blob.splitlines()]
+    lines = [x.decode('utf-8', errors='replace') for x in blob.split('\n')]
     if lines and 'coding=utf-8' in lines[0]:
       lines[0] = '#remove coding'
     return '\n'.join(lines).encode('ascii', errors='replace')
@@ -87,7 +87,7 @@ class PythonFile(object):
   def __init__(self, blob, filename='<expr>'):
     self._blob = self._remove_coding_header(blob)
     self.tree = ast.parse(self._blob, filename)
-    self.lines = OffByOneList(self._blob.splitlines())
+    self.lines = OffByOneList(self._blob.split('\n'))
     self.filename = filename
     self.logical_lines = dict((start, (start, stop, indent))
         for start, stop, indent in self.iter_logical_lines(self._blob))
@@ -113,7 +113,7 @@ class PythonFile(object):
     :param statement: Python file contents
     :return: Instance of PythonFile
     """
-    return cls('\n'.join(textwrap.dedent(statement).splitlines()[1:]))
+    return cls('\n'.join(textwrap.dedent(statement).split('\n')[1:]))
 
   @classmethod
   def iter_tokens(cls, blob):

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/.cache/v/cache/lastfailed
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/.cache/v/cache/lastfailed
@@ -1,0 +1,3 @@
+{
+  "test_common.py": true
+}

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/.cache/v/cache/lastfailed
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/.cache/v/cache/lastfailed
@@ -1,3 +1,0 @@
-{
-  "test_common.py": true
-}

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_common.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_common.py
@@ -31,6 +31,7 @@ FILE_TEXT = """
 
     def session(self):
       return self._session
+
 """
 
 
@@ -44,7 +45,7 @@ class MinimalCheckstylePlugin(CheckstylePlugin):
 @pytest.fixture
 def test_statement():
   """Pytest Fixture to create a test python file from statement"""
-  return '\n'.join(textwrap.dedent(FILE_TEXT).splitlines()[1:])
+  return '\n'.join(textwrap.dedent(FILE_TEXT).split('\n')[1:])
 
 
 @pytest.fixture
@@ -91,7 +92,7 @@ def test_python_file_exceeds_index(test_statement):
   """Test that we get an Index error when we exceed the line number"""
   test_python_file = PythonFile(test_statement, 'keeper.py')
   with pytest.raises(IndexError):
-    test_python_file[len(test_statement.splitlines()) + 1]
+    test_python_file[len(test_statement.split('\n')) + 1]
 
 
 def test_line_retrieval(test_python_file):
@@ -112,10 +113,11 @@ def test_line_retrieval(test_python_file):
     [""],
     ["  def session(self):"],
     ["    return self._session"],
+    [""]
   ]
-  assert expected == [test_python_file[x] for x in range(1,16)], \
+  assert expected == [test_python_file[x] for x in range(1,17)], \
     "Expected:\n{} Actual:\n{}".format(
-      pprint(expected), pprint([test_python_file[x] for x in range(1,16)]))
+      pprint(expected), pprint([test_python_file[x] for x in range(1,17)]))
 
 
 def test_rejoin(test_statement):
@@ -127,7 +129,7 @@ def test_rejoin(test_statement):
 def test_off_by_one_enumeration(test_statement):
   """Test that enumerate is offset by one"""
   python_file = PythonFile(test_statement, 'keeper.py')
-  assert list(python_file.enumerate()) == list(enumerate(test_statement.splitlines(), 1))
+  assert list(python_file.enumerate()) == list(enumerate(test_statement.split('\n'), 1))
 
 
 @pytest.mark.parametrize("ln_test_input,ln_test_expected", [

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_noqa.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_noqa.py
@@ -78,7 +78,6 @@ class TestPyStyleTask(PythonTaskTestBase):
   def test_noqa_line_filter_length(self):
     """Verify the number of lines filtered is what we expect"""
     nits = list(self.style_check.get_nits(self.no_qa_line))
-    map(print, nits)
     assert len(nits) == 1, ('Actually got nits: {}'.format(
       ' '.join('{}:{}'.format(nit._line_number, nit) for nit in nits)
     ))

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_noqa.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_noqa.py
@@ -42,8 +42,7 @@ def no_qa_line(request):
   """Py Test fixture to create a testing file for single line filters"""
   request.cls.no_qa_line = PythonFile.from_statement(textwrap.dedent("""
     print('This is not fine')
-    print('This is fine')  # noqa
-  """))
+    print('This is fine')  # noqa"""))
 
 
 @pytest.fixture()
@@ -52,8 +51,7 @@ def no_qa_file(request):
   request.cls.no_qa_file = PythonFile.from_statement(textwrap.dedent("""
       # checkstyle: noqa
       print('This is not fine')
-      print('This is fine')
-  """))
+      print('This is fine')"""))
 
 
 @pytest.mark.usefixtures('no_qa_file', 'no_qa_line')
@@ -80,6 +78,7 @@ class TestPyStyleTask(PythonTaskTestBase):
   def test_noqa_line_filter_length(self):
     """Verify the number of lines filtered is what we expect"""
     nits = list(self.style_check.get_nits(self.no_qa_line))
+    map(print, nits)
     assert len(nits) == 1, ('Actually got nits: {}'.format(
       ' '.join('{}:{}'.format(nit._line_number, nit) for nit in nits)
     ))


### PR DESCRIPTION
In checkstyle lines were split with str.splitlines(), this removed trailing empty strings
at the end of the file.  This caused index errors when a file had trailing blank lines.

Code has been updated to use split('\n') and the unit tests updated to catch this.