### PR TITLE
Add error message when a JDK is not installed

### DIFF
--- a/src/docs/install.md
+++ b/src/docs/install.md
@@ -2,9 +2,13 @@ Installing Pants
 ================
 
 There are a few ways to get a runnable version of pants set up for your workspace. Before
-beginning, please [consult the README](https://github.com/pantsbuild/pants/blob/master/README.md),
-to make sure your machine fits the requirements. In particular, you'll want to make sure that you
-have Python 2.7.x -- pants itself needs to be hosted on that version.
+beginning, make sure your machine fits the requirements. At a minimum, pants requires the following to run properly:
+
+* Linux or Mac OS X
+* Python 2.7.x (the latest stable version of 2.7 is recommended)
+* A C compiler, system headers, Python headers (to compile native Python modules)
+* OpenJDK 7 or greater, Oracle JDK 6 or greater
+* Internet access (so that pants can fully bootstrap itself)
 
 After you have pants installed, you'll need to
 [[Set up your code workspace to work with Pants|pants('src/docs:setup_repo')]].

--- a/src/python/pants/docs/docsite.json
+++ b/src/python/pants/docs/docsite.json
@@ -64,6 +64,7 @@
     { "page": "index",
       "children": [
         { "page": "first_concepts" },
+        { "page": "install" },
         { "page": "first_tutorial" },
         { "page": "target_addresses" },
         { "page": "JVMProjects",
@@ -93,7 +94,6 @@
         { "page": "publish" },
         { "page": "with_emacs" },
         { "page": "with_intellij" },
-        { "page": "install" },
         { "page": "setup_repo" },
         { "page": "build_dictionary" },
         { "page": "options_reference" },

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -211,8 +211,9 @@ class Distribution(object):
       self._is_jdk = True
     except self.Error as e:
       if self._jdk:
-        raise self.Error('Failed to validate javac executable. Please check you have a JDK'
-        ' installed. Original error: {}'.format(e))
+        logger.debug('Failed to validate javac executable. Please check you have a JDK '
+                      'installed. Original error: {}'.format(e))
+        raise
 
   def execute_java(self, *args, **kwargs):
     return execute_java(*args, distribution=self, **kwargs)
@@ -429,6 +430,7 @@ class DistributionLocator(Subsystem):
                      .format(dist, minimum_version, maximum_version, jdk))
         return dist
       except (ValueError, Distribution.Error):
+
         pass
 
     raise cls.Error('Failed to locate a {} distribution with minimum_version {}, maximum_version {}'

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -209,9 +209,10 @@ class Distribution(object):
     try:
       self._validated_executable('javac')  # Calling purely for the check and cache side effects
       self._is_jdk = True
-    except self.Error:
+    except self.Error as e:
       if self._jdk:
-        raise
+        raise self.Error('Failed to validate javac executable. Please check you have a JDK'
+        ' installed. Original error: {}'.format(e))
 
   def execute_java(self, *args, **kwargs):
     return execute_java(*args, distribution=self, **kwargs)


### PR DESCRIPTION
Add requirements to documentation and move "installing pants" to a more prominent place in the sidebar.