### PR TITLE
Report @Ignore tests in xml reports from JUnit and create report for tests that fail in initialization

### DIFF
--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -3,32 +3,41 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import org.junit.Assert;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests several recently added features in ConsoleRunner.
  * TODO: cover the rest of ConsoleRunner functionality.
  */
-public class ConsoleRunnerTest extends ConsoleRunnerTestHelper{
-
+public class ConsoleRunnerTest extends ConsoleRunnerTestHelper {
   @Test
   public void testNormalTesting() throws Exception {
     ConsoleRunnerImpl.main(asArgsArray("MockTest1 MockTest2 MockTest3"));
-    Assert.assertEquals("test11 test12 test13 test21 test22 test31 test32",
+    assertEquals("test11 test12 test13 test21 test22 test31 test32",
         TestRegistry.getCalledTests());
   }
 
   @Test
   public void testShardedTesting02() throws Exception {
     ConsoleRunnerImpl.main(asArgsArray("MockTest1 MockTest2 MockTest3 -test-shard 0/2"));
-    Assert.assertEquals("test11 test13 test22 test32", TestRegistry.getCalledTests());
+    assertEquals("test11 test13 test22 test32", TestRegistry.getCalledTests());
   }
 
   @Test
   public void testShardedTesting13() throws Exception {
     ConsoleRunnerImpl.main(asArgsArray("MockTest1 MockTest2 MockTest3 -test-shard 1/3"));
-    Assert.assertEquals("test12 test22", TestRegistry.getCalledTests());
+    assertEquals("test12 test22", TestRegistry.getCalledTests());
   }
 
   @Test
@@ -36,14 +45,14 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestHelper{
     // This tests a corner case when no tests from MockTest2 are going to run.
     ConsoleRunnerImpl.main(asArgsArray(
         "MockTest1 MockTest2 MockTest3 -test-shard 2/3"));
-    Assert.assertEquals("test13 test31", TestRegistry.getCalledTests());
+    assertEquals("test13 test31", TestRegistry.getCalledTests());
   }
 
   @Test
   public void testShardedTesting12WithParallelThreads() throws Exception {
     ConsoleRunnerImpl.main(asArgsArray(
         "MockTest1 MockTest2 MockTest3 -test-shard 1/2 -parallel-threads 4 -default-parallel"));
-    Assert.assertEquals("test12 test21 test31", TestRegistry.getCalledTests());
+    assertEquals("test12 test21 test31", TestRegistry.getCalledTests());
   }
 
   @Test
@@ -51,42 +60,226 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestHelper{
     // This tests a corner case when no tests from MockTest2 are going to run.
     ConsoleRunnerImpl.main(asArgsArray(
         "MockTest1 MockTest2 MockTest3 -test-shard 2/3 -parallel-threads 3 -default-parallel"));
-    Assert.assertEquals("test13 test31", TestRegistry.getCalledTests());
+    assertEquals("test13 test31", TestRegistry.getCalledTests());
   }
 
   @Test
   public void testFlakyTests() throws Exception {
-    TestRegistry.consoleRunnerTestRunsFlakyTests = true;
     FlakyTest.numFlakyTestInstantiations = 0;
     FlakyTest.numExpectedExceptionMethodInvocations = 0;
 
     try {
+      FlakyTest.flakyTestsShouldFail = true;
       ConsoleRunnerImpl.main(asArgsArray("FlakyTest -num-retries 2"));
-      Assert.fail("Should have failed with RuntimeException due to FlakyTest.methodAlwaysFails");
+      fail("Should have failed with RuntimeException due to FlakyTest.methodAlwaysFails");
       // FlakyTest.methodAlwaysFails fails this way - though perhaps that should be fixed to be an
       // RTE subclass.
       // SUPPRESS CHECKSTYLE RegexpSinglelineJava
     } catch (RuntimeException ex) {
       // Expected due to FlakyTest.methodAlwaysFails()
     } finally {
-      TestRegistry.consoleRunnerTestRunsFlakyTests = false;
+      FlakyTest.flakyTestsShouldFail = false;
     }
 
-    Assert.assertEquals("expected_ex flaky1 flaky1 flaky2 flaky2 flaky2 flaky3 flaky3 flaky3 "
+    assertEquals("expected_ex flaky1 flaky1 flaky2 flaky2 flaky2 flaky3 flaky3 flaky3 "
         + "notflaky", TestRegistry.getCalledTests());
 
     // Verify that FlakyTest class has been instantiated once per test method invocation,
     // including flaky test method invocations.
-    Assert.assertEquals(10, FlakyTest.numFlakyTestInstantiations);
+    assertEquals(10, FlakyTest.numFlakyTestInstantiations);
 
     // Verify that a method with expected exception is not treated
     // as flaky - that is, it should be invoked only once.
-    Assert.assertEquals(1, FlakyTest.numExpectedExceptionMethodInvocations);
+    assertEquals(1, FlakyTest.numExpectedExceptionMethodInvocations);
   }
 
   @Test
   public void testTestCase() throws Exception {
     ConsoleRunnerImpl.main(asArgsArray("SimpleTestCase"));
-    Assert.assertEquals("testDummy", TestRegistry.getCalledTests());
+    assertEquals("testDummy", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testXmlReportAll() throws Exception {
+    String testClassName = XmlReportTest.class.getCanonicalName();
+
+    XmlReportTest.failingTestsShouldFail = true;
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, true);
+    XmlReportTest.failingTestsShouldFail = false;
+
+    assertNotNull(testSuite);
+    assertEquals(4, testSuite.getTests());
+    assertEquals(1, testSuite.getFailures());
+    assertEquals(1, testSuite.getErrors());
+    assertEquals(1, testSuite.getSkipped());
+    assertTrue(Float.parseFloat(testSuite.getTime()) > 0);
+    assertEquals(testClassName, testSuite.getName());
+    assertEquals("Test output\n", testSuite.getOut());
+    assertEquals("", testSuite.getErr());
+
+    List<AntJunitXmlReportListener.TestCase> testCases = testSuite.getTestCases();
+    assertEquals(4, testCases.size());
+    sortTestCasesByName(testCases);
+
+    AntJunitXmlReportListener.TestCase errorTestCase = testCases.get(0);
+    assertEquals(testClassName, errorTestCase.getClassname());
+    assertEquals("testXmlErrors", errorTestCase.getName());
+    assertTrue(Float.parseFloat(errorTestCase.getTime()) > 0);
+    assertNull(errorTestCase.getFailure());
+    assertEquals("testXmlErrors exception", errorTestCase.getError().getMessage());
+    assertEquals("java.lang.Exception", errorTestCase.getError().getType());
+    assertThat(errorTestCase.getError().getStacktrace(),
+        containsString(testClassName + ".testXmlErrors("));
+
+    AntJunitXmlReportListener.TestCase failureTestCase = testCases.get(1);
+    assertEquals(testClassName, failureTestCase.getClassname());
+    assertEquals("testXmlFails", failureTestCase.getName());
+    assertTrue(Float.parseFloat(failureTestCase.getTime()) > 0);
+    assertNull(failureTestCase.getError());
+    assertEquals("java.lang.AssertionError", failureTestCase.getFailure().getType());
+    assertThat(failureTestCase.getFailure().getStacktrace(),
+        containsString(testClassName + ".testXmlFails("));
+
+    AntJunitXmlReportListener.TestCase passingTestCase = testCases.get(2);
+    assertEquals(testClassName, passingTestCase.getClassname());
+    assertEquals("testXmlPasses", passingTestCase.getName());
+    assertTrue(Float.parseFloat(passingTestCase.getTime()) > 0);
+    assertNull(passingTestCase.getFailure());
+    assertNull(passingTestCase.getError());
+
+    AntJunitXmlReportListener.TestCase ignoredTestCase = testCases.get(3);
+    assertEquals(testClassName, ignoredTestCase.getClassname());
+    assertEquals("testXmlSkipped", ignoredTestCase.getName());
+    assertEquals("0", ignoredTestCase.getTime());
+    assertNull(ignoredTestCase.getFailure());
+    assertNull(ignoredTestCase.getError());
+  }
+
+  @Test
+  public void testXmlReportAllIgnored() throws Exception {
+    String testClassName = XmlReportAllIgnoredTest.class.getCanonicalName();
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, false);
+
+    assertNotNull(testSuite);
+    assertEquals(2, testSuite.getTests());
+    assertEquals(0, testSuite.getFailures());
+    assertEquals(0, testSuite.getErrors());
+    assertEquals(2, testSuite.getSkipped());
+    assertEquals("0", testSuite.getTime());
+    assertEquals(testClassName, testSuite.getName());
+  }
+
+  @Test
+  public void testXmlReportFirstTestIgnored() throws Exception {
+    String testClassName = XmlReportFirstTestIngoredTest.class.getCanonicalName();
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, false);
+
+    assertNotNull(testSuite);
+    assertEquals(2, testSuite.getTests());
+    assertEquals(0, testSuite.getFailures());
+    assertEquals(0, testSuite.getErrors());
+    assertEquals(1, testSuite.getSkipped());
+    assertTrue(Float.parseFloat(testSuite.getTime()) > 0);
+    assertEquals(testClassName, testSuite.getName());
+  }
+
+  @Test
+  public void testXmlReportAllPassing() throws Exception {
+    String testClassName = XmlReportAllPassingTest.class.getCanonicalName();
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, false);
+
+    assertNotNull(testSuite);
+    assertEquals(2, testSuite.getTests());
+    assertEquals(0, testSuite.getFailures());
+    assertEquals(0, testSuite.getErrors());
+    assertEquals(0, testSuite.getSkipped());
+    assertTrue(Float.parseFloat(testSuite.getTime()) > 0);
+    assertEquals(testClassName, testSuite.getName());
+  }
+
+  @Test
+  public void testXmlReportXmlElements() throws Exception {
+    String testClassName = XmlReportAllPassingTest.class.getCanonicalName();
+    String xmlOutput = FileUtils.readFileToString(runTestAndReturnXmlFile(testClassName, false));
+
+    assertThat(xmlOutput, containsString("<testsuite"));
+    assertThat(xmlOutput, containsString("<properties>"));
+    assertThat(xmlOutput, containsString("<testcase"));
+    assertThat(xmlOutput, containsString("<system-out>"));
+    assertThat(xmlOutput, containsString("<system-err>"));
+    assertThat(xmlOutput, not(containsString("startNs")));
+    assertThat(xmlOutput, not(containsString("testClass")));
+  }
+
+  @Test
+  public void testXmlReportFailInSetup() throws Exception {
+    String testClassName = XmlReportFailInSetupTest.class.getCanonicalName();
+
+    XmlReportFailInSetupTest.shouldFailDuringSetup = true;
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, true);
+    XmlReportFailInSetupTest.shouldFailDuringSetup = false;
+
+    assertNotNull(testSuite);
+    assertEquals(2, testSuite.getTests());
+    assertEquals(0, testSuite.getFailures());
+    assertEquals(2, testSuite.getErrors());
+    assertEquals(0, testSuite.getSkipped());
+    assertTrue(Float.parseFloat(testSuite.getTime()) > 0);
+    assertEquals(testClassName, testSuite.getName());
+  }
+
+  @Test
+  public void testXmlReportIgnoredTestSuite() throws Exception {
+    String testClassName = XmlReportIgnoredTestSuiteTest.class.getCanonicalName();
+
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, false);
+
+    assertNotNull(testSuite);
+    assertEquals(1, testSuite.getTests());
+    assertEquals(0, testSuite.getFailures());
+    assertEquals(0, testSuite.getErrors());
+    assertEquals(1, testSuite.getSkipped());
+    assertEquals("0", testSuite.getTime());
+    assertEquals(testClassName, testSuite.getName());
+
+    List<AntJunitXmlReportListener.TestCase> testCases = testSuite.getTestCases();
+    assertEquals(1, testCases.size());
+
+    AntJunitXmlReportListener.TestCase testCase = testCases.get(0);
+    assertEquals(testClassName, testCase.getClassname());
+    assertEquals(testClassName, testCase.getName());
+    assertEquals("0", testCase.getTime());
+    assertNull(testCase.getError());
+    assertNull(testCase.getFailure());
+  }
+
+  @Test
+  public void testXmlFailInCustomTestRunner() throws Exception {
+    String testClassName = XmlReportCustomTestRunnerTest.class.getCanonicalName();
+
+    CustomTestRunner.shouldFailDuringInitialization = true;
+    AntJunitXmlReportListener.TestSuite testSuite = runTestAndParseXml(testClassName, true);
+    CustomTestRunner.shouldFailDuringInitialization = false;
+
+    assertNotNull(testSuite);
+    assertEquals(1, testSuite.getTests());
+    assertEquals(0, testSuite.getFailures());
+    assertEquals(1, testSuite.getErrors());
+    assertEquals(0, testSuite.getSkipped());
+    assertEquals("0", testSuite.getTime());
+    assertEquals(testClassName, testSuite.getName());
+
+    List<AntJunitXmlReportListener.TestCase> testCases = testSuite.getTestCases();
+    assertEquals(1, testCases.size());
+
+    AntJunitXmlReportListener.TestCase testCase = testCases.get(0);
+    assertEquals(testClassName, testCase.getClassname());
+    assertEquals(testClassName, testCase.getName());
+    assertEquals("0", testCase.getTime());
+    assertNull(testCase.getFailure());
+    assertEquals("failed in getTestRules", testCase.getError().getMessage());
+    assertEquals("java.lang.RuntimeException", testCase.getError().getType());
+    assertThat(testCase.getError().getStacktrace(),
+        containsString(CustomTestRunner.class.getCanonicalName() + ".getTestRules("));
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/impl/CustomTestRunner.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/CustomTestRunner.java
@@ -1,0 +1,25 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.rules.TestRule;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+public class CustomTestRunner extends BlockJUnit4ClassRunner {
+  public static boolean shouldFailDuringInitialization = false;
+
+  public CustomTestRunner(Class<?> klass) throws InitializationError {
+    super(klass);
+  }
+
+  @Override protected List<TestRule> getTestRules(Object target) {
+    if (shouldFailDuringInitialization) {
+      throw new RuntimeException("failed in getTestRules");
+    }
+    return new ArrayList<TestRule>();
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/FlakyTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/FlakyTest.java
@@ -17,6 +17,9 @@ import org.junit.Test;
  */
 public class FlakyTest {
 
+  /** Should be set to true only while tests from FlakyTest is executed from ConsoleRunnerTest */
+  public static boolean flakyTestsShouldFail = false;
+
   public static int numFlaky1Invocations = 0;
   public static int numFlaky2Invocations = 0;
   public static int numFlaky3Invocations = 0;
@@ -47,7 +50,7 @@ public class FlakyTest {
   @Test
   public void flakyMethodSucceedsAfter1Retry() throws Exception {
     numTestMethodInvocationsPerTestInstance++;
-    Assume.assumeTrue(TestRegistry.consoleRunnerTestRunsFlakyTests);
+    Assume.assumeTrue(flakyTestsShouldFail);
     TestRegistry.registerTestCall("flaky1");
     numFlaky1Invocations++;
     if (numFlaky1Invocations < 2) {
@@ -58,7 +61,7 @@ public class FlakyTest {
   @Test
   public void flakyMethodSucceedsAfter2Retries() throws Exception {
     numTestMethodInvocationsPerTestInstance++;
-    Assume.assumeTrue(TestRegistry.consoleRunnerTestRunsFlakyTests);
+    Assume.assumeTrue(flakyTestsShouldFail);
     TestRegistry.registerTestCall("flaky2");
     numFlaky2Invocations++;
     if (numFlaky2Invocations < 3) {
@@ -69,7 +72,7 @@ public class FlakyTest {
   @Test
   public void methodAlwaysFails() throws Exception {
     numTestMethodInvocationsPerTestInstance++;
-    Assume.assumeTrue(TestRegistry.consoleRunnerTestRunsFlakyTests);
+    Assume.assumeTrue(flakyTestsShouldFail);
     TestRegistry.registerTestCall("flaky3");
     numFlaky3Invocations++;
     throw new Exception("flaky3 failed on invocation number " + numFlaky3Invocations);

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportAllIgnoredTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportAllIgnoredTest.java
@@ -1,0 +1,22 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class XmlReportAllIgnoredTest {
+  @Ignore
+  @Test
+  public void testXmlIgnored() {
+    Assert.assertTrue(true);
+  }
+
+  @Ignore
+  @Test
+  public void testXmlIgnoredAgain() {
+    Assert.assertTrue(true);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportAllPassingTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportAllPassingTest.java
@@ -1,0 +1,19 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XmlReportAllPassingTest {
+  @Test
+  public void testXmlPassing() {
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testXmlPassingAgain() {
+    Assert.assertTrue(true);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportCustomTestRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportCustomTestRunnerTest.java
@@ -1,0 +1,16 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(CustomTestRunner.class)
+public class XmlReportCustomTestRunnerTest {
+  @Test
+  public void testXmlPassing() {
+    Assert.assertTrue(true);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportFailInSetupTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportFailInSetupTest.java
@@ -1,0 +1,29 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlReportFailInSetupTest {
+  public static boolean shouldFailDuringSetup = false;
+
+  @Before
+  public void setUp() throws Exception {
+    if (shouldFailDuringSetup) {
+      throw new Exception("Fail in setUp");
+    }
+  }
+
+  @Test
+  public void testXmlPassing() {
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testXmlPassingAgain() {
+    Assert.assertTrue(true);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportFirstTestIngoredTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportFirstTestIngoredTest.java
@@ -1,0 +1,21 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class XmlReportFirstTestIngoredTest {
+  @Ignore
+  @Test
+  public void testXmlIgnored() {
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testXmlPassing() {
+    Assert.assertTrue(true);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportIgnoredTestSuiteTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportIgnoredTestSuiteTest.java
@@ -1,0 +1,21 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore
+public class XmlReportIgnoredTestSuiteTest {
+  @Test
+  public void testXmlPassing() {
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testXmlFailing() {
+    Assert.assertTrue(false);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/XmlReportTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/XmlReportTest.java
@@ -1,0 +1,38 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
+
+
+public class XmlReportTest {
+  public static boolean failingTestsShouldFail = false;
+
+  @Test
+  public void testXmlPasses() {
+    System.out.println("Test output");;
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testXmlFails() {
+    Assume.assumeTrue(failingTestsShouldFail);
+    Assert.assertTrue(false);
+  }
+
+  @Test
+  public void testXmlErrors() throws Exception {
+    Assume.assumeTrue(failingTestsShouldFail);
+    throw new Exception("testXmlErrors exception");
+  }
+
+  @Ignore
+  @Test
+  public void testXmlSkipped() {
+    Assert.assertTrue(true);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestHelper.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestHelper.java
@@ -1,14 +1,31 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 package org.pantsbuild.tools.junit.impl;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.pantsbuild.junit.annotations.TestSerial;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 
 @TestSerial
 public class ConsoleRunnerTestHelper {
+
+  @Rule
+  public TemporaryFolder temporary = new TemporaryFolder();
 
   @Before
   public void setUp() {
@@ -24,9 +41,9 @@ public class ConsoleRunnerTestHelper {
   }
 
   protected void assertContainsTestOutput(String output) {
-    Assert.assertThat(output, CoreMatchers.containsString("test41"));
-    Assert.assertThat(output, CoreMatchers.containsString("start test42"));
-    Assert.assertThat(output, CoreMatchers.containsString("end test42"));
+    assertThat(output, CoreMatchers.containsString("test41"));
+    assertThat(output, CoreMatchers.containsString("start test42"));
+    assertThat(output, CoreMatchers.containsString("end test42"));
   }
 
   protected String[] asArgsArray(String cmdLine) {
@@ -37,5 +54,43 @@ public class ConsoleRunnerTestHelper {
       }
     }
     return args;
+  }
+
+  protected File runTestAndReturnXmlFile(String testClassName, boolean shouldFail)
+      throws IOException, JAXBException {
+    String outdirPath = temporary.newFolder("testOutputDir").getAbsolutePath();
+
+    String[] args = new String[] { testClassName, "-outdir", outdirPath, "-xmlreport"};
+    if (shouldFail) {
+      try {
+        ConsoleRunnerImpl.main(args);
+        fail("The ConsoleRunner should throw an exception when running these tests");
+      } catch (RuntimeException ex) {
+        // Expected
+      }
+    } else {
+      ConsoleRunnerImpl.main(args);
+    }
+
+    return new File(outdirPath, "TEST-" + testClassName + ".xml");
+  }
+
+  protected AntJunitXmlReportListener.TestSuite runTestAndParseXml(
+      String testClassName, boolean shouldFail) throws IOException, JAXBException {
+    File testXmlFile = runTestAndReturnXmlFile(testClassName, shouldFail);
+
+    JAXBContext jaxbContext = JAXBContext.newInstance(AntJunitXmlReportListener.TestSuite.class);
+
+    Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+    return (AntJunitXmlReportListener.TestSuite) jaxbUnmarshaller.unmarshal(testXmlFile);
+  }
+
+  protected void sortTestCasesByName(List<AntJunitXmlReportListener.TestCase> testCases) {
+    Collections.sort(testCases, new Comparator<AntJunitXmlReportListener.TestCase>() {
+      public int compare(AntJunitXmlReportListener.TestCase tc1,
+          AntJunitXmlReportListener.TestCase tc2) {
+        return tc1.getName().compareTo(tc2.getName());
+      }
+    });
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/lib/TestRegistry.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/TestRegistry.java
@@ -15,9 +15,6 @@ import java.util.List;
  * by pants, and they may catch TestRegistry singleton in uninitialized state.
  */
 final class TestRegistry {
-
-  /** Should be set to true only while tests from FlakyTest is executed from ConsoleRunnerTest */
-  public static boolean consoleRunnerTestRunsFlakyTests = false;
   private static List<String> testsCalled = new ArrayList<String>();
 
   // No instances of this classes can be constructed

--- a/tests/java/org/pantsbuild/tools/junit/runner/ConsoleRunnerConsoleOutputTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/runner/ConsoleRunnerConsoleOutputTest.java
@@ -1,3 +1,6 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 package org.pantsbuild.tools.junit.impl;
 
 import java.io.ByteArrayOutputStream;
@@ -19,9 +22,6 @@ public class ConsoleRunnerConsoleOutputTest extends ConsoleRunnerTestHelper {
 
   final static PrintStream stdout = System.out;
   final static PrintStream stderr = System.err;
-
-  @Rule
-  public TemporaryFolder temporary = new TemporaryFolder();
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {


### PR DESCRIPTION
Add ignored or skipped test to XML report generated for JUnit tests and generate reports for testsuites that fail during initialization. 