### PR TITLE
Explicitly set the synthetic task subclass's __module__.

### DIFF
--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -124,6 +124,7 @@ class _Goal(object):
                                       options_scope.replace('.', '_').replace('-', '_'))
     task_type = type(subclass_name, (superclass,), {
       '__doc__': superclass.__doc__,
+      '__module__': superclass.__module__,
       'options_scope': options_scope
     })
 

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -125,7 +125,8 @@ class _Goal(object):
     task_type = type(subclass_name, (superclass,), {
       '__doc__': superclass.__doc__,
       '__module__': superclass.__module__,
-      'options_scope': options_scope
+      'options_scope': options_scope,
+      '_stable_name': superclass.stable_name()
     })
 
     otn = self._ordered_task_names

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -53,8 +53,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
   """
   options_scope_category = ScopeInfo.TASK
 
-  # Tests may override this to provide a stable name despite the class name being a unique,
-  # synthetic name.
+  # We set this explicitly on the synthetic subclass, so that it shares a stable name with
+  # its superclass, which is not necessary for regular use, but can be convenient in tests.
   _stable_name = None
 
   @classmethod


### PR DESCRIPTION
This is so that it has the same stable_name() is the class
it's synthesized from, which is useful in tests.

Note that this change will invalidate all artifact caches,
as the stable_name is used to generate cache paths.