### PR TITLE
Remove the `contrib/haskell/examples/3rdparty:stack*` targets

### DIFF
--- a/contrib/haskell/examples/3rdparty/BUILD
+++ b/contrib/haskell/examples/3rdparty/BUILD
@@ -28,3 +28,16 @@ haskell_project(
     ':pipes',
   ],
 )
+
+haskell_source_package(
+  name='lens-family-core',
+  path='http://hackage.haskell.org/package/lens-family-core-1.2.0/lens-family-core-1.2.0.tar.gz',
+)
+
+haskell_project(
+  name='lens-family-core-project',
+  resolver='lts-3.1',
+  dependencies=[
+    ':lens-family-core',
+  ]
+)

--- a/contrib/haskell/examples/3rdparty/BUILD
+++ b/contrib/haskell/examples/3rdparty/BUILD
@@ -28,16 +28,3 @@ haskell_project(
     ':pipes',
   ],
 )
-
-haskell_source_package(
-  name='stack',
-  path='https://github.com/commercialhaskell/stack/archive/v0.1.3.1.tar.gz',
-)
-
-haskell_project(
-  name='stack-project',
-  resolver='lts-3.1',
-  dependencies=[
-    ':stack',
-  ]
-)


### PR DESCRIPTION
These take too long to compile because the root source project is quite large