### PR TITLE
Fixup `GoFetch` to respect transitive injections.

### DIFF
--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -69,22 +69,30 @@ class GoFetchTest(TaskTestBase):
     r2 = self.make_target(spec='3rdparty/go/r2', target_type=GoRemoteLibrary)
 
     go_fetch = self.create_task(self.context())
-    resolved = go_fetch._resolve(r1, self.address('3rdparty/go/r2'), 'r2', implict_ok=False)
+    resolved = go_fetch._resolve(r1, self.address('3rdparty/go/r2'), 'r2', implicit_ok=False)
     self.assertEqual(r2, resolved)
 
   def test_resolve_and_inject_explicit_failure(self):
     r1 = self.make_target(spec='3rdparty/go/r1', target_type=GoRemoteLibrary)
     go_fetch = self.create_task(self.context())
     with self.assertRaises(go_fetch.UndeclaredRemoteLibError) as cm:
-      go_fetch._resolve(r1, self.address('3rdparty/go/r2'), 'r2', implict_ok=False)
+      go_fetch._resolve(r1, self.address('3rdparty/go/r2'), 'r2', implicit_ok=False)
     self.assertEqual(cm.exception.address, self.address('3rdparty/go/r2'))
 
   def test_resolve_and_inject_implicit(self):
     r1 = self.make_target(spec='3rdparty/go/r1', target_type=GoRemoteLibrary)
     go_fetch = self.create_task(self.context())
-    r2 = go_fetch._resolve(r1, self.address('3rdparty/go/r2'), 'r2', implict_ok=True)
+    r2 = go_fetch._resolve(r1, self.address('3rdparty/go/r2'), 'r2', implicit_ok=True)
     self.assertEqual(self.address('3rdparty/go/r2'), r2.address)
     self.assertIsInstance(r2, GoRemoteLibrary)
+
+  def test_resolve_and_inject_implicit_already_exists(self):
+    r1 = self.make_target(spec='3rdparty/go/r1', target_type=GoRemoteLibrary)
+    self.make_target(spec='3rdparty/go/r2', target_type=GoRemoteLibrary)
+    go_fetch = self.create_task(self.context())
+    r2_resolved = go_fetch._resolve(r1, self.address('3rdparty/go/r2'), 'r2', implicit_ok=True)
+    self.assertEqual(self.address('3rdparty/go/r2'), r2_resolved.address)
+    self.assertIsInstance(r2_resolved, GoRemoteLibrary)
 
   def _create_package(self, dirpath, name, deps):
     """Creates a Go package inside dirpath named 'name' importing deps."""


### PR DESCRIPTION
Previously, a fetch could trigger injection of a `GoRemoteLibrary`
subgraph that was not tracked by `GoFetch` leading to the erroneous
assumption that it was safe to synthesize a target that was already
implicitly injected into the active graph.

Add a failing test for this scenario that is fixed by this change.

https://rbcommons.com/s/twitter/r/3270/