### PR TITLE
Make synthetic jar_library targets dependencies of android_binary.

### DIFF
--- a/3rdparty/android/BUILD
+++ b/3rdparty/android/BUILD
@@ -4,18 +4,18 @@
 
 android_dependency(name='android-support-v4',
   jars = [
-    jar(org='com.android.support', name='support-v4', rev='22.0.0'),
+    jar(org='com.android.support', name='support-v4', rev='22.0.0', ext='aar'),
   ],
 )
 
 android_dependency(name='appcompat-v7',
   jars = [
-    jar(org='com.android.support', name='appcompat-v7', rev='22.0.0'),
+    jar(org='com.android.support', name='appcompat-v7', rev='22.0.0', ext='aar'),
   ],
 )
 
 android_dependency(name='google-play-services',
   jars=[
-    jar(org='com.google.android.gms', name='play-services', rev='7.0.0'),
+    jar(org='com.google.android.gms', name='play-services', rev='7.0.0', ext='aar'),
   ],
 )

--- a/examples/src/android/hello_with_library/BUILD
+++ b/examples/src/android/hello_with_library/BUILD
@@ -7,9 +7,8 @@ android_binary(
   sources=rglobs('main/src/*.java'),
   manifest='main/AndroidManifest.xml',
   dependencies = [
-    '3rdparty/android:android-support-v4',
-    'examples/src/android/example_library',
     ':resources',
+    'examples/src/android/example_library',
     ':support-library',
   ],
 )

--- a/examples/src/android/hello_with_library/BUILD
+++ b/examples/src/android/hello_with_library/BUILD
@@ -7,8 +7,10 @@ android_binary(
   sources=rglobs('main/src/*.java'),
   manifest='main/AndroidManifest.xml',
   dependencies = [
+    '3rdparty/android:android-support-v4',
     'examples/src/android/example_library',
     ':resources',
+    ':support-library',
   ],
 )
 
@@ -18,3 +20,12 @@ android_resources(
   resource_dir='main/res'
 )
 
+android_library(
+  name='support-library',
+  libraries=['3rdparty/android:android-support-v4'],
+  include_patterns=[
+    '**/*.class',
+  ],
+  dependencies = [
+  ]
+)

--- a/src/python/pants/backend/android/tasks/aapt_builder.py
+++ b/src/python/pants/backend/android/tasks/aapt_builder.py
@@ -82,8 +82,10 @@ class AaptBuilder(AaptTask):
         resource_deps = self.context.build_graph.transitive_subgraph_of_addresses([binary.address])
         resource_dirs = [t.resource_dir for t in resource_deps if isinstance(t, AndroidResources)]
 
-        # Priority for resources is left to right, so reverse the collection order (DFS preorder).
-        args = self._render_args(binary, reversed(resource_dirs), dex_files)
+        # Priority for resources is left to right so dependency order matters.
+        # TODO(mateo): Make resources a first class AndroidBinary attribute to limit the order-dependent parts of the
+        # BUILD files.
+        args = self._render_args(binary, resource_dirs, dex_files)
         with self.context.new_workunit(name='apk-bundle',
                                        labels=[WorkUnitLabel.MULTITOOL]) as workunit:
           returncode = subprocess.call(args, stdout=workunit.output('stdout'),

--- a/src/python/pants/backend/android/tasks/aapt_gen.py
+++ b/src/python/pants/backend/android/tasks/aapt_gen.py
@@ -120,19 +120,17 @@ class AaptGen(AaptTask):
         if isinstance(tgt, AndroidLibrary) and tgt.manifest:
           gentargets.append(tgt)
       binary.walk(gather_gentargets)
-
       for gen in gentargets:
         aapt_output = self._relative_genfile(gen)
         aapt_file = os.path.join(self.aapt_out(binary), aapt_output)
 
         resource_deps = self.context.build_graph.transitive_subgraph_of_addresses([gen.address])
         resource_dirs = [t.resource_dir for t in resource_deps if isinstance(t, AndroidResources)]
-
         if resource_dirs:
           if aapt_file not in self._created_library_targets:
 
-            # Priority for resources is left->right, so reverse collection order (DFS preorder).
-            args = self._render_args(binary, gen.manifest, reversed(resource_dirs))
+            # Priority for resources is left->right, so dependency order matters (see TODO in aapt_builder).
+            args = self._render_args(binary, gen.manifest, resource_dirs)
             with self.context.new_workunit(name='aaptgen', labels=[WorkUnitLabel.MULTITOOL]) as workunit:
               returncode = subprocess.call(args,
                                            stdout=workunit.output('stdout'),

--- a/src/python/pants/backend/android/tasks/aapt_gen.py
+++ b/src/python/pants/backend/android/tasks/aapt_gen.py
@@ -73,6 +73,7 @@ class AaptGen(AaptTask):
         jar = JarDependency(org='com.google', name='android', rev=sdk, url=jar_url)
         address = Address(self.workdir, 'android-{0}.jar'.format(sdk))
         self._jar_library_by_sdk[sdk] = self.context.add_new_target(address, JarLibrary, jars=[jar])
+      binary.inject_dependency(self._jar_library_by_sdk[sdk].address)
 
   def _render_args(self, binary, manifest, resource_dirs):
     """Compute the args that will be passed to the aapt tool.
@@ -153,12 +154,11 @@ class AaptGen(AaptTask):
     """
     spec_path = os.path.join(os.path.relpath(self.aapt_out(binary), get_buildroot()))
     address = Address(spec_path=spec_path, target_name=gentarget.id)
-    deps = [self._jar_library_by_sdk[binary.target_sdk]]
     new_target = self.context.add_new_target(address,
                                              JavaLibrary,
                                              derived_from=gentarget,
                                              sources=[self._relative_genfile(gentarget)],
-                                             dependencies=deps)
+                                             dependencies=[])
     return new_target
 
   def aapt_out(self, binary):

--- a/src/python/pants/backend/android/tasks/unpack_libraries.py
+++ b/src/python/pants/backend/android/tasks/unpack_libraries.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from hashlib import sha1
 
+from pants.backend.android.targets.android_binary import AndroidBinary
 from pants.backend.android.targets.android_library import AndroidLibrary
 from pants.backend.android.targets.android_resources import AndroidResources
 from pants.backend.jvm.jar_dependency_utils import M2Coordinate
@@ -69,6 +70,11 @@ class UnpackLibraries(Task):
     return ['unpacked_libraries']
 
   @staticmethod
+  def is_binary(target):
+    """Return True for AndroidBinary targets."""
+    return isinstance(target, AndroidBinary)
+
+  @staticmethod
   def is_library(target):
     """Return True for AndroidLibrary targets."""
     # TODO(mateor) add AndroidBinary support. If include/exclude patterns aren't needed, an
@@ -80,10 +86,10 @@ class UnpackLibraries(Task):
     self._created_targets = {}
     self._unpacked_archives = set()
 
-  def create_classes_jar_target(self, target, coordinate, jar_file):
+  def create_classes_jar_target(self, library, coordinate, jar_file):
     """Create a JarLibrary target containing the jar_file as a JarDependency.
 
-    :param target: The new JarLibrary will be derived from this AndroidLibrary.
+    :param library: The new JarLibrary will be derived from this AndroidLibrary.
     :type target: :class:`pants.backend.android.targets.android_library.AndroidLibrary`
     :param coordinate: Archive coordinate fetched by ivy, e.g. 'org.pantsbuild:example::1.0:aar'.
     :type coordinate: :class:`pants.backend.jvm.jar_dependency_utils.M2Coordinate`
@@ -93,17 +99,17 @@ class UnpackLibraries(Task):
     """
     # TODO(mateor) add another JarDependency for every jar under 'libs'.
     jar_url = 'file://{0}'.format(jar_file)
-    jar_dep = JarDependency(org=target.id, name=coordinate.artifact_filename, rev=coordinate.rev,
+    jar_dep = JarDependency(org=library.id, name=coordinate.artifact_filename, rev=coordinate.rev,
                             url=jar_url)
     address = Address(self.workdir, '{}-classes.jar'.format(coordinate.artifact_filename))
     new_target = self.context.add_new_target(address, JarLibrary, jars=[jar_dep],
-                                             derived_from=target)
+                                             derived_from=library)
     return new_target
 
-  def create_resource_target(self, target, coordinate, manifest, resource_dir):
+  def create_resource_target(self, library, coordinate, manifest, resource_dir):
     """Create an AndroidResources target.
 
-    :param target: AndroidLibrary that the new AndroidResources target derives from.
+    :param library: AndroidLibrary that the new AndroidResources target derives from.
     :type target: :class:`pants.backend.android.targets.android_library.AndroidLibrary`
     :param coordinate: Archive coordinate fetched by ivy, e.g. 'org.pantsbuild:example::1.0:aar'.
     :type coordinate: :class:`pants.backend.jvm.jar_dependency_utils.M2Coordinate`
@@ -116,14 +122,15 @@ class UnpackLibraries(Task):
     address = Address(self.workdir, '{}-resources'.format(coordinate.artifact_filename))
     new_target = self.context.add_new_target(address, AndroidResources,
                                              manifest=manifest, resource_dir=resource_dir,
-                                             derived_from=target)
+                                             derived_from=library)
     return new_target
 
-  def create_android_library_target(self, target, coordinate, unpacked_aar_location):
+  def create_android_library_target(self, binary, library, coordinate, unpacked_aar_location):
     """Create an AndroidLibrary target.
 
     The aar files are unpacked and the contents used to create a new AndroidLibrary target.
-    :param AndroidLibrary target: AndroidLibrary that the new AndroidLibrary target derives from.
+    :param AndroidBinary binary: AndroidBinary that depends on the AndroidLibrary being processed.
+    :param AndroidLibrary library: AndroidLibrary that the new AndroidLibrary target derives from.
     :param coordinate: Archive coordinate fetched by ivy, e.g. 'org.pantsbuild:example::1.0:aar'.
     :type coordinate: :class:`pants.backend.jvm.jar_dependency_utils.M2Coordinate`
     :param string unpacked_aar_location: Full path of dir holding contents of an unpacked aar file.
@@ -141,27 +148,28 @@ class UnpackLibraries(Task):
     if not os.path.isfile(manifest):
       raise self.MissingElementException("An AndroidManifest.xml is expected in every unpacked "
                                          ".aar file but none was found in the {} archive "
-                                         "for the {} target".format(coordinate, target))
+                                         "for the {} target".format(coordinate, library))
 
     # Depending on the contents of the unpacked aar file, create the dependencies.
     deps = []
     if os.path.isdir(resource_dir):
-      deps.append(self.create_resource_target(target, coordinate, manifest, resource_dir))
-    if os.path.isfile(jar_file):
-      # TODO(mateo): This is not strictly correct and needs to be rethought. The correct thing is to operate over
-      # AndroidBinary targets instead - if a library depends on another library then our dependency inferral breaks.
-      # As it stands, the only way to get around this is to manually add the 3rdparty jar to the dependencies of the
-      # android_binary (see :hello_with_library example).
-      for dependent in target.dependents:
-        dependent.inject_dependency(self.create_classes_jar_target(target, coordinate, jar_file).address)
+      new_resource_target = self.create_resource_target(library, coordinate, manifest, resource_dir)
 
+      # # The new libraries resources must be compiled both by themselves and along with the dependent library.
+      deps.append(new_resource_target)
+    if os.path.isfile(jar_file):
+      if jar_file not in self._created_targets:
+        # TODO(mateo): So the binary needs the classes on the classpath. I should probably bundle up the include/exclude
+        # filtered classes and put them on the compile classpath, either as a jar or as source.
+        self._created_targets[jar_file] =  self.create_classes_jar_target(library, coordinate, jar_file)
+      binary.inject_dependency(self._created_targets[jar_file].address)
     address = Address(self.workdir, '{}-android_library'.format(coordinate.artifact_filename))
     new_target = self.context.add_new_target(address, AndroidLibrary,
                                              manifest=manifest,
-                                             include_patterns=target.payload.include_patterns,
-                                             exclude_patterns=target.payload.exclude_patterns,
+                                             include_patterns=library.payload.include_patterns,
+                                             exclude_patterns=library.payload.exclude_patterns,
                                              dependencies=deps,
-                                             derived_from=target)
+                                             derived_from=library)
     return new_target
 
   def _unpack_artifacts(self, jar_imports):
@@ -193,7 +201,7 @@ class UnpackLibraries(Task):
         ZIP.extract(jar_file, jar_outdir)
         self._unpacked_archives.add(aar_or_jar)
 
-  def _create_target(self, target, coordinates):
+  def _create_target(self, binary, library, coordinates):
     # Create a target for the components of an unpacked .aar file.
     for coordinate in coordinates:
       # The contents of the unpacked aar file must be made into an AndroidLibrary target.
@@ -203,16 +211,20 @@ class UnpackLibraries(Task):
           if not os.path.isdir(unpacked_location):
             raise self.MissingElementException('{}: Expected to unpack {} at {} but did not!'
                                                .format(target, coordinate, unpacked_location))
-          new_target = self.create_android_library_target(target,
+
+          # The binary is being threaded through because android binaries need the classes.jar on their classpath
+          # in jvm_compile.
+          new_target = self.create_android_library_target(binary,
+                                                          library,
                                                           coordinate,
                                                           unpacked_location)
           self._created_targets[coordinate] = new_target
-        target.inject_dependency(self._created_targets[coordinate].address)
 
+        library.inject_dependency(self._created_targets[coordinate].address)
       # The unpacked_libraries product is a dir containing the full unpacked source. The files
       # that match the include/exclude patterns are calculated during DxCompile.
       unpacked_products = self.context.products.get('unpacked_libraries')
-      unpacked_products.add(target, get_buildroot()).append(self.unpacked_jar_location(coordinate))
+      unpacked_products.add(library, get_buildroot()).append(self.unpacked_jar_location(coordinate))
 
   def execute(self):
     jar_import_products = self.context.products.get_data(JarImportProducts)
@@ -227,10 +239,14 @@ class UnpackLibraries(Task):
           self._unpack_artifacts(jar_imports)
 
     # Create the new targets from the contents of unpacked aar files.
-    for target in library_targets:
-      jar_imports = jar_import_products.imports(target)
-      if jar_imports:
-        self._create_target(target, (jar_import.coordinate for jar_import in jar_imports))
+    binary_targets = self.context.targets(predicate=self.is_binary)
+    for binary in binary_targets:
+      library_dependencies = [x for x in binary.dependencies if isinstance(x, AndroidLibrary)]
+
+      for library in library_dependencies:
+        jar_imports = jar_import_products.imports(library)
+        if jar_imports:
+          self._create_target(binary, library, (jar_import.coordinate for jar_import in jar_imports))
 
   def unpacked_jar_location(self, coordinate):
     """Location for unpacked jar files, whether imported as-is or found inside an aar file."""

--- a/tests/python/pants_test/android/tasks/test_aapt_gen.py
+++ b/tests/python/pants_test/android/tasks/test_aapt_gen.py
@@ -36,6 +36,18 @@ class TestAaptGen(TestAndroidBase):
           task.create_sdk_jar_deps(targets)
           self.assertNotEquals(task._jar_library_by_sdk['19'], task._jar_library_by_sdk['18'])
 
+  def test_create_sdk_dependency_injection(self):
+    with distribution() as dist:
+      with self.android_binary(target_name='binary1', target_sdk='18') as binary1:
+        with self.android_binary(target_name='binary2', target_sdk='19') as binary2:
+          self.set_options(sdk_path=dist)
+          task = self.create_task(self.context())
+          targets = [binary1, binary2]
+          task.create_sdk_jar_deps(targets)
+          self.assertIn(task._jar_library_by_sdk['18'], binary1.dependencies)
+          self.assertIn(task._jar_library_by_sdk['19'], binary2.dependencies)
+          self.assertNotIn(task._jar_library_by_sdk['19'], binary1.dependencies)
+
   def test_aapt_out_different_sdk(self):
     with self.android_binary(target_name='binary1', target_sdk='18') as binary1:
       with self.android_binary(target_name='binary2', target_sdk='19') as binary2:

--- a/tests/python/pants_test/android/tasks/test_dx_compile_integration.py
+++ b/tests/python/pants_test/android/tasks/test_dx_compile_integration.py
@@ -33,7 +33,7 @@ class DxCompileIntegrationTest(AndroidIntegrationTest):
     self.dx_test(AndroidIntegrationTest.TEST_TARGET)
 
   def dx_test(self, target):
-    pants_run = self.run_pants(['dex', target])
+    pants_run = self.run_pants(['binary', target])
     self.assert_success(pants_run)
 
   # TODO(mateor) decompile with smali and verify contents of created dex file.


### PR DESCRIPTION
There are a few other tiny fixes here to make all the
android tests go green - I am going to attempt to bring
the android backend into contrib.

Previously the jars were dependents of the library they belonged
to. But that was before the isolated_compile - with that
strategy the jars were not making it onto the classpath of the
android_binary. In a correctness sense, this is a better
representation of the graph.

Unfortunately, this commit does not quite cover all the dependency
inferral that the android backend had before isolated compile.

AndroidLibrary targets are just ways to attach resources to jars
and optionally define include/exclude patterns. So any
AndroidBinary thats depends on an AndroidLibrary should
get the libraries classes.jar on its classpath for free.
But as you can see with the change to hello_with_library,
more than one AndroidLibrary in a dependency chain
and you need to add the 3rdparty jars to the binary
target as well.

A nice followup would be to refactor unpack_libraries
and dx_compile to associate the unpacked_libraries
products with AndroidBinary targets instead of
AndroidLibrary. An issue will be opened.

With this commit, all the android tests go green and
./pants bundle examples/src/android::` runs succeessfully.