### PR TITLE
Add fail-slow handling to `Engine`.

### DIFF
--- a/src/python/pants/engine/exp/BUILD
+++ b/src/python/pants/engine/exp/BUILD
@@ -24,6 +24,7 @@ python_library(
   name='engine',
   sources=['engine.py'],
   dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:exceptions',
     'src/python/pants/engine/exp:scheduler',
     'src/python/pants/util:meta',

--- a/src/python/pants/engine/exp/engine.py
+++ b/src/python/pants/engine/exp/engine.py
@@ -12,24 +12,248 @@ import Queue
 from abc import abstractmethod
 from threading import Thread
 
+from twitter.common.collections.orderedset import OrderedSet
+
 from pants.base.exceptions import TaskError
 from pants.engine.exp.scheduler import Promise
 from pants.util.meta import AbstractClass
 
 
+class FailedToProduce(object):
+  """A product type to track failure roots when failing slow."""
+  # NB: A picklable top-level type to help support local multiprocessing uses.
+
+  def __init__(self, promise, plan, error=None, priors=None):
+    self._promise = promise
+    self._plan = plan
+    self._error = error
+    self._priors = priors
+
+  @property
+  def promise(self):
+    """Return the promise the failed plan was intended to satisfy.
+
+    :rtype: :class:`pants.engine.exp.scheduler.Promise`
+    """
+    return self._promise
+
+  @property
+  def plan(self):
+    """Return the plan that failed.
+
+    :rtype: :class:`pants.engine.exp.scheduler.Plan`
+    """
+    return self._plan
+
+  @property
+  def error(self):
+    """Return the error the plan raised.
+
+    The error can be `None` if the plan was not executed because one or more of its promised inputs
+    was in error.  In that case you can `walk` to explore the failure path that led here.
+
+    :rtype: :class:`pants.base.exceptions.TaskError`
+    """
+    return self._error
+
+  def walk(self, postorder=True):
+    """"""
+    visited = set()
+    for prior in self._walk(visited=visited, postorder=postorder):
+      yield prior
+
+  def _walk(self, visited, postorder=True):
+    if self not in visited:
+      visited.add(self)
+      if not postorder:
+        yield self
+      if self._priors:
+        for prior in self._priors:
+          for p in prior._walk(visited, postorder=postorder):
+            yield p
+      if postorder:
+        yield self
+
+  def __repr__(self):
+    return ('FailedToProduce(promise={!r}, plan={!r}, error={!r}, priors={!r})'
+            .format(self._promise, self._plan, self._error, self._priors))
+
+
+def maybe_fail_slow(executable, promise, plan, fail_slow=False):
+  """Executes executable respecting fail-slow semantics if requested.
+
+    :param executable: The callable to execute.
+    :type executable: A no-argument callable.
+    :param promise: The promise the executable's product satisfies.
+    :type promise: :class:`pants.engine.exp.scheduler.Promise`
+    :param plan: The plan the given `executable` executes.
+    :type plan: :class:`pants.engine.exp.scheduler.Plan`
+    :param bool fail_slow: `True` to fail slow, returning a chain of `FailedToProduce` products
+                           along error paths; `False` to let raised `TaskError`s bubble up.
+    :returns: The product of executable; ie: it's return value.  If `fail_slow` is in-effect, this
+              may be a `FailedToProduce` product that captures the executable's error.
+    """
+  # NB: A picklable top-level function to help support local multiprocessing uses.
+  try:
+    return executable()
+  except TaskError as error:
+    if fail_slow:
+      return FailedToProduce(promise, plan, error=error)
+    else:
+      raise error
+
+
+class FailSlowHelper(object):
+  """A collection of helper methods for dealing with fail-slow mode and `FailedToProduce` products.
+
+  This helper is safe for mixin to any type.
+  """
+
+  @staticmethod
+  def collect_inputs(products_by_promise, promise, plan):
+    """Collects the promised inputs for the given plan or else returns the failure product.
+
+    If all of the plan's promised inputs are available then a mapping from promises to input
+    products is returned; otherwise  a `FailedToProduce` product is constructed that records the
+    failure paths.
+
+    :param products_by_promise: A mapping of all collected products so far.
+    :type products_by_promise: dict of (:class:`pants.engine.exp.scheduler.Promise`, product)
+    :param promise: The promise the given plan satisfies.
+    :type promise: :class:`pants.engine.exp.scheduler.Promise`
+    :param plan: The plan to collect promised inputs for.
+    :type plan: :class:`pants.engine.exp.scheduler.Plan`
+    :returns: A mapping from the product types promised to the plan to the products that fulfill
+              those promises or else a single `FailedToProduce` product describing why this can't
+              be done.
+    :rtype: either a dict of (:class:`pants.engine.exp.scheduler.Promise`, product) or a
+            :class:`FailedToProduce` product encapsulating the failure paths.
+    """
+    inputs = {}
+    failed_to_produce = []
+    for pr in plan.promises:
+      product = products_by_promise[pr]
+      if isinstance(product, FailedToProduce):
+        failed_to_produce.append(product)
+      else:
+        inputs[pr] = product
+
+    if failed_to_produce:
+      return FailedToProduce(promise, plan, priors=failed_to_produce)
+    else:
+      return inputs
+
+  @staticmethod
+  def collect_root_outputs(products_by_promise, execution_graph):
+    """Collects the promised products that satisfy the original build request.
+
+    If all of the plan's promised inputs are available then a mapping from promises to input
+    products is returned; otherwise  a `FailedToProduce` product is constructed that records the
+    failure paths.
+
+    :param products_by_promise: A mapping of all collected products so far.
+    :type products_by_promise: dict of (:class:`pants.engine.exp.scheduler.Promise`, product)
+    :param execution_graph: The execution graph to collect root products for.
+    :type execution_graph: :class:`pants.engine.exp.scheduler.ExecutionGraph`
+    :returns: A mapping from the root promised product types to the products that fulfill those
+              promises.
+    :rtype: dict of (:class:`pants.engine.exp.scheduler.Promise`, product)
+    """
+    return {root_promise: products_by_promise[root_promise]
+            for root_promise in execution_graph.root_promises}
+
+  @staticmethod
+  def safe_execute(executable, promise, plan, fail_slow=False):
+    """Executes executable respecting fail-slow semantics if requested.
+
+    :param executable: The callable to execute.
+    :type executable: A no-argument callable.
+    :param promise: The promise the executable's product satisfies.
+    :type promise: :class:`pants.engine.exp.scheduler.Promise`
+    :param plan: The plan the given `executable` executes.
+    :type plan: :class:`pants.engine.exp.scheduler.Plan`
+    :param bool fail_slow: `True` to fail slow, returning a chain of `FailedToProduce` products
+                           along error paths; `False` to let raised `TaskError`s bubble up.
+    :returns: The product of executable; ie: it's return value.  If `fail_slow` is in-effect, this
+              may be a `FailedToProduce` product that captures the executable's error.
+    """
+    return maybe_fail_slow(executable, promise, plan, fail_slow=fail_slow)
+
+
 class Engine(AbstractClass):
   """An engine for running a pants command line."""
 
-  class Result(collections.namedtuple('Result', ['exit_code', 'root_products'])):
+  class PartialFailureError(TaskError):
+    """Indicates a partial failure to execute a build request when in fail-slow mode.
+
+    A `PartialFailureError` can be present in an `Engine.Result` but will never be raised by the
+    engine.  It serves as an aggregate of all failed promise paths and can be used to inspect them.
+
+    The `exit_code` of a PartialFailureError is always `1`.
+    """
+
+    def __init__(self, failed_to_produce):
+      """
+      :param failed_to_produce: A mapping of failed promises to the `FailedToProduce` product
+                                representing the failure.
+      :type failed_to_produce: dict of (:class:`pants.engine.exp.scheduler.Promise`,
+                                        :class:`FailedToProduce`)
+      """
+      failed_targets = OrderedSet()
+      for ftp in failed_to_produce.values():
+        for f in ftp.walk():
+          if isinstance(f.error, TaskError):
+            failed_targets.update(f.error.failed_targets)
+
+      super(Engine.PartialFailureError, self).__init__(exit_code=1,
+                                                       failed_targets=list(failed_targets))
+      self._failed_to_produce = failed_to_produce
+
+    @property
+    def failed_to_produce(self):
+      """Return the mapping of failed promises to `FailedToProduce` products.
+
+      :rtype: dict of (:class:`pants.engine.exp.scheduler.Promise`, :class:`FailedToProduce`)
+      """
+      return self._failed_to_produce
+
+  class Result(collections.namedtuple('Result', ['error', 'root_products'])):
     """Represents the result of a single engine run."""
 
     @classmethod
-    def success(cls, root_products):
-      return cls(exit_code=0, root_products=root_products)
+    def finished(cls, root_products):
+      """Create a success or partial success result from a finished run.
+
+      Runs can either finish with no errors, satisfying all promises, or they can partially finish
+      if run in fail-slow mode producing as many products as possible.
+      :param root_products: The mapping of promised root products to the actual products.  In
+                            fail-slow mode, some of the products may be :class:`FailedToProduce`
+                            products in which case these products will be mapped to an
+                            :class:`Engine.PartialFailureError` in the result.
+      :type root_products: dict of (:class:`pants.engine.exp.scheduler.Promise`, product)
+      :rtype: `Engine.Result`
+      """
+      failed_to_produce = {promise: product for promise, product in root_products.items()
+                           if isinstance(product, FailedToProduce)}
+      if not failed_to_produce:
+        return cls(error=None, root_products=root_products)
+      else:
+        return cls(error=Engine.PartialFailureError(failed_to_produce),
+                   root_products={promise: product for promise, product in root_products.items()
+                                  if not isinstance(product, FailedToProduce)})
 
     @classmethod
-    def failure(cls, exit_code):
-      return cls(exit_code=exit_code, root_products=None)
+    def failure(cls, error):
+      """Create a failure result.
+
+      A failure result represent a fail-fast run with an error.  It presents the error but no
+      products.
+
+      :param error: The execution error encountered.
+      :type error: :class:`pants.base.exceptions.TaskError`
+      :rtype: `Engine.Result`
+      """
+      return cls(error=error, root_products=None)
 
   def __init__(self, local_scheduler):
     """
@@ -38,59 +262,63 @@ class Engine(AbstractClass):
     """
     self._local_scheduler = local_scheduler
 
-  def execute(self, build_request):
+  def execute(self, build_request, fail_slow=False):
     """Executes the the requested build.
 
     :param build_request: The description of the goals to achieve.
     :type build_request: :class:`BuildRequest`
+    :param bool fail_slow: `True` to run as much of the build request as possible, returning a mix
+                           of successfully produced root products and failed products when failures
+                           are encountered.
     :returns: The result of the run.
     :rtype: :class:`Engine.Result`
     """
     execution_graph = self._local_scheduler.execution_graph(build_request)
     try:
-      root_products = self.reduce(execution_graph)
-      return self.Result.success(root_products)
+      root_products = self.reduce(execution_graph, fail_slow)
+      return self.Result.finished(root_products)
     except TaskError as e:
-      message = str(e)
-      if message:
-        print('\nFAILURE: {0}\n'.format(message))
-      else:
-        print('\nFAILURE\n')
-      return self.Result.failure(e.exit_code)
+      return self.Result.failure(e)
 
   @abstractmethod
-  def reduce(self, execution_graph):
+  def reduce(self, execution_graph, fail_slow=False):
     """Reduce the given execution graph returning its root products.
 
     :param execution_graph: An execution graph of plans to reduce.
     :type execution_graph: :class:`ExecutionGraph`
+    :param bool fail_slow: `True` to run as much of the build request as possible, returning a mix
+                           of successfully produced root products and failed products when failures
+                           are encountered.
     :returns: The root products promised by the execution graph.
     :rtype: dict of (:class:`Promise`, product)
     """
 
 
-class LocalSerialEngine(Engine):
+class LocalSerialEngine(FailSlowHelper, Engine):
   """An engine that runs tasks locally and serially in-process."""
 
-  def reduce(self, execution_graph):
-    # TODO(John Sirois): Robustify products_by_promise indexed accesses and raise helpful exceptions
-    # when there is an unexpected missed promise key.
-
+  def reduce(self, execution_graph, fail_slow=False):
     products_by_promise = {}
-    for product_type, plan in execution_graph.walk():
-      binding = plan.bind({promise: products_by_promise[promise] for promise in plan.promises})
-      product = binding.execute()
+    for promise, plan in execution_graph.walk():
+      inputs = self.collect_inputs(products_by_promise, promise, plan)
+      if isinstance(inputs, FailedToProduce):
+        # Short circuit plan execution since we don't have all the inputs it needs.
+        product = inputs
+      else:
+        binding = plan.bind(inputs)
+        product = self.safe_execute(binding.execute, promise, plan, fail_slow=fail_slow)
+
+      # Index the product across all promises we made for it.
       for subject in plan.subjects:
-        products_by_promise[Promise(product_type, subject)] = product
+        products_by_promise[promise.rebind(subject)] = product
 
-    return {root_promise: products_by_promise[root_promise]
-            for root_promise in execution_graph.root_promises}
+    return self.collect_root_outputs(products_by_promise, execution_graph)
 
 
-def _execute_plan(func, product_type, subjects, *args, **kwargs):
+def _execute_plan(func, promise, subjects, *args, **kwargs):
   # A picklable top-level function to help support local multiprocessing uses.
   product = func(*args, **kwargs)
-  return product_type, subjects, product
+  return promise, subjects, product
 
 
 class LocalMultiprocessEngine(Engine):
@@ -107,14 +335,16 @@ class LocalMultiprocessEngine(Engine):
     self._pool_size = pool_size if pool_size > 0 else multiprocessing.cpu_count()
     self._pool = multiprocessing.Pool(self._pool_size)
 
-  class Executor(Thread):
+  class Executor(FailSlowHelper, Thread):
     LAST_PLAN = object()
 
-    def __init__(self, pool, pool_size):
+    def __init__(self, pool, pool_size, fail_slow=False):
       super(LocalMultiprocessEngine.Executor, self).__init__()
 
       self._pool = pool
       self._pool_size = pool_size
+      self._fail_slow = fail_slow
+
       self._waiting = []
       self._plans = Queue.Queue(self._pool_size)
       self._results = Queue.Queue()
@@ -124,13 +354,13 @@ class LocalMultiprocessEngine(Engine):
       self.daemon = True
       self.start()
 
-    def enqueue(self, plan):
-      self._plans.put(plan)
+    def enqueue(self, promise, plan):
+      self._plans.put((promise, plan))
 
-    def finish(self, promises):
+    def finish(self, execution_graph):
       self._plans.put(self.LAST_PLAN)
       self.join()
-      return {promise: self._products_by_promise[promise] for promise in promises}
+      return self.collect_root_outputs(self._products_by_promise, execution_graph)
 
     def run(self):
       while True:
@@ -152,24 +382,39 @@ class LocalMultiprocessEngine(Engine):
           self._waiting.append(plan)
 
     def _submit_all_satisfied(self):
-      for index, (product_type, plan) in enumerate(self._waiting):
-        if all(promise in self._products_by_promise for promise in plan.promises):
+      for index, (promise, plan) in enumerate(self._waiting):
+        if all(pr in self._products_by_promise for pr in plan.promises):
           self._waiting.pop(index)
-          func, args, kwargs = plan.bind({promise: self._products_by_promise[promise]
-                                          for promise in plan.promises})
-          execute_plan = functools.partial(_execute_plan, func, product_type, plan.subjects)
-          self._pool.apply_async(execute_plan, args=args, kwds=kwargs, callback=self._results.put)
+          inputs = self.collect_inputs(self._products_by_promise, promise, plan)
+          if isinstance(inputs, FailedToProduce):
+            self._results.put((promise, plan.subjects, inputs))
+          else:
+            func, args, kwargs = plan.bind(inputs)
+
+            # TODO(John Sirois): Improve this 3-step.  Its very hard to read.
+            executable = functools.partial(func, *args, **kwargs)
+            maybe_fail_slow_executor = functools.partial(maybe_fail_slow,
+                                                         executable,
+                                                         promise,
+                                                         plan,
+                                                         self._fail_slow)
+            execute_plan = functools.partial(_execute_plan,
+                                             maybe_fail_slow_executor,
+                                             promise,
+                                             plan.subjects)
+
+            self._pool.apply_async(execute_plan, callback=self._results.put)
 
     def _gather_one(self):
-      product_type, subjects, product = self._results.get()
+      promise, subjects, product = self._results.get()
       for subject in subjects:
-        self._products_by_promise[Promise(product_type, subject)] = product
+        self._products_by_promise[promise.rebind(subject)] = product
 
-  def reduce(self, execution_graph):
-    executor = self.Executor(self._pool, self._pool_size)
-    for plan in execution_graph.walk():
-      executor.enqueue(plan)
-    return executor.finish(execution_graph.root_promises)
+  def reduce(self, execution_graph, fail_slow=False):
+    executor = self.Executor(self._pool, self._pool_size, fail_slow=fail_slow)
+    for promise, plan in execution_graph.walk():
+      executor.enqueue(promise, plan)
+    return executor.finish(execution_graph)
 
   def close(self):
     self._pool.close()

--- a/src/python/pants/engine/exp/engine.py
+++ b/src/python/pants/engine/exp/engine.py
@@ -394,6 +394,7 @@ class LocalMultiprocessEngine(Engine):
           self._waiting.pop(index)
           inputs = self.collect_inputs(self._products_by_promise, promise, plan)
           if isinstance(inputs, FailedToProduce):
+            # Short circuit plan execution since we don't have all the inputs it needs.
             self._results.put((promise, plan.subjects, inputs))
           else:
             func, args, kwargs = plan.bind(inputs)

--- a/src/python/pants/engine/exp/examples/BUILD
+++ b/src/python/pants/engine/exp/examples/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources=['planners.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/engine/exp:addressable',
     'src/python/pants/engine/exp:configuration',

--- a/src/python/pants/engine/exp/examples/planners.py
+++ b/src/python/pants/engine/exp/examples/planners.py
@@ -11,6 +11,7 @@ from abc import abstractmethod, abstractproperty
 
 from twitter.common.collections import OrderedSet
 
+from pants.base.exceptions import TaskError
 from pants.build_graph.address import Address
 from pants.engine.exp.addressable import SubclassesOf, addressable_list
 from pants.engine.exp.configuration import Configuration
@@ -37,7 +38,8 @@ def printing_func(func):
   @functools.wraps(func)
   def wrapper(**inputs):
     print('{} being executed with inputs: {}'.format(func.__name__, inputs))
-    return '<<<Fake{}Product>>>'.format(func.__name__)
+    product = func(**inputs)
+    return product if product else '<<<Fake{}Product>>>'.format(func.__name__)
   return wrapper
 
 
@@ -238,9 +240,15 @@ class ApacheThriftPlanner(ThriftPlanner):
                 strict=apache_thrift_config.strict)
 
 
+class ApacheThriftError(TaskError):
+  pass
+
+
 @printing_func
 def gen_apache_thrift(sources, rev, gen, strict):
-  pass
+  if rev == 'fail':
+    raise ApacheThriftError('Failed to generate via apache thrift for sources: {}, rev: {}, '
+                            'gen:{}, strict: {}'.format(sources, rev, gen, strict))
 
 
 class ScroogeConfiguration(ThriftConfiguration):

--- a/src/python/pants/engine/exp/examples/visualizer.py
+++ b/src/python/pants/engine/exp/examples/visualizer.py
@@ -24,8 +24,8 @@ def create_digraph(execution_graph):
   def format_promise(promise):
     return '{}({})'.format(promise.product_type.__name__, format_subject(promise.subject))
 
-  def format_label(product_type, plan):
-    return '{}:{}'.format(plan.func_or_task_type.value.__name__, product_type.__name__)
+  def format_label(promise, plan):
+    return '{}:{}'.format(plan.func_or_task_type.value.__name__, promise.product_type.__name__)
 
   colorscheme = 'set312'
   colors = {}
@@ -38,8 +38,8 @@ def create_digraph(execution_graph):
   yield '  concentrate=true;'
   yield '  rankdir=LR;'
 
-  for product_type, plan in execution_graph.walk():
-    label = format_label(product_type, plan)
+  for promise, plan in execution_graph.walk():
+    label = format_label(promise, plan)
     color = color_index(plan.func_or_task_type)
     if len(plan.subjects) > 1:
       # NB: naming a subgraph cluster* triggers drawing of a box around the subgraph.  We levarge
@@ -56,12 +56,12 @@ def create_digraph(execution_graph):
         yield ('    node [style=filled, fillcolor={color}, label="{label}"] "{node}";'
                .format(color=subgraph_node_color,
                        label=format_subject(subject),
-                       node=format_promise(Promise(product_type, subject))))
+                       node=format_promise(promise.rebind(subject))))
 
       yield '  }'
     else:
       subject = list(plan.subjects)[0]
-      node = Promise(product_type, subject)
+      node = promise.rebind(subject)
 
       yield ('  node [style=filled, fillcolor={color}, label="{label}({subject})"] "{node}";'
              .format(color=color,
@@ -69,10 +69,10 @@ def create_digraph(execution_graph):
                      subject=format_subject(subject),
                      node=format_promise(node)))
 
-    for promise in plan.promises:
+    for pr in plan.promises:
       for subject in plan.subjects:
-        yield '  "{}" -> "{}"'.format(format_promise(Promise(product_type, subject)),
-                                      format_promise(promise))
+        yield '  "{}" -> "{}"'.format(format_promise(promise.rebind(subject)),
+                                      format_promise(pr))
 
   yield '}'
 

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/selector/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/java/codegen/selector/BLD.json
@@ -23,3 +23,13 @@
     "src/thrift/codegen/selector"
   ]
 }
+
+{
+  "type_alias": "target",
+  "name": "failing",
+  "sources": ":sources",
+  "dependencies": [
+    "3rdparty/jvm:guava",
+    "src/thrift/codegen/selector:selector@failing"
+  ]
+}

--- a/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
+++ b/tests/python/pants_test/engine/exp/examples/scheduler_inputs/src/thrift/BLD.json
@@ -92,6 +92,13 @@
         "3rdparty/jvm:scala-library",
         ":slf4j-api"
       ]
+    },
+    {
+      "type_alias": "apache_thrift_configuration",
+      "name": "failing",
+      "rev": "fail",
+      "strict": true,
+      "gen": "java"
     }
   ]
 }

--- a/tests/python/pants_test/engine/exp/test_engine.py
+++ b/tests/python/pants_test/engine/exp/test_engine.py
@@ -10,8 +10,9 @@ import unittest
 from contextlib import closing
 
 from pants.build_graph.address import Address
-from pants.engine.exp.engine import LocalMultiprocessEngine, LocalSerialEngine
-from pants.engine.exp.examples.planners import Classpath, Javac, setup_json_scheduler
+from pants.engine.exp.engine import Engine, LocalMultiprocessEngine, LocalSerialEngine
+from pants.engine.exp.examples.planners import (ApacheThriftError, Classpath, Javac, Sources,
+                                                setup_json_scheduler)
 from pants.engine.exp.scheduler import BuildRequest, Promise
 
 
@@ -20,13 +21,19 @@ class EngineTest(unittest.TestCase):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
     self.graph, self.scheduler = setup_json_scheduler(build_root)
 
-    self.java = self.graph.resolve(Address.parse('src/java/codegen/simple'))
+    def resolve(spec):
+      return self.graph.resolve(Address.parse(spec))
+
+    self.java = resolve('src/java/codegen/simple')
+    self.java_fail_slow = resolve('src/java/codegen/selector:failing')
+    self.failing_thrift = resolve('src/thrift/codegen/selector:selector@failing')
 
   def assert_engine(self, engine):
     build_request = BuildRequest(goals=['compile'], addressable_roots=[self.java.address])
     result = engine.execute(build_request)
     self.assertEqual({Promise(Classpath, self.java): Javac.fake_product()},
                      result.root_products)
+    self.assertIsNone(result.error)
 
   def test_serial_engine(self):
     engine = LocalSerialEngine(self.scheduler)
@@ -35,3 +42,33 @@ class EngineTest(unittest.TestCase):
   def test_multiprocess_engine(self):
     with closing(LocalMultiprocessEngine(self.scheduler)) as engine:
       self.assert_engine(engine)
+
+  def assert_engine_fail_slow(self, engine):
+    build_request = BuildRequest(goals=['compile'],
+                                 addressable_roots=[self.java.address, self.java_fail_slow.address])
+    result = engine.execute(build_request, fail_slow=True)
+    self.assertEqual({Promise(Classpath, self.java): Javac.fake_product()},
+                     result.root_products)
+
+    self.assertIsInstance(result.error, Engine.PartialFailureError)
+    self.assertEqual(1, len(result.error.failed_to_produce))
+    failed_promise = Promise(Classpath, self.java_fail_slow)
+    failed_to_produce = result.error.failed_to_produce[failed_promise]
+    failing_configuration = self.failing_thrift.select_configuration('failing')
+    self.assertEqual([Promise(Sources.of('.java'), self.failing_thrift, failing_configuration),
+                      Promise(Classpath, self.failing_thrift, failing_configuration),
+                      Promise(Classpath, self.java_fail_slow)],
+                     [ftp.promise for ftp in failed_to_produce.walk(postorder=True)])
+    errors = [ftp.error for ftp in failed_to_produce.walk(postorder=True)]
+    self.assertEqual(3, len(errors))
+    root_error = errors[0]
+    self.assertIsInstance(root_error, ApacheThriftError)
+    self.assertEqual([None, None], errors[1:])
+
+  def test_serial_engine_fail_slow(self):
+    engine = LocalSerialEngine(self.scheduler)
+    self.assert_engine_fail_slow(engine)
+
+  def test_multiprocess_engine_fail_slow(self):
+    engine = LocalMultiprocessEngine(self.scheduler)
+    self.assert_engine_fail_slow(engine)

--- a/tests/python/pants_test/engine/exp/test_scheduler.py
+++ b/tests/python/pants_test/engine/exp/test_scheduler.py
@@ -23,26 +23,30 @@ class SchedulerTest(unittest.TestCase):
     self.thrift = self.graph.resolve(Address.parse('src/thrift/codegen/simple'))
     self.java = self.graph.resolve(Address.parse('src/java/codegen/simple'))
 
-  def assert_resolve_only(self, goals, root_specs, jar):
+  def extract_product_type_and_plan(self, plan):
+    promise, plan = plan
+    return promise.product_type, plan
+
+  def assert_resolve_only(self, goals, root_specs, jars):
     build_request = BuildRequest(goals=goals,
                                  addressable_roots=[Address.parse(spec) for spec in root_specs])
     execution_graph = self.scheduler.execution_graph(build_request)
 
     plans = list(execution_graph.walk())
     self.assertEqual(1, len(plans))
-    self.assertEqual((Promise(Classpath, jar),
-                      Plan(func_or_task_type=IvyResolve, subjects=[jar], jars=[jar])),
-                     plans[0])
+    self.assertEqual((Classpath,
+                      Plan(func_or_task_type=IvyResolve, subjects=jars, jars=list(jars))),
+                     self.extract_product_type_and_plan(plans[0]))
 
   def test_resolve(self):
     self.assert_resolve_only(goals=['resolve'],
                              root_specs=['3rdparty/jvm:guava'],
-                             jar=self.guava)
+                             jars=[self.guava])
 
   def test_compile_only_3rdaprty(self):
     self.assert_resolve_only(goals=['compile'],
                              root_specs=['3rdparty/jvm:guava'],
-                             jar=self.guava)
+                             jars=[self.guava])
 
   def test_gen_noop(self):
     # TODO(John Sirois): Ask around - is this OK?
@@ -62,14 +66,14 @@ class SchedulerTest(unittest.TestCase):
     plans = list(execution_graph.walk())
     self.assertEqual(1, len(plans))
 
-    self.assertEqual((Promise(Sources.of('.java'), self.thrift),
+    self.assertEqual((Sources.of('.java'),
                       Plan(func_or_task_type=gen_apache_thrift,
                            subjects=[self.thrift],
                            strict=True,
                            rev='0.9.2',
                            gen='java',
                            sources=['src/thrift/codegen/simple/simple.thrift'])),
-                     plans[0])
+                     self.extract_product_type_and_plan(plans[0]))
 
   def test_codegen_simple(self):
     build_request = BuildRequest(goals=['compile'], addressable_roots=[self.java.address])
@@ -78,37 +82,35 @@ class SchedulerTest(unittest.TestCase):
     plans = list(execution_graph.walk())
     self.assertEqual(4, len(plans))
 
-    slf4j_api = self.graph.resolve(Address.parse('src/thrift:slf4j-api'))
     thrift_jars = [Jar(org='org.apache.thrift', name='libthrift', rev='0.9.2'),
                    Jar(org='commons-lang', name='commons-lang', rev='2.5'),
-                   slf4j_api]
+                   self.graph.resolve(Address.parse('src/thrift:slf4j-api'))]
 
     jars = [self.guava] + thrift_jars
 
     # Independent leaves 1st
-    self.assertEqual({(Promise(Sources.of('.java'), self.thrift),
+    self.assertEqual({(Sources.of('.java'),
                        Plan(func_or_task_type=gen_apache_thrift,
                             subjects=[self.thrift],
                             strict=True,
                             rev='0.9.2',
                             gen='java',
                             sources=['src/thrift/codegen/simple/simple.thrift'])),
-                      (Promise(Classpath, self.guava),
-                       Plan(func_or_task_type=IvyResolve, subjects=jars, jars=jars))},
-                     set(plans[0:2]))
+                      (Classpath, Plan(func_or_task_type=IvyResolve, subjects=jars, jars=jars))},
+                     set(self.extract_product_type_and_plan(p) for p in plans[0:2]))
 
     # The rest is linked.
-    self.assertEqual((Promise(Classpath, self.thrift),
+    self.assertEqual((Classpath,
                       Plan(func_or_task_type=Javac,
                            subjects=[self.thrift],
                            sources=Promise(Sources.of('.java'), self.thrift),
                            classpath=[Promise(Classpath, jar) for jar in thrift_jars])),
-                     plans[2])
+                     self.extract_product_type_and_plan(plans[2]))
 
-    self.assertEqual((Promise(Classpath, self.java),
+    self.assertEqual((Classpath,
                       Plan(func_or_task_type=Javac,
                            subjects=[self.java],
                            sources=['src/java/codegen/simple/Simple.java'],
                            classpath=[Promise(Classpath, self.guava),
                                       Promise(Classpath, self.thrift)])),
-                     plans[3])
+                     self.extract_product_type_and_plan(plans[3]))


### PR DESCRIPTION
This allows for an engine execution to be in `fail_slow` mode, in which
case as much of the execution graph as can be executed is and failure
paths are recorded using a `FailedToProduce` product type.

A test is added with a failing path and a good path to exercise this
handling in both the serial and multiprocess engines.

https://rbcommons.com/s/twitter/r/3040/