### PR TITLE
[CI] Make it easy for tests to use the "real" python interpreter cache.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -443,7 +443,7 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
       }
       profile = self.get_options().profile
       if profile:
-        env['PEX_PROFILE'] = '{0}.subprocess.{1:.6f}'.format(profile, time.time())
+        env['PEX_PROFILE_FILENAME'] = '{0}.subprocess.{1:.6f}'.format(profile, time.time())
       with environment_as(**env):
         rc = self._pex_run(pex, workunit, args=args, setsid=True)
         return PythonTestResult.rc(rc)

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -72,6 +72,7 @@ python_tests(
     'src/python/pants/build_graph',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
+    'tests/python/pants_test/backend/python/tasks:interpreter_cache_test_mixin',
   ]
 )
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -26,11 +26,12 @@ from pants.base.exceptions import TaskError
 from pants.build_graph.register import build_file_aliases as register_core
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
+from pants_test.backend.python.tasks.interpreter_cache_test_mixin import InterpreterCacheTestMixin
 from pants_test.subsystem.subsystem_util import subsystem_instance
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
-class ExportTest(ConsoleTaskTestBase):
+class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
 
   @classmethod
   def task_type(cls):

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -1,10 +1,19 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+
+python_library(
+  name='interpreter_cache_test_mixin',
+  sources=['interpreter_cache_test_mixin.py'],
+  dependencies=[
+  ]
+)
+
 python_library(
   name='python_task_test_base',
   sources=['python_task_test_base.py'],
   dependencies=[
+    ':interpreter_cache_test_mixin',
     'src/python/pants/backend/python:plugin',
     'src/python/pants/build_graph',
     'tests/python/pants_test/tasks:task_test_base'

--- a/tests/python/pants_test/backend/python/tasks/interpreter_cache_test_mixin.py
+++ b/tests/python/pants_test/backend/python/tasks/interpreter_cache_test_mixin.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+
+class InterpreterCacheTestMixin(object):
+  """A mixin to allow tests to use the "real" interpreter cache.
+
+  This is so each test doesn't waste huge amounts of time recreating the cache on each run.
+
+  Note: Must be mixed in to a subclass of BaseTest.
+  """
+  
+  def setUp(self):
+    super(InterpreterCacheTestMixin, self).setUp()
+
+    # It would be nice to get the location of the real interpreter cache from PythonSetup,
+    # but unfortunately real subsystems aren't available here (for example, we have no access
+    # to the enclosing pants instance's options), so we have to hard-code it.
+    python_setup_workdir = os.path.join(self.real_build_root, '.pants.d', 'python-setup')
+    self.set_options_for_scope('python-setup',
+        interpreter_cache_dir=os.path.join(python_setup_workdir, 'interpreters'),
+        chroot_cache_dir=os.path.join(python_setup_workdir, 'chroots'))

--- a/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
+++ b/tests/python/pants_test/backend/python/tasks/python_task_test_base.py
@@ -10,21 +10,11 @@ from textwrap import dedent
 
 from pants.backend.python.register import build_file_aliases as register_python
 from pants.build_graph.address import Address
+from pants_test.backend.python.tasks.interpreter_cache_test_mixin import InterpreterCacheTestMixin
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
-class PythonTaskTestBase(TaskTestBase):
-  def setUp(self):
-    super(PythonTaskTestBase, self).setUp()
-
-    # Use the "real" interpreter cache, so tests don't waste huge amounts of time recreating it.
-    # It would be nice to get the location of the real interpreter cache from PythonSetup,
-    # but unfortunately real subsystems aren't available here (for example, we have no access
-    # to the enclosing pants instance's options), so we have to hard-code it.
-    python_setup_workdir = os.path.join(self.real_build_root, '.pants.d', 'python-setup')
-    self.set_options_for_scope('python-setup',
-        interpreter_cache_dir=os.path.join(python_setup_workdir, 'interpreters'),
-        chroot_cache_dir=os.path.join(python_setup_workdir, 'chroots'))
+class PythonTaskTestBase(InterpreterCacheTestMixin, TaskTestBase):
 
   @property
   def alias_groups(self):


### PR DESCRIPTION
This greatly speeds up tests that need to resolve an interpreter.
We already had this ability in PythonTaskTestBase, I just moved it
to a InterpreterCacheTestMixin, for easier re-use.

I then applied it to test_export.py, which was a very slow set of
tests (around a minute of runtime) due to repeated resolution of
interpreters. With this change those tests run in a 3-5 seconds.