### PR TITLE
Fixing malformatted xml report names from junit runner.

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -234,7 +234,7 @@ class AntJunitXmlReportListener extends RunListener {
 
     @XmlAttribute
     public String getName() {
-      return name;
+      return name.trim().replaceAll("[^a-zA-Z0-9_.-]", "-").replaceAll("[.]+$", "");
     }
 
     @XmlAttribute
@@ -412,7 +412,8 @@ class AntJunitXmlReportListener extends RunListener {
           suite.setErr(new String(streamSource.readErr(suite.testClass), Charsets.UTF_8));
         }
 
-        Writer xmlOut = new FileWriter(new File(outdir, String.format("TEST-%s.xml", suite.name)));
+        Writer xmlOut = new FileWriter(
+            new File(outdir, String.format("TEST-%s.xml", suite.getName())));
 
         // Only output valid XML1.0 characters - JAXB does not handle this.
         JAXB.marshal(suite, new XmlWriter(xmlOut) {

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BUILD
@@ -2,7 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(name='cucumber',
-  sources=['CukeTest.java'],
+  sources=[
+    'BadnamesTest.java',
+    'CukeTest.java',
+    'NormalTest.java',
+  ],
   dependencies=[
     ':lib',
   ],
@@ -10,6 +14,7 @@ junit_tests(name='cucumber',
 
 java_library(name='lib',
   sources=[
+    'BadnamesSteps.java',
     'DemoSteps.java',
   ],
   dependencies=[

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BadnamesSteps.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BadnamesSteps.java
@@ -1,0 +1,53 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.cucumber;
+
+import java.lang.Exception;
+import java.lang.RuntimeException;
+import java.util.List;
+import java.util.LinkedList;
+
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.When;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import static org.junit.Assert.assertArrayEquals;
+
+@ScenarioScoped
+public class BadnamesSteps {
+
+  private List<String> theStrings;
+  private List<String> theListOfStrings;
+
+  @Before public void before() {
+    theStrings = new LinkedList<String>();
+    theListOfStrings = new LinkedList<String>();
+  }
+
+  @After public void after() {
+    theStrings = null;
+    theListOfStrings = null;
+  }
+
+  @Given("^these strings: (.*)$")
+  public void theStrings(List<String> strings) {
+    this.theStrings.addAll(strings);
+  }
+
+  @When("^these string are added to a %%@@%! list$")
+  public void addStringsToList() {
+    this.theListOfStrings.addAll(this.theStrings);
+  }
+
+  @Then("^these strings should be in the list: (.*)$")
+  public void checkCart(List<String> expected) {
+    assertArrayEquals(
+        expected.toArray(new String[expected.size()]),
+        theListOfStrings.toArray(new String[theListOfStrings.size()])
+    );
+  }
+
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BadnamesTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BadnamesTest.java
@@ -11,5 +11,5 @@ import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class) @CucumberOptions(
     glue = {"org.pantsbuild.testproject.cucumber"})
-public class CukeTest {
+public class BadnamesTest {
 }

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
@@ -24,19 +24,25 @@ public class DemoSteps {
   @Before public void before() {
     fruits = new LinkedList<String>();
     veggies = new LinkedList<String>();
+    cart = new LinkedList<String>();
   }
 
   @After public void after() {
     fruits = null;
     veggies = null;
+    cart = null;
   }
 
-  @Given("^some fruit$")
+  @Given("^nothing in particular$")
+  public void nothingInParticular() {
+  }
+
+  @Given("^some fruit: (.*)$")
   public void addFruitToList(List<String> fruits) {
     this.fruits.addAll(fruits);
   }
 
-  @Given("^some veggies$")
+  @Given("^some veggies: (.*)$")
   public void addVeggiesToList(List<String> veggies) {
     this.veggies.addAll(veggies);
   }
@@ -47,7 +53,7 @@ public class DemoSteps {
     cart.addAll(veggies);
   }
 
-  @Then("^expect the cart to contain$")
+  @Then("^expect the cart to contain: (.*)$")
   public void checkCart(List<String> foods) {
     assertArrayEquals(
       foods.toArray(new String[cart.size()]),

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/NormalTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/NormalTest.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.cucumber;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class NormalTest {
+    @Test public void normalTest() {
+        assertEquals("NormalTest", getClass().getSimpleName());
+    }
+}

--- a/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/BUILD
@@ -2,5 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 resources(name='cucumber',
-  sources=['demo.feature'],
+  sources=[
+    'badnames.feature',
+    'demo.feature',
+  ],
 )

--- a/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/badnames.feature
+++ b/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/badnames.feature
@@ -1,0 +1,8 @@
+Feature: Demonstrates sanitization of names returned by Cucumber.
+  Background:
+    Given nothing in particular
+
+  Scenario: Demonstrates that %SPECIAL/symbols ! ~ * are sanitized.
+    Given these strings: hello, goodbye
+  When these string are added to a %%@@%! list
+  Then these strings should be in the list: hello, goodbye

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -95,5 +95,5 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
   @expectedFailure
   def test_junit_tests_using_cucumber(self):
     test_spec = 'testprojects/tests/java/org/pantsbuild/testproject/cucumber'
-    with self.pants_results(['clean-all', 'test.junit', test_spec]) as results:
+    with self.pants_results(['clean-all', 'test.junit', '--per-test-timer', test_spec]) as results:
       self.assert_success(results)


### PR DESCRIPTION
In https://rbcommons.com/s/twitter/r/3090/ I got the junit runner
to anticipate getting Descriptions with class names and method
names that were actually descriptions from frameworks like
cucumber. This stopped the runner from failing out with an NPE and
solved the internal use case I was checking against, but it turns
out there's another problem I overlooked (uncovered by running it
against another internal use-case).

The TestSuite names were also used to generate the filenames of the
xml reports. This does not work when the file name is some crazy
Cucumber scenario description complete with special characters and
who knows what.

So this sanitizes the name used for generating the xml file.