### PR TITLE
Remove deprecated code related to the `ProjectTree` change

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/dependees.py
+++ b/src/python/pants/backend/graph_info/tasks/dependees.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from collections import defaultdict
 
 from pants.backend.graph_info.tasks.target_filter_task_mixin import TargetFilterTaskMixin
-from pants.base.build_environment import get_buildroot
 from pants.task.console_task import ConsoleTask
 
 
@@ -28,12 +27,10 @@ class ReverseDepmap(TargetFilterTaskMixin, ConsoleTask):
 
     self._transitive = self.get_options().transitive
     self._closed = self.get_options().closed
-    # Will be provided through context.address_mapper.build_ignore_patterns.
-    self._spec_excludes = None
 
   def console_output(self, _):
     address_mapper = self.context.address_mapper
-    buildfiles = address_mapper.scan_build_files(base_path=None, spec_excludes=self._spec_excludes)
+    buildfiles = address_mapper.scan_build_files(base_path=None)
 
     build_graph = self.context.build_graph
     build_file_parser = self.context.build_file_parser

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -102,7 +102,7 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, Subsystem):
 
     register('--runtime', advanced=True, type=list_option, default=['//:scala-library'],
              help='Target specs pointing to the scala runtime libraries.',
-             deprecated_version='0.0.75',
+             deprecated_version='0.0.75', removal_version='0.0.79',
              deprecated_hint='Option is no longer used, --version is used to specify the major '
                              'version. The runtime is created based on major version. '
                              'The runtime target will be defined at the address //:scala-library '

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -17,10 +17,6 @@ class RuntimeClasspathPublisher(Task):
   @classmethod
   def register_options(cls, register):
     super(Task, cls).register_options(register)
-    register('--use-old-naming-style', advanced=True, default=True, action='store_true',
-             deprecated_version='0.0.71', removal_version='0.0.75',
-             deprecated_hint='Switch to use the safe identifier to construct canonical classpath.',
-             help='Use the old (unsafe) naming style construct canonical classpath.')
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -45,7 +45,6 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
     ':project_tree',
-    ':deprecated',
   ]
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -45,9 +45,6 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
     ':project_tree',
-    # TODO(tabishev): Remove this dependency after transition period.
-    # Currently needed because of FilesystemBuildFile declared in build_file.py.
-    ':file_system_project_tree',
     ':deprecated',
   ]
 )

--- a/src/python/pants/base/build_file.py
+++ b/src/python/pants/base/build_file.py
@@ -13,8 +13,7 @@ from pathspec import PathSpec
 from pathspec.gitignore import GitIgnorePattern
 from twitter.common.collections import OrderedSet
 
-from pants.base.deprecated import deprecated, deprecated_conditional
-from pants.base.file_system_project_tree import FileSystemProjectTree
+from pants.base.deprecated import deprecated_conditional
 from pants.util.dirutil import fast_relpath
 from pants.util.meta import AbstractClass
 
@@ -45,20 +44,15 @@ class BuildFile(AbstractClass):
     BuildFile._cache = {}
 
   @staticmethod
-  def _cached(project_tree, relpath, must_exist=True):
-    cache_key = (project_tree, relpath, must_exist)
+  def _cached(project_tree, relpath):
+    cache_key = (project_tree, relpath)
     if cache_key not in BuildFile._cache:
-      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath, must_exist)
+      BuildFile._cache[cache_key] = BuildFile(project_tree, relpath)
     return BuildFile._cache[cache_key]
 
   @staticmethod
   def _is_buildfile_name(name):
     return BuildFile._PATTERN.match(name)
-
-  # TODO(tabishev): Remove after transition period.
-  @classmethod
-  def _get_project_tree(cls, root_dir):
-    raise NotImplementedError()
 
   @staticmethod
   def _spec_excludes_to_gitignore_syntax(build_root, spec_excludes=None):
@@ -134,70 +128,37 @@ class BuildFile(AbstractClass):
     return OrderedSet(sorted((BuildFile._cached(project_tree, relpath) for relpath in build_files_without_ignores),
                              key=lambda build_file: build_file.full_path))
 
-  def __init__(self, project_tree, relpath, must_exist=True):
+  def __init__(self, project_tree, relpath):
     """Creates a BuildFile object representing the BUILD file family at the specified path.
 
     :param project_tree: Project tree the BUILD file exist in.
     :type project_tree: :class:`pants.base.project_tree.ProjectTree`
-    :param string relpath: The path relative to root_dir where the BUILD file is found - this can
-        either point directly at the BUILD file or else to a directory which contains BUILD files.
-    :param bool must_exist: If True, at least one BUILD file must exist at the given location or
-        else an` `MissingBuildFileError` is thrown
+    :param string relpath: The path relative to root_dir where the BUILD file is located.
     :raises IOError: if the root_dir path is not absolute.
-    :raises MissingBuildFileError: if the path does not house a BUILD file and must_exist is `True`.
+    :raises MissingBuildFileError: if the path does not house a BUILD file.
     """
-
-    if not must_exist:
-      logger.warn('BuildFile\'s must_exist parameter is deprecated and will be removed in 0.0.74 release. '
-                  'BuildFile should be created from existing file only.')
     if relpath is None:
-      logger.warn('BuildFile\'s relpath parameter is deprecated and will be removed in 0.0.74 release. '
-                  'BuildFile should be created with not None relpath only.')
+      raise self.BuildFileError("BuildFile\'s relpath parameter cannot be None.")
+    if os.path.isabs(relpath):
+      raise self.BuildFileError("BuildFile\'s relpath parameter cannot be absolute.")
 
     self.project_tree = project_tree
     self.root_dir = project_tree.build_root
 
-    path = os.path.join(self.root_dir, relpath) if relpath else self.root_dir
-    self._build_basename = self._BUILD_FILE_PREFIX
+    path = os.path.join(self.root_dir, relpath)
+    if not project_tree.exists(relpath):
+      raise self.MissingBuildFileError('BUILD file does not exist at: {path}'
+                                       .format(path=path))
 
-    if project_tree.isdir(fast_relpath(path, self.root_dir)):
-      logger.warn('BuildFile creation using folder path is deprecated and will be removed in 0.0.74 release. '
-                  'BuildFile should be created from path to file only.')
+    if project_tree.isdir(relpath):
+      raise self.MissingBuildFileError('Path to buildfile ({buildfile}) is a directory, '
+                                       'but it must be a file.'.format(buildfile=path))
 
-    if project_tree.isdir(fast_relpath(path, self.root_dir)):
-      buildfile = os.path.join(path, self._build_basename)
-    else:
-      buildfile = path
+    if not self._is_buildfile_name(os.path.basename(path)):
+      raise self.MissingBuildFileError('{path} is not a BUILD file'
+                                       .format(path=path))
 
-    # There is no BUILD file without a prefix so select any viable sibling
-    buildfile_relpath = fast_relpath(buildfile, self.root_dir)
-    if not project_tree.exists(buildfile_relpath) or project_tree.isdir(buildfile_relpath):
-      relpath = os.path.dirname(buildfile_relpath)
-      for build in self.project_tree.glob1(relpath, '{prefix}*'.format(prefix=self._BUILD_FILE_PREFIX)):
-        if self._is_buildfile_name(build) and self.project_tree.isfile(os.path.join(relpath, build)):
-          self._build_basename = build
-          buildfile = os.path.join(path, self._build_basename)
-          buildfile_relpath = fast_relpath(buildfile, self.root_dir)
-          break
-
-    if must_exist:
-      if not project_tree.exists(buildfile_relpath):
-        raise self.MissingBuildFileError('BUILD file does not exist at: {path}'
-                                         .format(path=buildfile))
-
-      # If a build file must exist then we want to make sure it's not a dir.
-      # In other cases we are ok with it being a dir, for example someone might have
-      # repo/scripts/build/doit.sh.
-      if project_tree.isdir(buildfile_relpath):
-        raise self.MissingBuildFileError('Path to buildfile ({buildfile}) is a directory, '
-                                         'but it must be a file.'.format(buildfile=buildfile))
-
-      if not self._is_buildfile_name(os.path.basename(buildfile)):
-        raise self.MissingBuildFileError('{path} is not a BUILD file'
-                                         .format(path=buildfile))
-
-    self.full_path = os.path.realpath(buildfile)
-
+    self.full_path = os.path.realpath(path)
     self.name = os.path.basename(self.full_path)
     self.parent_path = os.path.dirname(self.full_path)
 

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -17,6 +17,7 @@ python_library(
     'src/python/pants/base:build_file',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:file_system_project_tree',
     'src/python/pants/base:scm_project_tree',
     'src/python/pants/base:workunit',
     'src/python/pants/build_graph',

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -12,7 +12,6 @@ import pkg_resources
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_scm, pants_version
-from pants.base.build_file import BuildFile
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.exceptions import BuildConfigurationError
 from pants.base.file_system_project_tree import FileSystemProjectTree
@@ -178,15 +177,12 @@ class GoalRunnerFactory(object):
     self._tag = self._global_options.tag
     self._fail_fast = self._global_options.fail_fast
     # Will be provided through context.address_mapper.build_ignore_patterns.
-    self._spec_excludes = None
     self._explain = self._global_options.explain
     self._kill_nailguns = self._global_options.kill_nailguns
 
     self._project_tree = self._get_project_tree(self._global_options.build_file_rev)
     self._build_file_parser = BuildFileParser(self._build_config, self._root_dir)
     build_ignore_patterns = self._global_options.ignore_patterns or []
-    build_ignore_patterns.extend(BuildFile._spec_excludes_to_gitignore_syntax(self._root_dir,
-                                                                              self._global_options.spec_excludes))
     self._address_mapper = BuildFileAddressMapper(
       self._build_file_parser,
       self._project_tree,
@@ -271,7 +267,6 @@ class GoalRunnerFactory(object):
                         build_graph=self._build_graph,
                         build_file_parser=self._build_file_parser,
                         address_mapper=self._address_mapper,
-                        spec_excludes=self._spec_excludes,
                         invalidation_report=invalidation_report)
 
     return context, invalidation_report

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -11,7 +11,6 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_target_factory',
-    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/base:hash_utils',

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -18,8 +18,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
-from pants.base.deprecated import deprecated, deprecated_conditional
-from pants.base.project_tree import ProjectTree
+from pants.base.deprecated import deprecated_conditional
 from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
 from pants.build_graph.address import Address, parse_spec
 from pants.build_graph.address_lookup_error import AddressLookupError
@@ -74,12 +73,7 @@ class BuildFileAddressMapper(object):
     """
     self._build_file_parser = build_file_parser
     self._spec_path_to_address_map_map = {}  # {spec_path: {address: addressable}} mapping
-    if isinstance(project_tree, ProjectTree):
-      self._project_tree = project_tree
-    else:
-      # If project_tree is BuildFile class actually.
-      # TODO(tabishev): Remove after transition period.
-      self._project_tree = project_tree._get_project_tree(self.root_dir)
+    self._project_tree = project_tree
     self._build_ignore_patterns = PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns or [])
 
     self._exclude_target_regexps = exclude_target_regexps or []

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -336,7 +336,7 @@ class BuildGraph(AbstractClass):
     """
 
   @abstractmethod
-  def inject_specs_closure(self, specs, fail_fast=None, spec_excludes=None):
+  def inject_specs_closure(self, specs, fail_fast=None):
     """Resolves, constructs and injects Targets and their transitive closures of dependencies.
 
     :API: public
@@ -344,7 +344,6 @@ class BuildGraph(AbstractClass):
     :param specs: A list of base.specs.Spec objects to resolve and inject.
     :param fail_fast: Whether to fail quickly for the first error, or to complete all
       possible injections before failing.
-    :param spec_excludes: Deprecated: applied via the AddressMapper instead.
     :returns: Yields a sequence of resolved Address objects.
     """
 

--- a/src/python/pants/build_graph/mutable_build_graph.py
+++ b/src/python/pants/build_graph/mutable_build_graph.py
@@ -188,10 +188,9 @@ class MutableBuildGraph(BuildGraph):
       raise self.TransitiveLookupError("{message}\n  referenced from {spec}"
                                        .format(message=e, spec=target_address.spec))
 
-  def inject_specs_closure(self, specs, fail_fast=None, spec_excludes=None):
+  def inject_specs_closure(self, specs, fail_fast=None):
     for address in self._address_mapper.scan_specs(specs,
-                                                   fail_fast=fail_fast,
-                                                   spec_excludes=spec_excludes):
+                                                   fail_fast=fail_fast):
       self.inject_address_closure(address)
       yield address
 

--- a/src/python/pants/core_tasks/what_changed.py
+++ b/src/python/pants/core_tasks/what_changed.py
@@ -20,14 +20,11 @@ class WhatChanged(ChangedFileTaskMixin, ConsoleTask):
              help='Show changed files instead of the targets that own them.')
 
   def console_output(self, _):
-    # Will be provided through context.address_mapper.build_ignore_patterns.
-    spec_excludes = None
     change_calculator = self.change_calculator(self.get_options(),
                                                self.context.address_mapper,
                                                self.context.build_graph,
                                                scm=self.context.scm,
-                                               workspace=self.context.workspace,
-                                               spec_excludes=spec_excludes)
+                                               workspace=self.context.workspace)
     if self.get_options().files:
       for f in sorted(change_calculator.changed_files()):
         yield f

--- a/src/python/pants/engine/exp/legacy/graph.py
+++ b/src/python/pants/engine/exp/legacy/graph.py
@@ -121,7 +121,7 @@ class ExpGraph(BuildGraph):
   def inject_address_closure(self, address):
     raise NotImplementedError('Not implemented.')
 
-  def inject_specs_closure(self, specs, fail_fast=None, spec_excludes=None):
+  def inject_specs_closure(self, specs, fail_fast=None):
     # Request loading of these specs.
     request = self._scheduler.execution_request(products=[LegacyBuildGraphNode], subjects=specs)
     result = self._engine.execute(request)

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -57,7 +57,6 @@ python_library(
   sources = ['goal.py'],
   dependencies = [
     ':error',
-    'src/python/pants/base:deprecated',
   ],
 )
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -13,7 +13,6 @@ from contextlib import contextmanager
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot, get_scm
-from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.mutable_build_graph import MutableBuildGraph
@@ -63,14 +62,10 @@ class Context(object):
   def __init__(self, options, run_tracker, target_roots,
                requested_goals=None, target_base=None, build_graph=None,
                build_file_parser=None, address_mapper=None, console_outstream=None, scm=None,
-               workspace=None, spec_excludes=None, invalidation_report=None):
+               workspace=None, invalidation_report=None):
     """
     :API: public
     """
-    deprecated_conditional(lambda: spec_excludes is not None,
-                           '0.0.75',
-                           'Use address_mapper#build_ignore_patterns instead.')
-
     self._options = options
     self.build_graph = build_graph
     self.build_file_parser = build_file_parser
@@ -87,7 +82,6 @@ class Context(object):
     self._console_outstream = console_outstream or sys.stdout
     self._scm = scm or get_scm()
     self._workspace = workspace or (ScmWorkspace(self._scm) if self._scm else None)
-    self._spec_excludes = spec_excludes
     self._replace_targets(target_roots)
     self._invalidation_report = invalidation_report
 
@@ -158,11 +152,6 @@ class Context(object):
     :API: public
     """
     return self._workspace
-
-  @property
-  @deprecated('0.0.75')
-  def spec_excludes(self):
-    return self._spec_excludes
 
   @property
   def invalidation_report(self):
@@ -371,6 +360,6 @@ class Context(object):
     :returns: A new build graph encapsulating the targets found.
     """
     build_graph = MutableBuildGraph(self.address_mapper)
-    for address in self.address_mapper.scan_addresses(root, spec_excludes=self._spec_excludes):
+    for address in self.address_mapper.scan_addresses(root):
       build_graph.inject_address_closure(address)
     return build_graph

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -145,7 +145,7 @@ class GlobalOptionsRegistrar(Optionable):
              default=[register.bootstrap.pants_workdir],
              deprecated_hint='Use --ignore-patterns instead. Use .gitignore syntax for each item, '
                              'to simulate old behavior prefix each item with "/".',
-             deprecated_version='0.0.75',
+             deprecated_version='0.0.75', removal_version='0.0.79',
              help='Ignore these paths when evaluating the command-line target specs.  Useful with '
                   '::, to avoid descending into unneeded directories.')
     register('--ignore-patterns', advanced=True, action='append', fromfile=True,

--- a/src/python/pants/task/changed_file_task_mixin.py
+++ b/src/python/pants/task/changed_file_task_mixin.py
@@ -26,12 +26,7 @@ class ChangeCalculator(object):
                fast=False,
                changes_since=None,
                diffspec=None,
-               exclude_target_regexp=None,
-               spec_excludes=None):
-    deprecated_conditional(lambda: spec_excludes is not None,
-                           '0.0.75',
-                           'Use address_mapper#build_ignore_patterns instead.')
-
+               exclude_target_regexp=None):
     self._scm = scm
     self._workspace = workspace
     self._address_mapper = address_mapper
@@ -42,7 +37,6 @@ class ChangeCalculator(object):
     self._changes_since = changes_since
     self._diffspec = diffspec
     self._exclude_target_regexp = exclude_target_regexp
-    self._spec_excludes = spec_excludes
 
     self._mapper_cache = None
 
@@ -80,7 +74,7 @@ class ChangeCalculator(object):
       return changed
 
     # Load the whole build graph since we need it for dependee finding in either remaining case.
-    for address in self._address_mapper.scan_addresses(spec_excludes=self._spec_excludes):
+    for address in self._address_mapper.scan_addresses():
       self._build_graph.inject_address_closure(address)
 
     if self._include_dependees == 'direct':
@@ -133,11 +127,7 @@ class ChangedFileTaskMixin(object):
              help='Include direct or transitive dependees of changed targets.')
 
   @classmethod
-  def change_calculator(cls, options, address_mapper, build_graph, scm=None, workspace=None, spec_excludes=None):
-    deprecated_conditional(lambda: spec_excludes is not None,
-                           '0.0.75',
-                           'Use address_mapper#build_ignore_patterns instead.')
-
+  def change_calculator(cls, options, address_mapper, build_graph, scm=None, workspace=None):
     scm = scm or get_scm()
     if scm is None:
       raise TaskError('No SCM available.')
@@ -153,5 +143,4 @@ class ChangedFileTaskMixin(object):
                             diffspec=options.diffspec,
                             # NB: exclude_target_regexp is a global scope option registered
                             # elsewhere
-                            exclude_target_regexp=options.exclude_target_regexp,
-                            spec_excludes=spec_excludes)
+                            exclude_target_regexp=options.exclude_target_regexp)

--- a/src/python/pants/task/changed_target_task.py
+++ b/src/python/pants/task/changed_target_task.py
@@ -46,10 +46,7 @@ class ChangedTargetTask(ChangedFileTaskMixin, NoopExecTask):
     change_calculator = cls.change_calculator(
       options,
       address_mapper,
-      build_graph,
-      # Will be provided through address_mapper.build_ignore_patterns.
-      spec_excludes=None,
-    )
+      build_graph)
     changed_addresses = change_calculator.changed_target_addresses()
     readable = ''.join(sorted('\n\t* {}'.format(addr.reference()) for addr in changed_addresses))
     logger.info('Operating on changed {} target(s): {}'.format(len(changed_addresses), readable))

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -29,6 +29,7 @@ python_library(
     'src/python/pants/base:build_root',
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:file_system_project_tree',
     'src/python/pants/build_graph',
     'src/python/pants/goal:goal',
     'src/python/pants/source',

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -253,17 +253,11 @@ Invalid BUILD files for \[::\]$""", re.DOTALL)
     self.assert_scanned(['::'], expected=expected_specs, address_mapper=address_mapper_with_ignore)
 
   def test_exclude_target_regexps(self):
-    expected_specs = [':root', 'a', 'a:b', 'a/b', 'a/b:c']
-
-    # This bogus BUILD file gets in the way of parsing.
-    self.add_to_build_file('some/dir', 'COMPLETELY BOGUS BUILDFILE)\n')
-    with self.assertRaises(AddressLookupError):
-      self.assert_scanned(['::'], expected=expected_specs)
-
     address_mapper_with_exclude = BuildFileAddressMapper(self.build_file_parser,
                                                          self.project_tree,
-                                                         exclude_target_regexps=[r'.*some/dir.*'])
-    self.assert_scanned(['::'], expected=expected_specs, address_mapper=address_mapper_with_exclude)
+                                                         exclude_target_regexps=[r'.*:b.*'])
+    self.assert_scanned(['::'], expected=[':root', 'a', 'a/b:c'],
+                        address_mapper=address_mapper_with_exclude)
 
   def assert_scanned(self, specs_strings, expected, address_mapper=None):
     """Parse and scan the given specs."""

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -109,15 +109,6 @@ class BuildFileAddressMapperTest(BaseTest):
     with self.assertRaises(BuildFileAddressMapper.EmptyBuildFileError):
       self.address_mapper.resolve_spec('//:foo')
 
-  def test_context_scan_with_deprecated_spec_excludes(self):
-    # Can be removed while `spec_excludes` removal.
-    self.add_to_build_file('BUILD', 'target(name="foo")')
-    self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
-    context = self.context()
-    context._spec_excludes = ['subdir']
-    graph = context.scan()
-    self.assertEquals([target.address.spec for target in graph.targets()], ['//:foo'])
-
   def test_address_lookup_error_hierarchy(self):
     self.assertIsInstance(BuildFileAddressMapper.AddressNotInBuildFile(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.EmptyBuildFileError(), AddressLookupError)


### PR DESCRIPTION
I've removed code related to the `ProjectTree` change which was deprecated and planned to remove after 0.0.74 release. 