### PR TITLE
Prepare the `0.0.57` hotfix release.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -70,6 +70,7 @@ Created by running `./build-support/bin/contributors.sh`.
 + Mark McBride
 + Mateo Rodriguez
 + Mathew Jennings
++ Matt Landis
 + Matt Olsen
 + Matthew Jeffryes
 + Maxim Khutornenko
@@ -97,6 +98,7 @@ Created by running `./build-support/bin/contributors.sh`.
 + Tejal Desai
 + Tianshuo Deng
 + Tien Nguyen
++ Timur Abishev
 + Tina Huang
 + Todd Stumpf
 + Tom Dyas

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -1,6 +1,47 @@
 RELEASE HISTORY
 ===============
 
+0.0.57 (11/09/2015)
+-------------------
+
+Release Notes
+~~~~~~~~~~~~~
+
+This is a hotfix release that fixes a bug preventing repos using `plugins` in the `DEFAULT` section
+of `pants.ini` from upgrading to `0.0.56`.
+
+API Changes
+~~~~~~~~~~~
+
+* API Change: Move graph walking out of classpath_(util|products)
+  `RB #3036 <https://rbcommons.com/s/twitter/r/3036>`_
+
+Bugfixes
+~~~~~~~~
+
+* Fix bug when analysis file is corrupt or missing during an incremental compile
+  `RB #3101 <https://rbcommons.com/s/twitter/r/3101>`_
+
+* Update the option types for protobuf-gen to be list types, since they are all advanced.
+  `RB #3098 <https://rbcommons.com/s/twitter/r/3098>`_
+  `RB #3100 <https://rbcommons.com/s/twitter/r/3100>`_
+
+* Fix plugin option references in leaves.
+  `RB #3098 <https://rbcommons.com/s/twitter/r/3098>`_
+
+New Features
+~~~~~~~~~~~~
+
+* Seed the haskell contrib with `StackDistribution`.
+  `RB #2975 <https://rbcommons.com/s/twitter/r/2975>`_
+  `RB #3095 <https://rbcommons.com/s/twitter/r/3095>`_
+
+Small improvements, Refactoring and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Better error message for classpath entries outside the working directory
+  `RB #3099 <https://rbcommons.com/s/twitter/r/3099>`_
+
 0.0.56 (11/06/2015)
 -------------------
 
@@ -95,7 +136,7 @@ Bugfixes
 * Unshade org.pantsbuild.junit.annotation so that @TestParallel works
   `RB #3012 <https://rbcommons.com/s/twitter/r/3012>`_
 
-Improvements, Refactoring, and Tooling
+Small improvements, Refactoring and Tooling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Remove pytest helpers where unittest will do.

--- a/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
+++ b/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
@@ -45,7 +45,7 @@ class SimpleCodegenTask(Task):
              help='Skip targets with no sources defined.',
              advanced=True)
     register('--strategy', fingerprint=True, choices=['isolated', 'global'], default=None,
-              deprecated_version='0.0.57',
+              deprecated_version='0.0.58',
               deprecated_hint='Only isolated codegen is supported; this flag is ignored.',
               help='Selects the compilation strategy to use. The "global" strategy uses a shared '
                   'global directory for all generated code, and the "isolated" strategy uses '

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -77,7 +77,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
                   'which paths are used for tests.  This is usually what you want if your repo '
                   ' uses a maven style directory layout.')
     register('--infer-test-from-siblings', action='store_true',
-             deprecated_version='0.0.57',
+             deprecated_version='0.0.58',
              deprecated_hint='Setting test attribute on paths is now handled automatically.',
              help='When determining if a path should be added to the IDE, check to see if any of '
                   'its sibling source roots define test targets.  This is usually what '

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -6,4 +6,4 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 
-VERSION = '0.0.56'
+VERSION = '0.0.57'


### PR DESCRIPTION
This allow folks using `plugins` in `pants.ini` to upgrade and fixes a
regression in analysis parsing for jvm compiles.

I pushed two `0.0.57` deprecations forward to Friday.