### PR TITLE
Remove deprecated `--use-old-naming-style` flag.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/classpath_util.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_util.py
@@ -188,7 +188,6 @@ class ClasspathUtil(object):
   @classmethod
   def create_canonical_classpath(cls, classpath_products, targets, basedir,
                                  save_classpath_file=False,
-                                 use_target_id=True,
                                  internal_classpath_only=True,
                                  excludes=None):
     """Create a stable classpath of symlinks with standardized names.
@@ -209,10 +208,6 @@ class ClasspathUtil(object):
     :param basedir: Directory to create symlinks.
     :param save_classpath_file: An optional file with original classpath entries that symlinks
       are created from.
-    :param use_target_id: Optionally switch to the subdirectory based symlinks naming.
-      This is added for backward compatibility. Remove once intellij plugin is ready to use
-      `target.id` based output files.  See `use_old_naming_style` option in :class:
-      `pants.backend.jvm.tasks.jvm_compile.jvm_classpath_publisher.RuntimeClasspathPublisher`.
     :param internal_classpath_only: whether to create symlinks just for internal classpath or
        all classpath.
     :param excludes: classpath entries should be excluded.
@@ -237,21 +232,11 @@ class ClasspathUtil(object):
       This includes creating directories if it does not already exist, cleaning up
       previous classpath output related to the target.
       """
-      if use_target_id:
-        output_dir = basedir
-        # TODO(peiyu) improve readability once we deprecate the old naming style.
-        # For example, `-` is commonly placed in string format as opposed to here.
-        classpath_prefix_for_target = '{basedir}/{target_id}-'.format(basedir=basedir,
-                                                                      target_id=target.id)
-      else:
-        address = target.address
-        output_dir = os.path.join(
-          basedir,
-          # target.address.spec is used in export goal to identify targets
-          address.spec.replace(':', os.sep) if address.spec_path else address.target_name,
-        )
-        # append / to the end as part of the prefix
-        classpath_prefix_for_target = os.path.join(output_dir, '')
+      output_dir = basedir
+      # TODO(peiyu) improve readability once we deprecate the old naming style.
+      # For example, `-` is commonly placed in string format as opposed to here.
+      classpath_prefix_for_target = '{basedir}/{target_id}-'.format(basedir=basedir,
+                                                                    target_id=target.id)
 
       if os.path.exists(output_dir):
         delete_old_target_output_files(classpath_prefix_for_target)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -17,9 +17,8 @@ class RuntimeClasspathPublisher(Task):
   @classmethod
   def register_options(cls, register):
     super(Task, cls).register_options(register)
-    # NB: This is now unused in the code below and can be removed in 0.0.75 or later.
     register('--use-old-naming-style', advanced=True, default=True, action='store_true',
-             deprecated_version='0.0.71',
+             deprecated_version='0.0.71', removal_version='0.0.75',
              deprecated_hint='Switch to use the safe identifier to construct canonical classpath.',
              help='Use the old (unsafe) naming style construct canonical classpath.')
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -15,14 +15,6 @@ class RuntimeClasspathPublisher(Task):
   """Create stable symlinks for runtime classpath entries for JVM targets."""
 
   @classmethod
-  def register_options(cls, register):
-    super(Task, cls).register_options(register)
-    register('--use-old-naming-style', advanced=True, default=True, action='store_true',
-             deprecated_version='0.0.71',
-             deprecated_hint='Switch to use the safe identifier to construct canonical classpath.',
-             help='Use the old (unsafe) naming style construct canonical classpath.')
-
-  @classmethod
   def prepare(cls, options, round_manager):
     round_manager.require_data('runtime_classpath')
 
@@ -33,9 +25,7 @@ class RuntimeClasspathPublisher(Task):
   def execute(self):
     basedir = os.path.join(self.get_options().pants_distdir, self._output_folder)
     runtime_classpath = self.context.products.get_data('runtime_classpath')
-    use_target_id = not self.get_options().use_old_naming_style
     ClasspathUtil.create_canonical_classpath(runtime_classpath,
                                              self.context.targets(),
                                              basedir,
-                                             save_classpath_file=True,
-                                             use_target_id=use_target_id)
+                                             save_classpath_file=True)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -15,6 +15,15 @@ class RuntimeClasspathPublisher(Task):
   """Create stable symlinks for runtime classpath entries for JVM targets."""
 
   @classmethod
+  def register_options(cls, register):
+    super(Task, cls).register_options(register)
+    # NB: This is now unused in the code below and can be removed in 0.0.75 or later.
+    register('--use-old-naming-style', advanced=True, default=True, action='store_true',
+             deprecated_version='0.0.71',
+             deprecated_hint='Switch to use the safe identifier to construct canonical classpath.',
+             help='Use the old (unsafe) naming style construct canonical classpath.')
+
+  @classmethod
   def prepare(cls, options, round_manager):
     round_manager.require_data('runtime_classpath')
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_classpath_published.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_jvm_classpath_published.py
@@ -39,7 +39,7 @@ class RuntimeClasspathPublisherTest(TaskTestBase):
                                                     init_func=ClasspathProducts.init_func(self.pants_workdir))
       task = self.create_task(context)
 
-      target_classpath_output = os.path.join(dist_dir, self.options_scope, 'java', 'classpath', 'java_lib')
+      target_classpath_output = os.path.join(dist_dir, self.options_scope)
 
       # Create a classpath entry.
       touch(os.path.join(jar_dir, 'z1.jar'))

--- a/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classpath_util.py
@@ -128,8 +128,9 @@ class ClasspathUtilTest(BaseTest):
     classpath_products.add_jars_for_targets([a], 'default', [resolved_jar])
 
     with temporary_dir() as base_dir:
-      self._test_canonical_classpath_helper(classpath_products, [a],
-                                            base_dir, True,
+      self._test_canonical_classpath_helper(classpath_products,
+                                            [a],
+                                            base_dir,
                                             [
                                               'a.b.b-0.jar',
                                               'a.b.b-1',
@@ -146,8 +147,9 @@ class ClasspathUtilTest(BaseTest):
     # incrementally delete the resource dendendency
     classpath_products = ClasspathProducts(self.pants_workdir)
     classpath_products.add_for_target(a, [('default', self._path('a.jar'))])
-    self._test_canonical_classpath_helper(classpath_products, [a],
-                                          base_dir, True,
+    self._test_canonical_classpath_helper(classpath_products,
+                                          [a],
+                                          base_dir,
                                           [
                                             'a.b.b-0.jar',
                                           ],
@@ -160,8 +162,9 @@ class ClasspathUtilTest(BaseTest):
     classpath_products = ClasspathProducts(self.pants_workdir)
     classpath_products.add_for_target(a, [('default', self._path('a.jar')),
                                           ('default', self._path('b.jar'))])
-    self._test_canonical_classpath_helper(classpath_products, [a],
-                                          base_dir, True,
+    self._test_canonical_classpath_helper(classpath_products,
+                                          [a],
+                                          base_dir,
                                           [
                                             'a.b.b-0.jar',
                                             'a.b.b-1.jar'
@@ -171,41 +174,6 @@ class ClasspathUtilTest(BaseTest):
                                             '{}/a.jar:{}/b.jar\n'.format(self.pants_workdir,
                                                                          self.pants_workdir)
                                           })
-
-  def test_create_canonical_classpath_with_common_prefix(self):
-    """
-    A special case when two targets' canonical classpath share a common prefix.
-
-    Until we use `target.id` for canonical classpath, today's implementation is error-prone.
-    This is such a regression test case added for a bug discovered in
-    https://github.com/pantsbuild/pants/pull/2664
-
-    NOTE: incremental test case is covered by `RuntimeClasspathPublisherTest`.
-    TODO(peiyu) Remove once we fully migrate to use `target.id`.
-    """
-    # a and c' canonical classpath share a common prefix: a/b/b
-    a = self.make_target('a/b', JvmTarget)
-    c = self.make_target('a/b/b/c', JvmTarget)
-
-    classpath_products = ClasspathProducts(self.pants_workdir)
-
-    classpath_products.add_for_target(a, [('default', self._path('a.jar'))])
-    classpath_products.add_for_target(c, [('default', self._path('c.jar'))])
-
-    # target c first to verify its first created canonical classpath is preserved
-    with temporary_dir() as base_dir:
-      self._test_canonical_classpath_helper(classpath_products, [c, a],
-                                            base_dir, False,
-                                            [
-                                              'a/b/b/c/c/0.jar',
-                                              'a/b/b/0.jar',
-                                            ],
-                                            {
-                                              'a/b/b/classpath.txt':
-                                                '{}/a.jar\n'.format(self.pants_workdir),
-                                              'a/b/b/c/c/classpath.txt':
-                                                '{}/c.jar\n'.format(self.pants_workdir),
-                                            })
 
   def test_create_canonical_classpath_with_broken_classpath(self):
     """Test exception is thrown when the jar file is missing."""
@@ -222,9 +190,11 @@ class ClasspathUtilTest(BaseTest):
 
     with temporary_dir() as base_dir:
       with self.assertRaises(MissingClasspathEntryError):
-        self._test_canonical_classpath_helper(classpath_products, [a],
-                                              base_dir, False,
-                                              [], {})
+        self._test_canonical_classpath_helper(classpath_products,
+                                              [a],
+                                              base_dir,
+                                              [],
+                                              {})
 
   def test_create_canonical_classpath_no_duplicate_entry(self):
     """Test no more than one symlink are created for the same classpath entry."""
@@ -244,8 +214,9 @@ class ClasspathUtilTest(BaseTest):
       # Only target a generates symlink to jar library, target b skips creating the
       # symlink for the same jar library. Both targets' classpath.txt files should
       # still contain the jar library.
-      self._test_canonical_classpath_helper(classpath_products, [target_a, target_b],
-                                            base_dir, True,
+      self._test_canonical_classpath_helper(classpath_products,
+                                            [target_a, target_b],
+                                            base_dir,
                                             ['a.a-0.jar'],
                                             {
                                               'a.a-classpath.txt':
@@ -254,19 +225,19 @@ class ClasspathUtilTest(BaseTest):
                                                 '{}/{}\n'.format(self.pants_workdir, jar_path),
                                             })
 
-  def _test_canonical_classpath_helper(self, classpath_products, targets,
+  def _test_canonical_classpath_helper(self,
+                                       classpath_products,
+                                       targets,
                                        libs_dir,
-                                       use_target_id,
                                        expected_canonical_classpath,
                                        expected_classspath_files,
-                                       excludes=set()):
+                                       excludes=None):
     """
     Helper method to call `create_canonical_classpath` and verify generated canonical classpath.
 
     :param ClasspathProducts classpath_products: Classpath products.
     :param list targets: List of targets to generate canonical classpath from.
     :param string libs_dir: Directory where canonical classpath are to be generated.
-    :param bool use_target_id: Whether to use target_id based naming.
     :param list expected_canonical_classpath: List of canonical classpath relative to a base directory.
     :param dict expected_classspath_files: A dict of classpath.txt path to its expected content.
     """
@@ -274,7 +245,6 @@ class ClasspathUtilTest(BaseTest):
                                                                    targets,
                                                                    libs_dir,
                                                                    save_classpath_file=True,
-                                                                   use_target_id=use_target_id,
                                                                    internal_classpath_only=False,
                                                                    excludes=excludes)
     # check canonical path returned


### PR DESCRIPTION
This kills support in the `export-classpath` goal for the old style of
classpath segregation that mirrored a target's namespace as a directory
tree in favor of using a flat set of files differentiated by including
the target's id in their names.

https://rbcommons.com/s/twitter/r/3427/