### PR TITLE
Add public API markers for

### DIFF
--- a/src/python/pants/backend/python/pants_requirement.py
+++ b/src/python/pants/backend/python/pants_requirement.py
@@ -21,6 +21,8 @@ class PantsRequirement(object):
 
   NB: The requirement generated is for official pants releases on pypi; so may not be appropriate
   for use in a repo that tracks `pantsbuild/pants` or otherwise uses custom pants sdists.
+
+  :API: public
   """
 
   def __init__(self, parse_context):

--- a/src/python/pants/backend/python/python_requirement.py
+++ b/src/python/pants/backend/python/python_requirement.py
@@ -27,6 +27,8 @@ class PythonRequirement(object):
 
   To let other Targets depend on this ``python_requirement``, put it in a
   `python_requirement_library <#python_requirement_library>`_.
+
+  :API: public
   """
 
   def __init__(self, requirement, name=None, repository=None, version_filter=None, use_2to3=False,
@@ -45,42 +47,69 @@ class PythonRequirement(object):
     self.compatibility = compatibility or ['']
 
   def should_build(self, python, platform):
+    """
+    :API: public
+    """
     return self._version_filter(python, platform)
 
   @property
   def use_2to3(self):
+    """
+    :API: public
+    """
     return self._use_2to3
 
   @property
   def repository(self):
+    """
+    :API: public
+    """
     return self._repository
 
   # duck-typing Requirement interface for Resolver, since Requirement cannot be
   # subclassed (curses!)
   @property
   def key(self):
+    """
+    :API: public
+    """
     return self._requirement.key
 
   @property
   def extras(self):
+    """
+    :API: public
+    """
     return self._requirement.extras
 
   @property
   def specs(self):
+    """
+    :API: public
+    """
     return self._requirement.specs
 
   @property
   def project_name(self):
+    """
+    :API: public
+    """
     return self._requirement.project_name
 
   @property
   def requirement(self):
+    """
+    :API: public
+    """
     return self._requirement
 
   def __contains__(self, item):
     return item in self._requirement
 
   def cache_key(self):
+    """
+    :API: public
+    """
     return str(self._requirement)
 
   def __repr__(self):

--- a/src/python/pants/backend/python/targets/python_library.py
+++ b/src/python/pants/backend/python/targets/python_library.py
@@ -9,5 +9,8 @@ from pants.backend.python.targets.python_target import PythonTarget
 
 
 class PythonLibrary(PythonTarget):
-  """A Python library."""
+  """A Python library.
+
+  :API: public
+  """
   pass

--- a/src/python/pants/backend/python/targets/python_tests.py
+++ b/src/python/pants/backend/python/targets/python_tests.py
@@ -11,7 +11,10 @@ from pants.backend.python.targets.python_target import PythonTarget
 
 
 class PythonTests(PythonTarget):
-  """Python tests."""
+  """Python tests.
+
+  :API: public
+  """
 
   def __init__(self, coverage=None, timeout=None, **kwargs):
     """
@@ -25,8 +28,14 @@ class PythonTests(PythonTarget):
 
   @property
   def coverage(self):
+    """
+    :API: public
+    """
     return self._coverage
 
   @property
   def timeout(self):
+    """
+    :API: public
+    """
     return self._timeout

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -151,9 +151,6 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
           self.run_tests(test_targets, workunit)
 
   def run_tests(self, targets, workunit):
-    """
-    :API: public
-    """
     if self.get_options().fast:
       result = self._do_run_tests(targets, workunit)
       if not result.success:

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -71,6 +71,9 @@ class PythonTestResult(object):
 
 
 class PytestRun(TestRunnerTaskMixin, PythonTask):
+  """
+  :API: public
+  """
   _TESTING_TARGETS = [
     # Note: the requirement restrictions on pytest and pytest-cov match those in requirements.txt,
     # to avoid confusion when debugging pants tests.
@@ -148,6 +151,9 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
           self.run_tests(test_targets, workunit)
 
   def run_tests(self, targets, workunit):
+    """
+    :API: public
+    """
     if self.get_options().fast:
       result = self._do_run_tests(targets, workunit)
       if not result.success:


### PR DESCRIPTION
* python

The following modules were reviewed and all api's were left as private. As
far as I can tell these modules are not currently used by pluggins.

* pants.backend.python.antlr_builder
* pants.backend.python.code_generator
* pants.backend.python.interpreter_cache
* pants.backend.python.python_artifact
* pants.backend.python.python_binary
* pants.backend.python.python_binary_create
* pants.backend.python.python_chroot
* pants.backend.python.python_egg
* pants.backend.python.tasks.python_repl
* pants.backend.python.targets.python_requirement_library
* pants.backend.python.python_requirements
* pants.backend.python.tasks.python_run
* pants.backend.python.python_setup
* pants.backend.python.targets.python_target
* pants.backend.python.tasks.python_tasks
* pants.backend.python.sdist_builder
* pants.backend.python.tasks.setup_py
* pants.backend.python.thrift_builder