### PR TITLE
Support `go test` blackbox tests.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
@@ -121,9 +121,10 @@ class GoFetch(GoTask):
             os.symlink(os.path.join(root_dir, path), os.path.join(dest_dir, path))
 
         # Map the fetched remote sources.
-        go_remote_lib_src[go_remote_lib] = os.path.join(gopath, 'src', go_remote_lib.import_path)
+        pkg = go_remote_lib.import_path
+        go_remote_lib_src[go_remote_lib] = os.path.join(gopath, 'src', pkg)
 
-        for remote_import_path in self._get_remote_import_paths(go_remote_lib, gopath=gopath):
+        for remote_import_path in self._get_remote_import_paths(pkg, gopath=gopath):
           fetcher = self._get_fetcher(remote_import_path)
           remote_root = fetcher.root(remote_import_path)
           spec_path = os.path.join(go_remote_lib.target_base, remote_root)
@@ -193,12 +194,12 @@ class GoFetch(GoTask):
   def _is_relative(import_path):
     return import_path.startswith('.')
 
-  def _get_remote_import_paths(self, go_remote_lib, gopath=None):
-    """Returns the remote import paths declared by the given Go remote library.
+  def _get_remote_import_paths(self, pkg, gopath=None):
+    """Returns the remote import paths declared by the given remote Go `pkg`.
 
     NB: This only includes production code imports, no test code imports.
     """
-    import_listing = self.import_oracle.list_imports(go_remote_lib.import_path, gopath=gopath)
+    import_listing = self.import_oracle.list_imports(pkg, gopath=gopath)
     return [imp for imp in import_listing.imports
             if (not self.import_oracle.is_go_internal_import(imp) and
                 # We assume relative imports are local to the package and skip attempts to

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
@@ -121,10 +121,9 @@ class GoFetch(GoTask):
             os.symlink(os.path.join(root_dir, path), os.path.join(dest_dir, path))
 
         # Map the fetched remote sources.
-        pkg = go_remote_lib.import_path
-        go_remote_lib_src[go_remote_lib] = os.path.join(gopath, 'src', pkg)
+        go_remote_lib_src[go_remote_lib] = os.path.join(gopath, 'src', go_remote_lib.import_path)
 
-        for remote_import_path in self._get_remote_import_paths(pkg, gopath=gopath):
+        for remote_import_path in self._get_remote_import_paths(go_remote_lib, gopath=gopath):
           fetcher = self._get_fetcher(remote_import_path)
           remote_root = fetcher.root(remote_import_path)
           spec_path = os.path.join(go_remote_lib.target_base, remote_root)
@@ -194,10 +193,13 @@ class GoFetch(GoTask):
   def _is_relative(import_path):
     return import_path.startswith('.')
 
-  def _get_remote_import_paths(self, pkg, gopath=None):
-    """Returns the remote import paths declared by the given Go `pkg`."""
-    import_listing = self.import_oracle.list_imports(pkg, gopath=gopath)
-    return [imp for imp in import_listing.all_imports
+  def _get_remote_import_paths(self, go_remote_lib, gopath=None):
+    """Returns the remote import paths declared by the given Go remote library.
+
+    NB: This only includes production code imports, no test code imports.
+    """
+    import_listing = self.import_oracle.list_imports(go_remote_lib.import_path, gopath=gopath)
+    return [imp for imp in import_listing.imports
             if (not self.import_oracle.is_go_internal_import(imp) and
                 # We assume relative imports are local to the package and skip attempts to
                 # recursively resolve them.

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
@@ -12,6 +12,7 @@ from collections import namedtuple
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.task.task import Task
 from pants.util.memo import memoized_method, memoized_property
+from twitter.common.collections.orderedset import OrderedSet
 
 from pants.contrib.go.subsystems.go_distribution import GoDistribution
 from pants.contrib.go.targets.go_binary import GoBinary
@@ -105,7 +106,10 @@ class ImportOracle(object):
     #   http://blog.golang.org/c-go-cgo
     return import_path == 'C' or import_path in self.go_stdlib
 
-  class ImportListing(namedtuple('ImportListing', ['pkg_name', 'imports', 'test_imports'])):
+  class ImportListing(namedtuple('ImportListing', ['pkg_name',
+                                                   'imports',
+                                                   'test_imports',
+                                                   'x_test_imports'])):
     """Represents all the imports of a given package."""
 
     @property
@@ -114,7 +118,7 @@ class ImportOracle(object):
 
       :rtype: list of string
       """
-      return self.imports + self.test_imports
+      return list(OrderedSet(self.imports + self.test_imports + self.x_test_imports))
 
   @memoized_method
   def list_imports(self, pkg, gopath=None):
@@ -139,6 +143,15 @@ class ImportOracle(object):
         raise self.ListDepsError('Problem listing imports for {}: {} failed with exit code {}'
                                  .format(pkg, go_cmd, returncode))
       data = json.loads(out)
+
+      # XTestImports are for black box tests.  These test files live inside the package dir but
+      # declare a different package and thus can only access the public members of the package's
+      # production code.  This style of test necessarily means the test file will import the main
+      # package.  For pants, this would lead to a cyclic self-dependency, so we omit the main
+      # package as implicitly included as its own dependency.
+      x_test_imports = [i for i in data.get('XTestImports', []) if i != pkg]
+
       return self.ImportListing(pkg_name=data.get('Name'),
                                 imports=data.get('Imports', []),
-                                test_imports=data.get('TestImports', []))
+                                test_imports=data.get('TestImports', []),
+                                x_test_imports=x_test_imports)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -25,8 +25,6 @@ class GoTest(GoWorkspaceTask):
   @classmethod
   def register_options(cls, register):
     super(GoTest, cls).register_options(register)
-    register('--remote', action='store_true',
-             help='Enables running tests found in go_remote_libraries.')
     register('--build-and-test-flags', default='',
              help='Flags to pass in to `go test` tool.')
 
@@ -37,8 +35,7 @@ class GoTest(GoWorkspaceTask):
   def execute(self):
     # Only executes the tests from the package specified by the target roots, so
     # we don't run the tests for _all_ dependencies of said package.
-    targets = filter(self.is_go if self.get_options().remote else self.is_local_src,
-                     self.context.target_roots)
+    targets = filter(self.is_local_src, self.context.target_roots)
     for target in targets:
       self.ensure_workspace(target)
       self._go_test(target)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -44,26 +44,6 @@ class GoFetchTest(TaskTestBase):
                                                           gopath=self.build_root)
     self.assertItemsEqual(remote_import_ids, ['bitbucket.org/u/b', 'github.com/u/c'])
 
-  def test_get_remote_import_paths_relative_ignored(self):
-    go_fetch = self.create_task(self.context())
-    self.create_file('src/github.com/u/r/a/a_test.go', contents="""
-      package a
-
-      import (
-        "fmt"
-        "math"
-        "sync"
-
-        "bitbucket.org/u/b"
-        "github.com/u/c"
-        "./b"
-        "../c/d"
-      )
-    """)
-    remote_import_ids = go_fetch._get_remote_import_paths('github.com/u/r/a',
-                                                          gopath=self.build_root)
-    self.assertItemsEqual(remote_import_ids, ['bitbucket.org/u/b', 'github.com/u/c'])
-
   def test_resolve_and_inject_explicit(self):
     r1 = self.make_target(spec='3rdparty/go/r1', target_type=GoRemoteLibrary)
     r2 = self.make_target(spec='3rdparty/go/r2', target_type=GoRemoteLibrary)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch_integration.py
@@ -31,23 +31,10 @@ class GoFetchIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
 
-  def test_issues_2004(self):
-    # The target used here has test imports outside those used by the source code it tests (that
-    # code only depends on the stdlib).  These must be resolved for the test to be compiled and run:
-    #
-    # github.com/bitly/go-simplejson
-    # -> github.com/bmizerany/assert (testing)
-    #    -> github.com/kr/pretty (testing)
-    #       -> github.com/kr/text (testing)
-    args = ['test.go',
-            '--remote',
-            'contrib/go/examples/3rdparty/go/github.com/bitly/go-simplejson']
-    pants_run = self.run_pants(args)
-    self.assert_success(pants_run)
-
   def test_issues_2229(self):
     # The target used here has tests that use relative imports.  In order to resolve the target
-    # and compile it, pants must be able to handle the relative imports.
+    # and compile it, pants must be able to handle the relative imports (it does so by not placing
+    # remote test code in workspaces).
     args = ['compile',
             'contrib/go/examples/3rdparty/go/github.com/robertkrimen/otto']
     pants_run = self.run_pants(args)


### PR DESCRIPTION
The `go test` command supports black box tests.  These are tests that
live in the package directory of code they test, but which declare a
different package, namely a package of the same name as the test file.
For example, `lib/lib.go` might be tested by `lib/lib_test.go` which
declares itself to be in the `lib_test` package.  Since
`lib/lib_test.go` is in a different package from `lib/lib.go` it can
only access its exported symbols, and so black box testing is enforced
by the compiler.

The `go list` command, used by pants to form go roots and generate go
BUILD files categorizes imports from this style of test differently from
"normal" tests; ie: instead of listing these test imports under the
`TestImports` key, they are listed under the `XTestImports` key.  Add
support for this 3rd import category and arrange for `GoBuildgen` to
support these imports while simultaneously removing support for test
imports of either kind from `GoFetch`.  The latter is done for
simplicity since a remote libs test imports would only ever be needed to
run that remote lib's tests locally.

A failing test was added for a target with a black box test that is
fixed by this change.

https://rbcommons.com/s/twitter/r/3327/