### PR TITLE
Change how we detect the buildroot.

### DIFF
--- a/src/python/pants/base/build_root.py
+++ b/src/python/pants/base/build_root.py
@@ -15,13 +15,28 @@ from pants.util.meta import Singleton
 class BuildRoot(Singleton):
   """Represents the global workspace build root.
 
-  By default a pants workspace is defined by a root directory where the workspace configuration
-  file - 'pants.ini' - lives.  This path can also be manipulated through this interface for
-  re-location of the build root in tests.
+  By default a pants workspace is defined by a root directory where a file called 'pants' -
+  typically the pants runner script - lives.  This path can also be manipulated through
+  this interface for re-location of the build root in tests.
+
+  TODO: If this ever causes a problem (because some subdir that people run pants in
+        legitimately contains a file called 'pants') then we can add a second check for
+        an explicit sentinel file, like 'BUILDROOT'.
   """
 
   class NotFoundError(Exception):
     """Raised when unable to find the current workspace build root."""
+
+  @classmethod
+  def find_buildroot(cls):
+    buildroot = os.path.abspath(os.getcwd())
+    while not os.path.isfile(os.path.join(buildroot, 'pants')):
+      parent = os.path.dirname(buildroot)
+      if buildroot != parent:
+        buildroot = parent
+      else:
+        raise cls.NotFoundError('No file named pants in the cwd or any of its ancestors.')
+    return buildroot
 
   def __init__(self):
     self._root_dir = None
@@ -30,13 +45,7 @@ class BuildRoot(Singleton):
   def path(self):
     """Returns the build root for the current workspace."""
     if self._root_dir is None:
-      buildroot = os.path.abspath(os.getcwd())
-      while not os.path.exists(os.path.join(buildroot, 'pants.ini')):
-        if buildroot != os.path.dirname(buildroot):
-          buildroot = os.path.dirname(buildroot)
-        else:
-          raise self.NotFoundError('Could not find pants.ini!')
-      self._root_dir = os.path.realpath(buildroot)
+      self._root_dir = os.path.realpath(self.find_buildroot())
     return self._root_dir
 
   @path.setter

--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -33,10 +33,10 @@ class BuildRootTest(unittest.TestCase):
     BuildRoot().reset()
     self.assertEqual(self.original_root, BuildRoot().path)
 
-  def test_via_pantsini(self):
+  def test_via_pants_runner(self):
     with temporary_dir() as root:
       root = os.path.realpath(root)
-      touch(os.path.join(root, 'pants.ini'))
+      touch(os.path.join(root, 'pants'))
       with pushd(root):
         self.assertEqual(root, BuildRoot().path)
 

--- a/tests/python/pants_test/base/test_build_root.py
+++ b/tests/python/pants_test/base/test_build_root.py
@@ -55,3 +55,9 @@ class BuildRootTest(unittest.TestCase):
     self.assertEqual(BuildRoot().path, BuildRoot().path)
     BuildRoot().path = self.new_root
     self.assertEqual(BuildRoot().path, BuildRoot().path)
+
+  def test_not_found(self):
+    with temporary_dir() as root:
+      root = os.path.realpath(root)
+      with pushd(root):
+        self.assertRaises(BuildRoot.NotFoundError, lambda: BuildRoot().path)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -204,8 +204,6 @@ class BaseTest(unittest.TestCase):
     BuildRoot().path = self.build_root
     self.addCleanup(BuildRoot().reset)
 
-    # We need a pants.ini, even if empty. get_buildroot() uses its presence.
-    self.create_file('pants.ini')
     self._build_configuration = BuildConfiguration()
     self._build_configuration.register_aliases(self.alias_groups)
     self.build_file_parser = BuildFileParser(self._build_configuration, self.build_root)


### PR DESCRIPTION
Instead of looking for pants.ini we look for the pants runner script
(or any file named 'pants') in the cwd and its ancestors.

This should be a no-op for all existing pants repos, as they all
have a runner script in the buildroot.

This is because we don't want to give the location of pants.ini
any special extra meaning.  We want pants to work with multiple cascading
config files (instead of the clunky --config-file-override mechanism)
or even no config file at all. A future change will implement configurable
config file locations, and will explain in greater detail why that's a
good thing...