### PR TITLE
Allow setting SubProcPool workers via --num-foreground-workers 

### DIFF
--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -194,10 +194,12 @@ class SubprocPool(object):
     signal.signal(signal.SIGINT, lambda *args: sys.exit())
 
   @classmethod
-  def foreground(cls):
+  def foreground(cls, processes=None):
     with cls._lock:
       if cls._pool is None:
-        cls._pool = multiprocessing.Pool(initializer=SubprocPool.worker_init)
+        if processes is None:
+          processes = multiprocessing.cpu_count()
+        cls._pool = multiprocessing.Pool(processes=processes, initializer=SubprocPool.worker_init)
       return cls._pool
 
   @classmethod

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -187,6 +187,7 @@ class SubprocPool(object):
   """
   _pool = None
   _lock = threading.Lock()
+  _num_processes = multiprocessing.cpu_count()
 
   @staticmethod
   def worker_init():
@@ -194,11 +195,15 @@ class SubprocPool(object):
     signal.signal(signal.SIGINT, lambda *args: sys.exit())
 
   @classmethod
-  def foreground(cls, processes=None):
+  def set_num_processes(cls, num_processes):
+    cls._num_processes = num_processes
+
+  @classmethod
+  def foreground(cls):
     with cls._lock:
       if cls._pool is None:
-        processes = processes or multiprocessing.cpu_count()
-        cls._pool = multiprocessing.Pool(processes=processes, initializer=SubprocPool.worker_init)
+        cls._pool = multiprocessing.Pool(processes=cls._num_processes,
+                                         initializer=SubprocPool.worker_init)
       return cls._pool
 
   @classmethod

--- a/src/python/pants/base/worker_pool.py
+++ b/src/python/pants/base/worker_pool.py
@@ -197,8 +197,7 @@ class SubprocPool(object):
   def foreground(cls, processes=None):
     with cls._lock:
       if cls._pool is None:
-        if processes is None:
-          processes = multiprocessing.cpu_count()
+        processes = processes or multiprocessing.cpu_count()
         cls._pool = multiprocessing.Pool(processes=processes, initializer=SubprocPool.worker_init)
       return cls._pool
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -67,7 +67,8 @@ class RunTracker(Subsystem):
     register('--num-foreground-workers', advanced=True, type=int,
              default=multiprocessing.cpu_count(),
              help='Number of threads for foreground work.')
-    register('--num-background-workers', advanced=True, type=int, default=8,
+    register('--num-background-workers', advanced=True, type=int,
+             default=multiprocessing.cpu_count(),
              help='Number of threads for background work.')
 
   def __init__(self, *args, **kwargs):
@@ -124,7 +125,8 @@ class RunTracker(Subsystem):
     self._background_root_workunit = None
 
     # Trigger subproc pool init while our memory image is still clean (see SubprocPool docstring).
-    SubprocPool.foreground(self._num_foreground_workers)
+    SubprocPool.set_num_processes(self._num_foreground_workers)
+    SubprocPool.foreground()
 
     self._aborted = False
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import json
+import multiprocessing
 import os
 import sys
 import threading
@@ -63,7 +64,8 @@ class RunTracker(Subsystem):
              help='Upload stats to this URL on run completion.')
     register('--stats-upload-timeout', advanced=True, type=int, default=2,
              help='Wait at most this many seconds for the stats upload to complete.')
-    register('--num-foreground-workers', advanced=True, type=int, default=8,
+    register('--num-foreground-workers', advanced=True, type=int,
+             default=multiprocessing.cpu_count(),
              help='Number of threads for foreground work.')
     register('--num-background-workers', advanced=True, type=int, default=8,
              help='Number of threads for background work.')

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -122,7 +122,7 @@ class RunTracker(Subsystem):
     self._background_root_workunit = None
 
     # Trigger subproc pool init while our memory image is still clean (see SubprocPool docstring).
-    SubprocPool.foreground()
+    SubprocPool.foreground(self._num_foreground_workers)
 
     self._aborted = False
 


### PR DESCRIPTION
SubProcPool is defaulting to cpu_count() number of workers, which causes extra threads contention on mesos container environment where cpu_count() >> actual available cores.

_num-foreground-workers is set but never used, I suspect it's intended to influence SubProcPool.

@stuhood @jsirois @benjyw please review.

Note, dup of #2505 since I force-pushed the branch screwing up github PR.