### PR TITLE
Remove pytest helpers where unittest will do.

### DIFF
--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
@@ -5,11 +5,19 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import pytest
-from pants.util.contextutil import temporary_dir
+from unittest import skipUnless
+
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 from pants.contrib.cpp.toolchain.cpp_toolchain import CppToolchain
+
+
+def have_compiler():
+  try:
+    CppToolchain().compiler
+    return True
+  except CppToolchain.Error:
+    return False
 
 
 class CppIntegrationTest(PantsRunIntegrationTest):
@@ -22,46 +30,34 @@ class CppIntegrationTest(PantsRunIntegrationTest):
   TEST_LIBRARY_TARGET = 'contrib/cpp/examples/src/cpp/example/hello'
   TEST_RUN_TARGET = TEST_SIMPLE_BINARY_TARGET
 
-  @classmethod
-  def has_compiler(cls):
-    try:
-      CppToolchain().compiler
-      return True
-    except CppToolchain.Error:
-      return False
+  skipUnlessHaveCompiler = skipUnless(have_compiler(),
+                                      reason='cpp integration tests require compiler')
 
-  @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
-                      reason='cpp integration tests require compiler')
+  @skipUnlessHaveCompiler
   def test_cpp_library(self):
     self._binary_test(self.TEST_LIBRARY_TARGET)
 
-  @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
-                      reason='cpp integration tests require compiler')
+  @skipUnlessHaveCompiler
   def test_cpp_library_compile(self):
     self._compile_test(self.TEST_LIBRARY_TARGET)
 
-  @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
-                      reason='cpp integration tests require compiler')
+  @skipUnlessHaveCompiler
   def test_cpp_binary(self):
     self._binary_test(self.TEST_SIMPLE_BINARY_TARGET)
 
-  @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
-                      reason='cpp integration tests require compiler')
+  @skipUnlessHaveCompiler
   def test_cpp_binary_compile(self):
     self._compile_test(self.TEST_SIMPLE_BINARY_TARGET)
 
-  @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
-                      reason='cpp integration tests require compiler')
+  @skipUnlessHaveCompiler
   def test_cpp_binary_with_library(self):
     self._binary_test(self.TEST_BINARY_WITH_LIBRARY_TARGET)
 
-  @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
-                      reason='cpp integration tests require compiler')
+  @skipUnlessHaveCompiler
   def test_cpp_binary_with_library_compile(self):
     self._compile_test(self.TEST_BINARY_WITH_LIBRARY_TARGET)
 
-  @pytest.mark.skipif('not CppIntegrationTest.has_compiler()',
-                      reason='cpp integration tests require compiler')
+  @skipUnlessHaveCompiler
   def test_cpp_run(self):
     pants_run = self.run_pants(['run', self.TEST_RUN_TARGET])
     self.assert_success(pants_run)

--- a/tests/python/pants_test/authentication/test_netrc_util.py
+++ b/tests/python/pants_test/authentication/test_netrc_util.py
@@ -6,16 +6,16 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import re
+import unittest
 from contextlib import contextmanager
 
-import pytest
 from mock import MagicMock, mock_open, patch
 
 from pants.backend.authentication.netrc_util import Netrc
 
 
 @patch('os.path')
-class TestNetrcUtil(object):
+class TestNetrcUtil(unittest.TestCase):
 
   class MockOsPath(MagicMock):
     def __init__(self):
@@ -33,21 +33,21 @@ class TestNetrcUtil(object):
   def test_netrc_file_missing_error(self, MockOsPath):
     MockOsPath.exists.return_value = False
     netrc = Netrc()
-    with pytest.raises(netrc.NetrcError) as exc:
+    with self.assertRaises(netrc.NetrcError) as exc:
       netrc._ensure_loaded()
-    assert str(exc.value) == 'A ~/.netrc file is required to authenticate'
+    assert str(exc.exception) == 'A ~/.netrc file is required to authenticate'
 
   def test_netrc_parse_error(self, MockOsPath):
     with self.netrc('machine test') as netrc:
-      with pytest.raises(netrc.NetrcError) as exc:
+      with self.assertRaises(netrc.NetrcError) as exc:
         netrc._ensure_loaded()
-      assert re.search(r'Problem parsing', exc.value.message)
+      assert re.search(r'Problem parsing', exc.exception.message)
 
   def test_netrc_no_usable_blocks(self, MockOsPath):
     with self.netrc('') as netrc:
-      with pytest.raises(netrc.NetrcError) as exc:
+      with self.assertRaises(netrc.NetrcError) as exc:
         netrc._ensure_loaded()
-      assert str(exc.value) == 'Found no usable authentication blocks in ~/.netrc'
+      assert str(exc.exception) == 'Found no usable authentication blocks in ~/.netrc'
 
   @contextmanager
   def netrc(self, netrc_contents):

--- a/tests/python/pants_test/backend/codegen/tasks/test_protobuf_parse.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_protobuf_parse.py
@@ -8,8 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import unittest
 from textwrap import dedent
-
-import pytest
+from unittest.case import expectedFailure
 
 from pants.backend.codegen.tasks.protobuf_parse import (MESSAGE_PARSER, ProtobufParse, camelcase,
                                                         get_outer_class_name, update_type_list)
@@ -124,7 +123,7 @@ class ProtobufParseTest(unittest.TestCase):
 
   # TODO(Eric Ayers) The following tests won't pass because the .proto parse is not reliable.
   #  https://github.com/pantsbuild/pants/issues/96
-  @pytest.mark.xfail
+  @expectedFailure
   def test_inner_class_no_newline(self):
     with temporary_dir() as workdir:
       filename = 'inner_class_no_newline.proto'
@@ -145,7 +144,7 @@ class ProtobufParseTest(unittest.TestCase):
         self.assertEqual(set(), proto_parse.services)
         self.assertEqual('InnerClassNoNewline', proto_parse.outer_class_name)
 
-  @pytest.mark.xfail
+  @expectedFailure
   def test_no_newline_at_all1(self):
     with temporary_dir() as workdir:
       filename = 'no_newline_at_all1.proto'
@@ -161,7 +160,7 @@ class ProtobufParseTest(unittest.TestCase):
         self.assertEqual(set(), proto_parse.services)
         self.assertEqual('NoNewlineAtAll1', proto_parse.outer_class_name)
 
-  @pytest.mark.xfail
+  @expectedFailure
   def test_no_newline_at_all2(self):
     with temporary_dir() as workdir:
       filename = 'no_newline_at_all2.proto'
@@ -177,7 +176,7 @@ class ProtobufParseTest(unittest.TestCase):
         self.assertEqual(set(), proto_parse.services)
         self.assertEqual('NoNewlineAtAll2', proto_parse.outer_class_name)
 
-  @pytest.mark.xfail
+  @expectedFailure
   def test_no_newline_at_all3(self):
     with temporary_dir() as workdir:
       filename = 'no_newline_at_all3.proto'
@@ -192,7 +191,7 @@ class ProtobufParseTest(unittest.TestCase):
         self.assertEqual(set(), proto_parse.services)
         self.assertEqual('NoNewlineAtAll3', proto_parse.outer_class_name)
 
-  @pytest.mark.xfail
+  @expectedFailure
   def test_crazy_whitespace(self):
     with temporary_dir() as workdir:
       filename = 'crazy_whitespace.proto'

--- a/tests/python/pants_test/backend/python/tasks/checkstyle/test_common.py
+++ b/tests/python/pants_test/backend/python/tasks/checkstyle/test_common.py
@@ -9,8 +9,6 @@ import ast
 import textwrap
 import unittest
 
-import pytest
-
 from pants.backend.python.tasks.checkstyle.common import (CheckstylePlugin, Nit, OffByOneList,
                                                           PythonFile)
 from pants_test.option.util.fakes import create_options
@@ -79,12 +77,12 @@ class CommonTest(unittest.TestCase):
 
     PythonFile is offset by one to match users expectations with file line numbering.
     """
-    with pytest.raises(IndexError):
+    with self.assertRaises(IndexError):
       self._python_file_for_testing()[0]
 
   def test_python_file_exceeds_index(self):
     """Test that we get an Index error when we exceed the line number."""
-    with pytest.raises(IndexError):
+    with self.assertRaises(IndexError):
       self._python_file_for_testing()[len(self._statement_for_testing().split('\n')) + 1]
 
   def test_line_retrieval(self):
@@ -166,14 +164,14 @@ class CommonTest(unittest.TestCase):
     """Test index errors with data in list."""
     test_list = OffByOneList([])
     for k in (0, 4):
-      with pytest.raises(IndexError):
+      with self.assertRaises(IndexError):
         test_list[k]
 
   def test_index_error_no_data(self):
     """Test that when start or end are -1,0, or 1 we get an index error."""
     for index in [-1, 0, 1, slice(-1,0), slice(0,1)]:
       test_list = OffByOneList([])
-      with pytest.raises(IndexError):
+      with self.assertRaises(IndexError):
         test_list[index]
 
   def test_empty_slice(self):
@@ -196,5 +194,5 @@ class CommonTest(unittest.TestCase):
     test_list = OffByOneList([])
     # Test index type sanity.
     for value in (None, 2.0, type):
-      with pytest.raises(TypeError):
+      with self.assertRaises(TypeError):
         test_list[value]

--- a/tests/python/pants_test/base/test_revision.py
+++ b/tests/python/pants_test/base/test_revision.py
@@ -7,8 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-import pytest
-
 from pants.base.revision import Revision
 
 
@@ -20,7 +18,7 @@ class RevisionTest(unittest.TestCase):
 class SemverTest(RevisionTest):
   def test_bad(self):
     for bad_rev in ('a.b.c', '1.b.c', '1.2.c', '1.2.3;4', '1.2.3;4+5'):
-      with pytest.raises(Revision.BadRevision):
+      with self.assertRaises(Revision.BadRevision):
         Revision.semver(bad_rev)
 
   def test_simple(self):

--- a/tests/python/pants_test/fs/test_safe_filename.py
+++ b/tests/python/pants_test/fs/test_safe_filename.py
@@ -8,8 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import unittest
 
-import pytest
-
 from pants.fs.fs import safe_filename
 
 
@@ -25,7 +23,7 @@ class SafeFilenameTest(unittest.TestCase):
       return self._size * '*'
 
   def test_bad_name(self):
-    with pytest.raises(ValueError):
+    with self.assertRaises(ValueError):
       safe_filename(os.path.join('more', 'than', 'a', 'name.game'))
 
   def test_noop(self):
@@ -37,5 +35,5 @@ class SafeFilenameTest(unittest.TestCase):
                      safe_filename('jack', '.jill', digest=self.FixedDigest(2), max_length=8))
 
   def test_shorten_fail(self):
-    with pytest.raises(ValueError):
+    with self.assertRaises(ValueError):
       safe_filename('jack', '.beanstalk', digest=self.FixedDigest(3), max_length=12)

--- a/tests/python/pants_test/net/http/test_fetcher.py
+++ b/tests/python/pants_test/net/http/test_fetcher.py
@@ -9,7 +9,6 @@ import os
 from contextlib import closing
 
 import mox
-import pytest
 import requests
 from six import StringIO
 
@@ -102,7 +101,7 @@ class FetcherTest(mox.MoxTestBase):
 
     self.mox.ReplayAll()
 
-    with pytest.raises(self.fetcher.Error):
+    with self.assertRaises(self.fetcher.Error):
       self.fetcher.fetch('http://foo',
                          self.listener,
                          chunk_size_bytes=1024,
@@ -113,7 +112,7 @@ class FetcherTest(mox.MoxTestBase):
 
     self.mox.ReplayAll()
 
-    with pytest.raises(self.fetcher.TransientError):
+    with self.assertRaises(self.fetcher.TransientError):
       self.fetcher.fetch('http://foo',
                          self.listener,
                          chunk_size_bytes=1024,
@@ -124,12 +123,12 @@ class FetcherTest(mox.MoxTestBase):
 
     self.mox.ReplayAll()
 
-    with pytest.raises(self.fetcher.PermanentError) as e:
+    with self.assertRaises(self.fetcher.PermanentError) as e:
       self.fetcher.fetch('http://foo',
                          self.listener,
                          chunk_size_bytes=1024,
                          timeout_secs=60)
-    self.assertTrue(e.value.response_code is None)
+    self.assertTrue(e.exception.response_code is None)
 
   def test_http_error(self):
     self.requests.get('http://foo', stream=True, timeout=60).AndReturn(self.response)
@@ -140,12 +139,12 @@ class FetcherTest(mox.MoxTestBase):
 
     self.mox.ReplayAll()
 
-    with pytest.raises(self.fetcher.PermanentError) as e:
+    with self.assertRaises(self.fetcher.PermanentError) as e:
       self.fetcher.fetch('http://foo',
                          self.listener,
                          chunk_size_bytes=1024,
                          timeout_secs=60)
-    self.assertEqual(404, e.value.response_code)
+    self.assertEqual(404, e.exception.response_code)
 
   def test_iter_content_error(self):
     self.requests.get('http://foo', stream=True, timeout=60).AndReturn(self.response)
@@ -158,7 +157,7 @@ class FetcherTest(mox.MoxTestBase):
 
     self.mox.ReplayAll()
 
-    with pytest.raises(self.fetcher.TransientError):
+    with self.assertRaises(self.fetcher.TransientError):
       self.fetcher.fetch('http://foo',
                          self.listener,
                          chunk_size_bytes=1024,

--- a/tests/python/pants_test/process/test_xargs.py
+++ b/tests/python/pants_test/process/test_xargs.py
@@ -9,7 +9,6 @@ import errno
 import os
 
 import mox
-import pytest
 
 from pants.process.xargs import Xargs
 
@@ -32,9 +31,9 @@ class XargsTest(mox.MoxTestBase):
     self.call(['one', 'two', 'three', 'four']).AndRaise(exception)
     self.mox.ReplayAll()
 
-    with pytest.raises(Exception) as raised:
+    with self.assertRaises(Exception) as raised:
       self.xargs.execute(['one', 'two', 'three', 'four'])
-    self.assertTrue(exception is raised.value)
+    self.assertIs(exception, raised.exception)
 
   def test_execute_nosplit_fail(self):
     self.call(['one', 'two', 'three', 'four']).AndReturn(42)

--- a/tests/python/pants_test/python/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/python/test_interpreter_selection_integration.py
@@ -8,8 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import subprocess
 
-import pytest
-
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -36,7 +34,7 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
       self.assertEquals(version, '%s.%s' % (v[0], v[1]))
     else:
       print('No python %s found. Skipping.' % version)
-      pytest.skip('No python %s on system' % version)
+      self.skipTest('No python %s on system' % version)
 
   def _echo_version(self, version):
     with temporary_dir() as distdir:

--- a/tests/python/pants_test/python/test_python_run_integration.py
+++ b/tests/python/pants_test/python/test_python_run_integration.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import pytest
-
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -52,7 +50,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
       self.assertEquals(version, '%s.%s' % (v[0], v[1]))
     else:
       print('No python %s found. Skipping.' % version)
-      pytest.skip('No python %s on system' % version)
+      self.skipTest('No python %s on system' % version)
 
   def _run_echo_version(self, version):
     binary_name = 'echo_interpreter_version_%s' % version

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -12,8 +12,7 @@ import unittest
 from contextlib import contextmanager
 from itertools import izip_longest
 from textwrap import dedent
-
-import pytest
+from unittest import skipIf
 
 from pants.scm.git import Git
 from pants.scm.scm import Scm
@@ -65,7 +64,7 @@ def git_version():
   return Version(matches.group(1))
 
 
-@pytest.mark.skipif("git_version() < Version('1.7.10')")
+@skipIf(git_version() < Version('1.7.10'), 'The GitTest requires git >= 1.7.10.')
 class GitTest(unittest.TestCase):
 
   @staticmethod

--- a/tests/python/pants_test/targets/test_python_binary.py
+++ b/tests/python/pants_test/targets/test_python_binary.py
@@ -20,7 +20,7 @@ class TestPythonBinary(BaseTest):
     self.context()
 
   def test_python_binary_must_have_some_entry_point(self):
-    with pytest.raises(TargetDefinitionException):
+    with self.assertRaises(TargetDefinitionException):
       self.make_target(spec=':binary', target_type=PythonBinary)
 
   def test_python_binary_with_entry_point_no_source(self):
@@ -51,22 +51,22 @@ class TestPythonBinary(BaseTest):
                                                 source='bin/blork.py').entry_point
 
   def test_python_binary_with_entry_point_and_source_mismatch(self):
-    with pytest.raises(TargetDefinitionException):
+    with self.assertRaises(TargetDefinitionException):
       self.make_target(spec=':binary1',
                        target_type=PythonBinary,
                        entry_point='blork',
                        source='hork.py')
-    with pytest.raises(TargetDefinitionException):
+    with self.assertRaises(TargetDefinitionException):
       self.make_target(spec=':binary2',
                        target_type=PythonBinary,
                        entry_point='blork:main',
                        source='hork.py')
-    with pytest.raises(TargetDefinitionException):
+    with self.assertRaises(TargetDefinitionException):
       self.make_target(spec=':binary3',
                        target_type=PythonBinary,
                        entry_point='bin.blork',
                        source='blork.py')
-    with pytest.raises(TargetDefinitionException):
+    with self.assertRaises(TargetDefinitionException):
       self.make_target(spec=':binary4',
                        target_type=PythonBinary,
                        entry_point='bin.blork',

--- a/tests/python/pants_test/targets/test_sort_targets.py
+++ b/tests/python/pants_test/targets/test_sort_targets.py
@@ -29,7 +29,7 @@ class SortTargetsTest(BaseTest):
     # no cycles yet
     sort_targets([a])
     self.build_graph.inject_dependency(a.address, a.address)
-    with pytest.raises(CycleException):
+    with self.assertRaises(CycleException):
       sort_targets([a])
 
   def test_detect_cycle_indirect(self):
@@ -41,7 +41,7 @@ class SortTargetsTest(BaseTest):
     sort_targets([a])
 
     self.build_graph.inject_dependency(c.address, a.address)
-    with pytest.raises(CycleException):
+    with self.assertRaises(CycleException):
       sort_targets([a])
 
   def test_sort(self):

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -6,10 +6,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from unittest import expectedFailure
 
-import pytest
-
-from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -24,7 +22,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
     path = 'compile/jvm/java/classes/org/pantsbuild/example/hello/greet'.split('/')
     return os.path.join(workdir, *(path + [filename]))
 
-  @pytest.mark.xfail
+  @expectedFailure
   def test_compile_changed(self):
     cmd = ['compile-changed', '--diffspec={}'.format(self.ref_for_greet_change())]
 
@@ -52,7 +50,7 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
       self.assertTrue(os.path.exists(self.greet_classfile(workdir, 'Greeting.class')))
       self.assertTrue(os.path.exists(self.greet_classfile(workdir, 'GreetingTest.class')))
 
-  @pytest.mark.xfail
+  @expectedFailure
   def test_test_changed(self):
     with self.temporary_workdir() as workdir:
       cmd = ['test-changed', '--diffspec={}'.format(self.ref_for_greet_change())]

--- a/tests/python/pants_test/tasks/test_console_task.py
+++ b/tests/python/pants_test/tasks/test_console_task.py
@@ -9,8 +9,6 @@ import os
 import threading
 from Queue import Empty, Queue
 
-import pytest
-
 from pants.backend.core.tasks.console_task import ConsoleTask
 from pants_test.tasks.task_test_base import TaskTestBase
 
@@ -55,9 +53,9 @@ class ConsoleTaskTest(TaskTestBase):
       task.stop()
       execution.join()
 
-    with pytest.raises(Empty):
+    with self.assertRaises(Empty):
       e = raised.get_nowait()
 
-      # Instead of taking the generic pytest.raises message, provide a more detailed failure
+      # Instead of taking the generic assertRaises raises message, provide a more detailed failure
       # message that shows exactly what untrapped error was on the queue.
       self.fail('task raised {0}'.format(e))

--- a/tests/python/pants_test/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/tasks/test_jar_publish.py
@@ -244,7 +244,7 @@ class JarPublishTest(TaskTestBase):
     self.assertEquals(1, task.scm.push.call_count)
 
   def test_publish_local_only(self):
-    with pytest.raises(TaskError):
+    with self.assertRaises(TaskError):
       self.create_task(self.context())
 
 

--- a/tests/python/pants_test/tasks/test_list_goals.py
+++ b/tests/python/pants_test/tasks/test_list_goals.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import pytest
+from unittest import expectedFailure
 
 from pants.backend.core.tasks.list_goals import ListGoals
 from pants.backend.core.tasks.task import Task
@@ -82,7 +82,7 @@ class ListGoalsTest(ConsoleTaskTestBase):
 
   # TODO(John Sirois): Re-enable when fixing up ListGoals `--graph` in
   # https://github.com/pantsbuild/pants/issues/918
-  @pytest.mark.xfail
+  @expectedFailure
   def test_list_goals_graph(self):
     Goal.clear()
 


### PR DESCRIPTION
This is a global cleanup.  Some instances of pytest helper use are left
but they either are in tests that use test functions or where there is
no equivalent functionality in unittest(2).

https://rbcommons.com/s/twitter/r/3091/