### PR TITLE
Update scalac_plugin_args call to the new option name.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -240,7 +240,7 @@ class ZincCompile(JvmCompile):
     if not self.get_options().scalac_plugins:
       return []
 
-    plugin_args = self.get_options().plugin_args
+    plugin_args = self.get_options().scalac_plugin_args
     active_plugins = self._find_plugins()
     ret = []
     for name, jar in active_plugins.items():


### PR DESCRIPTION
This was failing internally because the flag didn't exist.