### PR TITLE
PR for Travis

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -233,3 +233,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
                       else self._depinfo.structs[language])
     deps.update(target.dependencies)
     return deps
+
+  @property
+  def _copy_target_attributes(self):
+    return ['provides']

--- a/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
+++ b/src/python/pants/backend/codegen/tasks/apache_thrift_gen.py
@@ -139,3 +139,7 @@ class ApacheThriftGen(SimpleCodegenTask):
 
   def execute_codegen(self, target, target_workdir):
     self._generate_thrift(target, target_workdir)
+
+  @property
+  def _copy_target_attributes(self):
+    return ['provides']

--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -190,3 +190,7 @@ class ProtobufGen(SimpleCodegenTask):
     for target in proto_targets:
       for path in self._jars_to_directories(target):
         yield os.path.relpath(path, get_buildroot())
+
+  @property
+  def _copy_target_attributes(self):
+    return ['provides']

--- a/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
+++ b/src/python/pants/backend/codegen/tasks/simple_codegen_task.py
@@ -157,25 +157,27 @@ class SimpleCodegenTask(Task):
           # And inject a synthetic target to represent it.
           self._inject_synthetic_target(vt.target, vt.results_dir)
 
+  @property
+  def _copy_target_attributes(self):
+    """Return a list of attributes to be copied from the target to derived synthetic targets."""
+    return []
+
   def _inject_synthetic_target(self, target, target_workdir):
     """Create, inject, and return a synthetic target for the given target and workdir.
 
     :param target: The target to inject a synthetic target for.
     :param target_workdir: The work directory containing the generated code for the target.
     """
+    copied_attributes = {}
+    for attribute in self._copy_target_attributes:
+      copied_attributes[attribute] = getattr(target, attribute)
     synthetic_target = self.context.add_new_target(
       address=self._get_synthetic_address(target, target_workdir),
       target_type=self.synthetic_target_type(target),
       dependencies=self.synthetic_target_extra_dependencies(target, target_workdir),
       sources=list(self.find_sources(target, target_workdir)),
       derived_from=target,
-
-      # TODO(John Sirois): This assumes - currently, a JvmTarget or PythonTarget which both
-      # happen to have this attribute for carrying publish metadata but share no interface
-      # that defines this canonical property.  Lift up an interface and check for it or else
-      # add a way for SimpleCodeGen subclasses to specify extra attribute names that should be
-      # copied over from the target to its derived target.
-      provides=target.provides,
+      **copied_attributes
     )
 
     build_graph = self.context.build_graph


### PR DESCRIPTION
Add a property to SimpleCodegenTask to allow subclasses to choose
which attributes to copy from the original target to the synthetic
target.

This fixes a TODO in the code and prepares for codegen in golang
(which doesn't do 'provides').