### PR TITLE
Fix exception in test mechanism in case of exception in @BeforeClass method.

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -290,10 +290,14 @@ public class ConsoleRunnerImpl {
     @Override
     public void testFailure(Failure failure) throws Exception {
       if (outputMode == OutputMode.FAILURE_ONLY) {
-        InMemoryStreamCapture capture = caseCaptures.remove(failure.getDescription());
-        capture.close();
-        SWAPPABLE_OUT.getOriginal().append(new String(capture.readOut()));
-        SWAPPABLE_ERR.getOriginal().append(new String(capture.readErr()));
+        if (caseCaptures.containsKey(failure.getDescription())) {
+          InMemoryStreamCapture capture = caseCaptures.remove(failure.getDescription());
+          capture.close();
+          SWAPPABLE_OUT.getOriginal().append(new String(capture.readOut()));
+          SWAPPABLE_ERR.getOriginal().append(new String(capture.readErr()));
+        } else {
+          // Do nothing. Can be in case of exception in @BeforeClass method.
+        }
       }
       super.testFailure(failure);
     }

--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -296,7 +296,8 @@ public class ConsoleRunnerImpl {
           SWAPPABLE_OUT.getOriginal().append(new String(capture.readOut()));
           SWAPPABLE_ERR.getOriginal().append(new String(capture.readErr()));
         } else {
-          // Do nothing. Can be in case of exception in @BeforeClass method.
+          // Do nothing.
+          // In case of exception in @BeforeClass method testFailure executes without testStarted.
         }
       }
       super.testFailure(failure);

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception/AllTests.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception/AllTests.java
@@ -1,0 +1,15 @@
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class AllTests {
+  @BeforeClass
+  public static void setUp() {
+    throw new RuntimeException();
+  }
+
+  @Test
+  public void test() {
+    // Do nothing.
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception/BUILD
@@ -1,0 +1,4 @@
+java_tests(name='tests',
+  sources=['AllTests.java'],
+  dependencies=['3rdparty:junit'],
+)

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -120,12 +120,22 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     self.assertNotIn('Success output', run_with_failure_only_output.stdout_data)
 
     run_with_none_output = run_test('NONE')
-    self.assertNotIn('Failure output', run_with_none_output)
-    self.assertNotIn('Success output', run_with_none_output)
+    self.assertNotIn('Failure output', run_with_none_output.stdout_data)
+    self.assertNotIn('Success output', run_with_none_output.stdout_data)
 
     run_with_default_output = run_test(None)
-    self.assertNotIn('Failure output', run_with_default_output)
-    self.assertNotIn('Success output', run_with_default_output)
+    self.assertNotIn('Failure output', run_with_default_output.stdout_data)
+    self.assertNotIn('Success output', run_with_default_output.stdout_data)
+
+  def test_junit_before_class_exception(self):
+    for output_mode in ['ALL', 'FAILURE_ONLY', 'NONE']:
+      run_result = self.run_pants([
+        'test.junit', '--no-test-junit-fail-fast',
+        '--output-mode=' + output_mode,
+        'testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception:tests'
+      ])
+      self.assertTrue('Test mechanism' not in run_result.stdout_data,
+                      'Test mechanism exception in case of ' + output_mode + ' output mode.')
 
   def test_junit_test_target_cwd(self):
     pants_run = self.run_pants([

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from unittest import skip
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -127,6 +128,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     self.assertNotIn('Failure output', run_with_default_output.stdout_data)
     self.assertNotIn('Success output', run_with_default_output.stdout_data)
 
+  @skip('Skipped before publishing junit runner update.')
   def test_junit_before_class_exception(self):
     for output_mode in ['ALL', 'FAILURE_ONLY', 'NONE']:
       run_result = self.run_pants([

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -36,9 +36,10 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/src/java/org/pantsbuild/testproject/cycle1',
       'testprojects/src/java/org/pantsbuild/testproject/cycle2',
       'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target',
+      'testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception:tests'
       'testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests',
       'testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests',
-      'testprojects/src/java/org/pantsbuild/testproject/junit/suppressoutput',
+      'testprojects/src/java/org/pantsbuild/testproject/junit/suppressoutput:tests',
       'testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist.*',
       'testprojects/src/python/antlr:test_antlr_failure',
       'testprojects/src/scala/org/pantsbuild/testproject/compilation_failure',

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -36,7 +36,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/src/java/org/pantsbuild/testproject/cycle1',
       'testprojects/src/java/org/pantsbuild/testproject/cycle2',
       'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target',
-      'testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception:tests'
+      'testprojects/src/java/org/pantsbuild/testproject/junit/beforeclassexception:tests',
       'testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests',
       'testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests',
       'testprojects/src/java/org/pantsbuild/testproject/junit/suppressoutput:tests',


### PR DESCRIPTION
NPE in test mechanism happens in case of output-mode equal to FAILURE_MODE and exception in method annotated with @BeforeClass.

This PR contains test for this case (currently skipped) and java junit runner fix.