### PR TITLE
Attempt a fix for flaky zinc compile failures under Travis-CI.

### DIFF
--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -3,3 +3,9 @@
 
 # Turn off all nailgun use.
 use_nailgun: False
+
+[compile.zinc]
+# If we use the default of 1 worker per core, we see too many cores under travis
+# and get oomkilled from launching too many workers with too much total memory
+# overhead.
+worker_count: 4


### PR DESCRIPTION
The change in https://rbcommons.com/s/twitter/r/3413 defaulted pants
to using 1 worker per core, but the containers used in Travis-CI seem
to see all cores on the host machine (~64) and this causes too many
workers to be launched and then they are subsequently killed by the
oomkiller.

https://rbcommons.com/s/twitter/r/3426/