### PR TITLE
[CI] Defer argparse registration to the last possible moment.

### DIFF
--- a/src/python/pants/backend/core/tasks/explain_options_task.py
+++ b/src/python/pants/backend/core/tasks/explain_options_task.py
@@ -83,7 +83,7 @@ class ExplainOptionsTask(ConsoleTask):
         yield '  overrode {}'.format(self._format_record(record))
 
   def _force_option_parsing(self):
-    scopes = list(self.context.options.tracker.option_history_by_scope.keys())
+    scopes = filter(self._scope_filter, list(self.context.options.known_scope_to_info.keys()))
     for scope in scopes:
       self.context.options.for_scope(scope)
 

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -34,12 +34,13 @@ class HelpFormatter(object):
   def _maybe_color(self, color, s):
     return color(s) if self._color else s
 
-  def format_options(self, scope, description, registration_args):
+  def format_options(self, scope, description, option_registrations_iter):
     """Return a help message for the specified options.
 
-    :param registration_args: A list of (args, kwargs) pairs, as passed in to options registration.
+    :param option_registrations_iter: An iterator over (args, kwargs) pairs, as passed in to
+                                      options registration.
     """
-    oshi = HelpInfoExtracter(self._scope).get_option_scope_help_info(registration_args)
+    oshi = HelpInfoExtracter(self._scope).get_option_scope_help_info(option_registrations_iter)
     lines = []
     def add_option(category, ohis):
       if ohis:

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -54,7 +54,7 @@ class HelpInfoExtracter(object):
 
     Callers can format this dict into cmd-line help, HTML or whatever.
     """
-    return cls(parser.scope).get_option_scope_help_info(parser.registration_args)
+    return cls(parser.scope).get_option_scope_help_info(parser.option_registrations_iter())
 
   @staticmethod
   def compute_default(kwargs):
@@ -100,12 +100,13 @@ class HelpInfoExtracter(object):
     self._scope = scope
     self._scope_prefix = scope.replace('.', '-')
 
-  def get_option_scope_help_info(self, registration_args):
+  def get_option_scope_help_info(self, option_registrations_iter):
     """Returns an OptionScopeHelpInfo for the options registered with the (args, kwargs) pairs."""
     basic_options = []
     recursive_options = []
     advanced_options = []
-    for args, kwargs in registration_args:
+    # Sort the arguments, so we display the help in alphabetical order.
+    for args, kwargs in sorted(option_registrations_iter):
       ohi = self.get_option_help_info(args, kwargs)
       if kwargs.get('advanced'):
         advanced_options.append(ohi)

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -132,6 +132,6 @@ class HelpPrinter(object):
     show_recursive = self._help_request.advanced
     show_advanced = self._help_request.advanced
     color = sys.stdout.isatty()
-    registration_args = self._options.get_parser(scope).registration_args
     help_formatter = HelpFormatter(scope, show_recursive, show_advanced, color)
-    return '\n'.join(help_formatter.format_options(scope, description, registration_args))
+    return '\n'.join(help_formatter.format_options(scope, description,
+        self._options.get_parser(scope).option_registrations_iter()))

--- a/src/python/pants/option/option_tracker.py
+++ b/src/python/pants/option/option_tracker.py
@@ -10,6 +10,7 @@ from collections import defaultdict, namedtuple
 from pants.option.ranked_value import RankedValue
 
 
+# TODO: Get rid of this? The parser should be able to lazily track.
 class OptionTracker(object):
   """Records a history of what options are set and where they came from."""
 

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -273,10 +273,10 @@ class OptionsTest(unittest.TestCase):
   def test_boolean_invalid_value(self):
     with self.assertRaises(Parser.BooleanConversionError):
       self._parse('./pants', config={'DEFAULT': {'store_true_flag': 11,
-                                                 }})
+                                                 }}).for_global_scope()
     with self.assertRaises(Parser.BooleanConversionError):
       self._parse('./pants', config={'DEFAULT': {'store_true_flag': 'AlmostTrue',
-                                               }})
+                                               }}).for_global_scope()
 
   def test_defaults(self):
     # Hard-coded defaults.
@@ -486,6 +486,7 @@ class OptionsTest(unittest.TestCase):
                                option_tracker=OptionTracker())
       options.register(GLOBAL_SCOPE, '--too-old-option', deprecated_version='0.0.24',
                        deprecated_hint='The semver for this option has already passed.')
+      options.for_global_scope()
 
   @contextmanager
   def warnings_catcher(self):
@@ -654,22 +655,23 @@ class OptionsTest(unittest.TestCase):
                           '--modifycompile="blah blah blah" --modifylogs="durrrr"')
 
     pairs = options.get_fingerprintable_for_scope('compile.scala')
+    print(pairs)
     self.assertEquals(len(pairs), 3)
     self.assertEquals(('', 'blah blah blah'), pairs[0])
     self.assertEquals(('', True), pairs[1])
     self.assertEquals((int, 77), pairs[2])
 
   def assert_fromfile(self, parse_func, expected_append=None, append_contents=None):
-    def assert_fromfile(dest, expected, contents):
+    def _do_assert_fromfile(dest, expected, contents):
       with temporary_file() as fp:
         fp.write(contents)
         fp.close()
         options = parse_func(dest, fp.name)
         self.assertEqual(expected, options.for_scope('fromfile')[dest])
 
-    assert_fromfile(dest='string', expected='jake', contents='jake')
-    assert_fromfile(dest='intvalue', expected=42, contents='42')
-    assert_fromfile(dest='dictvalue', expected={'a': 42, 'b': (1, 2)}, contents=dedent("""
+    _do_assert_fromfile(dest='string', expected='jake', contents='jake')
+    _do_assert_fromfile(dest='intvalue', expected=42, contents='42')
+    _do_assert_fromfile(dest='dictvalue', expected={'a': 42, 'b': (1, 2)}, contents=dedent("""
       {
         'a': 42,
         'b': (
@@ -678,7 +680,7 @@ class OptionsTest(unittest.TestCase):
         )
       }
       """))
-    assert_fromfile(dest='listvalue', expected=['a', 1, 2], contents=dedent("""
+    _do_assert_fromfile(dest='listvalue', expected=['a', 1, 2], contents=dedent("""
       ['a',
        1,
        2]
@@ -692,7 +694,7 @@ class OptionsTest(unittest.TestCase):
        42
       ]
       """)
-    assert_fromfile(dest='appendvalue', expected=expected_append, contents=append_contents)
+    _do_assert_fromfile(dest='appendvalue', expected=expected_append, contents=append_contents)
 
   def test_fromfile_flags(self):
     def parse_func(dest, fromfile):

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -113,9 +113,6 @@ def create_options(options, passthru_args=None):
     def items(self):
       return options.items()
 
-    def registration_args_iter_for_scope(self, scope):
-      return []
-
     def get_fingerprintable_for_scope(self, scope):
       return []
 


### PR DESCRIPTION
Now option registration just records the registration args,
and they get applied as needed, as an implementation detail.

This was also an opportunity to clean up and de-complicate
how we register recursive options, so the code is neater now.

The performance benefits are very noticeable in profiles.

Note that this means that some validation will only happen if
the options are actually requested, which required a few
changes in tests.