### PR TITLE
Prepare the pants `0.0.59` hotfix release.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,6 +55,7 @@ Created by running `./build-support/bin/contributors.sh`.
 + Joshua Cohen
 + Joshua Humphries
 + Justin Trobec
++ Karin Lundberg
 + Ken Kawamoto
 + Kevin Sweeney
 + Kris Wilson

--- a/src/python/pants/CHANGELOG.rst
+++ b/src/python/pants/CHANGELOG.rst
@@ -1,6 +1,43 @@
 RELEASE HISTORY
 ===============
 
+0.0.59 (11/15/2015)
+-------------------
+
+Release Notes
+~~~~~~~~~~~~~
+
+This is a hotfix release that pins an internal pants python requirement to prevent failures running
+`./pants test` against `python_tests` targets.
+See more details here: http://github.com/pantsbuild/pants/issues#issue/2566
+
+Bugfixes
+~~~~~~~~
+
+* Fixup floating `pytest-timeout` dep.
+  `RB #3126 <https://rbcommons.com/s/twitter/r/3126>`_
+
+New Features
+~~~~~~~~~~~~
+
+* Allow bundle to run for all targets, rather than just target roots
+  `RB #3119 <https://rbcommons.com/s/twitter/r/3119>`_
+
+* Allow per-jvm-target configuration of fatal warnings
+  `RB #3080 <https://rbcommons.com/s/twitter/r/3080>`_
+
+* Add options to repro and expand user on output file
+  `RB #3109 <https://rbcommons.com/s/twitter/r/3109>`_
+
+Small improvements, Refactoring and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Remove use of twitter.common.util.topological_sort in SortTargets
+  `RB #3121 <https://rbcommons.com/s/twitter/r/3121>`_
+
+* Delay many re.compile calls.
+  `RB #3122 <https://rbcommons.com/s/twitter/r/3122>`_
+
 0.0.58 (11/13/2015)
 -------------------
 

--- a/src/python/pants/backend/core/tasks/dependees.py
+++ b/src/python/pants/backend/core/tasks/dependees.py
@@ -23,7 +23,7 @@ class ReverseDepmap(TargetFilterTaskMixin, ConsoleTask):
     register('--closed', default=False, action='store_true',
              help='Include the input targets in the output along with the dependees.')
     register('--type', default=[], action='append',
-             deprecated_version='0.0.59',
+             deprecated_version='0.0.60',
              deprecated_hint='This never worked anyway. Do not use for now. May be reimplemented '
                              'in the future.',
              help="Identifies target types to include. Multiple type inclusions "

--- a/src/python/pants/backend/maven_layout/maven_layout.py
+++ b/src/python/pants/backend/maven_layout/maven_layout.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.base.deprecated import deprecated
 
 
-@deprecated(removal_version='0.0.59', hint_message='Maven layout is now supported out of the box. '
+@deprecated(removal_version='0.0.60', hint_message='Maven layout is now supported out of the box. '
                                                    'No special declarations neccessary.')
 def maven_layout(parse_context, basedir=''):
   pass

--- a/src/python/pants/backend/project_info/tasks/depmap.py
+++ b/src/python/pants/backend/project_info/tasks/depmap.py
@@ -46,7 +46,7 @@ class Depmap(ConsoleTask):
              help='Specifies the separator to use between the org/name/rev components of a '
                   'dependency\'s fully qualified name.')
     register('--path-to',
-             deprecated_version='0.0.59',
+             deprecated_version='0.0.60',
              deprecated_hint='Use the `path` and `paths` goal to find paths between targets.',
              help='Show only items on the path to the given target. This is a no-op for --graph.')
 

--- a/src/python/pants/base/source_root.py
+++ b/src/python/pants/base/source_root.py
@@ -220,7 +220,7 @@ class SourceRoot(object):
     cls._SOURCE_ROOT_TREE = SourceRootTree()
 
   @classmethod
-  @deprecated('0.0.59', 'use context.source_roots.find() or '
+  @deprecated('0.0.60', 'use context.source_roots.find() or '
                         'SourceRootConfig.global_instance().get_source_roots().find().')
   def find(cls, target):
     """Finds the source root for the given target.
@@ -243,7 +243,7 @@ class SourceRoot(object):
     return found_source_root
 
   @classmethod
-  @deprecated('0.0.59', 'use context.source_roots.find_by_path() or '
+  @deprecated('0.0.60', 'use context.source_roots.find_by_path() or '
                         'SourceRootConfig.global_instance().get_source_roots().find_by_path().')
   def find_by_path(cls, path):
     """Finds a registered source root for a given path

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -52,7 +52,7 @@ class SourceRootBootstrapper(Subsystem):
     super(SourceRootBootstrapper, cls).register_options(register)
     # TODO: Get rid of this in favor of source root registration at backend load time.
     register('--bootstrap-buildfiles', advanced=True, type=list_option, default=[],
-             deprecated_version='0.0.59',
+             deprecated_version='0.0.60',
              deprecated_hint='bootstrap BUILD files are no longer necessary or supported. '
                              'Source roots are configured in pants.ini or by default.',
              help='Initialize state by evaluating these buildfiles.')

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -257,7 +257,7 @@ class Target(AbstractTarget):
     if kwargs:
       self.UnknownArguments.check(self, kwargs)
 
-  @deprecated('0.0.59',
+  @deprecated('0.0.60',
               'The `no_cache` property is generally ambiguous, and is no longer necessary '
               'for jvm compiles.')
   def _set_no_cache(self):

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -6,4 +6,4 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 
-VERSION = '0.0.58'
+VERSION = '0.0.59'


### PR DESCRIPTION
This fixes a requirements conflict in the pants python test runner
caused by the release of `pytest-timeout` `1.0.0` on 11/15/2015 which
has a `pytest>=2.8.0` requirement conflicting with our own
`pytest>=2.6,<2.7` requirement.

Several `0.0.59` deprecations are pushed back to `0.0.60`.

https://rbcommons.com/s/twitter/r/3127/