### PR TITLE
BuildFile refactoring: create build files only from existed BUILD files

### DIFF
--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -139,10 +139,13 @@ class BuildFile(AbstractClass):
     """
 
     if strict_mode and not must_exist:
-      raise Exception("BuildFile must_exist parameter must be True in strict mode.")
+      raise Exception("BuildFile's must_exist parameter must be True in strict mode.")
 
     self.project_tree = project_tree
     self.root_dir = project_tree.build_root
+
+    if strict_mode and relpath is None:
+      raise Exception("BuildFile's relpath parameter must be not None in strict mode.")
 
     path = os.path.join(self.root_dir, relpath) if relpath else self.root_dir
     self._build_basename = self._BUILD_FILE_PREFIX

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -193,6 +193,7 @@ class BuildFile(AbstractClass):
     self.relpath = fast_relpath(self.full_path, self.root_dir)
     self.spec_path = os.path.dirname(self.relpath)
 
+  @deprecated('0.0.72')
   def file_exists(self):
     """Returns True if this BuildFile corresponds to a real BUILD file on disk."""
     return self.project_tree.exists(self.relpath) and self.project_tree.isfile(self.relpath)

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -139,9 +139,9 @@ class BuildFile(AbstractClass):
     """
 
     if not must_exist:
-      logger.warn('BuildFile\'s must_exist parameter must be True.')
+      raise Exception('BuildFile\'s must_exist parameter must be True.')
     if relpath is None:
-      logger.warn('BuildFile\'s relpath parameter must be not None.')
+      raise Exception('BuildFile\'s relpath parameter must be not None.')
 
     self.project_tree = project_tree
     self.root_dir = project_tree.build_root
@@ -150,7 +150,7 @@ class BuildFile(AbstractClass):
     self._build_basename = self._BUILD_FILE_PREFIX
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
-      logger.warn('BuildFile can be created only from path to file.')
+      raise Exception('BuildFile can be created only from path to file.')
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
       buildfile = os.path.join(path, self._build_basename)

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -46,10 +46,10 @@ class BuildFile(AbstractClass):
     BuildFile._cache = {}
 
   @staticmethod
-  def cached(project_tree, relpath, must_exist=True, strict_mode=False):
+  def cached(project_tree, relpath, must_exist=True):
     cache_key = (project_tree, relpath, must_exist)
     if cache_key not in BuildFile._cache:
-      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist, strict_mode)
+      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist)
     return BuildFile._cache[cache_key]
 
   @staticmethod
@@ -125,7 +125,7 @@ class BuildFile(AbstractClass):
           buildfiles.append(BuildFile.cached(project_tree, os.path.join(root, filename)))
     return OrderedSet(sorted(buildfiles, key=lambda buildfile: buildfile.full_path))
 
-  def __init__(self, project_tree, relpath, must_exist=True, strict_mode=False):
+  def __init__(self, project_tree, relpath, must_exist=True, strict_mode=True):
     """Creates a BuildFile object representing the BUILD file family at the specified path.
 
     :param project_tree: Project tree the BUILD file exist in.

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -146,6 +146,10 @@ class BuildFile(AbstractClass):
 
     path = os.path.join(self.root_dir, relpath) if relpath else self.root_dir
     self._build_basename = self._BUILD_FILE_PREFIX
+
+    if strict_mode and project_tree.isdir(fast_relpath(path, self.root_dir)):
+      raise Exception("BuildFile can be created only from path to file in strict mode.")
+
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
       buildfile = os.path.join(path, self._build_basename)
     else:
@@ -153,8 +157,6 @@ class BuildFile(AbstractClass):
 
     # There is no BUILD file without a prefix so select any viable sibling
     buildfile_relpath = fast_relpath(buildfile, self.root_dir)
-    if strict_mode and project_tree.isdir(buildfile_relpath):
-      raise Exception("BuildFile can be created only from path to file in strict mode.")
 
     if not project_tree.exists(buildfile_relpath) or project_tree.isdir(buildfile_relpath):
       relpath = os.path.dirname(buildfile_relpath)

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -46,10 +46,10 @@ class BuildFile(AbstractClass):
     BuildFile._cache = {}
 
   @staticmethod
-  def cached(project_tree, relpath, must_exist=True):
+  def cached(project_tree, relpath, must_exist=True, strict_mode=True):
     cache_key = (project_tree, relpath, must_exist)
     if cache_key not in BuildFile._cache:
-      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist)
+      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist, strict_mode)
     return BuildFile._cache[cache_key]
 
   @staticmethod

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -139,10 +139,10 @@ class BuildFile(AbstractClass):
     """
 
     if not must_exist:
-      logger.warn('BuildFile\'s must_exist parameter is deprecated and will be removed in 0.0.74 release.'
+      logger.warn('BuildFile\'s must_exist parameter is deprecated and will be removed in 0.0.74 release. '
                   'BuildFile should be created from existing file only.')
     if relpath is None:
-      logger.warn('BuildFile\'s relpath parameter is deprecated and will be removed in 0.0.74 release.'
+      logger.warn('BuildFile\'s relpath parameter is deprecated and will be removed in 0.0.74 release. '
                   'BuildFile should be created with not None relpath only.')
 
     self.project_tree = project_tree
@@ -152,7 +152,7 @@ class BuildFile(AbstractClass):
     self._build_basename = self._BUILD_FILE_PREFIX
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
-      logger.warn('BuildFile creation using folder path is deprecated and will be removed in 0.0.74 release.'
+      logger.warn('BuildFile creation using folder path is deprecated and will be removed in 0.0.74 release. '
                   'BuildFile should be created from path to file only.')
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -140,18 +140,17 @@ class BuildFile(AbstractClass):
 
     if strict_mode and not must_exist:
       raise Exception("BuildFile's must_exist parameter must be True in strict mode.")
+    if strict_mode and relpath is None:
+      raise Exception("BuildFile's relpath parameter must be not None in strict mode.")
 
     self.project_tree = project_tree
     self.root_dir = project_tree.build_root
-
-    if strict_mode and relpath is None:
-      raise Exception("BuildFile's relpath parameter must be not None in strict mode.")
 
     path = os.path.join(self.root_dir, relpath) if relpath else self.root_dir
     self._build_basename = self._BUILD_FILE_PREFIX
 
     if strict_mode and project_tree.isdir(fast_relpath(path, self.root_dir)):
-      raise Exception("BuildFile can be created only from path to file in strict mode.")
+      raise BuildFile.MissingBuildFileError("BuildFile can be created only from path to file in strict mode.")
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
       buildfile = os.path.join(path, self._build_basename)

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -46,10 +46,10 @@ class BuildFile(AbstractClass):
     BuildFile._cache = {}
 
   @staticmethod
-  def cached(project_tree, relpath, must_exist=True):
+  def cached(project_tree, relpath, must_exist=True, strict_mode=False):
     cache_key = (project_tree, relpath, must_exist)
     if cache_key not in BuildFile._cache:
-      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist)
+      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist, strict_mode)
     return BuildFile._cache[cache_key]
 
   @staticmethod

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -139,9 +139,11 @@ class BuildFile(AbstractClass):
     """
 
     if not must_exist:
-      logger.warn('BuildFile\'s must_exist parameter must be True.')
+      logger.warn('BuildFile\'s must_exist parameter is deprecated and will be removed in 0.0.74 release.'
+                  'BuildFile should be created from existing file only.')
     if relpath is None:
-      logger.warn('BuildFile\'s relpath parameter must be not None.')
+      logger.warn('BuildFile\'s relpath parameter is deprecated and will be removed in 0.0.74 release.'
+                  'BuildFile should be created with not None relpath only.')
 
     self.project_tree = project_tree
     self.root_dir = project_tree.build_root
@@ -150,7 +152,8 @@ class BuildFile(AbstractClass):
     self._build_basename = self._BUILD_FILE_PREFIX
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
-      logger.warn('BuildFile can be created only from path to file.')
+      logger.warn('BuildFile creation using folder path is deprecated and will be removed in 0.0.74 release.'
+                  'BuildFile should be created from path to file only.')
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
       buildfile = os.path.join(path, self._build_basename)
@@ -159,7 +162,6 @@ class BuildFile(AbstractClass):
 
     # There is no BUILD file without a prefix so select any viable sibling
     buildfile_relpath = fast_relpath(buildfile, self.root_dir)
-
     if not project_tree.exists(buildfile_relpath) or project_tree.isdir(buildfile_relpath):
       relpath = os.path.dirname(buildfile_relpath)
       for build in self.project_tree.glob1(relpath, '{prefix}*'.format(prefix=self._BUILD_FILE_PREFIX)):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -139,9 +139,9 @@ class BuildFile(AbstractClass):
     """
 
     if not must_exist:
-      raise Exception('BuildFile\'s must_exist parameter must be True.')
+      logger.warn('BuildFile\'s must_exist parameter must be True.')
     if relpath is None:
-      raise Exception('BuildFile\'s relpath parameter must be not None.')
+      logger.warn('BuildFile\'s relpath parameter must be not None.')
 
     self.project_tree = project_tree
     self.root_dir = project_tree.build_root
@@ -150,7 +150,7 @@ class BuildFile(AbstractClass):
     self._build_basename = self._BUILD_FILE_PREFIX
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
-      raise Exception('BuildFile can be created only from path to file.')
+      logger.warn('BuildFile can be created only from path to file.')
 
     if project_tree.isdir(fast_relpath(path, self.root_dir)):
       buildfile = os.path.join(path, self._build_basename)

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -206,7 +206,6 @@ class GoalRunnerFactory(object):
         logger.warning("Command-line argument '{0}' is ambiguous and was assumed to be "
                        "a goal. If this is incorrect, disambiguate it with ./{0}.".format(goal))
       except AddressLookupError:
-        # Goal name should not be possible to look up.
         pass
 
     if self._help_request:

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -183,12 +183,13 @@ class BuildFileAddressMapper(object):
     :rtype: :class:`pants.build_graph.address.Address`
     """
     spec_path, name = parse_spec(spec, relative_to=relative_to)
+    address = Address(spec_path, name)
     try:
-      BuildFile.cached(self._project_tree, spec_path, strict_mode=False)
-    except BuildFile.BuildFileError as e:
+      self.resolve(address)
+      return address
+    except AddressLookupError as e:
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))
-    return Address(spec_path, name)
 
   @deprecated('0.0.72', hint_message='Use scan_project_tree_build_files instead.')
   def scan_buildfiles(self, root_dir, base_path=None, spec_excludes=None):

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -84,7 +84,7 @@ class BuildFileAddressMapper(object):
     def are_siblings(a, b):  # Are the targets in the same directory?
       return path_parts(a)[0] == path_parts(b)[0]
 
-    build_file = BuildFile.cached(self._project_tree, spec_path)
+    build_file = BuildFile.cached(self._project_tree, spec_path, strict_mode=False)
 
     valid_specs = []
     all_same = True
@@ -173,7 +173,7 @@ class BuildFileAddressMapper(object):
     return self.get_build_file(relpath, must_exist)
 
   def get_build_file(self, relpath, must_exist=True):
-    return BuildFile.cached(self._project_tree, relpath, must_exist)
+    return BuildFile.cached(self._project_tree, relpath, must_exist, strict_mode=False)
 
   def spec_to_address(self, spec, relative_to=''):
     """A helper method for mapping a spec to the correct address.

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -155,20 +155,20 @@ class BuildFileAddressMapper(object):
     return BuildFile._cached(self._project_tree, relpath, must_exist)
 
   def spec_to_address(self, spec, relative_to=''):
-    """A helper method for mapping a spec to the correct address.
+    """A helper method for mapping a spec to the correct build file address.
 
     :param string spec: A spec to lookup in the map.
     :param string relative_to: Path the spec might be relative to
     :raises :class:`pants.build_graph.address_lookup_error.AddressLookupError`
             If the BUILD file cannot be found in the path specified by the spec.
     :returns: A new Address instance.
-    :rtype: :class:`pants.build_graph.address.Address`
+    :rtype: :class:`pants.build_graph.address.BuildFileAddress`
     """
     spec_path, name = parse_spec(spec, relative_to=relative_to)
     address = Address(spec_path, name)
     try:
-      self.resolve(address)
-      return address
+      build_file_address, _ = self.resolve(address)
+      return build_file_address
     except AddressLookupError as e:
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -68,7 +68,7 @@ class BuildFileAddressMapper(object):
   def root_dir(self):
     return self._build_file_parser.root_dir
 
-  def _raise_incorrect_address_error(self, build_file, wrong_target_name, targets):
+  def _raise_incorrect_address_error(self, spec_path, wrong_target_name, targets):
     """Search through the list of targets and return those which originate from the same folder
     which wrong_target_name resides in.
 
@@ -83,6 +83,8 @@ class BuildFileAddressMapper(object):
 
     def are_siblings(a, b):  # Are the targets in the same directory?
       return path_parts(a)[0] == path_parts(b)[0]
+
+    build_file = BuildFile.cached(self._project_tree, spec_path)
 
     valid_specs = []
     all_same = True
@@ -125,8 +127,7 @@ class BuildFileAddressMapper(object):
     """
     address_map = self._address_map_from_spec_path(address.spec_path)
     if address not in address_map:
-      build_file = BuildFile.cached(self._project_tree, address.spec_path, must_exist=False)
-      self._raise_incorrect_address_error(build_file, address.target_name, address_map)
+      self._raise_incorrect_address_error(address.spec_path, address.target_name, address_map)
     else:
       return address_map[address]
 

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -152,7 +152,7 @@ class BuildFileAddressMapper(object):
 
     :returns: a BuildFile
     """
-    return BuildFile.cached(self._project_tree, relpath, must_exist)
+    return BuildFile._cached(self._project_tree, relpath, must_exist)
 
   def spec_to_address(self, spec, relative_to=''):
     """A helper method for mapping a spec to the correct address.

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -170,9 +170,6 @@ class BuildFileAddressMapper(object):
 
     :returns: a BuildFile
     """
-    return self.get_build_file(relpath, must_exist)
-
-  def get_build_file(self, relpath, must_exist=True):
     return BuildFile.cached(self._project_tree, relpath, must_exist, strict_mode=False)
 
   def spec_to_address(self, spec, relative_to=''):
@@ -187,7 +184,7 @@ class BuildFileAddressMapper(object):
     """
     spec_path, name = parse_spec(spec, relative_to=relative_to)
     try:
-      self.get_build_file(spec_path)
+      BuildFile.cached(self._project_tree, spec_path, strict_mode=False)
     except BuildFile.BuildFileError as e:
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -79,14 +79,15 @@ class BuildFileAddressMapper(object):
 
     if not targets:
       raise self.EmptyBuildFileError(
-        '{was_not_found_message}, because that BUILD files contains no addressable entities.'.format(
-          was_not_found_message=was_not_found_message))
+        '{was_not_found_message}, because that directory contains no BUILD files defining addressable entities.'
+          .format(was_not_found_message=was_not_found_message))
 
-    # Print BUILD extensions if there's more than one BUILD file with targets only.
+    # Print BUILD file extensions if there's more than one BUILD file with targets only.
     if len(set([target.build_file for target in targets])) == 1:
       specs = [':{}'.format(target.target_name) for target in targets]
     else:
-      specs = ['{}:{}'.format(os.path.basename(target.build_file.relpath), target.target_name) for target in targets]
+      specs = [':{} (from {})'.format(target.target_name, os.path.basename(target.build_file.relpath))
+               for target in targets]
 
     # Might be neat to sort by edit distance or something, but for now alphabetical is fine.
     specs = [''.join(pair) for pair in sorted(specs)]
@@ -96,7 +97,6 @@ class BuildFileAddressMapper(object):
     raise self.AddressNotInBuildFile(
       '{was_not_found_message}. Perhaps you '
       'meant{one_of}: \n  {specs}'.format(was_not_found_message=was_not_found_message,
-                                          spec_path=spec_path,
                                           one_of=one_of,
                                           specs='\n  '.join(specs)))
 

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -164,7 +164,7 @@ class BuildFileAddressMapper(object):
     """Returns only the addresses gathered by `address_map_from_spec_path`, with no values."""
     return self._address_map_from_spec_path(spec_path).keys()
 
-  @deprecated('0.0.72', hint_message='Use get_build_file instead.')
+  @deprecated('0.0.72')
   def from_cache(self, root_dir, relpath, must_exist=True):
     """Return a BuildFile instance.  Args as per BuildFile.from_cache
 

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -74,19 +74,16 @@ class BuildFileAddressMapper(object):
 
     :raises: A helpful error message listing possible correct target addresses.
     """
-    build_file = BuildFile.cached(self._project_tree, spec_path, strict_mode=False)
+    was_not_found_message = '{target_name} was not found in BUILD files from {spec_path}'.format(
+      target_name=wrong_target_name, spec_path=os.path.join(self._project_tree.build_root, spec_path))
 
     if not targets:
-      # There were no targets in the BUILD file.
       raise self.EmptyBuildFileError(
-        ':{target_name} was not found in BUILD file {build_file}, because that '
-        'BUILD file contains no addressable entities.'.format(target_name=wrong_target_name,
-                                                              build_file=build_file))
+        '{was_not_found_message}, because that BUILD files contains no addressable entities.'.format(
+          was_not_found_message=was_not_found_message))
 
-    all_same = len(set([target.build_file for target in targets])) == 1
-
-    # Trim out BUILD extensions if there's only one anyway; no need to be redundant.
-    if all_same:
+    # Print BUILD extensions if there's more than one BUILD file with targets only.
+    if len(set([target.build_file for target in targets])) == 1:
       specs = [':{}'.format(target.target_name) for target in targets]
     else:
       specs = ['{}:{}'.format(os.path.basename(target.build_file.relpath), target.target_name) for target in targets]
@@ -97,9 +94,9 @@ class BuildFileAddressMapper(object):
     # Give different error messages depending on whether BUILD file was empty.
     one_of = ' one of' if len(specs) > 1 else ''  # Handle plurality, just for UX.
     raise self.AddressNotInBuildFile(
-      '{target_name} was not found in BUILD file {build_file}. Perhaps you '
-      'meant{one_of}: \n  {specs}'.format(target_name=wrong_target_name,
-                                          build_file=build_file,
+      '{was_not_found_message}. Perhaps you '
+      'meant{one_of}: \n  {specs}'.format(was_not_found_message=was_not_found_message,
+                                          spec_path=spec_path,
                                           one_of=one_of,
                                           specs='\n  '.join(specs)))
 

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -170,7 +170,7 @@ class BuildFileAddressMapper(object):
 
     :returns: a BuildFile
     """
-    return BuildFile.cached(self._project_tree, relpath, must_exist, strict_mode=False)
+    return BuildFile.cached(self._project_tree, relpath, must_exist)
 
   def spec_to_address(self, spec, relative_to=''):
     """A helper method for mapping a spec to the correct address.

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -66,7 +66,7 @@ def linkify(buildroot, s, memoized_urls):
         build_files = list(BuildFile.get_project_tree_build_files_family(
           FileSystemProjectTree(buildroot),
           putative_dir))
-        if len(build_files) > 0:
+        if build_files:
           path = build_files[0].relpath
         else:
           return None

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -63,8 +63,14 @@ def linkify(buildroot, s, memoized_urls):
       else:
         putative_dir = path
       if os.path.isdir(os.path.join(buildroot, putative_dir)):
-        build_file = BuildFile.cached(FileSystemProjectTree(buildroot), putative_dir, must_exist=False)
-        path = build_file.relpath
+        build_files = list(BuildFile.get_project_tree_build_files_family(
+          FileSystemProjectTree(buildroot),
+          putative_dir))
+        if len(build_files) > 0:
+          path = build_files[0].relpath
+        else:
+          return None
+
     if os.path.exists(os.path.join(buildroot, path)):
       # The reporting server serves file content at /browse/<path_from_buildroot>.
       return '/browse/{}'.format(path)

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -27,8 +27,8 @@ class BuildFileTestBase(unittest.TestCase):
   def scan_buildfiles(self, base_relpath, spec_excludes=None):
     return BuildFile.scan_project_tree_build_files(self._project_tree, base_relpath, spec_excludes)
 
-  def create_buildfile(self, relpath, must_exist=True):
-    return BuildFile(self._project_tree, relpath, must_exist=must_exist)
+  def create_buildfile(self, relpath):
+    return BuildFile(self._project_tree, relpath)
 
   def get_build_files_family(self, relpath):
     return BuildFile.get_project_tree_build_files_family(self._project_tree, relpath)

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -111,12 +111,6 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
         self.scan_buildfiles('suffix-test/child'))
 
-  def test_buildfile_with_build_dir(self):
-    # We should NOT be able to create a BuildFile instance against a dir called BUILD
-    # in the default case.
-    with self.assertRaises(BuildFile.MissingBuildFileError):
-      self.create_buildfile('grandparent/BUILD')
-
   def test_directory_called_build_skipped(self):
     # Ensure the buildfiles found do not include grandparent/BUILD since it is a dir.
     buildfiles = self.scan_buildfiles('grandparent')

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -90,11 +90,11 @@ class FilesystemBuildFileTest(BuildFileTestBase):
 
   def test_must_exist_true(self):
     with self.assertRaises(BuildFile.MissingBuildFileError):
-      self.create_buildfile("path-that-does-not-exist/BUILD", must_exist=True)
+      self.create_buildfile("path-that-does-not-exist/BUILD")
     with self.assertRaises(BuildFile.MissingBuildFileError):
-      self.create_buildfile("path-that-does-exist/BUILD", must_exist=True)
+      self.create_buildfile("path-that-does-exist/BUILD")
     with self.assertRaises(BuildFile.MissingBuildFileError):
-      self.create_buildfile("path-that-does-exist/BUILD.invalid.suffix", must_exist=True)
+      self.create_buildfile("path-that-does-exist/BUILD.invalid.suffix")
 
   def test_suffix_only(self):
     self.makedirs('suffix-test')
@@ -110,12 +110,6 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         self.get_build_files_family('suffix-test'))
     self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
         self.scan_buildfiles('suffix-test/child'))
-
-  def test_buildfile_with_dir_must_exist_false(self):
-    # We should be able to create a BuildFile against a dir called BUILD if must_exist is false.
-    # This is used in what_changed for example.
-    buildfile = self.create_buildfile('grandparent/BUILD', must_exist=False)
-    self.assertFalse(buildfile.file_exists())
 
   def test_buildfile_with_dir_must_exist_true(self):
     # We should NOT be able to create a BuildFile instance against a dir called BUILD

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -111,7 +111,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     self.assertEquals(OrderedSet([self.create_buildfile('suffix-test/child/BUILD.suffix3')]),
         self.scan_buildfiles('suffix-test/child'))
 
-  def test_buildfile_with_dir_must_exist_true(self):
+  def test_buildfile_with_build_dir(self):
     # We should NOT be able to create a BuildFile instance against a dir called BUILD
     # in the default case.
     with self.assertRaises(BuildFile.MissingBuildFileError):

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -127,12 +127,12 @@ class AddressTest(BaseAddressTest):
 class BuildFileAddressTest(BaseAddressTest):
   def test_build_file_forms(self):
     with self.workspace('a/b/c/BUILD') as root_dir:
-      build_file = BuildFile(FileSystemProjectTree(root_dir), relpath='a/b/c')
+      build_file = BuildFile(FileSystemProjectTree(root_dir), relpath='a/b/c/BUILD')
       self.assert_address('a/b/c', 'c', BuildFileAddress(build_file))
       self.assert_address('a/b/c', 'foo', BuildFileAddress(build_file, target_name='foo'))
       self.assertEqual('a/b/c:foo', BuildFileAddress(build_file, target_name='foo').spec)
 
     with self.workspace('BUILD') as root_dir:
-      build_file = BuildFile(FileSystemProjectTree(root_dir), relpath='')
+      build_file = BuildFile(FileSystemProjectTree(root_dir), relpath='BUILD')
       self.assert_address('', 'foo', BuildFileAddress(build_file, target_name='foo'))
       self.assertEqual('//:foo', BuildFileAddress(build_file, target_name='foo').spec)

--- a/tests/python/pants_test/build_graph/test_build_configuration.py
+++ b/tests/python/pants_test/build_graph/test_build_configuration.py
@@ -166,7 +166,7 @@ class BuildConfigurationTest(unittest.TestCase):
     with temporary_dir() as root:
       build_file_path = os.path.join(root, 'george', 'BUILD')
       touch(build_file_path)
-      build_file = BuildFile(FileSystemProjectTree(root), 'george')
+      build_file = BuildFile(FileSystemProjectTree(root), 'george/BUILD')
       parse_state = self.build_configuration.initialize_parse_state(build_file)
 
       self.assertEqual(0, len(parse_state.registered_addressable_instances))

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -74,7 +74,7 @@ class BuildFileAddressMapperTest(BaseTest):
   def test_raises_invalid_build_file_reference(self):
     # reference a BUILD file that doesn't exist
     with self.assertRaisesRegexp(BuildFileAddressMapper.InvalidBuildFileReference,
-                                 '^.*/non-existent-path does not contains any BUILD files.'
+                                 '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec //non-existent-path:a'):
       self.address_mapper.spec_to_address('//non-existent-path:a')
 

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -84,7 +84,7 @@ class BuildFileAddressMapperTest(BaseTest):
     # Create an address that doesn't exist in an existing BUILD file
     address = Address.parse(':bar')
     with self.assertRaisesRegexp(BuildFileAddressMapper.AddressNotInBuildFile,
-                                 '^bar was not found in BUILD file BuildFile\(BUILD, FileSystemProjectTree\(.*\)\). '
+                                 '^bar was not found in BUILD files from .*. '
                                  'Perhaps you meant:'
                                  '\s+:foo$'):
       self.address_mapper.resolve(address)
@@ -96,7 +96,7 @@ class BuildFileAddressMapperTest(BaseTest):
     # Create an address that doesn't exist in an existing BUILD file
     address = Address.parse(':bar')
     with self.assertRaisesRegexp(BuildFileAddressMapper.AddressNotInBuildFile,
-                                 '^bar was not found in BUILD file BuildFile\(BUILD.1, FileSystemProjectTree\(.*\)\). '
+                                 '^bar was not found in BUILD files from .*. '
                                  'Perhaps you meant one of:'
                                  '\s+BUILD.1:foo1'
                                  '\s+BUILD.2:foo2$'):

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -74,16 +74,32 @@ class BuildFileAddressMapperTest(BaseTest):
   def test_raises_invalid_build_file_reference(self):
     # reference a BUILD file that doesn't exist
     with self.assertRaisesRegexp(BuildFileAddressMapper.InvalidBuildFileReference,
-                                 '^BUILD file does not exist at: .*/non-existent-path'
+                                 '^.*/non-existent-path does not contains any BUILD files.'
                                  '\s+when translating spec //non-existent-path:a'):
       self.address_mapper.spec_to_address('//non-existent-path:a')
 
-  def test_raises_address_not_in_build_file(self):
+  def test_raises_address_not_in_one_build_file(self):
     self.add_to_build_file('BUILD', 'target(name="foo")')
 
     # Create an address that doesn't exist in an existing BUILD file
     address = Address.parse(':bar')
-    with self.assertRaises(BuildFileAddressMapper.AddressNotInBuildFile):
+    with self.assertRaisesRegexp(BuildFileAddressMapper.AddressNotInBuildFile,
+                                 '^bar was not found in BUILD file BuildFile\(BUILD, FileSystemProjectTree\(.*\)\). '
+                                 'Perhaps you meant:'
+                                 '\s+:foo$'):
+      self.address_mapper.resolve(address)
+
+  def test_raises_address_not_in_two_build_files(self):
+    self.add_to_build_file('BUILD.1', 'target(name="foo1")')
+    self.add_to_build_file('BUILD.2', 'target(name="foo2")')
+
+    # Create an address that doesn't exist in an existing BUILD file
+    address = Address.parse(':bar')
+    with self.assertRaisesRegexp(BuildFileAddressMapper.AddressNotInBuildFile,
+                                 '^bar was not found in BUILD file BuildFile\(BUILD.1, FileSystemProjectTree\(.*\)\). '
+                                 'Perhaps you meant one of:'
+                                 '\s+:foo1'
+                                 '\s+:foo2$'):
       self.address_mapper.resolve(address)
 
   def test_raises_address_invalid_address_error(self):
@@ -95,7 +111,7 @@ class BuildFileAddressMapperTest(BaseTest):
     with self.assertRaises(BuildFileAddressMapper.EmptyBuildFileError):
       self.address_mapper.resolve_spec('//:foo')
 
-  def test_address_lookup_error_hierarcy(self):
+  def test_address_lookup_error_hierarchy(self):
     self.assertIsInstance(BuildFileAddressMapper.AddressNotInBuildFile(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.EmptyBuildFileError(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.InvalidBuildFileReference(), AddressLookupError)

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -98,8 +98,8 @@ class BuildFileAddressMapperTest(BaseTest):
     with self.assertRaisesRegexp(BuildFileAddressMapper.AddressNotInBuildFile,
                                  '^bar was not found in BUILD files from .*. '
                                  'Perhaps you meant one of:'
-                                 '\s+BUILD.1:foo1'
-                                 '\s+BUILD.2:foo2$'):
+                                 '\s+:foo1 \(from BUILD.1\)'
+                                 '\s+:foo2 \(from BUILD.2\)$'):
       self.address_mapper.resolve(address)
 
   def test_raises_address_invalid_address_error(self):

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -98,8 +98,8 @@ class BuildFileAddressMapperTest(BaseTest):
     with self.assertRaisesRegexp(BuildFileAddressMapper.AddressNotInBuildFile,
                                  '^bar was not found in BUILD file BuildFile\(BUILD.1, FileSystemProjectTree\(.*\)\). '
                                  'Perhaps you meant one of:'
-                                 '\s+:foo1'
-                                 '\s+:foo2$'):
+                                 '\s+BUILD.1:foo1'
+                                 '\s+BUILD.2:foo2$'):
       self.address_mapper.resolve(address)
 
   def test_raises_address_invalid_address_error(self):

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -34,8 +34,8 @@ class BuildFileParserBasicsTest(BaseTest):
     return BuildFileAliases(targets={'jvm_binary': ErrorTarget,
                                      'java_library': ErrorTarget})
 
-  def create_buildfile(self, path, must_exist=True):
-    return BuildFile(FileSystemProjectTree(self.build_root), path, must_exist=must_exist)
+  def create_buildfile(self, path):
+    return BuildFile(FileSystemProjectTree(self.build_root), path)
 
   def test_addressable_exceptions(self):
     self.add_to_build_file('a/BUILD', 'target()')
@@ -102,8 +102,8 @@ class BuildFileParserTargetTest(BaseTest):
   def alias_groups(self):
     return BuildFileAliases(targets={'fake': ErrorTarget})
 
-  def create_buildfile(self, path, must_exist=True):
-    return BuildFile(FileSystemProjectTree(self.build_root), path, must_exist=must_exist)
+  def create_buildfile(self, path):
+    return BuildFile(FileSystemProjectTree(self.build_root), path)
 
   def test_trivial_target(self):
     self.add_to_build_file('BUILD', 'fake(name="foozle")')

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -65,7 +65,7 @@ class BuildFileParserBasicsTest(BaseTest):
 
   def test_noop_parse(self):
     self.add_to_build_file('BUILD', '')
-    build_file = self.create_buildfile('')
+    build_file = self.create_buildfile('BUILD')
     address_map = set(self.build_file_parser.parse_build_file(build_file))
     self.assertEqual(len(address_map), 0)
 

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -245,7 +245,7 @@ class BuildGraphTest(BaseTest):
     self.build_graph.inject_address_closure(Address.parse(spec))
 
   def test_invalid_address(self):
-    with self.assertRaisesRegexp(AddressLookupError, '^.* does not contains any BUILD files.$'):
+    with self.assertRaisesRegexp(AddressLookupError, '^.* does not contain any BUILD files.$'):
       self.inject_address_closure('//:a')
 
     self.add_to_build_file('BUILD',
@@ -253,7 +253,7 @@ class BuildGraphTest(BaseTest):
                            '  dependencies=["non-existent-path:b"],'
                            ')')
     with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
-                                 '^.*/non-existent-path does not contains any BUILD files.'
+                                 '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec non-existent-path:b'
                                  '\s+referenced from //:a$'):
       self.inject_address_closure('//:a')
@@ -268,7 +268,7 @@ class BuildGraphTest(BaseTest):
                            '  dependencies=["non-existent-path:c"],'
                            ')')
     with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
-                                 '^.*/non-existent-path does not contains any BUILD files.'
+                                 '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec non-existent-path:c'
                                  '\s+referenced from goodpath:b'
                                  '\s+referenced from //:a$'):
@@ -298,7 +298,7 @@ class BuildGraphTest(BaseTest):
                            '  dependencies=["non-existent-path:d"],'
                            ')')
     with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
-                                 '^.*/non-existent-path does not contains any BUILD files.'
+                                 '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec non-existent-path:d'
                                  '\s+referenced from goodpath:c'
                                  '\s+referenced from goodpath:b'

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -253,7 +253,7 @@ class BuildGraphTest(BaseTest):
                            '  dependencies=["non-existent-path:b"],'
                            ')')
     with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
-                                 '^BUILD file does not exist at:.*/non-existent-path/BUILD'
+                                 '^.*/non-existent-path does not contains any BUILD files.'
                                  '\s+when translating spec non-existent-path:b'
                                  '\s+referenced from //:a$'):
       self.inject_address_closure('//:a')
@@ -268,7 +268,7 @@ class BuildGraphTest(BaseTest):
                            '  dependencies=["non-existent-path:c"],'
                            ')')
     with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
-                                 '^BUILD file does not exist at: .*/non-existent-path/BUILD'
+                                 '^.*/non-existent-path does not contains any BUILD files.'
                                  '\s+when translating spec non-existent-path:c'
                                  '\s+referenced from goodpath:b'
                                  '\s+referenced from //:a$'):
@@ -298,7 +298,7 @@ class BuildGraphTest(BaseTest):
                            '  dependencies=["non-existent-path:d"],'
                            ')')
     with self.assertRaisesRegexp(BuildGraph.TransitiveLookupError,
-                                 '^BUILD file does not exist at:.*/non-existent-path/BUILD'
+                                 '^.*/non-existent-path does not contains any BUILD files.'
                                  '\s+when translating spec non-existent-path:d'
                                  '\s+referenced from goodpath:c'
                                  '\s+referenced from goodpath:b'


### PR DESCRIPTION
Currently it is possible to pass directory as input argument to BuildFile. Constructor of BuildFile trying to find any BUILD file in directory and use it. It's doesn't work well with `pants_build_ignore` option because this option can forbid some BUILD files extensions. 

This RB add constraint to BuildFile constructor: input path should be path to existing BUILD file only.

Also this RB as second diff contains mass renaming with removing `project_tree` substring from `BuildFile` methods. This renaming looks legal because this methods was introduced after last release.