### PR TITLE
Add public api markers for core_tasks

### DIFF
--- a/src/python/pants/core_tasks/noop.py
+++ b/src/python/pants/core_tasks/noop.py
@@ -9,7 +9,10 @@ from pants.task.noop_exec_task import NoopExecTask
 
 
 class NoopCompile(NoopExecTask):
-  """A no-op that provides a product type that can be used to force scheduling."""
+  """A no-op that provides a product type that can be used to force scheduling.
+
+  :API: public
+  """
 
   @classmethod
   def product_types(cls):
@@ -17,7 +20,10 @@ class NoopCompile(NoopExecTask):
 
 
 class NoopTest(NoopExecTask):
-  """A no-op that provides a product type that can be used to force scheduling."""
+  """A no-op that provides a product type that can be used to force scheduling.
+
+  :API: public
+  """
 
   @classmethod
   def product_types(cls):


### PR DESCRIPTION
The following modules were reviewed and all api's were left as private. As
far as I can tell these modules are not currently used by pluggins.

* pants.core_tasks.bash_completion.py
* pants.core_tasks.changed_target_tasks.py
* pants.core_tasks.clean.py
* pants.core_tasks.deferred_sources_mapper.py
* pants.core_tasks.explain_options_task.py
* pants.core_tasks.invalidate.py
* pants.core_tasks.list_goals.py
* pants.core_tasks.pantsd_kill.py
* pants.core_tasks.register.py
* pants.core_tasks.reporting_server_kill.py
* pants.core_tasks.reporting_server_run.py
* pants.core_tasks.roots.py
* pants.core_tasks.run_prep_command.py
* pants.core_tasks.targets_help.py
* pants.core_tasks.what_changed.py