### PR TITLE
Make multi-target node repl integration test faster.

### DIFF
--- a/contrib/node/examples/src/node/preinstalled-project/package.json
+++ b/contrib/node/examples/src/node/preinstalled-project/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "server-project",
+  "name": "preinstalled-project",
   "version": "1.0.0",
   "devDependencies": {
     "react": "0.13.3",
     "mocha": "2.3.0"
   },
+  "main": "src/Calculator.js",
   "scripts": {
     "test": "mocha ./test/*.js"
   }

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_repl_integration.py
@@ -50,16 +50,17 @@ class NodeReplIntegrationTest(PantsRunIntegrationTest):
     command = ['-q',
                'repl',
                'contrib/node/examples/3rdparty/node/react',
-               'contrib/node/examples/src/node/server-project']
+               'contrib/node/examples/src/node/preinstalled-project']
     program = dedent("""
         var React = require('react');
-        var Server = require('server-project');
+        var Calculator = require('preinstalled-project');
         var reactElem = React.renderToStaticMarkup(React.createElement("div", null, "Hello World"));
-        var serverInstance = new Server('127.0.0.1', 8080);
-        console.log('React: ' + reactElem + ', Server: ' + serverInstance.address);
+        var calc = new Calculator(0);
+        calc.add(1);
+        console.log('React: ' + reactElem + ', Calc + 1: ' + calc.number);
       """)
     pants_run = self.run_pants(command=command, stdin_data=program)
 
     self.assert_success(pants_run)
-    self.assertEqual('React: <div>Hello World</div>, Server: 127.0.0.1',
+    self.assertEqual('React: <div>Hello World</div>, Calc + 1: 1',
                      pants_run.stdout_data.strip())


### PR DESCRIPTION
The repl test uses a target with a large number of transitive dependencies which makes it take ~ 1 minute to run.
This switches the second target in the call to a smaller target.