### PR TITLE
Set public api markers for jvm tasks

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -128,9 +128,8 @@ class BundleCreate(JvmBinaryTask):
     """Create a self-contained application bundle.
 
     The bundle will contain the target classes, dependencies and resources.
-
-    :API: public
     """
+
     assert(isinstance(app, BundleCreate.App))
 
     bundle_dir = os.path.join(self.get_options().pants_distdir, '{}-bundle'.format(app.basename))

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -21,6 +21,9 @@ from pants.util.dirutil import safe_mkdir
 
 
 class BundleCreate(JvmBinaryTask):
+  """
+  :API: public
+  """
 
   # Directory for both internal and external libraries.
   LIBS_DIR = 'libs'
@@ -71,6 +74,9 @@ class BundleCreate(JvmBinaryTask):
     return True
 
   def execute(self):
+    """
+    :API: public
+    """
     archiver_type = self.get_options().archive
     archiver = archive.archiver(archiver_type) if archiver_type else None
 
@@ -122,6 +128,8 @@ class BundleCreate(JvmBinaryTask):
     """Create a self-contained application bundle.
 
     The bundle will contain the target classes, dependencies and resources.
+
+    :API: public
     """
     assert(isinstance(app, BundleCreate.App))
 

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -74,9 +74,6 @@ class BundleCreate(JvmBinaryTask):
     return True
 
   def execute(self):
-    """
-    :API: public
-    """
     archiver_type = self.get_options().archive
     archiver = archive.archiver(archiver_type) if archiver_type else None
 

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -19,7 +19,10 @@ from pants.util.dirutil import safe_open
 
 
 class Checkstyle(NailgunTask):
-  """Check Java code for style violations."""
+  """Check Java code for style violations.
+
+  :API: public
+  """
 
   _CHECKSTYLE_MAIN = 'com.puppycrawl.tools.checkstyle.Main'
 

--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -17,7 +17,10 @@ from pants.goal.products import UnionProducts
 
 
 class ClasspathEntry(object):
-  """Represents a java classpath entry."""
+  """Represents a java classpath entry.
+
+  :API: public
+  """
 
   def __init__(self, path):
     self._path = path
@@ -27,6 +30,8 @@ class ClasspathEntry(object):
     """Returns the pants internal path of this classpath entry.
 
     Suitable for use in constructing classpaths for pants executions and pants generated artifacts.
+
+    :API: public
 
     :rtype: string
     """
@@ -55,15 +60,24 @@ class ClasspathEntry(object):
 
   @classmethod
   def is_artifact_classpath_entry(cls, classpath_entry):
+    """
+    :API: public
+    """
     return isinstance(classpath_entry, ArtifactClasspathEntry)
 
   @classmethod
   def is_internal_classpath_entry(cls, classpath_entry):
+    """
+    :API: public
+    """
     return not cls.is_artifact_classpath_entry(classpath_entry)
 
 
 class ArtifactClasspathEntry(ClasspathEntry):
-  """Represents a resolved third party classpath entry."""
+  """Represents a resolved third party classpath entry.
+
+  :API: public
+  """
 
   def __init__(self, path, coordinate, cache_path):
     super(ArtifactClasspathEntry, self).__init__(path)
@@ -87,6 +101,8 @@ class ArtifactClasspathEntry(ClasspathEntry):
 
     Suitable for use in constructing classpaths for external tools that should not be subject to
     potential volatility in pants own internal caches.
+
+    :API: public
 
     :rtype: string
     """
@@ -132,6 +148,10 @@ def _not_excluded_filter(excludes):
 
 
 class ClasspathProducts(object):
+  """
+  :API: public
+  """
+
   def __init__(self, pants_workdir, classpaths=None, excludes=None):
     self._classpaths = classpaths or UnionProducts()
     self._excludes = excludes or UnionProducts()
@@ -139,6 +159,9 @@ class ClasspathProducts(object):
 
   @staticmethod
   def init_func(pants_workdir):
+    """
+    :API: public
+    """
     return lambda: ClasspathProducts(pants_workdir)
 
   def copy(self):
@@ -147,6 +170,8 @@ class ClasspathProducts(object):
     Edits to the copy's classpaths or exclude associations will not affect the classpaths or
     excludes in the original. The copy is shallow though, so edits to the the copy's product values
     will mutate the original's product values.  See `UnionProducts.copy`.
+
+    :API: public
 
     :rtype: :class:`ClasspathProducts`
     """

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -74,6 +74,8 @@ class IvyTaskMixin(TaskBase):
   parse the graph structure of dependencies. Therefore, this mixin explicitly disables the
   cache for its invalidation checks via the `use_cache=False` parameter. Tasks that extend
   the mixin may safely enable task-level caching settings.
+
+  :API: public
   """
 
   class Error(TaskError):
@@ -102,6 +104,8 @@ class IvyTaskMixin(TaskBase):
   def ivy_cache_dir(self):
     """The path of the ivy cache dir used for resolves.
 
+    :API: public
+
     :rtype: string
     """
     # TODO(John Sirois): Fixup the IvySubsystem to encapsulate its properties.
@@ -110,6 +114,8 @@ class IvyTaskMixin(TaskBase):
   def resolve(self, executor, targets, classpath_products, confs=None, extra_args=None,
               invalidate_dependents=False):
     """Resolves external classpath products (typically jars) for the given targets.
+
+    :API: public
 
     :param executor: A java executor to run ivy with.
     :type executor: :class:`pants.java.executor.Executor`
@@ -140,6 +146,9 @@ class IvyTaskMixin(TaskBase):
     return resolve_hash_names
 
   def ivy_classpath(self, targets, silent=True, workunit_name=None):
+    """
+    :API: public
+    """
     classpath, _, _ = self._ivy_resolve(targets, silent=silent, workunit_name=workunit_name)
     return classpath
 

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -235,6 +235,8 @@ class JarTask(NailgunTask):
 
   All subclasses will share the same underlying nailgunned jar tool and thus benefit from fast
   invocations.
+
+  :API: public
   """
 
   @classmethod
@@ -274,6 +276,8 @@ class JarTask(NailgunTask):
   @contextmanager
   def open_jar(self, path, overwrite=False, compressed=True, jar_rules=None):
     """Yields a Jar that will be written when the context exits.
+
+    :API: public
 
     :param string path: the path to the jar file
     :param bool overwrite: overwrite the file at ``path`` if it exists; ``False`` by default; ie:

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -59,6 +59,9 @@ def interpret_test_spec(test_spec):
 
 
 class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
+  """
+  :API: public
+  """
   _MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -17,9 +17,6 @@ class JvmToolTaskMixin(JvmToolMixin, TaskBase):
 
   @classmethod
   def prepare(cls, options, round_manager):
-    """
-    :API: public
-    """
     super(JvmToolTaskMixin, cls).prepare(options, round_manager)
     cls.prepare_tools(round_manager)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -10,10 +10,16 @@ from pants.task.task import TaskBase
 
 
 class JvmToolTaskMixin(JvmToolMixin, TaskBase):
-  """A JvmToolMixin specialized for mixing in to Tasks."""
+  """A JvmToolMixin specialized for mixing in to Tasks.
+
+  :API: public
+  """
 
   @classmethod
   def prepare(cls, options, round_manager):
+    """
+    :API: public
+    """
     super(JvmToolTaskMixin, cls).prepare(options, round_manager)
     cls.prepare_tools(round_manager)
 
@@ -32,6 +38,8 @@ class JvmToolTaskMixin(JvmToolMixin, TaskBase):
 
   def tool_classpath(self, key, scope=None):
     """Get a classpath for the tool previously registered under key in the given scope.
+
+    :API: public
 
     :param string key: The key the tool configuration was registered under.
     :param string scope: The scope the tool configuration was registered under; the task scope by

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -42,6 +42,9 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     return super(NailgunTaskBase, cls).global_subsystems() + (DistributionLocator,)
 
   def __init__(self, *args, **kwargs):
+    """
+    :API: public
+    """
     super(NailgunTaskBase, self).__init__(*args, **kwargs)
 
     id_tuple = (self.ID_PREFIX, self.__class__.__name__)
@@ -82,6 +85,8 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     If --no-use-nailgun is specified then the java main is run in a freshly spawned subprocess,
     otherwise a persistent nailgun server dedicated to this Task subclass is used to speed up
     amortized run times.
+
+    :API: public
     """
     executor = self.create_java_executor()
 
@@ -106,7 +111,11 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
 
 
 # TODO(John Sirois): This just prevents ripple - maybe inline
-class NailgunTask(NailgunTaskBase, Task): pass
+class NailgunTask(NailgunTaskBase, Task):
+  """
+  :API: public
+  """
+  pass
 
 
 class NailgunKillall(Task):

--- a/src/python/pants/backend/jvm/tasks/properties.py
+++ b/src/python/pants/backend/jvm/tasks/properties.py
@@ -19,11 +19,15 @@ class Properties(object):
 
   Originally copied from:
   https://github.com/twitter/commons/blob/master/src/python/twitter/common/config/properties.py
+
+  :API: public
   """
 
   @staticmethod
   def load(data):
     """Loads properties from an open stream or the contents of a string.
+
+    :API: public
 
     :param (string | open stream) data: An open stream or a string.
     :returns: A dict of parsed property data.
@@ -94,7 +98,10 @@ class Properties(object):
 
   @staticmethod
   def dump(props, output):
-    """Dumps a dict of properties to the specified open stream or file path."""
+    """Dumps a dict of properties to the specified open stream or file path.
+
+    :API: public
+    """
     def escape(token):
       return re.sub(r'([=:\s])', r'\\\1', token)
 

--- a/src/python/pants/backend/jvm/tasks/resources_task.py
+++ b/src/python/pants/backend/jvm/tasks/resources_task.py
@@ -16,6 +16,8 @@ class ResourcesTask(Task):
 
   This base assumes that resources targets or targets that generate resources are independent from
   each other and can be processed in isolation in any order.
+
+  :API: public
   """
 
   @classmethod
@@ -30,6 +32,9 @@ class ResourcesTask(Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
+    """
+    :API: public
+    """
     round_manager.require_data('compile_classpath')
 
   @property

--- a/src/python/pants/backend/jvm/tasks/resources_task.py
+++ b/src/python/pants/backend/jvm/tasks/resources_task.py
@@ -32,9 +32,6 @@ class ResourcesTask(Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
-    """
-    :API: public
-    """
     round_manager.require_data('compile_classpath')
 
   @property

--- a/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
@@ -20,6 +20,8 @@ class RunJvmPrepCommandBase(Task):
   This task is meant to be subclassed, setting the 'goal' variable appropriately.
 
   output unless the 'compile_classpath_only' field is set to True in the task
+
+  :API: public
   """
   goal = None
   classpath_product_only = False
@@ -40,6 +42,9 @@ class RunJvmPrepCommandBase(Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
+    """
+    :API: public
+    """
     super(RunJvmPrepCommandBase, cls).prepare(options, round_manager)
     round_manager.require_data('compile_classpath')
     if not cls.classpath_product_only:
@@ -50,6 +55,9 @@ class RunJvmPrepCommandBase(Task):
     return isinstance(tgt, JvmPrepCommand) and tgt.payload.get_field_value('goal') == cls.goal
 
   def execute(self):
+    """
+    :API: public
+    """
     if self.goal not in JvmPrepCommand.goals():
       raise  TaskError("Expected goal to be one of {}".format(JvmPrepCommand.goals()))
 

--- a/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/tasks/run_jvm_prep_command.py
@@ -55,9 +55,6 @@ class RunJvmPrepCommandBase(Task):
     return isinstance(tgt, JvmPrepCommand) and tgt.payload.get_field_value('goal') == cls.goal
 
   def execute(self):
-    """
-    :API: public
-    """
     if self.goal not in JvmPrepCommand.goals():
       raise  TaskError("Expected goal to be one of {}".format(JvmPrepCommand.goals()))
 

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -44,6 +44,8 @@ class Scalastyle(NailgunTask):
   """Checks scala source files to ensure they're stylish.
 
   Scalastyle only checks scala sources in non-synthetic targets.
+
+  :API: public
   """
 
   class UnspecifiedConfig(TaskError):

--- a/src/python/pants/backend/jvm/tasks/unpack_jars.py
+++ b/src/python/pants/backend/jvm/tasks/unpack_jars.py
@@ -43,6 +43,8 @@ class UnpackJars(Task):
   """Unpack artifacts specified by unpacked_jars() targets.
 
   Adds an entry to SourceRoot for the contents.
+
+  :API: public
   """
 
   class InvalidPatternError(Exception):
@@ -138,6 +140,9 @@ class UnpackJars(Task):
       ZIP.extract(jar_path, unpack_dir, filter_func=unpack_filter)
 
   def execute(self):
+    """
+    :API: public
+    """
     addresses = [target.address for target in self.context.targets()]
     closure = self.context.build_graph.transitive_subgraph_of_addresses(addresses)
     unpacked_jars_list = [t for t in closure if isinstance(t, UnpackedJars)]

--- a/src/python/pants/backend/jvm/tasks/unpack_jars.py
+++ b/src/python/pants/backend/jvm/tasks/unpack_jars.py
@@ -140,9 +140,6 @@ class UnpackJars(Task):
       ZIP.extract(jar_path, unpack_dir, filter_func=unpack_filter)
 
   def execute(self):
-    """
-    :API: public
-    """
     addresses = [target.address for target in self.context.targets()]
     closure = self.context.build_graph.transitive_subgraph_of_addresses(addresses)
     unpacked_jars_list = [t for t in closure if isinstance(t, UnpackedJars)]


### PR DESCRIPTION
The following modules were reviewed and all api's were left as private. As
far as I can tell these modules are not currently used by plugins.

pants.backend.jvm.tasks.benchmark_run
pants.backend.jvm.tasks.binary_create
pants.backend.jvm.tasks.bootstrap_jvm_tools
pants.backend.jvm.tasks.check_published_deps
pants.backend.jvm.tasks.classpath_util
pants.backend.jvm.tasks.coverage.base
pants.backend.jvm.tasks.coverage.cobertura
pants.backend.jvm.tasks.detect_duplicates
pants.backend.jvm.tasks.ivy_imports
pants.backend.jvm.tasks.ivy_resolve
pants.backend.jvm.tasks.jar_create
pants.backend.jvm.tasks.jar_import_products
pants.backend.jvm.tasks.jar_publish
pants.backend.jvm.tasks.javadoc_gen
pants.backend.jvm.tasks.jvm_binary_task
pants.backend.jvm.tasks.jvm_compile.analysis
pants.backend.jvm.tasks.jvm_compile.analysis_parser
pants.backend.jvm.tasks.jvm_compile.analysis_tools
pants.backend.jvm.tasks.jvm_compile.anonymizer
pants.backend.jvm.tasks.jvm_compile.compile_context
pants.backend.jvm.tasks.jvm_compile.execution_graph
pants.backend.jvm.tasks.jvm_compile.jvm_classpath_publisher
pants.backend.jvm.tasks.jvm_compile.jvm_compile
pants.backend.jvm.tasks.jvm_compile.zinc.bin.anonymize_analysis
pants.backend.jvm.tasks.jvm_compile.zinc.zinc_analysis
pants.backend.jvm.tasks.jvm_compile.zinc.zinc_analysis_diff
pants.backend.jvm.tasks.jvm_compile.zinc.zinc_analysis_parser
pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile
pants.backend.jvm.tasks.jvm_dependency_analyzer
pants.backend.jvm.tasks.jvm_dependency_check
pants.backend.jvm.tasks.jvm_dependency_usage
pants.backend.jvm.tasks.jvm_platform_analysis
pants.backend.jvm.tasks.jvm_run
pants.backend.jvm.tasks.jvm_task
pants.backend.jvm.tasks.jvmdoc_gen
pants.backend.jvm.tasks.prepare_resources
pants.backend.jvm.tasks.prepare_services
pants.backend.jvm.tasks.scala_repl
pants.backend.jvm.tasks.scaladoc_gen