### PR TITLE
[trigger ci]Change JarPublish.fingerprint to JarPublish.entry_fingerprint to ensu…

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -701,7 +701,7 @@ class JarPublish(ScmPublishMixin, JarTask):
           ))
         newentry = oldentry.with_sem_ver(sem_ver)
 
-      newfingerprint = self.fingerprint(target, fingerprint_internal)
+      newfingerprint = self.entry_fingerprint(target, fingerprint_internal)
       newentry = newentry.with_sha_and_fingerprint(head_sha, newfingerprint)
       no_changes = newentry.fingerprint == oldentry.fingerprint
 
@@ -848,7 +848,7 @@ class JarPublish(ScmPublishMixin, JarTask):
     return OrderedSet(filter(exportable,
                              reversed(sort_targets(filter(exportable, candidates)))))
 
-  def fingerprint(self, target, fingerprint_internal):
+  def entry_fingerprint(self, target, fingerprint_internal):
     sha = hashlib.sha1()
     sha.update(target.invalidation_hash())
 


### PR DESCRIPTION
…re task fingerprint can change

While doing some debugging in intellij, I noticed that JarPublish's fingerprint method was hilighted with a warning that it overrode a parent with a different signature. This lead me to realize that its fingerprint is now going to be a function rather than a string containing a hash. That didn't seem very good.

This renames the JarPublish fingerprint method so it is no longer overriding the property