### PR TITLE
[CI] Improve handling of -v, -V, --version and --pants-version.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -124,7 +124,7 @@ if [[ "${skip_bootstrap:-false}" == "false" ]]; then
       src/python/pants/bin:pants_local_binary && \
     mv dist/pants_local_binary.pex pants.pex && \
     ./pants.pex -V && \
-    ./pants.pex --pants-version
+    ./pants.pex --version
   ) || die "Failed to bootstrap pants."
 fi
 

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -36,7 +36,7 @@ function pkg_pants_install_test() {
     die "pip install of pantsbuild.pants failed!"
   execute_packaged_pants_with_internal_backends list src:: || \
     die "'pants list src::' failed in venv!"
-  [[ "$(execute_packaged_pants_with_internal_backends --pants-version 2>/dev/null)" \
+  [[ "$(execute_packaged_pants_with_internal_backends --version 2>/dev/null)" \
      == "$(local_version)" ]] || die "Installed version of pants does match local version!"
 }
 
@@ -117,7 +117,7 @@ function pkg_install_test_func() {
 }
 
 function local_version() {
-  run_local_pants --pants-version 2>/dev/null
+  run_local_pants --version 2>/dev/null
 }
 
 function build_packages() {

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -7,9 +7,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import sys
 
-from pants.base.build_environment import pants_release
+from pants.base.build_environment import pants_release, pants_version
 from pants.help.help_formatter import HelpFormatter
-from pants.option.arg_splitter import GLOBAL_SCOPE, NoGoalHelp, OptionsHelp, UnknownGoalHelp
+from pants.option.arg_splitter import (GLOBAL_SCOPE, NoGoalHelp, OptionsHelp, UnknownGoalHelp,
+                                       VersionHelp)
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.parser_hierarchy import enclosing_scope
 from pants.option.scope import ScopeInfo
@@ -35,7 +36,9 @@ class HelpPrinter(object):
     def print_hint():
       print('Use `pants goals` to list goals.')
       print('Use `pants help` to get help.')
-    if isinstance(self._help_request, OptionsHelp):
+    if isinstance(self._help_request, VersionHelp):
+      print(pants_version())
+    elif isinstance(self._help_request, OptionsHelp):
       self._print_options_help()
     elif isinstance(self._help_request, UnknownGoalHelp):
       print('Unknown goals: {}'.format(', '.join(self._help_request.unknown_goals)))

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -54,6 +54,11 @@ class OptionsHelp(HelpRequest):
     self.all_scopes = all_scopes
 
 
+class VersionHelp(HelpRequest):
+  """The user asked for the version of this instance of pants."""
+  pass
+
+
 class UnknownGoalHelp(HelpRequest):
   """The user specified an unknown goal (or task)."""
 
@@ -82,7 +87,8 @@ class ArgSplitter(object):
   _HELP_BASIC_ARGS = ('-h', '--help', 'help')
   _HELP_ADVANCED_ARGS = ('--help-advanced', 'help-advanced')
   _HELP_ALL_SCOPES_ARGS = ('--help-all', 'help-all')
-  _HELP_ARGS = _HELP_BASIC_ARGS + _HELP_ADVANCED_ARGS + _HELP_ALL_SCOPES_ARGS
+  _HELP_VERSION_ARGS = ('-v', '-V', '--version')
+  _HELP_ARGS = _HELP_BASIC_ARGS + _HELP_ADVANCED_ARGS + _HELP_ALL_SCOPES_ARGS + _HELP_VERSION_ARGS
 
   def __init__(self, known_scope_infos):
     self._known_scope_infos = known_scope_infos
@@ -113,14 +119,17 @@ class ArgSplitter(object):
   def _check_for_help_request(self, arg):
     if not arg in self._HELP_ARGS:
       return False
-    # First ensure that we have a basic OptionsHelp.
-    if not self._help_request:
-      self._help_request = OptionsHelp()
-    # Now see if we need to enhance it.
-    if isinstance(self._help_request, OptionsHelp):
-      advanced = self._help_request.advanced or arg in self._HELP_ADVANCED_ARGS
-      all_scopes = self._help_request.all_scopes or arg in self._HELP_ALL_SCOPES_ARGS
-      self._help_request = OptionsHelp(advanced=advanced, all_scopes=all_scopes)
+    if arg in self._HELP_VERSION_ARGS:
+      self._help_request = VersionHelp()
+    else:
+      # First ensure that we have a basic OptionsHelp.
+      if not self._help_request:
+        self._help_request = OptionsHelp()
+      # Now see if we need to enhance it.
+      if isinstance(self._help_request, OptionsHelp):
+        advanced = self._help_request.advanced or arg in self._HELP_ADVANCED_ARGS
+        all_scopes = self._help_request.all_scopes or arg in self._HELP_ALL_SCOPES_ARGS
+        self._help_request = OptionsHelp(advanced=advanced, all_scopes=all_scopes)
     return True
 
   def split_args(self, args=None):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -49,18 +49,12 @@ class GlobalOptionsRegistrar(Optionable):
     register('--colors', action='store_true', default=True, recursive=True,
              help='Set whether log messages are displayed in color.')
 
-    # NB: Right now this option is a placeholder that is unused within pants itself except when
-    # specified on the command line to print the OSS pants version.  Both the IntelliJ Pants plugin
-    # and the pantsbuild/setup bootstrap script grep for pants_version though so this option
-    # registration serves in part as documentation of the dependency.
-    # TODO(John Sirois): Move pantsbuild.pants bootstrapping into pants itself and have it use this
-    # version option directly.
-    register('-v', '-V', '--pants-version',
-             nargs='?',  # Allows using the flag with no args on the CLI to print version as well
-                         # as setting the version in pants.ini
-             default=pants_version(),  # Displays the current version correctly in `./pants -h`.
-             const=pants_version(),  # Displays the current version via `./pants -V`.
-             help="Prints pants' version number and exits.")
+    # Pants code uses this only to verify that we are of the requested version. However
+    # setup scripts, runner scripts, IDE plugins, etc., may grep this out of pants.ini
+    # and use it to select the right version.
+    # Note that to print the version of the pants instance you're running, use -v, -V or --version.
+    register('--pants-version', advanced=True, default=pants_version(),
+             help='Use this pants version.')
 
     register('--plugins', advanced=True, type=list_option, help='Load these plugins.')
     register('--plugin-cache-dir', advanced=True,

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -28,9 +28,9 @@ python_tests(
   sources=['test_goal_runner.py'],
   dependencies=[
     '3rdparty/python:setuptools',
+    'src/python/pants/base:exceptions',
     'src/python/pants/bin',
-    'src/python/pants/util:contextutil',
-    'tests/python/pants_test/option/util',
+    'src/python/pants/option',
   ]
 )
 

--- a/tests/python/pants_test/bin/test_goal_runner.py
+++ b/tests/python/pants_test/bin/test_goal_runner.py
@@ -8,24 +8,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import pytest
 from pkg_resources import WorkingSet
 
+from pants.base.exceptions import BuildConfigurationError
 from pants.bin.goal_runner import OptionsInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
-from pants.util.contextutil import temporary_dir
 
 
-@pytest.mark.parametrize('version_flag', ['-V', '--pants-version'])
-def test_version_request(version_flag):
-  class ExitException(Exception):
-    def __init__(self, exit_code):
-      self.exit_code = exit_code
+def test_invalid_version():
+  options_bootstrapper = OptionsBootstrapper(args=['--pants-version=99.99.9999'])
 
-  with temporary_dir() as build_root:
-    def exiter(exit_code):
-      raise ExitException(exit_code)
-
-    options_bootstrapper = OptionsBootstrapper(args=[version_flag])
-
-    with pytest.raises(ExitException) as excinfo:
-      OptionsInitializer(options_bootstrapper, WorkingSet(), exiter=exiter).setup()
-
-    assert 0 == excinfo.value.exit_code
+  with pytest.raises(BuildConfigurationError):
+    OptionsInitializer(options_bootstrapper, WorkingSet()).setup()

--- a/tests/python/pants_test/option/test_arg_splitter.py
+++ b/tests/python/pants_test/option/test_arg_splitter.py
@@ -8,7 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import shlex
 import unittest
 
-from pants.option.arg_splitter import ArgSplitter, NoGoalHelp, OptionsHelp, UnknownGoalHelp
+from pants.option.arg_splitter import (ArgSplitter, NoGoalHelp, OptionsHelp, UnknownGoalHelp,
+                                       VersionHelp)
 from pants.option.scope import ScopeInfo
 
 
@@ -56,6 +57,11 @@ class ArgSplitterTest(unittest.TestCase):
                 expected_is_help=True,
                 expected_help_advanced=expected_help_advanced,
                 expected_help_all=expected_help_all)
+
+  def _split_version_request(self, args_str):
+    splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
+    splitter.split_args(shlex.split(args_str))
+    self.assertTrue(isinstance(splitter.help_request, VersionHelp))
 
   def _split_unknown_goal(self, args_str, unknown_goals):
     splitter = ArgSplitter(ArgSplitterTest._known_scope_infos)
@@ -194,6 +200,13 @@ class ArgSplitterTest(unittest.TestCase):
                      {'': [], 'compile': []}, [], True, False)
     self._split_help('./pants compile help-all test --help', ['compile', 'test'],
                      {'': [], 'compile': [], 'test': []}, [], False, True)
+
+  def test_version_request_detection(self):
+    self._split_version_request('./pants -v')
+    self._split_version_request('./pants -V')
+    self._split_version_request('./pants --version')
+    # A version request supercedes anything else.
+    self._split_version_request('./pants --version compile --foo --bar path/to/target')
 
   def test_unknown_goal_detection(self):
     self._split_unknown_goal('./pants foo', ['foo'])

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -58,7 +58,7 @@ class OptionsTest(unittest.TestCase):
     def register_global(*args, **kwargs):
       options.register(GLOBAL_SCOPE, *args, **kwargs)
 
-    register_global('-v', '--verbose', action='store_true', help='Verbose output.', recursive=True)
+    register_global('-z', '--verbose', action='store_true', help='Verbose output.', recursive=True)
     register_global('-n', '--num', type=int, default=99, recursive=True, fingerprint=True)
     register_global('--y', action='append', type=int)
     register_global('--config-override', action='append')
@@ -161,7 +161,7 @@ class OptionsTest(unittest.TestCase):
     # Some basic smoke tests.
     options = self._parse('./pants --verbose')
     self.assertEqual(True, options.for_global_scope().verbose)
-    options = self._parse('./pants -v compile path/to/tgt')
+    options = self._parse('./pants -z compile path/to/tgt')
     self.assertEqual(['path/to/tgt'], options.target_specs)
     self.assertEqual(True, options.for_global_scope().verbose)
 
@@ -172,7 +172,7 @@ class OptionsTest(unittest.TestCase):
     self.assertEqual(True, options.for_scope('compile').verbose)
     self.assertEqual(False, options.for_scope('compile.java').verbose)
 
-    options = self._parse('./pants --verbose compile --no-verbose compile.java -v test '
+    options = self._parse('./pants --verbose compile --no-verbose compile.java -z test '
                           'test.junit --no-verbose')
     self.assertEqual(True, options.for_global_scope().verbose)
     self.assertEqual(False, options.for_scope('compile').verbose)


### PR DESCRIPTION
All these could be used with no argument to print the version and exit.
However we also had a hack where these could take an argument. Pants code
itself didn't use this argument, it was just there to document the fact
that the setup script and the intellij plugin grepped for pants_version
in pants.ini.

Unfortunately supporting this required some argparse hackery, and I want
to move us off argparse altogether (as it's now just a minor implementation
detail of the options system). It was also pretty confusing to have a flag
that did different things depending on whether it had an argument or not.

So now -v, -V and --version are special-cased outside the options system, just like
the -h, -H and --help flags. And indeed they resemble help requests far more
than they resemble options.

--pants-version is now an untirely unrelated option, that always takes an
argument. Pants uses it to verify that it is running at the required version.
Scripts can grep it out of pants.ini, as before.

The main user-facing implication is that using --pants-version with no
argument now issues an error instead of printing the version. However
this doesn't seem like a big deal, as it was the least intuitive of the
version-printing flags anyway. Use -v, -V or --version for this.