### PR TITLE
Cache npm resolves in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ cache:
   directories:
     - $HOME/.cache/pants
     - $HOME/.ivy2/pants
+    # TODO(John Sirois): Update this to ~/.npm/pants when pants starts
+    # using its own isolated cache:
+    #   https://github.com/pantsbuild/pants/issues/2485
+    - $HOME/.npm
     - build-support/isort.venv
     - build-support/pants_dev_deps.venv
 


### PR DESCRIPTION
This is intended to address flaky resolves that have
caused CI failures.  Only some time spent on master
w/o npm install related failures will tell if this is
effective.

https://rbcommons.com/s/twitter/r/3065/