### PR TITLE
Fixup links in `Test{Parallel,Serial}`.

### DIFF
--- a/src/java/org/pantsbuild/junit/annotations/TestParallel.java
+++ b/src/java/org/pantsbuild/junit/annotations/TestParallel.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotate that a test class can be run in parallel. See usage note in
- * {@link org.pantsbuild.tools.junit.impl.ConsoleRunnerImpl}. The {@link TestSerial} annotation
+ * {@code org.pantsbuild.tools.junit.impl.ConsoleRunnerImpl}. The {@link TestSerial} annotation
  * takes precedence over this annotation if a class has both (including via inheritance).
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/java/org/pantsbuild/junit/annotations/TestSerial.java
+++ b/src/java/org/pantsbuild/junit/annotations/TestSerial.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotate that a test class must be run in serial. See usage note in
- * {@link org.pantsbuild.tools.junit.impl.ConsoleRunnerImpl}. This annotation takes precedence
+ * {@code org.pantsbuild.tools.junit.impl.ConsoleRunnerImpl}. This annotation takes precedence
  * over a {@link TestParallel} annotation if a class has both (including via inheritance).
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
Java 8's javadoc flags these links as errors since the annotations
target does not depend on `ConsoleRunnerImpl`.  Change the reference to
be a plain code reference to work around this.

https://rbcommons.com/s/twitter/r/3326/