### PR TITLE
[CI] Create the argparse.ArgParser instance only on demand.

### DIFF
--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/util:eval',
+    'src/python/pants/util:memo',
     'src/python/pants/util:meta',
     'src/python/pants/util:strutil',
   ]


### PR DESCRIPTION
Its constructor is surprisingly heavyweight. This also allows
us to make it a temporary local variable, instead of a class member,
further emphasizing its role as a mere implementation detail.