### PR TITLE
option for explicit coverage output directory

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -110,6 +110,9 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
     register('--coverage',
              help='Emit coverage information for specified paths/modules. Value has two forms: '
                   '"module:list,of,modules" or "path:list,of,paths"')
+    register('--coverage-output-dir', metavar='<DIR>', default=None,
+             help='Directory to emit coverage reports to.'
+             'If not specified, a default within dist is used.')
     register('--shard',
              help='Subset of tests to run, in the form M/N, 0 <= M < N. For example, 1/3 means '
                   'run tests number 2, 5, 8, 11, ...')
@@ -410,9 +413,12 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
             # consider combining coverage files from all runs in this Tasks's execute and then
             # producing just 1 console and 1 html report whether or not the tests are run in fast
             # mode.
-            relpath = Target.maybe_readable_identify(targets)
-            pants_distdir = self.context.options.for_global_scope().pants_distdir
-            target_dir = os.path.join(pants_distdir, 'coverage', relpath)
+            if self.get_options().coverage_output_dir:
+              target_dir = self.get_options().coverage_output_dir
+            else:
+              relpath = Target.maybe_readable_identify(targets)
+              pants_distdir = self.context.options.for_global_scope().pants_distdir
+              target_dir = os.path.join(pants_distdir, 'coverage', relpath)
             safe_mkdir(target_dir)
             pex_run(args=['html', '-i', '--rcfile', coverage_rc, '-d', target_dir])
             coverage_xml = os.path.join(target_dir, 'coverage.xml')

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -5,8 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import time
 
+from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -38,3 +40,13 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
 
     # Ensure that the timeout message triggered.
     self.assertIn("FAILURE: Timeout of 1 seconds reached", pants_run.stdout_data)
+
+  def test_pytest_explicit_coverage(self):
+    with temporary_dir() as coverage_dir:
+      pants_run = self.run_pants(['clean-all',
+                                  'test.pytest',
+                                  '--test-pytest-coverage=path:testprojects',
+                                  '--test-pytest-coverage-output-dir={dir}'.format(dir=coverage_dir),
+                                  'testprojects/tests/python/pants/constants_only:constants_only'])
+      self.assert_success(pants_run)
+      self.assertTrue(os.path.exists(os.path.join(coverage_dir, 'coverage.xml')))


### PR DESCRIPTION
Currently the coverage output dir is either:
 * A directory named for the module under test (when testing a single
   module).
 * A directory named for a random hash (when testing multiple
   modules).

This is usually fine for humans, but it is more convenient to point CI
systems at a single consistent directory.

fixes #2792