### PR TITLE
Add `pants_requirement()` for plugin authors.

### DIFF
--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -5,6 +5,7 @@ python_library(
   name = 'plugin',
   sources = ['__init__.py', 'register.py'],
   dependencies = [
+    ':pants_requirement',
     ':python_artifact',
     ':python_requirement',
     ':python_requirements',
@@ -81,6 +82,17 @@ python_library(
     'src/python/pants/util:dirutil',
   ]
 )
+
+python_library(
+  name = 'pants_requirement',
+  sources = ['pants_requirement.py'],
+  dependencies = [
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/base:build_environment',
+  ]
+)
+
 
 python_library(
   name = 'python_artifact',

--- a/src/python/pants/backend/python/pants_requirement.py
+++ b/src/python/pants/backend/python/pants_requirement.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.backend.python.python_requirement import PythonRequirement
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.base.build_environment import pants_version
+
+
+def pants_requirement(parse_context, name=None):
+  """Exports a `python_requirement_library` pointing at the active pants' corresponding sdist.
+
+  This requirement is useful for custom plugin authors who want to build and test their plugin with
+  pants itself.  Using the resulting target as a dependency of their plugin target ensures the
+  dependency stays true to the surrounding repo's version of pants.
+
+  NB: The requirement generated is for official pants releases on pypi; so may not be appropriate
+  for use in a repo that tracks `pantsbuild/pants` or otherwise uses custom pants sdists.
+
+  :param string name: The name to use for the target, defaults to the parent dir name.
+  """
+  name = name or os.path.basename(parse_context.rel_path)
+  requirement = PythonRequirement(requirement='pantsbuild.pants=={}'.format(pants_version()))
+  parse_context.create_object(PythonRequirementLibrary, name=name, requirements=[requirement])

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.core.targets.dependencies import Dependencies
+from pants.backend.python.pants_requirement import pants_requirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import python_requirements
@@ -38,6 +39,7 @@ def build_file_aliases():
     },
     context_aware_object_factories={
       'python_requirements': BuildFileAliases.curry_context(python_requirements),
+      'pants_requirement': BuildFileAliases.curry_context(pants_requirement),
     }
   )
 

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -11,6 +11,18 @@ target(
 )
 
 python_tests(
+  name='pants_requirements',
+  sources=['test_pants_requirement.py'],
+  dependencies=[
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python:plugin',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/base:build_environment',
+    'tests/python/pants_test:base_test',
+  ]
+)
+
+python_tests(
   name='python_chroot',
   sources=['test_python_chroot.py'],
   dependencies=[

--- a/tests/python/pants_test/backend/python/test_pants_requirement.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement.py
@@ -13,15 +13,9 @@ from pants_test.base_test import BaseTest
 
 
 class PantsRequirementTest(BaseTest):
-  # NB: We use  aliases and BUILD files to test proper registration of anonymous targets and macros.
-
-  def setUp(self):
-    super(PantsRequirementTest, self).setUp()
-    # Force setup of SourceRootConfig subsystem, as go targets do computation on source roots.
-    self.context()
-
   @property
   def alias_groups(self):
+    # NB: We use aliases and BUILD files to test proper registration of the pants_requirement macro.
     return build_file_aliases()
 
   def assert_pants_requirement(self, python_requirement_library):

--- a/tests/python/pants_test/backend/python/test_pants_requirement.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.python_requirement import PythonRequirement
+from pants.backend.python.register import build_file_aliases
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.base.build_environment import pants_version
+from pants_test.base_test import BaseTest
+
+
+class PantsRequirementTest(BaseTest):
+  # NB: We use  aliases and BUILD files to test proper registration of anonymous targets and macros.
+
+  def setUp(self):
+    super(PantsRequirementTest, self).setUp()
+    # Force setup of SourceRootConfig subsystem, as go targets do computation on source roots.
+    self.context()
+
+  @property
+  def alias_groups(self):
+    return build_file_aliases()
+
+  def assert_pants_requirement(self, python_requirement_library):
+    self.assertIsInstance(python_requirement_library, PythonRequirementLibrary)
+    pants_requirement = PythonRequirement('pantsbuild.pants=={}'.format(pants_version()))
+    self.assertEqual([pants_requirement.requirement],
+                     list(pr.requirement for pr in python_requirement_library.payload.requirements))
+
+  def test_default_name(self):
+    self.add_to_build_file('3rdparty/python/pants', 'pants_requirement()')
+
+    python_requirement_library = self.target('3rdparty/python/pants')
+    self.assert_pants_requirement(python_requirement_library)
+
+  def test_custom_name(self):
+    self.add_to_build_file('3rdparty/python/pants', "pants_requirement('pantsbuild.pants')")
+
+    python_requirement_library = self.target('3rdparty/python/pants:pantsbuild.pants')
+    self.assert_pants_requirement(python_requirement_library)


### PR DESCRIPTION
When writing a plugin outside the `pantsbuild/pants` repo, if you want
to use pants itself to build the plugin or test it, you need to express
a BUILD dependency on pants itself.  This should always match the
running pants and for users of the `pantsbuild.pants` official sdists,
this is awkward.  The `pants_requirement()` macro provides a clean way
to express the plugin's dependency on the correct pants distribution.

https://rbcommons.com/s/twitter/r/3112/