### PR TITLE
Add target id to export

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -56,7 +56,7 @@ class ExportTask(IvyTaskMixin, PythonTask):
   #
   # Note format changes in src/python/pants/docs/export.md and update the Changelog section.
   #
-  DEFAULT_EXPORT_VERSION = '1.0.4'
+  DEFAULT_EXPORT_VERSION = '1.0.5'
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -187,6 +187,7 @@ class ExportTask(IvyTaskMixin, PythonTask):
         'targets': [],
         'libraries': [],
         'roots': [],
+        'id': current_target.id,
         'target_type': get_target_type(current_target),
         'is_code_gen': current_target.is_codegen,
         'pants_target_type': self._get_pants_target_alias(type(current_target))

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -197,7 +197,7 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
 
   def test_version(self):
     result = self.execute_export_json('project_info:first')
-    self.assertEqual('1.0.4', result['version'])
+    self.assertEqual('1.0.5', result['version'])
 
   def test_sources(self):
     self.set_options(sources=True)

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -247,6 +247,7 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
       'globs': {'globs': ['project_info/this/is/a/source/Foo.scala',
                           'project_info/this/is/a/source/Bar.scala']},
       'libraries': ['org.apache:apache-jar:12.12.2012', 'org.scala-lang:scala-library:2.10.5'],
+      'id': 'project_info.jvm_target',
       'is_code_gen': False,
       'targets': ['project_info:jar_lib', '//:scala-library'],
       'roots': [


### PR DESCRIPTION
for intellij pants plugin to find classpath based on target id without compute target id in the plugin