### PR TITLE
A managed_jar_libraries factory to reduce 3rdparty duplication.

### DIFF
--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -25,7 +25,8 @@ from pants.backend.jvm.targets.java_tests import JavaTests
 from pants.backend.jvm.targets.jvm_app import Bundle, DirectoryReMapper, JvmApp
 from pants.backend.jvm.targets.jvm_binary import Duplicate, JarRules, JvmBinary, Skip
 from pants.backend.jvm.targets.jvm_prep_command import JvmPrepCommand
-from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDependencies
+from pants.backend.jvm.targets.managed_jar_dependencies import (ManagedJarDependencies,
+                                                                ManagedJarLibraries)
 from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.targets.scalac_plugin import ScalacPlugin
@@ -104,6 +105,7 @@ def build_file_aliases():
     },
     context_aware_object_factories={
       'bundle': Bundle,
+      'managed_jar_libraries': ManagedJarLibraries,
     }
   )
 

--- a/src/python/pants/backend/jvm/subsystems/jar_dependency_management.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_dependency_management.py
@@ -347,7 +347,13 @@ class JarDependencyManagementSetup(Task):
 
   def execute(self):
     self._resolve_default_target()
-    targets = self.context.targets(predicate=lambda t: isinstance(t, ManagedJarDependencies))
+    targets = set(self.context.targets(predicate=lambda t: isinstance(t, ManagedJarDependencies)))
+    # NB(gmalmquist): We have to explicitly load in managed_jar_dependencies referenced by the
+    # `managed_dependencies` field of jar_library(). They aren't included as dependencies of
+    # jar_library targets to avoid created cycles.
+    for library in self.context.targets(predicate=lambda t: isinstance(t, JarLibrary)):
+      if library.managed_dependencies:
+        targets.add(library.managed_dependencies)
     self._compute_artifact_sets(targets)
     self._validate_managed_jar_dependencies_targets(targets)
 

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -50,14 +50,11 @@ class JarLibrary(Target):
   def managed_dependencies(self):
     """The managed_jar_dependencies target this jar_library specifies, or None."""
     if self.payload.managed_dependencies:
-      return self._build_graph.get_target(Address.parse(self.payload.managed_dependencies,
-                                                        relative_to=self.address.spec_path))
+      address = Address.parse(self.payload.managed_dependencies,
+                              relative_to=self.address.spec_path)
+      self._build_graph.inject_address_closure(address)
+      return self._build_graph.get_target(address)
     return None
-
-  @property
-  def traversable_dependency_specs(self):
-    if self.payload.managed_dependencies:
-      yield self.payload.managed_dependencies
 
   @property
   def jar_dependencies(self):

--- a/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
+++ b/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
@@ -5,10 +5,15 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import copy
+
 from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import JarsField
+from pants.build_graph.address import Address
 from pants.build_graph.target import Target
+from pants.util.memo import memoized_property
 
 
 class ManagedJarDependencies(Target):
@@ -20,7 +25,7 @@ class ManagedJarDependencies(Target):
       Versions are pinned per (org, name, classifier, ext) artifact coordinate (excludes, etc are
       ignored for the purposes of pinning).
     """
-    jar_objects, self._library_specs = self._split_jars_and_specs(artifacts)
+    jar_objects, self._library_specs = self._split_jars_and_specs(artifacts or ())
     payload = payload or Payload()
     payload.add_fields({
       'artifacts': JarsField(jar_objects),
@@ -31,12 +36,14 @@ class ManagedJarDependencies(Target):
   def traversable_specs(self):
     return iter(self.library_specs)
 
-  @property
+  @memoized_property
   def library_specs(self):
     """Lists of specs to resolve to jar_libraries containing more jars."""
-    return self._library_specs
+    return [Address.parse(spec, relative_to=self.address.spec_path).spec
+            for spec in self._library_specs]
 
-  def _split_jars_and_specs(self, jars):
+  @classmethod
+  def _split_jars_and_specs(cls, jars):
     library_specs = []
     jar_objects = []
     for item in jars:
@@ -45,3 +52,112 @@ class ManagedJarDependencies(Target):
       else:
         library_specs.append(item)
     return jar_objects, library_specs
+
+
+class ManagedJarLibraries(object):
+  """Creates a managed_jar_dependencies(), and also generates a jar_library for each artifact.
+
+  Using this factory saves a lot of duplication. For example, this: ::
+
+      managed_jar_libraries(name='managed',
+        artifacts=[
+          jar('org.foobar', 'foobar', '1.2'),
+          jar('com.example', 'example', '8'),
+        ],
+      )
+
+  Is equivalent to: ::
+
+      managed_jar_dependencies(name='managed',
+        artifacts=[
+          jar('org.foobar', 'foobar', '1.2'),
+          jar('com.example', 'example', '8'),
+        ],
+      )
+
+      jar_library(name='org.foobar.foobar',
+        jars=[jar('org.foobar', 'foobar')],
+        managed_dependencies=':managed',
+      )
+
+      jar_library(name='com.example.example',
+        jars=[jar('com.example', 'example')],
+        managed_dependencies=':managed',
+      )
+
+  Which is also equivalent to: ::
+
+      managed_jar_dependencies(name='managed',
+        artifacts=[
+          ':org.foobar.foobar',
+          ':com.example.example',
+        ],
+      )
+
+      jar_library(name='org.foobar.foobar',
+        jars=[jar('org.foobar', 'foobar')],
+        managed_dependencies=':managed',
+      )
+
+      jar_library(name='com.example.example',
+        jars=[jar('com.example', 'example')],
+        managed_dependencies=':managed',
+      )
+
+  """
+
+  class JarLibraryNameCollision(TargetDefinitionException):
+    """Two generated jar_libraries would have the same name."""
+
+  def __init__(self, parse_context):
+    self._parse_context = parse_context
+
+  def __call__(self, name, artifacts=None, **kwargs):
+    """
+    :param string name: The name of the generated managed_jar_dependencies() target.
+    :param artifacts: List of `jar <#jar>`_\s or specs to jar_library targets with pinned versions.
+      Versions are pinned per (org, name, classifier, ext) artifact coordinate (excludes, etc are
+      ignored for the purposes of pinning).
+    """
+    management = self._parse_context.create_object('managed_jar_dependencies',
+                                                   name=name,
+                                                   artifacts=artifacts,
+                                                   **kwargs)
+    jars, _ = ManagedJarDependencies._split_jars_and_specs(artifacts)
+    for library_name, dep in self._jars_by_name(management, jars).items():
+      self._parse_context.create_object('jar_library',
+                                        name=library_name,
+                                        jars=[copy.deepcopy(dep)],
+                                        managed_dependencies=':{}'.format(name))
+
+  @classmethod
+  def _jars_by_name(cls, management, jars):
+    jars_by_name = {}
+    for dep in jars:
+      library_name = cls._jar_library_name(dep)
+      if library_name in jars_by_name:
+        previous = jars_by_name[library_name]
+        raise cls.JarLibraryNameCollision(
+          management,
+          'Two jar coordinates would generate the same name. Please put one of them in a separate '
+          'jar_library() definition.\n  {coord1}: {name}\n  {coord2}: {name}\n'.format(
+            coord1=previous,
+            coord2=dep,
+            name=library_name,
+          )
+        )
+      jars_by_name[library_name] = dep
+    return jars_by_name
+
+  @classmethod
+  def _jar_coordinate_parts(cls, coord):
+    yield coord.org
+    yield coord.name
+    if coord.classifier:
+      yield coord.classifier
+    if coord.ext:
+      yield coord.ext
+
+  @classmethod
+  def _jar_library_name(cls, coord):
+    return '.'.join(cls._jar_coordinate_parts(coord))

--- a/testprojects/3rdparty/managed/BUILD
+++ b/testprojects/3rdparty/managed/BUILD
@@ -1,0 +1,30 @@
+# This file is used to integration test the managed_jar_libraries factory for managed dependencies
+# and jar libraries.
+# It also serves as a very simple example of how it might be used.
+
+managed_jar_libraries(name='managed',
+  artifacts=[
+    jar('info.cukes', 'cucumber-core', '1.2.4'),
+    jar('org.eclipse.jetty', 'jetty-jsp', '9.2.9.v20150224'),
+    jar('jersey', 'jersey', '0.7-ea', classifier='sources'),
+    ':args4j.args4j',
+  ],
+)
+
+jar_library(name='args4j.args4j',
+  jars=[
+    jar('args4j', 'args4j', '2.32'),
+  ],
+  managed_dependencies=':managed', # This line is unnecessary if ':managed' is the default.
+)
+
+target(name='example-dependee',
+  dependencies=[
+    # Explicitly created:
+    ':args4j.args4j',
+    # Implicitly created:
+    ':info.cukes.cucumber-core',
+    ':jersey.jersey.sources',
+    ':org.eclipse.jetty.jetty-jsp',
+  ],
+)

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management_integration.py
@@ -131,3 +131,27 @@ class JarDependencyManagementIntegrationTest(PantsRunIntegrationTest):
       self.set_managed: True,
       self.set_managed2: False,
     }, 'forceful', conflict_strategy='USE_MANAGED')
+
+  def test_managed_jar_libraries_targets(self):
+    expected_specs = [
+      'testprojects/3rdparty/managed:args4j.args4j',
+      'testprojects/3rdparty/managed:example-dependee',
+      'testprojects/3rdparty/managed:info.cukes.cucumber-core',
+      'testprojects/3rdparty/managed:jersey.jersey.sources',
+      'testprojects/3rdparty/managed:managed',
+      'testprojects/3rdparty/managed:org.eclipse.jetty.jetty-jsp',
+    ]
+    run = self.run_pants([
+      'filter',
+      'testprojects/3rdparty/managed::',
+    ])
+    self.assert_success(run)
+    for spec in expected_specs:
+      self.assertIn(spec, run.stdout_data)
+
+  def test_managed_jar_libraries_resolve(self):
+    run = self.run_pants([
+      'resolve',
+      'testprojects/3rdparty/managed::',
+    ])
+    self.assert_success(run)

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_integration.py
@@ -397,9 +397,13 @@ class IdeaIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
                     })
 
   def test_all_targets(self):
-    # The android targets won't work if the Android ADK is not installed.
-    self._idea_test(['src::', 'tests::', 'examples::', 'testprojects::',
-                     '--exclude-target-regexp=.*android.*'])
+    self._idea_test([
+      'src::', 'tests::', 'examples::', 'testprojects::',
+      # The android targets won't work if the Android ADK is not installed.
+      '--exclude-target-regexp=.*android.*',
+      # Won't work until https://rbcommons.com/s/twitter/r/3367/ lands.
+      '--exclude-target-regexp=testprojects/3rdparty/managed.*',
+    ])
 
   def test_ivy_classifiers(self):
     def do_check(path):

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -26,6 +26,8 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/src/java/org/pantsbuild/testproject/thriftdeptest',
       # TODO(Eric Ayers): I don't understand why this fails
       'testprojects/src/java/org/pantsbuild/testproject/jvmprepcommand:compile-prep-command',
+      # This won't work without special config until https://rbcommons.com/s/twitter/r/3367/ lands.
+      'testprojects/3rdparty/managed',
     ]
 
     # Targets that are intended to fail


### PR DESCRIPTION
In an effort to reduce duplication of 3rdparty configuration, I
introduced a `managed_jar_libraries` factory. It syntactically
appears very similarly to a managed_jar_dependencies target, but it
also generates jar_library targets for each jar() it contains. It
does not generate anything for artifacts which are specified
indirectly with a jar_library spec (rather than a directly embedded
jar() object), because that would be redundant (and could even
likely conflict with existing definitions in the BUILD file).