### PR TITLE
Peiyu/engine/more pickle cleanups

### DIFF
--- a/src/python/pants/engine/exp/engine.py
+++ b/src/python/pants/engine/exp/engine.py
@@ -130,7 +130,7 @@ class LocalSerialEngine(Engine):
 
 def _try_pickle(obj):
   try:
-    pickle.dumps(obj, protocol=-1)
+    pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
   except Exception as e:
     # Unfortunately, pickle can raise things other than PickleError instances.  For example it
     # will raise ValueError when handed a lambda; so we handle the otherwise overly-broad

--- a/src/python/pants/engine/exp/storage.py
+++ b/src/python/pants/engine/exp/storage.py
@@ -161,10 +161,7 @@ class Storage(Closable):
     self._contents = contents
     self._key_mappings = key_mappings
     self._debug = debug
-    # TODO: Have seen strange inconsistencies with pickle protocol version 1/2 (ie, the
-    # binary versions): in particular, bytes added into the middle of otherwise identical
-    # objects.
-    self._protocol = protocol if protocol is not None else 0
+    self._protocol = protocol if protocol is not None else pickle.HIGHEST_PROTOCOL
 
   def put(self, obj):
     """Serialize and hash a Serializable, returning a unique key to retrieve it later.

--- a/src/python/pants/engine/exp/storage.py
+++ b/src/python/pants/engine/exp/storage.py
@@ -101,17 +101,6 @@ class Key(object):
   def __str__(self):
     return repr(self)
 
-  # NB: since we define `__slots__` for space saving as opposed to `__dict__`,
-  # `__getstate__` and` __setstate__` are needed for pickling and unpickling.
-  # TODO (peiyu) it's possible we don't need them under pickle binary protocols,
-  # which currently fail for other reasons.
-  def __getstate__(self):
-    return zip(self.__slots__, [self._digest, self._type, self._hash, self._string])
-
-  def __setstate__(self, state):
-    for slot, value in state:
-      setattr(self, slot, value)
-
 
 class InvalidKeyError(Exception):
   """Indicate an invalid `Key` entry"""
@@ -224,7 +213,8 @@ class Storage(Closable):
     Unlike content storage, key mappings allows overwriting existing entries,
     meaning a key can be re-mapped to a different key.
     """
-    self._key_mappings.put(key=from_key.digest, value=pickle.dumps(to_key))
+    self._key_mappings.put(key=from_key.digest,
+                           value=pickle.dumps(to_key, protocol=self._protocol))
 
   def get_mapping(self, from_key):
     """Retrieve the mapping Key from a given Key.


### PR DESCRIPTION
Looks like all the weirdness we had with pickle can be explained by the default memo mode.

Now with https://rbcommons.com/s/twitter/r/3574/, I am able to clean up two more TODOs related
to pickle:

* Use binary protocol by default, was forced to use text protocol.
* Remove __getstate__ and __setstate__, now with binary protocol isn't necessary.