### PR TITLE
[CI] Make a nasty hack in export.py more resilient.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -489,11 +489,8 @@ python_library(
   name = 'resources_task',
   sources = ['resources_task.py'],
   dependencies = [
-    ':classpath_products',
     'src/python/pants/backend/core/tasks:task',
-    'src/python/pants/base:build_environment',
     'src/python/pants/option',
-    'src/python/pants/util:dirutil',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/resources_task.py
+++ b/src/python/pants/backend/jvm/tasks/resources_task.py
@@ -5,15 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
 from abc import abstractmethod
-from collections import defaultdict
 
 from pants.backend.core.tasks.task import Task
-from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
-from pants.base.build_environment import get_buildroot
 from pants.option.custom_types import list_option
-from pants.util.dirutil import relativize_path, safe_mkdir
 
 
 class ResourcesTask(Task):
@@ -43,6 +38,7 @@ class ResourcesTask(Task):
 
   def execute(self):
     # Tracked and returned for use in tests.
+    # TODO: Rewrite those tests. execute() is not supposed to return anything.
     processed_targets = []
 
     compile_classpath = self.context.products.get_data('compile_classpath')

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -31,6 +31,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
+from pants.option.errors import OptionsError
 from pants.option.ranked_value import RankedValue
 from pants.util.memo import memoized_property
 
@@ -126,7 +127,11 @@ class ExportTask(IvyTaskMixin, PythonTask):
     # Kill it ASAP, and update test_export_integration#test_export_jar_path_with_excludes_soft to
     # use the flag actually scoped for this task.
     export_options = self.get_options()
-    ivy_options = self.context.options.for_scope('resolve.ivy')
+    try:
+      ivy_options = self.context.options.for_scope('resolve.ivy')
+    except OptionsError:
+      # No resolve.ivy task installed, so continue silently.
+      ivy_options = []
     for name in set.intersection(set(export_options), set(ivy_options)):
       if not ivy_options.is_default(name):
         setattr(export_options, name, RankedValue(RankedValue.FLAG, ivy_options[name]))


### PR DESCRIPTION
We (foursquare) have no resolve.ivy task installed at all, so the
hacky code should not fail on this.