### PR TITLE
Upgrade to junit-runner 1.0.0.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -96,7 +96,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     cls.register_jvm_tool(register,
                           'junit',
                           classpath=[
-                            JarDependency(org='org.pantsbuild', name='junit-runner', rev='0.0.13'),
+                            JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.0'),
                           ],
                           main=JUnitRun._MAIN,
                           # TODO(John Sirois): Investigate how much less we can get away with.


### PR DESCRIPTION
Although a major version bump, the only change was removal of the
deprecated `-suppress-output` flag which was already unused by the
pants junit task.

https://rbcommons.com/s/twitter/r/3232/