### PR TITLE
Fix `./pants list` without arguments output

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/listtargets.py
+++ b/src/python/pants/backend/graph_info/tasks/listtargets.py
@@ -79,4 +79,4 @@ class ListTargets(ConsoleTask):
     if self.context.target_roots:
       return self.context.target_roots
     else:
-      return self.context.scan().targets()
+      return self.context.scan().targets(predicate=lambda target: not target.is_synthetic)

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -72,6 +72,7 @@ python_tests(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/build_graph',
+    'src/python/pants/backend/python/targets:python',
     'tests/python/pants_test/tasks:task_test_base',
   ],
 )

--- a/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
@@ -13,6 +13,7 @@ from pants.backend.jvm.artifact import Artifact
 from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.scala_artifact import ScalaArtifact
 from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.python.targets.python_library import PythonLibrary
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
@@ -41,6 +42,7 @@ class ListTargetsTest(BaseListTargetsTest):
       targets={
         'target': Target,
         'java_library': JavaLibrary,
+        'python_library': PythonLibrary,
       },
       objects={
         'pants': lambda x: x,
@@ -187,3 +189,14 @@ class ListTargetsTest(BaseListTargetsTest):
       """).strip(),
       options={'documented': True}
     )
+
+  def test_no_synthetic_resources_in_output(self):
+    self.add_to_build_file('BUILD', dedent("""
+    python_library(
+      name = 'lib',
+      resources = ['BUILD'],
+    )
+    """))
+    output = self.execute_console_task()
+    self.assertIn('//:lib', output)
+    self.assertTrue(all('synthetic' not in line for line in output))


### PR DESCRIPTION
Output of `./pants list` call without arguments can contain synthetic targets.
This RB removes them from output.