### PR TITLE
Add the Android SDK to the linux CI and turn on Android tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@
 # cache configured below.
 sudo: false
 
+# These are needed to run the Android SDK tools.
+addons:
+  apt:
+    packages:
+    - lib32stdc++6
+    - lib32z1
+    - lib32z1-dev
 
 before_cache:
   # Kill all python bytecode in our cached venvs.  Some files appear to
@@ -34,6 +41,8 @@ cache:
     # using its own isolated cache:
     #   https://github.com/pantsbuild/pants/issues/2485
     - $HOME/.npm
+    - $HOME/.android
+    - $SDK_INSTALL_LOCATION
     - build-support/isort.venv
     - build-support/pants_dev_deps.venv
 
@@ -47,6 +56,8 @@ install:
 
 env:
   global:
+    - SDK_INSTALL_LOCATION="$HOME/opt/android-sdk-install"
+    - ANDROID_HOME="$SDK_INSTALL_LOCATION/android-sdk-linux"
     - CXX=g++
     - PANTS_CONFIG_OVERRIDE="['pants.travis-ci.ini']"
     # Credentials for OSX syncing: GH_USER, GH_EMAIL, GH_TOKEN
@@ -60,7 +71,7 @@ env:
     - CI_FLAGS="-cjlpn 'Various pants self checks'"  # (fkmsr)
     - CI_FLAGS="-fkmsrcn -u 0/2 'Unit tests for pants and pants-plugins - shard 1'"  # (jlp)
     - CI_FLAGS="-fkmsrcn -u 1/2 'Unit tests for pants and pants-plugins - shard 2'"
-    - CI_FLAGS="-fkmsrcjlpa 'Python contrib tests'"  # (n)
+    - CI_FLAGS="-fkmsrcjlp 'Python contrib tests'"  # (n)
     - CI_FLAGS="-fkmsrjlpn -i 0/6 'Python integration tests for pants - shard 1'"  # (c)
     - CI_FLAGS="-fkmsrjlpn -i 1/6 'Python integration tests for pants - shard 2'"
     - CI_FLAGS="-fkmsrjlpn -i 2/6 'Python integration tests for pants - shard 3'"
@@ -68,8 +79,10 @@ env:
     - CI_FLAGS="-fkmsrjlpn -i 4/6 'Python integration tests for pants - shard 5'"
     - CI_FLAGS="-fkmsrjlpn -i 5/6 'Python integration tests for pants - shard 6'"
 
+
 before_script: |
   ./build-support/bin/ci-sync.sh
+  ./build-support/bin/install-android-sdk.sh
 
 script: |
   uname -a

--- a/build-support/bin/install-android-sdk.sh
+++ b/build-support/bin/install-android-sdk.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Install the Android SDK for the Pants Android contrib module.
+
+set -xf
+
+# SDK_INSTALL_LOCATION and ANDROID_HOME set in travis.yaml.
+ANDROID_SDK_URL="http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz"
+SDK_FILE=$(basename "$ANDROID_SDK_URL")
+
+# The debug.keystore has a well-known definition and location.
+KEYSTORE_LOCATION="$HOME"/.android
+
+# Add SDKs as needed.
+declare -a SDK_MODULES=(android-19 \
+                        android-20 \
+                        android-21 \
+                        android-22 \
+                        build-tools-19.1.0 \
+                        extra-android-support \
+                        extra-google-m2repository \
+                        extra-android-m2repository \
+                        platform-tools)
+
+mkdir -p "$SDK_INSTALL_LOCATION"
+mkdir -p "$KEYSTORE_LOCATION"
+
+
+function join { local IFS="$1"; shift; echo "$*"; }
+MODULE_LIST=$(join , ${SDK_MODULES[@]})
+
+echo "Downloading $ANDROID_SDK_URL..."
+SDK_ARCHIVE_LOCATION="$SDK_INSTALL_LOCATION"/"$SDK_FILE"
+
+wget -nc "$ANDROID_SDK_URL" -O "$SDK_ARCHIVE_LOCATION"
+tar -C "$SDK_INSTALL_LOCATION" -xf "$SDK_ARCHIVE_LOCATION"
+
+echo "y" | "$ANDROID_HOME"/tools/android update sdk -u --all --filter "$MODULE_LIST" &>/dev/null
+
+# Generate well known debug.keystore if the SDK hasn't created it.
+DEBUG_KEYSTORE="$KEYSTORE_LOCATION"/debug.keystore
+if [[ ! -f "$DEBUG_KEYSTORE" ]]; then
+    keytool -genkey -v -keystore "$KEYSTORE_LOCATION"/debug.keystore -alias androiddebugkey -storepass android  \
+        -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+fi

--- a/build-support/bin/install-android-sdk.sh
+++ b/build-support/bin/install-android-sdk.sh
@@ -4,8 +4,6 @@
 
 # Install the Android SDK for the Pants Android contrib module.
 
-set -xf
-
 # SDK_INSTALL_LOCATION and ANDROID_HOME set in travis.yaml.
 ANDROID_SDK_URL="http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz"
 SDK_FILE=$(basename "$ANDROID_SDK_URL")
@@ -34,10 +32,16 @@ MODULE_LIST=$(join , ${SDK_MODULES[@]})
 echo "Downloading $ANDROID_SDK_URL..."
 SDK_ARCHIVE_LOCATION="$SDK_INSTALL_LOCATION"/"$SDK_FILE"
 
-wget -nc "$ANDROID_SDK_URL" -O "$SDK_ARCHIVE_LOCATION"
-tar -C "$SDK_INSTALL_LOCATION" -xf "$SDK_ARCHIVE_LOCATION"
+if [[ ! -f "$SDK_ARCHIVE_LOCATION" ]]; then
+    wget -nc "$ANDROID_SDK_URL" -O "$SDK_ARCHIVE_LOCATION"
+fi
 
-echo "y" | "$ANDROID_HOME"/tools/android update sdk -u --all --filter "$MODULE_LIST" &>/dev/null
+if [[ ! -d "$SDK_INSTALL_LOCATION" ]]; then
+    tar -C "$SDK_INSTALL_LOCATION" -xf "$SDK_ARCHIVE_LOCATION"
+fi
+
+# Spamming 'y' was failing non-deterministically so sleep between echos.
+( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | "$ANDROID_HOME"/tools/android update sdk -u --all --filter "$MODULE_LIST"
 
 # Generate well known debug.keystore if the SDK hasn't created it.
 DEBUG_KEYSTORE="$KEYSTORE_LOCATION"/debug.keystore

--- a/build-support/bin/install-android-sdk.sh
+++ b/build-support/bin/install-android-sdk.sh
@@ -32,16 +32,16 @@ MODULE_LIST=$(join , ${SDK_MODULES[@]})
 echo "Downloading $ANDROID_SDK_URL..."
 SDK_ARCHIVE_LOCATION="$SDK_INSTALL_LOCATION"/"$SDK_FILE"
 
-if [[ ! -f "$SDK_ARCHIVE_LOCATION" ]]; then
-    wget -nc "$ANDROID_SDK_URL" -O "$SDK_ARCHIVE_LOCATION"
-fi
+# Travis is going to cache this location so no need to do this more than once. The android tool is just an
+# update wrapper, so this will work even if Android version is bumped.
 
-if [[ ! -d "$SDK_INSTALL_LOCATION" ]]; then
-    tar -C "$SDK_INSTALL_LOCATION" -xf "$SDK_ARCHIVE_LOCATION"
-fi
+wget -nc "$ANDROID_SDK_URL" -O "$SDK_ARCHIVE_LOCATION"
+
+tar -C "$SDK_INSTALL_LOCATION" -xf "$SDK_ARCHIVE_LOCATION"
 
 # Spamming 'y' was failing non-deterministically so sleep between echos.
-( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | "$ANDROID_HOME"/tools/android update sdk -u --all --filter "$MODULE_LIST"
+( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | \
+    "$ANDROID_HOME"/tools/android update sdk -u --all --filter "$MODULE_LIST"
 
 # Generate well known debug.keystore if the SDK hasn't created it.
 DEBUG_KEYSTORE="$KEYSTORE_LOCATION"/debug.keystore


### PR DESCRIPTION
This installs and caches the Android SDK on linux CI
runs. The debug.keystore used to be installed along
with the SDK - but I had to recreate it for the CI.
That directory is cached so it should only run once
or if a layer changes.

The Android tests will now be run in the contrib shard.

In 3531 I maintained the '-a' flag as a way to skip
running Android tests, even now that it is moved to
contrib. I did that because since the OSX CI is not
container based it would have to redownload the entire
SDK each run. So Android tests (and the install-android-sdk
script) are only being run on the Linux CI.

Testing Done:
This is dependent on CR 3530 and 3531 landing - which move android into contrib.

A CI run that installs the SDK into the container and runs the Android test suite is green:
https://travis-ci.org/pantsbuild/pants/pull_requests

Bugs closed: 937, 2993, 3006, 3012

Reviewed at https://rbcommons.com/s/twitter/r/3538/