### PR TITLE
[Trigger CI] Allow alternate_target_roots to specify an empty collection

### DIFF
--- a/src/python/pants/engine/round_engine.py
+++ b/src/python/pants/engine/round_engine.py
@@ -116,7 +116,7 @@ class RoundEngine(Engine):
       self._target_roots = None
 
     def propose_alternates(self, proposer, target_roots):
-      if target_roots:
+      if target_roots is not None:
         if self._target_roots and (self._target_roots != target_roots):
           raise self.ConflictingProposalsError(
               'Already have a proposal by {0} for {1} and cannot accept conflicting proposal '
@@ -125,7 +125,7 @@ class RoundEngine(Engine):
         self._target_roots = target_roots
 
     def apply(self, context):
-      if self._target_roots:
+      if self._target_roots is not None:
         context._replace_targets(self._target_roots)
 
   def _visit_goal(self, goal, context, goal_info_by_goal, target_roots_replacement):

--- a/tests/python/pants_test/engine/test_round_engine.py
+++ b/tests/python/pants_test/engine/test_round_engine.py
@@ -81,8 +81,8 @@ class RoundEngineTest(EngineTestBase, BaseTest):
     return super(RoundEngineTest,
                  self).install_task(name=name, action=task_type, goal=goal).task_types()
 
-  def create_context(self, for_task_types=None):
-    self._context = self.context(for_task_types=for_task_types)
+  def create_context(self, for_task_types=None, target_roots=None):
+    self._context = self.context(for_task_types=for_task_types, target_roots=target_roots)
     self.assertTrue(self._context.is_unlocked())
 
   def assert_actions(self, *expected_execute_ordering):
@@ -219,3 +219,13 @@ class RoundEngineTest(EngineTestBase, BaseTest):
     self.create_context(for_task_types=task1+task2)
     with self.assertRaises(self.engine.TargetRootsReplacement.ConflictingProposalsError):
       self.engine.attempt(self._context, self.as_goals('goal1', 'goal2'))
+
+  def test_replace_target_roots_to_empty_list(self):
+    task1 = self.install_task('task1', goal='goal1')
+    task2 = self.install_task('task2', goal='goal2', alternate_target_roots=[])
+    target = self.make_target('t')
+    self.create_context(for_task_types=task1+task2, target_roots=[target])
+
+    self.engine.attempt(self._context, self.as_goals('goal1', 'goal2'))
+
+    self.assertEquals([], self._context.target_roots)


### PR DESCRIPTION
For tasks like test-changed, it makes sense for them to become no-ops when there are no changed targets. This patch allows alternates to be set to an empty set so that test-changed will run no tests when there are no changed targets rather than running all the tests.