### PR TITLE
Add options to repro and expand user on output file

### DIFF
--- a/src/python/pants/bin/repro.py
+++ b/src/python/pants/bin/repro.py
@@ -59,13 +59,14 @@ class Repro(object):
     :param string buildroot: Capture the workspace at this buildroot.
     :param ignore: Ignore these top-level files/dirs under buildroot.
     """
-    if os.path.realpath(os.path.expanduser(path)).startswith(buildroot):
+    path = os.path.expanduser(path)
+    if os.path.realpath(path).startswith(buildroot):
       raise ReproError('Repro capture file location must be outside the build root.')
     if not path.endswith('tar.gz') and not path.endswith('.tgz'):
       path += '.tar.gz'
     if os.path.exists(path):
       raise ReproError('Repro capture file already exists: {}'.format(path))
-    self._path = os.path.expanduser(path)
+    self._path = path
     self._buildroot = buildroot
     self._ignore = ignore
 
@@ -76,7 +77,6 @@ class Repro(object):
     with open_tar(self._path, 'w:gz', dereference=True, compresslevel=6) as tarout:
       for relpath in os.listdir(self._buildroot):
         if relpath not in self._ignore:
-          print('Adding {}...'.format(relpath))
           tarout.add(os.path.join(self._buildroot, relpath), relpath)
 
       with temporary_file() as tmpfile:

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -50,9 +50,11 @@ python_tests(
 
 python_tests(
   name='repro',
-  sources=['test_repro.py', 'repro_mixin.py'],
+  sources=['test_repro.py'],
   dependencies=[
+    ':repro_mixin',
     'src/python/pants/bin',
+    'src/python/pants/fs',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ]
@@ -60,11 +62,21 @@ python_tests(
 
 python_tests(
   name='repro_ignore',
-  sources=['test_repro_ignore.py', 'repro_mixin.py'],
+  sources=['test_repro_ignore.py'],
   dependencies=[
+    ':repro_mixin',
     'src/python/pants/bin',
+    'src/python/pants/fs',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
+  ]
+)
+
+python_library(
+  name='repro_mixin',
+  sources=['repro_mixin.py'],
+  dependencies=[
+    'src/python/pants/util:dirutil',
   ]
 )

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -65,6 +65,7 @@ python_tests(
   sources=['test_repro_ignore.py'],
   dependencies=[
     ':repro_mixin',
+    'src/python/pants/base:build_root',
     'src/python/pants/bin',
     'src/python/pants/fs',
     'src/python/pants/util:dirutil',

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -8,6 +8,7 @@ target(
     ':goal_runner',
     ':plugin_resolver',
     ':repro',
+    ':repro_ignore',
   ]
 )
 
@@ -47,13 +48,23 @@ python_tests(
   ]
 )
 
-
 python_tests(
   name='repro',
-  sources=['test_repro.py'],
+  sources=['test_repro.py', 'repro_mixin.py'],
   dependencies=[
     'src/python/pants/bin',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+  ]
+)
+
+python_tests(
+  name='repro_ignore',
+  sources=['test_repro_ignore.py', 'repro_mixin.py'],
+  dependencies=[
+    'src/python/pants/bin',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
   ]
 )

--- a/tests/python/pants_test/bin/repro_mixin.py
+++ b/tests/python/pants_test/bin/repro_mixin.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.util.dirutil import safe_mkdir_for
+
+
+class ReproMixin(object):
+  """ Additional helper methods for use in Repro tests"""
+
+  def add_file(self, root, path, content):
+    """Add a file with specified contents
+
+    :param root: (string) Root directory for path.
+    :param path: (string) Path relative to root.
+    :param content: (string) Content to write to file.
+    """
+    fullpath = os.path.join(root, path)
+    safe_mkdir_for(fullpath)
+    with open(fullpath, 'w') as outfile:
+      outfile.write(content)
+
+  def assert_not_exists(self, root, path):
+    """Assert a file at relpath doesn't exist
+
+    :param root: (string) Root directory of path.
+    :param path: (string) Path relative to tar.gz.
+    :return: bool
+    """
+    fullpath = os.path.join(root, path)
+    self.assertFalse(os.path.exists(fullpath))
+
+  def assert_file(self, root, path, expected_content=None):
+    """ Assert that a file exists with the content specified
+
+    :param root: (string) Root directory of path.
+    :param path: (string) Path relative to tar.gz.
+    :param expected_content: (string) file contents.
+    :return: bool
+    """
+    fullpath = os.path.join(root, path)
+    print(fullpath)
+    self.assertTrue(os.path.isfile(fullpath))
+    if expected_content:
+      with open(fullpath, 'r') as infile:
+        content = infile.read()
+      self.assertEqual(expected_content, content)

--- a/tests/python/pants_test/bin/repro_mixin.py
+++ b/tests/python/pants_test/bin/repro_mixin.py
@@ -16,9 +16,9 @@ class ReproMixin(object):
   def add_file(self, root, path, content):
     """Add a file with specified contents
 
-    :param root: (string) Root directory for path.
-    :param path: (string) Path relative to root.
-    :param content: (string) Content to write to file.
+    :param str root: Root directory for path.
+    :param str path: Path relative to root.
+    :param str content: Content to write to file.
     """
     fullpath = os.path.join(root, path)
     safe_mkdir_for(fullpath)
@@ -28,8 +28,8 @@ class ReproMixin(object):
   def assert_not_exists(self, root, path):
     """Assert a file at relpath doesn't exist
 
-    :param root: (string) Root directory of path.
-    :param path: (string) Path relative to tar.gz.
+    :param str root: Root directory of path.
+    :param str path: Path relative to tar.gz.
     :return: bool
     """
     fullpath = os.path.join(root, path)
@@ -38,13 +38,12 @@ class ReproMixin(object):
   def assert_file(self, root, path, expected_content=None):
     """ Assert that a file exists with the content specified
 
-    :param root: (string) Root directory of path.
-    :param path: (string) Path relative to tar.gz.
-    :param expected_content: (string) file contents.
+    :param str root: Root directory of path.
+    :param str path: Path relative to tar.gz.
+    :param str expected_content: file contents.
     :return: bool
     """
     fullpath = os.path.join(root, path)
-    print(fullpath)
     self.assertTrue(os.path.isfile(fullpath))
     if expected_content:
       with open(fullpath, 'r') as infile:

--- a/tests/python/pants_test/bin/test_repro.py
+++ b/tests/python/pants_test/bin/test_repro.py
@@ -10,6 +10,7 @@ import unittest
 from functools import partial
 
 from pants.bin.repro import Repro
+from pants.fs.archive import TGZ
 from pants.util.contextutil import open_tar, temporary_dir
 from pants_test.bin.repro_mixin import ReproMixin
 
@@ -31,8 +32,7 @@ class ReproTest(unittest.TestCase, ReproMixin):
       repro.capture(run_info_dict={'foo': 'bar', 'baz': 'qux'})
 
       extract_dir = os.path.join(tmpdir, 'extract')
-      with open_tar(repro_file, 'r:gz') as tar:
-        tar.extractall(extract_dir)
+      TGZ.extract(repro_file, extract_dir)
 
       assert_file = partial(self.assert_file, extract_dir)
       assert_file('baz.txt', 'baz')

--- a/tests/python/pants_test/bin/test_repro_ignore.py
+++ b/tests/python/pants_test/bin/test_repro_ignore.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import shutil
+from functools import partial
+
+from pants.backend.core.tasks.clean import Cleaner
+from pants.bin.repro import Reproducer
+from pants.util.contextutil import open_tar, pushd, temporary_dir
+from pants_test.bin.repro_mixin import ReproMixin
+from pants_test.tasks.task_test_base import TaskTestBase
+
+
+class ReproOptionsTest(TaskTestBase, ReproMixin):
+
+  @classmethod
+  def task_type(cls):
+    return Cleaner
+
+  def test_ignore_dir(self):
+    """Verify that passing --repro-ignore option ignores the directory"""
+
+    # Buildroot is is based on your cwd so we need to step into a fresh
+    # directory for repro to look at.
+    with pushd(self.build_root):
+      with temporary_dir() as capture_dir:
+
+        add_file = partial(self.add_file, self.build_root)
+        add_file('pants.ini', '')
+        add_file('.git/foo', 'foo')
+        add_file('dist/bar', 'bar')
+        add_file('foo/bar', 'baz')
+        add_file('src/test1', 'test1')
+        add_file('src/test2', 'test1')
+
+        repro_file = os.path.join(capture_dir, 'repro.tar.gz')
+        self.set_options_for_scope(Reproducer.options_scope,
+                                   capture=repro_file,
+                                   ignore=['src'],
+                                   pants_distdir='dist')
+
+        self.create_task(self.context())
+        repro = Reproducer.global_instance().create_repro()
+        repro.capture(run_info_dict={'foo': 'bar', 'baz': 'qux'})
+
+        # clean_task.execute()
+
+        extract_loc = os.path.join(capture_dir, 'extract')
+        with open_tar(repro_file, 'r:gz') as tar:
+          tar.extractall(extract_loc)
+
+        assert_file = partial(self.assert_file, extract_loc)
+        assert_file('foo/bar', 'baz')
+
+        assert_not_exists = partial(self.assert_not_exists, extract_loc)
+        assert_not_exists('.git')
+        assert_not_exists('src')

--- a/tests/python/pants_test/bin/test_repro_ignore.py
+++ b/tests/python/pants_test/bin/test_repro_ignore.py
@@ -11,6 +11,7 @@ from functools import partial
 
 from pants.backend.core.tasks.clean import Cleaner
 from pants.bin.repro import Reproducer
+from pants.fs.archive import TGZ
 from pants.util.contextutil import open_tar, pushd, temporary_dir
 from pants_test.bin.repro_mixin import ReproMixin
 from pants_test.tasks.task_test_base import TaskTestBase
@@ -20,6 +21,7 @@ class ReproOptionsTest(TaskTestBase, ReproMixin):
 
   @classmethod
   def task_type(cls):
+    """ Dummy task to invoke options to be fetched from subsystem """
     return Cleaner
 
   def test_ignore_dir(self):
@@ -46,13 +48,10 @@ class ReproOptionsTest(TaskTestBase, ReproMixin):
 
         self.create_task(self.context())
         repro = Reproducer.global_instance().create_repro()
-        repro.capture(run_info_dict={'foo': 'bar', 'baz': 'qux'})
-
-        # clean_task.execute()
+        repro.capture(run_info_dict={})
 
         extract_loc = os.path.join(capture_dir, 'extract')
-        with open_tar(repro_file, 'r:gz') as tar:
-          tar.extractall(extract_loc)
+        TGZ.extract(repro_file, extract_loc)
 
         assert_file = partial(self.assert_file, extract_loc)
         assert_file('foo/bar', 'baz')

--- a/tests/python/pants_test/bin/test_repro_ignore.py
+++ b/tests/python/pants_test/bin/test_repro_ignore.py
@@ -44,7 +44,6 @@ class ReproOptionsTest(unittest.TestCase, ReproMixin):
                 ignore=['src'],
             )}
             with subsystem_instance(Reproducer, **options) as repro_sub:
-              # self.create_task(self.context())
               repro = repro_sub.create_repro()  # This is normally called in pants_exe
               repro.capture(run_info_dict={})
 

--- a/tests/python/pants_test/bin/test_repro_ignore.py
+++ b/tests/python/pants_test/bin/test_repro_ignore.py
@@ -6,56 +6,54 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import shutil
+import unittest
 from functools import partial
 
-from pants.backend.core.tasks.clean import Cleaner
+from pants.base.build_root import BuildRoot
 from pants.bin.repro import Reproducer
 from pants.fs.archive import TGZ
-from pants.util.contextutil import open_tar, pushd, temporary_dir
+from pants.util.contextutil import pushd, temporary_dir
 from pants_test.bin.repro_mixin import ReproMixin
-from pants_test.tasks.task_test_base import TaskTestBase
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
-class ReproOptionsTest(TaskTestBase, ReproMixin):
-
-  @classmethod
-  def task_type(cls):
-    """ Dummy task to invoke options to be fetched from subsystem """
-    return Cleaner
+class ReproOptionsTest(unittest.TestCase, ReproMixin):
 
   def test_ignore_dir(self):
     """Verify that passing --repro-ignore option ignores the directory"""
 
     # Buildroot is is based on your cwd so we need to step into a fresh
     # directory for repro to look at.
-    with pushd(self.build_root):
-      with temporary_dir() as capture_dir:
+    root_instance = BuildRoot()
+    with temporary_dir() as build_root:
+      with root_instance.temporary(build_root):
+        with pushd(build_root):
+          with temporary_dir() as capture_dir:
+            add_file = partial(self.add_file, build_root)
+            add_file('pants.ini', '')
+            add_file('.git/foo', 'foo')
+            add_file('dist/bar', 'bar')
+            add_file('foo/bar', 'baz')
+            add_file('src/test1', 'test1')
+            add_file('src/test2', 'test1')
 
-        add_file = partial(self.add_file, self.build_root)
-        add_file('pants.ini', '')
-        add_file('.git/foo', 'foo')
-        add_file('dist/bar', 'bar')
-        add_file('foo/bar', 'baz')
-        add_file('src/test1', 'test1')
-        add_file('src/test2', 'test1')
+            repro_file = os.path.join(capture_dir, 'repro.tar.gz')
+            options = {
+              'repro':dict(
+                capture=repro_file,
+                ignore=['src'],
+            )}
+            with subsystem_instance(Reproducer, **options) as repro_sub:
+              # self.create_task(self.context())
+              repro = repro_sub.create_repro()  # This is normally called in pants_exe
+              repro.capture(run_info_dict={})
 
-        repro_file = os.path.join(capture_dir, 'repro.tar.gz')
-        self.set_options_for_scope(Reproducer.options_scope,
-                                   capture=repro_file,
-                                   ignore=['src'],
-                                   pants_distdir='dist')
+              extract_loc = os.path.join(capture_dir, 'extract')
+              TGZ.extract(repro_file, extract_loc)
 
-        self.create_task(self.context())
-        repro = Reproducer.global_instance().create_repro()
-        repro.capture(run_info_dict={})
+              assert_file = partial(self.assert_file, extract_loc)
+              assert_file('foo/bar', 'baz')
 
-        extract_loc = os.path.join(capture_dir, 'extract')
-        TGZ.extract(repro_file, extract_loc)
-
-        assert_file = partial(self.assert_file, extract_loc)
-        assert_file('foo/bar', 'baz')
-
-        assert_not_exists = partial(self.assert_not_exists, extract_loc)
-        assert_not_exists('.git')
-        assert_not_exists('src')
+              assert_not_exists = partial(self.assert_not_exists, extract_loc)
+              assert_not_exists('.git')
+              assert_not_exists('src')

--- a/tests/python/pants_test/bin/test_repro_ignore.py
+++ b/tests/python/pants_test/bin/test_repro_ignore.py
@@ -39,7 +39,7 @@ class ReproOptionsTest(unittest.TestCase, ReproMixin):
 
             repro_file = os.path.join(capture_dir, 'repro.tar.gz')
             options = {
-              'repro':dict(
+              'repro': dict(
                 capture=repro_file,
                 ignore=['src'],
             )}


### PR DESCRIPTION
* Add an option to repro that allows the user to ignore dirs.  This was added to
  allow users to submit an archive of important dirs when they do clean-all that
  don't include the whole source tree.
* Update repro to expand userdir