### PR TITLE
ANDROID_HOME resolving was failing with 'ivy pattern must be absolute'.

### DIFF
--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -22,15 +22,15 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
        -->
   <properties environment="env"/>
-  <property name="ANDROID_HOME"
-            value="/please-export-your-ANDROID_HOME"
-            unlessset="env.ANDROID_HOME"/>
-  <property name="ANDROID_HOME"
+  <property name="android.home"
             value="${env.ANDROID_HOME}"
+            override="false"
             ifset="env.ANDROID_HOME"/>
-
-  <property name="android.repo.dir" value="${ANDROID_HOME}/extras/android/m2repository"/>
-  <property name="google.repo.dir" value="${ANDROID_HOME}/extras/google/m2repository"/>
+  <property name="android.home"
+            value="/please-export-your-ANDROID_HOME"
+            override="false"/>
+  <property name="android.repo.dir" value="${android.home}/extras/android/m2repository"/>
+  <property name="google.repo.dir" value="${android.home}/extras/google/m2repository"/>
 
   <resolvers>
 


### PR DESCRIPTION
I am unclear why this started failing out of the blue, our best first
guess is that it took a fresh setup to trigger. But HEAD and 0.0.59
releases were confirmed to fail to ivy-resolve with:

17:49:25 00:01       [ivy-bootstrap]
                     ==== stderr ====
                     Exception in thread "main" java.text.ParseException: failed to load settings from file:/Users/dan/p/pants/build-support/ivy/ivysettings.xml: impossible to add configured child for ivy on class org.apache.ivy.plugins.resolver.FileSystemResolver: ivy pattern must be absolute: ${env.ANDROID_HOME}/extras/android/m2repository/[organisation]/[module]/[revision]/[module]-[revision].pom
                     	at org.apache.ivy.core.settings.XmlSettingsParser.doParse(XmlSettingsParser.java:165)
                     	at org.apache.ivy.core.settings.XmlSettingsParser.parse(XmlSettingsParser.java:150)
                     	at org.apache.ivy.core.settings.IvySettings.load(IvySettings.java:391)

This just reorders the conditional setting. Now we just don'y
override any environmental values with our dummy 'export' line.