### PR TITLE
Bump pex version pinning to 1.1.2.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -7,7 +7,7 @@ Markdown==2.1.1
 mock==1.3.0
 mox==0.5.3
 pep8==1.6.2
-pex==1.1.1
+pex==1.1.2
 psutil==3.1.1
 pyflakes==0.9.2
 Pygments==1.4

--- a/tests/python/pants_test/bin/test_plugin_resolver.py
+++ b/tests/python/pants_test/bin/test_plugin_resolver.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 import pytest
+from pex.crawler import Crawler
 from pex.installer import Packager
 from pex.resolver import Unsatisfiable
 from pkg_resources import Requirement, WorkingSet
@@ -121,6 +122,7 @@ def test_inexact_requirements():
     # pex to a TLL expiry resolve and then fail.
     safe_rmtree(repo_dir)
     safe_rmtree(cache_dir)
+    Crawler.reset_cache()  # Reset the pex Crawler cache.
     time.sleep(1.5)
 
     with pytest.raises(Unsatisfiable):


### PR DESCRIPTION
This pulls in https://github.com/pantsbuild/pex/commit/fcdee8a6d13138de29c59820045c6bbe9cf7f0ea for an expected speedup in python chroot creation.