### PR TITLE
 Make remaining evaluations of globs lazy

### DIFF
--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -11,7 +11,7 @@ from twitter.common.dirutil.fileset import Fileset
 
 
 def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), key_arg=None,
-    allowable=(list, Fileset, OrderedSet, set, tuple), allowable_add=(),
+    allowable=(list, Fileset, OrderedSet, set, tuple), allowable_add=(), passthrough=(Fileset,),
     raise_type=ValueError):
   """
   This function is used to ensure that parameters set by users in BUILD files are of acceptable types.
@@ -23,6 +23,7 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
   :param allowable     : the acceptable types for obj. We do not want to allow any iterable (eg string).
   :param allowable_add : additional acceptable types; pass this to add to the default allowable types,
                          rather than to replace them.
+  :param passthrough   : the acceptable types which are passed through without being copied into a list.
   :param raise_type    : the error to throw if the type is not correct.
   """
   def get_key_msg(key=None):
@@ -43,7 +44,11 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
         '{}Expected an object of acceptable type {}, received None and can_be_none is False'
           .format(key_msg, allowable))
 
-  if isinstance(val, allowable):
+  if not isinstance(val, allowable):
+    raise raise_type(
+        '{}Expected an object of acceptable type {}, received {} instead'
+        .format(key_msg, allowable, val))
+  elif not isinstance(val, passthrough):
     lst = list(val)
     for e in lst:
       if not isinstance(e, expected_type):
@@ -52,6 +57,4 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
             .format(key_msg, expected_type, e, e.__class__))
     return lst
   else:
-    raise raise_type(
-        '{}Expected an object of acceptable type {}, received {} instead'
-        .format(key_msg, allowable, val))
+    return val

--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -11,8 +11,7 @@ from twitter.common.dirutil.fileset import Fileset
 
 
 def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), key_arg=None,
-    allowable=(list, Fileset, OrderedSet, set, tuple), allowable_add=(),
-    raise_type=ValueError):
+    allowable=(list, Fileset, OrderedSet, set, tuple), raise_type=ValueError):
   """
   This function is used to ensure that parameters set by users in BUILD files are of acceptable types.
   :param obj           : the object that may be a list. It will pass if it is of type in allowable.
@@ -21,8 +20,6 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
   :param default       : this is the default to return if can_be_none is True and obj is None.
   :param key_arg       : this is the name of the key to which obj belongs to
   :param allowable     : the acceptable types for obj. We do not want to allow any iterable (eg string).
-  :param allowable_add : additional acceptable types; pass this to add to the default allowable types,
-                         rather than to replace them.
   :param raise_type    : the error to throw if the type is not correct.
   """
   def get_key_msg(key=None):
@@ -31,7 +28,7 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
     else:
       return "In key '{}': ".format(key)
 
-  allowable = tuple(allowable) + tuple(allowable_add)
+  allowable = tuple(allowable)
 
   key_msg = get_key_msg(key_arg)
   val = obj

--- a/src/python/pants/base/validation.py
+++ b/src/python/pants/base/validation.py
@@ -11,7 +11,7 @@ from twitter.common.dirutil.fileset import Fileset
 
 
 def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), key_arg=None,
-    allowable=(list, Fileset, OrderedSet, set, tuple), allowable_add=(), passthrough=(Fileset,),
+    allowable=(list, Fileset, OrderedSet, set, tuple), allowable_add=(),
     raise_type=ValueError):
   """
   This function is used to ensure that parameters set by users in BUILD files are of acceptable types.
@@ -23,7 +23,6 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
   :param allowable     : the acceptable types for obj. We do not want to allow any iterable (eg string).
   :param allowable_add : additional acceptable types; pass this to add to the default allowable types,
                          rather than to replace them.
-  :param passthrough   : the acceptable types which are passed through without being copied into a list.
   :param raise_type    : the error to throw if the type is not correct.
   """
   def get_key_msg(key=None):
@@ -44,11 +43,7 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
         '{}Expected an object of acceptable type {}, received None and can_be_none is False'
           .format(key_msg, allowable))
 
-  if not isinstance(val, allowable):
-    raise raise_type(
-        '{}Expected an object of acceptable type {}, received {} instead'
-        .format(key_msg, allowable, val))
-  elif not isinstance(val, passthrough):
+  if isinstance(val, allowable):
     lst = list(val)
     for e in lst:
       if not isinstance(e, expected_type):
@@ -57,4 +52,6 @@ def assert_list(obj, expected_type=string_types, can_be_none=True, default=(), k
             .format(key_msg, expected_type, e, e.__class__))
     return lst
   else:
-    return val
+    raise raise_type(
+        '{}Expected an object of acceptable type {}, received {} instead'
+        .format(key_msg, allowable, val))

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -26,7 +26,8 @@ class SourcesField(PayloadField):
     :param filespec: glob and exclude data that generated this set of sources
     """
     self._rel_path = sources_rel_path
-    self._source_paths = assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,))
+    self._source_paths = assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,),
+                                     passthrough=(FilesetWithSpec,))
     self._ref_address = ref_address
     self._filespec = filespec
 
@@ -125,7 +126,8 @@ class DeferredSourcesField(SourcesField):
       raise self.AlreadyPopulatedError("Called with rel_path={rel_path} sources={sources}"
       .format(rel_path=rel_path, sources=sources))
     self._rel_path = rel_path
-    self._source_paths = assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,))
+    self._source_paths = assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,),
+                                     passthrough=(FilesetWithSpec,))
     self._populated = True
 
   def _validate_populated(self):

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -91,7 +91,7 @@ class SourcesField(PayloadField):
     if isinstance(sources, FilesetWithSpec):
       return sources
     else:
-      return assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,))
+      return assert_list(sources, key_arg='sources')
 
 
 class DeferredSourcesField(SourcesField):

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -26,8 +26,7 @@ class SourcesField(PayloadField):
     :param filespec: glob and exclude data that generated this set of sources
     """
     self._rel_path = sources_rel_path
-    self._source_paths = assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,),
-                                     passthrough=(FilesetWithSpec,))
+    self._source_paths = self._validate_source_paths(sources)
     self._ref_address = ref_address
     self._filespec = filespec
 
@@ -88,6 +87,12 @@ class SourcesField(PayloadField):
         hasher.update(f.read())
     return hasher.hexdigest()
 
+  def _validate_source_paths(self, sources):
+    if isinstance(sources, FilesetWithSpec):
+      return sources
+    else:
+      return assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,))
+
 
 class DeferredSourcesField(SourcesField):
   """A SourcesField that isn't populated immediately when the graph is constructed.
@@ -126,8 +131,7 @@ class DeferredSourcesField(SourcesField):
       raise self.AlreadyPopulatedError("Called with rel_path={rel_path} sources={sources}"
       .format(rel_path=rel_path, sources=sources))
     self._rel_path = rel_path
-    self._source_paths = assert_list(sources, key_arg='sources', allowable_add=(FilesetWithSpec,),
-                                     passthrough=(FilesetWithSpec,))
+    self._source_paths = self._validate_source_paths(sources)
     self._populated = True
 
   def _validate_populated(self):

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -47,3 +47,11 @@ class ParseValidation(unittest.TestCase):
     assert_list(['1', '2'], allowable_add=(GeneratorType,))
     with self.assertRaises(ValueError):
       assert_list(generator(), allowable_add=[])
+
+  def test_passthrough(self):
+    input = []
+    output = assert_list(input, passthrough=list)
+    self.assertIs(input, output)
+
+    output = assert_list(input)
+    self.assertIsNot(input, output)

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -47,11 +47,3 @@ class ParseValidation(unittest.TestCase):
     assert_list(['1', '2'], allowable_add=(GeneratorType,))
     with self.assertRaises(ValueError):
       assert_list(generator(), allowable_add=[])
-
-  def test_passthrough(self):
-    input = []
-    output = assert_list(input, passthrough=list)
-    self.assertIs(input, output)
-
-    output = assert_list(input)
-    self.assertIsNot(input, output)

--- a/tests/python/pants_test/base/test_validation.py
+++ b/tests/python/pants_test/base/test_validation.py
@@ -37,13 +37,4 @@ class ParseValidation(unittest.TestCase):
     with self.assertRaisesRegexp(ValueError, "In key 'artifacts':"):
       assert_list([["file3.txt"]], key_arg='artifacts')  # All values most be strings
     with self.assertRaisesRegexp(ValueError, "In key 'jars':"):
-      assert_list(None, can_be_none=False, key_arg='jars')  # The default is ok as None only when can_be_noe is true
-
-  def test_additional_allowables(self):
-    def generator():
-      for x in range(11):
-        yield str(x)
-    assert_list(generator(), allowable_add=(GeneratorType,))
-    assert_list(['1', '2'], allowable_add=(GeneratorType,))
-    with self.assertRaises(ValueError):
-      assert_list(generator(), allowable_add=[])
+      assert_list(None, can_be_none=False, key_arg='jars')  # The default is ok as None only when can_be_none is true

--- a/tests/python/pants_test/source/test_payload_fields.py
+++ b/tests/python/pants_test/source/test_payload_fields.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.source.payload_fields import SourcesField
+from pants.source.wrapped_globs import FilesetWithSpec
 from pants_test.base_test import BaseTest
 
 
@@ -69,3 +70,18 @@ class PayloadTest(BaseTest):
           ).fingerprint()
 
     self.assertNotEqual(fp1, fp2)
+
+  def test_fails_on_invalid_sources_kwarg(self):
+    with self.assertRaises(ValueError):
+      SourcesField(sources_rel_path='anything',
+                   sources='not-a-list')
+
+  def test_passes_fileset_with_spec_through(self):
+    self.create_file('foo/a.txt', 'a_contents')
+
+    fileset = FilesetWithSpec('foo', 'a.txt', lambda: ['a.txt'])
+    sf = SourcesField(sources_rel_path='foo',
+                      sources=fileset)
+
+    self.assertIs(fileset, sf.source_paths)
+    self.assertEqual(['a.txt'], list(sf.source_paths))


### PR DESCRIPTION
This changes validation.assert_list so it allows passthrough types which are not copied into a list. This allows globs to remain unfulfilled until use rather than eagerly doing directory scanning on target initialization.
    
It also changes jvm_app's bundle so that its filemap is also lazily created rather than eagerly.