### PR TITLE
[trigger ci] Make IvyTaskMixin.ivy_resolve private, introduce ivy_classpath; clean…

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -183,7 +183,7 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
                                                             init_func=lambda: defaultdict(dict))
       # We leave a callback in the products map because we want these Ivy calls
       # to be done lazily (they might never actually get executed) and we want
-      # to hit Task.invalidated (called in Task.ivy_resolve) on the instance of
+      # to hit Task.invalidated (called in Task._ivy_resolve) on the instance of
       # BootstrapJvmTools rather than the instance of whatever class requires
       # the bootstrap tools.  It would be awkward and possibly incorrect to call
       # self.invalidated twice on a Task that does meaningful invalidation on its
@@ -204,8 +204,7 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
 
   def _bootstrap_classpath(self, jvm_tool, targets):
     workunit_name = 'bootstrap-{}'.format(jvm_tool.key)
-    classpath, _, _ = self.ivy_resolve(targets, silent=True, workunit_name=workunit_name)
-    return classpath
+    return self.ivy_classpath(targets, silent=True, workunit_name=workunit_name)
 
   @memoized_property
   def shader(self):

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -130,7 +130,7 @@ class IvyTaskMixin(TaskBase):
     return resolve_hash_names
 
   def ivy_classpath(self, targets, silent=True, workunit_name=None):
-    classpath, _, _ = self.ivy_resolve(targets, silent=silent, workunit_name=workunit_name)
+    classpath, _, _ = self._ivy_resolve(targets, silent=silent, workunit_name=workunit_name)
     return classpath
 
   def _resolve_subset(self, executor, targets, classpath_products, confs=None, extra_args=None,

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -129,13 +129,17 @@ class IvyTaskMixin(TaskBase):
                                                      pinned_artifacts=artifact_set))
     return resolve_hash_names
 
+  def ivy_classpath(self, targets, silent=True, workunit_name=None):
+    classpath, _, _ = self.ivy_resolve(targets, silent=silent, workunit_name=workunit_name)
+    return classpath
+
   def _resolve_subset(self, executor, targets, classpath_products, confs=None, extra_args=None,
               invalidate_dependents=False, pinned_artifacts=None):
     classpath_products.add_excludes_for_targets(targets)
 
     # After running ivy, we parse the resulting report, and record the dependencies for
     # all relevant targets (ie: those that have direct dependencies).
-    _, symlink_map, resolve_hash_name = self.ivy_resolve(
+    _, symlink_map, resolve_hash_name = self._ivy_resolve(
       targets,
       executor=executor,
       workunit_name='ivy-resolve',
@@ -193,7 +197,7 @@ class IvyTaskMixin(TaskBase):
   # TODO(Eric Ayers): Change this method to relocate the resolution reports to under workdir
   # and return that path instead of having everyone know that these reports live under the
   # ivy cache dir.
-  def ivy_resolve(self,
+  def _ivy_resolve(self,
                   targets,
                   executor=None,
                   silent=False,


### PR DESCRIPTION
… up some ivy resolve tests

ivy_resolve does too many things and exposes results that aren't used by callers outside of IvyTaskMixin. This change introduces a new entrypoint for just resolving the classpath and makes ivy_resolve private.

With this, we can more easily change IvyTaskMixin's internals because they are better encapsulated.