### PR TITLE
Enable optional cleaning of additional pants generated dirs

### DIFF
--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -36,10 +36,10 @@ class Cleaner(Task):
   @classmethod
   def register_options(cls, register):
     super(Cleaner, cls).register_options(register)
-    register('--include-ivy', action='store_true', default=False,
-             help='include .ivy directory')
-    register('--include-buildcache', action='store_true', default=False,
-             help='include .buildcache directory')
+    register('--clean-ivy', action='store_true', default=False,
+             help='include ivy cache directory')
+    register('--clean-cache', action='store_true', default=False,
+             help='include cache directory')
 
   def execute(self):
     print()

--- a/src/python/pants/backend/core/tasks/clean.py
+++ b/src/python/pants/backend/core/tasks/clean.py
@@ -8,6 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.backend.core.tasks.task import Task
+from pants.cache.cache_setup import CacheSetup
+from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.util.dirutil import safe_rmtree
 
 
@@ -22,5 +24,51 @@ class Invalidator(Task):
 class Cleaner(Task):
   """Clean all current build products."""
 
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(Cleaner, cls).subsystem_dependencies() + (
+      CacheSetup.scoped(cls), IvySubsystem.scoped(cls))
+
+  @classmethod
+  def task_subsystems(cls):
+    return super(Cleaner, cls).task_subsystems() + (IvySubsystem,)
+
+  @classmethod
+  def register_options(cls, register):
+    super(Cleaner, cls).register_options(register)
+    register('--skip-ivy', action='store_true', default=True,
+             help='Skip .ivy directory')
+    register('--skip-buildcache', action='store_true', default=True,
+             help='Skip .buildcache directory')
+    register('--skip-pex', action='store_true', default=True,
+             help='Skip .pex directory')
+
   def execute(self):
+    print()
+
+    options = self.get_options()
+    cache = CacheSetup.scoped_instance(self)
+    cache_options = cache.get_options()
+
+    ivy = IvySubsystem.scoped_instance(self)
+    ivy_options = ivy.get_options()
+
     safe_rmtree(self.get_options().pants_workdir)
+    if not options.skip_buildcache and cache_options.read_from:
+      for dir in cache_options.read_from:
+        print('Removing cache [read] dir: {}'.format(dir))
+        safe_rmtree(dir)
+
+    if not options.skip_buildcache and cache_options.write_to:
+      for dir in cache_options.write_to:
+        print('Removing cache [read] dir: {}'.format(dir))
+        safe_rmtree(dir)
+
+    if not self.get_options().skip_pex:
+      pex_path = os.path.join(options.pants_workdir, '.pex')
+      print('Removing .pex dir: {}'.format(pex_path))
+      safe_rmtree(pex_path)
+
+    if not options.skip_ivy:
+      print('Removing Ivy cache dir: {}'.format(ivy_options.cache_dir))
+      safe_rmtree(ivy_options.cache_dir)

--- a/tests/python/pants_test/backend/core/tasks/BUILD
+++ b/tests/python/pants_test/backend/core/tasks/BUILD
@@ -27,9 +27,16 @@ python_tests(
 )
 
 python_tests(
+  name='clean_all',
+  sources=['test_cleanall.py'],
+  coverage=['pants.backend.core.tasks.clean_all'],
+  dependencies=['src/python/pants/util:dirutil']
+)
+
+python_tests(
   name='cache_cleanup',
-  sources=['test_cache_cleanup.py'],
-  coverage=['pants.backend.core.tasks.bash_completion'],
+  sources=['test_cleanall.py'],
+  coverage=['pants.backend.core.tasks.cache_cleanup'],
   dependencies=[
     'src/python/pants/backend/jvm/tasks/jvm_compile:zinc',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/backend/core/tasks/BUILD
+++ b/tests/python/pants_test/backend/core/tasks/BUILD
@@ -12,6 +12,8 @@ target(
     ':scm_publish',
     ':target_filter_task_mixin',
     ':test_task_mixin',
+    ':clean_all',
+    ':cache_cleanup',
   ],
 )
 
@@ -30,12 +32,15 @@ python_tests(
   name='clean_all',
   sources=['test_cleanall.py'],
   coverage=['pants.backend.core.tasks.clean_all'],
-  dependencies=['src/python/pants/util:dirutil']
+  dependencies=[
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:int-test',
+  ]
 )
 
 python_tests(
   name='cache_cleanup',
-  sources=['test_cleanall.py'],
+  sources=['test_cache_cleanup.py'],
   coverage=['pants.backend.core.tasks.cache_cleanup'],
   dependencies=[
     'src/python/pants/backend/jvm/tasks/jvm_compile:zinc',

--- a/tests/python/pants_test/backend/core/tasks/test_cleanall.py
+++ b/tests/python/pants_test/backend/core/tasks/test_cleanall.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class CleanAllTest(PantsRunIntegrationTest):
+  def gen_ivy_option(self, f):
+    return '--ivy-cache-dir={}'.format(f)
+
+  def test_optional_removal_positive(self):
+    """Verify that directories are moved when specified"""
+    with temporary_dir() as cache_dir:
+      with temporary_dir() as ivy_dir:
+        pex_dir = os.environ.get('PEX_ROOT')
+        config = {
+          'cache': {'write_to': [cache_dir],
+                    'read_from': [cache_dir]},
+        }
+
+        pants_run = self.run_pants(['clean-all',
+                                    '--no-skip-buildcache',
+                                    '--no-skip-ivy',
+                                    '--no-skip-pex',
+                                    self.gen_ivy_option(ivy_dir)
+                                    ],
+                                   config=config)
+        print()
+        map(print,pants_run.stdout_data.split('\n'))
+        self.assert_success(pants_run)
+
+        assert not os.path.exists(cache_dir), 'Cache dir still exists'.format(cache_dir)
+        assert not os.path.exists(ivy_dir), 'Ivy dir still exists {}'.format(ivy_dir)
+
+  def test_optional_removal_negative(self):
+    """Verify that directories are left alone if skipped"""
+    with temporary_dir() as cache_dir:
+      with temporary_dir() as ivy_dir:
+        config = {
+          'cache': {'write_to': [cache_dir],
+                    'read_from': [cache_dir]},
+          'ivy': {'cache_dir': [ivy_dir]}
+        }
+
+        pants_run = self.run_pants(['clean-all',
+                                    '--skip-buildcache',
+                                    '--skip-ivy',
+                                    '--skip-pex',
+                                    ],
+                                   config=config)
+        self.assert_success(pants_run)
+
+        self.assertTrue(os.path.exists(cache_dir))
+        self.assertTrue(os.path.exists(ivy_dir))

--- a/tests/python/pants_test/backend/core/tasks/test_cleanall.py
+++ b/tests/python/pants_test/backend/core/tasks/test_cleanall.py
@@ -21,14 +21,13 @@ class CleanAllTest(PantsRunIntegrationTest):
       with temporary_dir() as ivy_dir:
         pex_dir = os.environ.get('PEX_ROOT')
         config = {
-          'cache': {'write_to': [cache_dir],
-                    'read_from': [cache_dir]},
+          'cache': {'write_to': [cache_dir, 'https://pants.build.com/test'],
+                    'read_from': [cache_dir, 'https://pants.build.com/test']},
         }
 
         pants_run = self.run_pants(['clean-all',
-                                    '--no-skip-buildcache',
-                                    '--no-skip-ivy',
-                                    '--no-skip-pex',
+                                    '--include-buildcache',
+                                    '--include-ivy',
                                     self.gen_ivy_option(ivy_dir)
                                     ],
                                    config=config)
@@ -44,15 +43,14 @@ class CleanAllTest(PantsRunIntegrationTest):
     with temporary_dir() as cache_dir:
       with temporary_dir() as ivy_dir:
         config = {
-          'cache': {'write_to': [cache_dir],
-                    'read_from': [cache_dir]},
+          'cache': {'write_to': [cache_dir, 'https://pants.build.com/test'],
+                    'read_from': [cache_dir, 'https://pants.build.com/test']},
           'ivy': {'cache_dir': [ivy_dir]}
         }
 
         pants_run = self.run_pants(['clean-all',
-                                    '--skip-buildcache',
-                                    '--skip-ivy',
-                                    '--skip-pex',
+                                    '--no-include-buildcache',
+                                    '--no-include-ivy',
                                     ],
                                    config=config)
         self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/core/tasks/test_cleanall.py
+++ b/tests/python/pants_test/backend/core/tasks/test_cleanall.py
@@ -35,8 +35,8 @@ class CleanAllTest(PantsRunIntegrationTest):
         map(print,pants_run.stdout_data.split('\n'))
         self.assert_success(pants_run)
 
-        assert not os.path.exists(cache_dir), 'Cache dir still exists'.format(cache_dir)
-        assert not os.path.exists(ivy_dir), 'Ivy dir still exists {}'.format(ivy_dir)
+        self.assertFalse(os.path.exists(cache_dir))
+        self.assertFalse(os.path.exists(ivy_dir))
 
   def test_optional_removal_negative(self):
     """Verify that directories are left alone if skipped"""

--- a/tests/python/pants_test/backend/core/tasks/test_cleanall.py
+++ b/tests/python/pants_test/backend/core/tasks/test_cleanall.py
@@ -26,8 +26,8 @@ class CleanAllTest(PantsRunIntegrationTest):
         }
 
         pants_run = self.run_pants(['clean-all',
-                                    '--include-buildcache',
-                                    '--include-ivy',
+                                    '--clean-buildcache',
+                                    '--clean-ivy',
                                     self.gen_ivy_option(ivy_dir)
                                     ],
                                    config=config)
@@ -49,8 +49,8 @@ class CleanAllTest(PantsRunIntegrationTest):
         }
 
         pants_run = self.run_pants(['clean-all',
-                                    '--no-include-buildcache',
-                                    '--no-include-ivy',
+                                    '--no-clean-buildcache',
+                                    '--no-clean-ivy',
                                     ],
                                    config=config)
         self.assert_success(pants_run)


### PR DESCRIPTION
* Isolate pants pex root so that it doesn't interfere with other
  users .pex dir
* Add an option to repro that allows the user to ignore dirs.  This
  was added to allow users to submit an archive of important dirs
  when they do clean-all that don't include the whole source tree.
* Update repro to expand userdir

  For example:
    pants --repro-capture=/tmp/data.tar.gz --repro-ignore=src clean-all

* Add the ability to clean .pex
* Add the ability to clean .buildcache
* Add the ability to clean .ivy2