### PR TITLE
[CI] Get rid of argparse usage entirely.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -33,11 +33,11 @@ class JvmRun(JvmTask):
     super(JvmRun, cls).register_options(register)
     register('--only-write-cmd-line', metavar='<file>',
              help='Instead of running, just write the cmd line to this file.')
-    # Note the unusual registration pattern. This is so we can support three cases:
+    # Note the use of implicit_value. This is so we can support three cases:
     # --cwd=<path>
-    # --cwd (defaults to the value of 'const', which is None here)
-    # No explicit --cwd at all (defaults to the value of 'default')
-    register('--cwd', default=_CWD_NOT_PRESENT, nargs='?',
+    # --cwd (uses the implicit value)
+    # No explicit --cwd at all (uses the default)
+    register('--cwd', default=_CWD_NOT_PRESENT, implicit_value='',
              help='Set the working directory. If no argument is passed, use the target path.')
     register('--main', metavar='<main class>',
              help='Invoke this class (overrides "main"" attribute in jvm_binary targets)')

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -97,6 +97,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
+    'src/python/pants/option',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -31,6 +31,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
+from pants.option.ranked_value import RankedValue
 from pants.util.memo import memoized_property
 
 
@@ -128,7 +129,7 @@ class ExportTask(IvyTaskMixin, PythonTask):
     ivy_options = self.context.options.for_scope('resolve.ivy')
     for name in set.intersection(set(export_options), set(ivy_options)):
       if not ivy_options.is_default(name):
-        setattr(export_options, name, ivy_options[name])
+        setattr(export_options, name, RankedValue(RankedValue.FLAG, ivy_options[name]))
     confs = confs or export_options.confs
 
     compile_classpath = None

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -11,7 +11,6 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/util:eval',
-    'src/python/pants/util:memo',
     'src/python/pants/util:meta',
     'src/python/pants/util:strutil',
   ]

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.option.arg_splitter import GLOBAL_SCOPE
+
 
 class OptionsError(Exception):
   """An options system-related error."""
@@ -13,9 +15,39 @@ class OptionsError(Exception):
 
 class RegistrationError(OptionsError):
   """An error at option registration time."""
-  pass
+
+  def __init__(self, msg, scope, option):
+    super(RegistrationError, self).__init__(
+      '{} [option {} in {}].'.format(msg, option,
+      'global scope' if scope == GLOBAL_SCOPE else 'scope {}'.format(scope)))
 
 
 class ParseError(OptionsError):
   """An error at flag parsing time."""
   pass
+
+
+# Subclasses of RegistrationError. The distinction between them is useful mainly for testing
+# that the error we get is the one we expect.
+# TODO: Similar thing for ParseError.
+def mk_registration_error(msg):
+  class Anon(RegistrationError):
+    def __init__(self, scope, option, **msg_format_args):
+      super(Anon, self).__init__(msg.format(**msg_format_args), scope, option)
+  return Anon
+
+
+BooleanOptionImplicitVal = mk_registration_error('Boolean option cannot specify an implicit value.')
+BooleanOptionNameWithNo = mk_registration_error('Boolean option names cannot start with --no.')
+BooleanOptionType = mk_registration_error('Boolean option cannot specify a type.')
+FrozenRegistration = mk_registration_error('Cannot register an option on a scope after registering '
+                                           'on any of its inner scopes.')
+ImplicitValIsNone = mk_registration_error('Implicit value cannot be None.')
+InvalidAction = mk_registration_error('Invalid action {action}.')
+InvalidKwarg = mk_registration_error('Invalid registration kwarg {kwarg}.')
+NoOptionNames = mk_registration_error('No option names provided.')
+OptionNameDash = mk_registration_error('Option name must begin with a dash.')
+OptionNameDoubleDash = mk_registration_error('Long option name must begin with a double-dash.')
+RecursiveSubsystemOption = mk_registration_error("Subsystem option cannot specify 'recursive'. "
+                                                 "Subsystem options are always recursive.")
+Shadowing = mk_registration_error('Option shadows an option in scope {outer_scope}')

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -22,9 +22,6 @@ class OptionValueContainer(object):
      the inner one from config).
 
      See ranked_value.py for more details.
-
-  Note that this container is suitable for passing as the namespace argument to argparse's
-  parse_args() method.
   """
 
   def __init__(self):
@@ -35,11 +32,7 @@ class OptionValueContainer(object):
 
     Returns one of the constants in RankedValue.
     """
-    val = self._value_map.get(key)
-    if isinstance(val, RankedValue):
-      return val.rank
-    else:  # Values without rank are assumed to be flag values set by argparse.
-      return RankedValue.FLAG
+    return self._value_map.get(key).rank
 
   def is_flagged(self, key):
     """Returns `True` if the value for the specified key was supplied via a flag.
@@ -94,19 +87,14 @@ class OptionValueContainer(object):
   def _set(self, key, value):
     if key in self._value_map:
       existing_value = self._value_map[key]
-      if isinstance(existing_value, RankedValue):
-        existing_rank = existing_value.rank
-      else:
-        # Values without rank are assumed to be flag values set by argparse.
-        existing_rank = RankedValue.FLAG
+      existing_rank = existing_value.rank
     else:
       existing_rank = RankedValue.NONE
 
     if isinstance(value, RankedValue):
       new_rank = value.rank
     else:
-      # Values without rank are assumed to be flag values set by argparse.
-      new_rank = RankedValue.FLAG
+      raise AttributeError('Value must be of type RankedValue: {}'.format(value))
 
     if new_rank >= existing_rank:
       # We set values from outer scopes before values from inner scopes, so
@@ -118,7 +106,6 @@ class OptionValueContainer(object):
     return getattr(self, key)
 
   # Support attribute setting, e.g., opts.foo = 42.
-  # This is necessary so that we can be used as an argparse namespace.
   def __setattr__(self, key, value):
     if key == '_value_map':
       return super(OptionValueContainer, self).__setattr__(key, value)

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -36,7 +36,7 @@ class Optionable(AbstractClass):
   def register_options(cls, register):
     """Register options for this optionable.
 
-    Subclasses may override and call register(*args, **kwargs) with argparse arguments.
+    Subclasses may override and call register(*args, **kwargs).
     """
 
   @classmethod

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -216,11 +216,11 @@ class Options(object):
       return []
 
   def register(self, scope, *args, **kwargs):
-    """Register an option in the given scope, using argparse params."""
+    """Register an option in the given scope."""
     self.get_parser(scope).register(*args, **kwargs)
 
   def registration_function_for_optionable(self, optionable_class):
-    """Returns a function for registering argparse args on the given scope."""
+    """Returns a function for registering options on the given scope."""
     # TODO(benjy): Make this an instance of a class that implements __call__, so we can
     # docstring it, and so it's less weird than attatching properties to a function.
     def register(*args, **kwargs):

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -9,31 +9,21 @@ import copy
 import os
 import re
 import warnings
-from argparse import ArgumentParser
+from collections import defaultdict
 
 import six
 
 from pants.base.deprecated import check_deprecated_semver
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import list_option
-from pants.option.errors import ParseError, RegistrationError
+from pants.option.errors import (BooleanOptionImplicitVal, BooleanOptionNameWithNo,
+                                 BooleanOptionType, FrozenRegistration, ImplicitValIsNone,
+                                 InvalidAction, InvalidKwarg, NoOptionNames, OptionNameDash,
+                                 OptionNameDoubleDash, ParseError, RecursiveSubsystemOption,
+                                 Shadowing)
 from pants.option.option_util import is_boolean_flag
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo
-from pants.util.memo import memoized_property
-
-
-# Standard ArgumentParser prints usage and exits on error. We subclass so we can raise instead.
-# Note that subclassing ArgumentParser for this purpose is allowed by the argparse API.
-class CustomArgumentParser(ArgumentParser):
-
-  def __init__(self, scope, *args, **kwargs):
-    super(CustomArgumentParser, self).__init__(*args, **kwargs)
-    self._scope = scope
-
-  def error(self, message):
-    scope = 'global' if self._scope == GLOBAL_SCOPE else self._scope
-    raise ParseError('{0} in {1} scope'.format(message, scope))
 
 
 class Parser(object):
@@ -95,18 +85,7 @@ class Parser(object):
     self._known_args = set()
 
     # List of (args, kwargs) registration pairs, exactly as captured at registration time.
-    # Note that:
-    # 1. kwargs may include our custom, non-argparse arguments (e.g., 'recursive' and 'advanced').
-    # 2. kwargs will include a value for 'default', computed from env vars, pants.ini and the
-    #    static 'default' in the originally passed-in kwargs (if any).
     self._option_registrations = []
-
-    # Names of args that have already been registered with argparse.  Used to prevent
-    # double-registration (e.g., during bootstrapping).
-    self._argparse_registered_args = set()
-
-    # Map of dest -> (deprecated_version, deprecated_hint), for deprecated options.
-    self._deprecated_option_dests = {}
 
     # A Parser instance, or None for the global scope parser.
     self._parent_parser = parent_parser
@@ -129,24 +108,78 @@ class Parser(object):
 
   def parse_args(self, flags, namespace):
     """Set values for this parser's options on the namespace object."""
-    for args, kwargs in self.option_registrations_iter():
-      self._argparse_register(args, kwargs)
-    new_args = vars(self._argparser.parse_args(flags))
-    namespace.update(new_args)
 
-    # Check for deprecated flags.
-    for key in self._deprecated_option_dests.keys():
-      if namespace.get_rank(key) == RankedValue.FLAG:
-        warnings.warn('*** {}'.format(self._deprecated_message(key)), DeprecationWarning,
-                      stacklevel=9999)  # Out of range stacklevel to suppress printing src line.
+    # Create a map of flag to list of values.  None signals no value given (e.g., -x, --foo).
+    # The value is a list because the user may specify the same flag multiple times, and that's
+    # sometimes OK (e.g., when action=='append').
+    flag_value_map = defaultdict(list)
+    for flag in flags:
+      key, has_equals_sign, flag_val = flag.partition('=')
+      if not has_equals_sign:
+        if not flag.startswith('--'):  # '-xfoo' style.
+          key = flag[0:2]
+          flag_val = flag[2:]
+        if not flag_val:
+          # Either a short option with no value or a long option with no equals sign.
+          # Important so we can distinguish between no value ('--foo') and setting to an empty
+          # string ('--foo='), for options with an implicit_value.
+          flag_val = None
+      flag_value_map[key].append(flag_val)
+
+    for args, kwargs in self._unnormalized_option_registrations_iter():
+      self._validate(args, kwargs)
+      dest = kwargs.get('dest') or self._select_dest(args)
+      is_bool = is_boolean_flag(kwargs)
+
+      # Compute the values provided on the command line for this option.  Note tha there may be
+      # multiple values, for any combination of the following reasons:
+      #   - The user used the same flag multiple times.
+      #   - The user specified a boolean flag (--foo) and its inverse (--no-foo).
+      #   - The option has multiple names, and the user used more than one of them.
+      #
+      # We also check if the option is deprecated, but we only do so if the option is explicitly
+      # specified as a command-line flag, so we don't spam users with deprecated option values
+      # specified in config, which isn't something they control.
+      implicit_value = kwargs.get('implicit_value')
+      flag_vals = []
+      for arg in args:
+        if arg in flag_value_map:
+          self._check_deprecated(dest, kwargs)
+          if is_bool:
+            flag_vals.append('true' if kwargs['action'] == 'store_true' else 'false')
+          else:
+            vals = flag_value_map[arg]
+            for v in vals:
+              if v is None:
+                if implicit_value is None:
+                  raise ParseError('Missing value for command line flag {}'.format(arg))
+                else:
+                  flag_vals.append(implicit_value)
+              else:
+                flag_vals.append(v)
+          del flag_value_map[arg]
+        elif is_bool and self._inverse_arg(arg) in flag_value_map:
+          self._check_deprecated(dest, kwargs)
+          del flag_value_map[self._inverse_arg(arg)]
+          flag_vals.append('false' if kwargs['action'] == 'store_true' else 'true')
+
+      # Get the value for this option, falling back to defaults as needed.
+      val = self._compute_value(dest, kwargs, flag_vals)
+      setattr(namespace, dest, val)
+
+    if flag_value_map:
+      raise ParseError('Unrecognized command line flags on {}: {}'.format(
+        self._scope_str(), ', '.join(flag_value_map.keys())))
+
     return namespace
 
   def option_registrations_iter(self):
     """Returns an iterator over the normalized registration arguments of each option in this parser.
 
+    Useful for generating help and other documentation.
+
     Each yielded item is an (args, kwargs) pair, as passed to register(), except that kwargs
     will be normalized in the following ways:
-
       - It will always have 'dest' explicitly set.
       - It will always have 'default' explicitly set, and the value will be a RankedValue.
       - For recursive options, the original registrar will also have 'recursive_root' set.
@@ -154,30 +187,44 @@ class Parser(object):
     Note that recursive options we inherit from a parent will also be yielded here, with
     the correctly-scoped default value.
     """
-    def normalize_kwargs(orig_kwargs):
+    def normalize_kwargs(args, orig_kwargs):
       nkwargs = copy.copy(orig_kwargs)
-      if 'dest' not in nkwargs:
-        nkwargs['dest'] = self._select_dest(args)
+      dest = nkwargs.get('dest') or self._select_dest(args)
+      nkwargs['dest'] = dest
       if not ('default' in nkwargs and isinstance(nkwargs['default'], RankedValue)):
-        nkwargs['default'] = self._compute_default(nkwargs)  # Requires dest to be set.
+        nkwargs['default'] = self._compute_value(dest, nkwargs, [])
       return nkwargs
 
     # First yield any recursive options we inherit from our parent.
     if self._parent_parser:
       for args, kwargs in self._parent_parser._recursive_option_registration_args():
-        yield args, normalize_kwargs(kwargs)
+        yield args, normalize_kwargs(args, kwargs)
 
     # Then yield our directly-registered options.
     # This must come after yielding inherited recursive options, so we can detect shadowing.
     for args, kwargs in self._option_registrations:
-      normalized_kwargs = normalize_kwargs(kwargs)
+      normalized_kwargs = normalize_kwargs(args, kwargs)
       if 'recursive' in normalized_kwargs:
-        if self._scope_info.category == ScopeInfo.SUBSYSTEM:
-          raise RegistrationError("Subsystem option {} in scope {} sets 'recursive'. Subsystem "
-                                  "options are always recursive.".format(args[0], self.scope))
         # If we're the original registrar, make sure we can distinguish that.
         normalized_kwargs['recursive_root'] = True
       yield args, normalized_kwargs
+
+  def _unnormalized_option_registrations_iter(self):
+    """Returns an iterator over the raw registration arguments of each option in this parser.
+
+    Each yielded item is an (args, kwargs) pair, exactly as passed to register().
+
+    Note that recursive options we inherit from a parent will also be yielded here.
+    """
+    # First yield any recursive options we inherit from our parent.
+    if self._parent_parser:
+      for args, kwargs in self._parent_parser._recursive_option_registration_args():
+        yield args, kwargs
+    # Then yield our directly-registered options.
+    for args, kwargs in self._option_registrations:
+      if 'recursive' in kwargs and self._scope_info.category == ScopeInfo.SUBSYSTEM:
+        raise RecursiveSubsystemOption(self.scope, args[0])
+      yield args, kwargs
 
   def _recursive_option_registration_args(self):
     """Yield args, kwargs pairs for just our recursive options.
@@ -195,25 +242,9 @@ class Parser(object):
         yield args, kwargs
 
   def register(self, *args, **kwargs):
-    """Register an option, using argparse params.
-
-    Note that we don't actually do the argparse registration yet. That's done lazily.
-
-    Custom extensions to argparse params:
-    :param advanced: If True, the option will be suppressed when displaying help.
-    :param recursive: If True, the option will be registered on all subscopes as well.
-    :param fingerprint: If True, this option is mixed into fingerprints generated by tasks
-                        that use it.
-    :param fromfile: If True, this option supports the --foo=@filepath notation, in which the
-                     option value is read from the file.
-    :param deprecated_version: Mark an option as deprecated.  The value is a semver that indicates
-       the release at which the option should be removed from the code.
-    :param deprecated_hint: A message to display to the user when displaying help for or invoking
-       a deprecated option.
-    """
+    """Register an option."""
     if self._frozen:
-      raise RegistrationError('Cannot register option {} in scope {} after registering options '
-                              'in any of its inner scopes.'.format(args[0], self._scope))
+      raise FrozenRegistration(self.scope, args[0])
 
     # Prevent further registration in enclosing scopes.
     ancestor = self._parent_parser
@@ -221,90 +252,70 @@ class Parser(object):
       ancestor._freeze()
       ancestor = ancestor._parent_parser
 
-    # Record the args. We'll do the underlying argparse registration on-demand.
+    # Record the args. We'll do the underlying parsing on-demand.
     self._option_registrations.append((args, kwargs))
     if self._parent_parser:
       for arg in args:
         existing_scope = self._parent_parser._existing_scope(arg)
         if existing_scope is not None:
-          raise RegistrationError('Option {} in scope {} already registered in {}'.format(
-            arg, self.scope, _scope_str(existing_scope)))
+          raise Shadowing(self.scope, arg, outer_scope=_scope_str(existing_scope))
     self._known_args.update(args)
 
-  @memoized_property
-  def _argparser(self):
-    return CustomArgumentParser(scope=self._scope, conflict_handler='resolve')
+  def _check_deprecated(self, dest, kwargs):
+    """Checks option for deprecation and issues a warning if necessary.
 
-  def _argparse_register(self, args, kwargs):
-    """Do the deferred argparse registration."""
-    # This check prevents repeat registration of the same option, e.g., during bootstrapping,
-    # when we parse some global options multiple times.
-    if args[0] not in self._argparse_registered_args:
-      self._validate(args, kwargs)
-      argparse_kwargs = self._clean_argparse_kwargs(kwargs)
-      if is_boolean_flag(argparse_kwargs):
-        inverse_args = self._create_inverse_args(args)
-        if inverse_args:
-          inverse_argparse_kwargs = self._create_inverse_kwargs(argparse_kwargs)
-          group = self._argparser.add_mutually_exclusive_group()
-          group.add_argument(*args, **argparse_kwargs)
-          group.add_argument(*inverse_args, **inverse_argparse_kwargs)
-        else:
-          self._argparser.add_argument(*args, **argparse_kwargs)
-      else:
-        self._argparser.add_argument(*args, **argparse_kwargs)
-    self._argparse_registered_args.update(args)
-
-  def _deprecated_message(self, dest):
-    """Returns the message to be displayed when a deprecated option is specified on the cmd line.
-
-    Assumes that the option is indeed deprecated.
-
-    :param dest: The dest of the option being invoked.
+    :param arg: The name of the option to check.
     """
-    deprecated_version, deprecated_hint = self._deprecated_option_dests[dest]
-    scope = self._scope or 'DEFAULT'
-    message = 'Option {dest} in scope {scope} is deprecated and will be removed in version ' \
-              '{removal_version}'.format(dest=dest, scope=scope,
-                                         removal_version=deprecated_version)
-    hint = deprecated_hint or ''
-    return '{}. {}'.format(message, hint)
+    deprecated_ver = kwargs.get('deprecated_version', None)
+    if deprecated_ver is not None:
+      msg = 'Option {dest} in {scope} is deprecated and will be removed in version ' \
+            '{removal_version}.  {hint}'.format(dest=dest, scope=self._scope_str(),
+                                                removal_version=deprecated_ver,
+                                                hint=kwargs.get('deprecated_hint', ''))
+      warnings.warn('*** {}'.format(msg), DeprecationWarning,
+                    stacklevel=9999)  # Out of range stacklevel to suppress printing src line.
 
-  _custom_kwargs = ('advanced', 'recursive', 'recursive_root', 'registering_class',
-                    'fingerprint', 'deprecated_version', 'deprecated_hint', 'fromfile')
-
-  def _clean_argparse_kwargs(self, kwargs):
-    deprecated_version = kwargs.get('deprecated_version', None)
-    deprecated_hint = kwargs.get('deprecated_hint', '')
-
-    if deprecated_version is not None:
-      check_deprecated_semver(deprecated_version)
-      self._deprecated_option_dests[kwargs['dest']] = (deprecated_version, deprecated_hint)
-
-    # For argparse registration, remove our custom kwargs.
-    argparse_kwargs = dict(kwargs)
-    for custom_kwarg in self._custom_kwargs:
-      argparse_kwargs.pop(custom_kwarg, None)
-    return argparse_kwargs
+  _allowed_registration_kwargs = {
+    'type', 'action', 'choices', 'dest', 'default', 'implicit_value', 'metavar',
+    'help', 'advanced', 'recursive', 'recursive_root', 'registering_class',
+    'fingerprint', 'deprecated_version', 'deprecated_hint', 'fromfile'
+  }
 
   def _validate(self, args, kwargs):
-    """Ensure that the caller isn't trying to use unsupported argparse features."""
-    scope_str = _scope_str(self.scope)
+    """Validate option registration arguments."""
+    def error(exception_type, arg_name=None, **msg_kwargs):
+      if arg_name is None:
+        arg_name = args[0] if args else '<unknown>'
+      raise exception_type(self.scope, arg_name, **msg_kwargs)
+
+    scope_str = self._scope_str()
     if not args:
-      raise RegistrationError('No args provided for option in {}'.format(scope_str))
+      error(NoOptionNames)
+    # validate args.
     for arg in args:
       if not arg.startswith('-'):
-        raise RegistrationError('Option {} in {} must begin '
-                                'with a dash.'.format(arg, scope_str))
+        error(OptionNameDash, arg_name=arg)
       if not arg.startswith('--') and len(arg) > 2:
-        raise RegistrationError('Multicharacter option {} in {} must begin '
-                                'with a double-dash'.format(arg, scope_str))
-    if 'nargs' in kwargs and kwargs['nargs'] != '?':
-      raise RegistrationError('nargs={} unsupported in registration of option {} in '
-                              '{}.'.format(kwargs['nargs'], args, scope_str))
-    if 'required' in kwargs:
-      raise RegistrationError('required unsupported in registration of option {} in '
-                              '{}.'.format(args, scope_str))
+        error(OptionNameDoubleDash, arg_name=arg)
+
+    # Validate kwargs.
+    if kwargs.get('action', 'store') not in {'store', 'store_true', 'store_false', 'append'}:
+      error(InvalidAction, action=kwargs['action'])
+
+    if is_boolean_flag(kwargs) and 'type' in kwargs:
+      error(BooleanOptionType)
+    if 'implicit_value' in kwargs:
+      if is_boolean_flag(kwargs):
+        error(BooleanOptionImplicitVal)
+      elif kwargs['implicit_value'] is None:
+        error(ImplicitValIsNone)
+    for kwarg in kwargs:
+      if kwarg not in self._allowed_registration_kwargs:
+        error(InvalidKwarg, kwarg=kwarg)
+
+    deprecated_ver = kwargs.get('deprecated_version')
+    if deprecated_ver is not None:
+      check_deprecated_semver(deprecated_ver)
 
   def _existing_scope(self, arg):
     if arg in self._known_args:
@@ -319,20 +330,16 @@ class Parser(object):
   def _select_dest(self, args):
     """Select the dest name for the option.
 
-    Replicated from the dest inference logic in argparse:
     '--foo-bar' -> 'foo_bar' and '-x' -> 'x'.
     """
     arg = next((a for a in args if a.startswith('--')), args[0])
     return arg.lstrip('-').replace('-', '_')
 
-  def _compute_default(self, kwargs):
-    """Compute the default value to use for an option's registration.
+  def _compute_value(self, dest, kwargs, flag_vals):
+    """Compute the value to use for an option.
 
     The source of the default value is chosen according to the ranking in RankedValue.
-
-    Note: Only call if kwargs has a 'dest' key set.
     """
-    dest = kwargs['dest']
     is_fromfile = kwargs.get('fromfile', False)
     action = kwargs.get('action')
     if is_fromfile and action and action != 'append':
@@ -376,7 +383,8 @@ class Parser(object):
           with open(fromfile) as fp:
             return fp.read().strip()
         except IOError as e:
-          raise self.FromfileError('Failed to read {} from file {}: {}'.format(dest, fromfile, e))
+          raise self.FromfileError('Failed to read {} in {} from file {}: {}'.format(
+            dest, self._scope_str() ,fromfile, e))
       else:
         # Support a literal @ for fromfile values via @@.
         return val_str[1:] if is_fromfile and val_str.startswith('@@') else val_str
@@ -387,52 +395,65 @@ class Parser(object):
     def parse_typed_item(val_str):
       return None if val_str is None else value_type(expand(val_str))
 
-    # Handle the forthcoming conversions argparse will need to do by placing our parse hook - we
-    # handle the conversions for env and config ourselves below.  Unlike the env and config
-    # handling, `action='append'` does not need to be handled specially since appended flag values
-    # come as single items' thus only `parse_typed_item` is ever needed for the flag value type
-    # conversions.
-    if is_fromfile:
-      kwargs['type'] = parse_typed_item
+    flag_val = None
+    if flag_vals:
+      if action == 'append':
+        flag_val = [parse_typed_item(v) for v in flag_vals]
+      elif len(flag_vals) > 1:
+        raise ParseError('Multiple cmd line flags specified for option {} in {}'.format(
+          dest, self._scope_str()))
+      else:
+        flag_val = parse_typed_item(flag_vals[0])
 
     default, parse = ([], parse_typed_list) if action == 'append' else (None, parse_typed_item)
+
     config_val = parse(config_val_str)
     env_val = parse(env_val_str)
     hardcoded_val = kwargs.get('default')
 
     config_details = 'in {}'.format(config_source_file) if config_source_file else None
 
-    choices = list(RankedValue.prioritized_iter(None, env_val, config_val, hardcoded_val, default))
-    for choice in reversed(choices):
-      details = config_details if choice.rank == RankedValue.CONFIG else None
-      self._option_tracker.record_option(scope=self._scope, option=dest, value=choice.value,
-                                         rank=choice.rank, details=details)
+    ranked_vals = list(reversed(list(RankedValue.prioritized_iter(
+      flag_val, env_val, config_val, hardcoded_val, default))))
+    choices = kwargs.get('choices')
+    for ranked_val in ranked_vals:
+      details = config_details if ranked_val.rank == RankedValue.CONFIG else None
+      self._option_tracker.record_option(scope=self._scope, option=dest, value=ranked_val.value,
+                                         rank=ranked_val.rank, details=details)
 
-    return choices[0]
+    def check(val):
+      if choices is not None and val is not None and val not in choices:
+        raise ParseError('{} is not an allowed value for option {} in {}. '
+                         'Must be one of: {}'.format(
+          val, dest, self._scope_str(), choices
+        ))
+      return val
 
-  def _create_inverse_args(self, args):
-    inverse_args = []
-    for arg in args:
-      if arg.startswith('--'):
-        if arg.startswith('--no-'):
-          raise RegistrationError(
-            'Invalid option name "{}". Boolean options names cannot start with --no-'.format(arg))
-        inverse_args.append('--no-{}'.format(arg[2:]))
-    return inverse_args
+    if action == 'append':
+      non_none_ranked_vals = filter(None, ranked_vals)
+      merged_rank = non_none_ranked_vals[-1].rank
+      merged_val = [check(val) for vals in non_none_ranked_vals for val in vals.value]
+      return RankedValue(merged_rank, merged_val)
+    else:
+      map(lambda rv: check(rv.value), ranked_vals)
+      return ranked_vals[-1]
 
-  def _create_inverse_kwargs(self, kwargs):
-    """Create the kwargs for registering the inverse of a boolean flag."""
-    inverse_kwargs = copy.copy(kwargs)
-    inverse_action = 'store_true' if kwargs.get('action') == 'store_false' else 'store_false'
-    inverse_kwargs['action'] = inverse_action
-    inverse_kwargs.pop('default', None)
-    return inverse_kwargs
+  def _inverse_arg(self, arg):
+    if arg.startswith('--'):
+      if arg.startswith('--no-'):
+        raise BooleanOptionNameWithNo(self.scope, arg)
+      return '--no-{}'.format(arg[2:])
+    else:
+      return None
 
   def _register_child_parser(self, child):
     self._child_parsers.append(child)
 
   def _freeze(self):
     self._frozen = True
+
+  def _scope_str(self):
+    return _scope_str(self.scope)
 
   def __str__(self):
     return 'Parser({})'.format(self._scope)

--- a/src/python/pants/option/ranked_value.py
+++ b/src/python/pants/option/ranked_value.py
@@ -118,14 +118,6 @@ class RankedValue(object):
   def value(self):
     return self._value
 
-  def __copy__(self):
-    # The only time copy.copy() is called on a RankedValue is when the action is 'append', in which
-    # case argparse copies the default value (which will be a RankedValue wrapping a list), appends
-    # to it, and then sets the copy as the new value.
-    # We expect argparse to set regular values, not RankedValue instances, so we return a copy of
-    # the underlying list here.
-    return copy.copy(self._value)
-
   def __eq__(self, other):
     return self._rank == other._rank and self._value == other._value
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.util.contextutil import temporary_dir
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
 
 
@@ -35,7 +34,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
         target = 'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target'
         pants_run = self.run_test_compile(
           workdir, cachedir, target,
-          extra_args=['--no-color'], clean_all=True
+          extra_args=['--no-colors'], clean_all=True
         )
         self.assertIn('[warn] import sun.security.x509.X500Name;', pants_run.stdout_data)
         self.assertIn('[error]     System2.out.println("Hello World!");', pants_run.stdout_data)

--- a/tests/python/pants_test/option/test_option_value_container.py
+++ b/tests/python/pants_test/option/test_option_value_container.py
@@ -14,9 +14,9 @@ from pants.option.ranked_value import RankedValue
 
 class OptionValueContainerTest(unittest.TestCase):
 
-  def test_standard_values(self):
+  def test_unknown_values(self):
     o = OptionValueContainer()
-    o.foo = 1
+    o.foo = RankedValue(RankedValue.HARDCODED, 1)
     self.assertEqual(1, o.foo)
 
     with self.assertRaises(AttributeError):
@@ -33,7 +33,7 @@ class OptionValueContainerTest(unittest.TestCase):
     o.foo = RankedValue(RankedValue.ENVIRONMENT, 33)
     self.assertEqual(33, o.foo)
     self.assertEqual(RankedValue.ENVIRONMENT, o.get_rank('foo'))
-    o.foo = 44  # No explicit rank is assumed to be a FLAG.
+    o.foo = RankedValue(RankedValue.FLAG, 44)
     self.assertEqual(44, o.foo)
     self.assertEqual(RankedValue.FLAG, o.get_rank('foo'))
 
@@ -54,7 +54,7 @@ class OptionValueContainerTest(unittest.TestCase):
 
   def test_indexing(self):
     o = OptionValueContainer()
-    o.foo = 1
+    o.foo = RankedValue(RankedValue.CONFIG, 1)
     self.assertEqual(1, o['foo'])
 
     self.assertEqual(1, o.get('foo'))
@@ -67,23 +67,23 @@ class OptionValueContainerTest(unittest.TestCase):
 
   def test_iterator(self):
     o = OptionValueContainer()
-    o.a = 3
-    o.b = 2
-    o.c = 1
+    o.a = RankedValue(RankedValue.FLAG, 3)
+    o.b = RankedValue(RankedValue.FLAG, 2)
+    o.c = RankedValue(RankedValue.FLAG, 1)
     names = list(iter(o))
     self.assertListEqual(['a', 'b', 'c'], names)
 
   def test_copy(self):
     # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
     o = OptionValueContainer()
-    o.foo = 1
-    o.bar = {'a': 111}
+    o.foo = RankedValue(RankedValue.FLAG, 1)
+    o.bar = RankedValue(RankedValue.FLAG, {'a': 111})
 
     p = copy.copy(o)
 
     # Verify that the result is in fact a copy.
     self.assertEqual(1, p.foo)  # Has original attribute.
-    o.baz = 42
+    o.baz = RankedValue(RankedValue.FLAG, 42)
     self.assertFalse(hasattr(p, 'baz'))  # Does not have attribute added after the copy.
 
     # Verify that it's a shallow copy by modifying a referent in o and reading it in p.
@@ -93,14 +93,14 @@ class OptionValueContainerTest(unittest.TestCase):
   def test_deepcopy(self):
     # copy semantics can get hairy when overriding __setattr__/__getattr__, so we test them.
     o = OptionValueContainer()
-    o.foo = 1
-    o.bar = {'a': 111}
+    o.foo = RankedValue(RankedValue.FLAG, 1)
+    o.bar = RankedValue(RankedValue.FLAG, {'a': 111})
 
     p = copy.deepcopy(o)
 
     # Verify that the result is in fact a copy.
     self.assertEqual(1, p.foo)  # Has original attribute.
-    o.baz = 42
+    o.baz = RankedValue(RankedValue.FLAG, 42)
     self.assertFalse(hasattr(p, 'baz'))  # Does not have attribute added after the copy.
 
     # Verify that it's a deep copy by modifying a referent in o and reading it in p.

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -202,6 +202,9 @@ class OptionsTest(unittest.TestCase):
                           config={'DEFAULT': {'y': ['88', '-99']}})
     self.assertEqual([88, -99, 5, -6, 77], options.for_global_scope().y)
 
+    options = self._parse('./pants')
+    self.assertEqual([], options.for_global_scope().y)
+
     options = self._parse('./pants ', env={'PANTS_CONFIG_OVERRIDE': "['123','456']"})
     self.assertEqual(['123','456'], options.for_global_scope().config_override)
 
@@ -350,24 +353,22 @@ class OptionsTest(unittest.TestCase):
     self.assertEqual([42, 99], options.for_global_scope().int_choices)
 
   def test_validation(self):
-    def check(expected_error, *args, **kwargs):
+    def assertError(expected_error, *args, **kwargs):
       with self.assertRaises(expected_error):
         options = Options.create(args=[], env={}, config=self._create_config({}),
                                  known_scope_infos=[], option_tracker=OptionTracker())
         options.register(GLOBAL_SCOPE, *args, **kwargs)
         options.for_global_scope()
 
-    # Note: it's a little fragile to test for specific strings, but the alternative is to create
-    # a large number of RegistrationError subclasses, and that seems like overkill in this case.
-    check(NoOptionNames)
-    check(OptionNameDash, 'badname')
-    check(OptionNameDoubleDash, '-badname')
-    check(InvalidAction, '--foo', action='store_const')
-    check(InvalidKwarg, '--foo', badkwarg=42)
-    check(ImplicitValIsNone, '--foo', implicit_value=None)
-    check(BooleanOptionType, '--foo', action='store_true', type=int)
-    check(BooleanOptionImplicitVal, '--foo', action='store_true', implicit_value=False)
-    check(BooleanOptionNameWithNo, '--no-foo', action='store_true')
+    assertError(NoOptionNames)
+    assertError(OptionNameDash, 'badname')
+    assertError(OptionNameDoubleDash, '-badname')
+    assertError(InvalidAction, '--foo', action='store_const')
+    assertError(InvalidKwarg, '--foo', badkwarg=42)
+    assertError(ImplicitValIsNone, '--foo', implicit_value=None)
+    assertError(BooleanOptionType, '--foo', action='store_true', type=int)
+    assertError(BooleanOptionImplicitVal, '--foo', action='store_true', implicit_value=False)
+    assertError(BooleanOptionNameWithNo, '--no-foo', action='store_true')
 
   def test_frozen_registration(self):
     options = Options.create(args=[], env={}, config=self._create_config({}),

--- a/tests/python/pants_test/option/test_options_bootstrapper.py
+++ b/tests/python/pants_test/option/test_options_bootstrapper.py
@@ -136,15 +136,16 @@ class BootstrapOptionsTest(unittest.TestCase):
       """))
       fp.close()
 
-      bootstrapper_single_config = OptionsBootstrapper(configpath=fp.name,
-                                                       args=['--config-override={}'.format(fp.name)])
+      bootstrapper_single_config = OptionsBootstrapper(
+        configpath=fp.name, args=['--config-override={}'.format(fp.name)])
 
       opts_single_config  = bootstrapper_single_config.get_full_options(known_scope_infos=[
           ScopeInfo('', ScopeInfo.GLOBAL),
           ScopeInfo('compile.apt', ScopeInfo.TASK),
           ScopeInfo('fruit', ScopeInfo.TASK),
       ])
-      opts_single_config.register('', '--config-override')  # So we don't choke on it on the cmd line.
+      # So we don't choke on it on the cmd line.
+      opts_single_config.register('', '--config-override', action='append')
       opts_single_config.register('compile.apt', '--worker-count')
       opts_single_config.register('fruit', '--apple')
 
@@ -168,7 +169,8 @@ class BootstrapOptionsTest(unittest.TestCase):
           ScopeInfo('compile.apt', ScopeInfo.TASK),
           ScopeInfo('fruit', ScopeInfo.TASK),
         ])
-        opts_double_config.register('', '--config-override')  # So we don't choke on it on the cmd line.
+        # So we don't choke on it on the cmd line.
+        opts_double_config.register('', '--config-override', action='append')
         opts_double_config.register('compile.apt', '--worker-count')
         opts_double_config.register('fruit', '--apple')
 


### PR DESCRIPTION
It had become an implementation detail, and a minor one at that.
We had already duplicated a lot of its logic (around types and actions,
in particular) in order to correctly compute defaults.  So we might as
well go the extra mile and get rid of it. Especially since its init
sequence is quite expensive, and we create one argparser per scope,
which is not how it was designed to be used.