### PR TITLE
Fixup NailgunClient-related OSX CI break

### DIFF
--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -134,7 +134,7 @@ class NailgunClient(object):
   DEFAULT_NG_HOST = '127.0.0.1'
   DEFAULT_NG_PORT = 2113
 
-  def __init__(self, host=DEFAULT_NG_HOST, port=DEFAULT_NG_PORT, ins=None, out=None, err=None,
+  def __init__(self, host=DEFAULT_NG_HOST, port=DEFAULT_NG_PORT, ins=sys.stdin, out=None, err=None,
                workdir=None):
     """Creates a nailgun client that can be used to issue zero or more nailgun commands.
 
@@ -145,11 +145,11 @@ class NailgunClient(object):
                      in which case no input is read
     :param file out: a stream to write command standard output to (defaults to stdout)
     :param file err: a stream to write command standard error to (defaults to stderr)
-    :param string workdir: the default working directory for all nailgun commands (defaults to PWD)
+    :param string workdir: the default working directory for all nailgun commands (defaults to CWD)
     """
     self._host = host
     self._port = port
-    self._stdin = ins or sys.stdin
+    self._stdin = ins
     self._stdout = out or sys.stdout
     self._stderr = err or sys.stderr
     self._workdir = workdir or os.path.abspath(os.path.curdir)

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -52,3 +52,11 @@ python_tests(
     'src/python/pants/util:dirutil',
   ]
 )
+
+python_tests(
+  name = 'nailgun_integration',
+  sources = ['test_nailgun_integration.py'],
+  dependencies = [
+    'tests/python/pants_test:int-test'
+  ]
+)

--- a/tests/python/pants_test/java/test_nailgun_integration.py
+++ b/tests/python/pants_test/java/test_nailgun_integration.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class TestNailgunIntegration(PantsRunIntegrationTest):
+  def test_scala_repl_helloworld_input(self):
+    """Integration test to exercise possible closed-loop breakages in NailgunClient, NailgunSession
+    and InputReader.
+    """
+    target = 'examples/src/scala/org/pantsbuild/example/hello/welcome'
+    pants_run = self.run_pants(
+      command=['repl', target, '--quiet'],
+      stdin_data=(
+        'import org.pantsbuild.example.hello.welcome.WelcomeEverybody\n'
+        'println(WelcomeEverybody("World" :: Nil).head)\n'
+      ),
+      # Override the PANTS_CONFIG_OVERRIDE="['pants.travis-ci.ini']" used within TravisCI to enable
+      # nailgun usage for the purpose of exercising that stack in the integration test.
+      config={'DEFAULT': {'use_nailgun': True}}
+    )
+    self.assert_success(pants_run)
+    self.assertIn('Hello, World!', pants_run.stdout_data.splitlines())

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -131,7 +131,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     :returns a tuple (returncode, stdout_data, stderr_data).
     """
     with self.temporary_workdir() as workdir:
-      return self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env,  **kwargs)
+      return self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env, **kwargs)
 
   @contextmanager
   def pants_results(self, command, config=None, stdin_data=None, extra_env=None, **kwargs):
@@ -145,7 +145,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     :returns a tuple (returncode, stdout_data, stderr_data).
     """
     with self.temporary_workdir() as workdir:
-      yield self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env,  **kwargs)
+      yield self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env, **kwargs)
 
   def bundle_and_run(self, target, bundle_name, args=None):
     """Creates the bundle with pants, then does java -jar {bundle_name}.jar to execute the bundle.


### PR DESCRIPTION
Address integration test failure/regression that disallowed NailgunClient._stdin from being None, thus causing spurious InputReader firing.

Fixes #2488