### PR TITLE
Remove unneeded args4j handler registrations that cause failures in tests and rename TestParser

### DIFF
--- a/src/java/org/pantsbuild/args4j/Parser.java
+++ b/src/java/org/pantsbuild/args4j/Parser.java
@@ -126,6 +126,14 @@ public class Parser {
       return Result.failure(cmdLineParser, "Invalid command line:\n\t%s", e.getLocalizedMessage());
     } catch (InvalidCmdLineArgumentException e) {
       return Result.failure(cmdLineParser, "Invalid command line parameter:\n\t%s", e.getMessage());
+    } finally {
+      // Unregister our custom CmdLineParser handlers because the OptionHandlerRegistry
+      // is a global singleton and we don't want to affect other users of CmdLineParser.
+      // This is most common when multiple tests are run at the same time.
+      OptionHandlerRegistry.getRegistry().registerHandler(
+          boolean.class, org.kohsuke.args4j.spi.BooleanOptionHandler.class);
+      OptionHandlerRegistry.getRegistry().registerHandler(
+          Boolean.class, org.kohsuke.args4j.spi.BooleanOptionHandler.class);
     }
   }
 }

--- a/tests/java/org/pantsbuild/args4j/ParserTest.java
+++ b/tests/java/org/pantsbuild/args4j/ParserTest.java
@@ -13,9 +13,10 @@ import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.Option;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class TestParser {
+public class ParserTest {
   public static class Options {
     @Option(name = "-v")
     boolean verbose;
@@ -53,18 +54,44 @@ public class TestParser {
   @Test
   public void testPositionalFirst() {
     Options options = parseSuccess("one", "two", "three", "-v");
+    assertTrue(options.verbose);
     assertEquals(ImmutableList.of("one", "two", "three"), ImmutableList.copyOf(options.positional));
   }
 
   @Test
   public void testPositionalLast() {
     Options options = parseSuccess("-v", "one", "two", "three");
+    assertTrue(options.verbose);
     assertEquals(ImmutableList.of("one", "two", "three"), ImmutableList.copyOf(options.positional));
+  }
+
+  @Test
+  public void testPositionalMiddle() {
+    Options options = parseSuccess("one", "-v", "two", "three");
+    assertTrue(options.verbose);
+    assertEquals(ImmutableList.of("two", "three", "one"), ImmutableList.copyOf(options.positional));
   }
 
   @Test
   public void testPositionalOnly() {
     Options options = parseSuccess("one", "two", "three");
     assertEquals(ImmutableList.of("one", "two", "three"), ImmutableList.copyOf(options.positional));
+  }
+
+  @Test
+  public void testBooleanOptions() {
+    Options options = parseSuccess("-v=False");
+    assertFalse(options.verbose);
+    options = parseSuccess("-v=1");
+    assertFalse(options.verbose);
+    options = parseSuccess("-v=yes");
+    assertFalse(options.verbose);
+    options = parseSuccess("-v=on");
+    assertFalse(options.verbose);
+    options = parseSuccess("-v=anything");
+    assertFalse(options.verbose);
+
+    options = parseSuccess("-v=true");
+    assertTrue(options.verbose);
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestHelper.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestHelper.java
@@ -60,7 +60,7 @@ public class ConsoleRunnerTestHelper {
       throws IOException, JAXBException {
     String outdirPath = temporary.newFolder("testOutputDir").getAbsolutePath();
 
-    String[] args = new String[] { testClassName, "-outdir", outdirPath, "-xmlreport"};
+    String[] args = new String[] { testClassName, "-xmlreport", "-outdir", outdirPath};
     if (shouldFail) {
       try {
         ConsoleRunnerImpl.main(args);


### PR DESCRIPTION
These Arg4j handler registrations cause odd behavior in the tests and seem to not be needed since they handlers are already registered by default. 