### PR TITLE
[CI] Move the test runner task mixin out of backend/core.

### DIFF
--- a/src/python/pants/backend/core/tasks/BUILD
+++ b/src/python/pants/backend/core/tasks/BUILD
@@ -71,7 +71,6 @@ target(
     ':sorttargets',
     ':targets_help',
     ':task',
-    ':test_task_mixin',
     ':what_changed',
   ]
 )
@@ -396,15 +395,6 @@ python_library(
 resources(
   name = 'targets_help_resources',
   sources = globs('templates/targets_help/*.mustache'),
-)
-
-python_library(
-  name = 'test_task_mixin',
-  sources = ['test_task_mixin.py'],
-  dependencies = [
-    'src/python/pants/base:exceptions',
-    'src/python/pants/util:timeout',
-  ],
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from six.moves import range
 from twitter.common.collections import OrderedSet
 
-from pants.backend.core.tasks.test_task_mixin import TestTaskMixin
 from pants.backend.jvm.subsystems.shader import Shader
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.java_tests import JavaTests as junit_tests
@@ -30,6 +29,7 @@ from pants.base.workunit import WorkUnitLabel
 from pants.binaries import binary_util
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
+from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
 from pants.util.strutil import pluralize
 from pants.util.xml_parser import XmlParser
 
@@ -56,7 +56,7 @@ def interpret_test_spec(test_spec):
     return (None, (classname_or_srcfile, methodname))
 
 
-class JUnitRun(TestTaskMixin, JvmToolTaskMixin, JvmTask):
+class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
   _MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   @classmethod
@@ -369,7 +369,7 @@ class JUnitRun(TestTaskMixin, JvmToolTaskMixin, JvmTask):
   def _partition_by_jvm_options(self, tests_to_targets, tests):
     """Partitions a list of tests by the jvm options to run them with.
 
-    :param dict tests_to_target: A mapping from each test to its target.
+    :param dict tests_to_targets: A mapping from each test to its target.
     :param list tests: The list of tests to run.
     :returns: A list of tuples where the first element is an array of jvm options and the second
       is a list of tests to run with the jvm options. Each test in tests will appear in exactly
@@ -448,7 +448,7 @@ class JUnitRun(TestTaskMixin, JvmToolTaskMixin, JvmTask):
 
   def _execute(self, targets):
     """
-    Implements the primary junit test execution. This method is called by the TestTaskMixin,
+    Implements the primary junit test execution. This method is called by the TestRunnerTaskMixin,
     which contains the primary Task.execute function and wraps this method in timeouts.
     """
 
@@ -458,7 +458,7 @@ class JUnitRun(TestTaskMixin, JvmToolTaskMixin, JvmTask):
     # and report on all the original targets, not just the test targets.
     #
     # We've already filtered out the non-test targets in the
-    # TestTaskMixin, so the mixin passes to us both the test
+    # TestRunnerTaskMixin, so the mixin passes to us both the test
     # targets and the unfiltered list of targets
     tests_and_targets = self._collect_test_targets(self._get_test_targets())
 

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -15,8 +15,6 @@ python_library(
     '3rdparty/python:six',
     'src/python/pants/backend/codegen/targets:python',
     'src/python/pants/backend/core/targets:common',
-    'src/python/pants/backend/core/tasks:repl_task_mixin',
-    'src/python/pants/backend/core/tasks:test_task_mixin',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:antlr_builder',
     'src/python/pants/backend/python:interpreter_cache',

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -20,7 +20,6 @@ from pex.pex_info import PexInfo
 from six import StringIO
 from six.moves import configparser
 
-from pants.backend.core.tasks.test_task_mixin import TestTaskMixin
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.backend.python.targets.python_tests import PythonTests
@@ -28,6 +27,7 @@ from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.exceptions import TaskError, TestFailedTaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
+from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
 from pants.util.contextutil import (environment_as, temporary_dir, temporary_file,
                                     temporary_file_path)
 from pants.util.dirutil import safe_mkdir, safe_open
@@ -67,7 +67,7 @@ class PythonTestResult(object):
     return self._failed_targets
 
 
-class PytestRun(TestTaskMixin, PythonTask):
+class PytestRun(TestRunnerTaskMixin, PythonTask):
   _TESTING_TARGETS = [
     # Note: the requirement restrictions on pytest and pytest-cov match those in requirements.txt,
     # to avoid confusion when debugging pants tests.

--- a/src/python/pants/task/BUILD
+++ b/src/python/pants/task/BUILD
@@ -19,5 +19,6 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
+    'src/python/pants/util:timeout',
   ],
 )

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -11,7 +11,7 @@ from pants.base.exceptions import TestFailedTaskError
 from pants.util.timeout import Timeout, TimeoutReached
 
 
-class TestTaskMixin(object):
+class TestRunnerTaskMixin(object):
   """A mixin to combine with test runner tasks.
 
   The intent is to migrate logic over time out of JUnitRun and PytestRun, so the functionality
@@ -20,7 +20,7 @@ class TestTaskMixin(object):
 
   @classmethod
   def register_options(cls, register):
-    super(TestTaskMixin, cls).register_options(register)
+    super(TestRunnerTaskMixin, cls).register_options(register)
     register('--skip', action='store_true', help='Skip running tests.')
     register('--timeouts', action='store_true', default=True,
              help='Enable test target timeouts. If timeouts are enabled then tests with a timeout= parameter '

--- a/tests/python/pants_test/backend/core/tasks/BUILD
+++ b/tests/python/pants_test/backend/core/tasks/BUILD
@@ -11,7 +11,7 @@ target(
     ':mutex_task_mixin',
     ':scm_publish',
     ':target_filter_task_mixin',
-    ':test_task_mixin',
+    ':testrunner_task_mixin',
   ],
 )
 
@@ -161,10 +161,11 @@ python_tests(
 )
 
 python_tests(
-  name='test_task_mixin',
-  sources=['test_test_task_mixin.py'],
+  name='testrunner_task_mixin',
+  sources=['test_testrunner_task_mixin.py'],
   dependencies=[
-    'src/python/pants/backend/core/tasks:test_task_mixin',
+    'src/python/pants/task',
+    'src/python/pants/util:timeout',
     'tests/python/pants_test/tasks:task_test_base',
     '3rdparty/python:mock',
   ]

--- a/tests/python/pants_test/backend/core/tasks/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/backend/core/tasks/test_testrunner_task_mixin.py
@@ -7,9 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from mock import patch
 
-from pants.backend.core.tasks.test_task_mixin import TestTaskMixin
 from pants.base.exceptions import TestFailedTaskError
 from pants.task.task import TaskBase
+from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
 from pants.util.timeout import TimeoutReached
 from pants_test.tasks.task_test_base import TaskTestBase
 
@@ -23,10 +23,10 @@ targetA = DummyTestTarget('TargetA')
 targetB = DummyTestTarget('TargetB', timeout=1)
 
 
-class TestTaskMixinTest(TaskTestBase):
+class TestRunnerTaskMixinTest(TaskTestBase):
   @classmethod
   def task_type(cls):
-    class TestTaskMixinTask(TestTaskMixin, TaskBase):
+    class TestRunnerTaskMixinTask(TestRunnerTaskMixin, TaskBase):
       call_list = []
 
       def _execute(self, all_targets):
@@ -51,7 +51,7 @@ class TestTaskMixinTest(TaskTestBase):
       def _timeout_abort_handler(self):
         self.call_list.append(['_timeout_abort_handler'])
 
-    return TestTaskMixinTask
+    return TestRunnerTaskMixinTask
 
   def test_execute_normal(self):
     task = self.create_task(self.context())
@@ -98,10 +98,10 @@ class TestTaskMixinTest(TaskTestBase):
     self.assertEquals(task._timeout_for_targets([targetA, targetB]), 3)
 
 
-class TestTaskMixinTimeoutTest(TaskTestBase):
+class TestRunnerTaskMixinTimeoutTest(TaskTestBase):
   @classmethod
   def task_type(cls):
-    class TestTaskMixinTask(TestTaskMixin, TaskBase):
+    class TestRunnerTaskMixinTask(TestRunnerTaskMixin, TaskBase):
       call_list = []
 
       def _execute(self, all_targets):
@@ -119,13 +119,13 @@ class TestTaskMixinTimeoutTest(TaskTestBase):
       def _validate_target(self, target):
         self.call_list.append(['_validate_target', target])
 
-    return TestTaskMixinTask
+    return TestRunnerTaskMixinTask
 
   def test_timeout(self):
     self.set_options(timeouts=True)
     task = self.create_task(self.context())
 
-    with patch('pants.backend.core.tasks.test_task_mixin.Timeout') as mock_timeout:
+    with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       mock_timeout().__exit__.side_effect = TimeoutReached(1)
 
       with self.assertRaises(TestFailedTaskError):
@@ -139,7 +139,7 @@ class TestTaskMixinTimeoutTest(TaskTestBase):
     self.set_options(timeouts=False)
     task = self.create_task(self.context())
 
-    with patch('pants.backend.core.tasks.test_task_mixin.Timeout') as mock_timeout:
+    with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       task.execute()
 
       # Ensures that Timeout is instantiated with no timeout.

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -275,6 +275,7 @@ python_tests(
     'src/python/pants/java/distribution:distribution',
     'src/python/pants/java:executor',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:timeout',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import subprocess
-from collections import defaultdict
 from textwrap import dedent
 
 from mock import patch
@@ -18,7 +17,6 @@ from pants.backend.jvm.tasks.junit_run import JUnitRun
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.goal.products import MultipleRootedProducts
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.java.distribution.distribution import DistributionLocator
@@ -95,7 +93,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
   def test_junit_runner_timeout_success(self):
     """When we set a timeout and don't force failure, succeed."""
 
-    with patch('pants.backend.core.tasks.test_task_mixin.Timeout') as mock_timeout:
+    with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       self.set_options(timeout_default=1)
       self.set_options(timeouts=True)
       self.execute_junit_runner(
@@ -118,7 +116,7 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
   def test_junit_runner_timeout_fail(self):
     """When we set a timeout and force a failure, fail."""
 
-    with patch('pants.backend.core.tasks.test_task_mixin.Timeout') as mock_timeout:
+    with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       mock_timeout().__exit__.side_effect = TimeoutReached(1)
 
       self.set_options(timeout_default=1)

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -38,6 +38,7 @@ python_tests(
     'src/python/pants/backend/python/tasks:python',
     'src/python/pants/backend/python:python_setup',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:timeout',
   ]
 )
 

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -231,7 +231,7 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
   def test_one_timeout(self):
     """When we have two targets, any of them doesn't have a timeout, and we have no default, then no timeout is set."""
 
-    with patch('pants.backend.core.tasks.test_task_mixin.Timeout') as mock_timeout:
+    with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       self.run_tests(targets=[self.sleep_no_timeout, self.sleep_timeout])
 
       # Ensures that Timeout is instantiated with no timeout.
@@ -241,7 +241,7 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
   def test_timeout(self):
     """Check that a failed timeout returns the right results."""
 
-    with patch('pants.backend.core.tasks.test_task_mixin.Timeout') as mock_timeout:
+    with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       mock_timeout().__exit__.side_effect = TimeoutReached(1)
       self.run_failing_tests(targets=[self.sleep_timeout],
                              failed_targets=[self.sleep_timeout])


### PR DESCRIPTION
Also rename it to emphasize that it's for test runners, not for tests...