### PR TITLE
Add fingerprints to python style options

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -60,7 +60,8 @@ class PythonCheckStyleTask(PythonTask):
              help='Only messages at this severity or higher are logged. [COMMENT WARNING ERROR].')
     register('--strict', fingerprint=True, default=False, action='store_true',
              help='If enabled, have non-zero exit status for any nit at WARNING or higher.')
-    register('--skip', fingerprint=True, default=False, action='store_true',
+    # Skip short circuits before fingerprinting
+    register('--skip', default=False, action='store_true',
              help='If enabled, skip this style checker.')
     register('--suppress', fingerprint=True, type=file_option, default=None,
              help='Takes a XML file where specific rules on specific files will be skipped.')

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -11,6 +11,7 @@ from collections import namedtuple
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.exceptions import TaskError
+from pants.option.custom_types import file_option
 
 from pants.contrib.python.checks.tasks.checkstyle.common import Nit, PythonFile
 from pants.contrib.python.checks.tasks.checkstyle.file_excluder import FileExcluder
@@ -55,15 +56,15 @@ class PythonCheckStyleTask(PythonTask):
   @classmethod
   def register_options(cls, register):
     super(PythonCheckStyleTask, cls).register_options(register)
-    register('--severity', default='COMMENT', type=str,
+    register('--severity', fingerprint=True, default='COMMENT', type=str,
              help='Only messages at this severity or higher are logged. [COMMENT WARNING ERROR].')
-    register('--strict', default=False, action='store_true',
+    register('--strict', fingerprint=True, default=False, action='store_true',
              help='If enabled, have non-zero exit status for any nit at WARNING or higher.')
-    register('--skip', default=False, action='store_true',
+    register('--skip', fingerprint=True, default=False, action='store_true',
              help='If enabled, skip this style checker.')
-    register('--suppress', type=str, default=None,
+    register('--suppress', fingerprint=True, type=file_option, default=None,
              help='Takes a XML file where specific rules on specific files will be skipped.')
-    register('--fail', default=True, action='store_true',
+    register('--fail', fingerprint=True, default=True, action='store_true',
              help='Prevent test failure but still produce output for problems.')
 
   @classmethod

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pep8_subsystem.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pep8_subsystem.py
@@ -48,9 +48,9 @@ class PEP8Subsystem(PluginSubsystemBase):
   @classmethod
   def register_options(cls, register):
     super(PEP8Subsystem, cls).register_options(register)
-    register('--ignore', type=list_option, default=cls.DEFAULT_IGNORE_CODES,
+    register('--ignore', fingerprint=True, type=list_option, default=cls.DEFAULT_IGNORE_CODES,
              help='Prevent test failure but still produce output for problems.')
-    register('--max-length', type=int, default=100,
+    register('--max-length', fingerprint=True, type=int, default=100,
              help='Max line length to use for PEP8 checks.')
 
   def get_plugin_type(self):


### PR DESCRIPTION
Fix issues where users update style suppression file after they have
run a local build.  Previously the user wouldn't see style errors after
the user updated the suppression file.  Also update some other style
related options to fingerprint.