### PR TITLE
prefer explicit jvm locations over internal heuristics

### DIFF
--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -294,14 +294,14 @@ class DistributionLinuxLocationTest(BaseDistributionLocationTest):
         dist = DistributionLocator.locate(minimum_version='2')
         self.assertEqual(jdk2_home, dist.home)
 
-  def test_locate_trumps_path(self):
+  def test_default_to_path(self):
     with self.java_dist_dir() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as path_jdk:
         with env(PATH=os.path.join(path_jdk, 'bin')):
           dist = DistributionLocator.locate(minimum_version='2')
-          self.assertEqual(jdk2_home, dist.home)
-          dist = DistributionLocator.locate(minimum_version='3')
           self.assertEqual(path_jdk, dist.home)
+          dist = DistributionLocator.locate(maximum_version='2')
+          self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk_home_trumps(self):
     with self.java_dist_dir() as (jdk1_home, jdk2_home):
@@ -377,14 +377,14 @@ class DistributionOSXLocationTest(BaseDistributionLocationTest):
         dist = DistributionLocator.locate(minimum_version='2')
         self.assertEqual(jdk2_home, dist.home)
 
-  def test_locate_trumps_path(self):
+  def test_default_to_path(self):
     with self.java_home_exe() as (jdk1_home, jdk2_home):
       with distribution(executables=exe('bin/java', version='3')) as path_jdk:
         with env(PATH=os.path.join(path_jdk, 'bin')):
-          dist = DistributionLocator.locate()
-          self.assertEqual(jdk1_home, dist.home)
-          dist = DistributionLocator.locate(minimum_version='3')
+          dist = DistributionLocator.locate(minimum_version='2')
           self.assertEqual(path_jdk, dist.home)
+          dist = DistributionLocator.locate(maximum_version='2')
+          self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk_home_trumps(self):
     with self.java_home_exe() as (jdk1_home, jdk2_home):


### PR DESCRIPTION
Previously if --jvm-distributions-paths was not provided, pants
searched for jvms in the folling order:
 (A) JAVA_HOME/JDK_HOME
 (B) Look at common file system locations
 (C) java on PATH

This commit change that order to always prefer the explicit user
configurations (A, C) over heuristics (B).  Besides just being more
consistent, this means when a user gets an error about java not
working when invoked by pants, they are more likely to be using the
same jdk when they try to reproduce it.

An additional benefit is that the user chosen jvm likely "works"
(without pants needing to maintain careful min/max version constraints
for every too), while old EOL things in /usr/lib/jvm may not.  For
example our Centos6 CI server has the super old `java-1.5.0-gcj`
package, which does not work with modern ivy.

fixes #2682