### PR TITLE
Fixup the `NodePreinstalledModuleResolver`.

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/node_preinstalled_module_resolver.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/node_preinstalled_module_resolver.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import os
+import shutil
 from contextlib import closing
 
 import six.moves.urllib.error as urllib_error
@@ -76,4 +77,4 @@ class NodePreinstalledModuleResolver(Subsystem, NodeResolverBase):
                         .format(target=target.address.reference(),
                                 dependencies_archive_url=target.dependencies_archive_url))
 
-      os.rename(extracted_node_modules, os.path.join(results_dir, 'node_modules'))
+      shutil.move(extracted_node_modules, os.path.join(results_dir, 'node_modules'))


### PR DESCRIPTION
Previously, it assumed the `/tmp` extraction dir was on the same
filesystem as the build root (it used `os.rename`).  This change fixes
the rename to use `shutil.move` which also uses `os.rename` - but only
when appropriate.

The existing `NodeResolveIntegrationTest`
`test_resolve_preinstalled_node_module_project` failed on machines with
`/tmp` on a seperate filesystem from the build root and now passes on
those machines.

https://rbcommons.com/s/twitter/r/3240/