### PR TITLE
Support sharding of descendant (::) specs.

### DIFF
--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -131,6 +131,7 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':build_file',
+    ':hash_utils',
     'src/python/pants/build_graph',
   ],
 )

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -31,3 +31,8 @@ def hash_file(path, digest=None):
       digest.update(s)
       s = fd.read(8192)
   return digest.hexdigest()
+
+
+def compute_shard(str, mod):
+  """Computes the mod-hash of the given string, using a sha1 hash."""
+  return int(hash_all([str]), 16) % mod

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -60,7 +60,7 @@ class CmdLineSpecParserTest(BaseTest):
     self.assert_parsed(cmdline_spec='a/b:', expected=['a/b', 'a/b:c'])
     self.assert_parsed(cmdline_spec='//a/b:', expected=['a/b', 'a/b:c'])
 
-  def test_sibling_or_descendents(self):
+  def test_sibling_or_descendants(self):
     self.assert_parsed(cmdline_spec='::', expected=[':root', 'a', 'a:b', 'a/b', 'a/b:c'])
     self.assert_parsed(cmdline_spec='//::', expected=[':root', 'a', 'a:b', 'a/b', 'a/b:c'])
 
@@ -69,6 +69,21 @@ class CmdLineSpecParserTest(BaseTest):
 
     self.assert_parsed(cmdline_spec='a/b::', expected=['a/b', 'a/b:c'])
     self.assert_parsed(cmdline_spec='//a/b::', expected=['a/b', 'a/b:c'])
+
+  def test_sharded_descendants(self):
+    self.assert_parsed(cmdline_spec='::0/1', expected=[':root', 'a', 'a:b', 'a/b', 'a/b:c'])
+
+    self.assert_parsed(cmdline_spec='::0/2', expected=['a', 'a:b'])
+    self.assert_parsed(cmdline_spec='::1/2', expected=[':root', 'a/b', 'a/b:c'])
+
+    self.assert_parsed(cmdline_spec='::0/3', expected=[])
+    self.assert_parsed(cmdline_spec='::1/3', expected=[':root', 'a:b', 'a/b:c'])
+    self.assert_parsed(cmdline_spec='::2/3', expected=['a', 'a/b'])
+
+    self.assert_parsed(cmdline_spec='::0/4', expected=[])
+    self.assert_parsed(cmdline_spec='::1/4', expected=[':root', 'a/b:c'])
+    self.assert_parsed(cmdline_spec='::2/4', expected=['a', 'a:b'])
+    self.assert_parsed(cmdline_spec='::3/4', expected=['a/b'])
 
   def test_absolute(self):
     self.assert_parsed(cmdline_spec=os.path.join(self.build_root, 'a'), expected=['a'])

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -5,9 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import math
+
 import mox
 
-from pants.base.hash_utils import hash_all, hash_file
+from pants.base.hash_utils import compute_shard, hash_all, hash_file
 from pants.util.contextutil import temporary_file
 
 
@@ -35,3 +37,26 @@ class TestHashUtils(mox.MoxTestBase):
       fd.close()
 
       self.assertEqual('1137', hash_file(fd.name, digest=self.digest))
+
+  def test_compute_shard(self):
+    # Spot-check a couple of values, to make sure compute_shard doesn't do something completely degenerate.
+    self.assertEqual(31, compute_shard('', 42))
+    self.assertEqual(35, compute_shard('foo', 42))
+    self.assertEqual(5, compute_shard('bar', 42))
+
+  def test_compute_shard_distribution(self):
+    # Check that shard distribution isn't obviously broken.
+    nshards = 7
+    mean_samples_per_shard = 10000
+    nsamples = nshards * mean_samples_per_shard
+
+    distribution = [0] * nshards
+    for n in range(0, nsamples):
+      shard = compute_shard(str(n), nshards)
+      distribution[shard] += 1
+
+    variance = sum([(x - mean_samples_per_shard) ** 2 for x in distribution]) / nshards
+    stddev = math.sqrt(variance)
+
+    # We arbitrarily assert that a stddev of less than 1% of the mean is good enough for sanity-checking purposes.
+    self.assertLess(stddev, 100)


### PR DESCRIPTION
This new syntax looks like ::shard/nshards.
For example, foo/bar::4/7 will take only those targets in foo/bar::
whose hash modulo 7 is equal to 4.

This is useful primarily for splitting up tests and running them in
multiple disjoint batches. E.g., N CI workers could each run:

./pants test tests/python/pants_test::i/N --tag=integration

with a different value of 0<=i<N for each job.