### PR TITLE
Allow setting SubProcPool workers via --num-foreground-workers

### DIFF
--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -194,10 +194,12 @@ class SubprocPool(object):
     signal.signal(signal.SIGINT, lambda *args: sys.exit())
 
   @classmethod
-  def foreground(cls):
+  def foreground(cls, processes=None):
     with cls._lock:
       if cls._pool is None:
-        cls._pool = multiprocessing.Pool(initializer=SubprocPool.worker_init)
+        if processes is None:
+          processes = multiprocessing.cpu_count()
+        cls._pool = multiprocessing.Pool(processes=processes, initializer=SubprocPool.worker_init)
       return cls._pool
 
   @classmethod

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -197,8 +197,7 @@ class SubprocPool(object):
   def foreground(cls, processes=None):
     with cls._lock:
       if cls._pool is None:
-        if processes is None:
-          processes = multiprocessing.cpu_count()
+        processes = processes or multiprocessing.cpu_count()
         cls._pool = multiprocessing.Pool(processes=processes, initializer=SubprocPool.worker_init)
       return cls._pool
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -122,7 +122,7 @@ class RunTracker(Subsystem):
     self._background_root_workunit = None
 
     # Trigger subproc pool init while our memory image is still clean (see SubprocPool docstring).
-    SubprocPool.foreground()
+    SubprocPool.foreground(self._num_foreground_workers)
 
     self._aborted = False
 


### PR DESCRIPTION
SubProcPool is defaulting to cpu_count() number of workers, which causes extra threads contention on mesos container environment where cpu_count() >> actual available cores.

_num-foreground-workers is set but never used, I suspect it's intended to influence SubProcPool.

@stuhood @jsirois @benjyw please review.