### PR TITLE
[CI] Better implementation of the reporting emitter thread.

### DIFF
--- a/3rdparty/python/twitter/commons/requirements.txt
+++ b/3rdparty/python/twitter/commons/requirements.txt
@@ -2,5 +2,4 @@ twitter.common.collections>=0.3.1,<0.4
 twitter.common.config>=0.3.1,<0.4
 twitter.common.confluence>=0.3.1,<0.4
 twitter.common.dirutil>=0.3.1,<0.4
-twitter.common.threading>=0.3.1,<0.4
 twitter.common.util>=0.3.1,<0.4

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -121,7 +121,7 @@ class RunTracker(Subsystem):
     self._background_worker_pool = None
     self._background_root_workunit = None
 
-    # Trigger subproc pool init while our memory image is still clean (see SubprocPool docstring)
+    # Trigger subproc pool init while our memory image is still clean (see SubprocPool docstring).
     SubprocPool.foreground()
 
     self._aborted = False
@@ -284,7 +284,7 @@ class RunTracker(Subsystem):
 
     SubprocPool.shutdown(self._aborted)
 
-    # Run a dummy work unit to write out one last timestamp
+    # Run a dummy work unit to write out one last timestamp.
     with self.new_workunit("complete"):
       pass
 

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -8,7 +8,6 @@ python_library(
     ':reporting_resources',
   ],
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.threading',
     '3rdparty/python:ansicolors',
     '3rdparty/python:pystache',
     '3rdparty/python:six',
@@ -37,6 +36,5 @@ python_library(
   name='report',
   sources=['report.py'],
   dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.threading',
   ],
 )

--- a/src/python/pants/reporting/report.py
+++ b/src/python/pants/reporting/report.py
@@ -7,11 +7,24 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import threading
 
-from twitter.common.threading import PeriodicThread
-
 
 class ReportingError(Exception):
   pass
+
+
+class EmitterThread(threading.Thread):
+  def __init__(self, report):
+    super(EmitterThread, self).__init__()
+    self._report = report
+    self._stop = threading.Event()
+    self.daemon = True
+
+  def run(self):
+    while not self._stop.wait(timeout=0.5):
+      self._report.flush()
+
+  def stop(self):
+    self._stop.set()
 
 
 class Report(object):
@@ -35,9 +48,7 @@ class Report(object):
 
   def __init__(self):
     # We periodically emit newly gathered output from tool invocations.
-    self._emitter_thread = \
-      PeriodicThread(target=self.flush, name='output-emitter', period_secs=0.5)
-    self._emitter_thread.daemon = True
+    self._emitter_thread = EmitterThread(self)
 
     # Map from workunit id to workunit.
     self._workunits = {}


### PR DESCRIPTION
Previously it used twitter.commons.threading.PeriodicThread, which
it turns out just calls time.sleep() in a loop. So we were wasting
up to half a second on a no-op pants shutdown just for that thread
to exit.

Now we use proper event signaling, so the thread can be interrrupted
immediately.

This also gets rid of the t.c.threading dep entirely.