### PR TITLE
Multiple dependency_managements with multiple ivy resolves.

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -354,7 +354,8 @@ class IvyUtils(object):
     return ret
 
   @classmethod
-  def generate_ivy(cls, targets, jars, excludes, ivyxml, confs, resolve_hash_name=None):
+  def generate_ivy(cls, targets, jars, excludes, ivyxml, confs, resolve_hash_name=None,
+                   pinned_artifacts=None):
     if resolve_hash_name:
       org = IvyUtils.INTERNAL_ORG_NAME
       name = resolve_hash_name
@@ -369,7 +370,7 @@ class IvyUtils(object):
       jars.append(jar)
 
     manager = JarDependencyManagement.global_instance()
-    artifact_set = PinnedJarArtifactSet(manager.for_targets(targets))
+    artifact_set = PinnedJarArtifactSet(pinned_artifacts) # Copy, because we're modifying it.
     for jars in jars_by_key.values():
       for i, dep in enumerate(jars):
         direct_coord = M2Coordinate.create(dep)

--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -85,13 +85,14 @@ class IvyResolve(IvyTaskMixin, NailgunTask):
     targets = self.context.targets()
     compile_classpath = self.context.products.get_data('compile_classpath',
         init_func=ClasspathProducts.init_func(self.get_options().pants_workdir))
-    resolve_hash_name = self.resolve(executor=executor,
-                                     targets=targets,
-                                     classpath_products=compile_classpath,
-                                     confs=self.get_options().confs,
-                                     extra_args=self._args)
+    resolve_hash_names = self.resolve(executor=executor,
+                                      targets=targets,
+                                      classpath_products=compile_classpath,
+                                      confs=self.get_options().confs,
+                                      extra_args=self._args)
     if self._report:
-      self._generate_ivy_report(resolve_hash_name)
+      for resolve_hash_name in resolve_hash_names:
+        self._generate_ivy_report(resolve_hash_name)
 
   def check_artifact_cache_for(self, invalidation_check):
     # Ivy resolution is an output dependent on the entire target set, and is not divisible

--- a/testprojects/src/java/org/pantsbuild/testproject/depman/TEST_BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/depman/TEST_BUILD
@@ -23,6 +23,13 @@ jar_library(name='library-managed',
   managed_dependencies=':manager',
 )
 
+jar_library(name='library-managed2',
+  jars=[
+    jar(org='jersey', name='jersey'),
+  ],
+  managed_dependencies=':manager2',
+)
+
 jar_library(name='library-managed-forceful',
   jars=[
     jar(org='jersey', name='jersey', rev='0.5-ea', force=True),
@@ -65,6 +72,15 @@ jvm_binary(name='managed',
   platform='java7',
   dependencies=[
     ':library-managed',
+  ],
+)
+
+jvm_binary(name='managed2',
+  main='org.pantsbuild.testproject.depman.PrintClasspath',
+  source='PrintClasspath.java',
+  platform='java7',
+  dependencies=[
+    ':library-managed2',
   ],
 )
 

--- a/testprojects/tests/java/org/pantsbuild/testproject/depman/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/depman/BUILD
@@ -1,0 +1,54 @@
+# Tests for dependency management integration.
+
+managed_jar_dependencies(name='new-manager',
+  artifacts=[
+    jar('jersey', 'jersey', '0.7-ea'),
+  ],
+)
+
+managed_jar_dependencies(name='old-manager',
+  artifacts=[
+    jar('jersey', 'jersey', '0.4-ea'),
+  ],
+)
+
+jar_library(name='common-lib',
+  jars=[
+    jar('javax.annotation', 'jsr250-api', '1.0'),
+    jar('javax.persistence', 'persistence-api', '1.0.2'),
+    jar('javax.servlet', 'servlet-api', '2.5'),
+    jar('com.sun.xml.txw2', 'txw2', '20110809'),
+  ],
+)
+
+jar_library(name='old-jersey',
+  jars=[
+    jar('jersey', 'jersey'),
+  ],
+  managed_dependencies=':old-manager',
+)
+
+jar_library(name='new-jersey',
+  jars=[
+    jar('jersey', 'jersey'),
+  ],
+  managed_dependencies=':new-manager',
+)
+
+junit_tests(name='old-tests',
+  sources=['OldTest.java'],
+  dependencies=[
+    '3rdparty:junit',
+    ':common-lib',
+    ':old-jersey',
+  ],
+)
+
+junit_tests(name='new-tests',
+  sources=['NewTest.java'],
+  dependencies=[
+    '3rdparty:junit',
+    ':common-lib',
+    ':new-jersey',
+  ],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/depman/NewTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/depman/NewTest.java
@@ -1,0 +1,21 @@
+package org.pantsbuild.testproject.depman.NewTest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests that should have jersey-0.7-ea on the classpath. */
+public class NewTest {
+
+  @Test
+  public void testNewIsPresent() {
+    assertEquals("WadlFactory", com.sun.ws.rest.impl.wadl.WadlFactory.class.getSimpleName());
+  }
+
+  @Test(expected=ClassNotFoundException.class)
+  public void testOldNotPresent() throws ClassNotFoundException {
+    String notInNew = "com.sun.ws.rest.tools.webapp.writer.WebApp";
+    getClass().getClassLoader().loadClass(notInNew);
+  }
+
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/depman/OldTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/depman/OldTest.java
@@ -1,0 +1,21 @@
+package org.pantsbuild.testproject.depman.OldTest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests that should have jersey-0.4-ea on the classpath. */
+public class OldTest {
+
+  @Test
+  public void testOldIsPresent() {
+    assertEquals("WebApp", com.sun.ws.rest.tools.webapp.writer.WebApp.class.getSimpleName());
+  }
+
+  @Test(expected=ClassNotFoundException.class)
+  public void testNewNotPresent() throws ClassNotFoundException {
+    String notInOld = "com.sun.ws.rest.impl.wadl.WadlFactory";
+    getClass().getClassLoader().loadClass(notInOld);
+  }
+
+}

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
@@ -8,7 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from collections import namedtuple
 from contextlib import contextmanager
+from unittest import expectedFailure
 
+from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -47,28 +49,28 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(run)
     return run.stdout_data
 
-  def _assert_classpath_contents(self, expected_sets, spec_name, **kwargs):
+  def _assert_run_classpath(self, expected_sets, spec_name, **kwargs):
     classpath = self._classpath_result(spec_name, **kwargs)
     for jar_set, value in expected_sets.items():
       for jar in jar_set:
         self.assertEquals(value, jar in classpath)
 
   def test_unmanaged_no_default(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.set_default: True,
       self.set_managed: False,
       self.set_managed2: False,
     }, 'unmanaged')
 
   def test_unmanaged_default2(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.set_default: False,
       self.set_managed: False,
       self.set_managed2: True,
     }, 'unmanaged', default_target=self.manager2_target, conflict_strategy='USE_MANAGED')
 
   def test_managed(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       ('commons-io',): False,
       self.set_default: False,
       self.set_managed: True,
@@ -76,21 +78,21 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
     }, 'managed', conflict_strategy='USE_MANAGED')
 
   def test_managed_ignore_default(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.set_default: False,
       self.set_managed: True,
       self.set_managed2: False,
     }, 'managed', default_target=self.manager2_target, conflict_strategy='USE_MANAGED')
 
   def test_managed_auto(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.set_default: False,
       self.set_managed: True,
       self.set_managed2: False,
     }, 'managed-auto')
 
   def test_managed_use_direct(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.JarSet(self.set_default.jersey, self.set_managed.jsr311): True,
       self.set_managed2: False,
     }, 'managed', conflict_strategy='USE_DIRECT')
@@ -109,13 +111,13 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
     self.assertIn('An artifact directly specified', run.stdout_data)
 
   def test_managed_forceful(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.JarSet(self.set_default.jersey, self.set_managed.jsr311): True,
       self.set_managed2: False,
     }, 'forceful', conflict_strategy='USE_DIRECT_IF_FORCED')
 
   def test_managed_redundant(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.set_default: False,
       self.set_managed: True,
       self.set_managed2: False,
@@ -126,7 +128,7 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
     self.assert_failure(run)
 
   def test_managed_forceful_use_managed(self):
-    self._assert_classpath_contents({
+    self._assert_run_classpath({
       self.set_default: False,
       self.set_managed: True,
       self.set_managed2: False,
@@ -153,5 +155,51 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
     run = self.run_pants([
       'resolve',
       'testprojects/3rdparty/managed::',
+    ])
+    self.assert_success(run)
+
+  def test_two_managers_build(self):
+    with self._testing_build_file():
+      with temporary_dir() as distdir:
+        run = self.run_pants([
+          '--pants-distdir={}'.format(distdir),
+          'binary',
+          '{}:{}'.format(self.project, 'managed'),
+          '{}:{}'.format(self.project, 'managed2'),
+          '--jar-dependency-management-default-target={}'.format(''),
+          '--jar-dependency-management-conflict-strategy={}'.format('USE_MANAGED'),
+        ])
+        self.assert_success(run)
+        bin1 = os.path.join(distdir, 'managed.jar')
+        bin2 = os.path.join(distdir, 'managed2.jar')
+        self.assertTrue(os.path.exists(bin1))
+        self.assertTrue(os.path.exists(bin2))
+
+  def test_all_targets_work(self):
+    with self._testing_build_file():
+      run = self.run_pants([
+        'export',
+        '{}::'.format(self.project),
+        '--jar-dependency-management-default-target={}'.format(''),
+        '--jar-dependency-management-conflict-strategy={}'.format('USE_MANAGED'),
+      ])
+      self.assert_success(run)
+
+  def test_unit_tests_with_different_sets(self):
+    run = self.run_pants([
+      'test',
+      '--test-junit-batch-size=1',
+      'testprojects/tests/java/org/pantsbuild/testproject/depman::',
+    ])
+    self.assert_success(run)
+
+  @expectedFailure
+  def test_unit_tests_with_different_sets_one_batch(self):
+    # NB(gmalmquist): Currently, junit_run isn't smart enough to partition the targets to run
+    # separately if they depend on jar_libraries which resolve using different managed dependencies.
+    run = self.run_pants([
+      'test',
+      '--test-junit-batch-size=2',
+      'testprojects/tests/java/org/pantsbuild/testproject/depman::',
     ])
     self.assert_success(run)

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_integration.py
@@ -401,8 +401,10 @@ class IdeaIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       'src::', 'tests::', 'examples::', 'testprojects::',
       # The android targets won't work if the Android ADK is not installed.
       '--exclude-target-regexp=.*android.*',
-      # Won't work until https://rbcommons.com/s/twitter/r/3367/ lands.
-      '--exclude-target-regexp=testprojects/3rdparty/managed.*',
+      # IdeaGen resolves source jars by default, which causes a collision with these targets because
+      # they explicitly include jersey.jersey's source jar.
+      '--exclude-target-regexp=testprojects/3rdparty/managed:jersey.jersey.sources',
+      '--exclude-target-regexp=testprojects/3rdparty/managed:example-dependee',
     ])
 
   def test_ivy_classifiers(self):

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -26,8 +26,6 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/src/java/org/pantsbuild/testproject/thriftdeptest',
       # TODO(Eric Ayers): I don't understand why this fails
       'testprojects/src/java/org/pantsbuild/testproject/jvmprepcommand:compile-prep-command',
-      # This won't work without special config until https://rbcommons.com/s/twitter/r/3367/ lands.
-      'testprojects/3rdparty/managed',
     ]
 
     # Targets that are intended to fail
@@ -52,6 +50,9 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist',
       'testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist:missingdirectdepswhitelist',
+      # These don't pass without special config.
+      'testprojects/tests/java/org/pantsbuild/testproject/depman:new-tests',
+      'testprojects/tests/java/org/pantsbuild/testproject/depman:old-tests',
     ]
 
     # May not succeed without java8 installed


### PR DESCRIPTION
This is the second pass of implementing dependency management in
pants.

The first pass was reviewed here:

    https://rbcommons.com/s/twitter/r/3336/

The design document is available here:

    https://docs.google.com/document/d/1AM_0e1Az_NHtR150Zsuyaa6u7InzBQGLq8MrUT57Od8/edit#

This change allows managed_jar_dependencies targets to be chained
together; the set of pinned artifact is the union of all jar
coordinates specified by the transitive closure of the target
specified in a jar_library's managed_dependencies field.

When there are conflicts between dependencies in the transitive
closure, the versions specified by dependees override the versions
specified by their dependencies. Thus, the artifacts specified in
the target directly referenced by the `managed_dependencies=` field
have the highest priority (which seems to be the most intuitive).

The change to make ivy do multiple resolves is fairly simple; see
ivy_task_mixin.py's resolve() method.