### PR TITLE
Preparation to moving workdir outside of build root

### DIFF
--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
@@ -69,7 +69,7 @@ class CppIntegrationTest(PantsRunIntegrationTest):
                   pants_run.stdout_data)
 
   def _run_with_cache(self, task, target):
-    with temporary_dir(root_dir=self.workdir_root()) as cache:
+    with self.temporary_cachedir() as cache:
       args = [
         'clean-all',
         task,

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_compile_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_compile_integration.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.subsystem.subsystem_util import subsystem_instance
 
@@ -17,7 +16,7 @@ from pants.contrib.go.subsystems.go_distribution import GoDistribution
 class GoCompileIntegrationTest(PantsRunIntegrationTest):
 
   def test_go_compile_simple(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       args = ['compile',
               'contrib/go/examples/src/go/libA']
       pants_run = self.run_pants_with_workdir(args, workdir)

--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -8,25 +8,14 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.core.tasks.task import Task
-from pants.base.build_environment import PANTS_WORKDIR_SUFFIX
-from pants.base.exceptions import TaskError
 from pants.util.dirutil import safe_rmtree
-
-
-def _cautious_get_working_directory(task):
-  """Check that working directory ends with right suffix before make destructive actions"""
-  workdir = task.get_options().pants_workdir
-  if not workdir.endswith(PANTS_WORKDIR_SUFFIX):
-    raise TaskError('DANGER: Attempting to use working directory {}, which is not ends with \'.pants.d\'!'
-                    .format(workdir))
-  return workdir
 
 
 class Invalidator(Task):
   """Invalidate the entire build."""
 
   def execute(self):
-    build_invalidator_dir = os.path.join(_cautious_get_working_directory(self), 'build_invalidator')
+    build_invalidator_dir = os.path.join(self.get_options().pants_workdir, 'build_invalidator')
     safe_rmtree(build_invalidator_dir)
 
 
@@ -34,4 +23,4 @@ class Cleaner(Task):
   """Clean all current build products."""
 
   def execute(self):
-    safe_rmtree(_cautious_get_working_directory(self))
+    safe_rmtree(self.get_options().pants_workdir)

--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -8,17 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.core.tasks.task import Task
-from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError
 from pants.util.dirutil import safe_rmtree
-
-
-def _cautious_rmtree(root):
-  real_buildroot = os.path.realpath(os.path.abspath(get_buildroot()))
-  real_root = os.path.realpath(os.path.abspath(root))
-  if not real_root.startswith(real_buildroot):
-    raise TaskError('DANGER: Attempting to delete {}, which is not under the build root!'.format(real_root))
-  safe_rmtree(real_root)
 
 
 class Invalidator(Task):
@@ -26,11 +16,11 @@ class Invalidator(Task):
 
   def execute(self):
     build_invalidator_dir = os.path.join(self.get_options().pants_workdir, 'build_invalidator')
-    _cautious_rmtree(build_invalidator_dir)
+    safe_rmtree(build_invalidator_dir)
 
 
 class Cleaner(Task):
   """Clean all current build products."""
 
   def execute(self):
-    _cautious_rmtree(self.get_options().pants_workdir)
+    safe_rmtree(self.get_options().pants_workdir)

--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -21,6 +21,7 @@ def _cautious_get_working_directory(task):
                     .format(workdir))
   return workdir
 
+
 class Invalidator(Task):
   """Invalidate the entire build."""
 

--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -8,14 +8,24 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.core.tasks.task import Task
+from pants.base.exceptions import TaskError
+from pants.option.global_options import PANTS_WORKDIR_SUFFIX
 from pants.util.dirutil import safe_rmtree
 
+
+def _cautious_get_working_directory(task):
+  """Check that working directory ends with right suffix before make destructive actions"""
+  workdir = task.get_options().pants_workdir
+  if not workdir.endswith(PANTS_WORKDIR_SUFFIX):
+    raise TaskError('DANGER: Attempting to use working directory {}, which is not ends with \'.pants.d\'!'
+                    .format(workdir))
+  return workdir
 
 class Invalidator(Task):
   """Invalidate the entire build."""
 
   def execute(self):
-    build_invalidator_dir = os.path.join(self.get_options().pants_workdir, 'build_invalidator')
+    build_invalidator_dir = os.path.join(_cautious_get_working_directory(self), 'build_invalidator')
     safe_rmtree(build_invalidator_dir)
 
 
@@ -23,4 +33,4 @@ class Cleaner(Task):
   """Clean all current build products."""
 
   def execute(self):
-    safe_rmtree(self.get_options().pants_workdir)
+    safe_rmtree(_cautious_get_working_directory(self))

--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -8,8 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.core.tasks.task import Task
+from pants.base.build_environment import PANTS_WORKDIR_SUFFIX
 from pants.base.exceptions import TaskError
-from pants.option.global_options import PANTS_WORKDIR_SUFFIX
 from pants.util.dirutil import safe_rmtree
 
 

--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -9,7 +9,6 @@ import os
 
 from pants.backend.jvm.targets.exclude import Exclude
 from pants.backend.jvm.targets.jvm_target import JvmTarget
-from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.goal.products import UnionProducts
 
@@ -121,10 +120,14 @@ def _not_excluded_filter(excludes):
 
 
 class ClasspathProducts(object):
-  def __init__(self, classpaths=None, excludes=None):
+  def __init__(self, pants_workdir, classpaths=None, excludes=None):
     self._classpaths = classpaths or UnionProducts()
     self._excludes = excludes or UnionProducts()
-    self._buildroot = get_buildroot()
+    self._pants_workdir = pants_workdir
+
+  @staticmethod
+  def init_func(pants_workdir):
+    return lambda: ClasspathProducts(pants_workdir)
 
   def copy(self):
     """Returns a copy of this ClasspathProducts.
@@ -135,7 +138,8 @@ class ClasspathProducts(object):
 
     :rtype: :class:`ClasspathProducts`
     """
-    return ClasspathProducts(classpaths=self._classpaths.copy(),
+    return ClasspathProducts(pants_workdir=self._pants_workdir,
+                             classpaths=self._classpaths.copy(),
                              excludes=self._excludes.copy())
 
   def add_for_targets(self, targets, classpath_elements):
@@ -289,17 +293,17 @@ class ClasspathProducts(object):
     self._classpaths.add_for_target(target, elements)
 
   def _validate_classpath_tuples(self, classpath, target):
-    """Validates that all files are located within the working copy, to simplify relativization.
+    """Validates that all files are located within the working directory, to simplify relativization.
 
     :param classpath: The list of classpath tuples. Each tuple is a 2-tuple of ivy_conf and
                       ClasspathEntry.
     :param target: The target that the classpath tuple is being registered for.
-    :raises: `TaskError` when the path is outside the build root
+    :raises: `TaskError` when the path is outside the work directory
     """
     for classpath_tuple in classpath:
       conf, classpath_entry = classpath_tuple
       path = classpath_entry.path
-      if os.path.relpath(path, self._buildroot).startswith(os.pardir):
+      if os.path.relpath(path, self._pants_workdir).startswith(os.pardir):
         raise TaskError(
-          'Classpath entry {} for target {} is located outside the buildroot.'
+          'Classpath entry {} for target {} is located outside the working directory.'
           .format(path, target.address.spec))

--- a/src/python/pants/backend/jvm/tasks/ivy_imports.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_imports.py
@@ -42,7 +42,7 @@ class IvyImports(IvyTaskMixin, NailgunTask):
     for target in targets:
       all_targets.update(target.imported_jar_libraries)
 
-    imports_classpath = ClasspathProducts()
+    imports_classpath = ClasspathProducts(self.get_options().pants_workdir)
     self.resolve(executor=self.create_java_executor(),
                  targets=all_targets,
                  classpath_products=imports_classpath,

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -95,7 +95,7 @@ class IvyResolve(IvyTaskMixin, NailgunTask):
     executor = self.create_java_executor()
     targets = self.context.targets()
     compile_classpath = self.context.products.get_data('compile_classpath',
-                                                       init_func=ClasspathProducts)
+                                                       init_func=ClasspathProducts.init_func(self.get_options().pants_workdir))
     resolve_hash_name = self.resolve(executor=executor,
                                      targets=targets,
                                      classpath_products=compile_classpath,

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -133,7 +133,7 @@ class ExportTask(IvyTaskMixin, PythonTask):
 
     compile_classpath = None
     if confs:
-      compile_classpath = ClasspathProducts()
+      compile_classpath = ClasspathProducts(self.get_options().pants_workdir)
       self.resolve(executor=executor,
                    targets=targets,
                    classpath_products=compile_classpath,

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -170,7 +170,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
       confs.append('sources')
     if self.get_options().javadoc_jars:
       confs.append('javadoc')
-    compile_classpath = ClasspathProducts()
+    compile_classpath = ClasspathProducts(self.get_options().pants_workdir)
     self.resolve(executor=executor,
                  targets=targets,
                  classpath_products=compile_classpath,
@@ -299,7 +299,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
     external_javadoc_jar_dir = os.path.join(self.gen_project_workdir, 'external-libjavadoc')
     safe_mkdir(external_javadoc_jar_dir, clean=True)
 
-    classpath_products = self.resolve_jars(targets) or ClasspathProducts()
+    classpath_products = self.resolve_jars(targets) or ClasspathProducts(self.get_options().pants_workdir)
     cp_entry_by_classifier_by_orgname = defaultdict(lambda: defaultdict(dict))
     for conf, jar_entry in classpath_products.get_artifact_classpath_entries_for_targets(targets):
       coord = (jar_entry.coordinate.org, jar_entry.coordinate.name)

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -17,9 +17,6 @@ from pants.version import VERSION as _VERSION
 logger = logging.getLogger(__name__)
 
 
-PANTS_WORKDIR_SUFFIX = '.pants.d'
-
-
 def pants_version():
   """Returns the pants semantic version number: http://semver.org/"""
   return _VERSION

--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -17,6 +17,9 @@ from pants.version import VERSION as _VERSION
 logger = logging.getLogger(__name__)
 
 
+PANTS_WORKDIR_SUFFIX = '.pants.d'
+
+
 def pants_version():
   """Returns the pants semantic version number: http://semver.org/"""
   return _VERSION

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -11,7 +11,7 @@ import sys
 import pkg_resources
 
 from pants.backend.core.tasks.task import QuietTaskMixin
-from pants.base.build_environment import PANTS_WORKDIR_SUFFIX, get_scm
+from pants.base.build_environment import get_scm
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.scm_build_file import ScmBuildFile
@@ -325,7 +325,7 @@ class GoalRunner(object):
 
   def _execute_engine(self):
     workdir = self._context.options.for_global_scope().pants_workdir
-    if not workdir.endswith(PANTS_WORKDIR_SUFFIX):
+    if not workdir.endswith(".pants.d"):
       self._context.log.error('Pants working directory should end with \'.pants.d\', currently it is {}\n'
                               .format(workdir))
       return 1

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -30,7 +30,7 @@ from pants.help.help_printer import HelpPrinter
 from pants.java.nailgun_executor import NailgunProcessGroup
 from pants.logging.setup import setup_logging
 from pants.option.custom_types import list_option
-from pants.option.global_options import GlobalOptionsRegistrar
+from pants.option.global_options import PANTS_WORKDIR_SUFFIX, GlobalOptionsRegistrar
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.report import Report
 from pants.reporting.reporting import Reporting
@@ -324,6 +324,12 @@ class GoalRunner(object):
     return {SourceRootBootstrapper, SourceRootConfig, Reporting, Reproducer, RunTracker}
 
   def _execute_engine(self):
+    workdir = self._context.options.for_global_scope().pants_workdir
+    if not workdir.endswith(PANTS_WORKDIR_SUFFIX):
+      self._context.log.error('Pants working directory should end with \'.pants.d\', currently it is {}\n'
+                              .format(workdir))
+      return 1
+
     unknown_goals = [goal.name for goal in self._goals if not goal.ordered_task_names()]
     if unknown_goals:
       self._context.log.error('Unknown goal(s): {}\n'.format(' '.join(unknown_goals)))

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -325,7 +325,7 @@ class GoalRunner(object):
 
   def _execute_engine(self):
     workdir = self._context.options.for_global_scope().pants_workdir
-    if not workdir.endswith(".pants.d"):
+    if not workdir.endswith('.pants.d'):
       self._context.log.error('Pants working directory should end with \'.pants.d\', currently it is {}\n'
                               .format(workdir))
       return 1

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -11,7 +11,7 @@ import sys
 import pkg_resources
 
 from pants.backend.core.tasks.task import QuietTaskMixin
-from pants.base.build_environment import get_scm
+from pants.base.build_environment import PANTS_WORKDIR_SUFFIX, get_scm
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.scm_build_file import ScmBuildFile
@@ -30,7 +30,7 @@ from pants.help.help_printer import HelpPrinter
 from pants.java.nailgun_executor import NailgunProcessGroup
 from pants.logging.setup import setup_logging
 from pants.option.custom_types import list_option
-from pants.option.global_options import PANTS_WORKDIR_SUFFIX, GlobalOptionsRegistrar
+from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.reporting.report import Report
 from pants.reporting.reporting import Reporting

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,6 +16,9 @@ from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 
 
+PANTS_WORKDIR_SUFFIX = '.pants.d'
+
+
 class GlobalOptionsRegistrar(Optionable):
   options_scope = GLOBAL_SCOPE
   options_scope_category = ScopeInfo.GLOBAL
@@ -75,7 +78,7 @@ class GlobalOptionsRegistrar(Optionable):
     register('--pants-configdir', advanced=True, metavar='<dir>', default=get_pants_configdir(),
              help='Use this dir for global config files.')
     register('--pants-workdir', advanced=True, metavar='<dir>',
-             default=os.path.join(buildroot, '.pants.d'),
+             default=os.path.join(buildroot, PANTS_WORKDIR_SUFFIX),
              help='Write intermediate output files to this dir.')
     register('--pants-supportdir', advanced=True, metavar='<dir>',
              default=os.path.join(buildroot, 'build-support'),

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -8,15 +8,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 
-from pants.base.build_environment import (get_buildroot, get_pants_cachedir, get_pants_configdir,
-                                          pants_version)
+from pants.base.build_environment import (PANTS_WORKDIR_SUFFIX, get_buildroot, get_pants_cachedir,
+                                          get_pants_configdir, pants_version)
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import list_option
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
-
-
-PANTS_WORKDIR_SUFFIX = '.pants.d'
 
 
 class GlobalOptionsRegistrar(Optionable):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -8,8 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 
-from pants.base.build_environment import (PANTS_WORKDIR_SUFFIX, get_buildroot, get_pants_cachedir,
-                                          get_pants_configdir, pants_version)
+from pants.base.build_environment import (get_buildroot, get_pants_cachedir, get_pants_configdir,
+                                          pants_version)
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import list_option
 from pants.option.optionable import Optionable
@@ -75,7 +75,7 @@ class GlobalOptionsRegistrar(Optionable):
     register('--pants-configdir', advanced=True, metavar='<dir>', default=get_pants_configdir(),
              help='Use this dir for global config files.')
     register('--pants-workdir', advanced=True, metavar='<dir>',
-             default=os.path.join(buildroot, PANTS_WORKDIR_SUFFIX),
+             default=os.path.join(buildroot, ".pants.d"),
              help='Write intermediate output files to this dir.')
     register('--pants-supportdir', advanced=True, metavar='<dir>',
              default=os.path.join(buildroot, 'build-support'),

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -75,7 +75,7 @@ class GlobalOptionsRegistrar(Optionable):
     register('--pants-configdir', advanced=True, metavar='<dir>', default=get_pants_configdir(),
              help='Use this dir for global config files.')
     register('--pants-workdir', advanced=True, metavar='<dir>',
-             default=os.path.join(buildroot, ".pants.d"),
+             default=os.path.join(buildroot, '.pants.d'),
              help='Write intermediate output files to this dir.')
     register('--pants-supportdir', advanced=True, metavar='<dir>',
              default=os.path.join(buildroot, 'build-support'),

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -48,7 +48,7 @@ def environment_as(**kwargs):
 
 
 @contextmanager
-def temporary_dir(root_dir=None, cleanup=True):
+def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
   """
     A with-context that creates a temporary directory.
 
@@ -56,7 +56,7 @@ def temporary_dir(root_dir=None, cleanup=True):
     :param string root_dir: The parent directory to create the temporary directory.
     :param bool cleanup: Whether or not to clean up the temporary directory.
   """
-  path = tempfile.mkdtemp(dir=root_dir)
+  path = tempfile.mkdtemp(dir=root_dir, suffix=suffix)
   try:
     yield path
   finally:

--- a/tests/python/pants_test/android/tasks/test_aapt_builder_integration.py
+++ b/tests/python/pants_test/android/tasks/test_aapt_builder_integration.py
@@ -9,7 +9,6 @@ import os
 import re
 import unittest
 
-from pants.util.contextutil import temporary_dir
 from pants_test.android.android_integration_test import AndroidIntegrationTest
 
 
@@ -43,7 +42,7 @@ class AaptBuilderIntegrationTest(AndroidIntegrationTest):
                                      'and ANDROID_HOME set in path.'.format(TOOLS))
   def test_android_library_products(self):
     # Doing the work under a tempdir gives us a handle for the workdir and guarantees a clean build.
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       spec = 'examples/src/android/hello_with_library:'
       pants_run = self.run_pants_with_workdir(['apk', '-ldebug', spec], workdir)
       self.assert_success(pants_run)

--- a/tests/python/pants_test/android/tasks/test_aapt_gen_integration.py
+++ b/tests/python/pants_test/android/tasks/test_aapt_gen_integration.py
@@ -9,7 +9,6 @@ import os
 import re
 import unittest
 
-from pants.util.contextutil import temporary_dir
 from pants_test.android.android_integration_test import AndroidIntegrationTest
 
 
@@ -43,7 +42,7 @@ class AaptGenIntegrationTest(AndroidIntegrationTest):
   # TODO(mateor) Write a testproject instead of using hello_with_library which may change.
   def test_android_library_dep(self):
     # Doing the work under a tempdir gives us a handle for the workdir and guarantees a clean build.
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       spec = 'examples/src/android/hello_with_library:'
       pants_run = self.run_pants_with_workdir(['gen', '-ldebug', spec], workdir)
       self.assert_success(pants_run)

--- a/tests/python/pants_test/android/tasks/test_unpack_libraries_integration.py
+++ b/tests/python/pants_test/android/tasks/test_unpack_libraries_integration.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import unittest
 
-from pants.util.contextutil import temporary_dir
 from pants_test.android.android_integration_test import AndroidIntegrationTest
 
 
@@ -22,7 +21,7 @@ class UnpackLibrariesIntegrationTest(AndroidIntegrationTest):
   @unittest.skipUnless(tools, reason='UnpackLibraries integration test requires that '
                                      'ANDROID_HOME is set.')
   def test_library_unpack(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       spec = 'examples/src/android/hello_with_library:'
       pants_run = self.run_pants_with_workdir(['unpack-jars', spec], workdir)
       self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_binary_task_test_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_binary_task_test_base.py
@@ -32,7 +32,7 @@ class JvmBinaryTaskTestBase(JvmToolTaskTestBase):
     coordinate = M2Coordinate(org=org, name=name, rev=rev, classifier=classifier, ext=ext)
     cache_path = 'not/a/real/cache/path'
     jar_name = str(coordinate)
-    pants_path = self.create_file(jar_name) if materialize else os.path.join(self.build_root,
+    pants_path = self.create_workdir_file(jar_name) if materialize else os.path.join(self.pants_workdir,
                                                                              jar_name)
     return ResolvedJar(coordinate=coordinate, cache_path=cache_path, pants_path=pants_path)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_binary_task_test_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_binary_task_test_base.py
@@ -55,4 +55,4 @@ class JvmBinaryTaskTestBase(JvmToolTaskTestBase):
     :returns: The classpath products associated with the given `context`
     :rtype: :class:`pants.backend.jvm.tasks.classpath_products.ClasspathProducts`
     """
-    return context.products.get_data('runtime_classpath', init_func=ClasspathProducts)
+    return context.products.get_data('runtime_classpath', init_func=ClasspathProducts.init_func(self.pants_workdir))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
@@ -24,7 +24,7 @@ class BaseCompileIT(PantsRunIntegrationTest):
 
     By default, runs twice to shake out errors related to noops.
     """
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with temporary_dir(root_dir=self.workdir_root()) as cachedir:
         for i in six.moves.xrange(0, iterations):
           pants_run = self.run_test_compile(workdir, cachedir, target,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/base_compile_integration_test.py
@@ -25,7 +25,7 @@ class BaseCompileIT(PantsRunIntegrationTest):
     By default, runs twice to shake out errors related to noops.
     """
     with self.temporary_workdir() as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as cachedir:
+      with self.temporary_cachedir() as cachedir:
         for i in six.moves.xrange(0, iterations):
           pants_run = self.run_test_compile(workdir, cachedir, target,
                                             clean_all=(i == 0),

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/jvm_platform_integration_mixin.py
@@ -65,7 +65,7 @@ class JvmPlatformIntegrationMixin(object):
       jar_name = jar_name[jar_name.find(':') + 1:]
     with temporary_dir() as cache_dir:
       config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
-      with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with self.temporary_workdir() as workdir:
         pants_run = self.run_pants_with_workdir(
           ['binary'] + self.get_pants_compile_args()
           + ['compile.checkstyle', '--skip', spec]
@@ -194,7 +194,7 @@ class JvmPlatformIntegrationMixin(object):
       }
 
       # We run these all in the same working directory, because we're testing caching behavior.
-      with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with self.temporary_workdir() as workdir:
 
         def compile_diamond(platform):
           return self.run_pants_with_workdir(['--jvm-platform-platforms={}'.format(platforms),

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -27,7 +27,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
 
   def test_stale_artifacts_rmd_when_cache_used_with_zinc(self):
     with temporary_dir() as cache_dir, \
-        temporary_dir(root_dir=self.workdir_root()) as workdir, \
+        self.temporary_workdir() as workdir, \
         temporary_dir(root_dir=get_buildroot()) as src_dir:
 
       config = {
@@ -87,7 +87,7 @@ class CacheCompileIntegrationTest(BaseCompileIT):
   def test_incremental_caching(self):
     """Tests that with --no-incremental-caching, we don't write incremental artifacts."""
     with temporary_dir() as cache_dir, \
-        temporary_dir(root_dir=self.workdir_root()) as workdir, \
+        self.temporary_workdir() as workdir, \
         temporary_dir(root_dir=get_buildroot()) as src_dir:
 
       def config(incremental_caching):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -20,7 +20,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
     with temporary_dir() as cache_dir:
       config = {'cache.compile.zinc': {'write_to': [cache_dir]}}
 
-      with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with self.temporary_workdir() as workdir:
         pants_run = self.run_pants_with_workdir(
           ['compile',
            'testprojects/src/java/org/pantsbuild/testproject/publish/hello/main:',
@@ -161,7 +161,7 @@ class JavaCompileIntegrationTest(BaseCompileIT):
     # We want to ensure that running java compile with binary incompatible libraries will
     # produces two different artifacts.
 
-    with temporary_dir(root_dir=self.workdir_root()) as workdir,  temporary_dir() as cache_dir:
+    with self.temporary_workdir() as workdir, temporary_dir() as cache_dir:
       path_prefix = 'testprojects/src/java/org/pantsbuild/testproject/jarversionincompatibility'
       dotted_path = path_prefix.replace(os.path.sep, '.')
       artifact_dir = os.path.join(cache_dir, ZincCompile.stable_name(),

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -20,7 +20,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
       pass
 
   def test_in_process(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with temporary_dir(root_dir=self.workdir_root()) as cachedir:
         pants_run = self.run_test_compile(
           workdir, cachedir, 'examples/src/java/org/pantsbuild/example/hello/main',
@@ -30,7 +30,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         self.assertNotIn('Forking javac', pants_run.stdout_data)
 
   def test_log_level(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with temporary_dir(root_dir=self.workdir_root()) as cachedir:
         target = 'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target'
         pants_run = self.run_test_compile(
@@ -41,7 +41,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         self.assertIn('[error]     System2.out.println("Hello World!");', pants_run.stdout_data)
 
   def test_unicode_source_symbol(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with temporary_dir(root_dir=self.workdir_root()) as cachedir:
         target = 'testprojects/src/scala/org/pantsbuild/testproject/unicode/unicodedep/consumer'
         pants_run = self.run_test_compile(
@@ -107,7 +107,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
 
     # Try to reproduce second compile that fails with missing symbol
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with temporary_dir(root_dir=self.workdir_root()) as cachedir:
         # This annotation processor has a unique external dependency
         self.assert_success(self.run_test_compile(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -21,7 +21,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_in_process(self):
     with self.temporary_workdir() as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as cachedir:
+      with self.temporary_cachedir() as cachedir:
         pants_run = self.run_test_compile(
           workdir, cachedir, 'examples/src/java/org/pantsbuild/example/hello/main',
           extra_args=['-ldebug'], clean_all=True
@@ -31,7 +31,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_log_level(self):
     with self.temporary_workdir() as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as cachedir:
+      with self.temporary_cachedir() as cachedir:
         target = 'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target'
         pants_run = self.run_test_compile(
           workdir, cachedir, target,
@@ -42,7 +42,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_unicode_source_symbol(self):
     with self.temporary_workdir() as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as cachedir:
+      with self.temporary_cachedir() as cachedir:
         target = 'testprojects/src/scala/org/pantsbuild/testproject/unicode/unicodedep/consumer'
         pants_run = self.run_test_compile(
           workdir, cachedir, target,
@@ -108,7 +108,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
     # Try to reproduce second compile that fails with missing symbol
     with self.temporary_workdir() as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as cachedir:
+      with self.temporary_cachedir() as cachedir:
         # This annotation processor has a unique external dependency
         self.assert_success(self.run_test_compile(
           workdir,

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
@@ -86,7 +86,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
       pass
 
   def test_zinc_unsupported_option(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with temporary_dir(root_dir=self.workdir_root()) as cachedir:
         # compile with an unsupported flag
         pants_run = self.run_test_compile(

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
@@ -87,7 +87,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_zinc_unsupported_option(self):
     with self.temporary_workdir() as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as cachedir:
+      with self.temporary_cachedir() as cachedir:
         # compile with an unsupported flag
         pants_run = self.run_test_compile(
             workdir,

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -54,7 +54,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
   @ensure_cached(expected_num_artifacts=2)
   def test_config_invalidates_targets(self, cache_args):
     with self.temporary_workdir() as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as tmp:
+      with temporary_dir() as tmp:
         configs = [
             dedent("""
               <module name="TreeWalker">

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -16,7 +16,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
 
   def test_checkstyle_cached(self):
     with temporary_dir(root_dir=self.workdir_root()) as cache:
-      with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with self.temporary_workdir() as workdir:
         args = [
             'clean-all',
             'compile.checkstyle',
@@ -53,7 +53,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
 
   @ensure_cached(expected_num_artifacts=2)
   def test_config_invalidates_targets(self, cache_args):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with temporary_dir(root_dir=self.workdir_root()) as tmp:
         configs = [
             dedent("""
@@ -85,7 +85,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
 
   @ensure_cached(expected_num_artifacts=2)
   def test_jvm_tool_changes_invalidate_targets(self, cache_args):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       # Ensure that only the second use of the default checkstyle will not invalidate anything.
       for checkstyle_jar in (None, 'testprojects/3rdparty/checkstyle', None):
         args = [

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -15,7 +15,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensur
 class CheckstyleIntegrationTest(PantsRunIntegrationTest):
 
   def test_checkstyle_cached(self):
-    with temporary_dir(root_dir=self.workdir_root()) as cache:
+    with self.temporary_cachedir() as cache:
       with self.temporary_workdir() as workdir:
         args = [
             'clean-all',

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -380,7 +380,7 @@ class ClasspathProductsTest(BaseTest):
     return self.path('ivy/jars/com.example/lib/jars/123.4.jar')
 
   def path(self, p):
-    return os.path.join(self.build_root, p)
+    return os.path.join(self.pants_workdir, p)
 
   def add_jar_classpath_element_for_path(self,
                                          classpath_product,

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -30,7 +30,7 @@ class ClasspathProductsTest(BaseTest):
   def test_single_classpath_element_no_excludes(self):
     a = self.make_target('a', JvmTarget)
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     path = self.path('jar/path')
     self.add_jar_classpath_element_for_path(classpath_product, a, path)
 
@@ -40,7 +40,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     resolved_jar = self.add_jar_classpath_element_for_path(classpath_product,
                                                            a,
                                                            self._example_jar_path())
@@ -67,29 +67,29 @@ class ClasspathProductsTest(BaseTest):
   def test_fails_if_paths_outside_buildroot(self):
     a = self.make_target('a', JvmTarget)
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     with self.assertRaises(TaskError) as cm:
       classpath_product.add_for_target(a, [('default', '/dev/null')])
 
     self.assertEqual(
-      'Classpath entry /dev/null for target a:a is located outside the buildroot.',
+      'Classpath entry /dev/null for target a:a is located outside the working directory.',
       str(cm.exception))
 
   def test_fails_if_jar_paths_outside_buildroot(self):
     a = self.make_target('a', JvmTarget)
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     with self.assertRaises(TaskError) as cm:
       classpath_product.add_jars_for_targets([a], 'default', [(resolved_example_jar_at('/dev/null'))])
 
     self.assertEqual(
-      'Classpath entry /dev/null for target a:a is located outside the buildroot.',
+      'Classpath entry /dev/null for target a:a is located outside the working directory.',
       str(cm.exception))
 
   def test_excluded_classpath_element(self):
     a = self.make_target('a', JvmTarget, excludes=[Exclude('com.example', 'lib')])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path)
     self.add_excludes_for_targets(classpath_product, a)
@@ -102,7 +102,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_jar_classpath_element_for_path(classpath_product, a, self._example_jar_path())
     self.add_excludes_for_targets(classpath_product, b, a)
 
@@ -113,7 +113,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     classpath_product.add_for_target(a, [('default', example_jar_path)])
     classpath_product.add_excludes_for_targets([a, b])
@@ -125,7 +125,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget)
     a = self.make_target('a', JvmTarget, dependencies=[b], excludes=[Exclude('com.example', 'lib')])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     self.add_jar_classpath_element_for_path(classpath_product, b, example_jar_path)
     self.add_excludes_for_targets(classpath_product, b, a)
@@ -138,7 +138,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     com_example_jar_path = self._example_jar_path()
     org_example_jar_path = self.path('ivy/jars/org.example/lib/123.4.jar')
     classpath_product.add_jars_for_targets([a], 'default',
@@ -156,7 +156,7 @@ class ClasspathProductsTest(BaseTest):
     a = self.make_target('a', JvmTarget, dependencies=[b], excludes=[Exclude('com.example', 'lib')])
 
     example_jar_path = self._example_jar_path()
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_jar_classpath_element_for_path(classpath_product, b, example_jar_path)
     self.add_excludes_for_targets(classpath_product, a)
 
@@ -168,7 +168,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget)
     a = self.make_target('a', JvmTarget, excludes=[Exclude('com.example', 'lib')])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_example_jar_classpath_element_for(classpath_product, b)
     self.add_excludes_for_targets(classpath_product, a)
 
@@ -180,7 +180,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget)
     a = self.make_target('a', JvmTarget, excludes=[Exclude('com.exam')], dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_example_jar_classpath_element_for(classpath_product, b)
     self.add_excludes_for_targets(classpath_product, a)
 
@@ -192,7 +192,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget)
     a = self.make_target('a', JvmTarget, excludes=[Exclude('com.example')], dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_example_jar_classpath_element_for(classpath_product, b)
     self.add_excludes_for_targets(classpath_product, a)
 
@@ -206,7 +206,7 @@ class ClasspathProductsTest(BaseTest):
     consumer = self.make_target('consumer', JvmTarget)
     root = self.make_target('root', JvmTarget, dependencies=[provider, consumer])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_example_jar_classpath_element_for(classpath_product, consumer)
     self.add_excludes_for_targets(classpath_product, consumer, provider, root)
 
@@ -220,7 +220,7 @@ class ClasspathProductsTest(BaseTest):
                          provides=Artifact('com.example', 'li', Repository()))
     root = self.make_target('root', JvmTarget, dependencies=[provider])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_example_jar_classpath_element_for(classpath_product, root)
     self.add_excludes_for_targets(classpath_product, provider, root)
 
@@ -233,7 +233,7 @@ class ClasspathProductsTest(BaseTest):
                          provides=Artifact('com.example.lib', '', Repository()))
     root = self.make_target('root', JvmTarget, dependencies=[provider])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     self.add_example_jar_classpath_element_for(classpath_product, root)
     self.add_excludes_for_targets(classpath_product, provider, root)
 
@@ -247,7 +247,7 @@ class ClasspathProductsTest(BaseTest):
 
     example_jar_path = self._example_jar_path()
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     classpath_product.add_for_target(b, [('default', example_jar_path)])
     self.add_excludes_for_targets(classpath_product, a)
 
@@ -258,7 +258,7 @@ class ClasspathProductsTest(BaseTest):
   def test_jar_missing_pants_path_fails_adding(self):
     b = self.make_target('b', JvmTarget)
 
-    classpath_products = ClasspathProducts()
+    classpath_products = ClasspathProducts(self.pants_workdir)
     with self.assertRaises(TaskError) as cm:
       classpath_products.add_jars_for_targets([b], 'default',
                                               [ResolvedJar(M2Coordinate(org='org', name='name'),
@@ -271,7 +271,7 @@ class ClasspathProductsTest(BaseTest):
   def test_get_classpath_entries_for_targets_respect_excludes(self):
     a = self.make_target('a', JvmTarget, excludes=[Exclude('com.example', 'lib')])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path)
     self.add_excludes_for_targets(classpath_product, a)
@@ -283,7 +283,7 @@ class ClasspathProductsTest(BaseTest):
   def test_get_classpath_entries_for_targets_ignore_excludes(self):
     a = self.make_target('a', JvmTarget, excludes=[Exclude('com.example', 'lib')])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     resolved_jar = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path,
                                                            conf='fred-conf')
@@ -300,7 +300,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     resolved_jar = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path)
 
@@ -321,7 +321,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     resolved_jar = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path)
 
@@ -341,7 +341,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget, excludes=[Exclude('com.example', 'lib')])
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
     resolved_jar = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path)
 
@@ -360,7 +360,7 @@ class ClasspathProductsTest(BaseTest):
     b = self.make_target('b', JvmTarget)
     a = self.make_target('a', JvmTarget, dependencies=[b])
 
-    classpath_product = ClasspathProducts()
+    classpath_product = ClasspathProducts(self.pants_workdir)
 
     # This artifact classpath entry should be ignored.
     example_jar_path = self._example_jar_path()

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -65,7 +65,7 @@ class IvyResolveTest(JvmToolTaskTestBase):
     context = self.context(target_roots=[losing_lib, winning_lib])
 
     def artifact_path(name):
-      return os.path.join(self.build_root, 'ivy_artifact', name)
+      return os.path.join(self.pants_workdir, 'ivy_artifact', name)
 
     symlink_map = {artifact_path('bogus0'): artifact_path('bogus0'),
                    artifact_path('bogus1'): artifact_path('bogus1'),

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -144,16 +144,16 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
       self.assertEqual(args, (1,))
 
   def execute_junit_runner(self, content):
-
     # Create the temporary base test directory
     test_rel_path = 'tests/java/org/pantsbuild/foo'
-    test_abs_path = os.path.join(self.build_root, test_rel_path)
-    self.create_dir(test_rel_path)
+    test_abs_path = self.create_dir(test_rel_path)
 
     # Generate the temporary java test source code.
     test_java_file_rel_path = os.path.join(test_rel_path, 'FooTest.java')
-    test_java_file_abs_path = os.path.join(self.build_root, test_java_file_rel_path)
-    self.create_file(test_java_file_rel_path, content)
+    test_java_file_abs_path = self.create_file(test_java_file_rel_path, content)
+
+    # Create the temporary classes directory under work dir
+    test_classes_abs_path = self.create_workdir_dir(test_rel_path)
 
     # Invoke ivy to resolve classpath for junit.
     classpath_file_abs_path = os.path.join(test_abs_path, 'junit.classpath')
@@ -172,7 +172,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
     # the test on.
     javac = distribution.binary('javac')
     subprocess.check_call(
-      [javac, '-d', test_abs_path, '-cp', classpath, test_java_file_abs_path])
+      [javac, '-d', test_classes_abs_path, '-cp', classpath, test_java_file_abs_path])
 
     # Create a java_tests target and a synthetic resource target.
     java_tests = self.create_library(test_rel_path, 'java_tests', 'foo_test', ['FooTest.java'])
@@ -189,7 +189,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
     # the compiled test java classes that JUnitRun will know which test
     # classes to execute. In a normal run, this "runtime_classpath" will be
     # populated by java compilation step.
-    self.populate_runtime_classpath(context=context, classpath=[test_abs_path])
+    self.populate_runtime_classpath(context=context, classpath=[test_classes_abs_path])
 
     # Finally execute the task.
     self.execute(context)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
@@ -27,7 +27,7 @@ class TestJvmDependencyUsage(TaskTestBase):
     context = self.context(target_roots=target_classfiles.keys())
 
     # Create classfiles in a target-specific directory, and add it to the classpath for the target.
-    classpath_products = context.products.get_data('runtime_classpath', ClasspathProducts)
+    classpath_products = context.products.get_data('runtime_classpath', ClasspathProducts.init_func(self.pants_workdir))
     for target, classfiles in target_classfiles.items():
       target_dir = os.path.join(self.test_workdir, target.id)
       safe_mkdir(target_dir)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
@@ -38,7 +38,7 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
       return '{}:{}'.format(self.javadir, name)
 
     def clean_all(self):
-      return self.test.run_pants(['clean-all'])
+      return self.test.run_pants_with_workdir(['clean-all'], workdir=self.workdir)
 
     def jvm_platform_validate(self, *targets):
       return self.test.run_pants_with_workdir(['jvm-platform-validate', '--check=fatal']

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis_integration.py
@@ -47,11 +47,11 @@ class JvmPlatformAnalysisIntegrationTest(PantsRunIntegrationTest):
 
   @contextmanager
   def setup_sandbox(self):
-    with temporary_dir('.') as tempdir:
-      workdir = os.path.abspath(tempdir)
-      javadir = os.path.join(tempdir, 'src', 'java')
-      os.makedirs(javadir)
-      yield self.JavaSandbox(self, os.path.join(workdir, '.pants.d'), javadir)
+    with temporary_dir('.') as sourcedir:
+      with self.temporary_workdir() as workdir:
+        javadir = os.path.join(sourcedir, 'src', 'java')
+        os.makedirs(javadir)
+        yield self.JavaSandbox(self, workdir, javadir)
 
   @property
   def _good_one_two(self):

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -31,7 +31,7 @@ class JvmRunTest(JvmTaskTestBase):
                                   main='org.pantsbuild.Binary')
     context = self.context(target_roots=[jvm_binary])
     jvm_run = self.create_task(context)
-    self._cmdline_classpath = [os.path.join(self.build_root, c) for c in ['bob', 'fred']]
+    self._cmdline_classpath = [os.path.join(self.pants_workdir, c) for c in ['bob', 'fred']]
     self.populate_runtime_classpath(context=jvm_run.context, classpath=self._cmdline_classpath)
     with temporary_dir() as pwd:
       with pushd(pwd):

--- a/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
@@ -44,7 +44,7 @@ class ResourcesTaskTestBase(TaskTestBase):
   def create_resources_task(self, target_roots=None, **options):
     self.set_options(**options)
     context = self.context(target_roots=target_roots)
-    context.products.safe_create_data('compile_classpath', init_func=ClasspathProducts)
+    context.products.safe_create_data('compile_classpath', init_func=ClasspathProducts.init_func(self.pants_workdir))
     return self.create_task(context)
 
   def create_target(self, spec, contents=None, **kwargs):

--- a/tests/python/pants_test/backend/project_info/tasks/resolve_jars_test_mixin.py
+++ b/tests/python/pants_test/backend/project_info/tasks/resolve_jars_test_mixin.py
@@ -26,9 +26,9 @@ class ResolveJarsTestMixin(object):
     raise NotImplementedError()
 
   def _test_jar_lib_with_url(self, load_all):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as source_dir:
-        with temporary_dir(root_dir=self.workdir_root()) as dist_dir:
+    with self.temporary_workdir() as workdir:
+      with self.temporary_sourcedir() as source_dir:
+        with temporary_dir() as dist_dir:
           os.makedirs(os.path.join(source_dir, 'src'))
           with open(os.path.join(source_dir, 'src', 'BUILD.one'), 'w+') as f:
             f.write(dedent("""

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -164,7 +164,7 @@ class ExportTest(ConsoleTaskTestBase):
 
   def execute_export(self, *specs):
     context = self.context(target_roots=[self.target(spec) for spec in specs])
-    context.products.safe_create_data('compile_classpath', init_func=ClasspathProducts)
+    context.products.safe_create_data('compile_classpath', init_func=ClasspathProducts.init_func(self.pants_workdir))
     task = self.create_task(context)
     return list(task.console_output(list(task.context.targets()),
                                     context.products.get_data('compile_classpath')))

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -13,7 +13,6 @@ from twitter.common.collections import maybe_list
 
 from pants.base.build_environment import get_buildroot
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.util.contextutil import temporary_dir
 from pants_test.backend.project_info.tasks.resolve_jars_test_mixin import ResolveJarsTestMixin
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.subsystem.subsystem_util import subsystem_instance
@@ -63,7 +62,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
         self.assertTrue(os.path.exists(path), 'Expected jar at {} to actually exist.'.format(path))
 
   def test_export_code_gen(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'examples/tests/java/org/pantsbuild/example/usethrift:usethrift'
       json_data = self.run_export(test_target, workdir, load_libs=True)
       thrift_target_name = ('examples.src.thrift.org.pantsbuild.example.precipitation'
@@ -74,14 +73,14 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       self.assertTrue(any(p.match(target) for target in json_data.get('targets').keys()))
 
   def test_export_json_transitive_jar(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'examples/tests/java/org/pantsbuild/example/usethrift:usethrift'
       json_data = self.run_export(test_target, workdir, load_libs=True)
       targets = json_data.get('targets')
       self.assertIn('org.hamcrest:hamcrest-core:1.3', targets[test_target]['libraries'])
 
   def test_export_jar_path_with_excludes(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'testprojects/src/java/org/pantsbuild/testproject/exclude:foo'
       json_data = self.run_export(test_target, workdir, load_libs=True)
       self.assertIsNone(json_data
@@ -93,7 +92,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       self.assertTrue('com.typesafe.sbt:incremental-compiler' in foo_target.get('excludes'))
 
   def test_export_jar_path_with_excludes_soft(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'testprojects/src/java/org/pantsbuild/testproject/exclude:'
       json_data = self.run_export(test_target,
                                   workdir,
@@ -110,7 +109,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       self.assertTrue('org.pantsbuild' in foo_target.get('excludes'))
 
   def test_export_jar_path(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'examples/tests/java/org/pantsbuild/example/usethrift:usethrift'
       json_data = self.run_export(test_target, workdir, load_libs=True)
       with subsystem_instance(IvySubsystem) as ivy_subsystem:
@@ -133,14 +132,14 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
         )
 
   def test_dep_map_for_java_sources(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'examples/src/scala/org/pantsbuild/example/scala_with_java_sources'
       json_data = self.run_export(test_target, workdir)
       targets = json_data.get('targets')
       self.assertIn('examples/src/java/org/pantsbuild/example/java_sources:java_sources', targets)
 
   def test_sources_and_javadocs(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'examples/src/scala/org/pantsbuild/example/scala_with_java_sources'
       json_data = self.run_export(test_target, workdir, load_libs=True)
       scala_lang_lib = json_data.get('libraries').get('org.scala-lang:scala-library:2.10.4')
@@ -150,7 +149,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       self.assertIsNotNone(scala_lang_lib['javadoc'])
 
   def test_ivy_classifiers(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'testprojects/tests/java/org/pantsbuild/testproject/ivyclassifier:ivyclassifier'
       json_data = self.run_export(test_target, workdir, load_libs=True)
       with subsystem_instance(IvySubsystem) as ivy_subsystem:
@@ -175,7 +174,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
         )
 
   def test_distributions_and_platforms(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       test_target = 'examples/src/java/org/pantsbuild/example/hello/simple'
       json_data = self.run_export(test_target, workdir, load_libs=False, extra_args=[
         '--jvm-platform-default-platform=java7',
@@ -215,7 +214,7 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
         json_data['jvm_platforms'])
 
   def test_intellij_integration(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       targets = ['src/python/::', 'tests/python/pants_test:all', 'contrib/::']
       excludes = [
         '--exclude-target-regexp=.*go/examples.*',

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -52,6 +52,15 @@ class BaseTest(unittest.TestCase):
     safe_mkdir(path)
     return path
 
+  def create_workdir_dir(self, relpath):
+    """Creates a directory under the work directory.
+
+    relpath: The relative path to the directory from the work directory.
+    """
+    path = os.path.join(self.pants_workdir, relpath)
+    safe_mkdir(path)
+    return path
+
   def create_file(self, relpath, contents='', mode='wb'):
     """Writes to a file under the buildroot.
 
@@ -60,6 +69,18 @@ class BaseTest(unittest.TestCase):
     mode:     The mode to write to the file in - over-write by default.
     """
     path = os.path.join(self.build_root, relpath)
+    with safe_open(path, mode=mode) as fp:
+      fp.write(contents)
+    return path
+
+  def create_workdir_file(self, relpath, contents='', mode='wb'):
+    """Writes to a file under the work directory.
+
+    relpath:  The relative path to the file from the work directory.
+    contents: A string containing the contents of the file - '' by default..
+    mode:     The mode to write to the file in - over-write by default.
+    """
+    path = os.path.join(self.pants_workdir, relpath)
     with safe_open(path, mode=mode) as fp:
       fp.write(contents)
     return path

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from tempfile import mkdtemp
 from textwrap import dedent
 
-from pants.base import build_environment
+from pants.base.build_environment import PANTS_WORKDIR_SUFFIX
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
@@ -157,7 +157,7 @@ class BaseTest(unittest.TestCase):
     self.build_root = os.path.realpath(mkdtemp(suffix='_BUILD_ROOT'))
     self.addCleanup(safe_rmtree, self.build_root)
 
-    self.pants_workdir = os.path.join(self.build_root, '.pants.d')
+    self.pants_workdir = os.path.join(self.build_root, PANTS_WORKDIR_SUFFIX)
     safe_mkdir(self.pants_workdir)
 
     self.options = defaultdict(dict)  # scope -> key-value mapping.

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 from tempfile import mkdtemp
 from textwrap import dedent
 
-from pants.base.build_environment import PANTS_WORKDIR_SUFFIX
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
@@ -157,7 +156,7 @@ class BaseTest(unittest.TestCase):
     self.build_root = os.path.realpath(mkdtemp(suffix='_BUILD_ROOT'))
     self.addCleanup(safe_rmtree, self.build_root)
 
-    self.pants_workdir = os.path.join(self.build_root, PANTS_WORKDIR_SUFFIX)
+    self.pants_workdir = os.path.join(self.build_root, ".pants.d")
     safe_mkdir(self.pants_workdir)
 
     self.options = defaultdict(dict)  # scope -> key-value mapping.

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -156,7 +156,7 @@ class BaseTest(unittest.TestCase):
     self.build_root = os.path.realpath(mkdtemp(suffix='_BUILD_ROOT'))
     self.addCleanup(safe_rmtree, self.build_root)
 
-    self.pants_workdir = os.path.join(self.build_root, ".pants.d")
+    self.pants_workdir = os.path.join(self.build_root, '.pants.d')
     safe_mkdir(self.pants_workdir)
 
     self.options = defaultdict(dict)  # scope -> key-value mapping.

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from tempfile import mkdtemp
 from textwrap import dedent
 
+from pants.base import build_environment
 from pants.base.build_file import FilesystemBuildFile
 from pants.base.build_root import BuildRoot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser

--- a/tests/python/pants_test/jvm/jvm_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_task_test_base.py
@@ -41,4 +41,4 @@ class JvmTaskTestBase(TaskTestBase):
     runtime_classpath.add_for_target(tgt, [('default', classpath_dir)])
 
   def get_runtime_classpath(self, context):
-    return context.products.get_data('runtime_classpath', init_func=ClasspathProducts)
+    return context.products.get_data('runtime_classpath', init_func=ClasspathProducts.init_func(self.pants_workdir))

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -73,6 +73,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     except OSError:
       return False
 
+  # todo: change all usages to self.temporary_workdir
   def workdir_root(self):
     # We can hard-code '.pants.d' here because we know that will always be its value
     # in the pantsbuild/pants repo (e.g., that's what we .gitignore in that repo).
@@ -81,6 +82,9 @@ class PantsRunIntegrationTest(unittest.TestCase):
     root = os.path.join(get_buildroot(), '.pants.d', 'tmp')
     safe_mkdir(root)
     return root
+
+  def temporary_workdir(self):
+    return temporary_dir(root_dir=self.workdir_root())
 
   def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None,
                              **kwargs):
@@ -124,7 +128,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     :param kwargs: Extra keyword args to pass to `subprocess.Popen`.
     :returns a tuple (returncode, stdout_data, stderr_data).
     """
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       return self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env,  **kwargs)
 
   @contextmanager
@@ -138,7 +142,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     :param kwargs: Extra keyword args to pass to `subprocess.Popen`.
     :returns a tuple (returncode, stdout_data, stderr_data).
     """
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       yield self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env,  **kwargs)
 
   def bundle_and_run(self, target, bundle_name, args=None):

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -86,6 +86,9 @@ class PantsRunIntegrationTest(unittest.TestCase):
   def temporary_workdir(self):
     return temporary_dir(root_dir=self.workdir_root())
 
+  def temporary_cachedir(self):
+    return temporary_dir(root_dir=self.workdir_root())
+
   def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None,
                              **kwargs):
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -17,6 +17,7 @@ from colors import strip_color
 
 from pants.base.build_environment import get_buildroot
 from pants.fs.archive import ZIP
+from pants.option.global_options import PANTS_WORKDIR_SUFFIX
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open
 
@@ -80,7 +81,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     # which we don't have a reference to here.
     root = os.path.join(get_buildroot(), '.pants.d', 'tmp')
     safe_mkdir(root)
-    return temporary_dir(root_dir=root)
+    return temporary_dir(root_dir=root, suffix=PANTS_WORKDIR_SUFFIX)
 
   def temporary_cachedir(self):
     return temporary_dir(suffix="__CACHEDIR")

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -15,7 +15,7 @@ from operator import eq, ne
 
 from colors import strip_color
 
-from pants.base.build_environment import PANTS_WORKDIR_SUFFIX, get_buildroot
+from pants.base.build_environment import get_buildroot
 from pants.fs.archive import ZIP
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open
@@ -80,7 +80,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     # which we don't have a reference to here.
     root = os.path.join(get_buildroot(), '.pants.d', 'tmp')
     safe_mkdir(root)
-    return temporary_dir(root_dir=root, suffix=PANTS_WORKDIR_SUFFIX)
+    return temporary_dir(root_dir=root, suffix=".pants.d")
 
   def temporary_cachedir(self):
     return temporary_dir(suffix="__CACHEDIR")

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -15,9 +15,8 @@ from operator import eq, ne
 
 from colors import strip_color
 
-from pants.base.build_environment import get_buildroot
+from pants.base.build_environment import PANTS_WORKDIR_SUFFIX, get_buildroot
 from pants.fs.archive import ZIP
-from pants.option.global_options import PANTS_WORKDIR_SUFFIX
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -89,6 +89,9 @@ class PantsRunIntegrationTest(unittest.TestCase):
   def temporary_cachedir(self):
     return temporary_dir(suffix="__CACHEDIR")
 
+  def temporary_sourcedir(self):
+    return temporary_dir(root_dir=get_buildroot())
+
   def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None,
                              **kwargs):
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -80,10 +80,10 @@ class PantsRunIntegrationTest(unittest.TestCase):
     # which we don't have a reference to here.
     root = os.path.join(get_buildroot(), '.pants.d', 'tmp')
     safe_mkdir(root)
-    return temporary_dir(root_dir=root, suffix=".pants.d")
+    return temporary_dir(root_dir=root, suffix='.pants.d')
 
   def temporary_cachedir(self):
-    return temporary_dir(suffix="__CACHEDIR")
+    return temporary_dir(suffix='__CACHEDIR')
 
   def temporary_sourcedir(self):
     return temporary_dir(root_dir=get_buildroot())

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -73,18 +73,14 @@ class PantsRunIntegrationTest(unittest.TestCase):
     except OSError:
       return False
 
-  # todo: change all usages to self.temporary_workdir
-  def workdir_root(self):
+  def temporary_workdir(self):
     # We can hard-code '.pants.d' here because we know that will always be its value
     # in the pantsbuild/pants repo (e.g., that's what we .gitignore in that repo).
     # Grabbing the pants_workdir config would require this pants's config object,
     # which we don't have a reference to here.
     root = os.path.join(get_buildroot(), '.pants.d', 'tmp')
     safe_mkdir(root)
-    return root
-
-  def temporary_workdir(self):
-    return temporary_dir(root_dir=self.workdir_root())
+    return temporary_dir(root_dir=root)
 
   def temporary_cachedir(self):
     return temporary_dir(suffix="__CACHEDIR")

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -87,7 +87,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     return temporary_dir(root_dir=self.workdir_root())
 
   def temporary_cachedir(self):
-    return temporary_dir(root_dir=self.workdir_root())
+    return temporary_dir(suffix="__CACHEDIR")
 
   def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None,
                              **kwargs):

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -25,7 +25,7 @@ _PRE = re.compile(ur'^\d+,ZincCompile,\w+,\S+,pre-check,(True|False)')
 class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
 
   def test_invalidation_report_output(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       command = ['compile',
                  'examples/src/java/org/pantsbuild/example/hello/main',
                  '--reporting-invalidation-report']

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -422,3 +422,10 @@ python_tests(
   ]
 )
 
+python_tests(
+  name = 'clean_all_integration',
+  sources = ['test_clean_all_integration.py'],
+  dependencies = [
+    'tests/python/pants_test:int-test',
+  ]
+)

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -427,5 +427,6 @@ python_tests(
   sources = ['test_clean_all_integration.py'],
   dependencies = [
     'tests/python/pants_test:int-test',
+    'src/python/pants/util:contextutil',
   ]
 )

--- a/tests/python/pants_test/tasks/test_antlr_integration.py
+++ b/tests/python/pants_test/tasks/test_antlr_integration.py
@@ -28,7 +28,7 @@ class AntlrIntegrationTest(PantsRunIntegrationTest):
     # Use the same temporary workdir because generated target's name includes the workdir.
     # Use the same artifact_cache dir to share artifacts across two runs.
     with self.temporary_workdir() as tmp_workdir:
-      with temporary_dir(root_dir=self.workdir_root()) as artifact_cache:
+      with temporary_dir() as artifact_cache:
         # Note that this only works as a test with clean-all because AntlrGen does not use
         # the artifact cache, just the local build invalidator.  As such, the clean-all
         # actually forces it to re-gen _unlike_ the jvm compile tasks.  If AntlrGen starts

--- a/tests/python/pants_test/tasks/test_antlr_integration.py
+++ b/tests/python/pants_test/tasks/test_antlr_integration.py
@@ -27,7 +27,7 @@ class AntlrIntegrationTest(PantsRunIntegrationTest):
   def test_compile_antlr_cached(self):
     # Use the same temporary workdir because generated target's name includes the workdir.
     # Use the same artifact_cache dir to share artifacts across two runs.
-    with temporary_dir(root_dir=self.workdir_root()) as tmp_workdir:
+    with self.temporary_workdir() as tmp_workdir:
       with temporary_dir(root_dir=self.workdir_root()) as artifact_cache:
         # Note that this only works as a test with clean-all because AntlrGen does not use
         # the artifact cache, just the local build invalidator.  As such, the clean-all

--- a/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
+++ b/tests/python/pants_test/tasks/test_bootstrap_jvm_tools_integration.py
@@ -12,7 +12,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class BootstrapJvmToolsIntegrationTest(PantsRunIntegrationTest):
 
   def test_zinc_tool_reuse_between_scala_and_java(self):
-    with temporary_dir(root_dir=self.workdir_root()) as artifact_cache:
+    with temporary_dir() as artifact_cache:
       bootstrap_args = [
         'bootstrap.bootstrap-jvm-tools',
         "--cache-write-to=['{}']".format(artifact_cache),

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -28,7 +28,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
   def test_compile_changed(self):
     cmd = ['compile-changed', '--diffspec={}'.format(self.ref_for_greet_change())]
 
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       # Nothing exists.
       self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
       self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
@@ -40,7 +40,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
       self.assertTrue(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
       self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
 
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       # Nothing exists.
       self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
       self.assertFalse(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
@@ -54,7 +54,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
 
   @pytest.mark.xfail
   def test_test_changed(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       cmd = ['test-changed', '--diffspec={}'.format(self.ref_for_greet_change())]
       junit_out = os.path.join(workdir, 'test', 'junit',
         'org.pantsbuild.example.hello.greet.GreetingTest.out.txt')

--- a/tests/python/pants_test/tasks/test_clean_all_integration.py
+++ b/tests/python/pants_test/tasks/test_clean_all_integration.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class CleanAllTest(PantsRunIntegrationTest):
+
+  def test_clean_all_on_wrong_dir(self):
+    with temporary_dir() as workdir:
+      self.assert_failure(self.run_pants_with_workdir(["clean-all"], workdir))

--- a/tests/python/pants_test/tasks/test_ivy_resolve_integration.py
+++ b/tests/python/pants_test/tasks/test_ivy_resolve_integration.py
@@ -8,14 +8,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
-from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class IvyResolveIntegrationTest(PantsRunIntegrationTest):
 
   def test_ivy_resolve_gives_correct_exception_on_cycles(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       pants_run = self.run_pants_with_workdir([
           'compile', 'testprojects/src/java/org/pantsbuild/testproject/cycle1'], workdir)
       self.assert_failure(pants_run)
@@ -23,7 +22,7 @@ class IvyResolveIntegrationTest(PantsRunIntegrationTest):
 
   def test_java_compile_with_ivy_report(self):
     # Ensure the ivy report file gets generated
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       ivy_report_dir = '{workdir}/ivy-report'.format(workdir=workdir)
       pants_run = self.run_pants_with_workdir([
           'compile',

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -29,7 +29,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     self._assert_junit_output_exists_for_class(workdir, 'org.pantsbuild.example.hello.welcome.WelSpec')
 
   def test_junit_test_custom_interpreter(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       pants_run = self.run_pants_with_workdir([
           'test',
           'examples/tests/java/org/pantsbuild/example/hello/greet',
@@ -41,7 +41,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       self._assert_junit_output(workdir)
 
   def test_junit_test(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       pants_run = self.run_pants_with_workdir([
           'test',
           'testprojects/tests/scala/org/pantsbuild/testproject/empty'],
@@ -49,7 +49,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       self.assert_failure(pants_run)
 
   def test_junit_test_with_test_option_with_relpath(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       pants_run = self.run_pants_with_workdir([
           'test',
           '--test-junit-test=examples/tests/java/org/pantsbuild/example/hello/greet/GreetingTest.java',
@@ -60,7 +60,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       self._assert_junit_output_exists_for_class(workdir, 'org.pantsbuild.example.hello.greet.GreetingTest')
 
   def test_junit_test_with_test_option_with_dot_slash_relpath(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       pants_run = self.run_pants_with_workdir([
           'test',
           '--test-junit-test=./examples/tests/java/org/pantsbuild/example/hello/greet/GreetingTest.java',
@@ -71,7 +71,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       self._assert_junit_output_exists_for_class(workdir, 'org.pantsbuild.example.hello.greet.GreetingTest')
 
   def test_junit_test_with_test_option_with_classname(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       pants_run = self.run_pants_with_workdir([
           'test',
           '--test-junit-test=org.pantsbuild.example.hello.greet.GreetingTest',
@@ -293,7 +293,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
       yield tests_subdir
 
   def test_junit_test_failure_summary(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with self._failing_test_cases() as tests_dir:
         pants_run = self.run_pants_with_workdir([
           'test',
@@ -322,7 +322,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           self.assertIn('\n'.join(group), output)
 
   def test_junit_test_no_failure_summary(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with self._failing_test_cases() as tests_dir:
         pants_run = self.run_pants_with_workdir([
           'test',
@@ -336,7 +336,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
                          output)
 
   def test_junit_test_successes_and_failures(self):
-    with temporary_dir(root_dir=self.workdir_root()) as workdir:
+    with self.temporary_workdir() as workdir:
       with self._mixed_test_cases() as tests_dir:
         pants_run = self.run_pants_with_workdir([
           'test',

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -148,7 +148,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
 
   @contextmanager
   def _failing_test_cases(self):
-    with temporary_dir(root_dir=self.workdir_root()) as source_dir:
+    with temporary_dir() as source_dir:
       with open(os.path.join(source_dir, 'BUILD'), 'w+') as f:
         f.write('source_root("{}/tests")\n'.format(os.path.basename(source_dir)))
       tests_dir = os.path.join(source_dir, 'tests')
@@ -246,7 +246,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
 
   @contextmanager
   def _mixed_test_cases(self):
-    with temporary_dir(root_dir=self.workdir_root()) as source_dir:
+    with temporary_dir() as source_dir:
       with open(os.path.join(source_dir, 'BUILD'), 'w+') as f:
         f.write('source_root("{}/tests")\n'.format(os.path.basename(source_dir)))
       tests_dir = os.path.join(source_dir, 'tests')

--- a/tests/python/pants_test/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/tasks/test_junit_tests_integration.py
@@ -8,11 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from contextlib import contextmanager
 from textwrap import dedent
-from xml.etree import ElementTree
 
-import pytest
-
-from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -148,7 +144,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
 
   @contextmanager
   def _failing_test_cases(self):
-    with temporary_dir() as source_dir:
+    with self.temporary_sourcedir() as source_dir:
       with open(os.path.join(source_dir, 'BUILD'), 'w+') as f:
         f.write('source_root("{}/tests")\n'.format(os.path.basename(source_dir)))
       tests_dir = os.path.join(source_dir, 'tests')
@@ -246,7 +242,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
 
   @contextmanager
   def _mixed_test_cases(self):
-    with temporary_dir() as source_dir:
+    with self.temporary_sourcedir() as source_dir:
       with open(os.path.join(source_dir, 'BUILD'), 'w+') as f:
         f.write('source_root("{}/tests")\n'.format(os.path.basename(source_dir)))
       tests_dir = os.path.join(source_dir, 'tests')

--- a/tests/python/pants_test/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/tasks/test_jvm_task.py
@@ -33,7 +33,7 @@ class JvmTaskTest(JvmTaskTestBase):
 
     context = self.context(target_roots=[self.t1, self.t2, self.t3])
 
-    self.classpath = [os.path.join(self.build_root, entry) for entry in 'a', 'b']
+    self.classpath = [os.path.join(self.pants_workdir, entry) for entry in 'a', 'b']
     self.populate_runtime_classpath(context, self.classpath)
 
     self.task = self.create_task(context)

--- a/tests/python/pants_test/tasks/test_jvm_task.py
+++ b/tests/python/pants_test/tasks/test_jvm_task.py
@@ -49,4 +49,4 @@ class JvmTaskTest(JvmTaskTestBase):
                      self.task.classpath([self.t1], classpath_prefix=['first']))
 
   def test_classpath_custom_product(self):
-    self.assertEqual([], self.task.classpath([self.t1], classpath_product=ClasspathProducts()))
+    self.assertEqual([], self.task.classpath([self.t1], classpath_product=ClasspathProducts(self.pants_workdir)))

--- a/tests/python/pants_test/tasks/test_scalastyle_integration.py
+++ b/tests/python/pants_test/tasks/test_scalastyle_integration.py
@@ -12,7 +12,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class ScalastyleIntegrationTest(PantsRunIntegrationTest):
   def test_scalastyle_cached(self):
     with temporary_dir(root_dir=self.workdir_root()) as cache:
-      with temporary_dir(root_dir=self.workdir_root()) as workdir:
+      with self.temporary_workdir() as workdir:
         scalastyle_args = [
           'clean-all',
           'compile.scalastyle',

--- a/tests/python/pants_test/tasks/test_scalastyle_integration.py
+++ b/tests/python/pants_test/tasks/test_scalastyle_integration.py
@@ -11,7 +11,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class ScalastyleIntegrationTest(PantsRunIntegrationTest):
   def test_scalastyle_cached(self):
-    with temporary_dir(root_dir=self.workdir_root()) as cache:
+    with self.temporary_cachedir() as cache:
       with self.temporary_workdir() as workdir:
         scalastyle_args = [
           'clean-all',


### PR DESCRIPTION
I'm currently working on moving working directory (pants_workdir) outside of build root.

I've decided to divide work into two separate parts: preparation and main part. For preparation I want to:
1) get single point (field) for working directory in tests (both unit and integration), now it's BaseTest#pants_workdir and PantsRunIntegrationTest#workdir_root.
2) fix issues with working directories in tests (i.e. relying on BUILD_ROOT/.pants.d working directory structure in tests code)
3) fix wrong assumptions in new environment (i.e. assertion like class path entries should be in build root or clean-all can operate only on build root content)

For second part I want to change single point for working directory to arbitrary one and fix tests after that, also I want to take a look into all ".pants.d" usages and portable version of zinc analysis file.

This pull request contains preparation part.