### PR TITLE
[trigger ci] reset Subsystems when creating a new context in tests

### DIFF
--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -274,7 +274,10 @@ class BaseTest(unittest.TestCase):
     options = create_options_for_optionables(optionables,
                                              extra_scopes=extra_scopes,
                                              options=options)
-    Subsystem._options = options
+
+    Subsystem.reset(reset_options=True)
+    Subsystem.set_options(options)
+
     context = create_context(options=options,
                              passthru_args=passthru_args,
                              target_roots=target_roots,

--- a/tests/python/pants_test/core_tasks/test_roots.py
+++ b/tests/python/pants_test/core_tasks/test_roots.py
@@ -9,8 +9,6 @@ import os
 
 from pants.base.build_environment import get_buildroot
 from pants.core_tasks.roots import ListRoots
-from pants.source.source_root import SourceRootConfig
-from pants_test.subsystem.subsystem_util import subsystem_instance
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
@@ -19,22 +17,20 @@ class ListRootsTest(ConsoleTaskTestBase):
   def task_type(cls):
     return ListRoots
 
-  def _add_source_root(self, source_root_config, path, langs):
-    os.makedirs(os.path.join(get_buildroot(), path))
-    source_root_config.get_source_roots().add_source_root(path, langs)
+  def _create_source_roots(self, source_root_dict):
+    self.set_options_for_scope('source', source_roots=source_root_dict)
+    for dir in source_root_dict.keys():
+      os.makedirs(os.path.join(get_buildroot(), dir))
 
   def test_no_langs(self):
-    with subsystem_instance(SourceRootConfig) as source_root_config:
-      self._add_source_root(source_root_config, 'fakeroot', tuple())
-      self.assert_console_output('fakeroot: *')
+    self._create_source_roots({'fakeroot': tuple()})
+    self.assert_console_output('fakeroot: *')
 
   def test_single_source_root(self):
-    with subsystem_instance(SourceRootConfig) as source_root_config:
-      self._add_source_root(source_root_config, 'fakeroot', ('lang1', 'lang2'))
-      self.assert_console_output('fakeroot: lang1,lang2')
+    self._create_source_roots({'fakeroot': ('lang1', 'lang2')})
+    self.assert_console_output('fakeroot: lang1,lang2')
 
   def test_multiple_source_roots(self):
-    with subsystem_instance(SourceRootConfig) as source_root_config:
-      self._add_source_root(source_root_config, 'fakerootA', ('lang1',))
-      self._add_source_root(source_root_config, 'fakerootB', ('lang2',))
-      self.assert_console_output('fakerootA: lang1', 'fakerootB: lang2')
+    self._create_source_roots({'fakerootA': ('lang1',),
+                               'fakerootB': ('lang2',)})
+    self.assert_console_output('fakerootA: lang1', 'fakerootB: lang2')


### PR DESCRIPTION
Subsystem instances may cache options values, so it's not sufficient to just assign to Subsystem._options, we also need to clear out the subsystem instances.

This change causes context creation to clear the global subsystems, and fixes the one test that had issues with doing so to use options rather than reaching into the subsystem instance directly.