### PR TITLE
add if_files_changed option to changed task so we can check affected targets without a git branch

### DIFF
--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -294,6 +294,13 @@ class WhatChangedTest(WhatChangedTestBasic):
       ),
     )
 
+  def test_if_files_changed_files(self):
+    self.assert_console_output(
+      'root/src/java/a:a_java',
+      options={'if_files_changed': ['root/src/java/a/b/c/Foo.java']},
+      workspace=self.workspace(),
+    )
+
   def test_include_dependees(self):
     self.assert_console_output(
       'root/src/py/dependency_tree/a:a',


### PR DESCRIPTION
This change will let us check which targets are affected by source file changes without having to put those changes in a branch or a committing the changes to git.  