### PR TITLE
support searching multiple linux java dist dirs

### DIFF
--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -308,8 +308,8 @@ class DistributionLocator(Subsystem):
   options_scope = 'jvm-distributions'
   _CACHE = {}
   # The `/usr/lib/jvm` dir is a common target of packages built for redhat and debian as well as
-  # other more exotic distributions.
-  _JAVA_DIST_DIR = '/usr/lib/jvm'
+  # other more exotic distributions.  SUSE uses lib64
+  _JAVA_DIST_DIRS = ['/usr/lib/jvm', '/usr/lib64/jvm']
   _OSX_JAVA_HOME_EXE = '/usr/libexec/java_home'
 
   @classmethod
@@ -483,11 +483,12 @@ class DistributionLocator(Subsystem):
 
   @classmethod
   def _linux_java_homes(cls):
-    if os.path.isdir(cls._JAVA_DIST_DIR):
-      for path in os.listdir(cls._JAVA_DIST_DIR):
-        home = os.path.join(cls._JAVA_DIST_DIR, path)
-        if os.path.isdir(home):
-          yield cls._Location.from_home(home)
+    for java_dist_dir in cls._JAVA_DIST_DIRS:
+      if os.path.isdir(java_dist_dir):
+        for path in os.listdir(java_dist_dir):
+          home = os.path.join(java_dist_dir, path)
+          if os.path.isdir(home):
+            yield cls._Location.from_home(home)
 
   @classmethod
   def _osx_java_homes(cls):

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -153,12 +153,12 @@ class BaseDistributionLocationTest(unittest.TestCase):
     self.addCleanup(safe_rmtree, tmpdir)
     return tmpdir
 
-  def set_up_no_linux_discovery(self):
-    orig_java_dist_dir = DistributionLocator._JAVA_DIST_DIR
+  def set_up_no_linux_discovery(self, index=0):
+    orig_java_dist_dir = DistributionLocator._JAVA_DIST_DIRS[index]
 
     def restore_java_dist_dir():
-      DistributionLocator._JAVA_DIST_DIR = orig_java_dist_dir
-    DistributionLocator._JAVA_DIST_DIR = self.make_tmp_dir()
+      DistributionLocator._JAVA_DIST_DIRS[index] = orig_java_dist_dir
+    DistributionLocator._JAVA_DIST_DIRS[index] = self.make_tmp_dir()
     self.addCleanup(restore_java_dist_dir)
 
   def set_up_no_osx_discovery(self):
@@ -275,12 +275,12 @@ class DistributionLinuxLocationTest(BaseDistributionLocationTest):
           os.symlink(jdk1_home, jdk1_home_link)
           os.symlink(jdk2_home, jdk2_home_link)
 
-          original_java_dist_dir = DistributionLocator._JAVA_DIST_DIR
-          DistributionLocator._JAVA_DIST_DIR = java_dist_dir
+          original_java_dist_dir = DistributionLocator._JAVA_DIST_DIRS[0]
+          DistributionLocator._JAVA_DIST_DIRS[0] = java_dist_dir
           try:
             yield jdk1_home_link, jdk2_home_link
           finally:
-            DistributionLocator._JAVA_DIST_DIR = original_java_dist_dir
+            DistributionLocator._JAVA_DIST_DIRS[0] = original_java_dist_dir
 
   def test_locate_jdk1(self):
     with env():
@@ -324,6 +324,12 @@ class DistributionLinuxLocationTest(BaseDistributionLocationTest):
           self.assertEqual(jdk1_home, dist.home)
           dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
+
+
+class DistributionLinuxAltLocationTest(DistributionLinuxLocationTest):
+  def setUp(self):
+    self.set_up_no_linux_discovery(index=1)
+    self.set_up_no_osx_discovery()
 
 
 class DistributionOSXLocationTest(BaseDistributionLocationTest):


### PR DESCRIPTION
SUSE is an odd ball out and does not use `/usr/lib/jvm`.  This makes
the unit tests somewhat more awkward with the temporary dirs and
reaching into the class.  I think cleaner long term approach would be
to use a fake file sytem (such as pyfakefs) instead of actual temp
dirs, but that is beyond the scope of this change.

fixes #2931