### PR TITLE
[CI] Properly deprecate the Dependencies alias.

### DIFF
--- a/src/python/pants/backend/core/register.py
+++ b/src/python/pants/backend/core/register.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 from pants.backend.core.from_target import FromTarget
-from pants.backend.core.targets.dependencies import Dependencies, DeprecatedDependencies
+from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.doc import Page, Wiki, WikiArtifact
 from pants.backend.core.targets.prep_command import PrepCommand
 from pants.backend.core.targets.resources import Resources
@@ -42,6 +42,7 @@ from pants.backend.core.wrapped_globs import Globs, RGlobs, ZGlobs
 from pants.base.build_environment import get_buildroot, pants_version
 from pants.base.source_root import SourceRoot
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
 from pants.goal.task_registrar import TaskRegistrar as task
 
 
@@ -58,12 +59,11 @@ class BuildFilePath(object):
 def build_file_aliases():
   return BuildFileAliases(
     targets={
-      # NB: the 'dependencies' alias is deprecated in favor of the 'target' alias
-      'dependencies': DeprecatedDependencies,
+      'dependencies': Dependencies,  # Deprecated, will be removed soon.
       'page': Page,
       'prep_command': PrepCommand,
       'resources': Resources,
-      'target': Dependencies,
+      'target': Target,
     },
     objects={
       'ConfluencePublish': ConfluencePublish,

--- a/src/python/pants/backend/core/targets/BUILD
+++ b/src/python/pants/backend/core/targets/BUILD
@@ -17,6 +17,7 @@ python_library(
     'resources.py',
   ],
   dependencies = [
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',

--- a/src/python/pants/backend/core/targets/dependencies.py
+++ b/src/python/pants/backend/core/targets/dependencies.py
@@ -15,8 +15,9 @@ class Dependencies(Target):
 
   NB: This class is commonly referred to by the alias 'target' in BUILD files.
   """
-  
+
   @deprecated('0.0.64', 'Replace dependencies(...) with target(...) in your BUILD files. '
                         'Replace uses of Dependencies with Target in your code.')
   def __init__(self, *args, **kwargs):
-    super(Dependencies, self).__init__(*args, **kwargs)
+    raise RuntimeError('For {}: dependencies(...) targets no longer work. Replace with '
+                       'target(...) in your BUILD files.'.format(kwargs['address'].spec))

--- a/src/python/pants/backend/core/targets/dependencies.py
+++ b/src/python/pants/backend/core/targets/dependencies.py
@@ -5,12 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import logging
-
+from pants.base.deprecated import deprecated
 from pants.build_graph.target import Target
-
-
-logger = logging.getLogger(__name__)
 
 
 class Dependencies(Target):
@@ -19,13 +15,8 @@ class Dependencies(Target):
 
   NB: This class is commonly referred to by the alias 'target' in BUILD files.
   """
-
-
-class DeprecatedDependencies(Dependencies):
-  """A subclass for Dependencies that warns that the 'dependencies' alias is deprecated."""
-
+  
+  @deprecated('0.0.64', 'Replace dependencies(...) with target(...) in your BUILD files. '
+                        'Replace uses of Dependencies with Target in your code.')
   def __init__(self, *args, **kwargs):
-    logger.warn("For {0} : The alias 'dependencies(..)' has been deprecated in favor of "
-                "'target(..)'"
-                .format(kwargs['address'].spec))
-    super(DeprecatedDependencies, self).__init__(*args, **kwargs)
+    super(Dependencies, self).__init__(*args, **kwargs)

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -385,6 +385,7 @@ python_library(
     ':jvm_dependency_analyzer',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:build_environment',
+    'src/python/pants/build_graph',
     'src/python/pants/util:fileutil',
   ]
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -11,7 +11,6 @@ import itertools
 import os
 from collections import defaultdict
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.resources import Resources
 from pants.backend.core.tasks.group_task import GroupMember
 from pants.backend.jvm.subsystems.java import Java
@@ -548,7 +547,7 @@ class JvmCompile(NailgunTaskBase, GroupMember):
     """
     def resolve(t):
       for declared in t.dependencies:
-        if isinstance(declared, Dependencies) or type(declared) == Target:
+        if type(declared) == Target:
           for r in resolve(declared):
             yield r
         elif isinstance(declared, self.compiler_plugin_types):

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -8,9 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import json
 import os
 import sys
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.resources import Resources
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
@@ -80,7 +79,7 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
       with open(output_file, 'w') as fh:
         self._render(graph, fh)
     else:
-      sys.stdout.write('\n')
+      sys.stdout.write(b'\n')
       self._render(graph, sys.stdout)
 
   def _render(self, graph, fh):
@@ -92,7 +91,7 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
   def _resolve_aliases(self, target):
     """Recursively resolve `target` aliases."""
     for declared in target.dependencies:
-      if isinstance(declared, Dependencies) or type(declared) == Target:
+      if type(declared) == Target:
         for r in self._resolve_aliases(declared):
           yield r
       else:
@@ -105,8 +104,7 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
   def _select(self, target):
     if self.get_options().internal_only and isinstance(target, JarLibrary):
       return False
-    elif isinstance(target, (Dependencies, Resources)) or type(target) == Target:
-      # ignore aliases and resources
+    elif isinstance(target, Resources) or type(target) == Target:
       return False
     else:
       return True

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -116,6 +116,7 @@ python_library(
     'src/python/pants/backend/core/targets:common',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:build_environment',
+    'src/python/pants/build_graph',
     'src/python/pants/invalidation',
     'src/python/pants/util:dirutil'
   ],

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -11,6 +11,7 @@ python_library(
     ':python_requirements',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/base:deprecated',
     'src/python/pants/build_graph',
     'src/python/pants/goal:task_registrar',
   ]

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -20,7 +20,6 @@ from twitter.common.collections import OrderedSet
 
 from pants.backend.codegen.targets.python_antlr_library import PythonAntlrLibrary
 from pants.backend.codegen.targets.python_thrift_library import PythonThriftLibrary
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.prep_command import PrepCommand
 from pants.backend.core.targets.resources import Resources
 from pants.backend.python.antlr_builder import PythonAntlrBuilder
@@ -31,6 +30,7 @@ from pants.backend.python.targets.python_requirement_library import PythonRequir
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.thrift_builder import PythonThriftBuilder
 from pants.base.build_environment import get_buildroot
+from pants.build_graph.target import Target
 from pants.invalidation.build_invalidator import BuildInvalidator, CacheKeyGenerator
 from pants.util.dirutil import safe_mkdir, safe_mkdtemp, safe_rmtree
 
@@ -184,7 +184,7 @@ class PythonChroot(object):
         if isinstance(trg, target_type):
           children[target_key].add(trg)
           return
-        elif isinstance(trg, Dependencies):
+        elif type(trg) == Target:
           return
       raise self.InvalidDependencyException(trg)
     for target in targets:

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -18,9 +18,18 @@ from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
 from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
 from pants.backend.python.tasks.setup_py import SetupPy
+from pants.base.deprecated import deprecated
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.goal.task_registrar import TaskRegistrar as task
+
+
+class PythonTestSuite(Target):
+  @deprecated('0.0.64', 'Replace python_test_suite(...) with target(...) in your BUILD files. '
+                        'Replace uses of PythonTestSuite with Target in your code.')
+  def __init__(self, *args, **kwargs):
+    raise RuntimeError('For {}: python_test_suite(...) targets no longer work. Replace with '
+                       'target(...) in your BUILD files.'.format(kwargs['address'].spec))
 
 
 def build_file_aliases():
@@ -29,7 +38,7 @@ def build_file_aliases():
       'python_binary': PythonBinary,
       'python_library': PythonLibrary,
       'python_requirement_library': PythonRequirementLibrary,
-      'python_test_suite': Target,  # Legacy alias.
+      'python_test_suite': PythonTestSuite,
       'python_tests': PythonTests,
     },
     objects={

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.python.pants_requirement import pants_requirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
@@ -20,6 +19,7 @@ from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
 from pants.backend.python.tasks.setup_py import SetupPy
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
 from pants.goal.task_registrar import TaskRegistrar as task
 
 
@@ -29,7 +29,7 @@ def build_file_aliases():
       'python_binary': PythonBinary,
       'python_library': PythonLibrary,
       'python_requirement_library': PythonRequirementLibrary,
-      'python_test_suite': Dependencies,  # Legacy alias.
+      'python_test_suite': Target,  # Legacy alias.
       'python_tests': PythonTests,
     },
     objects={

--- a/tests/python/pants_test/backend/core/tasks/test_dependees.py
+++ b/tests/python/pants_test/backend/core/tasks/test_dependees.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from textwrap import dedent
 
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.resources import Resources
 from pants.backend.core.tasks.dependees import ReverseDepmap
 from pants.backend.jvm.targets.jar_dependency import JarDependency
@@ -18,6 +17,7 @@ from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
@@ -48,7 +48,7 @@ class ReverseDepmapTest(BaseReverseDepmapTest):
   def alias_groups(self):
     return BuildFileAliases(
       targets={
-        'target': Dependencies,
+        'target': Target,
         'jar_library': JarLibrary,
         'java_library': JavaLibrary,
         'java_thrift_library': JavaThriftLibrary,

--- a/tests/python/pants_test/backend/core/tasks/test_filter.py
+++ b/tests/python/pants_test/backend/core/tasks/test_filter.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from textwrap import dedent
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.doc import Page
 from pants.backend.core.tasks.filter import Filter
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -15,6 +14,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
@@ -24,7 +24,7 @@ class BaseFilterTest(ConsoleTaskTestBase):
   def alias_groups(self):
     return BuildFileAliases(
       targets={
-        'target': Dependencies,
+        'target': Target,
         'java_library': JavaLibrary,
         'page': Page,
         'python_library': PythonLibrary,

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -399,7 +399,7 @@ python_tests(
   dependencies = [
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jvm_platform_analysis',
-    'src/python/pants/util:contextutil',
+    'src/python/pants/build_graph',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_check_published_deps.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_check_published_deps.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from textwrap import dedent
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.scala_artifact import ScalaArtifact
@@ -18,6 +17,7 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.backend.jvm.tasks.check_published_deps import CheckPublishedDeps
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
@@ -27,7 +27,7 @@ class CheckPublishedDepsTest(ConsoleTaskTestBase):
   def alias_groups(self):
     return BuildFileAliases(
       targets={
-        'target': Dependencies,
+        'target': Target,
         'jar_library': JarLibrary,
         'java_library': JavaLibrary,
       },

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
@@ -8,10 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import unittest
 
-import pytest
 from mock import Mock
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.scala_artifact import ScalaArtifact
@@ -20,6 +18,7 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.jar_publish import JarPublish
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
 from pants.scm.scm import Scm
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_walk
@@ -48,7 +47,7 @@ class JarPublishTest(TaskTestBase):
       targets={
         'jar_library': JarLibrary,
         'java_library': JavaLibrary,
-        'target': Dependencies,
+        'target': Target,
       },
       objects={
         'artifact': Artifact,

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_platform_analysis.py
@@ -5,9 +5,9 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.jvm_platform_analysis import JvmPlatformExplain, JvmPlatformValidate
+from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
@@ -27,7 +27,7 @@ class JvmPlatformAnalysisTestMixin(object):
   def _plain(self, name, deps=None):
     """Make a non-jvm target, useful for testing non-jvm intermediate dependencies."""
     return self.make_target(spec='java:{}'.format(name),
-                            target_type=Dependencies,
+                            target_type=Target,
                             dependencies=deps or [],)
 
   def simple_task(self, targets, **options):

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -30,6 +30,7 @@ python_tests(
     'src/python/pants/backend/project_info/tasks:dependencies',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/build_graph',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )
@@ -80,6 +81,7 @@ python_tests(
     'src/python/pants/backend/project_info/tasks:export',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/base:exceptions',
+    'src/python/pants/build_graph',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ]

--- a/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.core.targets.dependencies import Dependencies as DepBag
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -13,6 +12,7 @@ from pants.backend.project_info.tasks.dependencies import Dependencies
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
@@ -65,7 +65,7 @@ class NonPythonDependenciesTest(ConsoleTaskTestBase):
 
     self.make_target(
       'project:dep-bag',
-      target_type=DepBag,
+      target_type=Target,
       dependencies=[
         second,
         project

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -10,7 +10,6 @@ import os
 from textwrap import dedent
 
 from pants.backend.core.register import build_file_aliases as register_core
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.targets.resources import Resources
 from pants.backend.jvm.register import build_file_aliases as register_jvm
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -26,6 +25,7 @@ from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.project_info.tasks.export import Export
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.base.exceptions import TaskError
+from pants.build_graph.target import Target
 from pants_test.subsystem.subsystem_util import subsystem_instance
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
@@ -56,7 +56,7 @@ class ExportTest(ConsoleTaskTestBase):
 
       self.make_target(
         'project_info:first',
-        target_type=Dependencies,
+        target_type=Target,
       )
 
       jar_lib = self.make_target(
@@ -122,7 +122,7 @@ class ExportTest(ConsoleTaskTestBase):
 
       self.make_target(
         'project_info:top_dependency',
-        target_type=Dependencies,
+        target_type=Target,
         dependencies=[jvm_binary],
       )
 

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -139,11 +139,6 @@ class BaseTest(unittest.TestCase):
 
   @property
   def alias_groups(self):
-    # NB: In a normal pants deployment, 'target' is an alias for
-    # `pants.backend.core.targets.dependencies.Dependencies`.  We avoid that dependency on the core
-    # backend here since the `BaseTest` is used by lower level tests in base and since the
-    # `Dependencies` type itself is nothing more than an alias for Target that carries along a
-    # pydoc for the BUILD dictionary.
     return BuildFileAliases(targets={'target': Target})
 
   def setUp(self):

--- a/tests/python/pants_test/tasks/test_group_task.py
+++ b/tests/python/pants_test/tasks/test_group_task.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import itertools
 import uuid
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.tasks.group_task import GroupIterator, GroupMember, GroupTask
 from pants.build_graph.target import Target
 from pants.engine.round_manager import RoundManager
@@ -274,7 +273,7 @@ class EmptyGroupTaskTest(BaseGroupTaskTest):
 class TransitiveGroupTaskTest(BaseGroupTaskTest):
   def create_targets(self):
     self.a = self.make_target('src/scala:a', self.ScalaLibrary)
-    self.b = self.make_target('src/deps:b', Dependencies, dependencies=[self.a])
+    self.b = self.make_target('src/deps:b', Target, dependencies=[self.a])
     self.c = self.make_target('src/java:c', self.JavaLibrary, dependencies=[self.b])
     self.d = self.make_target('src/scala:d', self.ScalaLibrary, dependencies=[self.c])
     return [self.d]

--- a/tests/python/pants_test/tasks/test_listtargets.py
+++ b/tests/python/pants_test/tasks/test_listtargets.py
@@ -8,13 +8,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from textwrap import dedent
 
-from pants.backend.core.targets.dependencies import Dependencies
 from pants.backend.core.tasks.listtargets import ListTargets
 from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.scala_artifact import ScalaArtifact
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
@@ -39,7 +39,7 @@ class ListTargetsTest(BaseListTargetsTest):
   def alias_groups(self):
     return BuildFileAliases(
       targets={
-        'target': Dependencies,
+        'target': Target,
         'java_library': JavaLibrary,
       },
       objects={


### PR DESCRIPTION
I killed the Dependencies/DeprecatedDependencies dichotomy,
since we now have a proper deprecation mechanism. I left
the Dependencies name because that's the one that may still be
used externally.