### PR TITLE
Add option to disable synthetic jar creation for jvm tasks

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -38,6 +38,8 @@ class JVM(Subsystem):
              ],
              help='The JVM remote-debugging arguments. {debug_port} will be replaced with '
                   'the value of the --debug-port option.')
+    register('--synthetic-jar', advanced=True, action='store_true', default=True,
+             help="Use synthetic jar ability to handle long classpaths.")
 
   def get_jvm_options(self):
     """Return the options to run this JVM with.

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -38,8 +38,8 @@ class JVM(Subsystem):
              ],
              help='The JVM remote-debugging arguments. {debug_port} will be replaced with '
                   'the value of the --debug-port option.')
-    register('--synthetic-jar', advanced=True, action='store_true', default=True,
-             help="Use synthetic jar ability to handle long classpaths.")
+    register('--synthetic-classpath', advanced=True, action='store_true', default=True,
+             help="Use synthetic jar to work around classpath length restrictions.")
 
   def get_jvm_options(self):
     """Return the options to run this JVM with.

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -99,6 +99,7 @@ class BenchmarkRun(JvmToolTaskMixin, JvmTask):
                              workunit_factory=self.context.new_workunit,
                              workunit_name='caliper',
                              workunit_labels=[WorkUnitLabel.RUN],
-                             executor=java_executor)
+                             executor=java_executor,
+                             create_synthetic_jar=self.create_synthetic_jar)
     if exit_code != 0:
       raise TaskError('java {} ... exited non-zero ({})'.format(self._CALIPER_MAIN, exit_code))

--- a/src/python/pants/backend/jvm/tasks/benchmark_run.py
+++ b/src/python/pants/backend/jvm/tasks/benchmark_run.py
@@ -100,6 +100,6 @@ class BenchmarkRun(JvmToolTaskMixin, JvmTask):
                              workunit_name='caliper',
                              workunit_labels=[WorkUnitLabel.RUN],
                              executor=java_executor,
-                             create_synthetic_jar=self.create_synthetic_jar)
+                             create_synthetic_jar=self.synthetic_classpath)
     if exit_code != 0:
       raise TaskError('java {} ... exited non-zero ({})'.format(self._CALIPER_MAIN, exit_code))

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -98,6 +98,9 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     register('--allow-empty-sources', action='store_true', default=False, advanced=True,
              help='Allows a junit_tests() target to be defined with no sources.  Otherwise,'
                   'such a target will raise an error during the test run.')
+    register('--synthetic-jar', advanced=True, action='store_true', default=True,
+             help="Use synthetic jar ability to handle long classpaths.")
+
     cls.register_jvm_tool(register,
                           'junit',
                           classpath=[
@@ -365,6 +368,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
               workunit_labels=[WorkUnitLabel.TEST],
               cwd=workdir,
               synthetic_jar_dir=self.workdir,
+              create_synthetic_jar=self.get_options().synthetic_jar,
             ))
 
           if result != 0 and self._fail_fast:

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -98,9 +98,6 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     register('--allow-empty-sources', action='store_true', default=False, advanced=True,
              help='Allows a junit_tests() target to be defined with no sources.  Otherwise,'
                   'such a target will raise an error during the test run.')
-    register('--synthetic-jar', advanced=True, action='store_true', default=True,
-             help="Use synthetic jar ability to handle long classpaths.")
-
     cls.register_jvm_tool(register,
                           'junit',
                           classpath=[
@@ -368,7 +365,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
               workunit_labels=[WorkUnitLabel.TEST],
               cwd=workdir,
               synthetic_jar_dir=self.workdir,
-              create_synthetic_jar=self.get_options().synthetic_jar,
+              create_synthetic_jar=self.create_synthetic_jar,
             ))
 
           if result != 0 and self._fail_fast:

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -365,7 +365,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
               workunit_labels=[WorkUnitLabel.TEST],
               cwd=workdir,
               synthetic_jar_dir=self.workdir,
-              create_synthetic_jar=self.create_synthetic_jar,
+              create_synthetic_jar=self.synthetic_classpath,
             ))
 
           if result != 0 and self._fail_fast:

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -97,7 +97,7 @@ class JvmRun(JvmTask):
           args=self.args,
           cwd=working_dir,
           synthetic_jar_dir=self.workdir,
-          create_synthetic_jar=self.create_synthetic_jar
+          create_synthetic_jar=self.synthetic_classpath
         )
 
       if self.only_write_cmd_line:

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -41,6 +41,8 @@ class JvmRun(JvmTask):
              help='Set the working directory. If no argument is passed, use the target path.')
     register('--main', metavar='<main class>',
              help='Invoke this class (overrides "main"" attribute in jvm_binary targets)')
+    register('--synthetic-jar', advanced=True, action='store_true', default=True,
+             help="Use synthetic jar ability to handle long classpaths.")
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -97,6 +99,7 @@ class JvmRun(JvmTask):
           args=self.args,
           cwd=working_dir,
           synthetic_jar_dir=self.workdir,
+          create_synthetic_jar=self.get_options().synthetic_jar
         )
 
       if self.only_write_cmd_line:

--- a/src/python/pants/backend/jvm/tasks/jvm_run.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_run.py
@@ -41,8 +41,6 @@ class JvmRun(JvmTask):
              help='Set the working directory. If no argument is passed, use the target path.')
     register('--main', metavar='<main class>',
              help='Invoke this class (overrides "main"" attribute in jvm_binary targets)')
-    register('--synthetic-jar', advanced=True, action='store_true', default=True,
-             help="Use synthetic jar ability to handle long classpaths.")
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -99,7 +97,7 @@ class JvmRun(JvmTask):
           args=self.args,
           cwd=working_dir,
           synthetic_jar_dir=self.workdir,
-          create_synthetic_jar=self.get_options().synthetic_jar
+          create_synthetic_jar=self.create_synthetic_jar
         )
 
       if self.only_write_cmd_line:

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -33,7 +33,7 @@ class JvmTask(Task):
     self.jvm_options = self.jvm.get_jvm_options()
     self.args = self.jvm.get_program_args()
     self.confs = self.get_options().confs
-    self.create_synthetic_jar = self.jvm.get_options().synthetic_jar
+    self.synthetic_classpath = self.jvm.get_options().synthetic_classpath
 
   def classpath(self, targets, classpath_prefix=None, classpath_product=None):
     """Builds a transitive classpath for the given targets.

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -33,6 +33,7 @@ class JvmTask(Task):
     self.jvm_options = self.jvm.get_jvm_options()
     self.args = self.jvm.get_program_args()
     self.confs = self.get_options().confs
+    self.create_synthetic_jar = self.jvm.get_options().synthetic_jar
 
   def classpath(self, targets, classpath_prefix=None, classpath_product=None):
     """Builds a transitive classpath for the given targets.

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/BUILD
@@ -1,0 +1,23 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='util',
+  sources=['Util.java'],
+  dependencies=[],
+)
+
+jvm_binary(name='run',
+  source='SyntheticJarRun.java',
+  main='org.pantsbuild.testproject.syntheticjar.run.SyntheticJarRun',
+  dependencies=[
+    ':util',
+  ],
+)
+
+junit_tests(name='test',
+  sources=['SyntheticJarTest.java'],
+  dependencies=[
+    '3rdparty:junit',
+    ':util',
+  ],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(name='util',

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarRun.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarRun.java
@@ -1,4 +1,4 @@
-// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 package org.pantsbuild.testproject.syntheticjar.run;

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarRun.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarRun.java
@@ -1,0 +1,10 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.syntheticjar.run;
+
+public class SyntheticJarRun {
+  public static void main(String[] args) {
+    org.pantsbuild.testproject.syntheticjar.util.Util.failIfSyntheticJar();
+  }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarRun.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarRun.java
@@ -5,6 +5,6 @@ package org.pantsbuild.testproject.syntheticjar.run;
 
 public class SyntheticJarRun {
   public static void main(String[] args) {
-    org.pantsbuild.testproject.syntheticjar.util.Util.failIfSyntheticJar();
+    org.pantsbuild.testproject.syntheticjar.util.Util.detectSyntheticJar();
   }
 }

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarTest.java
@@ -1,4 +1,4 @@
-// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 package org.pantsbuild.testproject.syntheticjar.run;

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarTest.java
@@ -1,0 +1,13 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.syntheticjar.run;
+
+import org.junit.Test;
+
+public class SyntheticJarTest {
+  @Test
+  public void testSyntheticJar() {
+    org.pantsbuild.testproject.syntheticjar.util.Util.failIfSyntheticJar();
+  }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarTest.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/SyntheticJarTest.java
@@ -8,6 +8,6 @@ import org.junit.Test;
 public class SyntheticJarTest {
   @Test
   public void testSyntheticJar() {
-    org.pantsbuild.testproject.syntheticjar.util.Util.failIfSyntheticJar();
+    org.pantsbuild.testproject.syntheticjar.util.Util.detectSyntheticJar();
   }
 }

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/Util.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/Util.java
@@ -8,11 +8,10 @@ import java.net.URLClassLoader;
 import java.util.Arrays;
 
 public class Util {
-  public static void failIfSyntheticJar() {
+  public static void detectSyntheticJar() {
     URL[] urls = ((URLClassLoader) Thread.currentThread().getContextClassLoader()).getURLs();
-    if (urls.length == 1) {
-      throw new IllegalStateException("Synthetic jar run is detected, classpath: " +
-          Arrays.toString(urls));
-    }
+    String detectStatus = urls.length == 1 ? "detected" : "not detected";
+    System.out.println("Synthetic jar run is " + detectStatus + ", classpath: " +
+      Arrays.toString(urls));
   }
 }

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/Util.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/Util.java
@@ -1,4 +1,4 @@
-// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 package org.pantsbuild.testproject.syntheticjar.util;
@@ -9,7 +9,7 @@ import java.util.Arrays;
 
 public class Util {
   public static void failIfSyntheticJar() {
-    URL[] urls = ((URLClassLoader) (Thread.currentThread().getContextClassLoader())).getURLs();
+    URL[] urls = ((URLClassLoader) Thread.currentThread().getContextClassLoader()).getURLs();
     if (urls.length == 1) {
       throw new IllegalStateException("Synthetic jar run is detected, classpath: " +
           Arrays.toString(urls));

--- a/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/Util.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/syntheticjar/Util.java
@@ -1,0 +1,18 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.syntheticjar.util;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+
+public class Util {
+  public static void failIfSyntheticJar() {
+    URL[] urls = ((URLClassLoader) (Thread.currentThread().getContextClassLoader())).getURLs();
+    if (urls.length == 1) {
+      throw new IllegalStateException("Synthetic jar run is detected, classpath: " +
+          Arrays.toString(urls));
+    }
+  }
+}

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -105,6 +105,6 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
 
     self.assert_success(self.run_pants(
       ['test.junit',
-       '--no-synthetic-jar',
+       '--no-jvm-synthetic-classpath',
        'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:test',
       ]))

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -99,12 +99,15 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
       self.assert_success(results)
 
   def test_disable_synthetic_jar(self):
-    self.assert_failure(self.run_pants(
+    output = self.run_pants(
       ['test.junit',
-       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:test']))
+       '--output-mode=ALL',
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:test']).stdout_data
+    self.assertIn('Synthetic jar run is detected', output)
 
-    self.assert_success(self.run_pants(
+    output = self.run_pants(
       ['test.junit',
+        '--output-mode=ALL',
        '--no-jvm-synthetic-classpath',
-       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:test',
-      ]))
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:test']).stdout_data
+    self.assertIn('Synthetic jar run is not detected', output)

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -97,3 +97,14 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     test_spec = 'testprojects/tests/java/org/pantsbuild/testproject/cucumber'
     with self.pants_results(['clean-all', 'test.junit', '--per-test-timer', test_spec]) as results:
       self.assert_success(results)
+
+  def test_disable_synthetic_jar(self):
+    self.assert_failure(self.run_pants(
+      ['test.junit',
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:test']))
+
+    self.assert_success(self.run_pants(
+      ['test.junit',
+       '--no-synthetic-jar',
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:test',
+      ]))

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
@@ -63,12 +63,13 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
     self.assertIn('Found readme.txt', stdout_data)
 
   def test_disable_synthetic_jar(self):
-    self.assert_failure(self.run_pants(
+    output = self.run_pants(
       ['run',
-       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run']))
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run']).stdout_data
+    self.assertIn('Synthetic jar run is detected', output)
 
-    self.assert_success(self.run_pants(
+    output = self.run_pants(
       ['run',
        '--no-jvm-synthetic-classpath',
-       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run',
-      ]))
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run']).stdout_data
+    self.assertIn('Synthetic jar run is not detected', output)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
@@ -61,3 +61,14 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
                                  '--run-jvm-cwd='
                                  'testprojects/src/java/org/pantsbuild/testproject/cwdexample/subdir')
     self.assertIn('Found readme.txt', stdout_data)
+
+  def test_disable_synthetic_jar(self):
+    self.assert_failure(self.run_pants(
+      ['run',
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run']))
+
+    self.assert_success(self.run_pants(
+      ['run',
+       'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run',
+       '--no-run-jvm-synthetic-jar'
+      ]))

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
@@ -69,6 +69,6 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
 
     self.assert_success(self.run_pants(
       ['run',
+       '--no-jvm-synthetic-classpath',
        'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar:run',
-       '--no-run-jvm-synthetic-jar'
       ]))

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -47,6 +47,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/src/thrift/org/pantsbuild/thrift_linter:',
       'testprojects/tests/java/org/pantsbuild/testproject/dummies:failing_target',
       'testprojects/tests/java/org/pantsbuild/testproject/empty:',
+      'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar',
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist',
       'testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist:missingdirectdepswhitelist',

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -47,7 +47,6 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/src/thrift/org/pantsbuild/thrift_linter:',
       'testprojects/tests/java/org/pantsbuild/testproject/dummies:failing_target',
       'testprojects/tests/java/org/pantsbuild/testproject/empty:',
-      'testprojects/tests/java/org/pantsbuild/testproject/syntheticjar',
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist',
       'testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist:missingdirectdepswhitelist',


### PR DESCRIPTION
If jvm program trying to inspect it's own classpath and make logic based on it our approach with synthetic jar creation can fail. At current moment it was happened at least twice: with scala repl task and with idea integration tests. For this cases I've added support to run java applications/tests in 'plain' mode - without synthetic jar creation.

This PR introduces new option to JVM subsystem and use this option in some of the `JvmTask`s. I've made change to `junit_run`, `jvm_run` and `benchmark_run` tasks. `JvmdocGen` is not affected as it doesn't reuse `synthetic_jar` code, and  `scala_repl` is not affected as working well with `synthetic_jar`.