### PR TITLE
Adds support for golang meta info for imports

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
@@ -365,8 +365,7 @@ class ArchiveFetcher(Fetcher, Subsystem):
     match, _ = self._matcher(import_path)
     return match.string[:match.end()]
 
-  def fetch(self, import_path, dest, rev=None, url_info=None,
-            meta_repo_url=None):
+  def fetch(self, import_path, dest, rev=None, url_info=None, meta_repo_url=None):
     match, url_info = self._matcher(import_path)
     pkg = GoRemoteLibrary.remote_package_path(self.root(import_path), import_path)
     archive_url = match.expand(url_info.url_format).format(

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -221,3 +221,37 @@ class GoFetchTest(TaskTestBase):
     remote_import_ids = go_fetch._get_remote_import_paths('github.com/u/a',
                                                           gopath=self.build_root)
     self.assertItemsEqual(remote_import_ids, ['bitbucket.org/u/b', 'github.com/u/c'])
+
+  def test_find_meta_tag_with_meta_tag(self):
+    test_html = """<!DOCTYPE html>
+    <html>
+    <head>
+    <meta name="go-import" content="google.golang.org/api git https://code.googlesource.com/google-api-go-client">
+    <meta name="go-source" content="google.golang.org/api https://github.com/google/google-api-go-client https://github.com/google/google-api-go-client/tree/master{/dir} https://github.com/google/google-api-go-client/tree/master{/dir}/{file}#L{line}">
+    <meta http-equiv="refresh" content="0; url=https://godoc.org/google.golang.org/api/googleapi">
+    </head>
+    <body>
+    Nothing to see here. Please <a href="https://godoc.org/google.golang.org/api/googleapi">move along</a>.
+    </body>
+    </html>"""
+
+    go_fetch = self.create_task(self.context())
+    meta_tag_content = go_fetch._find_meta_tag(test_html)
+
+    self.assertEqual(meta_tag_content, "google.golang.org/api git https://code.googlesource.com/google-api-go-client")
+
+  def test_find_meta_tag_with_meta_tag_single_line(self):
+    test_html = '<!DOCTYPE html><html><head><meta name="go-import" content="google.golang.org/api git https://code.googlesource.com/google-api-go-client"></head><body> Nothing to see here.</body></html>'
+
+    go_fetch = self.create_task(self.context())
+    meta_tag_content = go_fetch._find_meta_tag(test_html)
+
+    self.assertEqual(meta_tag_content, "google.golang.org/api git https://code.googlesource.com/google-api-go-client")
+
+  def test_find_meta_tag_without_meta_tag(self):
+    test_html = "<!DOCTYPE html><html><head></head><body> Nothing to see here.</body></html>"
+
+    go_fetch = self.create_task(self.context())
+    meta_tag_content = go_fetch._find_meta_tag(test_html)
+
+    self.assertEqual(meta_tag_content, None)

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -222,7 +222,7 @@ class GoFetchTest(TaskTestBase):
                                                           gopath=self.build_root)
     self.assertItemsEqual(remote_import_ids, ['bitbucket.org/u/b', 'github.com/u/c'])
 
-  def test_find_meta_tag_with_meta_tag(self):
+  def test_find_meta_tag_multiline(self):
     test_html = """<!DOCTYPE html>
     <html>
     <head>
@@ -238,17 +238,17 @@ class GoFetchTest(TaskTestBase):
     go_fetch = self.create_task(self.context())
     meta_tag_content = go_fetch._find_meta_tag(test_html)
 
-    self.assertEqual(meta_tag_content, "google.golang.org/api git https://code.googlesource.com/google-api-go-client")
+    self.assertEqual(meta_tag_content, ('google.golang.org/api', 'git', 'https://code.googlesource.com/google-api-go-client'))
 
-  def test_find_meta_tag_with_meta_tag_single_line(self):
+  def test_find_meta_tag_single_line(self):
     test_html = '<!DOCTYPE html><html><head><meta name="go-import" content="google.golang.org/api git https://code.googlesource.com/google-api-go-client"></head><body> Nothing to see here.</body></html>'
 
     go_fetch = self.create_task(self.context())
     meta_tag_content = go_fetch._find_meta_tag(test_html)
 
-    self.assertEqual(meta_tag_content, "google.golang.org/api git https://code.googlesource.com/google-api-go-client")
+    self.assertEqual(meta_tag_content, ('google.golang.org/api', 'git', 'https://code.googlesource.com/google-api-go-client'))
 
-  def test_find_meta_tag_without_meta_tag(self):
+  def test_no_meta_tag(self):
     test_html = "<!DOCTYPE html><html><head></head><body> Nothing to see here.</body></html>"
 
     go_fetch = self.create_task(self.context())


### PR DESCRIPTION
- Adds a check for meta information for golang imports
- Passes additional information to the archive fetcher to  properly
  download imports that use meta info (e.g. google.golang.org)