### PR TITLE
BuildFile refactoring: remove usages and deprecate of BuildFile's family, ancestors, siblings and descendants methods

### DIFF
--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -595,8 +595,8 @@ class Project(object):
         for descendant in BuildFile.scan_project_tree_build_files(build_file.project_tree, dir_relpath,
                                                                   spec_excludes=self.spec_excludes):
           candidates.update(self.target_util.get_all_addresses(descendant))
-        if not Project._is_root_relpath(dir_relpath):
-          for ancestor in Project._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath)):
+        if not self._is_root_relpath(dir_relpath):
+          for ancestor in self._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath)):
             candidates.update(self.target_util.get_all_addresses(ancestor))
 
         def is_sibling(target):
@@ -687,15 +687,15 @@ class Project(object):
     self.checkstyle_classpath = checkstyle_classpath
     self.scala_compiler_classpath = scalac_classpath
 
-  @staticmethod
-  def _collect_ancestor_build_files(project_tree, dir_relpath):
+  @classmethod
+  def _collect_ancestor_build_files(cls, project_tree, dir_relpath):
     for build_file in BuildFile.get_project_tree_build_files_family(project_tree, dir_relpath):
       yield build_file
-    while not Project._is_root_relpath(dir_relpath):
+    while not cls._is_root_relpath(dir_relpath):
       dir_relpath = os.path.dirname(dir_relpath)
       for build_file in BuildFile.get_project_tree_build_files_family(project_tree, dir_relpath):
         yield build_file
 
-  @staticmethod
-  def _is_root_relpath(relpath):
+  @classmethod
+  def _is_root_relpath(cls, relpath):
     return relpath == '.' or relpath == ''

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -588,11 +588,11 @@ class Project(object):
         target_dirset = find_source_basedirs(target)
         if not isinstance(target.address, BuildFileAddress):
           return []  # Siblings only make sense for BUILD files.
-        candidates = self.target_util.get_all_addresses(target.address.build_file)
+        candidates = OrderedSet()
+        for sibling in target.address.build_file.family():
+          candidates.update(self.target_util.get_all_addresses(sibling))
         for ancestor in target.address.build_file.ancestors():
           candidates.update(self.target_util.get_all_addresses(ancestor))
-        for sibling in target.address.build_file.siblings():
-          candidates.update(self.target_util.get_all_addresses(sibling))
         for descendant in target.address.build_file.descendants(spec_excludes=self.spec_excludes):
           candidates.update(self.target_util.get_all_addresses(descendant))
 

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -200,18 +200,10 @@ class BuildFile(AbstractClass):
     """Returns all BUILD files in ancestor directories of this BUILD file's parent directory."""
 
     parent_buildfiles = OrderedSet()
-
-    def is_root(path):
-      return os.path.abspath(self.root_dir) == os.path.abspath(path)
-
-    parentdir = self.parent_path
-    visited = set()
-    while parentdir not in visited and not is_root(parentdir):
-      visited.add(parentdir)
+    parentdir = fast_relpath(self.parent_path, self.root_dir)
+    while parentdir != '':
       parentdir = os.path.dirname(parentdir)
-      parent_buildfiles.update(BuildFile.get_project_tree_build_files_family(self.project_tree,
-                                                                             fast_relpath(parentdir, self.root_dir)))
-
+      parent_buildfiles.update(BuildFile.get_project_tree_build_files_family(self.project_tree, parentdir))
     return parent_buildfiles
 
   def siblings(self):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -197,6 +197,7 @@ class BuildFile(AbstractClass):
       descendants.discard(sibling)
     return descendants
 
+  @deprecated('0.0.72')
   def ancestors(self):
     """Returns all BUILD files in ancestor directories of this BUILD file's parent directory."""
 

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -245,7 +245,7 @@ class BuildFile(AbstractClass):
       if BuildFile._is_buildfile_name(build) and project_tree.isfile(os.path.join(dir_relpath, build)):
         yield BuildFile.cached(project_tree, os.path.join(dir_relpath, build))
 
-  # todo: deprecate
+  @deprecated('0.0.72', hint_message='Use get_project_tree_build_files_family instead.')
   def family(self):
     """Returns an iterator over all the BUILD files co-located with this BUILD file including this
     BUILD file itself.  The family forms a single logical BUILD file composed of the canonical BUILD

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -197,9 +197,9 @@ class BuildFile(AbstractClass):
   def descendants(self, spec_excludes=None):
     """Returns all BUILD files in descendant directories of this BUILD file's parent directory."""
 
-    descendants = self.scan_project_tree_build_files(self.project_tree,
-                                                     fast_relpath(self.parent_path, self.root_dir),
-                                                     spec_excludes=spec_excludes)
+    descendants = BuildFile.scan_project_tree_build_files(self.project_tree,
+                                                          fast_relpath(self.parent_path, self.root_dir),
+                                                          spec_excludes=spec_excludes)
     for sibling in self.family():
       descendants.discard(sibling)
     return descendants
@@ -211,7 +211,7 @@ class BuildFile(AbstractClass):
       parent = os.path.dirname(dirname)
       for parent_buildfile in self._get_all_build_files(parent):
         buildfile = os.path.join(parent, parent_buildfile)
-        return parent, self.cached(self.project_tree, fast_relpath(buildfile, self.root_dir))
+        return parent, BuildFile.cached(self.project_tree, fast_relpath(buildfile, self.root_dir))
       return parent, None
 
     parent_buildfiles = OrderedSet()
@@ -236,7 +236,7 @@ class BuildFile(AbstractClass):
     for build in self._get_all_build_files(self.parent_path):
       if self.name != build:
         siblingpath = os.path.join(os.path.dirname(self.relpath), build)
-        yield self.cached(self.project_tree, siblingpath)
+        yield BuildFile.cached(self.project_tree, siblingpath)
 
   @classmethod
   def get_project_tree_build_files_family(cls, project_tree, dir_relpath):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -219,7 +219,7 @@ class BuildFile(AbstractClass):
   @classmethod
   def get_project_tree_build_files_family(cls, project_tree, dir_relpath):
     """Returns all the BUILD files on a path"""
-    for build in project_tree.glob1(dir_relpath, '{prefix}*'.format(prefix=BuildFile._BUILD_FILE_PREFIX)):
+    for build in sorted(project_tree.glob1(dir_relpath, '{prefix}*'.format(prefix=BuildFile._BUILD_FILE_PREFIX))):
       if BuildFile._is_buildfile_name(build) and project_tree.isfile(os.path.join(dir_relpath, build)):
         yield BuildFile.cached(project_tree, os.path.join(dir_relpath, build))
 

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -150,7 +150,7 @@ class BuildFile(AbstractClass):
     # There is no BUILD file without a prefix so select any viable sibling
     buildfile_relpath = fast_relpath(buildfile, self.root_dir)
     if not project_tree.exists(buildfile_relpath) or project_tree.isdir(buildfile_relpath):
-      relpath = fast_relpath(path, self.root_dir)
+      relpath = os.path.dirname(buildfile_relpath)
       for build in self.project_tree.glob1(relpath, '{prefix}*'.format(prefix=self._BUILD_FILE_PREFIX)):
         if self._is_buildfile_name(build) and self.project_tree.isfile(os.path.join(relpath, build)):
           self._build_basename = build

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -218,8 +218,8 @@ class BuildFile(AbstractClass):
       if self != build:
         yield build
 
-  @classmethod
-  def get_project_tree_build_files_family(cls, project_tree, dir_relpath):
+  @staticmethod
+  def get_project_tree_build_files_family(project_tree, dir_relpath):
     """Returns all the BUILD files on a path"""
     for build in sorted(project_tree.glob1(dir_relpath, '{prefix}*'.format(prefix=BuildFile._BUILD_FILE_PREFIX))):
       if BuildFile._is_buildfile_name(build) and project_tree.isfile(os.path.join(dir_relpath, build)):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -206,6 +206,7 @@ class BuildFile(AbstractClass):
       parent_buildfiles.update(BuildFile.get_project_tree_build_files_family(self.project_tree, parentdir))
     return parent_buildfiles
 
+  @deprecated('0.0.72')
   def siblings(self):
     """Returns an iterator over all the BUILD files co-located with this BUILD file not including
     this BUILD file itself"""

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -41,12 +41,12 @@ class BuildFile(AbstractClass):
 
   _cache = {}
 
-  @classmethod
-  def clear_cache(cls):
+  @staticmethod
+  def clear_cache():
     BuildFile._cache = {}
 
-  @classmethod
-  def cached(cls, project_tree, relpath, must_exist=True):
+  @staticmethod
+  def cached(project_tree, relpath, must_exist=True):
     cache_key = (project_tree, relpath, must_exist)
     if cache_key not in BuildFile._cache:
       BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist)
@@ -62,9 +62,9 @@ class BuildFile(AbstractClass):
         results.append(build)
     return sorted(results)
 
-  @classmethod
-  def _is_buildfile_name(cls, name):
-    return cls._PATTERN.match(name)
+  @staticmethod
+  def _is_buildfile_name(name):
+    return BuildFile._PATTERN.match(name)
 
   # TODO(tabishev): Remove after transition period.
   @classmethod
@@ -83,8 +83,8 @@ class BuildFile(AbstractClass):
   def from_cache(cls, root_dir, relpath, must_exist=True):
     return BuildFile.cached(cls._get_project_tree(root_dir), relpath, must_exist)
 
-  @classmethod
-  def scan_project_tree_build_files(cls, project_tree, base_relpath, spec_excludes=None):
+  @staticmethod
+  def scan_project_tree_build_files(project_tree, base_relpath, spec_excludes=None):
     """Looks for all BUILD files
     :param project_tree: Project tree to scan in.
     :type project_tree: :class:`pants.base.project_tree.ProjectTree`
@@ -115,8 +115,8 @@ class BuildFile(AbstractClass):
       raise Exception('base_relpath parameter should be a relative path.')
 
     if base_relpath and not project_tree.isdir(base_relpath):
-      raise cls.BadPathError('Can only scan directories and {0} is not a valid dir'
-                              .format(base_relpath))
+      raise BuildFile.BadPathError('Can only scan directories and {0} is not a valid dir'
+                                   .format(base_relpath))
 
     buildfiles = []
     if spec_excludes:
@@ -131,7 +131,7 @@ class BuildFile(AbstractClass):
       for subdir in to_remove:
         dirs.remove(subdir)
       for filename in files:
-        if cls._is_buildfile_name(filename):
+        if BuildFile._is_buildfile_name(filename):
           buildfiles.append(BuildFile.cached(project_tree, os.path.join(root, filename)))
     return OrderedSet(sorted(buildfiles, key=lambda buildfile: buildfile.full_path))
 

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -186,6 +186,7 @@ class BuildFile(AbstractClass):
     """Returns True if this BuildFile corresponds to a real BUILD file on disk."""
     return self.project_tree.exists(self.relpath) and self.project_tree.isfile(self.relpath)
 
+  @deprecated('0.0.72')
   def descendants(self, spec_excludes=None):
     """Returns all BUILD files in descendant directories of this BUILD file's parent directory."""
 
@@ -251,7 +252,7 @@ class BuildFile(AbstractClass):
     return not self.__eq__(other)
 
   def __repr__(self):
-    return '{}({}, {})'.format(self.__class__.__name__, self.full_path, self.project_tree)
+    return '{}({}, {})'.format(self.__class__.__name__, self.relpath, self.project_tree)
 
 
 # Deprecated, will be removed after 0.0.72. Create BuildFile with IoFilesystem instead.

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -52,6 +52,7 @@ class BuildFile(AbstractClass):
       BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist)
     return BuildFile._cache[cache_key]
 
+  # todo: remove
   def _get_all_build_files(self, path):
     """Returns all the BUILD files on a path"""
     results = []
@@ -237,14 +238,19 @@ class BuildFile(AbstractClass):
         siblingpath = os.path.join(os.path.dirname(self.relpath), build)
         yield self.cached(self.project_tree, siblingpath)
 
+  @classmethod
+  def get_project_tree_build_files_family(cls, project_tree, dir_relpath):
+    """Returns all the BUILD files on a path"""
+    for build in project_tree.glob1(dir_relpath, '{prefix}*'.format(prefix=BuildFile._BUILD_FILE_PREFIX)):
+      if BuildFile._is_buildfile_name(build) and project_tree.isfile(os.path.join(dir_relpath, build)):
+        yield BuildFile.cached(project_tree, os.path.join(dir_relpath, build))
+
+  # todo: deprecate
   def family(self):
     """Returns an iterator over all the BUILD files co-located with this BUILD file including this
     BUILD file itself.  The family forms a single logical BUILD file composed of the canonical BUILD
     file if it exists and sibling build files each with their own extension, eg: BUILD.extras."""
-
-    yield self
-    for sibling in self.siblings():
-      yield sibling
+    return BuildFile.get_project_tree_build_files_family(self.project_tree, os.path.dirname(self.relpath))
 
   def source(self):
     """Returns the source code for this BUILD file."""

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -15,7 +15,6 @@ import six
 from twitter.common.collections import OrderedSet, maybe_list
 
 from pants.base.build_file import BuildFile
-from pants.build_graph.address import Address, parse_spec
 from pants.build_graph.address_lookup_error import AddressLookupError
 
 
@@ -162,9 +161,7 @@ class CmdLineSpecParser(object):
     else:
       spec_parts = spec.rsplit(':', 1)
       spec_parts[0] = normalize_spec_path(spec_parts[0])
-      spec_path, target_name = parse_spec(':'.join(spec_parts))
       try:
-        self._address_mapper.get_build_file(spec_path)
-      except BuildFile.BuildFileError as e:
+        return {self._address_mapper.spec_to_address(':'.join(spec_parts))}
+      except AddressLookupError as e:
         raise self.BadSpecError(e)
-      return {Address(spec_path, target_name)}

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -144,13 +144,11 @@ class BuildFileAddressMapper(object):
     """
     if spec_path not in self._spec_path_to_address_map_map:
       try:
-        try:
-          build_file = BuildFile.cached(self._project_tree, spec_path)
-        except BuildFile.BuildFileError as e:
-          raise self.BuildFileScanError("{message}\n searching {spec_path}"
-                                        .format(message=e,
-                                                spec_path=spec_path))
-        mapping = self._build_file_parser.address_map_from_build_file(build_file)
+        build_files = list(BuildFile.get_project_tree_build_files_family(self._project_tree, spec_path))
+        if len(build_files) == 0:
+          raise self.BuildFileScanError("There is no build files found "
+                                        "searching {spec_path}".format(spec_path=spec_path))
+        mapping = self._build_file_parser.address_map_from_build_files(build_files)
       except BuildFileParser.BuildFileParserError as e:
         raise AddressLookupError("{message}\n Loading addresses from '{spec_path}' failed."
                                  .format(message=e, spec_path=spec_path))

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
+
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.base.deprecated import deprecated
@@ -146,8 +148,8 @@ class BuildFileAddressMapper(object):
       try:
         build_files = list(BuildFile.get_project_tree_build_files_family(self._project_tree, spec_path))
         if len(build_files) == 0:
-          raise self.BuildFileScanError("There is no build files found "
-                                        "searching {spec_path}".format(spec_path=spec_path))
+          raise self.BuildFileScanError("There is no build files found in "
+                                        "{spec_path}".format(spec_path=os.path.join(self.root_dir, spec_path)))
         mapping = self._build_file_parser.address_map_from_build_files(build_files)
       except BuildFileParser.BuildFileParserError as e:
         raise AddressLookupError("{message}\n Loading addresses from '{spec_path}' failed."

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -148,8 +148,8 @@ class BuildFileAddressMapper(object):
       try:
         build_files = list(BuildFile.get_project_tree_build_files_family(self._project_tree, spec_path))
         if len(build_files) == 0:
-          raise self.BuildFileScanError("There is no build files found in "
-                                        "{spec_path}".format(spec_path=os.path.join(self.root_dir, spec_path)))
+          raise self.BuildFileScanError("{spec_path} does not contains any BUILD files."
+                                        .format(spec_path=os.path.join(self.root_dir, spec_path)))
         mapping = self._build_file_parser.address_map_from_build_files(build_files)
       except BuildFileParser.BuildFileParserError as e:
         raise AddressLookupError("{message}\n Loading addresses from '{spec_path}' failed."

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -147,7 +147,7 @@ class BuildFileAddressMapper(object):
     if spec_path not in self._spec_path_to_address_map_map:
       try:
         build_files = list(BuildFile.get_project_tree_build_files_family(self._project_tree, spec_path))
-        if len(build_files) == 0:
+        if not build_files:
           raise self.BuildFileScanError("{spec_path} does not contains any BUILD files."
                                         .format(spec_path=os.path.join(self.root_dir, spec_path)))
         mapping = self._build_file_parser.address_map_from_build_files(build_files)

--- a/src/python/pants/build_graph/build_file_parser.py
+++ b/src/python/pants/build_graph/build_file_parser.py
@@ -62,16 +62,20 @@ class BuildFileParser(object):
     """Returns a copy of the registered build file aliases this build file parser uses."""
     return self._build_configuration.registered_aliases()
 
-  def address_map_from_build_file(self, build_file):
-    family_address_map_by_build_file = self.parse_build_file_family(build_file)
+  def address_map_from_build_files(self, build_files):
+    family_address_map_by_build_file = self.parse_build_files(build_files)
     address_map = {}
     for build_file, sibling_address_map in family_address_map_by_build_file.items():
       address_map.update(sibling_address_map)
     return address_map
 
-  def parse_build_file_family(self, build_file):
+  # todo: deprecate
+  def address_map_from_build_file(self, build_file):
+    return self.address_map_from_build_files(build_file.family())
+
+  def parse_build_files(self, build_files):
     family_address_map_by_build_file = {}  # {build_file: {address: addressable}}
-    for bf in build_file.family():
+    for bf in build_files:
       bf_address_map = self.parse_build_file(bf)
       for address, addressable in bf_address_map.items():
         for sibling_build_file, sibling_address_map in family_address_map_by_build_file.items():
@@ -84,6 +88,10 @@ class BuildFileParser(object):
                       target_name=address.target_name))
       family_address_map_by_build_file[bf] = bf_address_map
     return family_address_map_by_build_file
+
+  # todo: deprecate
+  def parse_build_file_family(self, build_file):
+    return self.parse_build_files(build_file.family())
 
   def parse_build_file(self, build_file):
     """Capture Addressable instances from parsing `build_file`.

--- a/src/python/pants/build_graph/build_file_parser.py
+++ b/src/python/pants/build_graph/build_file_parser.py
@@ -10,6 +10,8 @@ import warnings
 
 import six
 
+from pants.base.deprecated import deprecated
+
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +71,7 @@ class BuildFileParser(object):
       address_map.update(sibling_address_map)
     return address_map
 
-  # todo: deprecate
+  @deprecated('0.0.72', hint_message='Use address_map_from_build_files instead.')
   def address_map_from_build_file(self, build_file):
     return self.address_map_from_build_files(build_file.family())
 
@@ -89,7 +91,7 @@ class BuildFileParser(object):
       family_address_map_by_build_file[bf] = bf_address_map
     return family_address_map_by_build_file
 
-  # todo: deprecate
+  @deprecated('0.0.72', hint_message='Use parse_build_files instead.')
   def parse_build_file_family(self, build_file):
     return self.parse_build_files(build_file.family())
 

--- a/src/python/pants/build_graph/source_mapper.py
+++ b/src/python/pants/build_graph/source_mapper.py
@@ -48,7 +48,7 @@ class SpecSourceMapper(SourceMapper):
     # a top-level source has empty dirname, so do/while instead of straight while loop.
     while path:
       path = os.path.dirname(path)
-      build_files = BuildFile.get_buildfiles_family(self._address_mapper._project_tree, path)
+      build_files = BuildFile.get_project_tree_build_files_family(self._address_mapper._project_tree, path)
       result.extend(list(self._find_targets_for_source(source, build_files)))
       if self._stop_after_match and len(result) > 0:
         break

--- a/src/python/pants/build_graph/source_mapper.py
+++ b/src/python/pants/build_graph/source_mapper.py
@@ -8,8 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from collections import defaultdict
 
-from pants.base.build_environment import get_buildroot
-from pants.base.build_file import BuildFile
 from pants.source.payload_fields import DeferredSourcesField
 
 
@@ -42,36 +40,33 @@ class SpecSourceMapper(SourceMapper):
   def target_addresses_for_source(self, source):
     result = []
 
-    root = get_buildroot()
     path = source
 
     # a top-level source has empty dirname, so do/while instead of straight while loop.
     while path:
       path = os.path.dirname(path)
-      build_files = BuildFile.get_project_tree_build_files_family(self._address_mapper._project_tree, path)
-      result.extend(list(self._find_targets_for_source(source, build_files)))
+      result.extend(list(self._find_targets_for_source(source, path)))
       if self._stop_after_match and len(result) > 0:
         break
 
     return result
 
-  def _find_targets_for_source(self, source, build_files):
-    for build_file in build_files:
-      for address in self._address_mapper.addresses_in_spec_path(build_file.spec_path):
-        self._build_graph.inject_address_closure(address)
-        target = self._build_graph.get_target(address)
-        sources = target.payload.get_field('sources')
-        if sources and not isinstance(sources, DeferredSourcesField) and sources.matches(source):
-          yield address
-        if address.build_file.relpath == source:
-          yield address
-        if target.has_resources:
-          for resource in target.resources:
-            """
-            :type resource: pants.build_graph.resources.Resources
-            """
-            if resource.payload.sources.matches(source):
-              yield address
+  def _find_targets_for_source(self, source, spec_path):
+    for address in self._address_mapper.addresses_in_spec_path(spec_path):
+      self._build_graph.inject_address_closure(address)
+      target = self._build_graph.get_target(address)
+      sources = target.payload.get_field('sources')
+      if sources and not isinstance(sources, DeferredSourcesField) and sources.matches(source):
+        yield address
+      if address.build_file.relpath == source:
+        yield address
+      if target.has_resources:
+        for resource in target.resources:
+          """
+          :type resource: pants.build_graph.resources.Resources
+          """
+          if resource.payload.sources.matches(source):
+            yield address
 
 
 class LazySourceMapper(SourceMapper):
@@ -120,7 +115,6 @@ class LazySourceMapper(SourceMapper):
       return
     self._searched_sources.add(source)
 
-    root = get_buildroot()
     path = os.path.dirname(source)
 
     # a top-level source has empty dirname, so do/while instead of straight while loop.
@@ -128,8 +122,7 @@ class LazySourceMapper(SourceMapper):
     while walking:
       # It is possible
       if path not in self._mapped_paths:
-        build_files = BuildFile.get_project_tree_build_files_family(self._address_mapper._project_tree, path)
-        self._map_sources_from_family(build_files)
+        self._map_sources_from_spec_path(path)
         self._mapped_paths.add(path)
       elif not self._stop_after_match:
         # If not in stop-after-match mode, once a path is seen visited, all parents can be assumed.
@@ -142,24 +135,23 @@ class LazySourceMapper(SourceMapper):
       walking = bool(path)
       path = os.path.dirname(path)
 
-  def _map_sources_from_family(self, build_files):
+  def _map_sources_from_spec_path(self, spec_path):
     """Populate mapping of source to owning addresses with targets from given BUILD files.
 
-    :param iterable<BuildFile> build_files: a family of BUILD files from which to map sources.
+    :param spec_path: a spec_path of targets from which to map sources.
     """
-    for build_file in build_files:
-      for address in self._address_mapper.addresses_in_spec_path(build_file.spec_path):
-        self._build_graph.inject_address_closure(address)
-        target = self._build_graph.get_target(address)
-        if target.has_resources:
-          for resource in target.resources:
-            for item in resource.sources_relative_to_buildroot():
-              self._source_to_address[item].add(target.address)
+    for address in self._address_mapper.addresses_in_spec_path(spec_path):
+      self._build_graph.inject_address_closure(address)
+      target = self._build_graph.get_target(address)
+      if target.has_resources:
+        for resource in target.resources:
+          for item in resource.sources_relative_to_buildroot():
+            self._source_to_address[item].add(target.address)
 
-        for target_source in target.sources_relative_to_buildroot():
-          self._source_to_address[target_source].add(target.address)
-        if not target.is_synthetic:
-          self._source_to_address[target.address.build_file.relpath].add(target.address)
+      for target_source in target.sources_relative_to_buildroot():
+        self._source_to_address[target_source].add(target.address)
+      if not target.is_synthetic:
+        self._source_to_address[target.address.build_file.relpath].add(target.address)
 
   def target_addresses_for_source(self, source):
     """Attempt to find targets which own a source by searching up directory structure to buildroot.

--- a/src/python/pants/build_graph/source_mapper.py
+++ b/src/python/pants/build_graph/source_mapper.py
@@ -49,7 +49,6 @@ class SpecSourceMapper(SourceMapper):
       try:
         result.extend(self._find_targets_for_source(source, path))
       except AddressLookupError:
-        # Ignore address lookup errors.
         pass
       if self._stop_after_match and len(result) > 0:
         break
@@ -130,7 +129,6 @@ class LazySourceMapper(SourceMapper):
         try:
           self._map_sources_from_spec_path(path)
         except AddressLookupError:
-          # Ignore address lookup errors.
           pass
         self._mapped_paths.add(path)
       elif not self._stop_after_match:

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -24,7 +24,7 @@ class BuildFileTestBase(unittest.TestCase):
   def touch(self, path):
     touch(self.fullpath(path))
 
-  def scan_buildfiles(self, base_relpath=None, spec_excludes=None):
+  def scan_buildfiles(self, base_relpath, spec_excludes=None):
     return BuildFile.scan_project_tree_build_files(self._project_tree, base_relpath, spec_excludes)
 
   def create_buildfile(self, relpath, must_exist=True):

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -9,10 +9,9 @@ import os
 import shutil
 import tempfile
 import unittest
-from abc import abstractmethod
 
 from pants.base.build_file import BuildFile
-from pants.util.dirutil import fast_relpath, safe_mkdir, touch
+from pants.util.dirutil import safe_mkdir, touch
 
 
 class BuildFileTestBase(unittest.TestCase):
@@ -30,6 +29,9 @@ class BuildFileTestBase(unittest.TestCase):
 
   def create_buildfile(self, relpath, must_exist=True):
     return BuildFile(self._project_tree, relpath, must_exist=must_exist)
+
+  def get_build_files_family(self, relpath):
+    return BuildFile.get_project_tree_build_files_family(self._project_tree, relpath)
 
   def setUp(self):
     self.base_dir = tempfile.mkdtemp()

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -107,13 +107,13 @@ class CmdLineSpecParserTest(BaseTest):
 
   def test_does_not_exist(self):
     with self.assertRaises(self.spec_parser.BadSpecError):
-      self.spec_parser.parse_addresses('c').next()
+      list(self.spec_parser.parse_addresses('c'))
 
     with self.assertRaises(self.spec_parser.BadSpecError):
-      self.spec_parser.parse_addresses('c:').next()
+      list(self.spec_parser.parse_addresses('c:'))
 
     with self.assertRaises(self.spec_parser.BadSpecError):
-      self.spec_parser.parse_addresses('c::').next()
+      list(self.spec_parser.parse_addresses('c::'))
 
   def assert_parsed(self, cmdline_spec, expected):
     def sort(addresses):

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -173,16 +173,16 @@ class CmdLineSpecParserBadBuildTest(BaseTest):
     self.NO_FAIL_FAST_RE = re.compile(r"""^--------------------
 .*
 Exception message: name 'a_is_bad' is not defined
- while executing BUILD file BuildFile\((/[^/]+)*/bad/a/BUILD, FileSystemProjectTree\(.*\)\)
+ while executing BUILD file BuildFile\(bad/a/BUILD, FileSystemProjectTree\(.*\)\)
  Loading addresses from 'bad/a' failed\.
 .*
 Exception message: name 'b_is_bad' is not defined
- while executing BUILD file BuildFile\((/[^/]+)*T/bad/b/BUILD, FileSystemProjectTree\(.*\)\)
+ while executing BUILD file BuildFile\(bad/b/BUILD, FileSystemProjectTree\(.*\)\)
  Loading addresses from 'bad/b' failed\.
 Invalid BUILD files for \[::\]$""", re.DOTALL)
 
     self.FAIL_FAST_RE = """^name 'a_is_bad' is not defined
- while executing BUILD file BuildFile\((/[^/]+)*/bad/a/BUILD\, FileSystemProjectTree\(.*\)\)
+ while executing BUILD file BuildFile\(bad/a/BUILD\, FileSystemProjectTree\(.*\)\)
  Loading addresses from 'bad/a' failed.$"""
 
   def test_bad_build_files(self):

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -49,11 +49,13 @@ class FilesystemBuildFileTest(BuildFileTestBase):
 
   def testDescendants(self):
     self.assertEquals(OrderedSet([
+        self.create_buildfile('grandparent/parent/BUILD'),
+        self.create_buildfile('grandparent/parent/BUILD.twitter'),
         self.create_buildfile('grandparent/parent/child1/BUILD'),
         self.create_buildfile('grandparent/parent/child1/BUILD.twitter'),
         self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
-        self.create_buildfile('grandparent/parent/child5'),
-    ]), self.buildfile.descendants())
+        self.create_buildfile('grandparent/parent/child5/BUILD'),
+    ]), self.scan_buildfiles('grandparent/parent'))
 
   def test_descendants_with_spec_excludes(self):
     self.assertEquals(OrderedSet([
@@ -90,7 +92,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         self.create_buildfile('suffix-test/BUILD.suffix2')]),
         self.get_build_files_family('suffix-test'))
     self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
-        buildfile.descendants())
+        self.scan_buildfiles('suffix-test/child'))
 
   def testAncestorsSuffix1(self):
     self.makedirs('suffix-test1/parent')

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -57,10 +57,12 @@ class FilesystemBuildFileTest(BuildFileTestBase):
 
   def test_descendants_with_spec_excludes(self):
     self.assertEquals(OrderedSet([
+        self.create_buildfile('grandparent/parent/BUILD'),
+        self.create_buildfile('grandparent/parent/BUILD.twitter'),
         self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
-        self.create_buildfile('grandparent/parent/child5'),
+        self.create_buildfile('grandparent/parent/child5/BUILD'),
       ]),
-      self.buildfile.descendants(spec_excludes=['grandparent/parent/child1']))
+      self.scan_buildfiles('grandparent/parent', spec_excludes=['grandparent/parent/child1']))
 
   # # todo: just remove, not working, but meaningless
   # def testMustExistFalse(self):

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -41,12 +41,6 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     buildfile = self.create_buildfile('grandparent/parent/child2/child3/BUILD')
     self.assertEquals(OrderedSet([buildfile]), self.get_build_files_family('grandparent/parent/child2/child3'))
 
-  def testAncestors(self):
-    self.assertEquals(OrderedSet([
-        self.create_buildfile('BUILD'),
-        self.create_buildfile('BUILD.twitter'),
-    ]), self.buildfile.ancestors())
-
   def testDescendants(self):
     self.assertEquals(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
@@ -66,11 +60,6 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       ]),
       self.scan_buildfiles('grandparent/parent', spec_excludes=['grandparent/parent/child1']))
 
-  # # todo: just remove, not working, but meaningless
-  # def testMustExistFalse(self):
-  #   buildfile = self.create_buildfile("path-that-does-not-exist/BUILD", must_exist=False)
-  #   self.assertEquals(OrderedSet([buildfile]), buildfile.family())
-  #
   def testMustExistTrue(self):
     with self.assertRaises(BuildFile.MissingBuildFileError):
       self.create_buildfile("path-that-does-not-exist/BUILD", must_exist=True)
@@ -93,29 +82,6 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         self.get_build_files_family('suffix-test'))
     self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
         self.scan_buildfiles('suffix-test/child'))
-
-  def testAncestorsSuffix1(self):
-    self.makedirs('suffix-test1/parent')
-    self.touch('suffix-test1/parent/BUILD.suffix')
-    self.touch('suffix-test1/BUILD')
-    buildfile = self.create_buildfile('suffix-test1/parent/BUILD.suffix')
-    self.assertEquals(OrderedSet([
-        self.create_buildfile('suffix-test1/BUILD'),
-        self.create_buildfile('BUILD'),
-        self.create_buildfile('BUILD.twitter')]),
-        buildfile.ancestors())
-
-  def testAncestorsSuffix2(self):
-    self.makedirs('suffix-test2')
-    self.makedirs('suffix-test2/subdir')
-    self.touch('suffix-test2/subdir/BUILD.foo')
-    self.touch('suffix-test2/BUILD.bar')
-    buildfile = self.create_buildfile('suffix-test2/subdir/BUILD.foo')
-    self.assertEquals(OrderedSet([
-        self.create_buildfile('suffix-test2/BUILD.bar'),
-        self.create_buildfile('BUILD'),
-        self.create_buildfile('BUILD.twitter')]),
-        buildfile.ancestors())
 
   def test_buildfile_with_dir_must_exist_false(self):
     # We should be able to create a BuildFile against a dir called BUILD if must_exist is false.

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -62,10 +62,11 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       ]),
       self.buildfile.descendants(spec_excludes=['grandparent/parent/child1']))
 
-  def testMustExistFalse(self):
-    buildfile = self.create_buildfile("path-that-does-not-exist/BUILD", must_exist=False)
-    self.assertEquals(OrderedSet([buildfile]), buildfile.family())
-
+  # # todo: just remove, not working, but meaningless
+  # def testMustExistFalse(self):
+  #   buildfile = self.create_buildfile("path-that-does-not-exist/BUILD", must_exist=False)
+  #   self.assertEquals(OrderedSet([buildfile]), buildfile.family())
+  #
   def testMustExistTrue(self):
     with self.assertRaises(BuildFile.MissingBuildFileError):
       self.create_buildfile("path-that-does-not-exist/BUILD", must_exist=True)

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -36,10 +36,12 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     self.assertEquals(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
         self.create_buildfile('grandparent/parent/BUILD.twitter'),
-    ]), self.buildfile.family())
+    ]), BuildFile.get_project_tree_build_files_family(self._project_tree, 'grandparent/parent'))
 
     buildfile = self.create_buildfile('grandparent/parent/child2/child3/BUILD')
-    self.assertEquals(OrderedSet([buildfile]), buildfile.family())
+    self.assertEquals(OrderedSet([buildfile]),
+                      BuildFile.get_project_tree_build_files_family(self._project_tree,
+                                                                    'grandparent/parent/child2/child3'))
 
   def testAncestors(self):
     self.assertEquals(OrderedSet([
@@ -86,7 +88,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         OrderedSet(buildfile.siblings()))
     self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/BUILD.suffix'),
         self.create_buildfile('suffix-test/BUILD.suffix2')]),
-        buildfile.family())
+        BuildFile.get_project_tree_build_files_family(self._project_tree, 'suffix-test'))
     self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
         buildfile.descendants())
 
@@ -172,8 +174,8 @@ class FilesystemBuildFileTest(BuildFileTestBase):
                       buildfiles)
 
   def test_dir_is_primary(self):
-    buildfile = self.create_buildfile('issue_1742')
-    self.assertEqual([self.create_buildfile('issue_1742/BUILD.sibling')], list(buildfile.family()))
+    self.assertEqual([self.create_buildfile('issue_1742/BUILD.sibling')],
+                     list(BuildFile.get_project_tree_build_files_family(self._project_tree, 'issue_1742')))
 
   def test_invalid_root_dir_error(self):
     self.touch('BUILD')

--- a/tests/python/pants_test/base/test_scm_build_file.py
+++ b/tests/python/pants_test/base/test_scm_build_file.py
@@ -37,7 +37,7 @@ class ScmBuildFileTest(BuildFileTestBase):
       my_buildfile = self.create_buildfile('grandparent/parent/BUILD')
       buildfile = self.create_buildfile('grandparent/parent/BUILD.twitter')
 
-      self.assertEquals(OrderedSet([buildfile, my_buildfile]),
+      self.assertEquals(OrderedSet([my_buildfile, buildfile]),
                         OrderedSet(self.get_build_files_family('grandparent/parent')))
 
       self.assertEquals(OrderedSet([self.create_buildfile('grandparent/parent/child2/child3/BUILD')]),

--- a/tests/python/pants_test/base/test_scm_build_file.py
+++ b/tests/python/pants_test/base/test_scm_build_file.py
@@ -37,11 +37,11 @@ class ScmBuildFileTest(BuildFileTestBase):
       my_buildfile = self.create_buildfile('grandparent/parent/BUILD')
       buildfile = self.create_buildfile('grandparent/parent/BUILD.twitter')
 
-      self.assertEquals(OrderedSet([buildfile]), OrderedSet(my_buildfile.siblings()))
-      self.assertEquals(OrderedSet([my_buildfile]), OrderedSet(buildfile.siblings()))
+      self.assertEquals(OrderedSet([buildfile, my_buildfile]),
+                        OrderedSet(self.get_build_files_family('grandparent/parent')))
 
-      buildfile = self.create_buildfile('grandparent/parent/child2/child3/BUILD')
-      self.assertEquals(OrderedSet(), OrderedSet(buildfile.siblings()))
+      self.assertEquals(OrderedSet([self.create_buildfile('grandparent/parent/child2/child3/BUILD')]),
+                        OrderedSet(self.get_build_files_family('grandparent/parent/child2/child3')))
 
       buildfiles = self.scan_buildfiles('grandparent')
 

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -142,7 +142,8 @@ class BuildFileParserTargetTest(BaseTest):
     base_build_file = self.create_buildfile('BUILD')
     foo_build_file = self.create_buildfile('BUILD.foo')
 
-    address_map = self.build_file_parser.address_map_from_build_file(bar_build_file)
+    address_map = self.build_file_parser.address_map_from_build_files(
+      BuildFile.get_project_tree_build_files_family(FileSystemProjectTree(self.build_root), "."))
     addresses = address_map.keys()
     self.assertEqual({bar_build_file, base_build_file, foo_build_file},
                      set([address.build_file for address in addresses]))
@@ -182,8 +183,8 @@ class BuildFileParserTargetTest(BaseTest):
       """))
 
     with self.assertRaises(BuildFileParser.SiblingConflictException):
-      base_build_file = self.create_buildfile('BUILD')
-      self.build_file_parser.address_map_from_build_file(base_build_file)
+      self.build_file_parser.address_map_from_build_files(
+        BuildFile.get_project_tree_build_files_family(FileSystemProjectTree(self.build_root), '.'))
 
 
 class BuildFileParserExposedObjectTest(BaseTest):

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -245,8 +245,7 @@ class BuildGraphTest(BaseTest):
     self.build_graph.inject_address_closure(Address.parse(spec))
 
   def test_invalid_address(self):
-    with self.assertRaisesRegexp(AddressLookupError,
-                                 '^There is no build files found in .*'):
+    with self.assertRaisesRegexp(AddressLookupError, '^.* does not contains any BUILD files.$'):
       self.inject_address_closure('//:a')
 
     self.add_to_build_file('BUILD',

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -246,7 +246,7 @@ class BuildGraphTest(BaseTest):
 
   def test_invalid_address(self):
     with self.assertRaisesRegexp(AddressLookupError,
-                                 '^BUILD file does not exist at:.*/BUILD'):
+                                 '^There is no build files found in .*'):
       self.inject_address_closure('//:a')
 
     self.add_to_build_file('BUILD',


### PR DESCRIPTION
In order to implement `pants_build_ignore` option I need to have as less as possible places where I need to pass this option to.

This RB remove usages/deprecate all returning `BuildFile`s methods except `scan_project_tree_build_files`, `get_project_tree_build_files_family` in `BuildFile` which sounds like sufficient interface to get `BuildFile`s in general.