### PR TITLE
Change the mechanism for detecting the buildroot.

### DIFF
--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -25,26 +25,21 @@ class BuildRootTest(unittest.TestCase):
     safe_rmtree(self.new_root)
 
   def test_via_set(self):
-    BuildRoot().path = self.new_root
+    BuildRoot().set_path(self.new_root)
     self.assertEqual(self.new_root, BuildRoot().path)
 
   def test_reset(self):
-    BuildRoot().path = self.new_root
+    BuildRoot().set_path(self.new_root)
     BuildRoot().reset()
     self.assertEqual(self.original_root, BuildRoot().path)
 
-  def test_via_pantsini(self):
+  def test_via_pants_runner(self):
     with temporary_dir() as root:
       root = os.path.realpath(root)
-      touch(os.path.join(root, 'pants.ini'))
+      touch(os.path.join(root, 'pants'))
       with pushd(root):
         self.assertEqual(root, BuildRoot().path)
-
       BuildRoot().reset()
-      child = os.path.join(root, 'one', 'two')
-      safe_mkdir(child)
-      with pushd(child):
-        self.assertEqual(root, BuildRoot().path)
 
   def test_temporary(self):
     with BuildRoot().temporary(self.new_root):
@@ -53,5 +48,5 @@ class BuildRootTest(unittest.TestCase):
 
   def test_singleton(self):
     self.assertEqual(BuildRoot().path, BuildRoot().path)
-    BuildRoot().path = self.new_root
+    BuildRoot().set_path(self.new_root)
     self.assertEqual(BuildRoot().path, BuildRoot().path)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -201,7 +201,7 @@ class BaseTest(unittest.TestCase):
       'write_to': [],
     }
 
-    BuildRoot().path = self.build_root
+    BuildRoot().set_path(self.build_root)
     self.addCleanup(BuildRoot().reset)
 
     # We need a pants.ini, even if empty. get_buildroot() uses its presence.


### PR DESCRIPTION
The new mechanism uses the cwd, but heuristically verifies
that there's a pants runner script in it.

The old mechanism climbed up the directory hierarchy until it
found a pants.ini file.

This change is because:

A) We don't want pants.ini to carry two unrelated meanings (config file,
   and build root indicator).
B) We want to support having the config file anywhere, and under any name,
   as determined by an option (a pending change implements this).
C) We want Pants to be able to run with no pants.ini at all, for
   conceptual neatness. "You must have at least an empty config file" is an
   odd requirement.
D) The directory climbing was overkill in practice, because running
   pants from anywhere other than the buildroot doesn't work anyway
   for a variety of reasons.

Note that this change doesn't preclude supporting running pants from
a subdir in the future, but for now it fails fast on this case,
instead of failing in some confusing way later on.