### PR TITLE
Do not compile on resource dependencies change

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -9,12 +9,14 @@ import functools
 import hashlib
 import itertools
 import os
-import shutil
 from collections import OrderedDict, defaultdict
 
 from pants.backend.core.tasks.group_task import GroupMember
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
+from pants.backend.jvm.targets.import_jars_mixin import ImportJarsMixin
 from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.backend.jvm.targets.jvm_app import JvmApp
+from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.jvm_compile.compile_context import CompileContext
 from pants.backend.jvm.tasks.jvm_compile.execution_graph import (ExecutionFailure, ExecutionGraph,
@@ -40,20 +42,27 @@ class ResolvedJarAwareTaskIdentityFingerprintStrategy(TaskIdentityFingerprintStr
     self._classpath_products = classpath_products
 
   def _build_hasher(self, target):
-    if isinstance(target, JarLibrary):
+    if isinstance(target, JvmTarget) or isinstance(target, JarLibrary) or \
+            isinstance(target, JvmApp) or isinstance(target, ImportJarsMixin):
+      # Something jvm related, use sources for fingerprinting.
       hasher = super(ResolvedJarAwareTaskIdentityFingerprintStrategy, self)._build_hasher(target)
-      # NB: Collects only the jars for the current jar_library, and hashes them to ensure that both
-      # the resolved coordinates, and the requested coordinates are used. This ensures that if a
-      # source file depends on a library with source compatible but binary incompatible signature
-      # changes between versions, that you won't get runtime errors due to using an artifact built
-      # against a binary incompatible version resolved for a previous compile.
-      classpath_entries = self._classpath_products.get_artifact_classpath_entries_for_targets(
-        [target])
-      for _, entry in classpath_entries:
-        hasher.update(str(entry.coordinate))
-      return hasher
+
+      if isinstance(target, JarLibrary):
+        # NB: Collects only the jars for the current jar_library, and hashes them to ensure that both
+        # the resolved coordinates, and the requested coordinates are used. This ensures that if a
+        # source file depends on a library with source compatible but binary incompatible signature
+        # changes between versions, that you won't get runtime errors due to using an artifact built
+        # against a binary incompatible version resolved for a previous compile.
+        classpath_entries = self._classpath_products.get_artifact_classpath_entries_for_targets(
+          [target])
+        for _, entry in classpath_entries:
+          hasher.update(str(entry.coordinate))
     else:
-      return hashlib.sha1()
+      # Just do nothing, this kind of dependency shouldn't affect result's hash.
+      hasher = hashlib.sha1()
+      hasher.update(self._task.fingerprint or '')
+
+    return hasher
 
   def __hash__(self):
     return hash((type(self), self._task.fingerprint))

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import functools
+import hashlib
 import itertools
 import os
 import shutil
@@ -39,8 +40,8 @@ class ResolvedJarAwareTaskIdentityFingerprintStrategy(TaskIdentityFingerprintStr
     self._classpath_products = classpath_products
 
   def _build_hasher(self, target):
-    hasher = super(ResolvedJarAwareTaskIdentityFingerprintStrategy, self)._build_hasher(target)
     if isinstance(target, JarLibrary):
+      hasher = super(ResolvedJarAwareTaskIdentityFingerprintStrategy, self)._build_hasher(target)
       # NB: Collects only the jars for the current jar_library, and hashes them to ensure that both
       # the resolved coordinates, and the requested coordinates are used. This ensures that if a
       # source file depends on a library with source compatible but binary incompatible signature
@@ -50,7 +51,9 @@ class ResolvedJarAwareTaskIdentityFingerprintStrategy(TaskIdentityFingerprintStr
         [target])
       for _, entry in classpath_entries:
         hasher.update(str(entry.coordinate))
-    return hasher
+      return hasher
+    else:
+      return hashlib.sha1()
 
   def __hash__(self):
     return hash((type(self), self._task.fingerprint))

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -55,7 +55,6 @@ class ResolvedJarAwareTaskIdentityFingerprintStrategy(TaskIdentityFingerprintStr
         [target])
       for _, entry in classpath_entries:
         hasher.update(str(entry.coordinate))
-
     return hasher
 
   def __hash__(self):

--- a/testprojects/src/java/org/pantsbuild/testproject/resdependency/java/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/resdependency/java/BUILD
@@ -1,0 +1,9 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name = 'testsources',
+  sources = ['HelloWorld.java'],
+  dependencies = [
+    'testprojects/src/java/org/pantsbuild/testproject/resdependency/resources:testresources',
+  ]
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/resdependency/java/HelloWorld.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/resdependency/java/HelloWorld.java
@@ -1,0 +1,11 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.hello.simple;
+
+public class HelloWorld {
+
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/resdependency/resources/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/resdependency/resources/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+resources(name='testresources',
+  sources=['resource.xml'],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/resdependency/resources/resource.xml
+++ b/testprojects/src/java/org/pantsbuild/testproject/resdependency/resources/resource.xml
@@ -1,0 +1,1 @@
+<xml>Hello World</xml>

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -45,6 +45,7 @@ python_library(
   dependencies = [
     '3rdparty/python:ansicolors',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:build_file',
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -156,6 +156,24 @@ class JavaCompileIntegrationTest(BaseCompileIT):
       '--compile-jvm-dep-check-missing-direct-deps=fatal',
     )
 
+  def test_java_compile_with_changes_in_resources_dependencies(self):
+    with self.source_clone('testprojects/src/java/org/pantsbuild/testproject/resdependency') as resdependency:
+      with self.temporary_workdir() as workdir:
+        with self.temporary_cachedir() as cachedir:
+          target = os.path.join(resdependency, 'java:testsources')
+
+          first_run = self.run_test_compile(workdir, cachedir, target, clean_all=True)
+          self.assert_success(first_run)
+          self.assertTrue("Compiling" in first_run.stdout_data)
+
+          with open(os.path.join(resdependency, 'resources/resource.xml'), 'w') as xml_resource:
+            xml_resource.write('<xml>Changed Hello World</xml>\n')
+
+          second_run = self.run_test_compile(workdir, cachedir, target, clean_all=False)
+          self.assert_success(second_run)
+          self.assertTrue("Compiling" not in second_run.stdout_data,
+                          "In case of resources change nothing should be recompiled")
+
   def test_java_compile_with_different_resolved_jars_produce_different_artifacts(self):
     # Since unforced dependencies resolve to the highest version including transitive jars,
     # We want to ensure that running java compile with binary incompatible libraries will

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -88,6 +88,25 @@ class PantsRunIntegrationTest(unittest.TestCase):
   def temporary_sourcedir(self):
     return temporary_dir(root_dir=get_buildroot())
 
+  @contextmanager
+  def source_clone(self, source_dir):
+    with self.temporary_sourcedir() as clone_dir:
+      target_spec_dir = os.path.relpath(clone_dir)
+
+      for root, dirs, files in os.walk(source_dir):
+        clone_root = os.path.join(clone_dir, os.path.relpath(root, source_dir))
+        for dir in dirs:
+          os.mkdir(os.path.join(clone_root, dir))
+        for file_name in files:
+          with open(os.path.join(root, file_name), 'r') as file:
+            content = file.read()
+          if file_name == 'BUILD':
+            content = content.replace(source_dir, target_spec_dir)
+          with open(os.path.join(clone_root, file_name), 'w') as file:
+            file.write(content)
+
+      yield clone_dir
+
   def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None,
                              **kwargs):
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -16,6 +16,7 @@ from operator import eq, ne
 from colors import strip_color
 
 from pants.base.build_environment import get_buildroot
+from pants.base.build_file import BuildFile
 from pants.fs.archive import ZIP
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open
@@ -93,17 +94,17 @@ class PantsRunIntegrationTest(unittest.TestCase):
     with self.temporary_sourcedir() as clone_dir:
       target_spec_dir = os.path.relpath(clone_dir)
 
-      for root, dirs, files in os.walk(source_dir):
-        clone_root = os.path.join(clone_dir, os.path.relpath(root, source_dir))
-        for dir in dirs:
-          os.mkdir(os.path.join(clone_root, dir))
-        for file_name in files:
-          with open(os.path.join(root, file_name), 'r') as file:
-            content = file.read()
-          if file_name == 'BUILD':
+      for dir_path, dir_names, file_names in os.walk(source_dir):
+        clone_dir_path = os.path.join(clone_dir, os.path.relpath(dir_path, source_dir))
+        for dir_name in dir_names:
+          os.mkdir(os.path.join(clone_dir_path, dir_name))
+        for file_name in file_names:
+          with open(os.path.join(dir_path, file_name), 'r') as f:
+            content = f.read()
+          if BuildFile._is_buildfile_name(file_name):
             content = content.replace(source_dir, target_spec_dir)
-          with open(os.path.join(clone_root, file_name), 'w') as file:
-            file.write(content)
+          with open(os.path.join(clone_dir_path, file_name), 'w') as f:
+            f.write(content)
 
       yield clone_dir
 


### PR DESCRIPTION
Target's jvm compile should not be triggered by changes in dependencies with Resources type.