### PR TITLE
remove alias all used by plugin integration test

### DIFF
--- a/build-support/pants-intellij.sh
+++ b/build-support/pants-intellij.sh
@@ -4,7 +4,7 @@
 # Note: for any modification in this file please modify ExportIntegrationTest#test_intellij_integration
 
 # We don't want to include targets which are used in unit tests in our project so let's exclude them.
-./pants export src/python/:: tests/python/pants_test:all contrib/:: \
+./pants export src/python/:: tests/python/pants_test:: contrib/:: \
     --exclude-target-regexp='.*go/examples.*' \
     --exclude-target-regexp='.*scrooge/tests/thrift.*' \
     --exclude-target-regexp='.*spindle/tests/thrift.*' \


### PR DESCRIPTION
https://travis-ci.org/wisechengyi/intellij-pants-plugin/builds/96865699 (plugin CI with pants master) shows error regarding alias 'all' which is not valid any more.