### PR TITLE
Getting the ./pants junit runner to work with Cucumber scenarios.

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -180,6 +180,7 @@ class AntJunitXmlReportListener extends RunListener {
   @XmlRootElement(name = "testsuite")
   static class TestSuite {
     private final String name;
+    private final Class<?> testClass;
 
     private int errors;
     private int failures;
@@ -203,10 +204,12 @@ class AntJunitXmlReportListener extends RunListener {
     TestSuite() {
       // for JAXB
       name = null;
+      testClass = null;
     }
 
     TestSuite(Description test) {
       name = test.getClassName();
+      testClass = test.getTestClass();
       try {
         hostname = InetAddress.getLocalHost().getHostName();
       } catch (UnknownHostException e) {
@@ -304,8 +307,8 @@ class AntJunitXmlReportListener extends RunListener {
     }
   }
 
-  private final Map<Class<?>, TestSuite> suites = Maps.newHashMap();
-  private final Map<Description, TestCase> cases = Maps.newHashMap();
+  private final Map<String, TestSuite> suites = Maps.newHashMap();
+  private final Map<String, TestCase> cases = Maps.newHashMap();
 
   private final File outdir;
   private final StreamSource streamSource;
@@ -320,11 +323,19 @@ class AntJunitXmlReportListener extends RunListener {
     createSuites(description.getChildren());
   }
 
-  private void createSuites(Iterable<Description> tests) {
+  private TestSuite getTestSuiteFor(Description description) {
+    return suites.get(description.getClassName());
+  }
+
+  private TestCase getTestCaseFor(Description description) {
+    return cases.get(Util.getPantsFriendlyDisplayName(description));
+  }
+
+  private void createSuites(Iterable<Description> tests) throws java.lang.Exception {
     for (Description test : tests) {
       createSuites(test.getChildren());
       if (Util.isRunnable(test)) {
-        Class<?> testClass = test.getTestClass();
+        String testClass = test.getClassName();
         TestSuite suite = suites.get(testClass);
         if (suite == null) {
           suite = new TestSuite(test);
@@ -332,15 +343,16 @@ class AntJunitXmlReportListener extends RunListener {
         }
         TestCase testCase = new TestCase(test);
         suite.testCases.add(testCase);
-        cases.put(test, testCase);
+        cases.put(Util.getPantsFriendlyDisplayName(test), testCase);
       }
     }
   }
 
   @Override
   public void testStarted(Description description) throws java.lang.Exception {
-    suites.get(description.getTestClass()).started();
-    cases.get(description).started();
+    if (!Util.isRunnable(description)) return;
+    getTestSuiteFor(description).started();
+    getTestCaseFor(description).started();
   }
 
   @Override
@@ -350,10 +362,7 @@ class AntJunitXmlReportListener extends RunListener {
     boolean isFailure = Util.isAssertionFailure(failure);
     TestSuite suite = null;
 
-    Class<?> testClass = description.getTestClass();
-    if (testClass != null) {
-      suite = suites.get(testClass);
-    }
+    suite = getTestSuiteFor(description);
     if (suite == null) {
       incrementUnknownSuiteFailure(description);
     } else {
@@ -364,7 +373,7 @@ class AntJunitXmlReportListener extends RunListener {
       }
     }
 
-    TestCase testCase = cases.get(description);
+    TestCase testCase = getTestCaseFor(description);
     if (testCase == null) {
       incrementUnknownTestCaseFailure(description, exception);
     } else {
@@ -378,19 +387,30 @@ class AntJunitXmlReportListener extends RunListener {
 
   @Override
   public void testFinished(Description description) throws java.lang.Exception {
-    cases.get(description).finished();
-    suites.get(description.getTestClass()).finished();
+    if (!Util.isRunnable(description)) {
+      return;
+    }
+    try {
+      getTestCaseFor(description).finished();
+    } catch (NullPointerException e) {
+      throw new RuntimeException("No TestCase for '" + description.getClassName() + "#"
+          + description.getMethodName() + "'");
+    }
+    try {
+      getTestSuiteFor(description).finished();
+    } catch (NullPointerException e) {
+      throw new RuntimeException("No suite for '" + description.getClassName() + "'.");
+    }
   }
 
   @Override
   public void testRunFinished(Result result) throws java.lang.Exception {
-    for (Entry<Class<?>, TestSuite> entry : suites.entrySet()) {
-      Class<?> testClass = entry.getKey();
-      TestSuite suite = entry.getValue();
-
+    for (TestSuite suite : suites.values()) {
       if (suite.wasStarted()) {
-        suite.setOut(new String(streamSource.readOut(testClass), Charsets.UTF_8));
-        suite.setErr(new String(streamSource.readErr(testClass), Charsets.UTF_8));
+        if (suite.testClass != null) {
+          suite.setOut(new String(streamSource.readOut(suite.testClass), Charsets.UTF_8));
+          suite.setErr(new String(streamSource.readErr(suite.testClass), Charsets.UTF_8));
+        }
 
         Writer xmlOut = new FileWriter(new File(outdir, String.format("TEST-%s.xml", suite.name)));
 
@@ -473,14 +493,14 @@ class AntJunitXmlReportListener extends RunListener {
    * @param exception exception to record.
    */
   private void incrementUnknownSuiteFailure(Description description) {
-    if (description == null || description.getTestClass() == null) {
+    if (description == null || description.getClassName() == null) {
       description = Description.createTestDescription(UnknownFailureSuite.class,
           "unknown");
     }
-    TestSuite unknownSuite = suites.get(description.getTestClass());
+    TestSuite unknownSuite = getTestSuiteFor(description);
     if (unknownSuite == null) {
       unknownSuite = new TestSuite(description);
-      suites.put(description.getTestClass(), unknownSuite);
+      suites.put(description.getClassName(), unknownSuite);
     }
     unknownSuite.incrementFailures();
   }
@@ -498,10 +518,10 @@ class AntJunitXmlReportListener extends RunListener {
    * @param exception exception to record.
    */
   private void incrementUnknownTestCaseFailure(Description description, Exception exception) {
-    TestCase unknownCase = cases.get(description);
+    TestCase unknownCase = getTestCaseFor(description);
     if (unknownCase == null) {
       unknownCase = new TestCase(description);
-      cases.put(description, unknownCase);
+      cases.put(Util.getPantsFriendlyDisplayName(description), unknownCase);
     }
     unknownCase.setFailure(exception);
   }
@@ -511,11 +531,12 @@ class AntJunitXmlReportListener extends RunListener {
   }
 
   @VisibleForTesting
-  protected Map<Class<?>, TestSuite> getSuites() {
+  protected Map<String, TestSuite> getSuites() {
     return suites;
   }
+
   @VisibleForTesting
-  protected Map<Description, TestCase> getCases() {
+  protected Map<String, TestCase> getCases() {
     return cases;
   }
 }

--- a/testprojects/3rdparty/cucumber/BUILD
+++ b/testprojects/3rdparty/cucumber/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jar_library(name='cuke-core',
+  jars=[
+    jar(org='info.cukes', name='cucumber-core', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='cuke-guice',
+  jars=[
+    jar(org='info.cukes', name='cucumber-guice', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='cuke-java',
+  jars=[
+    jar(org='info.cukes', name='cucumber-java', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='cuke-junit',
+  jars=[
+    jar(org='info.cukes', name='cucumber-junit', rev='1.2.4',)
+  ],
+)
+
+jar_library(name='com.google.inject.guice',
+  jars=[
+    jar(org='com.google.inject', name='guice', rev='4.0',)
+  ],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+junit_tests(name='cucumber',
+  sources=['CukeTest.java'],
+  dependencies=[
+    ':lib',
+  ],
+)
+
+java_library(name='lib',
+  sources=[
+    'DemoSteps.java',
+  ],
+  dependencies=[
+    '3rdparty:junit',
+    'testprojects/3rdparty/cucumber:cuke-core',
+    'testprojects/3rdparty/cucumber:cuke-guice',
+    'testprojects/3rdparty/cucumber:cuke-java',
+    'testprojects/3rdparty/cucumber:cuke-junit',
+    'testprojects/3rdparty/cucumber:com.google.inject.guice',
+    'testprojects/tests/resources/org/pantsbuild/testproject/cucumber',
+  ],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/CukeTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/CukeTest.java
@@ -1,0 +1,21 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.cucumber;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(Cucumber.class) @CucumberOptions(
+    glue = {"org.pantsbuild.testproject.cucumber"})
+public class CukeTest {
+
+  @Test public void normalTest() {
+    assertEquals("CukeTest", getClass().getSimpleName());
+  }
+
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
@@ -1,0 +1,58 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.cucumber;
+
+import java.util.List;
+import java.util.LinkedList;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import static org.junit.Assert.assertArrayEquals;
+
+@ScenarioScoped
+public class DemoSteps {
+
+  private List<String> fruits;
+  private List<String> veggies;
+  private List<String> cart;
+
+  @Before public void before() {
+    fruits = new LinkedList<String>();
+    veggies = new LinkedList<String>();
+  }
+
+  @After public void after() {
+    fruits = null;
+    veggies = null;
+  }
+
+  @Given("^some fruit$")
+  public void addFruitToList(List<String> fruits) {
+    this.fruits.addAll(fruits);
+  }
+
+  @Given("^some veggies$")
+  public void addVeggiesToList(List<String> veggies) {
+    this.veggies.addAll(veggies);
+  }
+
+  @When("^we go grocery shopping$")
+  public void gatherFood() {
+    cart.addAll(fruits);
+    cart.addAll(veggies);
+  }
+
+  @Then("^expect the cart to contain$")
+  public void checkCart(List<String> foods) {
+    assertArrayEquals(
+      foods.toArray(new String[cart.size()]),
+      cart.toArray(new String[cart.size()])
+    );
+  }
+
+}

--- a/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+resources(name='cucumber',
+  sources=['demo.feature'],
+)

--- a/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/demo.feature
+++ b/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/demo.feature
@@ -1,0 +1,15 @@
+Feature: Demonstrates the functionality of cucumber tests.
+  Background:
+    Given nothing in particular
+
+  Scenario: Demonstrates running tests works.
+    Given some fruit: peach, orange, apple
+    Given some veggies: carrot, potato, leek
+  When we go grocery shopping
+  Then expect the cart to contain: peach, orange, apple, carrot, potato, leek
+
+  Scenario: Demonstrates running more tests works.
+    Given some fruit: plum, tangerine
+    Given some veggies: onion, cabbage, lettuce
+  When we go grocery shopping
+  Then expect the cart to contain: plum, tangerine, onion, cabbage, lettuce

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import codecs
 import os.path
 import time
-from unittest import skipIf
+from unittest import expectedFailure, skipIf
 
 from pants.java.distribution.distribution import DistributionLocator
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -91,3 +91,9 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
 
     # Ensure that the timeout triggered.
     self.assertIn("FAILURE: Timeout of 1 seconds reached", pants_run.stdout_data)
+
+  @expectedFailure
+  def test_junit_tests_using_cucumber(self):
+    test_spec = 'testprojects/tests/java/org/pantsbuild/testproject/cucumber'
+    with self.pants_results(['clean-all', 'test.junit', test_spec]) as results:
+      self.assert_success(results)

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -20,6 +20,8 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       # to be first in the context, and test.junit mixes all classpaths.
       'testprojects/maven_layout/resource_collision/example_b/src/test/java/org/pantsbuild/duplicateres/exampleb:exampleb',
       'testprojects/maven_layout/resource_collision/example_c/src/test/java/org/pantsbuild/duplicateres/examplec:examplec',
+      # This will fail until we release and upgrade to junit runner 0.0.11.
+      'testprojects/tests/java/org/pantsbuild/testproject/cucumber',
     ]
 
     # Targets that are intended to fail


### PR DESCRIPTION
Cucumber Scenarios generate test Descriptions that are unusually
formatted. Cucumber sends the Scenario description as the
"class name", and the step description as the "method name". The
actual test class object is null.

This was causing the junit runner itself to generate NPEs and fail
on some of our internal targets which use Cucumber.

This fixes the problem by making the AntJunitXmlReportListener less
dependent on the specifics of what's stored in the class name and
method name fields.