### PR TITLE
Fix problem with too long classpath while starting scala repl: python part

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
@@ -14,7 +12,6 @@ from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.java.distribution.distribution import DistributionLocator
 from pants.task.repl_task_mixin import ReplTaskMixin
-from pants.util.contextutil import temporary_file
 
 
 class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
@@ -39,12 +36,10 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
     return isinstance(target, (JarLibrary, JvmTarget))
 
   def setup_repl_session(self, targets):
-    repl_classpath = self.tool_classpath('scala-repl')
-    return self.tool_classpath('pants-runner'), self.classpath(targets, classpath_prefix=repl_classpath)
+    return self.tool_classpath('pants-runner') + self.tool_classpath('scala-repl') +\
+           self.classpath(targets)
 
-  def launch_repl(self, session_setup):
-    runner_classpath, repl_classpath = session_setup
-
+  def launch_repl(self, classpath):
     # The scala repl requires -Dscala.usejavacp=true since Scala 2.8 when launching in the way
     # we do here (not passing -classpath as a program arg to scala.tools.nsc.MainGenericRunner).
     jvm_options = self.jvm_options
@@ -53,19 +48,10 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
 
     # NOTE: We execute with no workunit, as capturing REPL output makes it very sluggish.
     #
-    # NOTE: Using runner instead of synthetic jar here because the classLoader used by REPL
-    # does not load Class-Path from manifest, so we need another approach for long classpath
-    ScalaRepl.execute_java_with_runner(runner_classpath, repl_classpath,
-                                       self.get_options().main, jvm_options, self.args)
-
-  @staticmethod
-  def execute_java_with_runner(runner_classpath, classpath, main, jvm_options, args):
-    with temporary_file() as classpath_file:
-      classpath_file.write(os.pathsep.join(classpath))
-      classpath_file.close()
-
-      DistributionLocator.cached().execute_java(classpath=runner_classpath,
-                                                main=ScalaRepl._RUNNER_MAIN,
-                                                jvm_options=jvm_options,
-                                                args=[classpath_file.name, main] + args,
-                                                create_synthetic_jar=False)
+    # NOTE: Disable creating synthetic jar here because the classLoader used by REPL
+    # does not load Class-Path from manifest.
+    DistributionLocator.cached().execute_java(classpath=classpath,
+                                              main=ScalaRepl._RUNNER_MAIN,
+                                              jvm_options=jvm_options,
+                                              args=[self.get_options().main] + self.args,
+                                              create_synthetic_jar=True)

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -37,8 +37,8 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
     return isinstance(target, (JarLibrary, JvmTarget))
 
   def setup_repl_session(self, targets):
-    tools_classpath = self.tool_classpath('scala-repl')
-    return self.tool_classpath('pants-runner'), self.classpath(targets, classpath_prefix=tools_classpath)
+    repl_classpath = self.tool_classpath('scala-repl')
+    return self.tool_classpath('pants-runner'), self.classpath(targets, classpath_prefix=repl_classpath)
 
   def launch_repl(self, session_setup):
     runner_classpath, repl_classpath = session_setup

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -48,7 +48,7 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
 
     # NOTE: We execute with no workunit, as capturing REPL output makes it very sluggish.
     #
-    # NOTE: Disable creating synthetic jar here because the classLoader used by REPL
+    # NOTE: Using PantsRunner class because the classLoader used by REPL
     # does not load Class-Path from manifest.
     DistributionLocator.cached().execute_java(classpath=classpath,
                                               main=ScalaRepl._RUNNER_MAIN,

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -5,21 +5,28 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.java.distribution.distribution import DistributionLocator
 from pants.task.repl_task_mixin import ReplTaskMixin
+from pants.util.contextutil import temporary_file
 
 
 class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
+  _RUNNER_MAIN = 'org.pantsbuild.tools.runner.FileClassPathRunner'
+
   @classmethod
   def register_options(cls, register):
     super(ScalaRepl, cls).register_options(register)
     register('--main', default='scala.tools.nsc.MainGenericRunner',
              help='The entry point for running the repl.')
     cls.register_jvm_tool(register, 'scala-repl', classpath_spec='//:scala-repl')
+    cls.register_jvm_tool(register, 'pants-runner', classpath=[
+        JarDependency(org='org.pantsbuild', name='pants-runner', rev='0.0.1'),
+    ], main=ScalaRepl._RUNNER_MAIN)
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -30,9 +37,12 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
     return isinstance(target, (JarLibrary, JvmTarget))
 
   def setup_repl_session(self, targets):
-    return self.classpath(targets, classpath_prefix=self.tool_classpath('scala-repl'))
+    tools_classpath = self.tool_classpath('scala-repl')
+    return self.tool_classpath('pants-runner'), self.classpath(targets, classpath_prefix=tools_classpath)
 
-  def launch_repl(self, classpath):
+  def launch_repl(self, session_setup):
+    runner_classpath, repl_classpath = session_setup
+
     # The scala repl requires -Dscala.usejavacp=true since Scala 2.8 when launching in the way
     # we do here (not passing -classpath as a program arg to scala.tools.nsc.MainGenericRunner).
     jvm_options = self.jvm_options
@@ -41,10 +51,20 @@ class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
 
     # NOTE: We execute with no workunit, as capturing REPL output makes it very sluggish.
     #
-    # NOTE: Disable creating synthetic jar here because the classLoader used by REPL
-    # does not load Class-Path from manifest.
-    DistributionLocator.cached().execute_java(classpath=classpath,
-                                              main=self.get_options().main,
-                                              jvm_options=jvm_options,
-                                              args=self.args,
-                                              create_synthetic_jar=False)
+    # NOTE: Using runner instead of synthetic jar here because the classLoader used by REPL
+    # does not load Class-Path from manifest, so we need another approach for long classpath
+    ScalaRepl.execute_java_with_runner(runner_classpath, repl_classpath,
+                                       self.get_options().main, jvm_options, self.args)
+
+  @staticmethod
+  def execute_java_with_runner(runner_classpath, classpath, main, jvm_options, args):
+    with temporary_file() as classpath_file:
+      for classpath_element in classpath:
+        classpath_file.write(classpath_element + '\n')
+      classpath_file.close()
+
+      DistributionLocator.cached().execute_java(classpath=runner_classpath + ['@' + classpath_file.name],
+                                                main=ScalaRepl._RUNNER_MAIN,
+                                                jvm_options=jvm_options,
+                                                args=[main] + args,
+                                                create_synthetic_jar=False)


### PR DESCRIPTION
I will write later wrap up for arg too max problem in pants in general but tl;dr is:
synthetic jar solution works for cases without custom classloaders. When custom classloaders comes to the game with their own strategy to consider classpath (using URLs from app classloader + using class.path property directly) without care much about classpath specified in jar things going to fail.

One of the cases - scala repl. So I've adopted solution with using facebook buck runner (facebook/buck@a2070ad) to run scala repl. As runner fixes classloaders urls and class.path property it will work well with scala. As quickfix now - only for scala repl, maybe will be made more general in future.

Fix consist of two parts: java part with runner and python part for scala repl task. 
This is python part. 
Java part PR: https://github.com/pantsbuild/pants/pull/2646