### PR TITLE
Record the compile classpath used to compile jvm targets.

### DIFF
--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -227,6 +227,15 @@ class Target(AbstractTarget):
     """
     return cls.maybe_readable_combine_ids([target.id for target in targets])
 
+  @classmethod
+  def compute_target_id(cls, address):
+    """Computes a target id from the given address."""
+    id_candidate = address.path_safe_spec
+    if len(id_candidate) >= 200:
+      # two dots + 79 char head + 79 char tail + 40 char sha1
+      return '{}.{}.{}'.format(id_candidate[:79], sha1(id_candidate).hexdigest(), id_candidate[-79:])
+    return id_candidate
+
   @staticmethod
   def combine_ids(ids):
     """Generates a combined id for a set of ids.
@@ -564,11 +573,7 @@ class Target(AbstractTarget):
 
     :API: public
     """
-    id_candidate = self.address.path_safe_spec
-    if len(id_candidate) >= 200:
-      # two dots + 79 char head + 79 char tail + 40 char sha1
-      return '{}.{}.{}'.format(id_candidate[:79], sha1(id_candidate).hexdigest(), id_candidate[-79:])
-    return id_candidate
+    return self.compute_target_id(self.address)
 
   @property
   def identifier(self):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -19,6 +19,7 @@ python_tests(
   name='zinc_compile_integration',
   sources=['test_zinc_compile_integration.py'],
   dependencies=[
+    'src/python/pants/build_graph',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
   tags = {'integration'},

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
@@ -71,7 +71,11 @@ class BinaryCreateIntegrationTest(PantsRunIntegrationTest):
   def test_deploy_excludes(self):
     jar_filename = os.path.join('dist', 'deployexcludes.jar')
     safe_delete(jar_filename)
-    command = ['binary', 'testprojects/src/java/org/pantsbuild/testproject/deployexcludes']
+    command = [
+      '--no-compile-zinc-capture-classpath',
+      'binary',
+      'testprojects/src/java/org/pantsbuild/testproject/deployexcludes',
+    ]
     with self.pants_results(command) as pants_run:
       self.assert_success(pants_run)
       # The resulting binary should not contain any guava classes


### PR DESCRIPTION
This change makes `jvm_compile` write text files storing the
classpath for each jvm target it compiles to:

    .pants.d/compile/zinc/<sha>/<target.id>/<sha>/classes/compile_classpath/<target.id>.txt

Since these files are written to the classes/ directory, they end
up being bundled into jvm binaries. This can be useful to determine
how an artifact was built after the fact.

This behavior is enabled by default, and can be disabled with:

    --no-compile-zinc-capture-classpath