### PR TITLE
Add `go` and `go-env` goals.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/register.py
+++ b/contrib/go/src/python/pants/contrib/go/register.py
@@ -15,6 +15,7 @@ from pants.contrib.go.tasks.go_binary_create import GoBinaryCreate
 from pants.contrib.go.tasks.go_buildgen import GoBuildgen
 from pants.contrib.go.tasks.go_compile import GoCompile
 from pants.contrib.go.tasks.go_fetch import GoFetch
+from pants.contrib.go.tasks.go_go import GoEnv, GoGo
 from pants.contrib.go.tasks.go_run import GoRun
 from pants.contrib.go.tasks.go_test import GoTest
 
@@ -34,6 +35,8 @@ def build_file_aliases():
 def register_goals():
   task(name='go', action=GoBuildgen).install('buildgen').with_description(
     'Automatically generate BUILD files.')
+  task(name='go', action=GoGo).install('go')
+  task(name='go-env', action=GoEnv).install()
   task(name='go', action=GoFetch).install('resolve')
   task(name='go', action=GoCompile).install('compile')
   task(name='go', action=GoBinaryCreate).install('binary')

--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -5,6 +5,7 @@ target(
     ':go_buildgen',
     ':go_compile',
     ':go_fetch',
+    ':go_go',
     ':go_run',
     ':go_test',
   ]
@@ -64,6 +65,18 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
+  ]
+)
+
+python_library(
+  name='go_go',
+  sources=['go_go.py'],
+  dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:ansicolors',
+    'contrib/go/src/python/pants/contrib/go/tasks:go_workspace_task',
+    'src/python/pants/backend/core/tasks:task',
+    'src/python/pants/base:exceptions',
   ]
 )
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_go.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_go.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import subprocess
+from abc import abstractmethod
+
+from colors import green, red, yellow
+from pants.backend.core.tasks.task import QuietTaskMixin
+from pants.base.exceptions import TaskError
+from twitter.common.collections import OrderedSet
+
+from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
+
+
+class GoInteropTask(QuietTaskMixin, GoWorkspaceTask):
+  class MissingArgsError(TaskError):
+    """Indicates missing go targets or missing pass-through arguments."""
+
+  @classmethod
+  def supports_passthru_args(cls):
+    return True
+
+  def execute(self, **kwargs):
+    # NB: kwargs are for testing and pass-through to underlying subprocess process spawning.
+
+    go_targets = OrderedSet(target for target in self.context.target_roots if self.is_go(target))
+    args = self.get_passthru_args()
+    if not go_targets or not args:
+      msg = (yellow('The pants `{goal}` goal expects at least one go target and at least one '
+                    'pass-through argument to be specified, call with:\n') +
+             green('  ./pants {goal} {targets} -- {args}')
+             .format(goal=self.options_scope,
+                     targets=(green(' '.join(t.address.reference() for t in go_targets))
+                              if go_targets else red('[missing go targets]')),
+                     args=green(' '.join(args)) if args else red('[missing pass-through args]')))
+      raise self.MissingArgsError(msg)
+
+    go_path = OrderedSet()
+    import_paths = OrderedSet()
+    for target in go_targets:
+      self.ensure_workspace(target)
+      go_path.add(self.get_gopath(target))
+      import_paths.add(target.import_path)
+
+    self.execute_with_go_env(os.pathsep.join(go_path), list(import_paths), args, **kwargs)
+
+  @abstractmethod
+  def execute_with_go_env(self, go_path, import_paths, args, **kwargs):
+    """Subclasses should execute the go interop task in the given environment.
+
+    :param string go_path: The pre-formatted $GOPATH for the environment.
+    :param list import_paths: The import paths for all the go targets specified in the environment.
+    :param list args: The pass through arguments for the command to run in the go environment.
+    :param **kwargs: Any additional `subprocess` keyword-args; for testing.
+    """
+
+
+class GoEnv(GoInteropTask):
+  """Runs an arbitrary command in a go workspace defined by zero or more go targets."""
+
+  def execute_with_go_env(self, go_path, import_paths, args, **kwargs):
+    cmd = ' '.join(args)
+    env = os.environ.copy()
+    env.update(GOROOT=self.go_dist.goroot, GOPATH=go_path)
+    process = subprocess.Popen(cmd, shell=True, env=env, **kwargs)
+    result = process.wait()
+    if result != 0:
+      raise TaskError('{} failed with exit code {}'.format(cmd, result), exit_code=result)
+
+
+class GoGo(GoInteropTask):
+  """Runs an arbitrary go command against zero or more go targets."""
+
+  def execute_with_go_env(self, go_path, import_paths, args, **kwargs):
+    args = args + import_paths
+    cmd = args.pop(0)
+    go_cmd = self.go_dist.create_go_cmd(gopath=go_path, cmd=cmd, args=args)
+    result = go_cmd.spawn(**kwargs).wait()
+    if result != 0:
+      raise TaskError('{} failed with exit code {}'.format(go_cmd, result), exit_code=result)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -13,6 +13,7 @@ target(
     ':go_buildgen',
     ':go_compile',
     ':go_fetch',
+    ':go_go',
     ':go_workspace_task',
   ]
 )
@@ -88,6 +89,17 @@ python_tests(
     'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
     'contrib/go/src/python/pants/contrib/go/tasks:go_fetch',
     'src/python/pants/build_graph',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/tasks:task_test_base',
+  ]
+)
+
+python_tests(
+  name='go_go',
+  sources=['test_go_go.py'],
+  dependencies=[
+    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
+    'contrib/go/src/python/pants/contrib/go/tasks:go_go',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/tasks:task_test_base',
   ]

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_go.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_go.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.util.contextutil import temporary_file
+from pants_test.tasks.task_test_base import TaskTestBase
+
+from pants.contrib.go.targets.go_binary import GoBinary
+from pants.contrib.go.tasks.go_go import GoEnv, GoGo, GoInteropTask
+
+
+class GoInteropTaskTest(TaskTestBase):
+  class FakeGoInteropTask(GoInteropTask):
+    def __init__(self, *args, **kwargs):
+      super(GoInteropTaskTest.FakeGoInteropTask, self).__init__(*args, **kwargs)
+      self._called_with = None
+
+    def execute_with_go_env(self, go_path, import_paths, args, **kwargs):
+      self._called_with = go_path, import_paths, args, kwargs
+
+    @property
+    def called_with(self):
+      return self._called_with
+
+  @classmethod
+  def task_type(cls):
+    return cls.FakeGoInteropTask
+
+  def test_no_targets(self):
+    task = self.create_task(self.context(passthru_args=['vim']))
+    with self.assertRaises(GoInteropTask.MissingArgsError):
+      task.execute()
+
+  def test_no_passthrough_args(self):
+    go_binary = self.make_target(spec='src/go:binary', target_type=GoBinary)
+    task = self.create_task(self.context(target_roots=[go_binary]))
+    with self.assertRaises(GoInteropTask.MissingArgsError):
+      task.execute()
+
+  def test_missing_both(self):
+    task = self.create_task(self.context())
+    with self.assertRaises(GoInteropTask.MissingArgsError):
+      task.execute()
+
+  def test_ok(self):
+    go_binary = self.make_target(spec='src/go/bob', target_type=GoBinary)
+    task = self.create_task(self.context(target_roots=[go_binary], passthru_args=['vim']))
+    task.execute()
+    self.assertEqual((task.get_gopath(go_binary), ['bob'], ['vim'], {}), task.called_with)
+
+
+class GoEnvTest(TaskTestBase):
+  @classmethod
+  def task_type(cls):
+    return GoEnv
+
+  def test_execute(self):
+    bob_binary = self.make_target(spec='src/go/bob', target_type=GoBinary)
+    jane_binary = self.make_target(spec='src/go/jane', target_type=GoBinary)
+    task = self.create_task(self.context(target_roots=[bob_binary, jane_binary],
+                                         passthru_args=['echo', '$GOPATH']))
+    with temporary_file() as stdout:
+      task.execute(stdout=stdout)
+      stdout.close()
+      with open(stdout.name) as output:
+        self.assertEqual(output.read().strip(),
+                         os.pathsep.join([task.get_gopath(bob_binary),
+                                          task.get_gopath(jane_binary)]))
+
+
+class GoGoTest(TaskTestBase):
+  @classmethod
+  def task_type(cls):
+    return GoGo
+
+  def test_execute(self):
+    bob_binary = self.make_target(spec='src/go/bob', target_type=GoBinary)
+    jane_binary = self.make_target(spec='src/go/jane', target_type=GoBinary)
+
+    # A task to execute `go env GOPATH`.
+    task = self.create_task(self.context(target_roots=[bob_binary, jane_binary],
+                                         passthru_args=['env', 'GOPATH']))
+    with temporary_file() as stdout:
+      task.execute(stdout=stdout)
+      stdout.close()
+      with open(stdout.name) as output:
+        self.assertEqual(output.read().strip(),
+                         os.pathsep.join([task.get_gopath(bob_binary),
+                                          task.get_gopath(jane_binary)]))


### PR DESCRIPTION
These goals support running arbitrary go commands and arbitrary
third-party commands that respect the $GOROOT and $GOPATH.

In particular, 2 usecases are immediately enabled:
1. Certain enhanced Go editor environments now work with pants Go source
   trees including their 3rdparty deps, two of which this change was
   tested with: The GoSublime plugin for the Sublime Text editor and the
   go-vim plugin for the vim editor.
2. Certain go tooling without direct pants support can be used.  In
   particular `./pants go [targets] -- vet` now runs `go vet` for the
   given targets providing linting for common non-compile-time errors.

Tests are added for these tasks.

https://rbcommons.com/s/twitter/r/3060/