### PR TITLE
Introduce pants_build_ignore option

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -22,3 +22,4 @@ six>=1.9.0,<2
 thrift==0.9.1
 wheel==0.24.0
 zincutils==0.3.1
+pathspec==0.3.4

--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -28,7 +28,8 @@ class ReverseDepmap(TargetFilterTaskMixin, ConsoleTask):
 
     self._transitive = self.get_options().transitive
     self._closed = self.get_options().closed
-    self._spec_excludes = self.get_options().spec_excludes
+    # Will be provided through context.address_mapper.build_ignore_patterns.
+    self._spec_excludes = None
 
   def console_output(self, _):
     address_mapper = self.context.address_mapper

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -10,6 +10,8 @@ import os
 import shutil
 from collections import defaultdict
 
+import pathspec
+from pathspec.gitignore import GitIgnorePattern
 from twitter.common.collections.orderedset import OrderedSet
 
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
@@ -184,6 +186,13 @@ class IdeGen(IvyTaskMixin, NailgunTask):
                    isinstance(t, Resources)]
     if self.intransitive:
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
+
+    pants_build_ignore_paths = self.context.options.for_global_scope().pants_build_ignore
+    if pants_build_ignore_paths:
+      pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore_paths)
+    else:
+      pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, [])
+
     project = Project(self.project_name,
                       self.python,
                       self.skip_java,
@@ -195,7 +204,8 @@ class IdeGen(IvyTaskMixin, NailgunTask):
                       jvm_targets,
                       not self.intransitive,
                       self.TargetUtil(self.context),
-                      self.context.options.for_global_scope().spec_excludes)
+                      self.context.options.for_global_scope().spec_excludes,
+                      pants_build_ignore)
 
     if self.python:
       python_source_paths = self.get_options().python_source_paths
@@ -451,7 +461,7 @@ class Project(object):
     return collapsed_source_sets
 
   def __init__(self, name, has_python, skip_java, skip_scala, use_source_root, root_dir,
-               debug_port, context, targets, transitive, target_util, spec_excludes):
+               debug_port, context, targets, transitive, target_util, spec_excludes, pants_build_ignore):
     """Creates a new, unconfigured, Project based at root_dir and comprised of the sources visible
     to the given targets."""
     self.context = context
@@ -478,6 +488,7 @@ class Project(object):
     self.internal_jars = OrderedSet()
     self.external_jars = OrderedSet()
     self.spec_excludes = spec_excludes
+    self.pants_build_ignore = pants_build_ignore
 
   def configure_python(self, source_paths, test_paths, lib_paths):
     self.py_sources.extend(SourceSet(get_buildroot(), root, None) for root in source_paths)
@@ -593,10 +604,12 @@ class Project(object):
         build_file = target.address.build_file
         dir_relpath = os.path.dirname(build_file.relpath)
         for descendant in BuildFile.scan_build_files(build_file.project_tree, dir_relpath,
-                                                     spec_excludes=self.spec_excludes):
+                                                     spec_excludes=self.spec_excludes,
+                                                     pants_build_ignore=self.pants_build_ignore):
           candidates.update(self.target_util.get_all_addresses(descendant))
         if not self._is_root_relpath(dir_relpath):
-          for ancestor in self._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath)):
+          for ancestor in self._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath),
+                                                             self.pants_build_ignore):
             candidates.update(self.target_util.get_all_addresses(ancestor))
 
         def is_sibling(target):
@@ -688,12 +701,12 @@ class Project(object):
     self.scala_compiler_classpath = scalac_classpath
 
   @classmethod
-  def _collect_ancestor_build_files(cls, project_tree, dir_relpath):
-    for build_file in BuildFile.get_build_files_family(project_tree, dir_relpath):
+  def _collect_ancestor_build_files(cls, project_tree, dir_relpath, pants_build_ignore):
+    for build_file in BuildFile.get_build_files_family(project_tree, dir_relpath, pants_build_ignore):
       yield build_file
     while not cls._is_root_relpath(dir_relpath):
       dir_relpath = os.path.dirname(dir_relpath)
-      for build_file in BuildFile.get_build_files_family(project_tree, dir_relpath):
+      for build_file in BuildFile.get_build_files_family(project_tree, dir_relpath, pants_build_ignore):
         yield build_file
 
   @classmethod

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -21,6 +21,7 @@ from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.binaries import binary_util
 from pants.build_graph.address import BuildFileAddress
@@ -457,9 +458,13 @@ class Project(object):
     return collapsed_source_sets
 
   def __init__(self, name, has_python, skip_java, skip_scala, use_source_root, root_dir,
-               debug_port, context, targets, transitive, target_util, spec_excludes, build_ignore_patterns):
+               debug_port, context, targets, transitive, target_util, spec_excludes=None, build_ignore_patterns=None):
     """Creates a new, unconfigured, Project based at root_dir and comprised of the sources visible
     to the given targets."""
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use build_ignore_patterns instead.')
+
     self.context = context
     self.target_util = target_util
     self.name = name

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -188,7 +188,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
 
     build_ignore_patterns = PathSpec.from_lines(GitIgnorePattern,
-                                                self.context.options.for_global_scope().pants_build_ignore or [])
+                                                self.context.options.for_global_scope().build_file_ignore or [])
     project = Project(self.project_name,
                       self.python,
                       self.skip_java,

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -190,7 +190,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
 
     build_ignore_patterns = self.context.options.for_global_scope().build_file_ignore or []
     build_ignore_patterns.extend(BuildFile._spec_excludes_to_gitignore_syntax(
-      self._root_dir, self.context.options.for_global_scope().spec_excludes))
+      os.path.realpath(get_buildroot()), self.context.options.for_global_scope().spec_excludes))
 
     project = Project(self.project_name,
                       self.python,

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -188,8 +188,10 @@ class IdeGen(IvyTaskMixin, NailgunTask):
     if self.intransitive:
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
 
-    build_ignore_patterns = PathSpec.from_lines(GitIgnorePattern,
-                                                self.context.options.for_global_scope().build_file_ignore or [])
+    build_ignore_patterns = self.context.options.for_global_scope().build_file_ignore or []
+    build_ignore_patterns.extend(BuildFile._spec_excludes_to_gitignore_syntax(
+      self._root_dir, self.context.options.for_global_scope().spec_excludes))
+
     project = Project(self.project_name,
                       self.python,
                       self.skip_java,
@@ -201,8 +203,8 @@ class IdeGen(IvyTaskMixin, NailgunTask):
                       jvm_targets,
                       not self.intransitive,
                       self.TargetUtil(self.context),
-                      self.context.options.for_global_scope().spec_excludes,
-                      build_ignore_patterns)
+                      None,
+                      PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns))
 
     if self.python:
       python_source_paths = self.get_options().python_source_paths

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -188,7 +188,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
     if self.intransitive:
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
 
-    build_ignore_patterns = self.context.options.for_global_scope().build_file_ignore or []
+    build_ignore_patterns = self.context.options.for_global_scope().ignore_patterns or []
     build_ignore_patterns.extend(BuildFile._spec_excludes_to_gitignore_syntax(
       os.path.realpath(get_buildroot()), self.context.options.for_global_scope().spec_excludes))
 

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -10,7 +10,7 @@ import os
 import shutil
 from collections import defaultdict
 
-import pathspec
+from pathspec import PathSpec
 from pathspec.gitignore import GitIgnorePattern
 from twitter.common.collections.orderedset import OrderedSet
 
@@ -188,7 +188,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
 
     pants_build_ignore_paths = self.context.options.for_global_scope().pants_build_ignore
-    pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore_paths or [])
+    pants_build_ignore = PathSpec.from_lines(GitIgnorePattern, pants_build_ignore_paths or [])
 
     project = Project(self.project_name,
                       self.python,

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -605,8 +605,9 @@ class Project(object):
                                                      pants_build_ignore=self.pants_build_ignore):
           candidates.update(self.target_util.get_all_addresses(descendant))
         if not self._is_root_relpath(dir_relpath):
-          for ancestor in self._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath),
-                                                             self.pants_build_ignore):
+          ancestors = self._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath),
+                                                         self.pants_build_ignore)
+          for ancestor in ancestors:
             candidates.update(self.target_util.get_all_addresses(ancestor))
 
         def is_sibling(target):

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -188,10 +188,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
 
     pants_build_ignore_paths = self.context.options.for_global_scope().pants_build_ignore
-    if pants_build_ignore_paths:
-      pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore_paths)
-    else:
-      pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, [])
+    pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore_paths or [])
 
     project = Project(self.project_name,
                       self.python,

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -41,6 +41,7 @@ python_library(
   sources = ['build_file.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:pathspec',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
     ':project_tree',

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -73,8 +73,8 @@ class BuildFile(AbstractClass):
     return BuildFile._cached(cls._get_project_tree(root_dir), relpath, must_exist)
 
   @staticmethod
-  def _add_spec_excludes_to_build_ignore_patterns(build_root, build_ignore_patterns=None, spec_excludes=None):
-    def convert_to_gitignore_syntax(spec_excludes, build_root):
+  def _spec_excludes_to_gitignore_syntax(build_root, spec_excludes=None):
+    if spec_excludes:
       for path in spec_excludes:
         if os.path.isabs(path):
           realpath = os.path.realpath(path)
@@ -83,17 +83,16 @@ class BuildFile(AbstractClass):
         else:
           yield '/{}'.format(path)
 
+  @staticmethod
+  def _add_spec_excludes_to_build_ignore_patterns(build_root, build_ignore_patterns=None, spec_excludes=None):
     if not build_ignore_patterns:
       build_ignore_patterns = PathSpec.from_lines(GitIgnorePattern, [])
 
-    if spec_excludes:
-      # Hack, will be removed after spec_excludes removal.
-      patterns = list(build_ignore_patterns.patterns)
-      patterns.extend(PathSpec.from_lines(GitIgnorePattern,
-        convert_to_gitignore_syntax(spec_excludes, build_root)).patterns)
-      return PathSpec(patterns)
-    else:
-      return build_ignore_patterns
+    patterns = list(build_ignore_patterns.patterns)
+    patterns.extend(PathSpec.from_lines(
+      GitIgnorePattern,
+      BuildFile._spec_excludes_to_gitignore_syntax(build_root, spec_excludes)).patterns)
+    return PathSpec(patterns)
 
   @staticmethod
   def scan_build_files(project_tree, base_relpath, spec_excludes=None, build_ignore_patterns=None):
@@ -120,6 +119,7 @@ class BuildFile(AbstractClass):
       raise TypeError("build_ignore_patterns should be pathspec.pathspec.PathSpec instance, "
                       "instead {} was given.".format(type(build_ignore_patterns)))
 
+    # Hack, will be removed after spec_excludes removal.
     build_ignore_patterns = BuildFile._add_spec_excludes_to_build_ignore_patterns(project_tree.build_root,
                                                                                   build_ignore_patterns,
                                                                                   spec_excludes)

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -74,7 +74,7 @@ class BuildFile(AbstractClass):
     return BuildFile._cached(cls._get_project_tree(root_dir), relpath, must_exist)
 
   @staticmethod
-  def scan_build_files(project_tree, base_relpath, spec_excludes=None):
+  def scan_build_files(project_tree, base_relpath, spec_excludes=None, pants_build_ignore=None):
     """Looks for all BUILD files
     :param project_tree: Project tree to scan in.
     :type project_tree: :class:`pants.base.project_tree.ProjectTree`
@@ -233,7 +233,7 @@ class BuildFile(AbstractClass):
         yield build
 
   @staticmethod
-  def get_build_files_family(project_tree, dir_relpath):
+  def get_build_files_family(project_tree, dir_relpath, pants_build_ignore=None):
     """Returns all the BUILD files on a path"""
     for build in sorted(project_tree.glob1(dir_relpath, '{prefix}*'.format(prefix=BuildFile._BUILD_FILE_PREFIX))):
       if BuildFile._is_buildfile_name(build) and project_tree.isfile(os.path.join(dir_relpath, build)):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -130,8 +130,8 @@ class BuildFile(AbstractClass):
       build_files_without_ignores = rel_paths.difference(pants_build_ignore.match_files(rel_paths))
     else:
       build_files_without_ignores = rel_paths
-    return OrderedSet(sorted(BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores),
-                             key=lambda build_file: build_file.full_path)
+    return OrderedSet(sorted((BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores),
+                             key=lambda build_file: build_file.full_path))
 
   def __init__(self, project_tree, relpath, must_exist=True):
     """Creates a BuildFile object representing the BUILD file family at the specified path.

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -88,9 +88,9 @@ class BuildFile(AbstractClass):
         if os.path.isabs(path):
           realpath = os.path.realpath(path)
           if realpath.startswith(build_root):
-            yield '/' + fast_relpath(realpath, build_root)
+            yield '/{}'.format(fast_relpath(realpath, build_root))
         else:
-          yield '/' + path
+          yield '/{}'.format(path)
 
     if base_relpath and os.path.isabs(base_relpath):
       raise BuildFile.BadPathError('base_relpath parameter ({}) should be a relative path.'
@@ -113,8 +113,10 @@ class BuildFile(AbstractClass):
 
     build_files = set()
     for root, dirs, files in project_tree.walk(base_relpath or '', topdown=True):
-      excluded_dirs = list(pants_build_ignore.match_files([os.path.join(root, dirname) + '/' for dirname in dirs]))
+      excluded_dirs = list(pants_build_ignore.match_files(('{}/'.format(os.path.join(root, dirname))
+                                                           for dirname in dirs)))
       for subdir in excluded_dirs:
+        # Remove trailing '/' from paths which were added to indicate that paths are paths to directories.
         dirs.remove(fast_relpath(subdir, root)[:-1])
       for filename in files:
         if BuildFile._is_buildfile_name(filename):
@@ -128,7 +130,7 @@ class BuildFile(AbstractClass):
       build_files_without_ignores = rel_paths.difference(pants_build_ignore.match_files(rel_paths))
     else:
       build_files_without_ignores = rel_paths
-    return OrderedSet(sorted([BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores],
+    return OrderedSet(sorted((BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores),
                              key=lambda build_file: build_file.full_path))
 
   def __init__(self, project_tree, relpath, must_exist=True):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -111,7 +111,7 @@ class BuildFile(AbstractClass):
     if pants_build_ignore:
       abs_ignore_paths = [path for path in pants_build_ignore if os.path.isabs(path)]
       if any(abs_ignore_paths):
-        raise Exception('All pants_build_ignore paths passed to scan_build_files should be a relative. '
+        raise Exception('All pants_build_ignore paths passed to scan_build_files should be relative. '
                         'Absolute path {} was passed.'.format(abs_ignore_paths[0]))
 
     ignore_patterns = set()

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -128,7 +128,7 @@ class BuildFile(AbstractClass):
       build_files_without_ignores = rel_paths.difference(pants_build_ignore.match_files(rel_paths))
     else:
       build_files_without_ignores = rel_paths
-    return OrderedSet(sorted([BuildFile(project_tree, relpath) for relpath in build_files_without_ignores],
+    return OrderedSet(sorted([BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores],
                              key=lambda build_file: build_file.full_path))
 
   def __init__(self, project_tree, relpath, must_exist=True):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -113,8 +113,8 @@ class BuildFile(AbstractClass):
 
     build_files = set()
     for root, dirs, files in project_tree.walk(base_relpath or '', topdown=True):
-      excluded_dirs = list(pants_build_ignore.match_files(('{}/'.format(os.path.join(root, dirname))
-                                                           for dirname in dirs)))
+      excluded_dirs = list(pants_build_ignore.match_files('{}/'.format(os.path.join(root, dirname))
+                                                          for dirname in dirs))
       for subdir in excluded_dirs:
         # Remove trailing '/' from paths which were added to indicate that paths are paths to directories.
         dirs.remove(fast_relpath(subdir, root)[:-1])
@@ -130,8 +130,8 @@ class BuildFile(AbstractClass):
       build_files_without_ignores = rel_paths.difference(pants_build_ignore.match_files(rel_paths))
     else:
       build_files_without_ignores = rel_paths
-    return OrderedSet(sorted((BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores),
-                             key=lambda build_file: build_file.full_path))
+    return OrderedSet(sorted(BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores),
+                             key=lambda build_file: build_file.full_path)
 
   def __init__(self, project_tree, relpath, must_exist=True):
     """Creates a BuildFile object representing the BUILD file family at the specified path.

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -9,8 +9,8 @@ import logging
 import os
 import re
 
-import pathspec
-from pathspec.pathspec import PathSpec
+from pathspec import PathSpec
+from pathspec.gitignore import GitIgnorePattern
 from twitter.common.collections import OrderedSet
 
 from pants.base.deprecated import deprecated
@@ -99,7 +99,7 @@ class BuildFile(AbstractClass):
       raise BuildFile.BadPathError('Can only scan directories and {0} is not a valid dir.'
                                    .format(base_relpath))
     if pants_build_ignore is None:
-      pants_build_ignore = pathspec.PathSpec.from_lines(pathspec.GitIgnorePattern, [])
+      pants_build_ignore = PathSpec.from_lines(GitIgnorePattern, [])
     if not isinstance(pants_build_ignore, PathSpec):
       raise TypeError("pants_build_ignore should be pathspec.pathspec.PathSpec instance, "
                       "instead {} was given.".format(type(pants_build_ignore)))
@@ -107,9 +107,9 @@ class BuildFile(AbstractClass):
     if spec_excludes:
       # Hack, will be removed after spec_excludes removal.
       patterns = list(pants_build_ignore.patterns)
-      patterns.extend(pathspec.PathSpec.from_lines(pathspec.GitIgnorePattern,
+      patterns.extend(PathSpec.from_lines(GitIgnorePattern,
         convert_to_gitignore_syntax(spec_excludes, project_tree.build_root)).patterns)
-      pants_build_ignore = pathspec.PathSpec(patterns)
+      pants_build_ignore = PathSpec(patterns)
 
     build_files = set()
     for root, dirs, files in project_tree.walk(base_relpath or '', topdown=True):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -106,9 +106,10 @@ class BuildFile(AbstractClass):
 
     if spec_excludes:
       # Hack, will be removed after spec_excludes removal.
-      pants_build_ignore.patterns.append(pathspec.PathSpec.from_lines(
-        pathspec.GitIgnorePattern,
+      patterns = list(pants_build_ignore.patterns)
+      patterns.extend(pathspec.PathSpec.from_lines(pathspec.GitIgnorePattern,
         convert_to_gitignore_syntax(spec_excludes, project_tree.build_root)).patterns)
+      pants_build_ignore = pathspec.PathSpec(patterns)
 
     build_files = set()
     for root, dirs, files in project_tree.walk(base_relpath or '', topdown=True):

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -13,7 +13,7 @@ from pathspec import PathSpec
 from pathspec.gitignore import GitIgnorePattern
 from twitter.common.collections import OrderedSet
 
-from pants.base.deprecated import deprecated
+from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.util.dirutil import fast_relpath
 from pants.util.meta import AbstractClass
@@ -106,6 +106,10 @@ class BuildFile(AbstractClass):
     :param build_ignore_patterns: .gitignore like patterns to exclude from BUILD files scan.
     :type build_ignore_patterns: pathspec.pathspec.PathSpec
     """
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use build_ignore_patterns instead.')
+
     if base_relpath and os.path.isabs(base_relpath):
       raise BuildFile.BadPathError('base_relpath parameter ({}) should be a relative path.'
                                    .format(base_relpath))

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -34,9 +34,6 @@ class BuildFile(AbstractClass):
   class BadPathError(BuildFileError):
     """Raised when scan_buildfiles is called on a nonexistent directory."""
 
-  class BadPantsBuildIgnore(Exception):
-    """Raised when pants_build_ignore is bad."""
-
   _BUILD_FILE_PREFIX = 'BUILD'
   _PATTERN = re.compile('^{prefix}(\.[a-zA-Z0-9_-]+)?$'.format(prefix=_BUILD_FILE_PREFIX))
 
@@ -75,14 +72,6 @@ class BuildFile(AbstractClass):
     return BuildFile._cached(cls._get_project_tree(root_dir), relpath, must_exist)
 
   @staticmethod
-  def validate_pants_build_ignore(pants_build_ignore):
-    """Validate passed paths for being pants_build_ignore."""
-    abs_ignore_paths = [path for path in pants_build_ignore if os.path.isabs(path)]
-    if any(abs_ignore_paths):
-      raise BuildFile.BadPantsBuildIgnore('All pants_build_ignore paths should be relative. '
-                                          'Absolute path {} was passed.'.format(abs_ignore_paths[0]))
-
-  @staticmethod
   def scan_build_files(project_tree, base_relpath, spec_excludes=None, pants_build_ignore=None):
     """Looks for all BUILD files
     :param project_tree: Project tree to scan in.
@@ -90,8 +79,7 @@ class BuildFile(AbstractClass):
     :param base_relpath: Directory under root_dir to scan.
     :param spec_excludes: List of paths to exclude from the scan.  These can be absolute paths
       or paths that are relative to the root_dir.
-    :param pants_build_ignore: List of paths to exclude from the scan.
-      Each path should be a relative to the build root.
+    :param pants_build_ignore: .gitignore like patterns to exclude from BUILD files scan.
     """
     def convert_to_gitignore_syntax(spec_excludes, build_root):
       for path in spec_excludes:
@@ -108,8 +96,6 @@ class BuildFile(AbstractClass):
     if base_relpath and not project_tree.isdir(base_relpath):
       raise BuildFile.BadPathError('Can only scan directories and {0} is not a valid dir.'
                                    .format(base_relpath))
-    if pants_build_ignore:
-      BuildFile.validate_pants_build_ignore(pants_build_ignore)
 
     ignore_patterns = set()
     if spec_excludes:

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -148,7 +148,7 @@ class CmdLineSpecParser(object):
             deprecated_conditional(lambda: True,
                                    '0.0.75',
                                    'Filtering broken BUILD files based on exclude_target_regexp is deprecated '
-                                   'and will be removed. Use build_file_ignore instead.')
+                                   'and will be removed. Use ignore_patterns instead.')
           else:
             if fail_fast:
               raise self.BadSpecError(e)

--- a/src/python/pants/base/cmd_line_spec_parser.py
+++ b/src/python/pants/base/cmd_line_spec_parser.py
@@ -15,6 +15,7 @@ import six
 from twitter.common.collections import OrderedSet, maybe_list
 
 from pants.base.build_file import BuildFile
+from pants.base.deprecated import deprecated_conditional
 from pants.build_graph.address_lookup_error import AddressLookupError
 
 
@@ -52,6 +53,10 @@ class CmdLineSpecParser(object):
     """Indicates an invalid command line address selector."""
 
   def __init__(self, root_dir, address_mapper, spec_excludes=None, exclude_target_regexps=None):
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use build_ignore_patterns in address_mapper instead.')
+
     self._root_dir = os.path.realpath(root_dir)
     self._address_mapper = address_mapper
     self._spec_excludes = spec_excludes

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -183,7 +183,7 @@ class GoalRunnerFactory(object):
     self._project_tree = self._get_project_tree(self._global_options.build_file_rev)
     self._build_file_parser = BuildFileParser(self._build_config, self._root_dir)
     self._address_mapper = BuildFileAddressMapper(self._build_file_parser, self._project_tree,
-                                                  self._global_options.pants_build_ignore)
+                                                  self._global_options.build_file_ignore)
     self._build_graph = BuildGraph(self._address_mapper)
     self._spec_parser = CmdLineSpecParser(
       self._root_dir,

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -182,7 +182,8 @@ class GoalRunnerFactory(object):
 
     self._project_tree = self._get_project_tree(self._global_options.build_file_rev)
     self._build_file_parser = BuildFileParser(self._build_config, self._root_dir)
-    self._address_mapper = BuildFileAddressMapper(self._build_file_parser, self._project_tree)
+    self._address_mapper = BuildFileAddressMapper(self._build_file_parser, self._project_tree,
+                                                  self._global_options.pants_build_ignore)
     self._build_graph = BuildGraph(self._address_mapper)
     self._spec_parser = CmdLineSpecParser(
       self._root_dir,

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -184,7 +184,7 @@ class GoalRunnerFactory(object):
 
     self._project_tree = self._get_project_tree(self._global_options.build_file_rev)
     self._build_file_parser = BuildFileParser(self._build_config, self._root_dir)
-    build_ignore_patterns = self._global_options.build_file_ignore or []
+    build_ignore_patterns = self._global_options.ignore_patterns or []
     build_ignore_patterns.extend(BuildFile._spec_excludes_to_gitignore_syntax(self._root_dir,
                                                                               self._global_options.spec_excludes))
     self._address_mapper = BuildFileAddressMapper(self._build_file_parser, self._project_tree, build_ignore_patterns)

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -63,6 +63,8 @@ class BuildFileAddressMapper(object):
       # If project_tree is BuildFile class actually.
       # TODO(tabishev): Remove after transition period.
       self._project_tree = project_tree._get_project_tree(self.root_dir)
+    if pants_build_ignore:
+      BuildFile.validate_pants_build_ignore(pants_build_ignore)
     self._pants_build_ignore = pants_build_ignore
 
   @property

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -7,6 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
+import pathspec
+from pathspec.gitignore import GitIgnorePattern
+
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.base.deprecated import deprecated
@@ -63,7 +66,10 @@ class BuildFileAddressMapper(object):
       # If project_tree is BuildFile class actually.
       # TODO(tabishev): Remove after transition period.
       self._project_tree = project_tree._get_project_tree(self.root_dir)
-    self._pants_build_ignore = pants_build_ignore
+    if pants_build_ignore:
+      self._pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore)
+    else:
+      self._pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, [])
 
   @property
   def root_dir(self):

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -184,7 +184,8 @@ class BuildFileAddressMapper(object):
     return self.scan_build_files(base_path, spec_excludes)
 
   def scan_build_files(self, base_path, spec_excludes):
-    return BuildFile.scan_build_files(self._project_tree, base_path, spec_excludes)
+    return BuildFile.scan_build_files(self._project_tree, base_path, spec_excludes,
+                                      pants_build_ignore=self._pants_build_ignore)
 
   def specs_to_addresses(self, specs, relative_to=''):
     """The equivalent of `spec_to_address` for a group of specs all relative to the same path.

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-import pathspec
+from pathspec import PathSpec
 from pathspec.gitignore import GitIgnorePattern
 
 from pants.base.build_environment import get_buildroot
@@ -66,7 +66,7 @@ class BuildFileAddressMapper(object):
       # If project_tree is BuildFile class actually.
       # TODO(tabishev): Remove after transition period.
       self._project_tree = project_tree._get_project_tree(self.root_dir)
-    self._pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
+    self._pants_build_ignore = PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
 
   @property
   def root_dir(self):

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -52,7 +52,7 @@ class BuildFileAddressMapper(object):
   class InvalidRootError(BuildFileScanError):
     """Indicates an invalid scan root was supplied."""
 
-  def __init__(self, build_file_parser, project_tree, pants_build_ignore=None):
+  def __init__(self, build_file_parser, project_tree, build_ignore_patterns=None):
     """Create a BuildFileAddressMapper.
 
     :param build_file_parser: An instance of BuildFileParser
@@ -66,7 +66,7 @@ class BuildFileAddressMapper(object):
       # If project_tree is BuildFile class actually.
       # TODO(tabishev): Remove after transition period.
       self._project_tree = project_tree._get_project_tree(self.root_dir)
-    self._pants_build_ignore = PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
+    self._build_ignore_patterns = PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns or [])
 
   @property
   def root_dir(self):
@@ -134,7 +134,7 @@ class BuildFileAddressMapper(object):
     if spec_path not in self._spec_path_to_address_map_map:
       try:
         build_files = list(BuildFile.get_build_files_family(self._project_tree, spec_path,
-                                                            self._pants_build_ignore))
+                                                            self._build_ignore_patterns))
         if not build_files:
           raise self.BuildFileScanError("{spec_path} does not contain any BUILD files."
                                         .format(spec_path=os.path.join(self.root_dir, spec_path)))
@@ -188,7 +188,7 @@ class BuildFileAddressMapper(object):
 
   def scan_build_files(self, base_path, spec_excludes):
     return BuildFile.scan_build_files(self._project_tree, base_path, spec_excludes,
-                                      pants_build_ignore=self._pants_build_ignore)
+                                      build_ignore_patterns=self._build_ignore_patterns)
 
   def specs_to_addresses(self, specs, relative_to=''):
     """The equivalent of `spec_to_address` for a group of specs all relative to the same path.
@@ -220,7 +220,7 @@ class BuildFileAddressMapper(object):
       for build_file in BuildFile.scan_build_files(self._project_tree,
                                                    base_relpath=base_path,
                                                    spec_excludes=spec_excludes,
-                                                   pants_build_ignore=self._pants_build_ignore):
+                                                   build_ignore_patterns=self._build_ignore_patterns):
         for address in self.addresses_in_spec_path(build_file.spec_path):
           addresses.add(address)
     except BuildFile.BuildFileError as e:

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -12,7 +12,7 @@ from pathspec.gitignore import GitIgnorePattern
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
-from pants.base.deprecated import deprecated
+from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.base.project_tree import ProjectTree
 from pants.build_graph.address import Address, parse_spec
 from pants.build_graph.address_lookup_error import AddressLookupError
@@ -186,7 +186,10 @@ class BuildFileAddressMapper(object):
     """
     return self.scan_build_files(base_path, spec_excludes)
 
-  def scan_build_files(self, base_path, spec_excludes):
+  def scan_build_files(self, base_path, spec_excludes=None):
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use build_ignore_patterns consturctor parameter instead.')
     return BuildFile.scan_build_files(self._project_tree, base_path, spec_excludes,
                                       build_ignore_patterns=self._build_ignore_patterns)
 
@@ -206,6 +209,10 @@ class BuildFileAddressMapper(object):
     :rtype: set of :class:`pants.build_graph.address.Address`
     :raises AddressLookupError: if there is a problem parsing a BUILD file
     """
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use build_ignore_patterns constructor parameter instead.')
+
     root_dir = get_buildroot()
     base_path = None
 

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -63,8 +63,6 @@ class BuildFileAddressMapper(object):
       # If project_tree is BuildFile class actually.
       # TODO(tabishev): Remove after transition period.
       self._project_tree = project_tree._get_project_tree(self.root_dir)
-    if pants_build_ignore:
-      BuildFile.validate_pants_build_ignore(pants_build_ignore)
     self._pants_build_ignore = pants_build_ignore
 
   @property

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -66,10 +66,7 @@ class BuildFileAddressMapper(object):
       # If project_tree is BuildFile class actually.
       # TODO(tabishev): Remove after transition period.
       self._project_tree = project_tree._get_project_tree(self.root_dir)
-    if pants_build_ignore:
-      self._pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore)
-    else:
-      self._pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, [])
+    self._pants_build_ignore = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
 
   @property
   def root_dir(self):

--- a/src/python/pants/core_tasks/what_changed.py
+++ b/src/python/pants/core_tasks/what_changed.py
@@ -20,7 +20,8 @@ class WhatChanged(ChangedFileTaskMixin, ConsoleTask):
              help='Show changed files instead of the targets that own them.')
 
   def console_output(self, _):
-    spec_excludes = self.get_options().spec_excludes
+    # Will be provided through context.address_mapper.build_ignore_patterns.
+    spec_excludes = None
     change_calculator = self.change_calculator(self.get_options(),
                                                self.context.address_mapper,
                                                self.context.build_graph,

--- a/src/python/pants/engine/exp/legacy/commands.py
+++ b/src/python/pants/engine/exp/legacy/commands.py
@@ -53,6 +53,7 @@ def list():
                                           per_path_symbol_factory=per_path_symbol_factory)
   mapper = AddressMapper(build_root, parser=parser)
 
-  spec_excludes = options.for_global_scope().spec_excludes
+  # Should use build_ignore_patterns instead.
+  spec_excludes = None
   for address, obj in mapper.walk_addressables(path_excludes=spec_excludes):
     print(address.spec)

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_scm
+from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.build_graph import BuildGraph
@@ -61,6 +62,10 @@ class Context(object):
                requested_goals=None, target_base=None, build_graph=None,
                build_file_parser=None, address_mapper=None, console_outstream=None, scm=None,
                workspace=None, spec_excludes=None, invalidation_report=None):
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use address_mapper#build_ignore_patterns instead.')
+
     self._options = options
     self.build_graph = build_graph
     self.build_file_parser = build_file_parser
@@ -127,6 +132,7 @@ class Context(object):
     return self._workspace
 
   @property
+  @deprecated('0.0.75')
   def spec_excludes(self):
     return self._spec_excludes
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -137,11 +137,11 @@ class GlobalOptionsRegistrar(Optionable):
              deprecated_hint='Use --build-file-ignore instead.', deprecated_version='0.0.75',
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
-    register('--build-file-ignore', advanced=True, action='append',
+    register('--build-file-ignore', advanced=True, action='append', fromfile=True,
              default=['.*'],
-             help='Ignore these paths when reading BUILD files. Useful to to avoid descending into '
-                  'unneeded directories. Default stands for all files and directories starting with a dot. '
-                  'Syntax is the same as .gitignore which can be checked at https://git-scm.com/docs/gitignore.')
+             help='Patterns for ignoring files when reading BUILD files. '
+                  'Use to ignore unneeded directories or BUILD files. '
+                  'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')
     register('--fail-fast', advanced=True, action='store_true', recursive=True,
              help='Exit as quickly as possible on error, rather than attempting to continue '
                   'to process the non-erroneous subset of the input.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -137,10 +137,10 @@ class GlobalOptionsRegistrar(Optionable):
              default=[register.bootstrap.pants_workdir],
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
-    register('--pants-build-ignore', advanced=True, action='append',
+    register('--build-file-ignore', advanced=True, action='append',
              default=['.*'],
              help='Ignore these paths when reading BUILD files. Useful to to avoid descending into '
-                  'unneeded directories. Default stands for all files and directories starting from dot. '
+                  'unneeded directories. Default stands for all files and directories starting with a dot. '
                   'Syntax is the same as .gitignore which can be checked at https://git-scm.com/docs/gitignore.')
     register('--fail-fast', advanced=True, action='store_true', recursive=True,
              help='Exit as quickly as possible on error, rather than attempting to continue '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -138,7 +138,7 @@ class GlobalOptionsRegistrar(Optionable):
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
     register('--pants-build-ignore', advanced=True, action='append',
-             default=[register.bootstrap.pants_workdir],
+             default=['.*'],
              help='Ignore these paths when reading BUILD files. Useful to to avoid descending into '
                   'unneeded directories. Syntax is similar to .gitignore.')
     register('--fail-fast', advanced=True, action='store_true', recursive=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -137,6 +137,10 @@ class GlobalOptionsRegistrar(Optionable):
              default=[register.bootstrap.pants_workdir],
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
+    register('--pants-build-ignore', advanced=True, action='append',
+             default=[register.bootstrap.pants_workdir],
+             help='Ignore these paths when reading BUILD files. Useful to to avoid descending into '
+                  'unneeded directories. Syntax is similar to .gitignore.')
     register('--fail-fast', advanced=True, action='store_true', recursive=True,
              help='Exit as quickly as possible on error, rather than attempting to continue '
                   'to process the non-erroneous subset of the input.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -137,7 +137,7 @@ class GlobalOptionsRegistrar(Optionable):
              deprecated_hint='Use --build-file-ignore instead.', deprecated_version='0.0.75',
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
-    register('--build-file-ignore', advanced=True, action='append', fromfile=True,
+    register('--ignore-patterns', advanced=True, action='append', fromfile=True,
              default=['.*'],
              help='Patterns for ignoring files when reading BUILD files. '
                   'Use to ignore unneeded directories or BUILD files. '

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -140,7 +140,7 @@ class GlobalOptionsRegistrar(Optionable):
     register('--pants-build-ignore', advanced=True, action='append',
              default=['.*'],
              help='Ignore these paths when reading BUILD files. Useful to to avoid descending into '
-                  'unneeded directories. Syntax is similar to .gitignore.')
+                  'unneeded directories. Syntax is the same as .gitignore.')
     register('--fail-fast', advanced=True, action='store_true', recursive=True,
              help='Exit as quickly as possible on error, rather than attempting to continue '
                   'to process the non-erroneous subset of the input.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -140,7 +140,8 @@ class GlobalOptionsRegistrar(Optionable):
     register('--pants-build-ignore', advanced=True, action='append',
              default=['.*'],
              help='Ignore these paths when reading BUILD files. Useful to to avoid descending into '
-                  'unneeded directories. Syntax is the same as .gitignore.')
+                  'unneeded directories. Default stands for all files and directories starting from dot. '
+                  'Syntax is the same as .gitignore which can be checked at https://git-scm.com/docs/gitignore.')
     register('--fail-fast', advanced=True, action='store_true', recursive=True,
              help='Exit as quickly as possible on error, rather than attempting to continue '
                   'to process the non-erroneous subset of the input.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -134,6 +134,7 @@ class GlobalOptionsRegistrar(Optionable):
              recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
     register('--spec-excludes', advanced=True, action='append',
              default=[register.bootstrap.pants_workdir],
+             deprecated_hint='Use --build-file-ignore instead.', deprecated_version='0.0.75',
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
     register('--build-file-ignore', advanced=True, action='append',

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -130,8 +130,7 @@ class GlobalOptionsRegistrar(Optionable):
                   "are used.  Multiple constraints may be added.  They will be ORed together.")
     register('--exclude-target-regexp', advanced=True, action='append', default=[],
              metavar='<regexp>',
-             help='Exclude targets that match these regexes. Useful with ::, to ignore broken '
-                  'BUILD files.',
+             help='Exclude targets that match these regexes.',
              recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
     register('--spec-excludes', advanced=True, action='append',
              default=[register.bootstrap.pants_workdir],

--- a/src/python/pants/task/changed_file_task_mixin.py
+++ b/src/python/pants/task/changed_file_task_mixin.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import re
 
 from pants.base.build_environment import get_scm
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.build_graph.source_mapper import SpecSourceMapper
 from pants.goal.workspace import ScmWorkspace
@@ -27,6 +28,9 @@ class ChangeCalculator(object):
                diffspec=None,
                exclude_target_regexp=None,
                spec_excludes=None):
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use address_mapper#build_ignore_patterns instead.')
 
     self._scm = scm
     self._workspace = workspace
@@ -130,6 +134,10 @@ class ChangedFileTaskMixin(object):
 
   @classmethod
   def change_calculator(cls, options, address_mapper, build_graph, scm=None, workspace=None, spec_excludes=None):
+    deprecated_conditional(lambda: spec_excludes is not None,
+                           '0.0.75',
+                           'Use address_mapper#build_ignore_patterns instead.')
+
     scm = scm or get_scm()
     if scm is None:
       raise TaskError('No SCM available.')

--- a/src/python/pants/task/changed_target_task.py
+++ b/src/python/pants/task/changed_target_task.py
@@ -47,7 +47,8 @@ class ChangedTargetTask(ChangedFileTaskMixin, NoopExecTask):
       options,
       address_mapper,
       build_graph,
-      spec_excludes=options.spec_excludes,
+      # Will be provided through address_mapper.build_ignore_patterns.
+      spec_excludes=None,
     )
     changed_addresses = change_calculator.changed_target_addresses()
     readable = ''.join(sorted('\n\t* {}'.format(addr.reference()) for addr in changed_addresses))

--- a/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
@@ -231,7 +231,7 @@ class ReverseDepmapTest(BaseReverseDepmapTest):
        targets=[self.target('resources/a:a_resources')]
     )
 
-  def test_overlaps_without_pants_build_ignore(self):
+  def test_overlaps_without_build_ignore_patterns(self):
     self.assert_console_output(
       'overlaps:one',
       'overlaps:two',
@@ -242,11 +242,11 @@ class ReverseDepmapTest(BaseReverseDepmapTest):
 
 class ReverseDepmapTestWithPantsBuildIgnore(BaseReverseDepmapTest):
   @property
-  def pants_build_ignore(self):
+  def build_ignore_patterns(self):
     return ['overlaps']
 
-  def test_overlaps_with_pants_build_ignore(self):
+  def test_overlaps_with_build_ignore_patterns(self):
     self.assert_console_output(
       targets=[self.target('common/a')],
-      options={'pants_build_ignore': ['overlaps']}
+      options={'build_ignore_patterns': ['overlaps']}
     )

--- a/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
@@ -246,7 +246,4 @@ class ReverseDepmapTestWithPantsBuildIgnore(BaseReverseDepmapTest):
     return ['overlaps']
 
   def test_overlaps_with_build_ignore_patterns(self):
-    self.assert_console_output(
-      targets=[self.target('common/a')],
-      options={'build_ignore_patterns': ['overlaps']}
-    )
+    self.assert_console_output(targets=[self.target('common/a')])

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -158,8 +158,17 @@ python_tests(
 )
 
 python_tests(
-  name = 'test_spec_exclude_integration',
-  sources = [ 'test_spec_exclude_integration.py' ],
+  name = 'bundle_integration',
+  sources = [ 'test_bundle_integration.py' ],
+  dependencies = [
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
+  name = 'pants_build_ignore_pants_ini_integration',
+  sources = [ 'test_pants_build_ignore_pants_ini_integration.py' ],
   dependencies = [
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -167,8 +167,8 @@ python_tests(
 )
 
 python_tests(
-  name = 'pants_build_ignore_pants_ini_integration',
-  sources = [ 'test_pants_build_ignore_pants_ini_integration.py' ],
+  name = 'ignore_patterns_pants_ini_integration',
+  sources = [ 'test_ignore_patterns_pants_ini_integration.py' ],
   dependencies = [
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -27,18 +27,22 @@ class BuildFileTestBase(unittest.TestCase):
   def touch(self, path):
     touch(self.fullpath(path))
 
-  def scan_buildfiles(self, base_relpath, pants_build_ignore=None):
+  def create_ignore_spec(self, pants_build_ignore):
     if pants_build_ignore is not None:
-      spec = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore)
+      return pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore)
     else:
-      spec = pathspec.PathSpec.from_lines(GitIgnorePattern, [])
-    return BuildFile.scan_build_files(self._project_tree, base_relpath, pants_build_ignore=spec)
+      return pathspec.PathSpec.from_lines(GitIgnorePattern, [])
+
+  def scan_buildfiles(self, base_relpath, pants_build_ignore=None):
+    return BuildFile.scan_build_files(self._project_tree, base_relpath,
+                                      pants_build_ignore=self.create_ignore_spec(pants_build_ignore))
 
   def create_buildfile(self, relpath):
     return BuildFile(self._project_tree, relpath)
 
   def get_build_files_family(self, relpath, pants_build_ignore=None):
-    return BuildFile.get_build_files_family(self._project_tree, relpath, pants_build_ignore)
+    return BuildFile.get_build_files_family(self._project_tree, relpath,
+                                            pants_build_ignore=self.create_ignore_spec(pants_build_ignore))
 
   def setUp(self):
     self.base_dir = tempfile.mkdtemp()

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -24,8 +24,9 @@ class BuildFileTestBase(unittest.TestCase):
   def touch(self, path):
     touch(self.fullpath(path))
 
-  def scan_buildfiles(self, base_relpath, spec_excludes=None, pants_build_ignore=None):
-    return BuildFile.scan_build_files(self._project_tree, base_relpath, spec_excludes, pants_build_ignore)
+  def scan_buildfiles(self, base_relpath, pants_build_ignore=None):
+    return BuildFile.scan_build_files(self._project_tree, base_relpath,
+                                      pants_build_ignore=pants_build_ignore)
 
   def create_buildfile(self, relpath):
     return BuildFile(self._project_tree, relpath)

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -10,6 +10,9 @@ import shutil
 import tempfile
 import unittest
 
+import pathspec
+from pathspec.gitignore import GitIgnorePattern
+
 from pants.base.build_file import BuildFile
 from pants.util.dirutil import safe_mkdir, touch
 
@@ -25,8 +28,11 @@ class BuildFileTestBase(unittest.TestCase):
     touch(self.fullpath(path))
 
   def scan_buildfiles(self, base_relpath, pants_build_ignore=None):
-    return BuildFile.scan_build_files(self._project_tree, base_relpath,
-                                      pants_build_ignore=pants_build_ignore)
+    if pants_build_ignore is not None:
+      spec = pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore)
+    else:
+      spec = pathspec.PathSpec.from_lines(GitIgnorePattern, [])
+    return BuildFile.scan_build_files(self._project_tree, base_relpath, pants_build_ignore=spec)
 
   def create_buildfile(self, relpath):
     return BuildFile(self._project_tree, relpath)

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -27,19 +27,19 @@ class BuildFileTestBase(unittest.TestCase):
   def touch(self, path):
     touch(self.fullpath(path))
 
-  def _create_ignore_spec(self, pants_build_ignore):
-    return PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
+  def _create_ignore_spec(self, build_ignore_patterns):
+    return PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns or [])
 
-  def scan_buildfiles(self, base_relpath, pants_build_ignore=None):
+  def scan_buildfiles(self, base_relpath, build_ignore_patterns=None):
     return BuildFile.scan_build_files(self._project_tree, base_relpath,
-                                      pants_build_ignore=self._create_ignore_spec(pants_build_ignore))
+                                      build_ignore_patterns=self._create_ignore_spec(build_ignore_patterns))
 
   def create_buildfile(self, relpath):
     return BuildFile(self._project_tree, relpath)
 
-  def get_build_files_family(self, relpath, pants_build_ignore=None):
+  def get_build_files_family(self, relpath, build_ignore_patterns=None):
     return BuildFile.get_build_files_family(self._project_tree, relpath,
-                                            pants_build_ignore=self._create_ignore_spec(pants_build_ignore))
+                                            build_ignore_patterns=self._create_ignore_spec(build_ignore_patterns))
 
   def setUp(self):
     self.base_dir = tempfile.mkdtemp()

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -10,7 +10,7 @@ import shutil
 import tempfile
 import unittest
 
-import pathspec
+from pathspec import PathSpec
 from pathspec.gitignore import GitIgnorePattern
 
 from pants.base.build_file import BuildFile
@@ -28,7 +28,7 @@ class BuildFileTestBase(unittest.TestCase):
     touch(self.fullpath(path))
 
   def _create_ignore_spec(self, pants_build_ignore):
-    return pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
+    return PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
 
   def scan_buildfiles(self, base_relpath, pants_build_ignore=None):
     return BuildFile.scan_build_files(self._project_tree, base_relpath,

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -27,22 +27,19 @@ class BuildFileTestBase(unittest.TestCase):
   def touch(self, path):
     touch(self.fullpath(path))
 
-  def create_ignore_spec(self, pants_build_ignore):
-    if pants_build_ignore is not None:
-      return pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore)
-    else:
-      return pathspec.PathSpec.from_lines(GitIgnorePattern, [])
+  def _create_ignore_spec(self, pants_build_ignore):
+    return pathspec.PathSpec.from_lines(GitIgnorePattern, pants_build_ignore or [])
 
   def scan_buildfiles(self, base_relpath, pants_build_ignore=None):
     return BuildFile.scan_build_files(self._project_tree, base_relpath,
-                                      pants_build_ignore=self.create_ignore_spec(pants_build_ignore))
+                                      pants_build_ignore=self._create_ignore_spec(pants_build_ignore))
 
   def create_buildfile(self, relpath):
     return BuildFile(self._project_tree, relpath)
 
   def get_build_files_family(self, relpath, pants_build_ignore=None):
     return BuildFile.get_build_files_family(self._project_tree, relpath,
-                                            pants_build_ignore=self.create_ignore_spec(pants_build_ignore))
+                                            pants_build_ignore=self._create_ignore_spec(pants_build_ignore))
 
   def setUp(self):
     self.base_dir = tempfile.mkdtemp()

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -24,14 +24,14 @@ class BuildFileTestBase(unittest.TestCase):
   def touch(self, path):
     touch(self.fullpath(path))
 
-  def scan_buildfiles(self, base_relpath, spec_excludes=None):
-    return BuildFile.scan_build_files(self._project_tree, base_relpath, spec_excludes)
+  def scan_buildfiles(self, base_relpath, spec_excludes=None, pants_build_ignore=None):
+    return BuildFile.scan_build_files(self._project_tree, base_relpath, spec_excludes, pants_build_ignore)
 
   def create_buildfile(self, relpath):
     return BuildFile(self._project_tree, relpath)
 
-  def get_build_files_family(self, relpath):
-    return BuildFile.get_build_files_family(self._project_tree, relpath)
+  def get_build_files_family(self, relpath, pants_build_ignore=None):
+    return BuildFile.get_build_files_family(self._project_tree, relpath, pants_build_ignore)
 
   def setUp(self):
     self.base_dir = tempfile.mkdtemp()

--- a/tests/python/pants_test/base/test_bundle_integration.py
+++ b/tests/python/pants_test/base/test_bundle_integration.py
@@ -47,7 +47,7 @@ class Bundles(object):
   all_bundles = [lesser_of_two, once_upon_a_time, ten_thousand, there_was_a_duck]
 
 
-class SpecExcludeIntegrationTest(PantsRunIntegrationTest):
+class BundleIntegrationTest(PantsRunIntegrationTest):
   """Tests the functionality of the --spec-exclude flag in pants."""
 
   def _bundle_path(self, bundle):
@@ -139,53 +139,3 @@ class SpecExcludeIntegrationTest(PantsRunIntegrationTest):
         ],
         set(Bundles.all_bundles) - set([Bundles.there_was_a_duck, Bundles.once_upon_a_time]),
     )
-
-
-class SpecExcludePantsIniIntegrationTest(PantsRunIntegrationTest):
-  """Tests the functionality of the exclude_specs option in pants.ini ."""
-
-  def test_exclude_spec_pants_ini(self):
-    def output_to_list(output_filename):
-      with open(output_filename, 'r') as results_file:
-        return set([line.rstrip() for line in results_file.readlines()])
-
-    tempdir = tempfile.mkdtemp()
-    tmp_output = os.path.join(tempdir, 'minimize-output1.txt')
-    run_result = self.run_pants(['minimize',
-                                 'testprojects::',
-                                 '--quiet',
-                                 '--minimize-output-file={0}'.format(tmp_output)])
-    self.assert_success(run_result)
-    results = output_to_list(tmp_output)
-    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:ten-thousand',
-                  results)
-    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:once-upon-a-time',
-                  results)
-    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:lesser-of-two',
-                  results)
-    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:there-was-a-duck',
-                  results)
-
-    tmp_output = os.path.join(tempdir, 'minimize-output2.txt')
-
-    run_result = self.run_pants(['minimize',
-                                 'testprojects::',
-                                 '--quiet',
-                                 '--minimize-output-file={0}'.format(tmp_output)],
-                                config={
-                                    'DEFAULT': {
-                                        'spec_excludes': [
-                                            'testprojects/src/java/org/pantsbuild/testproject/phrases'
-                                        ]
-                                    }
-                                })
-    self.assert_success(run_result)
-    results = output_to_list(tmp_output)
-    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:ten-thousand',
-                     results)
-    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:once-upon-a-time',
-                     results)
-    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:lesser-of-two',
-                     results)
-    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:there-was-a-duck',
-                     results)

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -139,18 +139,10 @@ class CmdLineSpecParserTest(BaseTest):
     with self.assertRaises(CmdLineSpecParser.BadSpecError):
       self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
 
-    # Test relative path in pants_build_ignore.
     address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree,
                                                         pants_build_ignore=['some'])
     self.spec_parser = CmdLineSpecParser(self.build_root, address_mapper_with_ignore)
     self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
-
-    # Test absolute path in pants_build_ignore.
-    with self.assertRaises(BuildFile.BadPantsBuildIgnore):
-      address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree,
-                                                          pants_build_ignore=[os.path.join(self.build_root, 'some')])
-      self.spec_parser = CmdLineSpecParser(self.build_root, address_mapper_with_ignore)
-      self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
 
   def test_exclude_target_regexps(self):
     expected_specs = [':root', 'a', 'a:b', 'a/b', 'a/b:c']

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
+from pants.base.build_file import BuildFile
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_address_mapper import BuildFileAddressMapper
@@ -145,11 +146,10 @@ class CmdLineSpecParserTest(BaseTest):
     self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
 
     # Test absolute path in pants_build_ignore.
-    address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree,
-                                                        pants_build_ignore=[os.path.join(self.build_root, 'some')])
-    self.spec_parser = CmdLineSpecParser(self.build_root, address_mapper_with_ignore)
-    with self.assertRaisesRegexp(Exception, 'All pants_build_ignore paths passed to scan_build_files '
-                                            'should be relative.'):
+    with self.assertRaises(BuildFile.BadPantsBuildIgnore):
+      address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree,
+                                                          pants_build_ignore=[os.path.join(self.build_root, 'some')])
+      self.spec_parser = CmdLineSpecParser(self.build_root, address_mapper_with_ignore)
       self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
 
   def test_exclude_target_regexps(self):

--- a/tests/python/pants_test/base/test_cmd_line_spec_parser.py
+++ b/tests/python/pants_test/base/test_cmd_line_spec_parser.py
@@ -131,7 +131,7 @@ class CmdLineSpecParserTest(BaseTest):
     self.assertEqual(sort(Address.parse(addr) for addr in expected),
                      sort(self.spec_parser.parse_addresses(cmdline_spec_list)))
 
-  def test_pants_build_ignore(self):
+  def test_build_ignore_patterns(self):
     expected_specs = [':root', 'a', 'a:b', 'a/b', 'a/b:c']
 
     # This bogus BUILD file gets in the way of parsing.
@@ -140,7 +140,7 @@ class CmdLineSpecParserTest(BaseTest):
       self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
 
     address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree,
-                                                        pants_build_ignore=['some'])
+                                                        build_ignore_patterns=['some'])
     self.spec_parser = CmdLineSpecParser(self.build_root, address_mapper_with_ignore)
     self.assert_parsed_list(cmdline_spec_list=['::'], expected=expected_specs)
 

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -75,10 +75,18 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       ]), buildfiles)
 
   def test_build_files_scan_with_abspath_ignore(self):
-    with self.assertRaises(BuildFile.BadPantsBuildIgnore):
-      self.scan_buildfiles('', pants_build_ignore=[
-        os.path.join(self.root_dir, 'grandparent/parent/child1'),
-        os.path.join(self.root_dir, 'grandparent/parent/child2')])
+    self.touch('parent/BUILD')
+    self.assertEquals(OrderedSet([
+      self.create_buildfile('BUILD'),
+      self.create_buildfile('BUILD.twitter'),
+      self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/BUILD.twitter'),
+      self.create_buildfile('grandparent/parent/child1/BUILD'),
+      self.create_buildfile('grandparent/parent/child1/BUILD.twitter'),
+      self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
+      self.create_buildfile('grandparent/parent/child5/BUILD'),
+      self.create_buildfile('issue_1742/BUILD.sibling'),
+    ]), self.scan_buildfiles('', pants_build_ignore=['/parent']))
 
   def test_build_files_scan_with_wildcard_ignore(self):
     self.assertEquals(OrderedSet([

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -53,8 +53,8 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         self.create_buildfile('grandparent/parent/child5/BUILD'),
     ]), self.scan_buildfiles('grandparent/parent'))
 
-  def test_build_files_scan_with_relpath_excludes(self):
-    buildfiles = self.scan_buildfiles('', spec_excludes=[
+  def test_build_files_scan_with_relpath_ignore(self):
+    buildfiles = self.scan_buildfiles('', pants_build_ignore=[
         'grandparent/parent/child1',
         'grandparent/parent/child2'])
     self.assertEquals(OrderedSet([
@@ -66,7 +66,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         self.create_buildfile('issue_1742/BUILD.sibling'),
     ]), buildfiles)
 
-    buildfiles = self.scan_buildfiles('grandparent/parent', spec_excludes=['grandparent/parent/child1'])
+    buildfiles = self.scan_buildfiles('grandparent/parent', pants_build_ignore=['grandparent/parent/child1'])
     self.assertEquals(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
         self.create_buildfile('grandparent/parent/BUILD.twitter'),
@@ -74,19 +74,12 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         self.create_buildfile('grandparent/parent/child5/BUILD'),
       ]), buildfiles)
 
-  def test_build_files_scan_with_abspath_excludes(self):
-    buildfiles = self.scan_buildfiles('', spec_excludes=[
+  def test_build_files_scan_with_abspath_ignore(self):
+    with self.assertRaisesRegexp(Exception, 'All pants_build_ignore paths passed to scan_build_files '
+                                            'should be relative.'):
+      self.scan_buildfiles('', pants_build_ignore=[
         os.path.join(self.root_dir, 'grandparent/parent/child1'),
         os.path.join(self.root_dir, 'grandparent/parent/child2')])
-
-    self.assertEquals(OrderedSet([
-        self.create_buildfile('BUILD'),
-        self.create_buildfile('BUILD.twitter'),
-        self.create_buildfile('grandparent/parent/BUILD'),
-        self.create_buildfile('grandparent/parent/BUILD.twitter'),
-        self.create_buildfile('grandparent/parent/child5/BUILD'),
-        self.create_buildfile('issue_1742/BUILD.sibling'),
-    ]), buildfiles)
 
   def test_must_exist_true(self):
     with self.assertRaises(BuildFile.MissingBuildFileError):

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -75,8 +75,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       ]), buildfiles)
 
   def test_build_files_scan_with_abspath_ignore(self):
-    with self.assertRaisesRegexp(Exception, 'All pants_build_ignore paths passed to scan_build_files '
-                                            'should be relative.'):
+    with self.assertRaises(BuildFile.BadPantsBuildIgnore):
       self.scan_buildfiles('', pants_build_ignore=[
         os.path.join(self.root_dir, 'grandparent/parent/child1'),
         os.path.join(self.root_dir, 'grandparent/parent/child2')])

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -80,6 +80,53 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         os.path.join(self.root_dir, 'grandparent/parent/child1'),
         os.path.join(self.root_dir, 'grandparent/parent/child2')])
 
+  def test_build_files_scan_with_wildcard_ignore(self):
+    self.assertEquals(OrderedSet([
+      self.create_buildfile('BUILD'),
+      self.create_buildfile('BUILD.twitter'),
+      self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('issue_1742/BUILD.sibling'),
+    ]), self.scan_buildfiles('', pants_build_ignore=['child*']))
+
+  def test_build_files_scan_with_build_file_ignore(self):
+    self.assertEquals(OrderedSet([
+      self.create_buildfile('BUILD'),
+      self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/child1/BUILD'),
+      self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
+      self.create_buildfile('grandparent/parent/child5/BUILD'),
+      self.create_buildfile('issue_1742/BUILD.sibling'),
+    ]), self.scan_buildfiles('', pants_build_ignore=['BUILD.twitter']))
+
+  def test_subdir_ignore(self):
+    self.touch('grandparent/child1/BUILD')
+
+    self.assertEquals(OrderedSet([
+      self.create_buildfile('BUILD'),
+      self.create_buildfile('BUILD.twitter'),
+      self.create_buildfile('grandparent/child1/BUILD'),
+      self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
+      self.create_buildfile('grandparent/parent/child5/BUILD'),
+      self.create_buildfile('issue_1742/BUILD.sibling'),
+    ]), self.scan_buildfiles('', pants_build_ignore=['parent/child1']))
+
+  def test_subdir_file_pattern_ignore(self):
+    self.assertEquals(OrderedSet([
+      self.create_buildfile('BUILD'),
+      self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/child1/BUILD'),
+      self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
+      self.create_buildfile('grandparent/parent/child5/BUILD'),
+    ]), self.scan_buildfiles('', pants_build_ignore=['BUILD.*']))
+
+  def test_build_files_scan_with_non_default_relpath_ignore(self):
+    self.assertEquals(OrderedSet([
+      self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
+      self.create_buildfile('grandparent/parent/child5/BUILD'),
+    ]), self.scan_buildfiles('grandparent/parent', pants_build_ignore=['parent/child1']))
+
   def test_must_exist_true(self):
     with self.assertRaises(BuildFile.MissingBuildFileError):
       self.create_buildfile("path-that-does-not-exist/BUILD")

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -46,7 +46,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
   def test_build_files_family_lookup_with_ignore(self):
     self.assertEquals(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
-    ]), self.get_build_files_family('grandparent/parent', pants_build_ignore=['*.twitter']))
+    ]), self.get_build_files_family('grandparent/parent', build_ignore_patterns=['*.twitter']))
 
   def test_build_files_scan(self):
     self.assertEquals(OrderedSet([
@@ -59,7 +59,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     ]), self.scan_buildfiles('grandparent/parent'))
 
   def test_build_files_scan_with_relpath_ignore(self):
-    buildfiles = self.scan_buildfiles('', pants_build_ignore=[
+    buildfiles = self.scan_buildfiles('', build_ignore_patterns=[
         'grandparent/parent/child1',
         'grandparent/parent/child2'])
     self.assertEquals(OrderedSet([
@@ -71,7 +71,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
         self.create_buildfile('issue_1742/BUILD.sibling'),
     ]), buildfiles)
 
-    buildfiles = self.scan_buildfiles('grandparent/parent', pants_build_ignore=['grandparent/parent/child1'])
+    buildfiles = self.scan_buildfiles('grandparent/parent', build_ignore_patterns=['grandparent/parent/child1'])
     self.assertEquals(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),
         self.create_buildfile('grandparent/parent/BUILD.twitter'),
@@ -91,7 +91,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
       self.create_buildfile('grandparent/parent/child5/BUILD'),
       self.create_buildfile('issue_1742/BUILD.sibling'),
-    ]), self.scan_buildfiles('', pants_build_ignore=['/parent']))
+    ]), self.scan_buildfiles('', build_ignore_patterns=['/parent']))
 
   def test_build_files_scan_with_wildcard_ignore(self):
     self.assertEquals(OrderedSet([
@@ -100,7 +100,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('grandparent/parent/BUILD'),
       self.create_buildfile('grandparent/parent/BUILD.twitter'),
       self.create_buildfile('issue_1742/BUILD.sibling'),
-    ]), self.scan_buildfiles('', pants_build_ignore=['**/child*']))
+    ]), self.scan_buildfiles('', build_ignore_patterns=['**/child*']))
 
   def test_build_files_scan_with_build_file_ignore(self):
     self.assertEquals(OrderedSet([
@@ -110,7 +110,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
       self.create_buildfile('grandparent/parent/child5/BUILD'),
       self.create_buildfile('issue_1742/BUILD.sibling'),
-    ]), self.scan_buildfiles('', pants_build_ignore=['BUILD.twitter']))
+    ]), self.scan_buildfiles('', build_ignore_patterns=['BUILD.twitter']))
 
   def test_subdir_ignore(self):
     self.touch('grandparent/child1/BUILD')
@@ -124,7 +124,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
       self.create_buildfile('grandparent/parent/child5/BUILD'),
       self.create_buildfile('issue_1742/BUILD.sibling'),
-    ]), self.scan_buildfiles('', pants_build_ignore=['**/parent/child1']))
+    ]), self.scan_buildfiles('', build_ignore_patterns=['**/parent/child1']))
 
   def test_subdir_file_pattern_ignore(self):
     self.assertEquals(OrderedSet([
@@ -133,7 +133,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('grandparent/parent/child1/BUILD'),
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
       self.create_buildfile('grandparent/parent/child5/BUILD'),
-    ]), self.scan_buildfiles('', pants_build_ignore=['BUILD.*']))
+    ]), self.scan_buildfiles('', build_ignore_patterns=['BUILD.*']))
 
   def test_build_files_scan_with_non_default_relpath_ignore(self):
     self.assertEquals(OrderedSet([
@@ -141,7 +141,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('grandparent/parent/BUILD.twitter'),
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
       self.create_buildfile('grandparent/parent/child5/BUILD'),
-    ]), self.scan_buildfiles('grandparent/parent', pants_build_ignore=['**/parent/child1']))
+    ]), self.scan_buildfiles('grandparent/parent', build_ignore_patterns=['**/parent/child1']))
 
   def test_must_exist_true(self):
     with self.assertRaises(BuildFile.MissingBuildFileError):

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -43,6 +43,11 @@ class FilesystemBuildFileTest(BuildFileTestBase):
     buildfile = self.create_buildfile('grandparent/parent/child2/child3/BUILD')
     self.assertEquals(OrderedSet([buildfile]), self.get_build_files_family('grandparent/parent/child2/child3'))
 
+  def test_build_files_family_lookup_with_ignore(self):
+    self.assertEquals(OrderedSet([
+        self.create_buildfile('grandparent/parent/BUILD'),
+    ]), self.get_build_files_family('grandparent/parent', pants_build_ignore=['*.twitter']))
+
   def test_build_files_scan(self):
     self.assertEquals(OrderedSet([
         self.create_buildfile('grandparent/parent/BUILD'),

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -102,7 +102,7 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('issue_1742/BUILD.sibling'),
     ]), self.scan_buildfiles('', build_ignore_patterns=['**/child*']))
 
-  def test_build_files_scan_with_build_file_ignore(self):
+  def test_build_files_scan_with_ignore_patterns(self):
     self.assertEquals(OrderedSet([
       self.create_buildfile('BUILD'),
       self.create_buildfile('grandparent/parent/BUILD'),

--- a/tests/python/pants_test/base/test_filesystem_build_file.py
+++ b/tests/python/pants_test/base/test_filesystem_build_file.py
@@ -85,8 +85,9 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('BUILD'),
       self.create_buildfile('BUILD.twitter'),
       self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/BUILD.twitter'),
       self.create_buildfile('issue_1742/BUILD.sibling'),
-    ]), self.scan_buildfiles('', pants_build_ignore=['child*']))
+    ]), self.scan_buildfiles('', pants_build_ignore=['**/child*']))
 
   def test_build_files_scan_with_build_file_ignore(self):
     self.assertEquals(OrderedSet([
@@ -106,10 +107,11 @@ class FilesystemBuildFileTest(BuildFileTestBase):
       self.create_buildfile('BUILD.twitter'),
       self.create_buildfile('grandparent/child1/BUILD'),
       self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/BUILD.twitter'),
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
       self.create_buildfile('grandparent/parent/child5/BUILD'),
       self.create_buildfile('issue_1742/BUILD.sibling'),
-    ]), self.scan_buildfiles('', pants_build_ignore=['parent/child1']))
+    ]), self.scan_buildfiles('', pants_build_ignore=['**/parent/child1']))
 
   def test_subdir_file_pattern_ignore(self):
     self.assertEquals(OrderedSet([
@@ -123,9 +125,10 @@ class FilesystemBuildFileTest(BuildFileTestBase):
   def test_build_files_scan_with_non_default_relpath_ignore(self):
     self.assertEquals(OrderedSet([
       self.create_buildfile('grandparent/parent/BUILD'),
+      self.create_buildfile('grandparent/parent/BUILD.twitter'),
       self.create_buildfile('grandparent/parent/child2/child3/BUILD'),
       self.create_buildfile('grandparent/parent/child5/BUILD'),
-    ]), self.scan_buildfiles('grandparent/parent', pants_build_ignore=['parent/child1']))
+    ]), self.scan_buildfiles('grandparent/parent', pants_build_ignore=['**/parent/child1']))
 
   def test_must_exist_true(self):
     with self.assertRaises(BuildFile.MissingBuildFileError):

--- a/tests/python/pants_test/base/test_ignore_patterns_pants_ini_integration.py
+++ b/tests/python/pants_test/base/test_ignore_patterns_pants_ini_integration.py
@@ -11,7 +11,7 @@ import tempfile
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
-class PantsBuildIgnorePantsIniIntegrationTest(PantsRunIntegrationTest):
+class IgnorePatternsPantsIniIntegrationTest(PantsRunIntegrationTest):
   """Tests the functionality of the build_ignore_patterns option in pants.ini ."""
 
   def test_build_ignore_patterns_pants_ini(self):

--- a/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
+++ b/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
@@ -44,7 +44,7 @@ class PantsBuildIgnorePantsIniIntegrationTest(PantsRunIntegrationTest):
                                  '--minimize-output-file={0}'.format(tmp_output)],
                                 config={
                                     'DEFAULT': {
-                                        'build_file_ignore': [
+                                        'ignore_patterns': [
                                             'testprojects/src/java/org/pantsbuild/testproject/phrases'
                                         ]
                                     }

--- a/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
+++ b/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import tempfile
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class PantsBuildIgnorePantsIniIntegrationTest(PantsRunIntegrationTest):
+  """Tests the functionality of the pants_build_ignore option in pants.ini ."""
+
+  def test_pants_build_ignore_pants_ini(self):
+    def output_to_list(output_filename):
+      with open(output_filename, 'r') as results_file:
+        return set([line.rstrip() for line in results_file.readlines()])
+
+    tempdir = tempfile.mkdtemp()
+    tmp_output = os.path.join(tempdir, 'minimize-output1.txt')
+    run_result = self.run_pants(['minimize',
+                                 'testprojects::',
+                                 '--quiet',
+                                 '--minimize-output-file={0}'.format(tmp_output)])
+    self.assert_success(run_result)
+    results = output_to_list(tmp_output)
+    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:ten-thousand',
+                  results)
+    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:once-upon-a-time',
+                  results)
+    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:lesser-of-two',
+                  results)
+    self.assertIn('testprojects/src/java/org/pantsbuild/testproject/phrases:there-was-a-duck',
+                  results)
+
+    tmp_output = os.path.join(tempdir, 'minimize-output2.txt')
+
+    run_result = self.run_pants(['minimize',
+                                 'testprojects::',
+                                 '--quiet',
+                                 '--minimize-output-file={0}'.format(tmp_output)],
+                                config={
+                                    'DEFAULT': {
+                                        'pants_build_ignore': [
+                                            'testprojects/src/java/org/pantsbuild/testproject/phrases'
+                                        ]
+                                    }
+                                })
+    self.assert_success(run_result)
+    results = output_to_list(tmp_output)
+    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:ten-thousand',
+                     results)
+    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:once-upon-a-time',
+                     results)
+    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:lesser-of-two',
+                     results)
+    self.assertNotIn('testprojects/src/java/org/pantsbuild/testproject/phrases:there-was-a-duck',
+                     results)

--- a/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
+++ b/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
@@ -12,9 +12,9 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class PantsBuildIgnorePantsIniIntegrationTest(PantsRunIntegrationTest):
-  """Tests the functionality of the pants_build_ignore option in pants.ini ."""
+  """Tests the functionality of the build_ignore_patterns option in pants.ini ."""
 
-  def test_pants_build_ignore_pants_ini(self):
+  def test_build_ignore_patterns_pants_ini(self):
     def output_to_list(output_filename):
       with open(output_filename, 'r') as results_file:
         return set([line.rstrip() for line in results_file.readlines()])

--- a/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
+++ b/tests/python/pants_test/base/test_pants_build_ignore_pants_ini_integration.py
@@ -44,7 +44,7 @@ class PantsBuildIgnorePantsIniIntegrationTest(PantsRunIntegrationTest):
                                  '--minimize-output-file={0}'.format(tmp_output)],
                                 config={
                                     'DEFAULT': {
-                                        'pants_build_ignore': [
+                                        'build_file_ignore': [
                                             'testprojects/src/java/org/pantsbuild/testproject/phrases'
                                         ]
                                     }

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -144,7 +144,7 @@ class BaseTest(unittest.TestCase):
     return BuildFileAliases(targets={'target': Target})
 
   @property
-  def pants_build_ignore(self):
+  def build_ignore_patterns(self):
     return None
 
   def setUp(self):
@@ -183,7 +183,7 @@ class BaseTest(unittest.TestCase):
     self.build_file_parser = BuildFileParser(self._build_configuration, self.build_root)
     self.project_tree = FileSystemProjectTree(self.build_root)
     self.address_mapper = BuildFileAddressMapper(self.build_file_parser, self.project_tree,
-                                                 pants_build_ignore=self.pants_build_ignore)
+                                                 build_ignore_patterns=self.build_ignore_patterns)
     self.build_graph = BuildGraph(address_mapper=self.address_mapper)
 
   def buildroot_files(self, relpath=None):

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -143,6 +143,10 @@ class BaseTest(unittest.TestCase):
   def alias_groups(self):
     return BuildFileAliases(targets={'target': Target})
 
+  @property
+  def pants_build_ignore(self):
+    return None
+
   def setUp(self):
     super(BaseTest, self).setUp()
     Goal.clear()
@@ -178,7 +182,8 @@ class BaseTest(unittest.TestCase):
     self._build_configuration.register_aliases(self.alias_groups)
     self.build_file_parser = BuildFileParser(self._build_configuration, self.build_root)
     self.project_tree = FileSystemProjectTree(self.build_root)
-    self.address_mapper = BuildFileAddressMapper(self.build_file_parser, self.project_tree)
+    self.address_mapper = BuildFileAddressMapper(self.build_file_parser, self.project_tree,
+                                                 pants_build_ignore=self.pants_build_ignore)
     self.build_graph = BuildGraph(address_mapper=self.address_mapper)
 
   def buildroot_files(self, relpath=None):

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -177,7 +177,8 @@ class BaseTest(unittest.TestCase):
     self._build_configuration = BuildConfiguration()
     self._build_configuration.register_aliases(self.alias_groups)
     self.build_file_parser = BuildFileParser(self._build_configuration, self.build_root)
-    self.address_mapper = BuildFileAddressMapper(self.build_file_parser, FileSystemProjectTree(self.build_root))
+    self.project_tree = FileSystemProjectTree(self.build_root)
+    self.address_mapper = BuildFileAddressMapper(self.build_file_parser, self.project_tree)
     self.build_graph = BuildGraph(address_mapper=self.address_mapper)
 
   def buildroot_files(self, relpath=None):

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -51,12 +51,11 @@ class BuildFileAddressMapperTest(BaseTest):
                        BuildFileAddress(subdir_suffix_build_file, 'baz')},
                       self.address_mapper.scan_addresses())
 
-  def test_scan_addresses_with_excludes(self):
+  def test_scan_addresses_with_pants_build_ignore(self):
     root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
     self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
-    spec_excludes = [os.path.join(self.build_root, 'subdir')]
-    self.assertEquals({BuildFileAddress(root_build_file, 'foo')},
-                      self.address_mapper.scan_addresses(spec_excludes=spec_excludes))
+    address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree, ['subdir'])
+    self.assertEquals({BuildFileAddress(root_build_file, 'foo')}, address_mapper_with_ignore.scan_addresses())
 
   def test_scan_addresses_with_root(self):
     self.add_to_build_file('BUILD', 'target(name="foo")')

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -51,7 +51,7 @@ class BuildFileAddressMapperTest(BaseTest):
                        BuildFileAddress(subdir_suffix_build_file, 'baz')},
                       self.address_mapper.scan_addresses())
 
-  def test_scan_addresses_with_pants_build_ignore(self):
+  def test_scan_addresses_with_build_ignore_patterns(self):
     root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
     self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
     address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree, ['subdir'])

--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -57,7 +57,7 @@ class BaseWhatChangedTest(ConsoleTaskTestBase):
     return WhatChanged
 
   def assert_console_output(self, *output, **kwargs):
-    options = {'pants_build_ignore': [], 'exclude_target_regexp': []}
+    options = {'build_ignore_patterns': [], 'exclude_target_regexp': []}
     if 'options' in kwargs:
       options.update(kwargs['options'])
     kwargs['options'] = options
@@ -205,10 +205,10 @@ class WhatChangedTest(BaseWhatChangedTest):
       )
     """))
 
-  def test_pants_build_ignore(self):
+  def test_build_ignore_patterns(self):
     self.assert_console_output(
       'root/src/py/a:alpha',
-      options={'pants_build_ignore': 'root/src/py/1'},
+      options={'build_ignore_patterns': 'root/src/py/1'},
       workspace=self.workspace(files=['root/src/py/a/b/c', 'root/src/py/a/d'])
     )
 

--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -57,7 +57,7 @@ class BaseWhatChangedTest(ConsoleTaskTestBase):
     return WhatChanged
 
   def assert_console_output(self, *output, **kwargs):
-    options = {'spec_excludes': [], 'exclude_target_regexp': []}
+    options = {'pants_build_ignore': [], 'exclude_target_regexp': []}
     if 'options' in kwargs:
       options.update(kwargs['options'])
     kwargs['options'] = options
@@ -205,10 +205,10 @@ class WhatChangedTest(BaseWhatChangedTest):
       )
     """))
 
-  def test_spec_excludes(self):
+  def test_pants_build_ignore(self):
     self.assert_console_output(
       'root/src/py/a:alpha',
-      options={'spec_excludes': 'root/src/py/1'},
+      options={'pants_build_ignore': 'root/src/py/1'},
       workspace=self.workspace(files=['root/src/py/a/b/c', 'root/src/py/a/d'])
     )
 

--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -386,5 +386,5 @@ class WhatChangedTestWithIgnorePatterns(WhatChangedTestBasic):
   def test_build_ignore_patterns(self):
     self.assert_console_output(
       'root/src/py/a:alpha',
-      workspace=self.workspace(files=['root/src/py/a/b/c', 'root/src/py/a/d'])
+      workspace=self.workspace(files=['root/src/py/a/b/c', 'root/src/py/a/d', 'root/src/py/1/2'])
     )

--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -57,7 +57,7 @@ class BaseWhatChangedTest(ConsoleTaskTestBase):
     return WhatChanged
 
   def assert_console_output(self, *output, **kwargs):
-    options = {'build_ignore_patterns': [], 'exclude_target_regexp': []}
+    options = {'exclude_target_regexp': []}
     if 'options' in kwargs:
       options.update(kwargs['options'])
     kwargs['options'] = options
@@ -94,11 +94,8 @@ class WhatChangedTestBasic(BaseWhatChangedTest):
       workspace=self.workspace(files=['a/b/c', 'd', 'e/f'])
     )
 
-
-class WhatChangedTest(BaseWhatChangedTest):
-
   def setUp(self):
-    super(WhatChangedTest, self).setUp()
+    super(WhatChangedTestBasic, self).setUp()
 
     self.add_to_build_file('root/src/py/a', dedent("""
       python_library(
@@ -205,13 +202,8 @@ class WhatChangedTest(BaseWhatChangedTest):
       )
     """))
 
-  def test_build_ignore_patterns(self):
-    self.assert_console_output(
-      'root/src/py/a:alpha',
-      options={'build_ignore_patterns': 'root/src/py/1'},
-      workspace=self.workspace(files=['root/src/py/a/b/c', 'root/src/py/a/d'])
-    )
 
+class WhatChangedTest(WhatChangedTestBasic):
   def test_owned(self):
     self.assert_console_output(
       'root/src/py/a:alpha',
@@ -383,4 +375,16 @@ class WhatChangedTest(BaseWhatChangedTest):
     self.assert_console_output(
       '//:pants-config',
       workspace=self.workspace(files=['pants.ini'])
+    )
+
+
+class WhatChangedTestWithIgnorePatterns(WhatChangedTestBasic):
+  @property
+  def build_ignore_patterns(self):
+    return ['root/src/py/1']
+
+  def test_build_ignore_patterns(self):
+    self.assert_console_output(
+      'root/src/py/a:alpha',
+      workspace=self.workspace(files=['root/src/py/a/b/c', 'root/src/py/a/d'])
     )


### PR DESCRIPTION
Motivation:
`npm install` command creates a lot of `BUILD.md` files which pants fail to interpret as pants `BUILD` files.

Solution: 
Introduce `pants_build_ignore` option which behave like `.gitignore` but for pants `BUILD` files.
Dependency on `pathspec` library (sources: https://github.com/cpburnz/python-path-specification) was added to make .gitignore-like filtration. It doesn't contain any `C/C++` extensions.

Performance impact:
I've checked `pants_build_ignore` on big twitter repository trying to execute "scanning heavy" commands such as `filter` and `dependees`. There is no noticeable impact on `scan_build_files` performance (about 15%, but in general it's only about 2%) and some noticeable impact on `get_build_files_family` performance (about `x2.5`, but in general it's only about 7%).

But executions of `get_build_files_family` can be much faster as their result most likely was calculated already in `scan_build_files`. I will publish follow-up PR with this change.

Also I will publish follow-up PR with `spec_excludes` deprecation.