### PR TITLE
Prepare for a global --shard flag.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -190,7 +190,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     ./pants.pex ${PANTS_ARGS[@]} test.pytest \
       --fail-slow \
       --coverage=paths:pants/ \
-      --shard=${python_unit_shard} \
+      --test-pytest-test-shard=${python_unit_shard} \
       ${targets}
   ) || die "Core python test failure"
 fi
@@ -216,7 +216,7 @@ if [[ "${skip_integration:-false}" == "false" ]]; then
       ./pants.pex list tests/python:: | \
       xargs ./pants.pex --tag='+integration' filter --filter-type=python_tests
     ) && \
-    ./pants.pex ${PANTS_ARGS[@]} test.pytest --fail-slow --shard=${python_intg_shard} ${targets}
+    ./pants.pex ${PANTS_ARGS[@]} test.pytest --fail-slow --test-pytest-test-shard=${python_intg_shard} ${targets}
   ) || die "Pants Integration test failure"
 fi
 

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -213,7 +213,7 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
                                   bold=True, invert=True, yellow=True)
           """.format(shard=sharder.shard, nshards=sharder.nshards)))
         yield [path]
-    except Sharder.InvalidSpec as e:
+    except Sharder.InvalidShardSpec as e:
       raise self.InvalidShardSpecification(e)
 
   @contextmanager

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -26,6 +26,7 @@ from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError, TestFailedTaskError
+from pants.base.hash_utils import Sharder
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
@@ -117,7 +118,10 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
     register('--coverage-output-dir', metavar='<DIR>', default=None,
              help='Directory to emit coverage reports to.'
              'If not specified, a default within dist is used.')
-    register('--shard',
+    register('--shard', deprecated_version='0.0.76', removal_version='0.0.78',
+             deprecated_hint='Use --test-shard instead, with the same value.',
+             help='See --test-shard.')
+    register('--test-shard',
              help='Subset of tests to run, in the form M/N, 0 <= M < N. For example, 1/3 means '
                   'run tests number 2, 5, 8, 11, ...')
 
@@ -172,57 +176,45 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
         raise TestFailedTaskError(failed_targets=failed_targets)
 
   class InvalidShardSpecification(TaskError):
-    """Indicates an invalid `--shard` option."""
+    """Indicates an invalid `--test-shard` option."""
 
   @contextmanager
   def _maybe_shard(self):
-    shard_spec = self.get_options().shard
-    if not shard_spec:
+    shard_spec = self.get_options().test_shard or self.get_options().shard
+    if shard_spec is None:
       yield []
       return
 
-    components = shard_spec.split('/', 1)
-    if len(components) != 2:
-      raise self.InvalidShardSpecification("Invalid shard specification '{}', should be of form: "
-                                           "[shard index]/[total shards]".format(shard_spec))
+    try:
+      sharder = Sharder(shard_spec)
 
-    def ensure_int(item):
-      try:
-        return int(item)
-      except ValueError:
-        raise self.InvalidShardSpecification("Invalid shard specification '{}', item {} is not an "
-                                             "int".format(shard_spec, item))
+      if sharder.nshards < 2:
+        yield []
+        return
 
-    shard = ensure_int(components[0])
-    total = ensure_int(components[1])
-    if not (0 <= shard and shard < total):
-      raise self.InvalidShardSpecification("Invalid shard specification '{}', shard must "
-                                           "be >= 0 and < {}".format(shard_spec, total))
-    if total < 2:
-      yield []
-      return
-
-    with temporary_dir() as tmp:
-      path = os.path.join(tmp, 'conftest.py')
-      with open(path, 'w') as fp:
-        fp.write(dedent("""
-          def pytest_report_header(config):
-            return 'shard: {shard} of {total} (0-based shard numbering)'
+      with temporary_dir() as tmp:
+        path = os.path.join(tmp, 'conftest.py')
+        with open(path, 'w') as fp:
+          fp.write(dedent("""
+            def pytest_report_header(config):
+              return 'shard: {shard} of {nshards} (0-based shard numbering)'
 
 
-          def pytest_collection_modifyitems(session, config, items):
-            total_count = len(items)
-            removed = 0
-            for i, item in enumerate(list(items)):
-              if i % {total} != {shard}:
-                del items[i - removed]
-                removed += 1
-            reporter = config.pluginmanager.getplugin('terminalreporter')
-            reporter.write_line('Only executing {{}} of {{}} total tests in shard {shard} of '
-                                '{total}'.format(total_count - removed, total_count),
-                                bold=True, invert=True, yellow=True)
-        """.format(shard=shard, total=total)))
-      yield [path]
+            def pytest_collection_modifyitems(session, config, items):
+              total_count = len(items)
+              removed = 0
+              for i, item in enumerate(list(items)):
+                if i % {nshards} != {shard}:
+                  del items[i - removed]
+                  removed += 1
+              reporter = config.pluginmanager.getplugin('terminalreporter')
+              reporter.write_line('Only executing {{}} of {{}} total tests in shard {shard} of '
+                                  '{nshards}'.format(total_count - removed, total_count),
+                                  bold=True, invert=True, yellow=True)
+          """.format(shard=sharder.shard, nshards=sharder.nshards)))
+        yield [path]
+    except Sharder.InvalidSpec as e:
+      raise self.InvalidShardSpecification(e)
 
   @contextmanager
   def _maybe_emit_junit_xml(self, targets):

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -36,37 +36,50 @@ def hash_file(path, digest=None):
 class Sharder(object):
   """Assigns strings to shards pseudo-randomly, but stably."""
 
-  class InvalidSpec(Exception):
+  class InvalidShardSpec(Exception):
     """Indicates an invalid shard spec."""
 
-    def __init__(self, spec):
-      super(Sharder.InvalidSpec, self).__init__(
-          "InvalidShardSpecification '{}', should be of the form M/N, where M, N are ints "
-          "and 0 <= M < N.".format(spec))
+    def __init__(self, shard_spec):
+      """
+      :param string shard_spec: A string of the form M/N where M, N are ints and 0 <= M < N.
+      """
+      super(Sharder.InvalidShardSpec, self).__init__(
+          "Invalid shard spec '{}', should be of the form M/N, where M, N are ints "
+          "and 0 <= M < N.".format(shard_spec))
 
   @staticmethod
-  def compute_shard(str, mod):
-    """Computes the mod-hash of the given string, using a sha1 hash."""
-    return int(hash_all([str]), 16) % mod
+  def compute_shard(s, mod):
+    """Computes the mod-hash of the given string, using a sha1 hash.
 
-  def __init__(self, spec):
+    :param string s: The string to compute a shard for.
+    """
+    return int(hash_all([s]), 16) % mod
+
+  def __init__(self, shard_spec):
+    """
+    :param string shard_spec: A string of the form M/N where M, N are ints and 0 <= M < N.
+    """
     def ensure_int(s):
       try:
         return int(s)
       except ValueError:
-        raise self.InvalidSpec(spec)
+        raise self.InvalidShardSpec(shard_spec)
 
-    if spec is None:
-      raise self.InvalidSpec('None')
-    shard_str, _, nshards_str = spec.partition('/')
+    if shard_spec is None:
+      raise self.InvalidShardSpec('None')
+    shard_str, _, nshards_str = shard_spec.partition('/')
     self._shard = ensure_int(shard_str)
     self._nshards = ensure_int(nshards_str)
 
     if self._shard < 0 or self._shard >= self._nshards:
-      raise self.InvalidSpec(spec)
+      raise self.InvalidShardSpec(shard_spec)
 
-  def is_in_shard(self, str):
-    return self.compute_shard(str, self._nshards) == self._shard
+  def is_in_shard(self, s):
+    """Returns True iff the string s is in this shard.
+
+    :param string s: The string to check.
+    """
+    return self.compute_shard(s, self._nshards) == self._shard
 
   @property
   def shard(self):

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -47,7 +47,7 @@ python_tests(
   sources=['test_python_repl.py'],
   dependencies=[
     ':python_task_test_base',
-    'src/python/pants/backend/python/tasks:python',
+        'src/python/pants/backend/python/tasks:python',
     'src/python/pants/backend/python:all_utils',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -251,7 +251,8 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
   def test_error(self):
     """Test that a test that errors rather than fails shows up in TestFailedTaskError."""
 
-    self.run_failing_tests(targets=[self.red, self.green, self.error], failed_targets=[self.red, self.error])
+    self.run_failing_tests(targets=[self.red, self.green, self.error],
+                           failed_targets=[self.red, self.error])
 
   def test_error_outside_function(self):
     # If the test is outside a class or function, the failure line is in the following format:
@@ -284,7 +285,8 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
     self.run_failing_tests(targets=[self.green, self.red], failed_targets=[self.red])
 
   def test_one_timeout(self):
-    """When we have two targets, any of them doesn't have a timeout, and we have no default, then no timeout is set."""
+    # When we have two targets, any of them doesn't have a timeout, and we have no default,
+    # then no timeout is set.
 
     with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       self.run_tests(targets=[self.sleep_no_timeout, self.sleep_timeout])
@@ -294,7 +296,7 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
       self.assertEqual(args, (None,))
 
   def test_timeout(self):
-    """Check that a failed timeout returns the right results."""
+    # Check that a failed timeout returns the right results.
 
     with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       mock_timeout().__exit__.side_effect = TimeoutReached(1)
@@ -423,40 +425,46 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
     self.assertEqual([], not_run_statements)
 
   def test_sharding(self):
-    self.run_failing_tests(targets=[self.red, self.green], failed_targets=[self.red], shard='0/2')
-    self.run_tests(targets=[self.red, self.green], shard='1/2')
+    self.run_failing_tests(targets=[self.red, self.green], failed_targets=[self.red],
+                           test_shard='0/2')
+    self.run_tests(targets=[self.red, self.green], test_shard='1/2')
 
   def test_sharding_single(self):
-    self.run_failing_tests(targets=[self.red], failed_targets=[self.red], shard='0/1')
+    self.run_failing_tests(targets=[self.red], failed_targets=[self.red], test_shard='0/1')
 
   def test_sharding_invalid_shard_too_small(self):
     with self.assertRaises(PytestRun.InvalidShardSpecification):
-      self.run_tests(targets=[self.green], shard='-1/1')
+      self.run_tests(targets=[self.green], test_shard='-1/1')
 
   def test_sharding_invalid_shard_too_big(self):
     with self.assertRaises(PytestRun.InvalidShardSpecification):
-      self.run_tests(targets=[self.green], shard='1/1')
+      self.run_tests(targets=[self.green], test_shard='1/1')
 
   def test_sharding_invalid_shard_bad_format(self):
     with self.assertRaises(PytestRun.InvalidShardSpecification):
-      self.run_tests(targets=[self.green], shard='1')
+      self.run_tests(targets=[self.green], test_shard='1')
 
     with self.assertRaises(PytestRun.InvalidShardSpecification):
-      self.run_tests(targets=[self.green], shard='1/2/3')
+      self.run_tests(targets=[self.green], test_shard='1/2/3')
 
     with self.assertRaises(PytestRun.InvalidShardSpecification):
-      self.run_tests(targets=[self.green], shard='1/a')
+      self.run_tests(targets=[self.green], test_shard='1/a')
 
   def test_resultlog_regex(self):
     regex = PytestRun.RESULTLOG_FAILED_PATTERN
     for error_failure in ['E', 'F']:
-      self.assertEqual(regex.match('%s filename::class::method' % error_failure).group('file'), 'filename')
-      self.assertEqual(regex.match('%s filename::method' % error_failure).group('file'), 'filename')
+      self.assertEqual(regex.match('%s filename::class::method' % error_failure).group('file'),
+                       'filename')
+      self.assertEqual(regex.match('%s filename::method' % error_failure).group('file'),
+                       'filename')
       self.assertEqual(regex.match('%s filename' % error_failure).group('file'), 'filename')
       self.assertIsNone(regex.match(' %s filename'))
       self.assertIsNone(regex.match(' filename'))
       self.assertIsNone(regex.match('filename'))
       self.assertIsNone(regex.match('%sfilename'))
-      self.assertEqual(regex.match('%s   filename::class:method' % error_failure).group('file'), 'filename')
-      self.assertEqual(regex.match('%s file/name.py::class:method' % error_failure).group('file'), 'file/name.py')
-      self.assertEqual(regex.match('%s file:colons::class::method' % error_failure).group('file'), 'file:colons')
+      self.assertEqual(regex.match('%s   filename::class:method' % error_failure).group('file'),
+                       'filename')
+      self.assertEqual(regex.match('%s file/name.py::class:method' % error_failure).group('file'),
+                       'file/name.py')
+      self.assertEqual(regex.match('%s file:colons::class::method' % error_failure).group('file'),
+                       'file:colons')

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -70,7 +70,7 @@ class TestHashUtils(mox.MoxTestBase):
       self.assertEquals(expected_nshards, sharder.nshards)
 
     def check_bad_spec(spec):
-      self.assertRaises(Sharder.InvalidSpec, lambda: Sharder(spec))
+      self.assertRaises(Sharder.InvalidShardSpec, lambda: Sharder(spec))
 
     check('0/1', 0, 1)
     check('0/2', 0, 2)

--- a/tests/python/pants_test/base/test_hash_utils.py
+++ b/tests/python/pants_test/base/test_hash_utils.py
@@ -5,9 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import math
+
 import mox
 
-from pants.base.hash_utils import hash_all, hash_file
+from pants.base.hash_utils import Sharder, hash_all, hash_file
 from pants.util.contextutil import temporary_file
 
 
@@ -35,3 +37,56 @@ class TestHashUtils(mox.MoxTestBase):
       fd.close()
 
       self.assertEqual('1137', hash_file(fd.name, digest=self.digest))
+
+  def test_compute_shard(self):
+    # Spot-check a couple of values, to make sure compute_shard doesn't do something
+    # completely degenerate.
+    self.assertEqual(31, Sharder.compute_shard('', 42))
+    self.assertEqual(35, Sharder.compute_shard('foo', 42))
+    self.assertEqual(5, Sharder.compute_shard('bar', 42))
+
+  def test_compute_shard_distribution(self):
+    # Check that shard distribution isn't obviously broken.
+    nshards = 7
+    mean_samples_per_shard = 10000
+    nsamples = nshards * mean_samples_per_shard
+
+    distribution = [0] * nshards
+    for n in range(0, nsamples):
+      shard = Sharder.compute_shard(str(n), nshards)
+      distribution[shard] += 1
+
+    variance = sum([(x - mean_samples_per_shard) ** 2 for x in distribution]) / nshards
+    stddev = math.sqrt(variance)
+
+    # We arbitrarily assert that a stddev of less than 1% of the mean is good enough
+    # for sanity-checking purposes.
+    self.assertLess(stddev, 100)
+
+  def test_sharder(self):
+    def check(spec, expected_shard, expected_nshards):
+      sharder = Sharder(spec)
+      self.assertEquals(expected_shard, sharder.shard)
+      self.assertEquals(expected_nshards, sharder.nshards)
+
+    def check_bad_spec(spec):
+      self.assertRaises(Sharder.InvalidSpec, lambda: Sharder(spec))
+
+    check('0/1', 0, 1)
+    check('0/2', 0, 2)
+    check('1/2', 1, 2)
+    check('0/100', 0, 100)
+    check('99/100', 99, 100)
+
+    check_bad_spec('0/0')
+    check_bad_spec('-1/0')
+    check_bad_spec('0/-1')
+    check_bad_spec('1/1')
+    check_bad_spec('2/1')
+    check_bad_spec('100/100')
+    check_bad_spec('1/2/3')
+    check_bad_spec('/1')
+    check_bad_spec('1/')
+    check_bad_spec('/')
+    check_bad_spec('foo/1')
+    check_bad_spec('1/foo')


### PR DESCRIPTION
- Refactor shard spec parsing and application to a common utility.

- Rename test.pytest's --shard to --test-shard (and deprecate the
  old name) so it won't collide with the global name, and for
  uniformity with test.junit's similar flag.

When global sharding is implemented, the test tasks' sharding will
subshard on top of that. This is useful because sharding the input
targets may not be fine-grained enough (some repos have large numbers
of tests covered by a single target). However global sharding
may be good enough in many cases, and will prevent us from having
to implement sharding over and over again in every task that might
need it.