### PR TITLE
Peiyu/dudup bundle jars

### DIFF
--- a/src/python/pants/backend/jvm/tasks/classpath_util.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_util.py
@@ -278,7 +278,10 @@ class ClasspathUtil(object):
           if entry.is_excluded_by(excludes):
             continue
 
-          # Avoid creating symlink for the same entry twice.
+          # Avoid creating symlink for the same entry twice, only the first entry on
+          # classpath will get a symlink. The resulted symlinks as a whole are still stable,
+          # but may have non-consecutive suffixes because the 'missing' ones are those
+          # have already been created symlinks by previous targets.
           if entry in processed_entries:
             continue
           processed_entries.add(entry)

--- a/src/python/pants/backend/jvm/tasks/classpath_util.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_util.py
@@ -263,6 +263,7 @@ class ClasspathUtil(object):
     canonical_classpath = []
     target_to_classpath = cls.classpath_by_targets(targets, classpath_products)
 
+    processed_entries = set()
     for target, classpath_entries_for_target in target_to_classpath.items():
       if internal_classpath_only:
         classpath_entries_for_target = filter(ClasspathEntry.is_internal_classpath_entry,
@@ -278,6 +279,9 @@ class ClasspathUtil(object):
           if entry.is_excluded_by(excludes):
             continue
 
+          if entry in processed_entries:
+            continue
+
           # Create a unique symlink path by prefixing the base file name with a monotonic
           # increasing `index` to avoid name collisions.
           _, ext = os.path.splitext(entry.path)
@@ -290,6 +294,8 @@ class ClasspathUtil(object):
           os.symlink(entry.path, symlink_path)
           canonical_classpath.append(symlink_path)
           classpath.append(entry.path)
+
+          processed_entries.add(entry)
 
         if save_classpath_file:
           with safe_open('{}classpath.txt'.format(classpath_prefix_for_target), 'wb') as classpath_file:

--- a/src/python/pants/backend/jvm/tasks/classpath_util.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_util.py
@@ -271,7 +271,6 @@ class ClasspathUtil(object):
       if len(classpath_entries_for_target) > 0:
         classpath_prefix_for_target = prepare_target_output_folder(basedir, target)
 
-        classpath = []
         # Note: for internal targets pants has only one classpath entry, but user plugins
         # might generate additional entries, for example, build.properties for the target.
         # Also it's common to have multiple classpath entries associated with 3rdparty targets.
@@ -279,6 +278,7 @@ class ClasspathUtil(object):
           if entry.is_excluded_by(excludes):
             continue
 
+          # Avoid creating symlink on the same entry twice
           if entry in processed_entries:
             continue
 
@@ -293,11 +293,10 @@ class ClasspathUtil(object):
 
           os.symlink(entry.path, symlink_path)
           canonical_classpath.append(symlink_path)
-          classpath.append(entry.path)
-
           processed_entries.add(entry)
 
         if save_classpath_file:
+          classpath = [entry.path for entry in classpath_entries_for_target]
           with safe_open('{}classpath.txt'.format(classpath_prefix_for_target), 'wb') as classpath_file:
             classpath_file.write(os.pathsep.join(classpath).encode('utf-8'))
             classpath_file.write('\n')

--- a/src/python/pants/backend/jvm/tasks/classpath_util.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_util.py
@@ -278,9 +278,10 @@ class ClasspathUtil(object):
           if entry.is_excluded_by(excludes):
             continue
 
-          # Avoid creating symlink for the same entry twice
+          # Avoid creating symlink for the same entry twice.
           if entry in processed_entries:
             continue
+          processed_entries.add(entry)
 
           # Create a unique symlink path by prefixing the base file name with a monotonic
           # increasing `index` to avoid name collisions.
@@ -293,7 +294,6 @@ class ClasspathUtil(object):
 
           os.symlink(entry.path, symlink_path)
           canonical_classpath.append(symlink_path)
-          processed_entries.add(entry)
 
         if save_classpath_file:
           classpath = [entry.path for entry in classpath_entries_for_target]

--- a/src/python/pants/backend/jvm/tasks/classpath_util.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_util.py
@@ -278,7 +278,7 @@ class ClasspathUtil(object):
           if entry.is_excluded_by(excludes):
             continue
 
-          # Avoid creating symlink on the same entry twice
+          # Avoid creating symlink for the same entry twice
           if entry in processed_entries:
             continue
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
@@ -226,6 +226,33 @@ class ClasspathUtilTest(BaseTest):
                                               base_dir, False,
                                               [], {})
 
+  def test_create_canonical_classpath_no_duplicate_entry(self):
+    """Test no more than one symlink pointing to the same classpath entry."""
+    jar_path = 'ivy/jars/org.x/lib/x-1.0.jar'
+    resolved_jar = ResolvedJar(M2Coordinate(org='org', name='x', rev='1.0'),
+                               cache_path='somewhere',
+                               pants_path=self._path(jar_path))
+    target_a = self.make_target('a', JvmTarget)
+    target_b = self.make_target('b', JvmTarget)
+
+    classpath_products = ClasspathProducts(self.pants_workdir)
+    # Both target a and target b depends on the same jar library
+    classpath_products.add_jars_for_targets([target_a], 'default', [resolved_jar])
+    classpath_products.add_jars_for_targets([target_b], 'default', [resolved_jar])
+
+    with temporary_dir() as base_dir:
+      # Only target a generates symlink to dependency jar library, but both
+      # classpath.txt files contain the dependency jar.
+      self._test_canonical_classpath_helper(classpath_products, [target_a, target_b],
+                                            base_dir, True,
+                                            ['a.a-0.jar'],
+                                            {
+                                              'a.a-classpath.txt':
+                                                '{}/{}\n'.format(self.pants_workdir, jar_path),
+                                              'b.b-classpath.txt':
+                                                '{}/{}\n'.format(self.pants_workdir, jar_path),
+                                            })
+
   def _test_canonical_classpath_helper(self, classpath_products, targets,
                                        libs_dir,
                                        use_target_id,

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
@@ -227,7 +227,7 @@ class ClasspathUtilTest(BaseTest):
                                               [], {})
 
   def test_create_canonical_classpath_no_duplicate_entry(self):
-    """Test no more than one symlink pointing to the same classpath entry."""
+    """Test no more than one symlink are created for the same classpath entry."""
     jar_path = 'ivy/jars/org.x/lib/x-1.0.jar'
     resolved_jar = ResolvedJar(M2Coordinate(org='org', name='x', rev='1.0'),
                                cache_path='somewhere',
@@ -236,13 +236,14 @@ class ClasspathUtilTest(BaseTest):
     target_b = self.make_target('b', JvmTarget)
 
     classpath_products = ClasspathProducts(self.pants_workdir)
-    # Both target a and target b depends on the same jar library
+    # Both target a and target b depend on the same jar library
     classpath_products.add_jars_for_targets([target_a], 'default', [resolved_jar])
     classpath_products.add_jars_for_targets([target_b], 'default', [resolved_jar])
 
     with temporary_dir() as base_dir:
-      # Only target a generates symlink to dependency jar library, but both
-      # classpath.txt files contain the dependency jar.
+      # Only target a generates symlink to jar library, target b skips creating the
+      # symlink for the same jar library. Both targets' classpath.txt files should
+      # still contain the jar library.
       self._test_canonical_classpath_helper(classpath_products, [target_a, target_b],
                                             base_dir, True,
                                             ['a.a-0.jar'],


### PR DESCRIPTION
https://rbcommons.com/s/twitter/r/3329/ introduced classpath_util.classpath_by_targets

Among classpath grouped by target (3rdparty dependencies) duplicates are not
removed. So we see for example same guava library have more than one symlink
created. This results typically 10%-20% increase in size.

An example:
```
tw-mbp-peiyu:source peiyu$ ls -l dist/buildstats-package-dist-bundle/libs/|grep 3rdparty|grep guava
lrwxrwx---  1 peiyu  staff   95 Jan 20 13:53 3rdparty.jvm.cascading.cascading-local-4.jar -> /Users/peiyu/workspace/source/.pants.d/ivy/jars/com.google.guava/guava/bundles/guava-16.0.1.jar
lrwxrwx---  1 peiyu  staff   95 Jan 20 13:53 3rdparty.jvm.com.github.spullara.mustache.java.java-1.jar -> /Users/peiyu/workspace/source/.pants.d/ivy/jars/com.google.guava/guava/bundles/guava-16.0.1.jar
lrwxrwx---  1 peiyu  staff   95 Jan 20 13:53 3rdparty.jvm.com.google.guava.guava-0.jar -> /Users/peiyu/workspace/source/.pants.d/ivy/jars/com.google.guava/guava/bundles/guava-16.0.1.jar
lrwxrwx---  1 peiyu  staff   95 Jan 20 13:53 3rdparty.jvm.com.google.inject.extensions.guice-assistedinject-3.jar -> /Users/peiyu/workspace/source/.pants.d/ivy/jars/com.google.guava/guava/bundles/guava-16.0.1.jar
lrwxrwx---  1 peiyu  staff   95 Jan 20 13:53 3rdparty.jvm.com.google.inject.extensions.guice-multibindings-3.jar -> /Users/peiyu/workspace/source/.pants.d/ivy/jars/com.google.guava/guava/bundles/guava-16.0.1.jar
lrwxrwx---  1 peiyu  staff   95 Jan 20 13:53 3rdparty.jvm.com.google.inject.guice-2.jar -> /Users/peiyu/workspace/source/.pants.d/ivy/jars/com.google.guava/guava/bundles/guava-16.0.1.jar
lrwxrwx---  1 peiyu  staff   95 Jan 20 13:53 3rdparty.jvm.net.codingwell.scala-guice-2.jar -> /Users/peiyu/workspace/source/.pants.d/ivy/jars/com.google.guava/guava/bundles/guava-16.0.1.jar
```
This review removes duplicated jars.

Note: this review is limited to bug fix. Next time when we remove the
use_target_id flag, will probably do more cleanups since the logic is getting
complicated.