### PR TITLE
[CI Fix direct calls to superclass __init__.

### DIFF
--- a/src/python/pants/backend/core/tasks/markdown_to_html_utils.py
+++ b/src/python/pants/backend/core/tasks/markdown_to_html_utils.py
@@ -31,6 +31,7 @@ WIKILINKS_PATTERN = r'\[\[([^\]]+)\]\]'
 
 class WikilinksPattern(markdown.inlinepatterns.Pattern):
   def __init__(self, build_url, markdown_instance=None):
+    # Old-style class, so we must invoke __init__ this way.
     markdown.inlinepatterns.Pattern.__init__(self, WIKILINKS_PATTERN, markdown_instance)
     self.build_url = build_url
 
@@ -44,6 +45,7 @@ class WikilinksPattern(markdown.inlinepatterns.Pattern):
 
 class WikilinksExtension(markdown.Extension):
   def __init__(self, build_url, configs=None):
+    # Old-style class, so we must invoke __init__ this way.
     markdown.Extension.__init__(self, configs or {})
     self.build_url = build_url
 
@@ -122,6 +124,7 @@ class IncludeExcerptPattern(markdown.inlinepatterns.Pattern):
     """
     :param string source_path: Path to source `.md` file.
     """
+    # Old-style class, so we must invoke __init__ this way.
     markdown.inlinepatterns.Pattern.__init__(self, INCLUDE_PATTERN)
     self.source_path = source_path
 
@@ -163,6 +166,7 @@ class IncludeExcerptPattern(markdown.inlinepatterns.Pattern):
 
 class IncludeExcerptExtension(markdown.Extension):
   def __init__(self, source_path, configs=None):
+    # Old-style class, so we must invoke __init__ this way.
     markdown.Extension.__init__(self, configs or {})
     self.source_path = source_path
 

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -52,7 +52,8 @@ class PythonChroot(object):
 
   class InvalidDependencyException(Exception):
     def __init__(self, target):
-      Exception.__init__(self, "Not a valid Python dependency! Found: {}".format(target))
+      super(PythonChroot.InvalidDependencyException, self).__init__(
+        'Not a valid Python dependency! Found: {}'.format(target))
 
   @staticmethod
   def get_platforms(platform_list):

--- a/src/python/pants/base/generator.py
+++ b/src/python/pants/base/generator.py
@@ -12,16 +12,16 @@ import pystache
 from pants.base.mustache import MustacheRenderer
 
 
+# TODO(benjy): Get rid of this class? It just adds complexity, and a regular dict should be fine.
+# Unfortunately we first have to fix external uses of this should-be-internal-only class.
 class TemplateData(dict):
-  """Encapsulates data for a mustache template as a property-addressable read-only map-like struct.
-  """
+  """Encapsulates mustache template arguments as a property-addressable read-only object."""
 
   def __init__(self, **kwargs):
-    dict.__init__(self, MustacheRenderer.expand(kwargs))
+    super(TemplateData, self).__init__(MustacheRenderer.expand(kwargs))
 
   def extend(self, **kwargs):
-    """Returns a new TemplateData with this template's data overlayed by the key value pairs
-    specified as keyword arguments."""
+    """Returns a new instance with this instance's data overlayed by the key-value args."""
 
     props = self.copy()
     props.update(kwargs)
@@ -40,6 +40,7 @@ class TemplateData(dict):
     return 'TemplateData({})'.format(pprint.pformat(self))
 
 
+# TODO(benjy): Get rid of this class? It adds basically nothing over the MustacheRenderer.
 class Generator(object):
   """Generates pants intermediary output files using a configured mustache template."""
 

--- a/src/python/pants/base/mustache.py
+++ b/src/python/pants/base/mustache.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import pkgutil
-import urlparse
 
 import pystache
 import six
@@ -17,7 +16,7 @@ class MustacheRenderer(object):
   """Renders text using mustache templates."""
 
   class MustacheError(Exception):
-    """Indicates failure rendering mustache templates"""
+    """Indicates failure rendering mustache templates."""
 
   @staticmethod
   def expand(args):

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -195,14 +195,14 @@ class BuildGraph(object):
     """
     walked = set()
 
-    def _walk_rec(address):
-      if address not in walked:
-        walked.add(address)
-        target = self._target_by_address[address]
+    def _walk_rec(addr):
+      if addr not in walked:
+        walked.add(addr)
+        target = self._target_by_address[addr]
         if not predicate or predicate(target):
           if not postorder:
             work(target)
-          for dep_address in self._target_dependencies_by_address[address]:
+          for dep_address in self._target_dependencies_by_address[addr]:
             _walk_rec(dep_address)
           if postorder:
             work(target)
@@ -218,14 +218,14 @@ class BuildGraph(object):
     """
     walked = set()
 
-    def _walk_rec(address):
-      if address not in walked:
-        walked.add(address)
-        target = self._target_by_address[address]
+    def _walk_rec(addr):
+      if addr not in walked:
+        walked.add(addr)
+        target = self._target_by_address[addr]
         if not predicate or predicate(target):
           if not postorder:
             work(target)
-          for dep_address in self._target_dependees_by_address[address]:
+          for dep_address in self._target_dependees_by_address[addr]:
             _walk_rec(dep_address)
           if postorder:
             work(target)
@@ -243,7 +243,8 @@ class BuildGraph(object):
     :param function predicate: The predicate passed through to `walk_transitive_dependee_graph`.
     """
     ret = OrderedSet()
-    self.walk_transitive_dependee_graph(addresses, ret.add, predicate=predicate, postorder=False)
+    self.walk_transitive_dependee_graph(addresses, ret.add, predicate=predicate,
+                                        postorder=postorder)
     return ret
 
   def transitive_subgraph_of_addresses(self, addresses, predicate=None, postorder=False):
@@ -361,8 +362,8 @@ class BuildGraph(object):
         target = self.get_target(target_address)
 
       def inject_spec_closure(spec):
-        address = mapper.spec_to_address(spec, relative_to=target_address.spec_path)
-        self.inject_address_closure(address)
+        addr = mapper.spec_to_address(spec, relative_to=target_address.spec_path)
+        self.inject_address_closure(addr)
 
       for traversable_spec in target.traversable_dependency_specs:
         inject_spec_closure(traversable_spec)
@@ -417,7 +418,7 @@ class CycleException(Exception):
   """Thrown when a circular dependency is detected."""
 
   def __init__(self, cycle):
-    Exception.__init__(self, 'Cycle detected:\n\t{}'.format(
+    super(CycleException, self).__init__('Cycle detected:\n\t{}'.format(
         ' ->\n\t'.join(target.address.spec for target in cycle)
     ))
 
@@ -429,23 +430,23 @@ def invert_dependencies(targets):
   visited = set()
   path = OrderedSet()
 
-  def invert(target):
-    if target in path:
+  def invert(tgt):
+    if tgt in path:
       path_list = list(path)
-      cycle_head = path_list.index(target)
-      cycle = path_list[cycle_head:] + [target]
+      cycle_head = path_list.index(tgt)
+      cycle = path_list[cycle_head:] + [tgt]
       raise CycleException(cycle)
-    path.add(target)
-    if target not in visited:
-      visited.add(target)
-      if target.dependencies:
-        for dependency in target.dependencies:
-          inverted_deps[dependency].add(target)
+    path.add(tgt)
+    if tgt not in visited:
+      visited.add(tgt)
+      if tgt.dependencies:
+        for dependency in tgt.dependencies:
+          inverted_deps[dependency].add(tgt)
           invert(dependency)
       else:
-        roots.add(target)
+        roots.add(tgt)
 
-    path.remove(target)
+    path.remove(tgt)
 
   for target in targets:
     invert(target)

--- a/src/python/pants/cache/artifact.py
+++ b/src/python/pants/cache/artifact.py
@@ -52,7 +52,7 @@ class DirectoryArtifact(Artifact):
   """An artifact stored as loose files under a directory."""
 
   def __init__(self, artifact_root, directory):
-    Artifact.__init__(self, artifact_root)
+    super(DirectoryArtifact, self).__init__(artifact_root)
     self._directory = directory
 
   def exists(self):
@@ -83,9 +83,9 @@ class DirectoryArtifact(Artifact):
 class TarballArtifact(Artifact):
   """An artifact stored in a tarball."""
 
-  def __init__(self, artifact_root, tarfile, compression=9):
-    Artifact.__init__(self, artifact_root)
-    self._tarfile = tarfile
+  def __init__(self, artifact_root, tarfile_, compression=9):
+    super(TarballArtifact, self).__init__(artifact_root)
+    self._tarfile = tarfile_
     self._compression = compression
 
   def exists(self):
@@ -96,8 +96,7 @@ class TarballArtifact(Artifact):
     # but decompression times are much faster.
     mode = 'w:gz'
 
-    tar_kwargs = {'dereference': True, 'errorlevel': 2}
-    tar_kwargs['compresslevel'] = self._compression
+    tar_kwargs = {'dereference': True, 'errorlevel': 2, 'compresslevel': self._compression}
 
     with open_tar(self._tarfile, mode, **tar_kwargs) as tarout:
       for path in paths or ():

--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -44,9 +44,9 @@ class RESTfulArtifactCache(ArtifactCache):
 
   def __init__(self, artifact_root, url_base, local):
     """
-    :param str artifact_root: The path under which cacheable products will be read/written.
-    :param str url_base: The prefix for urls on some RESTful service. We must be able to PUT and
-                         GET to any path under this base.
+    :param string artifact_root: The path under which cacheable products will be read/written.
+    :param string url_base: The prefix for urls on some RESTful service. We must be able to PUT and
+                            GET to any path under this base.
     :param BaseLocalArtifactCache local: local cache instance for storing and creating artifacts
     """
     super(RESTfulArtifactCache, self).__init__(artifact_root)
@@ -111,7 +111,6 @@ class RESTfulArtifactCache(ArtifactCache):
     session = RequestsSession.instance()
 
     try:
-      response = None
       if 'PUT' == method:
         response = session.put(url, data=body, timeout=self._timeout_secs)
       elif 'GET' == method:

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -43,7 +43,7 @@ class TarArchiver(Archiver):
       tar.extractall(outdir)
 
   def __init__(self, mode, extension):
-    Archiver.__init__(self)
+    super(TarArchiver, self).__init__()
     self.mode = mode
     self.extension = extension
 
@@ -81,7 +81,7 @@ class ZipArchiver(Archiver):
             archive_file.extract(name, outdir)
 
   def __init__(self, compression):
-    Archiver.__init__(self)
+    super(ZipArchiver, self).__init__()
     self.compression = compression
 
   def create(self, basedir, outdir, name, prefix=None):

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -111,7 +111,7 @@ class VersionedTarget(VersionedTargetSet):
     self.target = target
     self.cache_key = cache_key
     # Must come after the assignments above, as they are used in the parent's __init__.
-    VersionedTargetSet.__init__(self, cache_manager, [self])
+    super(VersionedTarget, self).__init__(cache_manager, [self])
     self.id = target.id
 
   def create_results_dir(self, root_dir, allow_incremental):

--- a/src/python/pants/java/nailgun_executor.py
+++ b/src/python/pants/java/nailgun_executor.py
@@ -31,7 +31,7 @@ class NailgunProcessGroup(ProcessGroup):
   _NAILGUN_KILL_LOCK = threading.Lock()
 
   def __init__(self):
-    ProcessGroup.__init__(self, name='nailgun')
+    super(NailgunProcessGroup, self).__init__(name='nailgun')
     # TODO: this should enumerate the .pids dir first, then fallback to ps enumeration (& warn).
 
   def _iter_nailgun_instances(self, everywhere=False):

--- a/src/python/pants/pantsd/subsystem/watchman_launcher.py
+++ b/src/python/pants/pantsd/subsystem/watchman_launcher.py
@@ -23,7 +23,7 @@ class WatchmanLauncher(Subsystem):
              help='Watchman binary location (defaults to $PATH discovery).')
 
   def __init__(self, *args, **kwargs):
-    Subsystem.__init__(self, *args, **kwargs)
+    super(WatchmanLauncher, self).__init__(*args, **kwargs)
 
     options = self.get_options()
     self._workdir = options.pants_workdir

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -23,7 +23,7 @@ class Watchman(ProcessManager):
   EventHandler = namedtuple('EventHandler', ['name', 'metadata', 'callback'])
 
   def __init__(self, work_dir, log_level=1, watchman_path=None):
-    ProcessManager.__init__(self, name='watchman', process_name='watchman', socket_type=str)
+    super(Watchman, self).__init__(name='watchman', process_name='watchman', socket_type=str)
     self._logger = logging.getLogger(__name__)
     self._log_level = log_level
     self.watchman_path = self._resolve_watchman_path(watchman_path)

--- a/src/python/pants/reporting/html_reporter.py
+++ b/src/python/pants/reporting/html_reporter.py
@@ -48,7 +48,7 @@ class HtmlReporter(Reporter):
   Settings = namedtuple('Settings', Reporter.Settings._fields + ('html_dir', 'template_dir'))
 
   def __init__(self, run_tracker, settings):
-    Reporter.__init__(self, run_tracker, settings)
+    super(HtmlReporter, self).__init__(run_tracker, settings)
      # The main report, and associated tool outputs, go under this dir.
     self._html_dir = settings.html_dir
 

--- a/src/python/pants/reporting/reporting_server.py
+++ b/src/python/pants/reporting/reporting_server.py
@@ -56,6 +56,9 @@ class PantsHandler(BaseHTTPServer.BaseHTTPRequestHandler):
       ('/latestrunid', self._handle_latest_runid),  # Return id of latest pants run.
       ('/favicon.ico', self._handle_favicon)  # Return favicon.
     ]
+    # Note: BaseHTTPServer.BaseHTTPRequestHandler is an old-style class, so we must
+    # invoke its __init__ like this.
+    # TODO: Replace this entirely with a proper server as part of the pants daemon.
     BaseHTTPServer.BaseHTTPRequestHandler.__init__(self, request, client_address, server)
 
   def do_GET(self):

--- a/src/python/pants/rwbuf/read_write_buffer.py
+++ b/src/python/pants/rwbuf/read_write_buffer.py
@@ -56,7 +56,7 @@ class InMemoryRWBuf(_RWBuf):
   situations that require a real file (e.g., redirecting stdout/stderr of subprocess.Popen())."""
 
   def __init__(self):
-    _RWBuf.__init__(self, StringIO())
+    super(InMemoryRWBuf, self).__init__(StringIO())
     self._writepos = 0
 
   def do_write(self, s):

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -24,6 +24,7 @@ from pants.util.dirutil import safe_mkdir
 class SimpleRESTHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
   def __init__(self, request, client_address, server):
     # The base class implements GET and HEAD.
+    # Old-style class, so we must invoke __init__ this way.
     SimpleHTTPServer.SimpleHTTPRequestHandler.__init__(self, request, client_address, server)
 
   def do_HEAD(self):
@@ -53,6 +54,7 @@ class FailRESTHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
   """Reject all requests"""
 
   def __init__(self, request, client_address, server):
+    # Old-style class, so we must invoke __init__ this way.
     SimpleHTTPServer.SimpleHTTPRequestHandler.__init__(self, request, client_address, server)
 
   def _return_failed(self):
@@ -72,8 +74,8 @@ class FailRESTHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
     return self._return_failed()
 
 
-TEST_CONTENT1 = 'muppet'
-TEST_CONTENT2 = 'kermit'
+TEST_CONTENT1 = b'muppet'
+TEST_CONTENT2 = b'kermit'
 
 
 class TestArtifactCache(unittest.TestCase):
@@ -239,7 +241,7 @@ class TestArtifactCache(unittest.TestCase):
       with temporary_dir() as results_dir:
         with temporary_file_path(root_dir=results_dir) as canary:
           map(call_insert, [(cache, key, [path], False)])
-          results = map(call_use_cached_files, [(cache, key, results_dir)])
+          map(call_use_cached_files, [(cache, key, results_dir)])
           # Results content should have been deleted.
           self.assertFalse(os.path.exists(canary))
 
@@ -271,7 +273,7 @@ class TestArtifactCache(unittest.TestCase):
         self.assertTrue(os.path.exists(tarfile))
 
         with open(tarfile, 'w') as outfile:
-          outfile.write('not a valid tgz any more')
+          outfile.write(b'not a valid tgz any more')
 
         self.assertFalse(artifact_cache.use_cached_files(key))
         self.assertFalse(os.path.exists(tarfile))

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -45,7 +45,8 @@ class InvalidationCacheManagerTest(BaseTest):
   class TestInvalidationCacheManager(InvalidationCacheManager):
 
     def __init__(self, tmpdir):
-      InvalidationCacheManager.__init__(self, AppendingCacheKeyGenerator(), tmpdir, True)
+      super(InvalidationCacheManagerTest.TestInvalidationCacheManager, self).__init__(
+        AppendingCacheKeyGenerator(), tmpdir, True)
 
   def setUp(self):
     super(InvalidationCacheManagerTest, self).setUp()


### PR DESCRIPTION
Replaces them with super() calls where possible, or adds comments
for old-style classes.

Also driveby-fixes various style issues and inspections I saw along the way,
such as a few cases where we shadow builtins or variables.

Added a couple of TODOs to consider getting rid of a couple of classes
that seem to add more complexity than benefit.