### PR TITLE
Fixup floating `pytest-timeout` dep.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -73,7 +73,9 @@ class PytestRun(TestTaskMixin, PythonTask):
     # to avoid confusion when debugging pants tests.
     # TODO: make these an option, so any pants install base can pick their pytest version.
     PythonRequirement('pytest>=2.6,<2.7'),
-    PythonRequirement('pytest-timeout'),
+    # NB, pytest-timeout 1.0.0 introduces a conflicting pytest>=2.8.0 requirement, see:
+    #   https://github.com/pantsbuild/pants/issues/2566
+    PythonRequirement('pytest-timeout<1.0.0'),
     PythonRequirement('pytest-cov>=1.8,<1.9'),
     PythonRequirement('unittest2', version_filter=lambda py, pl: py.startswith('2')),
     PythonRequirement('unittest2py3k', version_filter=lambda py, pl: py.startswith('3'))


### PR DESCRIPTION
A `1.0.0` release of `pytest-timeout` bumped its pytest dep to
`>=2.8.0` which conflicts with our injected `pytest` requirement.  As a
bandaid, bound `pytest-timeout` to prevent conflict.

https://rbcommons.com/s/twitter/r/3126/