### PR TITLE
Peiyu/clean up corrupted local artifact

### DIFF
--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -9,7 +9,7 @@ import logging
 import os
 from contextlib import contextmanager
 
-from pants.cache.artifact import ArtifactError, TarballArtifact
+from pants.cache.artifact import TarballArtifact
 from pants.cache.artifact_cache import ArtifactCache, UnreadableArtifact
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import safe_delete, safe_mkdir, safe_mkdir_for, safe_rmtree
@@ -118,15 +118,10 @@ class LocalArtifactCache(BaseLocalArtifactCache):
           safe_rmtree(results_dir)
         artifact.extract()
         return True
-    except (ArtifactError, IOError) as non_retryable_exception:
-      logger.warn('Cleaning up corrupted artifact {0}: {1}'
-                  .format(tarfile, non_retryable_exception))
-      safe_delete(tarfile)
-      return UnreadableArtifact(cache_key, non_retryable_exception)
     except Exception as e:
-      # The rest exceptions could be transient, we can further refine this by moving
-      # non-retryable errors handling to the above section.
-      logger.warn('Error while reading {0}: {1}'.format(tarfile, e))
+      # TODO(davidt): Consider being more granular in what is caught.
+      logger.warn('Error while reading {0} from local artifact cache: {1}'.format(tarfile, e))
+      safe_delete(tarfile)
       return UnreadableArtifact(cache_key, e)
 
     return False

--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -9,7 +9,7 @@ import logging
 import os
 from contextlib import contextmanager
 
-from pants.cache.artifact import TarballArtifact
+from pants.cache.artifact import ArtifactError, TarballArtifact
 from pants.cache.artifact_cache import ArtifactCache, UnreadableArtifact
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import safe_delete, safe_mkdir, safe_mkdir_for, safe_rmtree

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -265,4 +265,13 @@ class TestArtifactCache(unittest.TestCase):
     with self.setup_local_cache() as artifact_cache:
       with self.setup_test_file(artifact_cache.artifact_root) as path:
         artifact_cache.insert(key, [path])
+        tarfile = artifact_cache._cache_file_for_key(key)
+
         self.assertTrue(artifact_cache.use_cached_files(key))
+        self.assertTrue(os.path.exists(tarfile))
+
+        with open(tarfile, 'w') as outfile:
+          outfile.write('not a valid tgz any more')
+
+        self.assertFalse(artifact_cache.use_cached_files(key))
+        self.assertFalse(os.path.exists(tarfile))

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -258,3 +258,11 @@ class TestArtifactCache(unittest.TestCase):
             map(call_use_cached_files, [(cache, key, results_dir)]),
             [False])
           self.assertTrue(os.path.exists(canary))
+
+  def test_corruptted_cached_file_cleaned_up(self):
+    key = CacheKey('muppet_key', 'fake_hash', 42)
+
+    with self.setup_local_cache() as artifact_cache:
+      with self.setup_test_file(artifact_cache.artifact_root) as path:
+        artifact_cache.insert(key, [path])
+        self.assertTrue(artifact_cache.use_cached_files(key))


### PR DESCRIPTION
Saw a bunch "CRC check failed" errors, it's ok for downloads to fail, but it's not ok to leave the corrupted artifacts in local cache. Because most of such errors are non-retryable, and if we don't clean up bad artifacts, next time (we still from time to time need clean-all) will be a cache hit first but then fail the check and do the compile again. As you can see most if not all [tarfile.ReadError](https://github.com/certik/python-2.7/blob/master/Lib/tarfile.py) and [IOError from gzip](https://github.com/certik/python-2.7/blob/c360290c3c9e55fbd79d6ceacdfc7cd4f393c1eb/Lib/gzip.py) are not retryable