### PR TITLE
Don't skip writing <artifact>s to ivy.xml even if there's only one.

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -556,11 +556,6 @@ class IvyUtils(object):
                           classifier=classifier)
       artifacts[(ext, url, classifier)] = artifact
 
-    if len(artifacts) == 1:
-      # If the only artifact has no attributes that we need a nested <artifact/> for, just emit
-      # a <dependency/>.
-      artifacts.pop((None, None, None), None)
-
     template = TemplateData(
         org=jar_attributes.org,
         module=jar_attributes.name,


### PR DESCRIPTION
We ran into a problem internally at Square where ivy would
stubbornly resolve a 'test-jar' instead of a 'jar' artifact, even
when we directly declared a dependency on the 'jar'. The reason for
this appears to be that pants was short-circuiting instead of
writing an explicit artifact for the 'jar'.

This changes:

   <dependency org="org.apache.hadoop"
                  name="hadoop-common"
                  rev="2.0.0-cdh4.6.0">
        <conf name="default" mapped="default"/>
        <!-- excludes, etc -->
    </dependency>

To:

   <dependency org="org.apache.hadoop"
                  name="hadoop-common"
                  rev="2.0.0-cdh4.6.0">
        <conf name="default" mapped="default"/>
        <artifact
          name="hadoop-common"
          type="jar"/>
        <!-- excludes, etc -->
    </dependency>

Which causes ivy to behave as expected.