### PR TITLE
[CI] Refactor the python checkstyle plugin system.

### DIFF
--- a/src/python/pants/backend/python/tasks/checkstyle/class_factoring.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/class_factoring.py
@@ -8,17 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import ast
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
-
-
-class ClassFactoringSubsystem(Subsystem):
-  options_scope = 'pycheck-class-factoring'
-
-  @classmethod
-  def register_options(cls, register):
-    super(ClassFactoringSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
 
 
 class ClassFactoring(CheckstylePlugin):
@@ -32,7 +21,6 @@ class ClassFactoring(CheckstylePlugin):
 
   recommend using self.CONSTANT instead of Distiller.CONSTANT as otherwise
   it makes subclassing impossible."""
-  subsystem = ClassFactoringSubsystem
 
   def iter_class_accessors(self, class_node):
     for node in ast.walk(class_node):

--- a/src/python/pants/backend/python/tasks/checkstyle/class_factoring_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/class_factoring_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class ClassFactoringSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-class-factoring'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.class_factoring import ClassFactoring
+    return ClassFactoring

--- a/src/python/pants/backend/python/tasks/checkstyle/common.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/common.py
@@ -113,7 +113,10 @@ class PythonFile(object):
     :param statement: Python file contents
     :return: Instance of PythonFile
     """
-    return cls('\n'.join(textwrap.dedent(statement).split('\n')[1:]))
+    lines = textwrap.dedent(statement).split('\n')
+    if lines and not lines[0]:  # Remove the initial empty line, which is an artifact of dedent.
+      lines = lines[1:]
+    return cls('\n'.join(lines))
 
   @classmethod
   def iter_tokens(cls, blob):
@@ -267,9 +270,11 @@ class Nit(object):
 class CheckstylePlugin(Interface):
   """Interface for checkstyle plugins."""
 
-  def __init__(self, python_file):
+  def __init__(self, options, python_file):
+    super(CheckstylePlugin, self).__init__()
     if not isinstance(python_file, PythonFile):
       raise TypeError('CheckstylePlugin takes PythonFile objects.')
+    self.options = options
     self.python_file = python_file
 
   def iter_ast_types(self, ast_type):

--- a/src/python/pants/backend/python/tasks/checkstyle/except_statements.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/except_statements.py
@@ -11,19 +11,8 @@ from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
 from pants.subsystem.subsystem import Subsystem
 
 
-class ExceptStatementsSubsystem(Subsystem):
-  options_scope = 'pycheck-except-statement'
-
-  @classmethod
-  def register_options(cls, register):
-    super(ExceptStatementsSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
-
-
 class ExceptStatements(CheckstylePlugin):
   """Do not allow non-3.x-compatible and/or dangerous except statements."""
-  subsystem = ExceptStatementsSubsystem
 
   @classmethod
   def blanket_excepts(cls, node):

--- a/src/python/pants/backend/python/tasks/checkstyle/except_statements_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/except_statements_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class ExceptStatementsSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-except-statement'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.except_statements import ExceptStatements
+    return ExceptStatements

--- a/src/python/pants/backend/python/tasks/checkstyle/future_compatibility.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/future_compatibility.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import ast
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
 
 
 # Warn on non 2.x/3.x compatible symbols:
@@ -30,22 +29,11 @@ from pants.subsystem.subsystem import Subsystem
 #
 # Class internals:
 #   __metaclass__
-class FutureCompatibilitySubsystem(Subsystem):
-  options_scope = 'pycheck-future-compat'
-
-  @classmethod
-  def register_options(cls, register):
-    super(FutureCompatibilitySubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
-
-
 class FutureCompatibility(CheckstylePlugin):
   """Warns about behavior that will likely break when moving to Python 3.x"""
   BAD_ITERS = frozenset(('iteritems', 'iterkeys', 'itervalues'))
   BAD_FUNCTIONS = frozenset(('xrange',))
   BAD_NAMES = frozenset(('basestring', 'unicode'))
-  subsystem = FutureCompatibilitySubsystem
 
   def nits(self):
     for call in self.iter_ast_types(ast.Call):

--- a/src/python/pants/backend/python/tasks/checkstyle/future_compatibility_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/future_compatibility_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class FutureCompatibilitySubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-future-compat'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.future_compatibility import FutureCompatibility
+    return FutureCompatibility

--- a/src/python/pants/backend/python/tasks/checkstyle/import_order.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/import_order.py
@@ -10,7 +10,6 @@ import os
 from distutils import sysconfig
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
 
 
 class ImportType(object):
@@ -47,16 +46,6 @@ class ImportType(object):
     return ' '.join(cls.NAMES.get(import_id, 'unknown') for import_id in import_order)
 
 
-class ImportOrderSubsystem(Subsystem):
-  options_scope = 'pycheck-import-order'
-
-  @classmethod
-  def register_options(cls, register):
-    super(ImportOrderSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
-
-
 class ImportOrder(CheckstylePlugin):
   # TODO(wickman)
   #   - Warn if a package is marked as a 3rdparty but it's actually a package
@@ -64,7 +53,6 @@ class ImportOrder(CheckstylePlugin):
   #     import (i.e. from __future__ import absolute_imports)
 
   STANDARD_LIB_PATH = os.path.realpath(sysconfig.get_python_lib(standard_lib=1))
-  subsystem = ImportOrderSubsystem
 
   @classmethod
   def extract_import_modules(cls, node):

--- a/src/python/pants/backend/python/tasks/checkstyle/import_order_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/import_order_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class ImportOrderSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-import-order'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.import_order import ImportOrder
+    return ImportOrder

--- a/src/python/pants/backend/python/tasks/checkstyle/indentation.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/indentation.py
@@ -8,25 +8,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import tokenize
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
 
 
 # TODO(wickman) Update this to sanitize line continuation styling as we have
 # disabled it from pep8.py due to mismatched indentation styles.
-class IndentationSubsystem(Subsystem):
-  options_scope = 'pycheck-indentation'
-
-  @classmethod
-  def register_options(cls, register):
-    super(IndentationSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
-
-
 class Indentation(CheckstylePlugin):
   """Enforce proper indentation."""
   INDENT_LEVEL = 2  # the one true way
-  subsystem = IndentationSubsystem
 
   def nits(self):
     indents = []

--- a/src/python/pants/backend/python/tasks/checkstyle/indentation_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/indentation_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class IndentationSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-indentation'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.indentation import Indentation
+    return Indentation

--- a/src/python/pants/backend/python/tasks/checkstyle/missing_contextmanager.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/missing_contextmanager.py
@@ -8,28 +8,16 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import ast
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
+
+
 # TODO(wickman)
 #
 # 1. open(foo) should always be done in a with context.
 #
 # 2. if you see acquire/release on the same variable in a particular ast
 #    body, warn about context manager use.
-from pants.subsystem.subsystem import Subsystem
-
-
-class MissingContextManagerSubsystem(Subsystem):
-  options_scope = 'pycheck-context-manager'
-
-  @classmethod
-  def register_options(cls, register):
-    super(MissingContextManagerSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
-
-
 class MissingContextManager(CheckstylePlugin):
   """Recommend the use of contextmanagers when it seems appropriate."""
-  subsystem = MissingContextManagerSubsystem
 
   def nits(self):
     with_contexts = set(self.iter_ast_types(ast.With))

--- a/src/python/pants/backend/python/tasks/checkstyle/missing_contextmanager_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/missing_contextmanager_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class MissingContextManagerSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-context-manager'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.missing_contextmanager import MissingContextManager
+    return MissingContextManager

--- a/src/python/pants/backend/python/tasks/checkstyle/new_style_classes.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/new_style_classes.py
@@ -8,22 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import ast
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
-
-
-class NewStyleClassesSubsystem(Subsystem):
-  options_scope = 'pycheck-newstyle-classes'
-
-  @classmethod
-  def register_options(cls, register):
-    super(NewStyleClassesSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
 
 
 class NewStyleClasses(CheckstylePlugin):
   """Enforce the use of new-style classes."""
-  subsystem = NewStyleClassesSubsystem
 
   def nits(self):
     for class_def in self.iter_ast_types(ast.ClassDef):

--- a/src/python/pants/backend/python/tasks/checkstyle/new_style_classes_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/new_style_classes_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class NewStyleClassesSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-newstyle-classes'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.new_style_classes import NewStyleClasses
+    return NewStyleClasses

--- a/src/python/pants/backend/python/tasks/checkstyle/newlines.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/newlines.py
@@ -8,21 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import ast
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
-
-
-class NewlinesSubsystem(Subsystem):
-  options_scope = 'pycheck-newlines'
-
-  @classmethod
-  def register_options(cls, register):
-    super(NewlinesSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
 
 
 class Newlines(CheckstylePlugin):
-  subsystem = NewlinesSubsystem
 
   def iter_toplevel_defs(self):
     for node in self.python_file.tree.body:

--- a/src/python/pants/backend/python/tasks/checkstyle/newlines_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/newlines_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class NewlinesSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-newlines'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.newlines import Newlines
+    return Newlines

--- a/src/python/pants/backend/python/tasks/checkstyle/pep8.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/pep8.py
@@ -8,22 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import pep8
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin, Nit, PythonFile
-from pants.option.custom_types import list_option
-from pants.subsystem.subsystem import Subsystem
-
-
-class PEP8Subsystem(Subsystem):
-  options_scope = 'pycheck-pep8'
-
-  @classmethod
-  def register_options(cls, register):
-    super(PEP8Subsystem, cls).register_options(register)
-    register('--ignore', type=list_option, default=DEFAULT_IGNORE_CODES,
-             help='Prevent test failure but still produce output for problems.')
-    register('--max-length', type=int, default=100,
-             help='Max line length to use for PEP8 checks.')
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
 
 
 class PEP8Error(Nit):
@@ -49,50 +33,16 @@ class PantsReporter(pep8.BaseReport):
     return self._twitter_errors
 
 
-DEFAULT_IGNORE_CODES = (
-  # continuation_line_indentation
-  'E121',
-  'E124',
-  'E125',
-  'E127',
-  'E128',
-
-  # imports_on_separate_lines
-  'E401',
-
-  # indentation
-  'E111',
-
-  # trailing_whitespace
-  'W291',
-  'W293',
-
-  # multiple statements
-  # A common (acceptable) exception pattern at Twitter is:
-  #   class MyClass(object):
-  #     class Error(Exception): pass
-  #     class DerpError(Error): pass
-  #     class HerpError(Error): pass
-  # We disable the pep8.py checking for these and instead have a more lenient filter
-  # in the whitespace checker.
-  'E701',
-  'E301',
-  'E302',
-  'W292'
-)
-
-
 class PEP8Checker(CheckstylePlugin):
   """Enforce PEP8 checks from the pep8 tool."""
-  subsystem = PEP8Subsystem
 
   def __init__(self, *args, **kwargs):
     super(PEP8Checker, self).__init__(*args, **kwargs)
     self.STYLE_GUIDE = pep8.StyleGuide(
-        max_line_length=self.subsystem.global_instance().get_options().max_length,
+        max_line_length=self.options.max_length,
         verbose=False,
         reporter=PantsReporter,
-        ignore=self.subsystem.global_instance().get_options().ignore)
+        ignore=self.options.ignore)
 
   def nits(self):
     report = self.STYLE_GUIDE.check_files([self.python_file.filename])

--- a/src/python/pants/backend/python/tasks/checkstyle/pep8_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/pep8_subsystem.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+from pants.option.custom_types import list_option
+
+
+class PEP8Subsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-pep8'
+
+  DEFAULT_IGNORE_CODES = (
+    # continuation_line_indentation
+    'E121',
+    'E124',
+    'E125',
+    'E127',
+    'E128',
+
+    # imports_on_separate_lines
+    'E401',
+
+    # indentation
+    'E111',
+
+    # trailing_whitespace
+    'W291',
+    'W293',
+
+    # multiple statements
+    # A common (acceptable) exception pattern at Twitter is:
+    #   class MyClass(object):
+    #     class Error(Exception): pass
+    #     class DerpError(Error): pass
+    #     class HerpError(Error): pass
+    # We disable the pep8.py checking for these and instead have a more lenient filter
+    # in the whitespace checker.
+    'E701',
+    'E301',
+    'E302',
+    'W292'
+  )
+
+  @classmethod
+  def register_options(cls, register):
+    super(PEP8Subsystem, cls).register_options(register)
+    register('--ignore', type=list_option, default=cls.DEFAULT_IGNORE_CODES,
+             help='Prevent test failure but still produce output for problems.')
+    register('--max-length', type=int, default=100,
+             help='Max line length to use for PEP8 checks.')
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.pep8 import PEP8Checker
+    return PEP8Checker

--- a/src/python/pants/backend/python/tasks/checkstyle/plugin_subsystem_base.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/plugin_subsystem_base.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.subsystem.subsystem import Subsystem
+
+
+class PluginSubsystemBase(Subsystem):
+
+  @classmethod
+  def register_options(cls, register):
+    super(PluginSubsystemBase, cls).register_options(register)
+    # All checks have this option.
+    register('--skip', default=False, action='store_true',
+             help='If enabled, skip this style checker.')
+
+  def get_plugin(self, python_file):
+    return self.get_plugin_type()(self.get_options(), python_file)
+
+  def get_plugin_type(self):
+    raise NotImplementedError('get_plugin() not implemented in class {}'.format(type(self)))

--- a/src/python/pants/backend/python/tasks/checkstyle/print_statements.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/print_statements.py
@@ -9,24 +9,12 @@ import ast
 import re
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
-
-
-class PrintStatementsSubsystem(Subsystem):
-  options_scope = 'pycheck-print-statements'
-
-  @classmethod
-  def register_options(cls, register):
-    super(PrintStatementsSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
 
 
 class PrintStatements(CheckstylePlugin):
   """Enforce the use of print as a function and not a statement."""
 
   FUNCTIONY_EXPRESSION = re.compile(r'^\s*\(.*\)\s*$')
-  subsystem = PrintStatementsSubsystem
 
   def nits(self):
     for print_stmt in self.iter_ast_types(ast.Print):

--- a/src/python/pants/backend/python/tasks/checkstyle/print_statements_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/print_statements_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class PrintStatementsSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-print-statements'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.print_statements import PrintStatements
+    return PrintStatements

--- a/src/python/pants/backend/python/tasks/checkstyle/pyflakes.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/pyflakes.py
@@ -8,17 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pyflakes.checker import Checker as FlakesChecker
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin, Nit
-from pants.subsystem.subsystem import Subsystem
-
-
-class FlakeCheckSubsystem(Subsystem):
-  options_scope = 'pycheck-pyflakes'
-
-  @classmethod
-  def register_options(cls, register):
-    super(FlakeCheckSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
 
 
 class FlakeError(Nit):
@@ -51,7 +40,6 @@ class FlakeError(Nit):
 
 class PyflakesChecker(CheckstylePlugin):
   """Detect common coding errors via the pyflakes package."""
-  subsystem = FlakeCheckSubsystem
 
   def nits(self):
     checker = FlakesChecker(self.python_file.tree, self.python_file.filename)

--- a/src/python/pants/backend/python/tasks/checkstyle/pyflakes_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/pyflakes_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class FlakeCheckSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-pyflakes'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.pyflakes import PyflakesChecker
+    return PyflakesChecker

--- a/src/python/pants/backend/python/tasks/checkstyle/register_plugins.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/register_plugins.py
@@ -5,32 +5,38 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks.checkstyle.class_factoring import ClassFactoring
-from pants.backend.python.tasks.checkstyle.except_statements import ExceptStatements
-from pants.backend.python.tasks.checkstyle.future_compatibility import FutureCompatibility
-from pants.backend.python.tasks.checkstyle.import_order import ImportOrder
-from pants.backend.python.tasks.checkstyle.indentation import Indentation
-from pants.backend.python.tasks.checkstyle.missing_contextmanager import MissingContextManager
-from pants.backend.python.tasks.checkstyle.new_style_classes import NewStyleClasses
-from pants.backend.python.tasks.checkstyle.newlines import Newlines
-from pants.backend.python.tasks.checkstyle.pep8 import PEP8Checker
-from pants.backend.python.tasks.checkstyle.print_statements import PrintStatements
-from pants.backend.python.tasks.checkstyle.pyflakes import PyflakesChecker
-from pants.backend.python.tasks.checkstyle.trailing_whitespace import TrailingWhitespace
-from pants.backend.python.tasks.checkstyle.variable_names import PEP8VariableNames
+from pants.backend.python.tasks.checkstyle.class_factoring_subsystem import ClassFactoringSubsystem
+from pants.backend.python.tasks.checkstyle.except_statements_subsystem import \
+  ExceptStatementsSubsystem
+from pants.backend.python.tasks.checkstyle.future_compatibility_subsystem import \
+  FutureCompatibilitySubsystem
+from pants.backend.python.tasks.checkstyle.import_order_subsystem import ImportOrderSubsystem
+from pants.backend.python.tasks.checkstyle.indentation_subsystem import IndentationSubsystem
+from pants.backend.python.tasks.checkstyle.missing_contextmanager_subsystem import \
+  MissingContextManagerSubsystem
+from pants.backend.python.tasks.checkstyle.new_style_classes_subsystem import \
+  NewStyleClassesSubsystem
+from pants.backend.python.tasks.checkstyle.newlines_subsystem import NewlinesSubsystem
+from pants.backend.python.tasks.checkstyle.pep8_subsystem import PEP8Subsystem
+from pants.backend.python.tasks.checkstyle.print_statements_subsystem import \
+  PrintStatementsSubsystem
+from pants.backend.python.tasks.checkstyle.pyflakes_subsystem import FlakeCheckSubsystem
+from pants.backend.python.tasks.checkstyle.trailing_whitespace_subsystem import \
+  TrailingWhitespaceSubsystem
+from pants.backend.python.tasks.checkstyle.variable_names_subsystem import VariableNamesSubsystem
 
 
 def register_plugins(task):
-  task.register_plugin(name='class-factoring', checker=ClassFactoring)
-  task.register_plugin(name='except-statement', checker=ExceptStatements)
-  task.register_plugin(name='future-compatibility', checker=FutureCompatibility)
-  task.register_plugin(name='import-order', checker=ImportOrder)
-  task.register_plugin(name='indentation', checker=Indentation)
-  task.register_plugin(name='missing-context-manager', checker=MissingContextManager)
-  task.register_plugin(name='new-style-classes', checker=NewStyleClasses)
-  task.register_plugin(name='newlines', checker=Newlines)
-  task.register_plugin(name='print-statements', checker=PrintStatements)
-  task.register_plugin(name='pyflakes', checker=PyflakesChecker)
-  task.register_plugin(name='trailing-whitespace', checker=TrailingWhitespace)
-  task.register_plugin(name='variable-names', checker=PEP8VariableNames)
-  task.register_plugin(name='pep8', checker=PEP8Checker)
+  task.register_plugin('class-factoring', ClassFactoringSubsystem)
+  task.register_plugin('except-statement', ExceptStatementsSubsystem)
+  task.register_plugin('future-compatibility', FutureCompatibilitySubsystem)
+  task.register_plugin('import-order', ImportOrderSubsystem)
+  task.register_plugin('indentation', IndentationSubsystem)
+  task.register_plugin('missing-context-manager', MissingContextManagerSubsystem)
+  task.register_plugin('new-style-classes', NewStyleClassesSubsystem)
+  task.register_plugin('newlines', NewlinesSubsystem)
+  task.register_plugin('print-statements', PrintStatementsSubsystem)
+  task.register_plugin('pyflakes', FlakeCheckSubsystem)
+  task.register_plugin('trailing-whitespace', TrailingWhitespaceSubsystem)
+  task.register_plugin('variable-names', VariableNamesSubsystem)
+  task.register_plugin('pep8', PEP8Subsystem)

--- a/src/python/pants/backend/python/tasks/checkstyle/trailing_whitespace.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/trailing_whitespace.py
@@ -10,22 +10,10 @@ import tokenize
 from collections import defaultdict
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
-
-
-class TrailingWhitespaceSubsystem(Subsystem):
-  options_scope = 'pycheck-trailing-whitespace'
-
-  @classmethod
-  def register_options(cls, register):
-    super(TrailingWhitespaceSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
 
 
 class TrailingWhitespace(CheckstylePlugin):
   """Warn on invalid trailing whitespace."""
-  subsystem = TrailingWhitespaceSubsystem
 
   @classmethod
   def build_exception_map(cls, tokens):

--- a/src/python/pants/backend/python/tasks/checkstyle/trailing_whitespace_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/trailing_whitespace_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class TrailingWhitespaceSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-trailing-whitespace'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.trailing_whitespace import TrailingWhitespace
+    return TrailingWhitespace

--- a/src/python/pants/backend/python/tasks/checkstyle/variable_names.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/variable_names.py
@@ -13,7 +13,6 @@ from functools import wraps
 from twitter.common.lang import Compatibility
 
 from pants.backend.python.tasks.checkstyle.common import CheckstylePlugin
-from pants.subsystem.subsystem import Subsystem
 
 
 ALL_LOWER_CASE_RE = re.compile(r'^[a-z][a-z\d]*$')
@@ -78,16 +77,6 @@ def is_constant(name):
   return UPPER_SNAKE_RE.match(name) is not None
 
 
-class VariableNamesSubsystem(Subsystem):
-  options_scope = 'pycheck-variable-names'
-
-  @classmethod
-  def register_options(cls, register):
-    super(VariableNamesSubsystem, cls).register_options(register)
-    register('--skip', default=False, action='store_true',
-             help='If enabled, skip this style checker.')
-
-
 class PEP8VariableNames(CheckstylePlugin):
   """Enforces PEP8 recommendations for variable names.
   Specifically:
@@ -97,7 +86,6 @@ class PEP8VariableNames(CheckstylePlugin):
      CLASS_LEVEL_CONSTANTS = {}
      GLOBAL_LEVEL_CONSTANTS = {}
   """
-  subsystem = VariableNamesSubsystem
 
   CLASS_GLOBAL_BUILTINS = frozenset((
     '__slots__',

--- a/src/python/pants/backend/python/tasks/checkstyle/variable_names_subsystem.py
+++ b/src/python/pants/backend/python/tasks/checkstyle/variable_names_subsystem.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
+
+
+class VariableNamesSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-variable-names'
+
+  def get_plugin_type(self):
+    from pants.backend.python.tasks.checkstyle.variable_names import PEP8VariableNames
+    return PEP8VariableNames

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/BUILD
@@ -14,7 +14,8 @@ python_tests(
   dependencies = [
     '3rdparty/python:mock',
     'src/python/pants/backend/python/tasks/checkstyle:all',
-    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'tests/python/pants_test:base_test',
+    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
+    'tests/python/pants_test/option/util',
   ]
 )

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/plugin_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/plugin_test_base.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import copy
+import unittest
+
+from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
+from pants_test.option.util.fakes import create_options
+
+
+class CheckstylePluginTestBase(unittest.TestCase):
+  plugin_type = None   # Subclasses must override.
+
+  def get_plugin(self, file_content, **options):
+    python_file = PythonFile.from_statement(file_content)
+    full_options = copy.copy(options)
+    full_options['skip'] = False
+    options_object = create_options({'foo': full_options}).for_scope('foo')
+    return self.plugin_type(options_object, python_file)
+
+  def assertNit(self, file_content, expected_code, expected_severity=Nit.ERROR,
+                expected_line_number=None):
+    plugin = self.get_plugin(file_content)
+    nits = list(plugin.nits())
+    self.assertEqual(1, len(nits))
+    self.assertEqual(expected_code, nits[0].code)
+    self.assertEqual(expected_severity, nits[0].severity)
+    if expected_line_number is not None:
+      self.assertEqual(expected_line_number, nits[0]._line_number)
+
+  def assertNoNits(self, file_content):
+    plugin = self.get_plugin(file_content)
+    nits = list(plugin.nits())
+    self.assertEqual(0, len(nits))

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_class_factoring.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_class_factoring.py
@@ -6,21 +6,21 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.python.tasks.checkstyle.class_factoring import ClassFactoring
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
+from pants.backend.python.tasks.checkstyle.common import Nit
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
 
 
-BAD_CLASS = PythonFile.from_statement("""
+BAD_CLASS = """
 class Distiller(object):
   CONSTANT = "foo"
 
   def foo(self, value):
     return os.path.join(Distiller.CONSTANT, value)
-""")
+"""
 
 
-def test_class_factoring():
-  plugin = ClassFactoring(BAD_CLASS)
-  nits = list(plugin.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T800'
-  assert nits[0].severity == Nit.WARNING
+class ClassFactoringTest(CheckstylePluginTestBase):
+  plugin_type = ClassFactoring
+
+  def test_class_factoring(self):
+    self.assertNit(BAD_CLASS, 'T800', Nit.WARNING)

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_common.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_common.py
@@ -7,12 +7,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import ast
 import textwrap
-from pprint import pprint
+import unittest
 
 import pytest
 
 from pants.backend.python.tasks.checkstyle.common import (CheckstylePlugin, Nit, OffByOneList,
                                                           PythonFile)
+from pants_test.option.util.fakes import create_options
 
 
 FILE_TEXT = """
@@ -36,190 +37,164 @@ FILE_TEXT = """
 
 
 class MinimalCheckstylePlugin(CheckstylePlugin):
-  """Minimal Checkstyle plugin used to test PythonFile interactions in Plugin"""
+  """Minimal Checkstyle plugin used to test PythonFile interactions in Plugin."""
 
   def nits(self):
     return []
 
 
-@pytest.fixture
-def test_statement():
-  """Pytest Fixture to create a test python file from statement"""
-  return '\n'.join(textwrap.dedent(FILE_TEXT).split('\n')[1:])
+class CommonTest(unittest.TestCase):
 
+  def _statement_for_testing(self):
+    """Pytest Fixture to create a test python file from statement."""
+    return '\n'.join(textwrap.dedent(FILE_TEXT).split('\n')[1:])
 
-@pytest.fixture
-def test_python_file():
-  """Pytest Fixture to create a test python file from statement"""
-  return PythonFile(test_statement(), 'keeper.py')
+  def _python_file_for_testing(self):
+    """Pytest Fixture to create a test python file from statement."""
+    return PythonFile(self._statement_for_testing(), 'keeper.py')
 
+  def _plugin_for_testing(self):
+    options_object = create_options({'foo': {'skip': False}}).for_scope('foo')
+    return MinimalCheckstylePlugin(options_object, self._python_file_for_testing())
 
-@pytest.fixture
-def check_plugin():
-  return MinimalCheckstylePlugin(test_python_file())
+  def test_python_file_name(self):
+    """Test that filename attrib is getting set properly."""
+    self.assertEqual('keeper.py', self._python_file_for_testing().filename)
 
+  def test_python_file_logical_lines(self):
+    """Test that we get back logical lines we expect."""
+    self.assertEqual({
+      1: (1, 2, 0),  # import ast
+      2: (2, 6, 0),  # from os.path import (", "    join,", "    split,", ")
+      7: (7, 8, 0),  # import zookeeper
+      10: (10, 11, 0),  # class Keeper(object):
+      11: (11, 12, 2),  # def __init__(self):
+      12: (12, 13, 4),  # self._session = None
+      14: (14, 15, 2),  # def session(self):
+      15: (15, 16, 4),  # return self._session
+    }, self._python_file_for_testing().logical_lines)
 
-def test_python_file_name(test_python_file):
-  """Test that filename attrib is getting set properly"""
-  assert test_python_file.filename == 'keeper.py'
+  def test_python_file_index_offset(self):
+    """Test that we can not index into a python file with 0.
 
-
-def test_python_file_logical_lines(test_python_file):
-  """Test that we get back logical lines we expect"""
-  assert test_python_file.logical_lines == {
-    1: (1, 2, 0),  # import ast
-    2: (2, 6, 0),  # from os.path import (", "    join,", "    split,", ")
-    7: (7, 8, 0),  # import zookeeper
-    10: (10, 11, 0),  # class Keeper(object):
-    11: (11, 12, 2),  # def __init__(self):
-    12: (12, 13, 4),  # self._session = None
-    14: (14, 15, 2),  # def session(self):
-    15: (15, 16, 4),  # return self._session
-  }
-
-
-def test_python_file_index_offset(test_python_file):
-  """Test that we can not index into a python file with 0
-
-  PythonFile is offset by one to match users expectations
-  with file line numbering.
-  """
-  with pytest.raises(IndexError):
-    test_python_file[0]
-
-
-def test_python_file_exceeds_index(test_statement):
-  """Test that we get an Index error when we exceed the line number"""
-  test_python_file = PythonFile(test_statement, 'keeper.py')
-  with pytest.raises(IndexError):
-    test_python_file[len(test_statement.split('\n')) + 1]
-
-
-def test_line_retrieval(test_python_file):
-  """Test that we get lines correctly when accessed by index"""
-  expected = [
-    ["import ast"],
-    ["from os.path import (", "    join,", "    split,", ")"],
-    ["    join,"],
-    ["    split,"],
-    [")"],
-    [""],
-    ["import zookeeper"],
-    [""],
-    [""],
-    ["class Keeper(object):"],
-    ["  def __init__(self):"],
-    ["    self._session = None"],
-    [""],
-    ["  def session(self):"],
-    ["    return self._session"],
-    [""]
-  ]
-  assert expected == [test_python_file[x] for x in range(1,17)], \
-    "Expected:\n{} Actual:\n{}".format(
-      pprint(expected), pprint([test_python_file[x] for x in range(1,17)]))
-
-
-def test_rejoin(test_statement):
-  """Test that when we stitch the PythonFile back up we get back our input"""
-  python_file = PythonFile(test_statement, 'keeper.py')
-  assert '\n'.join(python_file) == test_statement
-
-
-def test_off_by_one_enumeration(test_statement):
-  """Test that enumerate is offset by one"""
-  python_file = PythonFile(test_statement, 'keeper.py')
-  assert list(python_file.enumerate()) == list(enumerate(test_statement.split('\n'), 1))
-
-
-@pytest.mark.parametrize("ln_test_input,ln_test_expected", [
-  (['A123', 'You have a terrible taste in libraries'], None),
-  (['A123', 'You have a terrible taste in libraries', 7], '007'),
-  (['A123', 'You have a terrible taste in libraries', 2], '002-005'),
-])
-def test_line_number_return(check_plugin, ln_test_input, ln_test_expected):
-  error = check_plugin.error(*ln_test_input)
-  assert error.line_number == ln_test_expected, 'Unexpected Line number found'
-
-
-@pytest.mark.parametrize("code_test_input,code_test_expected", [
-  (['A123', 'You have a terrible taste in libraries'], 'A123'),
-  (['A321', 'You have a terrible taste in libraries', 2], 'A321'),
-  (['B321', 'You have a terrible taste in libraries', 7], 'B321'),
-])
-def test_code_return(check_plugin, code_test_input, code_test_expected):
-  error = check_plugin.error(*code_test_input)
-  assert error.code == code_test_expected, 'Unexpected code found'
-
-
-def test_error_severity(check_plugin):
-  """Test that we get Nit.Error when calling error"""
-  error = check_plugin.error('A123', 'Uh-oh this is bad')
-  assert error.severity == Nit.ERROR
-
-
-def test_warn_severity(check_plugin):
-  """Test that we get Nit.WARNING when calling warning"""
-  error = check_plugin.warning('A123', 'No worries, its just a warning')
-  assert error.severity == Nit.WARNING
-
-
-def test_style_error(test_python_file):
-  """Test error with actual AST node
-
-  Verify that when we fetch a node form AST and create an error we get the
-  same result as generating the error manually.
-  """
-  plugin = MinimalCheckstylePlugin(test_python_file)
-  import_from = None
-  for node in ast.walk(test_python_file.tree):
-    if isinstance(node, ast.ImportFrom):
-      import_from = node
-
-  ast_error = plugin.error('B380', "I don't like your from import!", import_from)
-  error = plugin.error('B380', "I don't like your from import!", 2)
-  assert str(error) == str(ast_error)
-
-
-def test_index_error_with_data():
-  """Test index errors with data in list"""
-  test_list = OffByOneList([])
-  for k in (0, 4):
+    PythonFile is offset by one to match users expectations with file line numbering.
+    """
     with pytest.raises(IndexError):
-      test_list[k]
+      self._python_file_for_testing()[0]
 
+  def test_python_file_exceeds_index(self):
+    """Test that we get an Index error when we exceed the line number."""
+    with pytest.raises(IndexError):
+      self._python_file_for_testing()[len(self._statement_for_testing().split('\n')) + 1]
 
-@pytest.mark.parametrize("index",
-  [-1, 0, 1, slice(-1,0), slice(0,1)]
-)
-def test_index_error_no_data(index):
-  """Test that when start or end are -1,0, or 1 we get an index error"""
-  test_list = OffByOneList([])
-  with pytest.raises(IndexError):
-    test_list[index]
+  def test_line_retrieval(self):
+    """Test that we get lines correctly when accessed by index."""
+    expected = [
+      ["import ast"],
+      ["from os.path import (", "    join,", "    split,", ")"],
+      ["    join,"],
+      ["    split,"],
+      [")"],
+      [""],
+      ["import zookeeper"],
+      [""],
+      [""],
+      ["class Keeper(object):"],
+      ["  def __init__(self):"],
+      ["    self._session = None"],
+      [""],
+      ["  def session(self):"],
+      ["    return self._session"],
+      [""]
+    ]
+    self.assertEqual(expected, [self._python_file_for_testing()[x] for x in range(1,17)])
 
+  def test_rejoin(self):
+    """Test that when we stitch the PythonFile back up we get back our input."""
+    self.assertEqual(self._statement_for_testing(), '\n'.join(self._python_file_for_testing()))
 
-def test_empty_slice():
-  """Test that we get an empty list if no elements in slice"""
-  test_list = OffByOneList([])
-  for s in (slice(1, 1), slice(1, 2), slice(-2, -1)):
-    assert test_list[s] == []
+  def test_off_by_one_enumeration(self):
+    """Test that enumerate is offset by one."""
+    self.assertEqual(list(enumerate(self._statement_for_testing().split('\n'), 1)),
+                     list(self._python_file_for_testing().enumerate()))
 
+  def test_line_number_return(self):
+    for ln_test_input, ln_test_expected in [
+      (['A123', 'You have a terrible taste in libraries'], None),
+      (['A123', 'You have a terrible taste in libraries', 7], '007'),
+      (['A123', 'You have a terrible taste in libraries', 2], '002-005'),
+    ]:
+      error = self._plugin_for_testing().error(*ln_test_input)
+      self.assertEqual(ln_test_expected, error.line_number)
 
-def test_off_by_one():
-  """Test that you fetch the value you put in"""
-  test_list = OffByOneList(['1', '2', '3'])
-  for k in (1, 2, 3):
-    assert test_list[k] == str(k)
-    assert test_list[k:k + 1] == [str(k)]
-    assert test_list.index(str(k)) == k
-    assert test_list.count(str(k)) == 1
-  assert list(reversed(test_list)) == ['3', '2', '1']
+  def test_code_return(self):
+    for code_test_input, code_test_expected in [
+      (['A123', 'You have a terrible taste in libraries'], 'A123'),
+      (['A321', 'You have a terrible taste in libraries', 2], 'A321'),
+      (['B321', 'You have a terrible taste in libraries', 7], 'B321'),
+    ]:
+      error = self._plugin_for_testing().error(*code_test_input)
+      self.assertEqual(code_test_expected, error.code)
 
+  def test_error_severity(self):
+    """Test that we get Nit.Error when calling error."""
+    error = self._plugin_for_testing().error('A123', 'Uh-oh this is bad')
+    self.assertEqual(Nit.ERROR, error.severity)
 
-def test_index_type():
-  test_list = OffByOneList([])
-  # Test Index Type Sanity
-  for value in (None, 2.0, type):
-    with pytest.raises(TypeError):
-      test_list[value]
+  def test_warn_severity(self):
+    """Test that we get Nit.WARNING when calling warning."""
+    error = self._plugin_for_testing().warning('A123', 'No worries, its just a warning')
+    self.assertEqual(Nit.WARNING, error.severity)
+
+  def test_style_error(self):
+    """Test error with actual AST node.
+
+    Verify that when we fetch a node form AST and create an error we get the
+    same result as generating the error manually.
+    """
+    plugin = MinimalCheckstylePlugin({}, PythonFile.from_statement(FILE_TEXT))
+    import_from = None
+    for node in ast.walk(self._python_file_for_testing().tree):
+      if isinstance(node, ast.ImportFrom):
+        import_from = node
+
+    ast_error = plugin.error('B380', "I don't like your from import!", import_from)
+    error = plugin.error('B380', "I don't like your from import!", 2)
+    self.assertEqual(str(ast_error), str(error))
+
+  def test_index_error_with_data(self):
+    """Test index errors with data in list."""
+    test_list = OffByOneList([])
+    for k in (0, 4):
+      with pytest.raises(IndexError):
+        test_list[k]
+
+  def test_index_error_no_data(self):
+    """Test that when start or end are -1,0, or 1 we get an index error."""
+    for index in [-1, 0, 1, slice(-1,0), slice(0,1)]:
+      test_list = OffByOneList([])
+      with pytest.raises(IndexError):
+        test_list[index]
+
+  def test_empty_slice(self):
+    """Test that we get an empty list if no elements in slice."""
+    test_list = OffByOneList([])
+    for s in (slice(1, 1), slice(1, 2), slice(-2, -1)):
+      self.assertEqual([], test_list[s])
+
+  def test_off_by_one(self):
+    """Test that you fetch the value you put in."""
+    test_list = OffByOneList(['1', '2', '3'])
+    for k in (1, 2, 3):
+      self.assertEqual(str(k), test_list[k])
+      self.assertEqual([str(k)], test_list[k:k + 1])
+      self.assertEqual(k, test_list.index(str(k)))
+      self.assertEqual(1, test_list.count(str(k)))
+    self.assertEqual(['3', '2', '1'], list(reversed(test_list)))
+
+  def test_index_type(self):
+    test_list = OffByOneList([])
+    # Test index type sanity.
+    for value in (None, 2.0, type):
+      with pytest.raises(TypeError):
+        test_list[value]

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_file_excluder.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_file_excluder.py
@@ -8,29 +8,24 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import textwrap
 
-import pytest
-
-from pants.backend.python.tasks.checkstyle.checker import PythonCheckStyleTask
 from pants.backend.python.tasks.checkstyle.file_excluder import FileExcluder
-from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
+from pants_test.base_test import BaseTest
 
 
 logger = logging.getLogger(__name__)
 
 
-class TestExcluder(PythonTaskTestBase):
-  def task_type(cls):
-    """Required method"""
-    return PythonCheckStyleTask
+class TestExcluder(BaseTest):
 
-  def setUp(self, *args, **kwargs):
-    super(TestExcluder, self).setUp(*args, **kwargs)
-    excludes_text = textwrap.dedent('''
+  def setUp(self):
+    super(TestExcluder, self).setUp()
+    excludes_text = textwrap.dedent("""
       # ignore C++
       .*\.cpp::.*
 
       # ignore python
-      .*\.py::Flake8''')
+      .*\.py::Flake8
+    """)
     self.excluder = FileExcluder(
       self._create_scalastyle_excludes_file([excludes_text]),
       logger)
@@ -41,13 +36,13 @@ class TestExcluder(PythonTaskTestBase):
       contents='\n'.join(exclude_patterns) if exclude_patterns else '')
 
   def test_excludes_cpp_any(self):
-    assert not self.excluder.should_include('test/file.cpp', '.*')
+    self.assertFalse(self.excluder.should_include('test/file.cpp', '.*'))
 
   def test_excludes_cpp_flake8(self):
-    assert not self.excluder.should_include('test/file.cpp', 'Flake8')
+    self.assertFalse(self.excluder.should_include('test/file.cpp', 'Flake8'))
 
   def test_excludes_python_flake8(self):
-    assert not self.excluder.should_include('test/file.py', 'Flake8')
+    self.assertFalse(self.excluder.should_include('test/file.py', 'Flake8'))
 
   def test_excludes_python_trailingws(self):
-    assert self.excluder.should_include('test/file.py', 'TrailingWhiteSpace')
+    self.assertTrue(self.excluder.should_include('test/file.py', 'TrailingWhiteSpace'))

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_import_order.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_import_order.py
@@ -8,145 +8,143 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import ast
 import textwrap
 
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
+from pants.backend.python.tasks.checkstyle.common import Nit
 from pants.backend.python.tasks.checkstyle.import_order import ImportOrder, ImportType
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
+
+
+IMPORT_CHUNKS = {
+  ImportType.STDLIB: """
+  import ast
+  from collections import namedtuple
+  import io
+  """,
+
+  ImportType.TWITTER: """
+  from twitter.common import app
+  from twitter.common.dirutil import (
+      safe_mkdtemp,
+      safe_open,
+      safe_rmtree)
+  """,
+
+  ImportType.GEN: """
+  from gen.twitter.aurora.ttypes import TwitterTaskInfo
+  """,
+
+  ImportType.PACKAGE: """
+  from .import_order import (
+      ImportOrder,
+      ImportType
+  )
+  """,
+
+  ImportType.THIRD_PARTY: """
+  from kazoo.client import KazooClient
+  import zookeeper
+  """,
+}
 
 
 def strip_newline(stmt):
   return textwrap.dedent('\n'.join(filter(None, stmt.splitlines())))
 
 
-IMPORT_CHUNKS = {
-  ImportType.STDLIB: strip_newline("""
-  import ast
-  from collections import namedtuple
-  import io
-  """),
-
-  ImportType.TWITTER: strip_newline("""
-  from twitter.common import app
-  from twitter.common.dirutil import (
-      safe_mkdtemp,
-      safe_open,
-      safe_rmtree)
-  """),
-
-  ImportType.GEN: strip_newline("""
-  from gen.twitter.aurora.ttypes import TwitterTaskInfo
-  """),
-
-  ImportType.PACKAGE: strip_newline("""
-  from .import_order import (
-      ImportOrder,
-      ImportType
-  )
-  """),
-
-  ImportType.THIRD_PARTY: strip_newline("""
-  from kazoo.client import KazooClient
-  import zookeeper
-  """),
-}
-
-
 def stitch_chunks(newlines, *chunks):
-  stitched = ('\n' * newlines).join(map(IMPORT_CHUNKS.get, chunks))
-  return stitched
+  return ('\n' * newlines).join([strip_newline(IMPORT_CHUNKS.get(c)) for c in chunks])
 
 
-def get_import_chunk_types(import_type):
-  chunks = list(ImportOrder(PythonFile(IMPORT_CHUNKS[import_type])).iter_import_chunks())
-  assert len(chunks) == 1
-  return tuple(map(type, chunks[0]))
+class ImportOrderTest(CheckstylePluginTestBase):
+  plugin_type = ImportOrder
 
+  def get_import_chunk_types(self, import_type):
+    chunks = list(self.get_plugin(IMPORT_CHUNKS[import_type]).iter_import_chunks())
+    self.assertEqual(1, len(chunks))
+    return tuple(map(type, chunks[0]))
 
-def test_classify_import_chunks():
-  assert get_import_chunk_types(ImportType.STDLIB) == (ast.Import, ast.ImportFrom, ast.Import)
-  assert get_import_chunk_types(ImportType.TWITTER) == (ast.ImportFrom, ast.ImportFrom)
-  assert get_import_chunk_types(ImportType.GEN) == (ast.ImportFrom,)
-  assert get_import_chunk_types(ImportType.PACKAGE) == (ast.ImportFrom,)
-  assert get_import_chunk_types(ImportType.THIRD_PARTY) == (ast.ImportFrom, ast.Import)
+  def test_classify_import_chunks(self):
+    self.assertEqual((ast.Import, ast.ImportFrom, ast.Import),
+                     self.get_import_chunk_types(ImportType.STDLIB))
+    self.assertEqual((ast.ImportFrom, ast.ImportFrom),
+                     self.get_import_chunk_types(ImportType.TWITTER))
+    self.assertEqual((ast.ImportFrom,),
+                     self.get_import_chunk_types(ImportType.GEN))
+    self.assertEqual((ast.ImportFrom,),
+                     self.get_import_chunk_types(ImportType.PACKAGE))
+    self.assertEqual((ast.ImportFrom, ast.Import),
+                     self.get_import_chunk_types(ImportType.THIRD_PARTY))
 
+  def test_classify_import(self):
+    for import_type, chunk in IMPORT_CHUNKS.items():
+      io = self.get_plugin(chunk)
+      import_chunks = list(io.iter_import_chunks())
+      self.assertEqual(1, len(import_chunks))
+      module_types, chunk_errors = io.classify_imports(import_chunks[0])
+      self.assertEqual(1, len(module_types))
+      self.assertEqual(import_type, module_types.pop())
+      self.assertEqual([], chunk_errors)
 
-def test_classify_import():
-  for import_type, chunk in IMPORT_CHUNKS.items():
-    io = ImportOrder(PythonFile(chunk))
+  PAIRS = (
+    (ImportType.STDLIB, ImportType.TWITTER),
+    (ImportType.TWITTER, ImportType.GEN),
+    (ImportType.PACKAGE, ImportType.THIRD_PARTY),
+  )
+
+  def test_pairwise_classify(self):
+    for first, second in self.PAIRS:
+      io = self.get_plugin(stitch_chunks(1, first, second))
+      import_chunks = list(io.iter_import_chunks())
+      self.assertEqual(2, len(import_chunks))
+
+      module_types, chunk_errors = io.classify_imports(import_chunks[0])
+      self.assertEqual(1, len(module_types))
+      self.assertEqual(0, len(chunk_errors))
+      self.assertEqual(first, module_types.pop())
+
+      module_types, chunk_errors = io.classify_imports(import_chunks[1])
+      self.assertEqual(1, len(module_types))
+      self.assertEqual(0, len(chunk_errors))
+      self.assertEqual(second, module_types.pop())
+
+    for second, first in self.PAIRS:
+      io = self.get_plugin(stitch_chunks(1, first, second))
+      import_chunks = list(io.iter_import_chunks())
+      self.assertEqual(2, len(import_chunks))
+      nits = list(io.nits())
+      self.assertEqual(1, len(nits))
+      self.assertEqual('T406', nits[0].code)
+      self.assertEqual(Nit.ERROR, nits[0].severity)
+
+  def test_multiple_imports_error(self):
+    io = self.get_plugin(stitch_chunks(0, ImportType.STDLIB, ImportType.TWITTER))
     import_chunks = list(io.iter_import_chunks())
-    assert len(import_chunks) == 1
+    self.assertEqual(1, len(import_chunks))
+
     module_types, chunk_errors = io.classify_imports(import_chunks[0])
-    assert len(module_types) == 1
-    assert module_types.pop() == import_type
-    assert chunk_errors == []
+    self.assertEqual(1, len(chunk_errors))
+    self.assertEqual('T405', chunk_errors[0].code)
+    self.assertEqual(Nit.ERROR, chunk_errors[0].severity)
+    self.assertItemsEqual([ImportType.STDLIB, ImportType.TWITTER], module_types)
 
-
-PAIRS = (
-  (ImportType.STDLIB, ImportType.TWITTER),
-  (ImportType.TWITTER, ImportType.GEN),
-  (ImportType.PACKAGE, ImportType.THIRD_PARTY),
-)
-
-
-def test_pairwise_classify():
-  for first, second in PAIRS:
-    io = ImportOrder(PythonFile(stitch_chunks(1, first, second)))
+    io = self.get_plugin("""
+      import io, pkg_resources
+    """)
     import_chunks = list(io.iter_import_chunks())
-    assert len(import_chunks) == 2
-
+    self.assertEqual(1, len(import_chunks))
     module_types, chunk_errors = io.classify_imports(import_chunks[0])
-    assert len(module_types) == 1
-    assert len(chunk_errors) == 0
-    assert module_types.pop() == first
+    self.assertEqual(3, len(chunk_errors))
+    self.assertItemsEqual(['T403', 'T405', 'T402'],
+                          [chunk_error.code for chunk_error in chunk_errors])
+    self.assertItemsEqual([ImportType.STDLIB, ImportType.THIRD_PARTY], module_types)
 
-    module_types, chunk_errors = io.classify_imports(import_chunks[1])
-    assert len(module_types) == 1
-    assert len(chunk_errors) == 0
-    assert module_types.pop() == second
+  def test_import_lexical_order(self):
+    imp = """
+      from twitter.common.dirutil import safe_rmtree, safe_mkdtemp
+    """
+    self.assertNit(imp, 'T401')
 
-  for second, first in PAIRS:
-    io = ImportOrder(PythonFile(stitch_chunks(1, first, second)))
-    import_chunks = list(io.iter_import_chunks())
-    assert len(import_chunks) == 2
-    nits = list(io.nits())
-    assert len(nits) == 1
-    assert nits[0].code == 'T406'
-    assert nits[0].severity == Nit.ERROR
-
-
-def test_multiple_imports_error():
-  io = ImportOrder(PythonFile(stitch_chunks(0, ImportType.STDLIB, ImportType.TWITTER)))
-  import_chunks = list(io.iter_import_chunks())
-  assert len(import_chunks) == 1
-
-  module_types, chunk_errors = io.classify_imports(import_chunks[0])
-  assert len(chunk_errors) == 1
-  assert chunk_errors[0].code == 'T405'
-  assert chunk_errors[0].severity == Nit.ERROR
-  assert set(module_types) == set([ImportType.STDLIB, ImportType.TWITTER])
-
-  io = ImportOrder(PythonFile('import io, pkg_resources'))
-  import_chunks = list(io.iter_import_chunks())
-  assert len(import_chunks) == 1
-  module_types, chunk_errors = io.classify_imports(import_chunks[0])
-  assert len(chunk_errors) == 3
-  assert set(chunk_error.code for chunk_error in chunk_errors) == set(['T403', 'T405', 'T402'])
-  assert set(module_types) == set([ImportType.STDLIB, ImportType.THIRD_PARTY])
-
-
-def test_import_lexical_order():
-  io = ImportOrder(PythonFile.from_statement("""
-    from twitter.common.dirutil import safe_rmtree, safe_mkdtemp
-  """))
-  nits = list(io.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T401'
-  assert nits[0].severity == Nit.ERROR
-
-
-def test_import_wildcard():
-  io = ImportOrder(PythonFile.from_statement("""
-    from twitter.common.dirutil import *
-  """))
-  nits = list(io.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T400'
-  assert nits[0].severity == Nit.ERROR
+  def test_import_wildcard(self):
+    imp = """
+      from twitter.common.dirutil import *
+    """
+    self.assertNit(imp, 'T400')

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_indentation.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_indentation.py
@@ -5,33 +5,31 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
 from pants.backend.python.tasks.checkstyle.indentation import Indentation
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
 
 
-def test_indentation():
-  ind = Indentation(PythonFile.from_statement("""
-    def foo():
+class IndentationTest(CheckstylePluginTestBase):
+  plugin_type = Indentation
+
+  def test_indentation(self):
+    statement = """
+      def foo():
+          pass
+    """
+    self.assertNit(statement, 'T100')
+
+    statement = """
+      def foo():
         pass
-  """))
-  nits = list(ind.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T100'
-  assert nits[0].severity == Nit.ERROR
+    """
+    self.assertNoNits(statement)
 
-  ind = Indentation(PythonFile.from_statement("""
-    def foo():
-      pass
-  """))
-  nits = list(ind.nits())
-  assert len(nits) == 0
-
-  ind = Indentation(PythonFile.from_statement("""
-    def foo():
-      baz = (
-          "this "
-          "is "
-          "ok")
-  """))
-  nits = list(ind.nits())
-  assert len(nits) == 0
+    statement = """
+      def foo():
+        baz = (
+            "this "
+            "is "
+            "ok")
+    """
+    self.assertNoNits(statement)

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_new_style_classes.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_new_style_classes.py
@@ -5,35 +5,31 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
 from pants.backend.python.tasks.checkstyle.new_style_classes import NewStyleClasses
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
 
 
-def test_new_style_classes():
-  nsc = NewStyleClasses(PythonFile.from_statement("""
-    class OldStyle:
-      pass
-    
-    class NewStyle(object):
-      pass
-  """))
-  nits = list(nsc.nits())
-  assert len(nits) == 1
-  assert nits[0]._line_number == 1
-  assert nits[0].code == 'T606'
-  assert nits[0].severity == Nit.ERROR
+class NewStyleClassesTest(CheckstylePluginTestBase):
+  plugin_type = NewStyleClasses
 
-  nsc = NewStyleClasses(PythonFile.from_statement("""
-    class NewStyle(OtherThing, ThatThing, WhatAmIDoing):
-      pass
-  """))
-  nits = list(nsc.nits())
-  assert len(nits) == 0
+  def test_new_style_classes(self):
+    statement = """
+      class OldStyle:
+        pass
 
-  nsc = NewStyleClasses(PythonFile.from_statement("""
-    class OldStyle():  # unspecified mro
-      pass
-  """))
-  nits = list(nsc.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T606'
+      class NewStyle(object):
+        pass
+    """
+    self.assertNit(statement, 'T606')
+
+    statement = """
+      class NewStyle(OtherThing, ThatThing, WhatAmIDoing):
+        pass
+    """
+    self.assertNoNits(statement)
+
+    statement = """
+      class OldStyle():  # unspecified mro
+        pass
+    """
+    self.assertNit(statement, 'T606')

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_newlines.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_newlines.py
@@ -5,103 +5,83 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
 from pants.backend.python.tasks.checkstyle.newlines import Newlines
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
 
 
-TOPLEVEL = """
-def foo():
-  pass%s
-%s
-  pass
-"""
+class NewlinesTest(CheckstylePluginTestBase):
+  plugin_type = Newlines
 
-
-def test_newlines():
-  for toplevel_def in ('def bar():', 'class Bar(object):'):
-    for num_newlines in (0, 1, 3, 4):
-      newlines = Newlines(PythonFile.from_statement(TOPLEVEL % ('\n' * num_newlines, toplevel_def)))
-      nits = list(newlines.nits())
-      assert len(nits) == 1
-      assert nits[0].code == 'T302'
-      assert nits[0].severity == Nit.ERROR
-    newlines = Newlines(PythonFile.from_statement(TOPLEVEL % ('\n\n', toplevel_def)))
-    assert len(list(newlines.nits())) == 0
-
-
-GOOD_CLASS_DEF_1 = """
-class Foo(object):
-  def __init__(self):
+  TOPLEVEL = """
+  def foo():
+    pass{}
+  {}
     pass
+  """
 
-  def bar(self):
-    pass
-"""
+  def test_newlines(self):
+    for toplevel_def in ('def bar():', 'class Bar(object):'):
+      for num_newlines in (0, 1, 3, 4):
+        statement = self.TOPLEVEL.format('\n' * num_newlines, toplevel_def)
+        self.assertNit(statement, 'T302')
+      statement = self.TOPLEVEL.format('\n\n', toplevel_def)
+      self.assertNoNits(statement)
 
-GOOD_CLASS_DEF_2 = """
-class Foo(object):
-  def __init__(self):
-    pass
+  GOOD_CLASS_DEF_1 = """
+  class Foo(object):
+    def __init__(self):
+      pass
 
-  # this should be fine
-  def bar(self):
-    pass
-"""
+    def bar(self):
+      pass
+  """
 
+  GOOD_CLASS_DEF_2 = """
+  class Foo(object):
+    def __init__(self):
+      pass
 
-GOOD_CLASS_DEF_3 = """
-class Foo(object):
-  class Error(Exception): pass
-  class SomethingError(Error): pass
+    # this should be fine
+    def bar(self):
+      pass
+  """
 
-  def __init__(self):
-    pass
+  GOOD_CLASS_DEF_3 = """
+  class Foo(object):
+    class Error(Exception): pass
+    class SomethingError(Error): pass
 
-  def bar(self):
-    pass
-"""
+    def __init__(self):
+      pass
 
+    def bar(self):
+      pass
+  """
 
-BAD_CLASS_DEF_1 = """
-class Foo(object):
-  class Error(Exception): pass
-  class SomethingError(Error): pass
-  def __init__(self):
-    pass
+  BAD_CLASS_DEF_1 = """
+  class Foo(object):
+    class Error(Exception): pass
+    class SomethingError(Error): pass
+    def __init__(self):
+      pass
 
-  def bar(self):
-    pass
-"""
+    def bar(self):
+      pass
+  """
 
-BAD_CLASS_DEF_2 = """
-class Foo(object):
-  class Error(Exception): pass
-  class SomethingError(Error): pass
+  BAD_CLASS_DEF_2 = """
+  class Foo(object):
+    class Error(Exception): pass
+    class SomethingError(Error): pass
 
-  def __init__(self):
-    pass
-  def bar(self):
-    pass
-"""
+    def __init__(self):
+      pass
+    def bar(self):
+      pass
+  """
 
-
-def test_classdefs():
-  newlines = Newlines(PythonFile.from_statement(GOOD_CLASS_DEF_1))
-  assert len(list(newlines.nits())) == 0
-
-  newlines = Newlines(PythonFile.from_statement(GOOD_CLASS_DEF_2))
-  assert len(list(newlines.nits())) == 0
-
-  newlines = Newlines(PythonFile.from_statement(BAD_CLASS_DEF_1))
-  nits = list(newlines.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T301'
-  assert nits[0]._line_number == 4
-  assert nits[0].severity == Nit.ERROR
-
-  newlines = Newlines(PythonFile.from_statement(BAD_CLASS_DEF_2))
-  nits = list(newlines.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T301'
-  assert nits[0]._line_number == 7
-  assert nits[0].severity == Nit.ERROR
+  def test_classdefs(self):
+    self.assertNoNits(self.GOOD_CLASS_DEF_1)
+    self.assertNoNits(self.GOOD_CLASS_DEF_2)
+    self.assertNit(self.BAD_CLASS_DEF_1, 'T301', expected_line_number=4)
+    self.assertNit(self.BAD_CLASS_DEF_2, 'T301', expected_line_number=7)

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_print_statements.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_print_statements.py
@@ -5,34 +5,32 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
 from pants.backend.python.tasks.checkstyle.print_statements import PrintStatements
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
 
 
-def test_print_override():
-  ps = PrintStatements(PythonFile.from_statement("""
-    from __future__ import print_function
-    print("I do what I want")
-    
-    class Foo(object):
-      def print(self):
-        "I can do this because it's not a reserved word."
-  """))
-  assert len(list(ps.nits())) == 0
+class PrintStatementsTest(CheckstylePluginTestBase):
+  plugin_type = PrintStatements
 
+  def test_print_override(self):
+    statement = """
+      from __future__ import print_function
+      print("I do what I want")
 
-def test_print_function():
-  ps = PrintStatements(PythonFile.from_statement("""
-    print("I do what I want")
-  """))
-  assert len(list(ps.nits())) == 0
+      class Foo(object):
+        def print(self):
+          "I can do this because it's not a reserved word."
+    """
+    self.assertNoNits(statement)
 
+  def test_print_function(self):
+    statement = """
+      print("I do what I want")
+    """
+    self.assertNoNits(statement)
 
-def test_print_statement():
-  ps = PrintStatements(PythonFile.from_statement("""
-    print["I do what I want"]
-  """))
-  nits = list(ps.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T607'
-  assert nits[0].severity == Nit.ERROR
+  def test_print_statement(self):
+    statement = """
+      print["I do what I want"]
+    """
+    self.assertNit(statement, 'T607')

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_trailing_whitespace.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_trailing_whitespace.py
@@ -5,66 +5,58 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import pytest
-
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
 from pants.backend.python.tasks.checkstyle.trailing_whitespace import TrailingWhitespace
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
 
 
-@pytest.mark.parametrize("test_input,results", [
-  ([9,0,0], False),
-  ([3,0,1], False),
-  ([3,17,17], False),
-  ([3,18,18], True),
-  ([3,18,10000], True),  # """ continued strings have no ends
-  ([6,8,8], False),
-  ([6,19,19], True),
-  ([6,19,23], True),
-  ([6,23,25], False),  # ("  " continued have string termination
-])
-def test_exception_map(test_input, results):
-  tw = TrailingWhitespace(PythonFile.from_statement("""
-  test_string_001 = ""
-  test_string_002 = " "
-  test_string_003 = \"\"\"  
-    foo   
-  \"\"\"
-  test_string_006 = ("   "
-                     "   ")
-  class Foo(object):
-    pass
-  # comment 010  
-  test_string_011 = ''
-  # comment 012
-  # comment 013
-  """))
-  assert len(list(tw.nits())) == 0
-  assert bool(tw.has_exception(*test_input)) == results
+class TrailingWhitespaceTest(CheckstylePluginTestBase):
+  plugin_type = TrailingWhitespace
 
+  def test_exception_map(self):
+    for test_input, results in [
+      ([9,0,0], False),
+      ([3,0,1], False),
+      ([3,17,17], False),
+      ([3,18,18], True),
+      ([3,18,10000], True),  # """ continued strings have no ends
+      ([6,8,8], False),
+      ([6,19,19], True),
+      ([6,19,23], True),
+      ([6,23,25], False),  # ("  " continued have string termination
+    ]:
+      tw = self.get_plugin("""
+      test_string_001 = ""
+      test_string_002 = " "
+      test_string_003 = \"\"\"
+        foo{}
+      \"\"\"
+      test_string_006 = ("   "
+                         "   ")
+      class Foo(object):
+        pass
+      # comment 010
+      test_string_011 = ''
+      # comment 012
+      # comment 013
+      """.format('   '))  # Add the trailing whitespace with format, so that IDEs don't remove it.
+      self.assertEqual(0, len(list(tw.nits())))
+      self.assertEqual(results, bool(tw.has_exception(*test_input)))
 
-def test_continuation_with_exception():
-  tw = TrailingWhitespace(PythonFile.from_statement("""
-  test_string_001 = ("   "  
-                     "   ")
-  """))
-  nits = list(tw.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T200'
-  assert nits[0].severity == Nit.ERROR
+  def test_continuation_with_exception(self):
+    statement = """
+    test_string_001 = ("   "{}
+                       "   ")
+    """.format('  ')  # Add the trailing whitespace with format, so that IDEs don't remove it.
+    self.assertNit(statement, 'T200')
 
-
-def test_trailing_slash():
-  tw = TrailingWhitespace(PythonFile.from_statement("""
-  foo = \\
-    123
-  bar = \"\"\"
-    bin/bash foo \\
-             bar \\
-             baz
-  \"\"\"
-  """))
-  nits = list(tw.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T201'
-  assert nits[0].severity == Nit.ERROR
-  assert nits[0]._line_number == 1
+  def test_trailing_slash(self):
+    statement = """
+    foo = \\
+      123
+    bar = \"\"\"
+      bin/bash foo \\
+               bar \\
+               baz
+    \"\"\"
+    """
+    self.assertNit(statement, 'T201', expected_line_number=1)

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_variable_names.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_variable_names.py
@@ -5,178 +5,146 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks.checkstyle.common import Nit, PythonFile
 from pants.backend.python.tasks.checkstyle.variable_names import (PEP8VariableNames,
                                                                   allow_underscores,
                                                                   is_builtin_name, is_lower_snake,
                                                                   is_reserved_name,
                                                                   is_reserved_with_trailing_underscore,
                                                                   is_upper_camel)
+from pants_test.backend.python.tasks.checkstyle.plugin_test_base import CheckstylePluginTestBase
 
 
-def test_allow_underscores():
-  @allow_underscores(0)
-  def no_underscores(name):
-    return name
-  assert no_underscores('foo') == 'foo'
-  assert no_underscores('foo_') == 'foo_'
-  assert no_underscores('_foo') is False
-  assert no_underscores('__foo') is False
+class PEP8VariableNamesTest(CheckstylePluginTestBase):
+  plugin_type = PEP8VariableNames
 
-  @allow_underscores(1)
-  def one_underscore(name):
-    return name
-  assert one_underscore('foo') == 'foo'
-  assert one_underscore('_foo') == 'foo'
-  assert one_underscore('_foo_') == 'foo_'
-  assert one_underscore('__foo') is False
-  assert one_underscore('___foo') is False
+  def test_allow_underscores(self):
+    @allow_underscores(0)
+    def no_underscores(name):
+      return name
+    self.assertEqual('foo', no_underscores('foo'))
+    self.assertEqual('foo_', no_underscores('foo_'))
+    self.assertFalse(no_underscores('_foo'))
+    self.assertFalse(no_underscores('__foo'))
 
+    @allow_underscores(1)
+    def one_underscore(name):
+      return name
+    self.assertEqual('foo', one_underscore('foo'))
+    self.assertEqual('foo', one_underscore('_foo'))
+    self.assertEqual('foo_', one_underscore('_foo_'))
+    self.assertFalse(one_underscore('__foo'))
+    self.assertFalse(one_underscore('___foo'))
 
-UPPER_CAMEL = (
-  'Rate',
-  'HTTPRate',
-  'HttpRate',
-  'Justastringofwords'
-)
+  UPPER_CAMEL = (
+    'Rate',
+    'HTTPRate',
+    'HttpRate',
+    'Justastringofwords'
+  )
 
-LOWER_SNAKE = (
-  'quiet',
-  'quiet_noises',
-)
+  LOWER_SNAKE = (
+    'quiet',
+    'quiet_noises',
+  )
 
+  def test_is_upper_camel(self):
+    for word in self.UPPER_CAMEL:
+      self.assertTrue(is_upper_camel(word))
+      self.assertTrue(is_upper_camel('_' + word))
+      self.assertFalse(is_upper_camel('__' + word))
+      self.assertFalse(is_upper_camel(word + '_'))
+    for word in self.LOWER_SNAKE:
+      self.assertFalse(is_upper_camel(word))
+      self.assertFalse(is_upper_camel('_' + word))
+      self.assertFalse(is_upper_camel(word + '_'))
 
-def test_is_upper_camel():
-  for word in UPPER_CAMEL:
-    assert is_upper_camel(word)
-    assert is_upper_camel('_' + word)
-    assert not is_upper_camel('__' + word)
-    assert not is_upper_camel(word + '_')
-  for word in LOWER_SNAKE:
-    assert not is_upper_camel(word)
-    assert not is_upper_camel('_' + word)
-    assert not is_upper_camel(word + '_')
+  def test_is_lower_snake(self):
+    for word in self.LOWER_SNAKE:
+      self.assertTrue(is_lower_snake(word))
+      self.assertTrue(is_lower_snake('_' + word))
+      self.assertTrue(is_lower_snake('__' + word))
+    for word in self.UPPER_CAMEL:
+      self.assertFalse(is_lower_snake(word))
+      self.assertFalse(is_lower_snake('_' + word))
 
+  def test_is_builtin_name(self):
+    self.assertTrue(is_builtin_name('__foo__'))
+    self.assertFalse(is_builtin_name('__fo_o__'))
+    self.assertFalse(is_builtin_name('__Foo__'))
+    self.assertFalse(is_builtin_name('__fOo__'))
+    self.assertFalse(is_builtin_name('__foo'))
+    self.assertFalse(is_builtin_name('foo__'))
 
-def test_is_lower_snake():
-  for word in LOWER_SNAKE:
-    assert is_lower_snake(word)
-    assert is_lower_snake('_' + word)
-    assert is_lower_snake('__' + word)
-  for word in UPPER_CAMEL:
-    assert not is_lower_snake(word)
-    assert not is_lower_snake('_' + word)
+  def test_is_reserved_name(self):
+    for name in ('for', 'super', 'id', 'type', 'class'):
+      self.assertTrue(is_reserved_name(name))
+    self.assertFalse(is_reserved_name('none'))
 
+  def test_is_reserved_with_trailing_underscore(self):
+    for name in ('super', 'id', 'type', 'class'):
+      self.assertTrue(is_reserved_with_trailing_underscore(name + '_'))
+      self.assertFalse(is_reserved_with_trailing_underscore(name + '__'))
+    for name in ('garbage', 'slots', 'metaclass'):
+      self.assertFalse(is_reserved_with_trailing_underscore(name + '_'))
 
-def test_is_builtin_name():
-  assert is_builtin_name('__foo__')
-  assert not is_builtin_name('__fo_o__')
-  assert not is_builtin_name('__Foo__')
-  assert not is_builtin_name('__fOo__')
-  assert not is_builtin_name('__foo')
-  assert not is_builtin_name('foo__')
-
-
-def test_is_reserved_name():
-  for name in ('for', 'super', 'id', 'type', 'class'):
-    assert is_reserved_name(name)
-  assert not is_reserved_name('none')
-
-
-def test_is_reserved_with_trailing_underscore():
-  for name in ('super', 'id', 'type', 'class'):
-    assert is_reserved_with_trailing_underscore(name + '_')
-    assert not is_reserved_with_trailing_underscore(name + '__')
-  for name in ('garbage', 'slots', 'metaclass'):
-    assert not is_reserved_with_trailing_underscore(name + '_')
-
-
-def test_class_names():
-  p8 = PEP8VariableNames(PythonFile.from_statement("""
-    class dhis_not_right(object):
-      pass
-  """))
-  nits = list(p8.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T000'
-  assert nits[0]._line_number == 1
-  assert nits[0].severity == Nit.ERROR
-
-
-def test_class_globals():
-  p8 = PEP8VariableNames(PythonFile.from_statement("""
-    class DhisRight(object):
-      RIGHT = 123
-      notRight = 321
-  """))
-  nits = list(p8.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T001'
-  assert nits[0]._line_number == 3
-  assert nits[0].severity == Nit.ERROR
-
-
-def test_builtin_overrides():
-  p8 = PEP8VariableNames(PythonFile.from_statement("""
-    def range():
-      print("Not in a class body")
-    
-    class DhisRight(object):
-      def any(self):
-        print("In a class body")
-  """))
-  nits = list(p8.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T801'
-  assert nits[0]._line_number == 1
-  assert nits[0].severity == Nit.ERROR
-
-
-def test_lower_snake_method_names():
-  p8 = PEP8VariableNames(PythonFile.from_statement("""
-    def totally_fine():
-      print("Not in a class body")
-    
-    class DhisRight(object):
-      def clearlyNotThinking(self):
-        print("In a class body")
-  """))
-  nits = list(p8.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T002'
-  assert nits[0]._line_number == 5
-  assert nits[0].severity == Nit.ERROR
-
-  p8 = PEP8VariableNames(PythonFile.from_statement("""
-    class DhisRight:
-      def clearlyNotThinking(self):
-        print("In a class body")
-  """))
-  nits = list(p8.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T002'
-  assert nits[0]._line_number == 2
-  assert nits[0].severity == Nit.ERROR
-
-  # Allow derivations from other modules to be ok.
-  p8 = PEP8VariableNames(PythonFile.from_statement("""
-    class TestCase(unittest.TestCase):
-      def setUp(self):
+  def test_class_names(self):
+    statement = """
+      class dhis_not_right(object):
         pass
-  """))
-  nits = list(p8.nits())
-  assert len(list(p8.nits())) == 0
+    """
+    self.assertNit(statement, 'T000', expected_line_number=1)
 
-  p8 = PEP8VariableNames(PythonFile.from_statement("""
-    def clearlyNotThinking():
-      print("Not in a class body")
-    
-    class DhisRight(object):
-      def totally_fine(self):
-        print("In a class body")
-  """))
-  nits = list(p8.nits())
-  assert len(nits) == 1
-  assert nits[0].code == 'T002'
-  assert nits[0]._line_number == 1
-  assert nits[0].severity == Nit.ERROR
+  def test_class_globals(self):
+    statement = """
+      class DhisRight(object):
+        RIGHT = 123
+        notRight = 321
+    """
+    self.assertNit(statement, 'T001', expected_line_number=3)
+
+  def test_builtin_overrides(self):
+    statement = """
+      def range():
+        print("Not in a class body")
+
+      class DhisRight(object):
+        def any(self):
+          print("In a class body")
+    """
+    self.assertNit(statement, 'T801', expected_line_number=1)
+
+  def test_lower_snake_method_names(self):
+    statement = """
+      def totally_fine():
+        print("Not in a class body")
+
+      class DhisRight(object):
+        def clearlyNotThinking(self):
+          print("In a class body")
+    """
+    self.assertNit(statement, 'T002', expected_line_number=5)
+
+    statement = """
+      class DhisRight:
+        def clearlyNotThinking(self):
+          print("In a class body")
+    """
+    self.assertNit(statement, 'T002', expected_line_number=2)
+
+    # Allow derivations from other modules to be ok.
+    statement = """
+      class TestCase(unittest.TestCase):
+        def setUp(self):
+          pass
+    """
+    self.assertNoNits(statement)
+
+    statement = """
+      def clearlyNotThinking():
+        print("Not in a class body")
+
+      class DhisRight(object):
+        def totally_fine(self):
+          print("In a class body")
+    """
+    self.assertNit(statement, 'T002', expected_line_number=1)


### PR DESCRIPTION
Now instead of the plugins knowing about their corresponding
subsystems, the subsystems know about (and create) the plugins.

This allows us to only import (and therefore parse and interpret)
code we're actually going to use.  Performance profiles show that
almost a second of startup time is spent just loading backends,
and checkstyle was a good chunk of that.

If we like how this works, we can contemplate something similar
for backend code in general. Right now we load huge amounts of code
even if we never invoke it.