### PR TITLE
Group classpath products by their targets

### DIFF
--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -6,7 +6,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-from collections import OrderedDict
+
+from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.targets.exclude import Exclude
 from pants.backend.jvm.targets.jvm_target import JvmTarget
@@ -115,8 +116,8 @@ def _matches_exclude(coordinate, exclude):
 
 
 def _not_excluded_filter(excludes):
-  def not_excluded(product_to_targets):
-    path_tuple = product_to_targets[0]
+  def not_excluded(product_to_target):
+    path_tuple = product_to_target[0]
     conf, classpath_entry = path_tuple
     return not classpath_entry.is_excluded_by(excludes)
   return not_excluded
@@ -219,7 +220,8 @@ class ClasspathProducts(object):
     :returns: The ordered (conf, classpath entry) tuples.
     :rtype: list of (string, :class:`ClasspathEntry`)
     """
-    return self.get_for_targets_by_product(targets, respect_excludes).keys()
+    return OrderedSet([cp for cp, target in self.get_for_targets_by_product(targets,
+                                                                            respect_excludes)])
 
   def get_for_targets_by_product(self, targets, respect_excludes=True):
     """Gets the classpath products for the given targets, grouped by products.
@@ -228,14 +230,13 @@ class ClasspathProducts(object):
 
     :param targets: The targets to lookup classpath products for.
     :param bool respect_excludes: `True` to respect excludes; `False` to ignore them.
-    :returns: The ordered (classpath products, an OrderedSet of targets) mappings.
-    :rtype: OrderedDict
+    :returns: The ordered (classpath, target) tuples.
     """
-    classpath_by_product = self._classpaths.get_for_targets_by_product(targets)
+    classpath_target_tuples = self._classpaths.get_product_target_mappings_for_targets(targets)
     if respect_excludes:
-      return self._filter_by_excludes(classpath_by_product, targets)
+      return self._filter_by_excludes(classpath_target_tuples, targets)
     else:
-      return classpath_by_product
+      return classpath_target_tuples
 
   def get_artifact_classpath_entries_for_targets(self, targets, respect_excludes=True):
     """Gets the artifact classpath products for the given targets.
@@ -269,12 +270,12 @@ class ClasspathProducts(object):
     return [(conf, cp_entry) for conf, cp_entry in classpath_tuples
             if not isinstance(cp_entry, ArtifactClasspathEntry)]
 
-  def _filter_by_excludes(self, classpath_by_product, root_targets):
+  def _filter_by_excludes(self, classpath_target_tuples, root_targets):
     # Excludes are always applied transitively, so regardless of whether a transitive
     # set of targets was included here, their closure must be included.
     closure = BuildGraph.closure(root_targets, bfs=True)
     excludes = self._excludes.get_for_targets(closure)
-    return OrderedDict(filter(_not_excluded_filter(excludes), classpath_by_product.items()))
+    return filter(_not_excluded_filter(excludes), classpath_target_tuples)
 
   def _add_excludes_for_target(self, target):
     if target.is_exported:

--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -222,13 +222,13 @@ class ClasspathProducts(object):
     return self.get_for_targets_by_product(targets, respect_excludes).keys()
 
   def get_for_targets_by_product(self, targets, respect_excludes=True):
-    """Gets the classpath products for the given targets, grouped by targets.
+    """Gets the classpath products for the given targets, grouped by products.
 
     Products are returned in order, optionally respecting target excludes.
 
     :param targets: The targets to lookup classpath products for.
     :param bool respect_excludes: `True` to respect excludes; `False` to ignore them.
-    :returns: The ordered ((string, :class:`ClasspathEntry`), targets) mappings.
+    :returns: The ordered (classpath products, an OrderedSet of targets) mappings.
     :rtype: OrderedDict
     """
     classpath_by_product = self._classpaths.get_for_targets_by_product(targets)

--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -220,13 +220,15 @@ class ClasspathProducts(object):
     :returns: The ordered (conf, classpath entry) tuples.
     :rtype: list of (string, :class:`ClasspathEntry`)
     """
-    return OrderedSet([cp for cp, target in self.get_for_targets_by_product(targets,
-                                                                            respect_excludes)])
 
-  def get_for_targets_by_product(self, targets, respect_excludes=True):
-    """Gets the classpath products for the given targets, grouped by products.
+    # remove the duplicate, preserve the ordering.
+    return list(OrderedSet([cp for cp, target in self.get_product_target_mappings_for_targets(
+                            targets, respect_excludes)]))
 
-    Products are returned in order, optionally respecting target excludes.
+  def get_product_target_mappings_for_targets(self, targets, respect_excludes=True):
+    """Gets the classpath products-target associations for the given targets.
+
+    Product-target tuples are returned in order, optionally respecting target excludes.
 
     :param targets: The targets to lookup classpath products for.
     :param bool respect_excludes: `True` to respect excludes; `False` to ignore them.

--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -230,7 +230,7 @@ class ClasspathProducts(object):
 
     :param targets: The targets to lookup classpath products for.
     :param bool respect_excludes: `True` to respect excludes; `False` to ignore them.
-    :returns: The ordered (classpath, target) tuples.
+    :returns: The ordered (classpath products, target) tuples.
     """
     classpath_target_tuples = self._classpaths.get_product_target_mappings_for_targets(targets)
     if respect_excludes:

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 
 import six
 from twitter.common.collections import OrderedSet
@@ -62,10 +62,22 @@ class UnionProducts(object):
 
   def get_for_targets(self, targets):
     """Gets the union of the products for the given targets, preserving the input order."""
-    products = OrderedSet()
+    return self.get_for_targets_by_product(targets).keys()
+
+  def get_for_targets_by_product(self, targets):
+    """Gets the products for the given targets, grouped by products, preserving the input order.
+
+    :param targets: The targets to lookup products for.
+    :returns: The ordered (product, targets) tuples.
+    """
+    targets_by_product = OrderedDict()
     for target in targets:
-      products.update(self._products_by_target[target])
-    return products
+      for product in self._products_by_target[target]:
+        if not product in targets_by_product:
+          targets_by_product[product] = OrderedSet()
+        targets_by_product[product].add(target)
+
+    return targets_by_product
 
   def target_for_product(self, product):
     """Looks up the target key for a product.

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import six
 from twitter.common.collections import OrderedSet
@@ -62,22 +62,23 @@ class UnionProducts(object):
 
   def get_for_targets(self, targets):
     """Gets the union of the products for the given targets, preserving the input order."""
-    return self.get_for_targets_by_product(targets).keys()
+    products = OrderedSet()
+    for target in targets:
+      products.update(self._products_by_target[target])
+    return products
 
-  def get_for_targets_by_product(self, targets):
-    """Gets the products for the given targets, grouped by products, preserving the input order.
+  def get_product_target_mappings_for_targets(self, targets):
+    """Gets the product-target associations for the given targets, preserving the input order.
 
     :param targets: The targets to lookup products for.
-    :returns: The ordered (product, targets) tuples.
+    :returns: The ordered (product, target) tuples.
     """
-    targets_by_product = OrderedDict()
+    product_target_mappings = []
     for target in targets:
       for product in self._products_by_target[target]:
-        if not product in targets_by_product:
-          targets_by_product[product] = OrderedSet()
-        targets_by_product[product].add(target)
+        product_target_mappings.append((product, target))
 
-    return targets_by_product
+    return product_target_mappings
 
   def target_for_product(self, product):
     """Looks up the target key for a product.

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_products.py
@@ -347,15 +347,17 @@ class ClasspathProductsTest(BaseTest):
     a = self.make_target('a', JvmTarget, dependencies=[b])
     classpath_product = ClasspathProducts(self.pants_workdir)
     example_jar_path = self._example_jar_path()
-    resolved_jar_a = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path,
-                                                             conf='fred-conf')
+
+    # resolved_jar is added for both a and b but should return only as one classpath entry
+    resolved_jar = self.add_jar_classpath_element_for_path(classpath_product, a, example_jar_path,
+                                                           conf='fred-conf')
     self.add_jar_classpath_element_for_path(classpath_product, b, example_jar_path,
-                                                            conf='fred-conf')
+                                            conf='fred-conf')
     classpath_target_tuples = classpath_product.get_classpath_entries_for_targets([a], respect_excludes=False)
 
     expected_entry = ArtifactClasspathEntry(example_jar_path,
-                                            resolved_jar_a.coordinate,
-                                            resolved_jar_a.cache_path)
+                                            resolved_jar.coordinate,
+                                            resolved_jar.cache_path)
     self.assertEqual([('fred-conf', expected_entry)], classpath_target_tuples)
 
   def test_get_artifact_classpath_entries_for_targets(self):

--- a/tests/python/pants_test/goal/test_union_products.py
+++ b/tests/python/pants_test/goal/test_union_products.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from collections import OrderedDict
+
 from twitter.common.collections import OrderedSet
 
 from pants.goal.products import UnionProducts
@@ -30,6 +32,19 @@ class UnionProductsTest(BaseTest):
     self.assertEquals(self.products.get_for_target(a), OrderedSet([1]))
     self.assertEquals(self.products.get_for_target(b), OrderedSet([2]))
     self.assertEquals(self.products.get_for_target(c), OrderedSet([3]))
+
+  def test_get_for_targets_by_product(self):
+    b = self.make_target('b')
+    a = self.make_target('a', dependencies=[b])
+    self.products.add_for_target(a, [1, 3])
+    self.products.add_for_target(b, [2, 3])
+
+    self.assertEquals(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 3, 2]))
+    self.assertEquals(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
+
+    self.assertEquals(self.products.get_for_targets_by_product(a.closure(bfs=True)),
+                      OrderedDict([(1, OrderedSet([a])), (3, OrderedSet([a, b])),
+                                   (2, OrderedSet([b]))]))
 
   def test_copy(self):
     c = self.make_target('c')

--- a/tests/python/pants_test/goal/test_union_products.py
+++ b/tests/python/pants_test/goal/test_union_products.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from collections import OrderedDict
-
 from twitter.common.collections import OrderedSet
 
 from pants.goal.products import UnionProducts
@@ -33,7 +31,7 @@ class UnionProductsTest(BaseTest):
     self.assertEquals(self.products.get_for_target(b), OrderedSet([2]))
     self.assertEquals(self.products.get_for_target(c), OrderedSet([3]))
 
-  def test_get_for_targets_by_product(self):
+  def test_get_product_target_mappings_for_targets(self):
     b = self.make_target('b')
     a = self.make_target('a', dependencies=[b])
     self.products.add_for_target(a, [1, 3])
@@ -42,9 +40,8 @@ class UnionProductsTest(BaseTest):
     self.assertEquals(self.products.get_for_targets(a.closure(bfs=True)), OrderedSet([1, 3, 2]))
     self.assertEquals(self.products.get_for_targets(b.closure(bfs=True)), OrderedSet([2, 3]))
 
-    self.assertEquals(self.products.get_for_targets_by_product(a.closure(bfs=True)),
-                      OrderedDict([(1, OrderedSet([a])), (3, OrderedSet([a, b])),
-                                   (2, OrderedSet([b]))]))
+    self.assertEquals(self.products.get_product_target_mappings_for_targets(a.closure(bfs=True)),
+                      [(1, a), (3, a), (2, b), (3, b)])
 
   def test_copy(self):
     c = self.make_target('c')


### PR DESCRIPTION
This review adds the convenient methods `get_for_targets_by_product`, to
`UnionProducts` and `ClasspathProducts` to return products or classpath
products associated with their targets.

This is so that we can look up products for the targets their belong to.

Background:

https://rbcommons.com/s/twitter/r/3329/ attempts to create 3rdparty libraries
symlinks same way as internal libraries are created, for bundle. There are two
options:

1. get the classpath products for all targets in `binary.closure(bfs=True)` in
   one call `get_classpath_entries_for_targets`
2. make the same call multiple times for each target
 
The issue with (2) is it does not respect the excludes same as (1), because
excludes are global.

This review will allow us after calling `get_classpath_entries_for_targets`,
get products' `target.id` for each products and make symlinks accordingly.