### PR TITLE
test_distribution should depend on what it tests

### DIFF
--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -6,6 +6,7 @@ python_tests(
   sources = ['test_distribution.py'],
   dependencies = [
     'src/python/pants/base:revision',
+    'src/python/pants/java/distribution',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/subsystem:subsystem_utils',


### PR DESCRIPTION
Omitting this resulted in a spooky error when testing only this target
in isolation:

```
===================== ERRORS =====================
 ERROR collecting tests/python/pants_test/java/distribution/test_distribution.py
tests/python/pants_test/java/distribution/test_distribution.py:19: in <module>
    from pants.java.distribution.distribution import Distribution, DistributionLocator
src/python/pants/java/distribution/distribution.py:19: in <module>
    from pants.java.util import execute_java
src/python/pants/java/util.py:15: in <module>
    from pants.java.nailgun_executor import NailgunExecutor
src/python/pants/java/nailgun_executor.py:23: in <module>
    from pants.pantsd.process_manager import ProcessGroup, ProcessManager
src/python/pants/pantsd/process_manager.py:16: in <module>
    import psutil
E   ImportError: No module named psutil
============ 1 error in 0.07 seconds =============
```