### PR TITLE
DO NOT MERGE: Demo a bug where cucumber breaks the junit runner.

### DIFF
--- a/testprojects/3rdparty/cucumber/BUILD
+++ b/testprojects/3rdparty/cucumber/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jar_library(name='cuke-core',
+  jars=[
+    jar(org='info.cukes', name='cucumber-core', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='cuke-guice',
+  jars=[
+    jar(org='info.cukes', name='cucumber-guice', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='cuke-java',
+  jars=[
+    jar(org='info.cukes', name='cucumber-java', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='cuke-junit',
+  jars=[
+    jar(org='info.cukes', name='cucumber-junit', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='com.google.inject.guice',
+  jars=[
+    jar(org='com.google.inject', name='guice', rev='4.0',)
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/cucumber/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+junit_tests(name='cucumber',
+  sources=['CukeTest.java'],
+  dependencies=[
+    ':lib',
+  ],
+)
+
+java_library(name='lib',
+  sources=[
+    'DemoSteps.java',
+  ],
+  dependencies=[
+    '3rdparty:junit',
+    'testprojects/3rdparty/cucumber:cuke-core',
+    'testprojects/3rdparty/cucumber:cuke-guice',
+    'testprojects/3rdparty/cucumber:cuke-java',
+    'testprojects/3rdparty/cucumber:cuke-junit',
+    'testprojects/3rdparty/cucumber:com.google.inject.guice',
+    'testprojects/src/resources/org/pantsbuild/testproject/cucumber',
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/cucumber/CukeTest.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/cucumber/CukeTest.java
@@ -1,0 +1,21 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.cucumber;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(Cucumber.class) @CucumberOptions(
+    glue = {"org.pantsbuild.testproject.cucumber"})
+public class CukeTest {
+
+  @Test public void normalTest() {
+    assertEquals("CukeTest", getClass().getSimpleName());
+  }
+
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
@@ -1,0 +1,58 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.cucumber;
+
+import java.util.List;
+import java.util.LinkedList;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import static org.junit.Assert.assertArrayEquals;
+
+@ScenarioScoped
+public class DemoSteps {
+
+  private List<String> fruits;
+  private List<String> veggies;
+  private List<String> cart;
+
+  @Before public void before() {
+    fruits = new LinkedList<String>();
+    veggies = new LinkedList<String>();
+  }
+
+  @After public void after() {
+    fruits = null;
+    veggies = null;
+  }
+
+  @Given("^some fruit$")
+  public void addFruitToList(List<String> fruits) {
+    this.fruits.addAll(fruits);
+  }
+
+  @Given("^some veggies$")
+  public void addVeggiesToList(List<String> veggies) {
+    this.veggies.addAll(veggies);
+  }
+
+  @When("^we go grocery shopping$")
+  public void gatherFood() {
+    cart.addAll(fruits);
+    cart.addAll(veggies);
+  }
+
+  @Then("^expect the cart to contain$")
+  public void checkCart(List<String> foods) {
+    assertArrayEquals(
+      foods.toArray(new String[cart.size()]),
+      cart.toArray(new String[cart.size()])
+    );
+  }
+
+}

--- a/testprojects/src/resources/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/src/resources/org/pantsbuild/testproject/cucumber/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+resources(name='cucumber',
+  sources=['demo.feature'],
+)

--- a/testprojects/src/resources/org/pantsbuild/testproject/cucumber/demo.feature
+++ b/testprojects/src/resources/org/pantsbuild/testproject/cucumber/demo.feature
@@ -1,0 +1,15 @@
+Feature: Demonstrates the functionality of cucumber tests.
+  Background:
+    Given nothing in particular
+
+  Scenario: Demonstrates running tests works.
+    Given some fruit: peach, orange, apple
+    Given some veggies: carrot, potato, leek
+  When we go grocery shopping
+  Then expect the cart to contain: peach, orange, apple, carrot, potato, leek
+
+  Scenario: Demonstrates running more tests works.
+    Given some fruit: plum, tangerine
+    Given some veggies: onion, cabbage, lettuce
+  When we go grocery shopping
+  Then expect the cart to contain: plum, tangerine, onion, cabbage, lettuce


### PR DESCRIPTION
Cucumber Scenarios generate test Descriptions that are unusually
formatted. Cucumber sends the Scenario description as the
"class name", and the step description as the "method name". The
actual test class object is null.

This causes the junit runner itself to generate NPEs and fail on
some of our internal targets which use Cucumber. This branch
demonstrates the failure.