### PR TITLE
Set public api markers for jvm backend

### DIFF
--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -19,6 +19,8 @@ class Artifact(PayloadField):
   """Represents a publishable jvm artifact ala maven or ivy.
 
   Used in the ``provides`` parameter to *jvm*\_library targets.
+
+  :API: public
   """
 
   def __init__(self, org, name, repo, publication_metadata=None):

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -48,6 +48,9 @@ class IvyResolveMappingError(Exception):
 
 
 class IvyModuleRef(object):
+  """
+  :API: public
+  """
 
   # latest.integration is ivy magic meaning "just get the latest version"
   _ANY_REV = 'latest.integration'
@@ -104,6 +107,9 @@ class IvyModuleRef(object):
 
 
 class IvyInfo(object):
+  """
+  :API: public
+  """
 
   def __init__(self, conf):
     self._conf = conf
@@ -210,7 +216,10 @@ class IvyInfo(object):
 
 
 class IvyUtils(object):
-  """Useful methods related to interaction with ivy."""
+  """Useful methods related to interaction with ivy.
+
+  :API: public
+  """
 
   ivy_lock = threading.RLock()
 
@@ -250,6 +259,9 @@ class IvyUtils(object):
                executor,
                workunit_name,
                workunit_factory):
+    """
+    :API: public
+    """
     ivy = ivy or Bootstrapper.default_ivy()
 
     ivy_args = ['-ivy', ivyxml]
@@ -273,6 +285,8 @@ class IvyUtils(object):
   @classmethod
   def symlink_cachepath(cls, ivy_cache_dir, inpath, symlink_dir, outpath):
     """Symlinks all paths listed in inpath that are under ivy_cache_dir into symlink_dir.
+
+    :API: public
 
     If there is an existing symlink for a file under inpath, it is used rather than creating
     a new symlink. Preserves all other paths. Writes the resulting paths to outpath.
@@ -316,6 +330,9 @@ class IvyUtils(object):
 
   @staticmethod
   def identify(targets):
+    """
+    :API: public
+    """
     targets = list(targets)
     if len(targets) == 1 and targets[0].is_jvm and getattr(targets[0], 'provides', None):
       return targets[0].provides.org, targets[0].provides.name
@@ -325,6 +342,8 @@ class IvyUtils(object):
   @classmethod
   def xml_report_path(cls, cache_dir, resolve_hash_name, conf):
     """The path to the xml report ivy creates after a retrieve.
+
+    :API: public
 
     :param string cache_dir: The path of the ivy cache dir used for resolves.
     :param string resolve_hash_name: Hash from the Cache key from the VersionedTargetSet used for
@@ -339,6 +358,8 @@ class IvyUtils(object):
   @classmethod
   def parse_xml_report(cls, conf, path):
     """Parse the ivy xml report corresponding to the name passed to ivy.
+
+    :API: public
 
     :param string conf: the ivy conf name (e.g. "default")
     :param string path: The path to the ivy report file.
@@ -379,6 +400,9 @@ class IvyUtils(object):
   @classmethod
   def generate_ivy(cls, targets, jars, excludes, ivyxml, confs, resolve_hash_name=None,
                    pinned_artifacts=None):
+    """
+    :API: public
+    """
     if resolve_hash_name:
       org = IvyUtils.INTERNAL_ORG_NAME
       name = resolve_hash_name
@@ -448,6 +472,8 @@ class IvyUtils(object):
     It also modifies the JarDependency objects' excludes to contain all the jars excluded by
     provides.
 
+    :API: public
+
     :param iterable targets: List of targets to collect JarDependencies and excludes from.
 
     :returns: A pair of a list of JarDependencies, and a set of excludes to apply globally.
@@ -476,16 +502,25 @@ class IvyUtils(object):
                                                                         proposed=jar)
 
     def collect_jars(target):
+      """
+      :API: public
+      """
       if isinstance(target, JarLibrary):
         for jar in target.jar_dependencies:
           add_jar(jar)
 
     def collect_excludes(target):
+      """
+      :API: public
+      """
       target_excludes = target.payload.get_field_value('excludes')
       if target_excludes:
         global_excludes.update(target_excludes)
 
     def collect_provide_excludes(target):
+      """
+      :API: public
+      """
       if not target.is_exported:
         return
       logger.debug('Automatically excluding jar {}.{}, which is provided by {}'.format(
@@ -493,6 +528,9 @@ class IvyUtils(object):
       provide_excludes.add(Exclude(org=target.provides.org, name=target.provides.name))
 
     def collect_elements(target):
+      """
+      :API: public
+      """
       targets_processed.add(target)
       collect_jars(target)
       collect_excludes(target)

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -286,8 +286,6 @@ class IvyUtils(object):
   def symlink_cachepath(cls, ivy_cache_dir, inpath, symlink_dir, outpath):
     """Symlinks all paths listed in inpath that are under ivy_cache_dir into symlink_dir.
 
-    :API: public
-
     If there is an existing symlink for a file under inpath, it is used rather than creating
     a new symlink. Preserves all other paths. Writes the resulting paths to outpath.
     Returns a map of path -> symlink to that path.
@@ -330,9 +328,6 @@ class IvyUtils(object):
 
   @staticmethod
   def identify(targets):
-    """
-    :API: public
-    """
     targets = list(targets)
     if len(targets) == 1 and targets[0].is_jvm and getattr(targets[0], 'provides', None):
       return targets[0].provides.org, targets[0].provides.name
@@ -400,9 +395,6 @@ class IvyUtils(object):
   @classmethod
   def generate_ivy(cls, targets, jars, excludes, ivyxml, confs, resolve_hash_name=None,
                    pinned_artifacts=None):
-    """
-    :API: public
-    """
     if resolve_hash_name:
       org = IvyUtils.INTERNAL_ORG_NAME
       name = resolve_hash_name
@@ -472,8 +464,6 @@ class IvyUtils(object):
     It also modifies the JarDependency objects' excludes to contain all the jars excluded by
     provides.
 
-    :API: public
-
     :param iterable targets: List of targets to collect JarDependencies and excludes from.
 
     :returns: A pair of a list of JarDependencies, and a set of excludes to apply globally.
@@ -502,25 +492,16 @@ class IvyUtils(object):
                                                                         proposed=jar)
 
     def collect_jars(target):
-      """
-      :API: public
-      """
       if isinstance(target, JarLibrary):
         for jar in target.jar_dependencies:
           add_jar(jar)
 
     def collect_excludes(target):
-      """
-      :API: public
-      """
       target_excludes = target.payload.get_field_value('excludes')
       if target_excludes:
         global_excludes.update(target_excludes)
 
     def collect_provide_excludes(target):
-      """
-      :API: public
-      """
       if not target.is_exported:
         return
       logger.debug('Automatically excluding jar {}.{}, which is provided by {}'.format(
@@ -528,9 +509,6 @@ class IvyUtils(object):
       provide_excludes.add(Exclude(org=target.provides.org, name=target.provides.name))
 
     def collect_elements(target):
-      """
-      :API: public
-      """
       targets_processed.add(target)
       collect_jars(target)
       collect_excludes(target)

--- a/src/python/pants/backend/jvm/jar_dependency_utils.py
+++ b/src/python/pants/backend/jvm/jar_dependency_utils.py
@@ -38,7 +38,10 @@ class ResolvedJar(object):
 
 
 class M2Coordinate(object):
-  """Represents a fully qualified name of an artifact."""
+  """Represents a fully qualified name of an artifact.
+
+  :API: public
+  """
 
   def __init__(self, org, name, rev=None, classifier=None, ext=None):
     """
@@ -62,6 +65,8 @@ class M2Coordinate(object):
   @classmethod
   def create(cls, jar):
     """Creates an actual M2Coordinate from the given M2Coordinate-like object (eg a JarDependency).
+
+    :API: public
 
     :param JarDependency jar: the input coordinate.
     :return: A new M2Coordinate, unless the input is already an M2Coordinate in which case it just
@@ -88,6 +93,8 @@ class M2Coordinate(object):
   @memoized_property
   def artifact_filename(self):
     """Returns the canonical maven-style filename for an artifact pointed at by this coordinate.
+
+    :API: public
 
     :rtype: string
     """

--- a/src/python/pants/backend/jvm/repository.py
+++ b/src/python/pants/backend/jvm/repository.py
@@ -9,7 +9,10 @@ import os
 
 
 class Repository(object):
-  """An artifact repository, such as a maven repo."""
+  """An artifact repository, such as a maven repo.
+
+  :API: public
+  """
 
   def __init__(self, name=None, url=None, push_db_basedir=None, **kwargs):
     """

--- a/src/python/pants/backend/jvm/scala_artifact.py
+++ b/src/python/pants/backend/jvm/scala_artifact.py
@@ -10,7 +10,10 @@ from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 
 
 class ScalaArtifact(Artifact):
-  """Extends Artifact to append the configured Scala version."""
+  """Extends Artifact to append the configured Scala version.
+
+  :API: public
+  """
 
   @property
   def name(self):

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -16,7 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class JVM(Subsystem):
-  """A JVM invocation."""
+  """A JVM invocation.
+
+  :API: public
+  """
   options_scope = 'jvm'
 
   @classmethod

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -48,7 +48,10 @@ scala_build_info = {
 
 
 class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, Subsystem):
-  """A scala platform."""
+  """A scala platform.
+
+  :API: public
+  """
 
   options_scope = 'scala-platform'
 

--- a/src/python/pants/backend/jvm/targets/annotation_processor.py
+++ b/src/python/pants/backend/jvm/targets/annotation_processor.py
@@ -9,7 +9,10 @@ from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrar
 
 
 class AnnotationProcessor(ExportableJvmLibrary):
-  """A Java library containing annotation processors."""
+  """A Java library containing annotation processors.
+
+  :API: public
+  """
 
   def __init__(self, processors=None, *args, **kwargs):
 

--- a/src/python/pants/backend/jvm/targets/exclude.py
+++ b/src/python/pants/backend/jvm/targets/exclude.py
@@ -7,7 +7,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 
 class Exclude(object):
-  """Represents a dependency exclude pattern to filter transitive dependencies against."""
+  """Represents a dependency exclude pattern to filter transitive dependencies against.
+
+  :API: public
+  """
 
   def __init__(self, org, name=None):
     """

--- a/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
+++ b/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
@@ -9,7 +9,10 @@ from pants.backend.jvm.targets.jvm_target import JvmTarget
 
 
 class ExportableJvmLibrary(JvmTarget):
-  """A baseclass for java targets that support being exported to an artifact repository."""
+  """A baseclass for java targets that support being exported to an artifact repository.
+
+  :API: public
+  """
 
   def __init__(self, *args, **kwargs):
     """

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -14,7 +14,10 @@ from pants.util.memo import memoized_property
 
 
 class JarDependency(object):
-  """A pre-built Maven repository dependency."""
+  """A pre-built Maven repository dependency.
+
+  :API: public
+  """
 
   def __init__(self, org, name, rev=None, force=False, ext=None, url=None, apidocs=None,
                classifier=None, mutable=None, intransitive=False, excludes=None):

--- a/src/python/pants/backend/jvm/targets/jar_library.py
+++ b/src/python/pants/backend/jvm/targets/jar_library.py
@@ -17,7 +17,10 @@ from pants.build_graph.target import Target
 
 
 class JarLibrary(Target):
-  """A set of external JAR files."""
+  """A set of external JAR files.
+
+  :API: public
+  """
 
   class WrongTargetTypeError(Exception):
     """Thrown if the wrong type of target is encountered."""
@@ -48,7 +51,10 @@ class JarLibrary(Target):
 
   @property
   def managed_dependencies(self):
-    """The managed_jar_dependencies target this jar_library specifies, or None."""
+    """The managed_jar_dependencies target this jar_library specifies, or None.
+
+    :API: public
+    """
     if self.payload.managed_dependencies:
       address = Address.parse(self.payload.managed_dependencies,
                               relative_to=self.address.spec_path)
@@ -58,10 +64,16 @@ class JarLibrary(Target):
 
   @property
   def jar_dependencies(self):
+    """
+    :API: public
+    """
     return self.payload.jars
 
   @property
   def excludes(self):
+    """
+    :API: public
+    """
     return self.payload.excludes
 
   @staticmethod
@@ -69,6 +81,8 @@ class JarLibrary(Target):
     """Convenience method to resolve a list of specs to JarLibraries and return its jars attributes.
 
     Expects that the jar_libraries are declared relative to this target.
+
+    :API: public
 
     :param Address relative_to: address target that references jar_library_specs, for
       error messages

--- a/src/python/pants/backend/jvm/targets/java_library.py
+++ b/src/python/pants/backend/jvm/targets/java_library.py
@@ -16,6 +16,8 @@ class JavaLibrary(ExportableJvmLibrary):
   goal on this target creates a ``.jar``; but that's an unusual thing to do.
   Instead, a ``jvm_binary`` might depend on this library; that binary is a
   more sensible thing to bundle.
+
+  :API: public
   """
 
   def __init__(self, *args, **kwargs):

--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -12,7 +12,10 @@ from pants.base.payload_field import PrimitiveField
 
 
 class JavaTests(JvmTarget):
-  """JUnit tests."""
+  """JUnit tests.
+
+  :API: public
+  """
 
   def __init__(self, cwd=None, test_platform=None, payload=None, timeout=None,
                extra_jvm_options=None, extra_env_vars=None, **kwargs):

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -50,10 +50,7 @@ class JarRule(FingerprintedMixin, AbstractClass):
 
 
 class Skip(JarRule):
-  """A rule that skips adding matched entries to a jar.
-
-  :API: public
-  """
+  """A rule that skips adding matched entries to a jar."""
 
   def __repr__(self):
     return "Skip(apply_pattern={})".format(self.payload.apply_pattern)

--- a/src/python/pants/backend/jvm/targets/jvm_binary.py
+++ b/src/python/pants/backend/jvm/targets/jvm_binary.py
@@ -50,7 +50,10 @@ class JarRule(FingerprintedMixin, AbstractClass):
 
 
 class Skip(JarRule):
-  """A rule that skips adding matched entries to a jar."""
+  """A rule that skips adding matched entries to a jar.
+
+  :API: public
+  """
 
   def __repr__(self):
     return "Skip(apply_pattern={})".format(self.payload.apply_pattern)
@@ -154,6 +157,8 @@ class JarRules(FingerprintedMixin):
   such that there are no duplicates in the final deploy jar.  The four
   `Duplicate <#Duplicate>`_ rules support resolution of these cases by allowing 1st wins,
   last wins, concatenation of the duplicate entry contents or raising an exception.
+
+  :API: public
   """
 
   @classmethod
@@ -194,6 +199,8 @@ class JarRules(FingerprintedMixin):
 
     Can be set with `set_default` but otherwise defaults to
     `skip_signatures_and_duplicates_concat_well_known_metadata`.
+
+    :API: public
     """
     if cls._DEFAULT is None:
       cls._DEFAULT = cls.skip_signatures_and_duplicates_concat_well_known_metadata()
@@ -222,7 +229,10 @@ class JarRules(FingerprintedMixin):
 
   @property
   def default_dup_action(self):
-    """The default action to take when a duplicate jar entry is encountered."""
+    """The default action to take when a duplicate jar entry is encountered.
+
+    :API: public
+    """
     return self.payload.default_dup_action
 
   @property
@@ -285,6 +295,8 @@ class JvmBinary(JvmTarget):
   * ``binary`` - Create an executable jar of the binary. On the JVM
     this means the jar has a manifest specifying the main class.
   * ``run`` - Executes the main class of this binary locally.
+
+  :API: public
   """
 
   def __init__(self,
@@ -300,6 +312,8 @@ class JvmBinary(JvmTarget):
                shading_rules=None,
                **kwargs):
     """
+    :API: public
+
     :param string main: The name of the ``main`` class, e.g.,
       ``'org.pantsbuild.example.hello.main.HelloMain'``. This class may be
       present as the source of this target or depended-upon library.

--- a/src/python/pants/backend/jvm/targets/jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/targets/jvm_prep_command.py
@@ -33,6 +33,8 @@ class JvmPrepCommand(JvmTarget):
   Pants will execute the `jvm_prep_command()` when processing the specified goal.  They will be
   triggered when running targets that depend on the `prep_command()` target or when the
   target is referenced from the command line.
+
+  :API: public
   """
   _goals=frozenset()
 

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -42,6 +42,8 @@ class JvmTarget(Target, Jarable):
                fatal_warnings=None,
                **kwargs):
     """
+    :API: public
+
     :param excludes: List of `exclude <#exclude>`_\s to filter this target's
       transitive dependencies against.
     :param sources: Source code files to build. Paths are relative to the BUILD

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -20,7 +20,10 @@ from pants.util.memo import memoized_property
 
 
 class JvmTarget(Target, Jarable):
-  """A base class for all java module targets that provides path and dependency translation."""
+  """A base class for all java module targets that provides path and dependency translation.
+
+  :API: public
+  """
 
   @classmethod
   def subsystems(cls):

--- a/src/python/pants/backend/jvm/targets/scala_library.py
+++ b/src/python/pants/backend/jvm/targets/scala_library.py
@@ -19,6 +19,8 @@ class ScalaLibrary(ExportableJvmLibrary):
   goal on this target creates a ``.jar``; but that's an unusual thing to do.
   Instead, a ``jvm_binary`` might depend on this library; that binary is a
   more sensible thing to bundle.
+
+  :API: public
   """
 
   @classmethod

--- a/src/python/pants/backend/jvm/targets/unpacked_jars.py
+++ b/src/python/pants/backend/jvm/targets/unpacked_jars.py
@@ -17,7 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 class UnpackedJars(ImportJarsMixin, Target):
-  """A set of sources extracted from JAR files."""
+  """A set of sources extracted from JAR files.
+
+  :API: public
+  """
 
   class ExpectedLibrariesError(Exception):
     """Thrown when the target has no libraries defined."""


### PR DESCRIPTION
The following modules were reviewed and all api's were left as private. As
far as I can tell these modules are not currently used by plugins.

pants.backend.jvm.subsystems.jar_tool
pants.backend.jvm.subsystems.java
pants.backend.jvm.subsystems.jvm_platform
pants.backend.jvm.subsystems.jvm_tool_mixin
pants.backend.jvm.subsystems.shader
pants.backend.jvm.subsystems.zinc_language_mixin
pants.backend.jvm.targets.annotation_processor
pants.backend.jvm.targets.benchmark
pants.backend.jvm.targets.credentials
pants.backend.jvm.targets.import_jars_mixin
pants.backend.jvm.targets.jarable
pants.backend.jvm.targets.java_agent
pants.backend.jvm.targets.jvm_app
pants.backend.jvm.targets.managed_jar_dependencies
pants.backend.jvm.targets.scala_jar_dependency
pants.backend.jvm.targets.scalac_plugin