### PR TITLE
Peiyu/Deprecate exception.message usages

### DIFF
--- a/src/python/pants/base/build_environment.py
+++ b/src/python/pants/base/build_environment.py
@@ -33,7 +33,7 @@ def get_buildroot():
   try:
     return BuildRoot().path
   except BuildRoot.NotFoundError as e:
-    print(e.message, file=sys.stderr)
+    print(str(e), file=sys.stderr)
     sys.exit(1)
 
 

--- a/src/python/pants/goal/artifact_cache_stats.py
+++ b/src/python/pants/goal/artifact_cache_stats.py
@@ -54,7 +54,7 @@ class ArtifactCacheStats(object):
       """Format into (target, cause) tuple."""
       target_address = tgt.address.reference()
       if isinstance(cause, UnreadableArtifact):
-        return (target_address, cause.err.message)
+        return (target_address, str(cause.err))
       elif cause == False:
         return (target_address, 'uncached')
       else:

--- a/tests/python/pants_test/authentication/test_netrc_util.py
+++ b/tests/python/pants_test/authentication/test_netrc_util.py
@@ -41,7 +41,7 @@ class TestNetrcUtil(unittest.TestCase):
     with self.netrc('machine test') as netrc:
       with self.assertRaises(netrc.NetrcError) as exc:
         netrc._ensure_loaded()
-      assert re.search(r'Problem parsing', exc.exception.message)
+      assert re.search(r'Problem parsing', str(exc.exception))
 
   def test_netrc_no_usable_blocks(self, MockOsPath):
     with self.netrc('') as netrc:


### PR DESCRIPTION
In fb30d2db66b95d2bb602cbaae60037c18d2710b6 
```
      if isinstance(cause, UnreadableArtifact):
       return (target_address, cause.err.message)
```
however, exception.message isn't always a string, it's `args[0]` whatever is passed as first argument [1], maybe string, maybe another wrapped exception. This results a later error when called by json.dump [2]

Further, exception.message is deprecated in python 3 [1], this PR drops such usages

[1] https://www.python.org/dev/peps/pep-0352
[2] bug stacktrace
```
  File "/Users/peiyu/.pex/install/pantsbuild.pants-0.0.0_fb30d2db66b95d2bb602cbaae60037c18d2710b6-py2-none-any.whl.5632d5cbfcdd1b48dcdcbd328644dfab1f356c58/pantsbuild.pants-0.0.0_fb30d2db66b95d2bb602cbaae60037c18d2710b6-py2-none-any.whl/pants/goal/run_tracker.py", line 263, in store_stats
    safe_file_dump(stats_file, json.dumps(stats))
...
Exception message: ConnectionError(ProtocolError('Connection aborted.', gaierror(8, 'nodename nor servname provided, or not known')),) is not JSON serializable
