### PR TITLE
Isolate .pex dir

### DIFF
--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -45,7 +45,6 @@ class PythonTask(Task):
     # Ideally this would be done in goal_runner or somewhere earlier but pex invocations
     # alter the environment state when we call it so we need to do this for each task.
     os.environ['PEX_ROOT'] = os.path.join(self.get_options().pants_workdir, '.pex')
-    print('Set to... {}'.format(os.path.join(self.get_options().pants_workdir, '.pex')))
     self._compatibilities = self.get_options().interpreter or [b'']
     self._interpreter_cache = None
     self._interpreter = None

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -40,6 +40,12 @@ class PythonTask(Task):
 
   def __init__(self, *args, **kwargs):
     super(PythonTask, self).__init__(*args, **kwargs)
+    # TODO: fix pex so that it doesn't mutate environment state
+    # https://github.com/pantsbuild/pex/issues/180
+    # Ideally this would be done in goal_runner or somewhere earlier but pex invocations
+    # alter the environment state when we call it so we need to do this for each task.
+    os.environ['PEX_ROOT'] = os.path.join(self.get_options().pants_workdir, '.pex')
+    print('Set to... {}'.format(os.path.join(self.get_options().pants_workdir, '.pex')))
     self._compatibilities = self.get_options().interpreter or [b'']
     self._interpreter_cache = None
     self._interpreter = None

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -49,6 +49,15 @@ python_tests(
 )
 
 python_tests(
+  name='pex_root',
+  sources=['test_pexroot.py'],
+  dependencies=[
+      'tests/python/pants_test:int-test',
+      'src/python/pants/util:contextutil',
+  ]
+)
+
+python_tests(
   name='repro',
   sources=['test_repro.py'],
   dependencies=[

--- a/tests/python/pants_test/bin/test_pexroot.py
+++ b/tests/python/pants_test/bin/test_pexroot.py
@@ -21,6 +21,6 @@ class TestPexRoot(PantsRunIntegrationTest):
                                     ['test',
                                       'tests/python/pants_test/backend/python/tasks:python_task'],
                                     workdir=workdir)
-
           self.assertTrue(pants_run)
+          map(print, pants_run.stdout_data.split('\n'))
       self.assertFalse(os.path.exists(user_pex))

--- a/tests/python/pants_test/bin/test_pexroot.py
+++ b/tests/python/pants_test/bin/test_pexroot.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.util.contextutil import environment_as, temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class TestPexRoot(PantsRunIntegrationTest):
+  def test_root_set(self):
+    with temporary_dir() as tmpdir:
+      with environment_as(HOME=tmpdir):
+        user_pex = os.path.join(tmpdir, '.pex')
+        with self.temporary_workdir() as workdir:
+          pants_run = self.run_pants_with_workdir(
+                                    ['test',
+                                      'tests/python/pants_test/backend/python/tasks:python_task'],
+                                    workdir=workdir)
+
+          self.assertTrue(pants_run)
+      self.assertFalse(os.path.exists(user_pex))


### PR DESCRIPTION
Ensure that we don't interfere with the users .pex directory in case
they use pex outside of pants.

* Test that updates no longer update users $HOME/.pex