### PR TITLE
Simplify build dict/reference information extraction.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/targets/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/targets/BUILD
@@ -30,6 +30,7 @@ python_library(
   dependencies=[
     ':go_target',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:parse_context',
     'src/python/pants/base:payload',
     'src/python/pants/source',
   ],

--- a/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
@@ -9,6 +9,7 @@ import os
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException
+from pants.base.parse_context import ParseContext
 from pants.base.payload import Payload
 from pants.build_graph.address import Address
 from pants.source.wrapped_globs import Globs
@@ -65,7 +66,7 @@ class GoLocalSource(GoTarget):
     # 2. resources: Even though go does not support them; ie by providing a protocol to embed them
     #    in binaries, it does allow them to be placed in a directory where a test might use them
     #    for example via plain old filesystem access.
-    globs = Globs(rel_path=os.path.join(get_buildroot(), address.spec_path))
+    globs = Globs(ParseContext(rel_path=address.spec_path, type_aliases={}))
     sources = globs('*', exclude=[globs('BUILD*'),
                                   # This skips dirents.
                                   globs('*/')])

--- a/contrib/scalajs/BUILD
+++ b/contrib/scalajs/BUILD
@@ -1,8 +1,0 @@
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
-# Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-source_root('3rdparty', jar_library)
-source_root('src/python', page, python_library, resources)
-source_root('tests/python', page, python_library, python_tests, resources)
-
-source_root('examples/src/scalajs', scala_library, scala_js_binary)

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -100,7 +100,7 @@ def build_file_aliases():
       'shading_exclude_package': Shading.ExcludePackage.new,
     },
     context_aware_object_factories={
-      'bundle': Bundle.factory,
+      'bundle': Bundle,
     }
   )
 

--- a/src/python/pants/backend/python/pants_requirement.py
+++ b/src/python/pants/backend/python/pants_requirement.py
@@ -12,7 +12,7 @@ from pants.backend.python.targets.python_requirement_library import PythonRequir
 from pants.base.build_environment import pants_version
 
 
-def pants_requirement(parse_context, name=None):
+class PantsRequirement(object):
   """Exports a `python_requirement_library` pointing at the active pants' corresponding sdist.
 
   This requirement is useful for custom plugin authors who want to build and test their plugin with
@@ -21,9 +21,16 @@ def pants_requirement(parse_context, name=None):
 
   NB: The requirement generated is for official pants releases on pypi; so may not be appropriate
   for use in a repo that tracks `pantsbuild/pants` or otherwise uses custom pants sdists.
-
-  :param string name: The name to use for the target, defaults to the parent dir name.
   """
-  name = name or os.path.basename(parse_context.rel_path)
-  requirement = PythonRequirement(requirement='pantsbuild.pants=={}'.format(pants_version()))
-  parse_context.create_object(PythonRequirementLibrary, name=name, requirements=[requirement])
+
+  def __init__(self, parse_context):
+    self._parse_context = parse_context
+
+  def __call__(self, name=None):
+    """
+    :param string name: The name to use for the target, defaults to the parent dir name.
+    """
+    name = name or os.path.basename(self._parse_context.rel_path)
+    requirement = PythonRequirement(requirement='pantsbuild.pants=={}'.format(pants_version()))
+    self._parse_context.create_object(PythonRequirementLibrary, name=name,
+                                      requirements=[requirement])

--- a/src/python/pants/backend/python/python_requirements.py
+++ b/src/python/pants/backend/python/python_requirements.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 
-def python_requirements(parse_context, requirements_relpath='requirements.txt'):
+class PythonRequirements(object):
   """Translates a pip requirements file into an equivalent set of python_requirements
 
   If the ``requirements.txt`` file has lines ``foo>=3.14`` and ``bar>=2.7``,
@@ -26,35 +26,41 @@ def python_requirements(parse_context, requirements_relpath='requirements.txt'):
 
   See the requirements file spec here:
   https://pip.pypa.io/en/latest/reference/pip_install.html#requirements-file-format
-
-  :param parse_context: (Don't specify this in a BUILD file; it's set automatically)
-  :param string requirements_relpath: The relative path from the parent dir of the BUILD file using
-      this function to the requirements file.  By default a `requirements.txt` file sibling to the
-      BUILD file is assumed.
   """
-  requirements = []
-  repository = None
 
-  requirements_path = os.path.join(parse_context.rel_path, requirements_relpath)
-  with open(requirements_path) as fp:
-    for line in fp:
-      line = line.strip()
-      if line and not line.startswith('#'):
-        if not line.startswith('-'):
-          requirements.append(line)
-        else:
-          # handle flags we know about
-          flag_value = line.split(' ', 1)
-          if len(flag_value) == 2:
-            flag = flag_value[0].strip()
-            value = flag_value[1].strip()
-            if flag in ('-f', '--find-links'):
-              if repository is not None:
-                raise ValueError('Only 1 --find-links url is supported per requirements file')
-              repository = value
+  def __init__(self, parse_context):
+    self._parse_context = parse_context
 
-  for requirement in requirements:
-    req = parse_context.create_object('python_requirement', requirement, repository=repository)
-    parse_context.create_object('python_requirement_library',
-                                name=req.project_name,
-                                requirements=[req])
+  def __call__(self, requirements_relpath='requirements.txt'):
+    """
+    :param string requirements_relpath: The relpath from this BUILD file to the requirements file.
+    Defaults to a `requirements.txt` file sibling to the BUILD file.
+    """
+
+    requirements = []
+    repository = None
+
+    requirements_path = os.path.join(self._parse_context.rel_path, requirements_relpath)
+    with open(requirements_path) as fp:
+      for line in fp:
+        line = line.strip()
+        if line and not line.startswith('#'):
+          if not line.startswith('-'):
+            requirements.append(line)
+          else:
+            # handle flags we know about
+            flag_value = line.split(' ', 1)
+            if len(flag_value) == 2:
+              flag = flag_value[0].strip()
+              value = flag_value[1].strip()
+              if flag in ('-f', '--find-links'):
+                if repository is not None:
+                  raise ValueError('Only 1 --find-links url is supported per requirements file')
+                repository = value
+
+    for requirement in requirements:
+      req = self._parse_context.create_object('python_requirement', requirement,
+                                              repository=repository)
+      self._parse_context.create_object('python_requirement_library',
+                                        name=req.project_name,
+                                        requirements=[req])

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -5,10 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.pants_requirement import pants_requirement
+from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.backend.python.python_requirements import python_requirements
+from pants.backend.python.python_requirements import PythonRequirements
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
@@ -19,7 +19,6 @@ from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
 from pants.backend.python.tasks.setup_py import SetupPy
 from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.build_graph.target import Target
 from pants.goal.task_registrar import TaskRegistrar as task
 
 
@@ -37,8 +36,8 @@ def build_file_aliases():
       'setup_py': PythonArtifact,
     },
     context_aware_object_factories={
-      'python_requirements': BuildFileAliases.curry_context(python_requirements),
-      'pants_requirement': BuildFileAliases.curry_context(pants_requirement),
+      'python_requirements': PythonRequirements,
+      'pants_requirement': PantsRequirement,
     }
   )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -111,7 +111,6 @@ python_library(
   sources = ['payload_field.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    ':build_environment',
     'src/python/pants/util:meta',
   ]
 )

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -6,13 +6,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import json
-import os
 from abc import abstractmethod
 from hashlib import sha1
 
 from twitter.common.collections import OrderedSet
 
-from pants.base.build_environment import get_buildroot
 from pants.util.meta import AbstractClass
 
 
@@ -110,28 +108,6 @@ class PythonRequirementsField(frozenset, PayloadField):
         )
         yield stable_json_sha1(hash_items)
     return combine_hashes(fingerprint_iter())
-
-
-def hash_bundle(bundle):
-  hasher = sha1()
-  hasher.update(bundle._rel_path)
-  for abs_path in sorted(bundle.filemap.keys()):
-    buildroot_relative_path = os.path.relpath(abs_path, get_buildroot())
-    hasher.update(buildroot_relative_path)
-    hasher.update(bundle.filemap[abs_path])
-    with open(abs_path, 'rb') as f:
-      hasher.update(f.read())
-  return hasher.hexdigest()
-
-
-class BundleField(tuple, PayloadField):
-  """A tuple subclass that mixes in PayloadField.
-
-  Must be initialized with an iterable of Bundle instances.
-  """
-
-  def _compute_fingerprint(self):
-    return combine_hashes(map(hash_bundle, self))
 
 
 class ExcludesField(OrderedSet, PayloadField):

--- a/src/python/pants/build_graph/build_file_aliases.py
+++ b/src/python/pants/build_graph/build_file_aliases.py
@@ -107,26 +107,6 @@ class BuildFileAliases(object):
     BUILD file parse.
   """
 
-  @classmethod
-  def curry_context(cls, wrappee):
-    """Curry a function with a build file context.
-
-    Given a function foo(ctx, bar) that you want to expose in BUILD files
-    as foo(bar), use::
-
-        context_aware_object_factories={
-          'foo': BuildFileAliases.curry_context(foo),
-        }
-    """
-    # You might wonder: why not just use lambda and functools.partial?
-    # That loses the __doc__, thus messing up the BUILD dictionary.
-    wrapper = lambda ctx: functools.partial(wrappee, ctx)
-    wrapper.__doc__ = wrappee.__doc__
-    wrapper.__name__ = str(".".join(["curry_context",
-                                     wrappee.__module__,
-                                     wrappee.__name__]))
-    return wrapper
-
   @staticmethod
   def _is_target_type(obj):
     return inspect.isclass(obj) and issubclass(obj, Target)

--- a/src/python/pants/build_graph/register.py
+++ b/src/python/pants/build_graph/register.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.base.build_environment import get_buildroot, pants_version
-from pants.base.source_root import SourceRoot
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.from_target import FromTarget
 from pants.build_graph.prep_command import PrepCommand
@@ -44,10 +43,9 @@ def build_file_aliases():
     },
     context_aware_object_factories={
       'buildfile_path': BuildFilePath,
-      'globs': Globs.factory,
+      'globs': Globs,
       'from_target': FromTarget,
-      'rglobs': RGlobs.factory,
-      'source_root': SourceRoot.factory,
-      'zglobs': ZGlobs.factory,
+      'rglobs': RGlobs,
+      'zglobs': ZGlobs,
     }
   )

--- a/src/python/pants/core_tasks/targets_help.py
+++ b/src/python/pants/core_tasks/targets_help.py
@@ -25,22 +25,17 @@ class TargetsHelp(ConsoleTask):
 
     alias = self.get_options().details
     if alias:
-      target_types = buildfile_aliases.target_types_by_alias.get(alias)
-      if target_types:
-        tti = next(x for x in extracter.get_target_type_info() if x.build_file_alias == alias)
-        yield blue('\n{}\n'.format(tti.description))
-        yield blue('{}('.format(alias))
+      tti = next(x for x in extracter.get_target_type_info() if x.symbol == alias)
+      yield blue('\n{}\n'.format(tti.description))
+      yield blue('{}('.format(alias))
 
-        for arg in extracter.get_target_args(list(target_types)[0]):
-          default = green('(default: {})'.format(arg.default) if arg.has_default else '')
-          yield '{:<30} {}'.format(
-            cyan('  {} = ...,'.format(arg.name)),
-            ' {}{}{}'.format(arg.description, ' ' if arg.description else '', default))
+      for arg in tti.args:
+        default = green('(default: {})'.format(arg.default) if arg.has_default else '')
+        yield '{:<30} {}'.format(
+          cyan('  {} = ...,'.format(arg.name)),
+          ' {}{}{}'.format(arg.description, ' ' if arg.description else '', default))
 
-        yield blue(')')
-      else:
-        yield 'No such target type: {}'.format(alias)
+      yield blue(')')
     else:
       for tti in extracter.get_target_type_info():
-        description = tti.description or '<Add description>'
-        yield '{} {}'.format(cyan('{:>30}:'.format(tti.build_file_alias)), description)
+        yield '{} {}'.format(cyan('{:>30}:'.format(tti.symbol)), tti.description)

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -87,8 +87,11 @@ class _Goal(object):
     # Return the docstring for the Task registered under the same name as this goal, if any.
     # This is a very common case, and therefore a useful idiom.
     namesake_task = self._task_type_by_name.get(self.name)
-    if namesake_task:
-      return namesake_task.__doc__
+    if namesake_task and namesake_task.__doc__:
+      # First line of docstring.
+      # TODO: This is repetitive of Optionable.get_description(). We should probably just
+      # make Goal an Optionable, for uniformity.
+      return namesake_task.__doc__.partition('\n')[0].strip()
     return ''
 
   def register_options(self, options):

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -6,6 +6,7 @@ python_library(
   sources=globs('*.py'),
   dependencies=[
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/option',
     'src/python/pants/subsystem',

--- a/src/python/pants/help/build_dictionary_info_extracter.py
+++ b/src/python/pants/help/build_dictionary_info_extracter.py
@@ -7,8 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import inspect
 import re
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 
+from pants.base.exceptions import TaskError
 from pants.build_graph.target import Target
 from pants.util.memo import memoized_method
 
@@ -18,13 +19,15 @@ class FunctionArg(namedtuple('_FunctionArg', ['name', 'description', 'has_defaul
   pass
 
 
-class TargetTypeInfo(namedtuple('_TargetTypeInfo', ['build_file_alias', 'description'])):
-  """A container for help information about a target type that can be used in a BUILD file."""
+class BuildSymbolInfo(namedtuple('_BuildSymbolInfo', ['symbol', 'description', 'args'])):
+  """A container for help information about a symbol that can be used in a BUILD file."""
   pass
 
 
 class BuildDictionaryInfoExtracter(object):
   """Extracts help information about the symbols that may be used in BUILD files."""
+
+  ADD_DESCR = '<Add description>'
 
   basic_target_args = [
     FunctionArg('name', '', False, None),
@@ -49,14 +52,19 @@ class BuildDictionaryInfoExtracter(object):
     return re.compile(':param\s+(\w+\s+)?(\w+):\s+(.*)')
 
   @classmethod
+  @memoized_method
+  def _get_default_value_re(cls):
+    return re.compile(' \([Dd]efault: (.*)\)')
+
+  @classmethod
   def get_arg_descriptions_from_docstring(cls, obj):
-    """Returns a map of arg name -> arg description found in :param: stanzas.
+    """Returns an ordered map of arg name -> arg description found in :param: stanzas.
 
     Note that this does not handle multiline descriptions.  Descriptions of target params
     should be a single sentence on the first line, followed by more text, if any, on
     subsequent lines.
     """
-    ret = {}
+    ret = OrderedDict()
     doc = obj.__doc__ or ''
     lines = [s.strip() for s in doc.split('\n')]
     param_re = cls._get_param_re()
@@ -68,12 +76,11 @@ class BuildDictionaryInfoExtracter(object):
     return ret
 
   @classmethod
-  def get_target_args(cls, target_type):
-    """Returns a list of FunctionArgs for the specified target_type."""
-    return list(cls._get_target_args(target_type))
+  def get_args_for_target_type(cls, target_type):
+    return list(cls._get_args_for_target_type(target_type))
 
   @classmethod
-  def _get_target_args(cls, target_type):
+  def _get_args_for_target_type(cls, target_type):
     # Target.__init__ has several args that are passed to it by TargetAddressable and not by
     # the BUILD file author, so we can't naively inspect it.  Instead we special-case its
     # true BUILD-file-facing arguments here.
@@ -86,9 +93,10 @@ class BuildDictionaryInfoExtracter(object):
 
     # Now look at the MRO, in reverse (so we see the more 'common' args first.
     methods_seen = set()  # Ensure we only look at each __init__ method once.
-    for _type in reversed([t for t in target_type.mro()
-                           if issubclass(t, Target) and not t == Target]):
-      if inspect.ismethod(_type.__init__) and _type.__init__ not in methods_seen:
+    for _type in reversed([t for t in target_type.mro() if issubclass(t, Target)]):
+      if (inspect.ismethod(_type.__init__) and
+          _type.__init__ not in methods_seen and
+          _type.__init__ != Target.__init__):
         for arg in cls._get_function_args(_type.__init__):
           if arg.name not in ignore_args:
             yield arg
@@ -112,25 +120,86 @@ class BuildDictionaryInfoExtracter(object):
     num_defaulted_args = len(argspec.defaults) if argspec.defaults is not None else 0
     first_defaulted_arg = len(arg_names) - num_defaulted_args
     for i in range(0, first_defaulted_arg):
-      yield FunctionArg(arg_names[i], arg_descriptions.get(arg_names[i], ''), False, None)
+      yield FunctionArg(arg_names[i], arg_descriptions.pop(arg_names[i], ''), False, None)
     for i in range(first_defaulted_arg, len(arg_names)):
-      yield FunctionArg(arg_names[i], arg_descriptions.get(arg_names[i], ''), True,
+      yield FunctionArg(arg_names[i], arg_descriptions.pop(arg_names[i], ''), True,
                         argspec.defaults[i - first_defaulted_arg])
+    if argspec.varargs:
+      yield FunctionArg('*{}'.format(argspec.varargs), arg_descriptions.pop(argspec.varargs, None),
+                        False, None)
+
+    if argspec.keywords:
+      # Any remaining arg_descriptions are for kwargs.
+      for arg_name, descr in arg_descriptions.items():
+        # Get the default value out of the description, if present.
+        mo = cls._get_default_value_re().search(descr)
+        default_value = mo.group(1) if mo else None
+        descr_sans_default = '{}{}'.format(descr[:mo.start()], descr[mo.end():]) if mo else descr
+        yield FunctionArg(arg_name, descr_sans_default, True, default_value)
 
   def __init__(self, buildfile_aliases):
     self._buildfile_aliases = buildfile_aliases
 
+  def get_target_args(self, alias):
+    """Returns a list of FunctionArgs for the specified target_type."""
+    target_types = list(self._buildfile_aliases.target_types_by_alias.get(alias))
+    if not target_types:
+      raise TaskError('No such target type: {}'.format(alias))
+    return self.get_args_for_target_type(target_types[0])
+
+  def get_object_args(self, alias):
+    obj_type = self._buildfile_aliases.objects.get(alias)
+    if not obj_type:
+      raise TaskError('No such object type: {}'.format(alias))
+    if inspect.isfunction(obj_type) or inspect.ismethod(obj_type):
+      return self.get_function_args(obj_type)
+    elif inspect.isclass(obj_type):
+      return self.get_function_args(obj_type.__init__)
+    elif hasattr(obj_type, '__call__'):
+      return self.get_function_args(obj_type.__call__)
+    else:
+      return []
+
+  def get_object_factory_args(self, alias):
+    obj_factory = self._buildfile_aliases.context_aware_object_factories.get(alias)
+    if not obj_factory:
+      raise TaskError('No such context aware object factory: {}'.format(alias))
+    return self.get_function_args(obj_factory.__call__)
+
   def get_target_type_info(self):
-    """Returns a sorted list of TargetTypeInfo for all known target types."""
+    """Returns a sorted list of BuildSymbolInfo for all known target types."""
     return sorted(self._get_target_type_info())
 
   def _get_target_type_info(self):
     for alias, target_type in self._buildfile_aliases.target_types.items():
-      yield TargetTypeInfo(alias, self.get_description_from_docstring(target_type))
+      yield BuildSymbolInfo(alias,
+                            self.get_description_from_docstring(target_type) or self.ADD_DESCR,
+                            self.get_target_args(alias))
     for alias, target_macro_factory in self._buildfile_aliases.target_macro_factories.items():
       # Take the description from the first target type we encounter that has one.
+      target_args = self.get_target_args(alias)
       for target_type in target_macro_factory.target_types:
         description = self.get_description_from_docstring(target_type)
         if description:
-          yield TargetTypeInfo(alias, description)
+          yield BuildSymbolInfo(alias, description, target_args)
           break
+      else:
+        yield BuildSymbolInfo(alias, self.ADD_DESCR, target_args)
+
+  def get_object_info(self):
+    return sorted(self._get_object_info())
+
+  def _get_object_info(self):
+    for alias, obj in self._buildfile_aliases.objects.items():
+      yield BuildSymbolInfo(alias,
+                            self.get_description_from_docstring(obj) or self.ADD_DESCR,
+                            self.get_object_args(alias))
+
+  def get_object_factory_info(self):
+    return sorted(self._get_object_factory_info())
+
+  def _get_object_factory_info(self):
+    for alias, factory_type in self._buildfile_aliases.context_aware_object_factories.items():
+      yield BuildSymbolInfo(alias,
+                            self.get_description_from_docstring(factory_type) or self.ADD_DESCR,
+                            self.get_object_factory_args(alias))

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -33,7 +33,9 @@ class OptionHelpInfo(namedtuple('_OptionHelpInfo',
   deprecated_hint: A deprecation hint message registered for this option (None otherwise).
   choices: If this option has a constrained list of choices, a csv list of the choices.
   """
-  pass
+
+  def comma_separated_display_args(self):
+    return ', '.join(self.display_args)
 
 
 class OptionScopeHelpInfo(namedtuple('_OptionScopeHelpInfo',
@@ -62,7 +64,7 @@ class HelpInfoExtracter(object):
     """Compute the default value to display in help for an option registered with these kwargs."""
     ranked_default = kwargs.get('default')
     action = kwargs.get('action')
-    typ = kwargs.get('type', str)
+    typ = None if action in ['store_true', 'store_false'] else kwargs.get('type', str)
 
     default = ranked_default.value if ranked_default else None
     if default is None:
@@ -73,11 +75,13 @@ class HelpInfoExtracter(object):
       else:
         return 'None'
 
-    if typ == list_option:
+    if typ == list_option or action == 'append':
       default_str = '[{}]'.format(','.join(["'{}'".format(s) for s in default]))
     elif typ == dict_option:
       default_str = '{{ {} }}'.format(
         ','.join(["'{}':'{}'".format(k, v) for k, v in default.items()]))
+    elif typ == str:
+      default_str = "'{}'".format(default).replace('\n', ' ')
     else:
       default_str = str(default)
     return default_str

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/failing/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/failing/BUILD
@@ -1,1 +1,0 @@
-source_root("testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests")

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/mixed/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/mixed/BUILD
@@ -1,1 +1,0 @@
-source_root("testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests")

--- a/tests/python/pants_test/backend/jvm/targets/BUILD
+++ b/tests/python/pants_test/backend/jvm/targets/BUILD
@@ -25,6 +25,7 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:parse_context',
     'src/python/pants/build_graph',
     'src/python/pants/source',
     'tests/python/pants_test:base_test',

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='pants_requirements',
+  name='pants_requirement',
   sources=['test_pants_requirement.py'],
   dependencies=[
     'src/python/pants/backend/python:python_requirement',

--- a/tests/python/pants_test/base/test_payload.py
+++ b/tests/python/pants_test/base/test_payload.py
@@ -23,7 +23,7 @@ class PayloadTest(BaseTest):
         'java_library': JavaLibrary,
       },
       context_aware_object_factories={
-        'globs': Globs.factory,
+        'globs': Globs,
       },
     )
 

--- a/tests/python/pants_test/build_graph/test_build_file_aliases.py
+++ b/tests/python/pants_test/build_graph/test_build_file_aliases.py
@@ -77,19 +77,6 @@ class BuildFileAliasesTest(unittest.TestCase):
                                       objects=objects,
                                       context_aware_object_factories=factories))
 
-  def test_curry_context(self):
-    def curry_me(ctx, bob):
-      """original doc"""
-      return ctx, bob
-
-    curried = BuildFileAliases.curry_context(curry_me)
-    func = curried(42)
-
-    self.assertEqual('original doc', curried.__doc__)
-    self.assertTrue('curry_me' in curried.__name__,
-                    'Unhelpful __name__: ' + curried.__name__)
-    self.assertEqual((42, 'fred'), func('fred'))
-
   def test_create_bad_targets(self):
     with self.assertRaises(TypeError):
       BuildFileAliases(targets={'fred': object()})

--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -42,8 +42,8 @@ class BaseWhatChangedTest(ConsoleTaskTestBase):
         'python_thrift_library': PythonThriftLibrary,
       },
       context_aware_object_factories={
-        'globs': Globs.factory,
-        'rglobs': RGlobs.factory,
+        'globs': Globs,
+        'rglobs': RGlobs,
         'from_target': FromTarget,
       },
       objects={

--- a/tests/python/pants_test/help/test_build_dictionary_info_extracter.py
+++ b/tests/python/pants_test/help/test_build_dictionary_info_extracter.py
@@ -9,11 +9,15 @@ import unittest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
 from pants.build_graph.target import Target
-from pants.help.build_dictionary_info_extracter import (BuildDictionaryInfoExtracter, FunctionArg,
-                                                        TargetTypeInfo)
+from pants.help.build_dictionary_info_extracter import (BuildDictionaryInfoExtracter,
+                                                        BuildSymbolInfo, FunctionArg)
 
 
 class BuildDictionaryInfoExtracterTest(unittest.TestCase):
+
+  def setUp(self):
+    super(BuildDictionaryInfoExtracterTest, self).setUp()
+    self.maxDiff = None
 
   def test_get_description_from_docstring(self):
     class Test1(object):
@@ -61,6 +65,23 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
     self.assertEqual([FunctionArg('arg1', '', False, None), FunctionArg('arg2', '', True, False)],
                      BuildDictionaryInfoExtracter.get_function_args(TestCls.__init__))
 
+    # Test *args, **kwargs situation.
+    def generic_func(arg1, arg2=42, *args, **kwargs):
+      """
+      :param arg1: The first arg.
+      :param arg2: The second arg.
+      :param args: Some extra varargs.
+      :param arg3: The third arg.
+      :param arg4: The fourth arg (default: 'Foo').
+      """
+
+    self.assertEqual([FunctionArg('arg1', 'The first arg.', False, None),
+                      FunctionArg('arg2', 'The second arg.', True, 42),
+                      FunctionArg('*args', 'Some extra varargs.', False, None),
+                      FunctionArg('arg3', 'The third arg.', True, None),
+                      FunctionArg('arg4', "The fourth arg.", True, "'Foo'")],
+                     BuildDictionaryInfoExtracter.get_function_args(generic_func))
+
   def test_get_target_args(self):
     class Target1(Target):
       def __init__(self, arg1, arg2=42, **kwargs):
@@ -77,14 +98,20 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
       def __init__(self, arg3, arg4=None, **kwargs):
         super(Target1, self).__init__(**kwargs)
 
-    self.maxDiff = None
     self.assertEqual(BuildDictionaryInfoExtracter.basic_target_args + [
                        FunctionArg('arg1', 'The first arg.', False, None),
                        FunctionArg('arg2', 'The second arg.', True, 42),
                        FunctionArg('arg3', '', False, None),
                        FunctionArg('arg4', '', True, None)
                      ],
-                     BuildDictionaryInfoExtracter.get_target_args(Target3))
+                     BuildDictionaryInfoExtracter.get_args_for_target_type(Target3))
+
+    # Check a trivial case.
+    class Target4(Target):
+      pass
+
+    self.assertEqual(BuildDictionaryInfoExtracter.basic_target_args,
+                     BuildDictionaryInfoExtracter.get_args_for_target_type(Target4))
 
   def test_get_target_type_info(self):
     class Target1(Target):
@@ -92,7 +119,7 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
       pass
 
     class Target2a(Target):
-      # No docstring, so we should take the onefrom Target2b.
+      # No docstring, so we should take the one from Target2b.
       pass
 
     class Target2b(Target):
@@ -116,7 +143,52 @@ class BuildDictionaryInfoExtracterTest(unittest.TestCase):
     )
 
     extracter = BuildDictionaryInfoExtracter(bfa)
-    self.assertEquals([TargetTypeInfo('target1', 'Target1 docstring.'),
-                       TargetTypeInfo('target2', 'Target2 docstring.'),
-                       TargetTypeInfo('target3', 'Target3 docstring.')],
+    args = BuildDictionaryInfoExtracter.basic_target_args
+    self.assertEquals([BuildSymbolInfo('target1', 'Target1 docstring.', args),
+                       BuildSymbolInfo('target2', 'Target2 docstring.', args),
+                       BuildSymbolInfo('target3', 'Target3 docstring.', args)],
                       extracter.get_target_type_info())
+
+  def test_get_object_info(self):
+    class Foo(object):
+      """Foo docstring."""
+
+      def __init__(self, bar, baz=42):
+        """
+        :param bar: Bar details.
+        :param int baz: Baz details.
+        """
+
+    bfa = BuildFileAliases(targets={},
+      objects={
+        'foo': Foo
+      },
+      context_aware_object_factories={},
+    )
+    extracter = BuildDictionaryInfoExtracter(bfa)
+    self.assertEquals([BuildSymbolInfo('foo', 'Foo docstring.',
+                                       [FunctionArg('bar', 'Bar details.', False, None),
+                                        FunctionArg('baz', 'Baz details.', True, 42)])],
+                      extracter.get_object_info())
+
+  def test_get_object_factory_info(self):
+    class Foo(object):
+      """Foo docstring."""
+
+      def __call__(self, bar, baz=42):
+        """
+        :param bar: Bar details.
+        :param int baz: Baz details.
+        """
+
+    bfa = BuildFileAliases(targets={},
+      objects={},
+      context_aware_object_factories={
+        'foo': Foo
+      }
+    )
+    extracter = BuildDictionaryInfoExtracter(bfa)
+    self.assertEquals([BuildSymbolInfo('foo', 'Foo docstring.',
+                                       [FunctionArg('bar', 'Bar details.', False, None),
+                                        FunctionArg('baz', 'Baz details.', True, 42)])],
+                      extracter.get_object_factory_info())

--- a/tests/python/pants_test/source/test_wrapped_globs.py
+++ b/tests/python/pants_test/source/test_wrapped_globs.py
@@ -25,8 +25,8 @@ class FilesetRelPathWrapperTest(BaseTest):
         'java_library': JavaLibrary,
       },
       context_aware_object_factories={
-        'globs': Globs.factory,
-        'rglobs': RGlobs.factory,
+        'globs': Globs,
+        'rglobs': RGlobs,
       },
     )
 


### PR DESCRIPTION
Previously we had various non-standard ways of providing
BUILD file objects and context-aware object factories: Some
were objects with __call__ methods, some were functions, some
were the results of currying the context arg.

All this made it difficult to introspect on these to identify
the args and docstrings used to generate the build dictionary.

This change standardizes how these objects are provided, and makes
corresponding changes to the info extracters to take advantage
of this.

A future change will use this to rewrite the build dictionary/reference
page generator, so we can get rid of reflect.py.