### PR TITLE
Retain file permissions when shading monolithic jars.

### DIFF
--- a/src/python/pants/util/fileutil.py
+++ b/src/python/pants/util/fileutil.py
@@ -15,6 +15,7 @@ def atomic_copy(src, dst):
   """Copy the file src to dst, overwriting dst atomically."""
   with temporary_file(root_dir=os.path.dirname(dst)) as tmp_dst:
     shutil.copyfile(src, tmp_dst.name)
+    os.chmod(tmp_dst.name, os.stat(src).st_mode)
     os.rename(tmp_dst.name, dst)
 
 

--- a/tests/python/pants_test/util/test_fileutil.py
+++ b/tests/python/pants_test/util/test_fileutil.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import unittest
 
 from pants.util.contextutil import temporary_file, temporary_file_path
@@ -21,6 +22,7 @@ class FileutilTest(unittest.TestCase):
         dst.close()
         with open(dst.name) as new_dst:
           self.assertEquals(src.name, new_dst.read())
+        self.assertEqual(os.stat(src.name).st_mode, os.stat(dst.name).st_mode)
 
   def test_line_count_estimator(self):
     with temporary_file_path() as src:


### PR DESCRIPTION
On some systems (macos at least), the atomic_copy function at the
end of the jar shading process would cause the file permissions to
be set to '-rw-------', instead of the normal '-rw-r--r--', because
of the permissions of the temporary file that atomic_copy creates.

This change simply records the permissions of the jar before
shading, and chmod's the shaded jar to have whatever permissions it
had previously.