### PR TITLE
Turn off ng under OSX-CI like we do for linux.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -23,6 +23,7 @@ matrix:
 env:
   global:
     - CXX=clang++
+    - PANTS_CONFIG_OVERRIDE="['pants.travis-ci.ini']"
   matrix:
     # No need to run the self-checks on OSX where vms are at a premium since these are file-level,
     # non-platform fragile lints.


### PR DESCRIPTION
We always should have been doing this, but a recent string of ng related
failures brought the old CI configuration issue to light.

https://rbcommons.com/s/twitter/r/3067/