### PR TITLE
Add support for extra_jvm_options to java_tests

### DIFF
--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -14,18 +14,22 @@ from pants.base.payload_field import PrimitiveField
 class JavaTests(JvmTarget):
   """Tests JVM sources with JUnit."""
 
-  def __init__(self, cwd=None, test_platform=None, payload=None, timeout=None, **kwargs):
+  def __init__(self, cwd=None, test_platform=None, payload=None, timeout=None,
+               extra_jvm_options=None, **kwargs):
     """
     :param str cwd: working directory (relative to the build root) for the tests under this
       target. If unspecified (None), the working directory will be controlled by junit_run's --cwd.
     :param str test_platform: The name of the platform (defined under the jvm-platform subsystem) to
       use for running tests (that is, a key into the --jvm-platform-platforms dictionary). If
       unspecified, the platform will default to the same one used for compilation.
+    :param list extra_jvm_options: A list of key value pairs of jvm options to use when running the
+      tests. Example: ['-Dexample.property=1'] If unspecified, no extra jvm options will be added.
     """
     self.cwd = cwd
     payload = payload or Payload()
     payload.add_fields({
-      'test_platform': PrimitiveField(test_platform)
+      'test_platform': PrimitiveField(test_platform),
+      'extra_jvm_options': PrimitiveField(tuple(extra_jvm_options or ()))
     })
     self._timeout = timeout
     super(JavaTests, self).__init__(payload=payload, **kwargs)

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -288,35 +288,37 @@ class JUnitRun(TestTaskMixin, JvmToolTaskMixin, JvmTask):
 
     result = 0
     for (workdir, platform), tests in tests_by_properties.items():
-      for batch in self._partition(tests):
-        # Batches of test classes will likely exist within the same targets: dedupe them.
-        relevant_targets = set(map(tests_to_targets.get, batch))
-        complete_classpath = OrderedSet()
-        complete_classpath.update(classpath_prepend)
-        complete_classpath.update(self.tool_classpath('junit'))
-        complete_classpath.update(self.classpath(relevant_targets,
-                                                 classpath_product=classpath_product))
-        complete_classpath.update(classpath_append)
-        distribution = self.preferred_jvm_distribution([platform])
-        with binary_util.safe_args(batch, self.get_options()) as batch_tests:
-          self.context.log.debug('CWD = {}'.format(workdir))
-          self.context.log.debug('platform = {}'.format(platform))
-          self._executor = SubprocessExecutor(distribution)
-          result += abs(distribution.execute_java(
-            executor=self._executor,
-            classpath=complete_classpath,
-            main=JUnitRun._MAIN,
-            jvm_options=self.jvm_options + extra_jvm_options,
-            args=self._args + batch_tests + [u'-xmlreport'],
-            workunit_factory=self.context.new_workunit,
-            workunit_name='run',
-            workunit_labels=[WorkUnitLabel.TEST],
-            cwd=workdir,
-            synthetic_jar_dir=self.workdir,
-          ))
+      for (target_jvm_options, target_tests) in self._partition_by_jvm_options(tests_to_targets,
+                                                                               tests):
+        for batch in self._partition(target_tests):
+          # Batches of test classes will likely exist within the same targets: dedupe them.
+          relevant_targets = set(map(tests_to_targets.get, batch))
+          complete_classpath = OrderedSet()
+          complete_classpath.update(classpath_prepend)
+          complete_classpath.update(self.tool_classpath('junit'))
+          complete_classpath.update(self.classpath(relevant_targets,
+                                                   classpath_product=classpath_product))
+          complete_classpath.update(classpath_append)
+          distribution = self.preferred_jvm_distribution([platform])
+          with binary_util.safe_args(batch, self.get_options()) as batch_tests:
+            self.context.log.debug('CWD = {}'.format(workdir))
+            self.context.log.debug('platform = {}'.format(platform))
+            self._executor = SubprocessExecutor(distribution)
+            result += abs(distribution.execute_java(
+              executor=self._executor,
+              classpath=complete_classpath,
+              main=JUnitRun._MAIN,
+              jvm_options=self.jvm_options + extra_jvm_options + target_jvm_options,
+              args=self._args + batch_tests + [u'-xmlreport'],
+              workunit_factory=self.context.new_workunit,
+              workunit_name='run',
+              workunit_labels=[WorkUnitLabel.TEST],
+              cwd=workdir,
+              synthetic_jar_dir=self.workdir,
+            ))
 
-          if result != 0 and self._fail_fast:
-            break
+            if result != 0 and self._fail_fast:
+              break
 
     if result != 0:
       failed_targets_and_tests = self._get_failed_targets(tests_to_targets)
@@ -350,6 +352,21 @@ class JUnitRun(TestTaskMixin, JvmToolTaskMixin, JvmTask):
       return tuple(prop(target) for prop in properties)
 
     return self._tests_by_property(tests_to_targets, combined_property)
+
+  def _partition_by_jvm_options(self, tests_to_targets, tests):
+    """Partitions a list of tests by the jvm options to run them with.
+
+    :param dict tests_to_target: A mapping from each test to its target.
+    :param list tests: The list of tests to run.
+    :returns: A list of tuples where the first element is an array of jvm options and the second
+      is a list of tests to run with the jvm options. Each test in tests will appear in exactly
+      one one tuple.
+    """
+    jvm_options_to_tests = defaultdict(list)
+    for test in tests:
+      extra_jvm_options = tests_to_targets[test].payload.extra_jvm_options
+      jvm_options_to_tests[extra_jvm_options].append(test)
+    return [(list(jvm_options), tests) for jvm_options, tests in jvm_options_to_tests.items()]
 
   def _partition(self, tests):
     stride = min(self._batch_size, len(tests))


### PR DESCRIPTION
This allows java_tests to include extra_jvm_options.
https://github.com/pantsbuild/pants/issues/2383