### PR TITLE
Add new `--fail-floating` option to `GoBuildgen`.

### DIFF
--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_buildgen.py
@@ -199,8 +199,8 @@ class GoBuildgenTest(TaskTestBase):
     self.assertEqual({'src/go/fred/BUILD.gen', 'src/go/jane/BUILD.gen'},
                      self.buildroot_files() - pre_execute_files)
 
-  def stitch_deps_remote(self, remote=True, materialize=False):
-    self.set_options(remote=remote, materialize=materialize)
+  def stitch_deps_remote(self, remote=True, materialize=False, fail_floating=False):
+    self.set_options(remote=remote, materialize=materialize, fail_floating=fail_floating)
     self.set_options_for_scope(Fetchers.options_scope,
                                mapping={r'pantsbuild.org/.*':
                                         '{}.{}'.format(FakeFetcher.__module__,
@@ -294,3 +294,7 @@ class GoBuildgenTest(TaskTestBase):
       self.stitch_deps_remote(remote=False)
     self.assertEqual(GoTargetGenerator.NewRemoteEncounteredButRemotesNotAllowedError,
                      type(exc.exception.cause))
+
+  def test_fail_floating(self):
+    with self.assertRaises(GoBuildgen.FloatingRemoteError):
+      self.stitch_deps_remote(remote=True, materialize=True, fail_floating=True)


### PR DESCRIPTION
This advanced option allows a repo to set a policy that floating
3rdparty Go dependencies are not allowed.  When buildgen is run and any
existing or new Go remote libraries are found with no `rev` specified
the build fails and instructions to remedy the situation logged.

There is no support yet for this `--fail-floating` mode when not
`--materializing` targets to disk.

https://rbcommons.com/s/twitter/r/3073/