### PR TITLE
Add _copy_target_attributes implementation to antlr

### DIFF
--- a/src/python/pants/backend/codegen/tasks/antlr_gen.py
+++ b/src/python/pants/backend/codegen/tasks/antlr_gen.py
@@ -124,3 +124,8 @@ class AntlrGen(SimpleCodegenTask, NailgunTask):
             f.write(lines[0])
           for line in lines[1:]:
             f.write(line)
+
+  @property
+  def _copy_target_attributes(self):
+    """Propagate the provides attribute to the synthetic java_library() target for publishing."""
+    return ['provides']


### PR DESCRIPTION
A previous code refactor allowed for subclasses to control
which attributes were copied.  Antlr_gen was left out which
caused problems with publish for antlr targets.  This fixes
publishing for antlr targets.

For ref:
https://rbcommons.com/s/twitter/r/3352
https://rbcommons.com/s/twitter/r/3402