### PR TITLE
excluding contrib/go for intellij pants plugin ci python test

### DIFF
--- a/build-support/pants-intellij.sh
+++ b/build-support/pants-intellij.sh
@@ -5,6 +5,7 @@
 
 # We don't want to include targets which are used in unit tests in our project so let's exclude them.
 ./pants export src/python/:: tests/python/pants_test:: contrib/:: \
+    --exclude-target-regexp='.*contrib/go.*' \
     --exclude-target-regexp='.*go/examples.*' \
     --exclude-target-regexp='.*scrooge/tests/thrift.*' \
     --exclude-target-regexp='.*spindle/tests/thrift.*' \


### PR DESCRIPTION
excluding contrib/go for intellij pants plugin ci python test