### PR TITLE
Allow bundle to run for all targets, not just target roots

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -63,7 +63,7 @@ class BundleCreate(JvmBinaryTask):
 
   def execute(self):
     archiver = archive.archiver(self._archiver_type) if self._archiver_type else None
-    for target in self.context.target_roots:
+    for target in self.context.targets():
       for app in map(self.App, filter(self.App.is_app, [target])):
         basedir = self.bundle(app)
         # NB(Eric Ayers): Note that this product is not housed/controlled under .pants.d/  Since


### PR DESCRIPTION
To allow us to build bundles as part of tests, this changes the bundle_create task to run for all targets, not just target roots.