### PR TITLE
BuildFile refactoring: rename scan_project_tree_build_files to scan_build_files, get_project_tree_build_files_family to get_build_files_family

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
@@ -248,8 +248,8 @@ class GoBuildgen(GoTask):
 
     def gather_go_buildfiles(rel_path):
       address_mapper = self.context.address_mapper
-      for build_file in address_mapper.scan_project_tree_build_files(base_path=rel_path,
-                                                                     spec_excludes=self.context.spec_excludes):
+      for build_file in address_mapper.scan_build_files(base_path=rel_path,
+                                                        spec_excludes=self.context.spec_excludes):
         existing_go_buildfiles.add(build_file.relpath)
 
     gather_go_buildfiles(generation_result.local_root)

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -32,7 +32,7 @@ class ReverseDepmap(TargetFilterTaskMixin, ConsoleTask):
 
   def console_output(self, _):
     address_mapper = self.context.address_mapper
-    buildfiles = address_mapper.scan_project_tree_build_files(base_path=None, spec_excludes=self._spec_excludes)
+    buildfiles = address_mapper.scan_build_files(base_path=None, spec_excludes=self._spec_excludes)
 
     build_graph = self.context.build_graph
     build_file_parser = self.context.build_file_parser

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -592,8 +592,8 @@ class Project(object):
         candidates = OrderedSet()
         build_file = target.address.build_file
         dir_relpath = os.path.dirname(build_file.relpath)
-        for descendant in BuildFile.scan_project_tree_build_files(build_file.project_tree, dir_relpath,
-                                                                  spec_excludes=self.spec_excludes):
+        for descendant in BuildFile.scan_build_files(build_file.project_tree, dir_relpath,
+                                                     spec_excludes=self.spec_excludes):
           candidates.update(self.target_util.get_all_addresses(descendant))
         if not self._is_root_relpath(dir_relpath):
           for ancestor in self._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath)):
@@ -689,11 +689,11 @@ class Project(object):
 
   @classmethod
   def _collect_ancestor_build_files(cls, project_tree, dir_relpath):
-    for build_file in BuildFile.get_project_tree_build_files_family(project_tree, dir_relpath):
+    for build_file in BuildFile.get_build_files_family(project_tree, dir_relpath):
       yield build_file
     while not cls._is_root_relpath(dir_relpath):
       dir_relpath = os.path.dirname(dir_relpath)
-      for build_file in BuildFile.get_project_tree_build_files_family(project_tree, dir_relpath):
+      for build_file in BuildFile.get_build_files_family(project_tree, dir_relpath):
         yield build_file
 
   @classmethod

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -129,8 +129,8 @@ class CmdLineSpecParser(object):
       spec_path = spec[:-len('::')]
       spec_dir = normalize_spec_path(spec_path)
       try:
-        build_files = self._address_mapper.scan_project_tree_build_files(base_path=spec_dir,
-                                                                         spec_excludes=self._spec_excludes)
+        build_files = self._address_mapper.scan_build_files(base_path=spec_dir,
+                                                            spec_excludes=self._spec_excludes)
       except (BuildFile.BuildFileError, AddressLookupError) as e:
         raise self.BadSpecError(e)
 

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -129,7 +129,7 @@ class BuildFileAddressMapper(object):
     """
     if spec_path not in self._spec_path_to_address_map_map:
       try:
-        build_files = list(BuildFile.get_project_tree_build_files_family(self._project_tree, spec_path))
+        build_files = list(BuildFile.get_build_files_family(self._project_tree, spec_path))
         if not build_files:
           raise self.BuildFileScanError("{spec_path} does not contain any BUILD files."
                                         .format(spec_path=os.path.join(self.root_dir, spec_path)))
@@ -173,16 +173,16 @@ class BuildFileAddressMapper(object):
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))
 
-  @deprecated('0.0.72', hint_message='Use scan_project_tree_build_files instead.')
+  @deprecated('0.0.72', hint_message='Use scan_build_files instead.')
   def scan_buildfiles(self, root_dir, base_path=None, spec_excludes=None):
     """Looks for all BUILD files in root_dir or its descendant directories.
 
     :returns: an OrderedSet of BuildFile instances.
     """
-    return self.scan_project_tree_build_files(base_path, spec_excludes)
+    return self.scan_build_files(base_path, spec_excludes)
 
-  def scan_project_tree_build_files(self, base_path, spec_excludes):
-    return BuildFile.scan_project_tree_build_files(self._project_tree, base_path, spec_excludes)
+  def scan_build_files(self, base_path, spec_excludes):
+    return BuildFile.scan_build_files(self._project_tree, base_path, spec_excludes)
 
   def specs_to_addresses(self, specs, relative_to=''):
     """The equivalent of `spec_to_address` for a group of specs all relative to the same path.
@@ -211,9 +211,9 @@ class BuildFileAddressMapper(object):
 
     addresses = set()
     try:
-      for build_file in BuildFile.scan_project_tree_build_files(self._project_tree,
-                                                                base_relpath=base_path,
-                                                                spec_excludes=spec_excludes):
+      for build_file in BuildFile.scan_build_files(self._project_tree,
+                                                   base_relpath=base_path,
+                                                   spec_excludes=spec_excludes):
         for address in self.addresses_in_spec_path(build_file.spec_path):
           addresses.add(address)
     except BuildFile.BuildFileError as e:

--- a/src/python/pants/reporting/linkify.py
+++ b/src/python/pants/reporting/linkify.py
@@ -63,7 +63,7 @@ def linkify(buildroot, s, memoized_urls):
       else:
         putative_dir = path
       if os.path.isdir(os.path.join(buildroot, putative_dir)):
-        build_files = list(BuildFile.get_project_tree_build_files_family(
+        build_files = list(BuildFile.get_build_files_family(
           FileSystemProjectTree(buildroot),
           putative_dir))
         if build_files:

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -25,13 +25,13 @@ class BuildFileTestBase(unittest.TestCase):
     touch(self.fullpath(path))
 
   def scan_buildfiles(self, base_relpath, spec_excludes=None):
-    return BuildFile.scan_project_tree_build_files(self._project_tree, base_relpath, spec_excludes)
+    return BuildFile.scan_build_files(self._project_tree, base_relpath, spec_excludes)
 
   def create_buildfile(self, relpath):
     return BuildFile(self._project_tree, relpath)
 
   def get_build_files_family(self, relpath):
-    return BuildFile.get_project_tree_build_files_family(self._project_tree, relpath)
+    return BuildFile.get_build_files_family(self._project_tree, relpath)
 
   def setUp(self):
     self.base_dir = tempfile.mkdtemp()

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -143,7 +143,7 @@ class BuildFileParserTargetTest(BaseTest):
     foo_build_file = self.create_buildfile('BUILD.foo')
 
     address_map = self.build_file_parser.address_map_from_build_files(
-      BuildFile.get_project_tree_build_files_family(FileSystemProjectTree(self.build_root), "."))
+      BuildFile.get_build_files_family(FileSystemProjectTree(self.build_root), "."))
     addresses = address_map.keys()
     self.assertEqual({bar_build_file, base_build_file, foo_build_file},
                      set([address.build_file for address in addresses]))
@@ -184,7 +184,7 @@ class BuildFileParserTargetTest(BaseTest):
 
     with self.assertRaises(BuildFileParser.SiblingConflictException):
       self.build_file_parser.address_map_from_build_files(
-        BuildFile.get_project_tree_build_files_family(FileSystemProjectTree(self.build_root), '.'))
+        BuildFile.get_build_files_family(FileSystemProjectTree(self.build_root), '.'))
 
 
 class BuildFileParserExposedObjectTest(BaseTest):


### PR DESCRIPTION
Rename `scan_project_tree_build_files` to `scan_build_files` and `get_project_tree_build_files_family` to `get_build_files_family`. 
This removal looks legal as this methods was introduced after last release.