### PR TITLE
Polishing --ignore-patterns change

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_buildgen.py
@@ -248,8 +248,7 @@ class GoBuildgen(GoTask):
 
     def gather_go_buildfiles(rel_path):
       address_mapper = self.context.address_mapper
-      for build_file in address_mapper.scan_build_files(base_path=rel_path,
-                                                        spec_excludes=self.context.spec_excludes):
+      for build_file in address_mapper.scan_build_files(base_path=rel_path):
         existing_go_buildfiles.add(build_file.relpath)
 
     gather_go_buildfiles(generation_result.local_root)

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -311,6 +311,6 @@ class Context(object):
     :returns: A new build graph encapsulating the targets found.
     """
     build_graph = BuildGraph(self.address_mapper)
-    for address in self.address_mapper.scan_addresses(root, spec_excludes=self.spec_excludes):
+    for address in self.address_mapper.scan_addresses(root, spec_excludes=self._spec_excludes):
       build_graph.inject_address_closure(address)
     return build_graph

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -134,7 +134,7 @@ class GlobalOptionsRegistrar(Optionable):
              recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
     register('--spec-excludes', advanced=True, action='append',
              default=[register.bootstrap.pants_workdir],
-             deprecated_hint='Use --build-file-ignore instead.', deprecated_version='0.0.75',
+             deprecated_hint='Use --ignore-patterns instead.', deprecated_version='0.0.75',
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
     register('--ignore-patterns', advanced=True, action='append', fromfile=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -134,7 +134,9 @@ class GlobalOptionsRegistrar(Optionable):
              recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
     register('--spec-excludes', advanced=True, action='append',
              default=[register.bootstrap.pants_workdir],
-             deprecated_hint='Use --ignore-patterns instead.', deprecated_version='0.0.75',
+             deprecated_hint='Use --ignore-patterns instead. Use .gitignore syntax for each item, '
+                             'to simulate old behavior prefix each item with "/".',
+             deprecated_version='0.0.75',
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
     register('--ignore-patterns', advanced=True, action='append', fromfile=True,

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -51,12 +51,6 @@ class BuildFileAddressMapperTest(BaseTest):
                        BuildFileAddress(subdir_suffix_build_file, 'baz')},
                       self.address_mapper.scan_addresses())
 
-  def test_scan_addresses_with_build_ignore_patterns(self):
-    root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
-    self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
-    address_mapper_with_ignore = BuildFileAddressMapper(self.build_file_parser, self.project_tree, ['subdir'])
-    self.assertEquals({BuildFileAddress(root_build_file, 'foo')}, address_mapper_with_ignore.scan_addresses())
-
   def test_scan_addresses_with_root(self):
     self.add_to_build_file('BUILD', 'target(name="foo")')
     subdir_build_file = self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
@@ -116,3 +110,20 @@ class BuildFileAddressMapperTest(BaseTest):
     self.assertIsInstance(BuildFileAddressMapper.InvalidBuildFileReference(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.InvalidAddressError(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.BuildFileScanError(), AddressLookupError)
+
+
+class BuildFileAddressMapperWithIgnoreTest(BaseTest):
+  @property
+  def build_ignore_patterns(self):
+    return ['subdir']
+
+  def test_scan_from_address_mapper(self):
+    root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
+    self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
+    self.assertEquals({BuildFileAddress(root_build_file, 'foo')}, self.address_mapper.scan_addresses())
+
+  def test_scan_from_context(self):
+    self.add_to_build_file('BUILD', 'target(name="foo")')
+    self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
+    graph = self.context().scan()
+    self.assertEquals([target.address.spec for target in graph.targets()], ['//:foo'])

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -104,6 +104,15 @@ class BuildFileAddressMapperTest(BaseTest):
     with self.assertRaises(BuildFileAddressMapper.EmptyBuildFileError):
       self.address_mapper.resolve_spec('//:foo')
 
+  def test_context_scan_with_deprecated_spec_excludes(self):
+    # Can be removed while `spec_excludes` removal.
+    self.add_to_build_file('BUILD', 'target(name="foo")')
+    self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
+    context = self.context()
+    context._spec_excludes = ['subdir']
+    graph = context.scan()
+    self.assertEquals([target.address.spec for target in graph.targets()], ['//:foo'])
+
   def test_address_lookup_error_hierarchy(self):
     self.assertIsInstance(BuildFileAddressMapper.AddressNotInBuildFile(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.EmptyBuildFileError(), AddressLookupError)


### PR DESCRIPTION
In process of OSS pants adoption in Twitter I've discovered couple of problems in `--ignore-patterns` change. 

This RB contain couple of fixes: 
- do not access deprecated property in `context.py`
- do not pass explicitly `spec_excludes` in `go_buildgen.py`
- use `--ignore-patterns` option name in deprecation message for `--spec-excludes`