### PR TITLE
[CI] Move ConsoleTask to pants/task.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -64,7 +64,6 @@ python_library(
     ':bash_completion_resources',
   ],
   dependencies = [
-    ':console_task',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/goal',
@@ -123,11 +122,11 @@ python_library(
   name = 'cloc',
   sources = ['cloc.py'],
   dependencies = [
-    ':console_task',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/binaries:binary_util',
+    'src/python/pants/task',
     'src/python/pants/util:contextutil',
   ],
 )
@@ -149,8 +148,8 @@ python_library(
   name = 'console_task',
   sources = ['console_task.py'],
   dependencies = [
+    'src/python/pants/base:deprecated',
     'src/python/pants/task',
-    'src/python/pants/util:dirutil',
   ],
 )
 
@@ -168,9 +167,9 @@ python_library(
   name = 'dependees',
   sources = ['dependees.py'],
   dependencies = [
-    ':console_task',
     ':target_filter_task_mixin',
     'src/python/pants/base:build_environment',
+    'src/python/pants/task',
   ],
 )
 
@@ -179,8 +178,8 @@ python_library(
   sources = ['explain_options_task.py'],
   dependencies = [
     '3rdparty/python:ansicolors',
-    ':console_task',
     'src/python/pants/option',
+    'src/python/pants/task',
   ],
 )
 
@@ -188,7 +187,7 @@ python_library(
   name = 'filemap',
   sources = ['filemap.py'],
   dependencies = [
-    ':console_task',
+    'src/python/pants/task',
   ],
 )
 
@@ -196,12 +195,12 @@ python_library(
   name = 'filter',
   sources = ['filter.py'],
   dependencies = [
-    ':console_task',
     ':target_filter_task_mixin',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
+    'src/python/pants/task',
     'src/python/pants/util:filtering',
   ],
 )
@@ -223,8 +222,8 @@ python_library(
   name = 'list_goals',
   sources = ['list_goals.py'],
   dependencies = [
-    ':console_task',
     'src/python/pants/goal',
+    'src/python/pants/task',
   ],
 )
 
@@ -233,7 +232,7 @@ python_library(
   sources = ['listtargets.py'],
   dependencies = [
     'src/python/pants/base:exceptions',
-    ':console_task',
+    'src/python/pants/task',
   ],
 )
 
@@ -269,7 +268,7 @@ python_library(
   name = 'minimal_cover',
   sources = ['minimal_cover.py'],
   dependencies = [
-    ':console_task',
+    'src/python/pants/task',
   ],
 )
 
@@ -294,7 +293,7 @@ python_library(
   name = 'pathdeps',
   sources = ['pathdeps.py'],
   dependencies = [
-    ':console_task',
+    'src/python/pants/task',
   ],
 )
 
@@ -302,8 +301,8 @@ python_library(
   name = 'paths',
   sources = ['paths.py'],
   dependencies = [
-    ':console_task',
     'src/python/pants/base:exceptions',
+    'src/python/pants/task',
     'src/python/pants/util:strutil',
   ],
 )
@@ -350,7 +349,7 @@ python_library(
   name = 'roots',
   sources = ['roots.py'],
   dependencies = [
-    ':console_task',
+    'src/python/pants/task',
   ],
 )
 
@@ -378,7 +377,6 @@ python_library(
   name = 'sorttargets',
   sources = ['sorttargets.py'],
   dependencies = [
-    ':console_task',
     'src/python/pants/build_graph',
     'src/python/pants/task',
   ],
@@ -400,8 +398,8 @@ python_library(
     ':targets_help_resources',
   ],
   dependencies = [
-    ':console_task',
     ':reflect',
+    'src/python/pants/task',
   ],
 )
 
@@ -423,8 +421,8 @@ python_library(
   name = 'list_owners',
   sources = ['list_owners.py'],
   dependencies = [
-    ':console_task',
     'src/python/pants/build_graph',
+    'src/python/pants/task',
   ],
 )
 
@@ -432,11 +430,11 @@ python_library(
   name = 'what_changed',
   sources = ['what_changed.py'],
   dependencies = [
-    ':console_task',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/goal:workspace',
+    'src/python/pants/task',
   ],
 )
 

--- a/src/python/pants/backend/core/tasks/bash_completion.py
+++ b/src/python/pants/backend/core/tasks/bash_completion.py
@@ -10,13 +10,13 @@ from collections import defaultdict
 
 from pkg_resources import resource_string
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator
 from pants.goal.goal import Goal
 from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.scope import ScopeInfo
+from pants.task.console_task import ConsoleTask
 from pants.task.task import TaskBase
 
 

--- a/src/python/pants/backend/core/tasks/cloc.py
+++ b/src/python/pants/backend/core/tasks/cloc.py
@@ -8,11 +8,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import subprocess
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.binaries.binary_util import BinaryUtil
+from pants.task.console_task import ConsoleTask
 from pants.util.contextutil import temporary_dir
 
 

--- a/src/python/pants/backend/core/tasks/console_task.py
+++ b/src/python/pants/backend/core/tasks/console_task.py
@@ -5,62 +5,15 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import errno
-import os
-from contextlib import contextmanager
-
-from pants.base.exceptions import TaskError
-from pants.task.task import QuietTaskMixin, Task
-from pants.util.dirutil import safe_open
+from pants.base.deprecated import deprecated_module
+from pants.task.console_task import ConsoleTask
 
 
-class ConsoleTask(QuietTaskMixin, Task):
-  """A task whose only job is to print information to the console.
+deprecated_module('0.0.64',
+                  hint_message='pants.backend.core.tasks.console_task has moved to '
+                               'pants.task.console_task. Replace deps on '
+                               'src/python/pants/backend/core/tasks:console_task with a dep on '
+                               'src/python/pants/task and change imports accordingly.')
 
-  ConsoleTasks are not intended to modify build state.
-  """
 
-  @classmethod
-  def register_options(cls, register):
-    super(ConsoleTask, cls).register_options(register)
-    register('--sep', default='\\n', metavar='<separator>',
-             help='String to use to separate results.')
-    register('--output-file', metavar='<path>',
-             help='Write the console output to this file instead.')
-
-  def __init__(self, *args, **kwargs):
-    super(ConsoleTask, self).__init__(*args, **kwargs)
-    self._console_separator = self.get_options().sep.decode('string-escape')
-    if self.get_options().output_file:
-      try:
-        self._outstream = safe_open(os.path.abspath(self.get_options().output_file), 'w')
-      except IOError as e:
-        raise TaskError('Error opening stream {out_file} due to'
-                        ' {error_str}'.format(out_file=self.get_options().output_file, error_str=e))
-    else:
-      self._outstream = self.context.console_outstream
-
-  @contextmanager
-  def _guard_sigpipe(self):
-    try:
-      yield
-    except IOError as e:
-      # If the pipeline only wants to read so much, that's fine; otherwise, this error is probably
-      # legitimate.
-      if e.errno != errno.EPIPE:
-        raise e
-
-  def execute(self):
-    with self._guard_sigpipe():
-      try:
-        targets = self.context.targets()
-        for value in self.console_output(targets):
-          self._outstream.write(str(value))
-          self._outstream.write(self._console_separator)
-      finally:
-        self._outstream.flush()
-        if self.get_options().output_file:
-          self._outstream.close()
-
-  def console_output(self, targets):
-    raise NotImplementedError('console_output must be implemented by subclasses of ConsoleTask')
+ConsoleTask = ConsoleTask

--- a/src/python/pants/backend/core/tasks/dependees.py
+++ b/src/python/pants/backend/core/tasks/dependees.py
@@ -7,9 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from collections import defaultdict
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.core.tasks.target_filter_task_mixin import TargetFilterTaskMixin
 from pants.base.build_environment import get_buildroot
+from pants.task.console_task import ConsoleTask
 
 
 class ReverseDepmap(TargetFilterTaskMixin, ConsoleTask):

--- a/src/python/pants/backend/core/tasks/explain_options_task.py
+++ b/src/python/pants/backend/core/tasks/explain_options_task.py
@@ -7,8 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from colors import black, blue, cyan, green, magenta, red, white
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.option.ranked_value import RankedValue
+from pants.task.console_task import ConsoleTask
 
 
 class ExplainOptionsTask(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/filemap.py
+++ b/src/python/pants/backend/core/tasks/filemap.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.task.console_task import ConsoleTask
 
 
 class Filemap(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/filter.py
+++ b/src/python/pants/backend/core/tasks/filter.py
@@ -7,12 +7,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import re
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.core.tasks.target_filter_task_mixin import TargetFilterTaskMixin
 from pants.base.build_environment import get_buildroot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exceptions import TaskError
 from pants.build_graph.address_lookup_error import AddressLookupError
+from pants.task.console_task import ConsoleTask
 from pants.util.filtering import create_filters, wrap_filters
 
 

--- a/src/python/pants/backend/core/tasks/list_goals.py
+++ b/src/python/pants/backend/core/tasks/list_goals.py
@@ -5,8 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.goal.goal import Goal
+from pants.task.console_task import ConsoleTask
 
 
 class ListGoals(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/list_owners.py
+++ b/src/python/pants/backend/core/tasks/list_owners.py
@@ -5,9 +5,9 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.base.exceptions import TaskError
 from pants.build_graph.source_mapper import LazySourceMapper
+from pants.task.console_task import ConsoleTask
 
 
 class ListOwners(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/listtargets.py
+++ b/src/python/pants/backend/core/tasks/listtargets.py
@@ -5,8 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.base.exceptions import TaskError
+from pants.task.console_task import ConsoleTask
 
 
 class ListTargets(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/minimal_cover.py
+++ b/src/python/pants/backend/core/tasks/minimal_cover.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.task.console_task import ConsoleTask
 
 
 class MinimalCover(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/pathdeps.py
+++ b/src/python/pants/backend/core/tasks/pathdeps.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.task.console_task import ConsoleTask
 
 
 class PathDeps(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/paths.py
+++ b/src/python/pants/backend/core/tasks/paths.py
@@ -8,8 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import copy
 from collections import deque
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.base.exceptions import TaskError
+from pants.task.console_task import ConsoleTask
 from pants.util.strutil import pluralize
 
 

--- a/src/python/pants/backend/core/tasks/roots.py
+++ b/src/python/pants/backend/core/tasks/roots.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.task.console_task import ConsoleTask
 
 
 class ListRoots(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/sorttargets.py
+++ b/src/python/pants/backend/core/tasks/sorttargets.py
@@ -7,8 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from collections import defaultdict
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.build_graph.build_graph import sort_targets
+from pants.task.console_task import ConsoleTask
 
 
 class SortTargets(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/targets_help.py
+++ b/src/python/pants/backend/core/tasks/targets_help.py
@@ -11,8 +11,8 @@ import re
 import pystache
 from pkg_resources import resource_string
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.core.tasks.reflect import assemble_buildsyms
+from pants.task.console_task import ConsoleTask
 
 
 class TargetsHelp(ConsoleTask):

--- a/src/python/pants/backend/core/tasks/what_changed.py
+++ b/src/python/pants/backend/core/tasks/what_changed.py
@@ -7,11 +7,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import re
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.base.build_environment import get_scm
 from pants.base.exceptions import TaskError
 from pants.build_graph.source_mapper import SpecSourceMapper
 from pants.goal.workspace import ScmWorkspace
+from pants.task.console_task import ConsoleTask
 
 
 class ChangeCalculator(object):

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -102,7 +102,7 @@ python_library(
   dependencies = [
     ':jar_publish',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/core/tasks:console_task',
+    'src/python/pants/task',
   ],
 )
 
@@ -391,7 +391,6 @@ python_library(
   sources = ['jvm_platform_analysis.py'],
   dependencies = [
     '3rdparty/python:ansicolors',
-    'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/base:exceptions',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/task',

--- a/src/python/pants/backend/jvm/tasks/check_published_deps.py
+++ b/src/python/pants/backend/jvm/tasks/check_published_deps.py
@@ -5,10 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.jar_publish import PushDb
+from pants.task.console_task import ConsoleTask
 
 
 class CheckPublishedDeps(ConsoleTask):

--- a/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_platform_analysis.py
@@ -11,11 +11,11 @@ from hashlib import sha1
 
 from colors import red
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TaskError
 from pants.base.fingerprint_strategy import FingerprintStrategy
 from pants.build_graph.build_graph import CycleException, sort_targets
+from pants.task.console_task import ConsoleTask
 from pants.task.task import Task
 from pants.util.memo import memoized_property
 

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -20,10 +20,10 @@ python_library(
   sources = ['dependencies.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:payload_field',
+    'src/python/pants/task',
   ],
 )
 
@@ -31,9 +31,9 @@ python_library(
   name = 'depmap',
   sources = ['depmap.py'],
   dependencies = [
-    'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:exceptions',
+    'src/python/pants/task',
   ],
 )
 
@@ -84,7 +84,6 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:pex',
     'src/python/pants/backend/core/targets:common',
-    'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
@@ -98,6 +97,7 @@ python_library(
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
     'src/python/pants/option',
+    'src/python/pants/task',
     'src/python/pants/util:memo',
   ],
 )
@@ -106,11 +106,11 @@ python_library(
   name = 'filedeps',
   sources = ['filedeps.py'],
   dependencies = [
-    'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/base:build_environment',
+    'src/python/pants/task',
   ],
 )
 

--- a/src/python/pants/backend/project_info/tasks/dependencies.py
+++ b/src/python/pants/backend/project_info/tasks/dependencies.py
@@ -7,10 +7,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.base.exceptions import TaskError
 from pants.base.payload_field import JarsField, PythonRequirementsField
+from pants.task.console_task import ConsoleTask
 
 
 class Dependencies(ConsoleTask):

--- a/src/python/pants/backend/project_info/tasks/depmap.py
+++ b/src/python/pants/backend/project_info/tasks/depmap.py
@@ -5,9 +5,9 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.base.exceptions import TaskError
+from pants.task.console_task import ConsoleTask
 
 
 class Depmap(ConsoleTask):

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -14,7 +14,6 @@ from pex.pex_info import PexInfo
 from twitter.common.collections import OrderedSet
 
 from pants.backend.core.targets.resources import Resources
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.ivy_utils import IvyModuleRef
 from pants.backend.jvm.jar_dependency_utils import M2Coordinate
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
@@ -33,6 +32,7 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.option.errors import OptionsError
 from pants.option.ranked_value import RankedValue
+from pants.task.console_task import ConsoleTask
 from pants.util.memo import memoized_property
 
 

--- a/src/python/pants/backend/project_info/tasks/filedeps.py
+++ b/src/python/pants/backend/project_info/tasks/filedeps.py
@@ -8,10 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import itertools
 import os
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.build_environment import get_buildroot
+from pants.task.console_task import ConsoleTask
 
 
 class FileDeps(ConsoleTask):

--- a/src/python/pants/task/BUILD
+++ b/src/python/pants/task/BUILD
@@ -4,7 +4,7 @@
 
 python_library(
   name = 'task',
-  sources = ['task.py'],
+  sources = globs('*.py'),
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:exceptions',
@@ -15,6 +15,7 @@ python_library(
     'src/python/pants/option',
     'src/python/pants/reporting',
     'src/python/pants/subsystem',
+    'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
   ],
 )

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import errno
+import os
+from contextlib import contextmanager
+
+from pants.base.exceptions import TaskError
+from pants.task.task import QuietTaskMixin, Task
+from pants.util.dirutil import safe_open
+
+
+class ConsoleTask(QuietTaskMixin, Task):
+  """A task whose only job is to print information to the console.
+
+  ConsoleTasks are not intended to modify build state.
+  """
+
+  @classmethod
+  def register_options(cls, register):
+    super(ConsoleTask, cls).register_options(register)
+    register('--sep', default='\\n', metavar='<separator>',
+             help='String to use to separate results.')
+    register('--output-file', metavar='<path>',
+             help='Write the console output to this file instead.')
+
+  def __init__(self, *args, **kwargs):
+    super(ConsoleTask, self).__init__(*args, **kwargs)
+    self._console_separator = self.get_options().sep.decode('string-escape')
+    if self.get_options().output_file:
+      try:
+        self._outstream = safe_open(os.path.abspath(self.get_options().output_file), 'w')
+      except IOError as e:
+        raise TaskError('Error opening stream {out_file} due to'
+                        ' {error_str}'.format(out_file=self.get_options().output_file, error_str=e))
+    else:
+      self._outstream = self.context.console_outstream
+
+  @contextmanager
+  def _guard_sigpipe(self):
+    try:
+      yield
+    except IOError as e:
+      # If the pipeline only wants to read so much, that's fine; otherwise, this error is probably
+      # legitimate.
+      if e.errno != errno.EPIPE:
+        raise e
+
+  def execute(self):
+    with self._guard_sigpipe():
+      try:
+        targets = self.context.targets()
+        for value in self.console_output(targets):
+          self._outstream.write(str(value))
+          self._outstream.write(self._console_separator)
+      finally:
+        self._outstream.flush()
+        if self.get_options().output_file:
+          self._outstream.close()
+
+  def console_output(self, targets):
+    raise NotImplementedError('console_output must be implemented by subclasses of ConsoleTask')

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -5,10 +5,10 @@ python_library(
   name = 'task_test_base',
   sources = ['task_test_base.py'],
   dependencies = [
-    'src/python/pants/backend/core/tasks:console_task',
     'src/python/pants/goal:context',
     'src/python/pants/ivy',
     'src/python/pants/util:contextutil',
+    'src/python/pants/task',
     'tests/python/pants_test:base_test',
   ]
 )
@@ -166,7 +166,7 @@ python_tests(
   sources = ['test_console_task.py'],
   dependencies = [
     ':task_test_base',
-    'src/python/pants/backend/core/tasks:console_task',
+    'src/python/pants/task',
   ]
 )
 
@@ -364,7 +364,6 @@ python_tests(
   name = 'list_owners',
   sources = ['test_list_owners.py'],
   dependencies = [
-    ':console_task',
     'src/python/pants/backend/core/tasks:list_owners',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:exceptions',

--- a/tests/python/pants_test/tasks/task_test_base.py
+++ b/tests/python/pants_test/tasks/task_test_base.py
@@ -10,9 +10,9 @@ import subprocess
 from contextlib import closing
 from StringIO import StringIO
 
-from pants.backend.core.tasks.console_task import ConsoleTask
 from pants.goal.goal import Goal
 from pants.ivy.bootstrapper import Bootstrapper
+from pants.task.console_task import ConsoleTask
 from pants.util.contextutil import temporary_dir
 from pants_test.base_test import BaseTest
 

--- a/tests/python/pants_test/tasks/test_console_task.py
+++ b/tests/python/pants_test/tasks/test_console_task.py
@@ -9,7 +9,7 @@ import os
 import threading
 from Queue import Empty, Queue
 
-from pants.backend.core.tasks.console_task import ConsoleTask
+from pants.task.console_task import ConsoleTask
 from pants_test.tasks.task_test_base import TaskTestBase
 
 


### PR DESCRIPTION
It doesn't belong in backend/core.

There are forwarding aliases in the original location, so
custom tasks referencing them won't break (but will display
a deprecation warning).