### PR TITLE
Allow running prep_commands in goals other than test

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_prep_command.py
+++ b/src/python/pants/backend/jvm/targets/jvm_prep_command.py
@@ -34,6 +34,8 @@ class JvmPrepCommand(JvmTarget):
   triggered when running targets that depend on the `prep_command()` target or when the
   target is referenced from the command line.
 
+  See also prep_command for running shell commands.
+
   :API: public
   """
   _goals=frozenset()
@@ -42,6 +44,11 @@ class JvmPrepCommand(JvmTarget):
   def add_goal(goal):
     """Add a named goal to the list of valid goals for the 'goal' parameter."""
     JvmPrepCommand._goals = frozenset(list(JvmPrepCommand._goals) + [goal])
+
+  @classmethod
+  def reset(cls):
+    """Used for testing purposes to reset state."""
+    cls._goals=frozenset()
 
   @staticmethod
   def goals():
@@ -66,6 +73,7 @@ class JvmPrepCommand(JvmTarget):
     })
     super(JvmPrepCommand, self).__init__(payload=payload, **kwargs)
     if not mainclass:
-      raise TargetDefinitionException(self, 'mainclass must be specified')
+      raise TargetDefinitionException(self, 'mainclass must be specified.')
     if goal not in self.goals():
-      raise TargetDefinitionException(self, 'goal must be one of {}.'.format(self.goals()))
+      raise TargetDefinitionException(self, 'Got goal "{}". Goal must be one of {}.'.format(
+          goal, self.goals()))

--- a/src/python/pants/build_graph/prep_command.py
+++ b/src/python/pants/build_graph/prep_command.py
@@ -5,24 +5,44 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.build_graph.target import Target
 
 
 class PrepCommand(Target):
-  """A command to be run prior to running tests.
+  """A shell command to be run prior to running a goal.
 
   For example, you can use `prep_command()` to execute a script that sets up tunnels to database
   servers. These tunnels could then be leveraged by integration tests.
 
-  Pants will only execute the `prep_command()` under the test goal, when testing targets that
-  depend on the `prep_command()` target.
+  Pants will only execute the `prep_command()` under the specified goal, when processing targets
+  that depend on the `prep_command()` target.  If not otherwise specified, prep_commands
+  execute in the test goal.
+
+  See also jvm_prep_command for running tasks defined by a JVM language.
 
   :API: public
   """
+  _goals=frozenset()
 
-  def __init__(self, prep_executable=None, prep_args=None, payload=None, prep_environ=False, **kwargs):
+  @staticmethod
+  def add_goal(goal):
+    """Add a named goal to the list of valid goals for the 'goal' parameter."""
+    PrepCommand._goals = frozenset(list(PrepCommand._goals) + [goal])
+
+  @classmethod
+  def reset(cls):
+    """Used for testing purposes to reset state."""
+    cls._goals=frozenset()
+
+  @staticmethod
+  def goals():
+    return PrepCommand._goals
+
+  def __init__(self, prep_executable=None, prep_args=None, payload=None, prep_environ=False,
+               goal=None, **kwargs):
     """
     :API: public
 
@@ -32,11 +52,21 @@ class PrepCommand(Target):
       a \\\\0-separated list of key=value pairs to insert into the environment.
       Note that this will pollute the environment for all future tests, so
       avoid it if at all possible.
+    :param goal: Pants goal to run this command in [test, binary or compile]. If not specified,
+                 runs in the 'test' goal.
     """
     payload = payload or Payload()
+    goal = goal or 'test'
+
     payload.add_fields({
+      'goal': PrimitiveField(goal),
       'prep_command_executable': PrimitiveField(prep_executable),
       'prep_command_args': PrimitiveField(prep_args or []),
       'prep_environ': PrimitiveField(prep_environ),
     })
     super(PrepCommand, self).__init__(payload=payload, **kwargs)
+    if not prep_executable:
+      raise TargetDefinitionException(self, 'prep_executable must be specified.')
+    if goal not in self.goals():
+      raise TargetDefinitionException(self, 'Got goal "{}". Goal must be one of {}.'.format(
+          goal, self.goals()))

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -17,7 +17,8 @@ from pants.core_tasks.pantsd_kill import PantsDaemonKill
 from pants.core_tasks.reporting_server_kill import ReportingServerKill
 from pants.core_tasks.reporting_server_run import ReportingServerRun
 from pants.core_tasks.roots import ListRoots
-from pants.core_tasks.run_prep_command import RunPrepCommand
+from pants.core_tasks.run_prep_command import (RunBinaryPrepCommand, RunCompilePrepCommand,
+                                               RunTestPrepCommand)
 from pants.core_tasks.targets_help import TargetsHelp
 from pants.core_tasks.what_changed import WhatChanged
 from pants.goal.goal import Goal
@@ -70,8 +71,11 @@ def register_goals():
   # Stub for other goals to schedule 'compile'. See noop_exec_task.py for why this is useful.
   task(name='compile', action=NoopCompile).install('compile')
 
-  # Must be the first thing we register under 'test'.
-  task(name='run_prep_command', action=RunPrepCommand).install('test')
+  # Prep commands must be the first thing we register under its goal.
+  task(name='test-prep-command', action=RunTestPrepCommand).install('test', first=True)
+  task(name='binary-prep-command', action=RunBinaryPrepCommand).install('binary', first=True)
+  task(name='compile-prep-command', action=RunCompilePrepCommand).install('compile', first=True)
+
   # Stub for other goals to schedule 'test'. See noop_exec_task.py for why this is useful.
   task(name='test', action=NoopTest).install('test')
 

--- a/testprojects/src/java/org/pantsbuild/testproject/prepcommand/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/prepcommand/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Integration tests for the jvm_prep_command() target
+
+java_library(name='jvmprepcommand',
+  sources=globs('*.java'),
+)
+
+prep_command(
+  name='test-prep-command',
+  prep_executable='touch',
+  prep_args=['/tmp/running-prep-in-goal-test.txt'],
+)
+
+prep_command(
+  name='binary-prep-command',
+  goal='binary',
+  prep_executable='touch',
+  prep_args=['/tmp/running-prep-in-goal-binary.txt'],
+)
+
+prep_command(
+  name='compile-prep-command',
+  goal='compile',
+  prep_executable='touch',
+  prep_args=['/tmp/running-prep-in-goal-compile.txt'],
+)

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -23,6 +23,17 @@ python_tests(
 )
 
 python_tests(
+    name = 'prep_command_integration',
+    sources = ['test_prep_command_integration.py'],
+    dependencies = [
+        'src/python/pants/util:contextutil',
+        'src/python/pants/util:dirutil',
+        'tests/python/pants_test:int-test',
+    ],
+    tags = {'integration'},
+)
+
+python_tests(
   name = 'run_prep_command',
   sources = ['test_run_prep_command.py'],
   dependencies = [

--- a/tests/python/pants_test/core_tasks/test_prep_command_integration.py
+++ b/tests/python/pants_test/core_tasks/test_prep_command_integration.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.util.contextutil import open_zip, temporary_dir
+from pants.util.dirutil import safe_delete
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class PrepCommandIntegration(PantsRunIntegrationTest):
+
+  SENTINELS = {
+    'test' : '/tmp/running-prep-in-goal-test.txt',
+    'compile' : '/tmp/running-prep-in-goal-compile.txt',
+    'binary' : '/tmp/running-prep-in-goal-binary.txt'
+  }
+
+  def setUp(self):
+    for path in self.SENTINELS.values():
+      safe_delete(path)
+
+  def assert_goal_ran(self, goal):
+    self.assertTrue(os.path.exists(self.SENTINELS[goal]))
+
+  def assert_goal_did_not_run(self, goal):
+    self.assertFalse(os.path.exists(self.SENTINELS[goal]))
+
+  def test_prep_command_in_compile(self):
+    pants_run = self.run_pants([
+      'compile',
+      'testprojects/src/java/org/pantsbuild/testproject/prepcommand::'])
+    self.assert_success(pants_run)
+
+    self.assert_goal_ran('compile')
+    self.assert_goal_did_not_run('test')
+    self.assert_goal_did_not_run('binary')
+
+  def test_prep_command_in_test(self):
+    pants_run = self.run_pants([
+      'test',
+      'testprojects/src/java/org/pantsbuild/testproject/prepcommand::'])
+    self.assert_success(pants_run)
+
+    self.assert_goal_ran('compile')
+    self.assert_goal_ran('test')
+    self.assert_goal_did_not_run('binary')
+
+  def test_prep_command_in_binary(self):
+    pants_run = self.run_pants([
+      'binary',
+      'testprojects/src/java/org/pantsbuild/testproject/prepcommand::'])
+    self.assert_success(pants_run)
+
+    self.assert_goal_ran('compile')
+    self.assert_goal_ran('binary')
+    self.assert_goal_did_not_run('test')

--- a/tests/python/pants_test/core_tasks/test_run_prep_command.py
+++ b/tests/python/pants_test/core_tasks/test_run_prep_command.py
@@ -9,19 +9,36 @@ import os
 
 from six.moves import range
 
-from pants.base.exceptions import TaskError
+from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.prep_command import PrepCommand
-from pants.core_tasks.run_prep_command import RunPrepCommand
+from pants.build_graph.target import Target
+from pants.core_tasks.run_prep_command import RunPrepCommandBase
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import touch
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
+class FakeRunPrepCommand(RunPrepCommandBase):
+  goal = 'test'
+
+
 class RunPrepCommandTest(TaskTestBase):
+
+  def setUp(self):
+    super (RunPrepCommandTest, self).setUp()
+    # This is normally taken care of in RunPrepCommandBase.register_options() when running pants,
+    # but these don't get called in testing unless you call `self.create_task()`.
+    # Some of these unit tests need to create targets before creating the task.
+    PrepCommand.add_goal('test')
+    PrepCommand.add_goal('binary')
+
+  def tearDown(self):
+    PrepCommand.reset()
+
   @classmethod
   def task_type(cls):
-    return RunPrepCommand
+    return FakeRunPrepCommand
 
   @property
   def alias_groups(self):
@@ -76,3 +93,26 @@ class RunPrepCommandTest(TaskTestBase):
       context = self.context(target_roots=[a])
       task = self.create_task(context=context, workdir='')
       task.execute()
+
+  def test_valid_target(self):
+    self.make_target('foo', PrepCommand, prep_executable='foo.sh')
+
+  def test_invalid_target(self):
+    with self.assertRaisesRegexp(TargetDefinitionException,
+                                 r'prep_executable must be specified'):
+      self.make_target('foo', PrepCommand,)
+
+    with self.assertRaisesRegexp(TargetDefinitionException,
+                                 r'.*Got goal "baloney". Goal must be one of.*'):
+      self.make_target('foo', PrepCommand, prep_executable='foo.sh', goal='baloney')
+
+  def test_runnable_prep_cmd(self):
+    test_prep_cmd = self.make_target('test-prep-cmd', PrepCommand, prep_executable='foo.sh')
+    binary_prep_cmd = self.make_target('binary-prep-cmd', PrepCommand, prep_executable='foo.sh', goal='binary')
+    not_a_prep_cmd = self.make_target('not-a-prep-cmd', Target)
+    task = self.create_task(context=self.context())
+
+    self.assertTrue(task.runnable_prep_cmd(test_prep_cmd))
+    # this target is a prep command, but not for a goal that is runnable in this task subclass
+    self.assertFalse(task.runnable_prep_cmd(binary_prep_cmd))
+    self.assertFalse(task.runnable_prep_cmd(not_a_prep_cmd))


### PR DESCRIPTION
This change refactors PrepCommand to allow specifying a goal to run in.
That goal must have a subclass of RunPrepCommandBase registered

Deprecates the RunPrepCommand task in favor of RunTestPrepCommand