### PR TITLE
Set public API markers for task and util

### DIFF
--- a/src/python/pants/task/repl_task_mixin.py
+++ b/src/python/pants/task/repl_task_mixin.py
@@ -17,6 +17,8 @@ class ReplTaskMixin(MutexTaskMixin):
 
   By mixing in this class, REPL implementations ensure they are the only REPL that is being run in
   the current pants session.
+
+  :API: public
   """
 
   @classmethod

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -589,6 +589,12 @@ class Task(TaskBase):
   :API: public
   """
 
+  def __init__(self, context, workdir):
+    """
+    :API: public
+    """
+    super(Task, self).__init__(context, workdir)
+
   @abstractmethod
   def execute(self):
     """Executes this task.

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -60,6 +60,9 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
   @classmethod
   def implementation_version(cls):
+    """
+    :API: public
+    """
     return [('TaskBase', 1)]
 
   @classmethod
@@ -81,6 +84,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     """The global subsystems this task uses.
 
     A tuple of subsystem types.
+
+    :API: public
     """
     return tuple()
 
@@ -89,6 +94,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     """The private, per-task subsystems this task uses.
 
     A tuple of subsystem types.
+
+    :API: public
     """
     return (CacheSetup,)
 
@@ -99,6 +106,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
     By default, each task is considered as creating a unique product type(s).
     Subclasses that create products, should override this to specify their unique product type(s).
+
+    :API: public
     """
     return []
 
@@ -114,7 +123,10 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
   @classmethod
   def supports_passthru_args(cls):
-    """Subclasses may override to indicate that they can use passthru args."""
+    """Subclasses may override to indicate that they can use passthru args.
+
+    :API: public
+    """
     return False
 
   @classmethod
@@ -134,6 +146,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     At most 1 unique proposal is allowed amongst all tasks involved in the run.  If more than 1
     unique list of target roots is proposed an error is raised during task scheduling.
 
+    :API: public
+
     :returns list: The new target roots to use or none to accept the CLI specified target roots.
     """
 
@@ -151,6 +165,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
     Typically a task that requires products from other goals would register interest in those
     products here and then retrieve the requested product mappings when executed.
+
+    :API: public
     """
 
   def __init__(self, context, workdir):
@@ -188,10 +204,16 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     self._fingerprint = None
 
   def get_options(self):
-    """Returns the option values for this task's scope."""
+    """Returns the option values for this task's scope.
+
+    :API: public
+    """
     return self.context.options.for_scope(self.options_scope)
 
   def get_passthru_args(self):
+    """
+    :API: public
+    """
     if not self.supports_passthru_args():
       raise TaskError('{0} Does not support passthru args.'.format(self.stable_name()))
     else:
@@ -203,6 +225,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
     It's not guaranteed that the workdir exists, just that no other task has been given this
     workdir path to use.
+
+    :API: public
     """
     return self._workdir
 
@@ -272,6 +296,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     which will automatically be uploaded to the cache. Tasks should place the output files
     for each VersionedTarget in said results directory. It is highly suggested to follow this
     schema for caching, rather than manually making updates to the artifact cache.
+
+    :API: public
     """
     return False
 
@@ -283,6 +309,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     for a target cloned into the results_dir for the current build (where possible). This
     copy-on-write behaviour allows for immutability of the results_dir once a target has been
     marked valid.
+
+    :API: public
     """
     return False
 
@@ -292,6 +320,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
     Deterministic per-target incremental compilation is a relatively difficult thing to implement,
     so this property provides an escape hatch to avoid caching things in that riskier case.
+
+    :API: public
     """
     return False
 
@@ -306,6 +336,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     """Checks targets for invalidation, first checking the artifact cache.
 
     Subclasses call this to figure out what to work on.
+
+    :API: public
 
     :param targets:               The targets to check for changes.
     :param invalidate_dependents: If True then any targets depending on changed targets are invalidated.
@@ -533,6 +565,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     """If a single target was specified on the cmd line, returns that target.
 
     Otherwise throws TaskError.
+
+    :API: public
     """
     target_roots = self.context.target_roots
     if len(target_roots) == 0:
@@ -555,7 +589,10 @@ class Task(TaskBase):
 
   @abstractmethod
   def execute(self):
-    """Executes this task."""
+    """Executes this task.
+
+    :API: public
+    """
 
 
 class QuietTaskMixin(object):

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -549,6 +549,8 @@ class Task(TaskBase):
   Tasks form the atoms of work done by pants and when executed generally produce artifacts as a
   side effect whether these be files on disk (for example compilation outputs) or characters output
   to the terminal (for example dependency graph metadata).
+
+  :API: public
   """
 
   @abstractmethod

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -180,6 +180,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     This allows us to change Task.__init__()'s arguments without
     changing every subclass. If the subclass does not need its own
     initialization, this method can (and should) be omitted entirely.
+
+    :API: public
     """
     super(TaskBase, self).__init__()
     self.context = context

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -591,6 +591,8 @@ class Task(TaskBase):
 
   def __init__(self, context, workdir):
     """
+    Add pass-thru Task Constructor for public API visibility.
+
     :API: public
     """
     super(Task, self).__init__(context, workdir)

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -66,6 +66,8 @@ def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
   """
     A with-context that creates a temporary directory.
 
+    :API: public
+
     You may specify the following keyword args:
     :param string root_dir: The parent directory to create the temporary directory.
     :param bool cleanup: Whether or not to clean up the temporary directory.
@@ -82,6 +84,8 @@ def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
 def temporary_file_path(root_dir=None, cleanup=True, suffix=''):
   """
     A with-context that creates a temporary file and returns its path.
+
+    :API: public
 
     You may specify the following keyword args:
     :param str root_dir: The parent directory to create the temporary file.
@@ -154,6 +158,8 @@ def pushd(directory):
 def open_zip(path_or_file, *args, **kwargs):
   """
     A with-context for zip files.  Passes through positional and kwargs to zipfile.ZipFile.
+
+    :API: public
   """
   try:
     allowZip64 = kwargs.pop('allowZip64', True)

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -43,7 +43,10 @@ def fast_relpath(path, start):
 def safe_mkdir(directory, clean=False):
   """Ensure a directory is present.
 
-  If it's not there, create it.  If it is, no-op. If clean is True, ensure the dir is empty."""
+  If it's not there, create it.  If it is, no-op. If clean is True, ensure the dir is empty.
+
+  :API: public
+  """
   if clean:
     safe_rmtree(directory)
   try:
@@ -92,6 +95,7 @@ def safe_walk(path, **kwargs):
     unicode_literals. See e.g.
     https://mail.python.org/pipermail/python-dev/2008-December/083856.html
 
+    :API: public
   """
   # If os.walk is given a text argument, it yields text values; if it
   # is given a binary argument, it yields binary values.
@@ -127,6 +131,8 @@ def safe_mkdtemp(cleaner=_mkdtemp_atexit_cleaner, **kw):
   """Create a temporary directory that is cleaned up on process exit.
 
   Arguments are as to tempfile.mkdtemp.
+
+  :API: public
   """
   # Proper lock sanitation on fork [issue 6721] would be desirable here.
   with _MKDTEMP_LOCK:
@@ -142,12 +148,18 @@ def register_rmtree(directory, cleaner=_mkdtemp_atexit_cleaner):
 
 
 def safe_rmtree(directory):
-  """Delete a directory if it's present. If it's not present, no-op."""
+  """Delete a directory if it's present. If it's not present, no-op.
+
+  :API: public
+  """
   shutil.rmtree(directory, ignore_errors=True)
 
 
 def safe_open(filename, *args, **kwargs):
-  """Open a file safely, ensuring that its directory exists."""
+  """Open a file safely, ensuring that its directory exists.
+
+  :API: public
+  """
   safe_mkdir_for(filename)
   return open(filename, *args, **kwargs)
 
@@ -256,6 +268,10 @@ def relative_symlink(source_path, link_path):
 
 
 def relativize_path(path, rootdir):
+  """
+
+  :API: public
+  """
   # Note that we can't test for length and return the shorter of the two, because we need these
   # paths to be stable across systems (e.g., because they get embedded in analysis files),
   # and this choice might be inconsistent across systems. So we assume the relpath is always
@@ -275,6 +291,8 @@ def relativize_paths(paths, rootdir):
 
 def touch(path, times=None):
   """Equivalent of unix `touch path`.
+
+    :API: public
 
     :path: The file to touch.
     :times Either a tuple of (atime, mtime) or else a single time to use for both.  If not

--- a/src/python/pants/util/filtering.py
+++ b/src/python/pants/util/filtering.py
@@ -56,7 +56,10 @@ def create_filter(predicate_param, predicate_factory):
 
 
 def wrap_filters(filters):
-  """Returns a single filter that short-circuit ANDs the specified filters."""
+  """Returns a single filter that short-circuit ANDs the specified filters.
+
+  :API: public
+  """
   def combined_filter(x):
     for filt in filters:
       if not filt(x):

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -56,6 +56,8 @@ def memoized(func=None, key_factory=equal_args, cache_factory=dict):
                                arguments.
   + `clear()`: Causes the memoization cache to be fully cleared.
 
+  :API: public
+
   :param func: The function to wrap.  Only generally passed by the python runtime and should be
                omitted when passing a custom `key_factory` or `cache_factory`.
   :param key_factory: A function that can form a cache key from the arguments passed to the
@@ -132,6 +134,8 @@ def memoized_method(func=None, key_factory=per_instance, **kwargs):
   ...   def name(self):
   ...     pass
 
+  :API: public
+
   :param func: The function to wrap.  Only generally passed by the python runtime and should be
                omitted when passing a custom `key_factory` or `cache_factory`.
   :param key_factory: A function that can form a cache key from the arguments passed to the
@@ -193,6 +197,8 @@ def memoized_property(func=None, key_factory=per_instance, **kwargs):
   >>> bar.now
   1433267424.056189
   >>>
+
+  :API: public
 
   :param func: The property getter method to wrap.  Only generally passed by the python runtime and
                should be omitted when passing a custom `key_factory` or `cache_factory`.

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -25,6 +25,9 @@ OS_ALIASES = {
 
 
 def get_os_name():
+  """
+  :API: public
+  """
   return os.uname()[0].lower()
 
 
@@ -38,6 +41,9 @@ def get_os_id(uname_func=None):
 
 
 def normalize_os_name(os_name):
+  """
+  :API: public
+  """
   if os_name not in OS_ALIASES:
     for proper_name, aliases in OS_ALIASES.items():
       if os_name in aliases:


### PR DESCRIPTION
The following modules were reviewed and all api's were left as private. As
far as I can tell these modules are not currently used by plugins.

 * pants.task.changed_file_task_mixin
 * pants.task.changed_target_task
 * pants.task.console_task
 * pants.task.mutex_task_mixin
 * pants.task.noop_exec_task
 * pants.task.scm_publish_mixin
 * pants.task.testrunner_task_mixin
 * pants.util.eval
 * pants.util.fileutil
 * pants.util.meta
 * pants.util.netrc
 * pants.util.objects
 * pants.util.process_handler
 * pants.util.rwbuf
 * pants.util.socket
 * pants.util.strutil
 * pants.util.timeout
 * pants.util.xml_parser