### PR TITLE
Refactory detect_duplicates with some user friendly features

### DIFF
--- a/migrations/options/src/python/migrate_config.py
+++ b/migrations/options/src/python/migrate_config.py
@@ -180,6 +180,7 @@ migrations = {
   ('binary', 'ng_daemons'): ('binary', 'use_nailgun'),
   ('binary.dex', 'ng_daemons'): ('binary.dex', 'use_nailgun'),
   ('binary.dup', 'ng_daemons'): ('binary.dup', 'use_nailgun'),
+  ('binary.dup', 'excludes'): ('binary.dup', 'exclude_files'),
 
   # NB: bundle.bundle -> bundle is a leaf scope
   ('bundle', 'ng_daemons'): ('bundle', 'use_nailgun'),

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -153,7 +153,9 @@ python_library(
     '3rdparty/python:pex',
     'src/python/pants/base:exceptions',
     'src/python/pants/java/jar:manifest',
+    'src/python/pants/option',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/detect_duplicates.py
+++ b/src/python/pants/backend/jvm/tasks/detect_duplicates.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import re
 from collections import defaultdict
 
 from pex.compatibility import to_bytes
@@ -14,11 +15,15 @@ from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.backend.jvm.tasks.jvm_binary_task import JvmBinaryTask
 from pants.base.exceptions import TaskError
 from pants.java.jar.manifest import Manifest
+from pants.option.custom_types import list_option
 from pants.util.contextutil import open_zip
+from pants.util.memo import memoized_property
 
 
-EXCLUDED_FILES = ['dependencies,license,notice,.DS_Store,notice.txt,cmdline.arg.info.txt.1,'
-                  'license.txt']
+EXCLUDED_FILES = ['.DS_Store', 'cmdline.arg.info.txt.1', 'dependencies',
+                  'license', 'license.txt', 'notice','notice.txt']
+EXCLUDED_DIRS = ['META-INF/services']
+EXCLUDED_PATTERNS=[r'^META-INF/[^/]+\.(SF|DSA|RSA)$']  # signature file
 
 
 class DuplicateDetector(JvmBinaryTask):
@@ -31,26 +36,55 @@ class DuplicateDetector(JvmBinaryTask):
   @classmethod
   def register_options(cls, register):
     super(DuplicateDetector, cls).register_options(register)
-    register('--excludes', default=EXCLUDED_FILES, action='append',
+
+    register('--excludes', default=[','.join(EXCLUDED_FILES)], action='append',
+             deprecated_version='0.0.65',
+             deprecated_hint='Use --exclude-files, --exclude-patterns, or --exclude-dirs instead.',
              help='Case insensitive filenames (without directory) to exclude from duplicate check. '
                   'Filenames can be specified in a comma-separated list or by using multiple '
                   'instances of this flag.')
+    register('--exclude-files', default=EXCLUDED_FILES, type=list_option,
+             help='Case insensitive filenames (without directory) to exclude from duplicate check.')
+    register('--exclude-dirs', default=EXCLUDED_DIRS, type=list_option,
+             help='Directory names to exclude from duplicate check.')
+    register('--exclude-patterns', default=EXCLUDED_PATTERNS, type=list_option,
+             help='Regular expressions matching paths (directory and filename) to exclude from '
+                  'the duplicate check.')
     register('--max-dups', type=int, default=10,
              help='Maximum number of duplicate classes to display per artifact.')
+    register('--skip', action='store_true', default=False,
+             help='Disable the dup checking step.')
 
   @classmethod
   def prepare(cls, options, round_manager):
     super(DuplicateDetector, cls).prepare(options, round_manager)
     round_manager.require_data('runtime_classpath')
 
-  def __init__(self, *args, **kwargs):
-    super(DuplicateDetector, self).__init__(*args, **kwargs)
-    self._fail_fast = self.get_options().fail_fast
-    excludes = self.get_options().excludes
-    self._excludes = set([x.lower() for exclude in excludes for x in exclude.split(',')])
-    self._max_dups = int(self.get_options().max_dups)
+  @memoized_property
+  def max_dups(self):
+    return int(self.get_options().max_dups)
+
+  @memoized_property
+  def exclude_files(self):
+    # Legacy, the excludes accepts a list of CSV filenames
+    legacy_excludes = [x.lower() for exclude in self.get_options().excludes or []
+                       for x in exclude.split(',')]
+    exclude_files = [x.lower() for x in self.get_options().exclude_files or []]
+    return set(exclude_files + legacy_excludes)
+
+  @memoized_property
+  def exclude_dirs(self):
+    return set(self.get_options().exclude_dirs)
+
+  @memoized_property
+  def exclude_patterns(self):
+    return [re.compile(x) for x in set(self.get_options().exclude_patterns or [])]
 
   def execute(self):
+    if self.get_options().skip:
+      self.context.log.debug("Duplicate checking is disabled.")
+      return None
+
     conflicts_by_binary = {}
     for binary_target in filter(self.is_binary, self.context.targets()):
       conflicts_by_artifacts = self.detect_duplicates_for_target(binary_target)
@@ -79,7 +113,7 @@ class DuplicateDetector(JvmBinaryTask):
     conflicts_by_artifacts = self._get_conflicts_by_artifacts(artifacts_by_file_name)
     if len(conflicts_by_artifacts) > 0:
       self._log_conflicts(conflicts_by_artifacts, binary_target)
-      if self._fail_fast:
+      if self.get_options().fail_fast:
         raise TaskError('Failing build for target {}.'.format(binary_target))
     return conflicts_by_artifacts
 
@@ -92,8 +126,7 @@ class DuplicateDetector(JvmBinaryTask):
     def record_file_ownership(target):
       entries = ClasspathUtil.internal_classpath([target], classpath_products)
       for f in ClasspathUtil.classpath_entries_contents(entries):
-        if not f.endswith('/'):
-          artifacts_by_file_name[f].add(target.address.reference())
+        artifacts_by_file_name[f].add(target.address.reference())
 
     binary_target.walk(record_file_ownership)
     return artifacts_by_file_name
@@ -109,16 +142,27 @@ class DuplicateDetector(JvmBinaryTask):
           # and need to do this to_bytes(...).decode('utf-8') dance to stay safe across all entry
           # name flavors and under all supported pythons.
           decoded_file_name = to_bytes(qualified_file_name).decode('utf-8')
-          if os.path.basename(decoded_file_name).lower() in self._excludes:
-            continue
-          if (not self._isdir(decoded_file_name)) and Manifest.PATH != decoded_file_name:
-            artifacts_by_file_name[decoded_file_name].add(coordinate.artifact_filename)
+          artifacts_by_file_name[decoded_file_name].add(coordinate.artifact_filename)
     return artifacts_by_file_name
+
+  def _is_excluded(self, path):
+    if self._isdir(path) or Manifest.PATH == path:
+      return True
+    if os.path.basename(path).lower() in self.exclude_files:
+      return True
+    if os.path.dirname(path) in self.exclude_dirs:
+      return True
+    for pattern in self.exclude_patterns:
+      if pattern.search(path):
+        return True
+    return False
 
   def _get_conflicts_by_artifacts(self, artifacts_by_file_name):
     conflicts_by_artifacts = defaultdict(set)
     for (file_name, artifacts) in artifacts_by_file_name.items():
       if (not artifacts) or len(artifacts) < 2:
+        continue
+      if self._is_excluded(file_name):
         continue
       conflicts_by_artifacts[tuple(sorted(str(a) for a in artifacts))].add(file_name)
     return conflicts_by_artifacts
@@ -131,8 +175,8 @@ class DuplicateDetector(JvmBinaryTask):
       self.context.log.warn(
         'Duplicate classes and/or resources detected in artifacts: {}'.format(artifacts))
       dup_list = list(duplicate_files)
-      for duplicate_file in dup_list[:self._max_dups]:
+      for duplicate_file in dup_list[:self.max_dups]:
         self.context.log.warn('     {}'.format(duplicate_file))
-      if len(dup_list) > self._max_dups:
+      if len(dup_list) > self.max_dups:
         self.context.log.warn('     ... {remaining} more ...'
-                              .format(remaining=(len(dup_list) - self._max_dups)))
+                              .format(remaining=(len(dup_list) - self.max_dups)))

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -12,6 +12,7 @@ target(
     ':check_published_deps',
     ':classpath_products',
     ':classpath_util',
+    ':detect_duplicates',
     ':ivy_imports',
     ':ivy_resolve',
     ':ivy_utils',
@@ -170,6 +171,21 @@ python_tests(
     'src/python/pants/goal:products',
     'tests/python/pants_test:base_test',
   ]
+)
+
+python_tests(
+  name = 'detect_duplicates',
+  sources = ['test_detect_duplicates.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm:jar_dependency_utils',
+    'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/backend/jvm/tasks:detect_duplicates',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/jvm:jvm_task_test_base'
+  ],
 )
 
 python_tests(

--- a/tests/python/pants_test/tasks/BUILD
+++ b/tests/python/pants_test/tasks/BUILD
@@ -17,7 +17,6 @@ target(
   name = 'tasks',
   dependencies = [
     ':builddict',
-    ':detect_duplicates',
     ':execution_graph',
     ':group_task',
     ':list_goals',
@@ -94,21 +93,6 @@ python_tests(
     'src/python/pants/backend/python:plugin',
     'tests/python/pants_test:base_test',
   ]
-)
-
-python_tests(
-  name = 'detect_duplicates',
-  sources = ['test_detect_duplicates.py'],
-  dependencies = [
-    'src/python/pants/backend/jvm:jar_dependency_utils',
-    'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm/targets:java',
-    'src/python/pants/backend/jvm/tasks:detect_duplicates',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
-    'tests/python/pants_test/jvm:jvm_task_test_base'
-  ],
 )
 
 python_tests(


### PR DESCRIPTION
- Deprecate the 'excludes' argument. Accepted a list of comma separated values
- Added --exclude-files to replace --excludes
- Added --exclude-dirs to exclude directories
- Added --exclude-patterns to use a regular expression
- Added --skip to easily turn off the duplicate checking feature
- Moved logic out of __init__()
- Moved the logic to check for excludes to a central place where it can
    be used to exclude classes on the classpath, not just artifacts in jars