### PR TITLE
[CI] Fix implementation of shallow copy on OptionValueContainer.

### DIFF
--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import copy
+
 from pants.option.ranked_value import RankedValue
 
 
@@ -135,3 +137,9 @@ class OptionValueContainer(object):
     """Returns an iterator over all option names, in lexicographical order."""
     for name in sorted(self._value_map.keys()):
       yield name
+
+  def __copy__(self):
+    """Ensure that a shallow copy has its own value map."""
+    ret = type(self)()
+    ret._value_map = copy.copy(self._value_map)
+    return ret

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -254,7 +254,7 @@ class Options(object):
     if scope == GLOBAL_SCOPE:
       values = OptionValueContainer()
     else:
-      values = copy.deepcopy(self.for_scope(enclosing_scope(scope)))
+      values = copy.copy(self.for_scope(enclosing_scope(scope)))
 
     # Now add our values.
     flags_in_scope = self._scope_to_flags.get(scope, [])

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -78,17 +78,31 @@ class OptionValueContainerTest(unittest.TestCase):
     o = OptionValueContainer()
     o.foo = 1
     o.bar = {'a': 111}
+
     p = copy.copy(o)
-    o.bar['b'] = 222  # Add to original dict.
-    self.assertEqual(1, p.foo)
-    self.assertEqual({'a': 111, 'b': 222}, p.bar)  # Ensure dict was not copied.
+
+    # Verify that the result is in fact a copy.
+    self.assertEqual(1, p.foo)  # Has original attribute.
+    o.baz = 42
+    self.assertFalse(hasattr(p, 'baz'))  # Does not have attribute added after the copy.
+
+    # Verify that it's a shallow copy by modifying a referent in o and reading it in p.
+    o.bar['b'] = 222
+    self.assertEqual({'a': 111, 'b': 222}, p.bar)
 
   def test_deepcopy(self):
-    # deepcopy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
+    # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
     o = OptionValueContainer()
     o.foo = 1
     o.bar = {'a': 111}
+
     p = copy.deepcopy(o)
-    o.bar['b'] = 222  # Add to original dict.
-    self.assertEqual(1, p.foo)
-    self.assertEqual({'a': 111}, p.bar)  # Ensure dict was copied.
+
+    # Verify that the result is in fact a copy.
+    self.assertEqual(1, p.foo)  # Has original attribute.
+    o.baz = 42
+    self.assertFalse(hasattr(p, 'baz'))  # Does not have attribute added after the copy.
+
+    # Verify that it's a deep copy by modifying a referent in o and reading it in p.
+    o.bar['b'] = 222
+    self.assertEqual({'a': 111}, p.bar)


### PR DESCRIPTION
- Adds a test to verify it.
- Uses it instead of an unnecessary deepcopy.

Those deepcopies were significant enough to show up in profiles.