### PR TITLE
Bump junit runner and jar tool versions to newly published

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -24,7 +24,7 @@ class JarTool(JvmToolMixin, Subsystem):
     cls.register_jvm_tool(register,
                           'jar-tool',
                           classpath=[
-                            JarDependency(org='org.pantsbuild', name='jar-tool', rev='0.0.8'),
+                            JarDependency(org='org.pantsbuild', name='jar-tool', rev='0.0.10'),
                           ])
 
   def run(self, context, runjava, args):

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -101,7 +101,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     cls.register_jvm_tool(register,
                           'junit',
                           classpath=[
-                            JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.1'),
+                            JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.2'),
                           ],
                           main=JUnitRun._MAIN,
                           # TODO(John Sirois): Investigate how much less we can get away with.


### PR DESCRIPTION
New versions of junit runner and jar tool was released: https://github.com/pantsbuild/pants/commit/301853fd0b4f3d988af341447544ffc4263d17c6 and https://github.com/pantsbuild/pants/commit/78d677b0807827951ac11e6340c200a3706608f7.
In this RB I've updated python code for this tools.