### PR TITLE
Do not return directories from BUILD file's globs implementation

### DIFF
--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -43,8 +43,7 @@ class FilesetWithSpec(object):
 
   @memoized_property
   def files(self):
-    # BUILD file's filespecs should return only files, not folders.
-    return [f for f in self._files_calculator() if os.path.isfile(os.path.join(get_buildroot(), self._rel_root, f))]
+    return self._files_calculator()
 
   def __iter__(self):
     return self.files.__iter__()
@@ -96,7 +95,9 @@ class FilesetRelPathWrapper(object):
         raise ValueError('Invalid glob {}, points outside BUILD file root {}'.format(glob, root))
 
     def files_calculator():
-      result = self.wrapped_fn(root=root, *patterns, **kwargs)
+      # BUILD file's filesets should contain only files, not folders.
+      result = (path for path in self.wrapped_fn(root=root, *patterns, **kwargs)
+                if os.path.isfile(os.path.join(get_buildroot(), rel_root, path)))
 
       for ex in excludes:
         result -= ex

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -95,14 +95,13 @@ class FilesetRelPathWrapper(object):
         raise ValueError('Invalid glob {}, points outside BUILD file root {}'.format(glob, root))
 
     def files_calculator():
-      # BUILD file's filesets should contain only files, not folders.
-      result = (path for path in self.wrapped_fn(root=root, *patterns, **kwargs)
-                if os.path.isfile(os.path.join(get_buildroot(), rel_root, path)))
+      result = self.wrapped_fn(root=root, *patterns, **kwargs)
 
       for ex in excludes:
         result -= ex
 
-      return result
+      # BUILD file's filesets should contain only files, not folders.
+      return [path for path in result if os.path.isfile(os.path.join(root, path))]
 
     buildroot = get_buildroot()
     rel_root = os.path.relpath(root, buildroot)

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -43,7 +43,8 @@ class FilesetWithSpec(object):
 
   @memoized_property
   def files(self):
-    return self._files_calculator()
+    # BUILD file's filespecs should return only files, not folders.
+    return [f for f in self._files_calculator() if os.path.isfile(os.path.join(get_buildroot(), self._rel_root, f))]
 
   def __iter__(self):
     return self.files.__iter__()

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -239,6 +239,20 @@ class BundleTest(BaseTest):
     with self.assertRaises(ValueError):
       _bundle(spec_path)(fileset=[globs("z/*")])
 
+  def test_bundle_hash_with_globs(self):
+    spec_path = 'y'
+    globs = _globs(spec_path)
+    self.create_file(os.path.join(spec_path, 'one.xml'))
+    self.create_file(os.path.join(spec_path, 'config/two.xml'))
+    app = self.make_target('y:app',
+                           JvmApp,
+                           dependencies=[],
+                           bundles=[
+                             _bundle(spec_path)(fileset=globs("*"))
+                           ])
+    # Call should be should be successful.
+    app.payload.fingerprint()
+
   def test_rel_path_with_glob_fails(self):
     # Globs are treated as eager, so rel_path doesn't affect their meaning.
     # The effect of this is likely to be confusing, so disallow it.

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -250,7 +250,7 @@ class BundleTest(BaseTest):
                            bundles=[
                              _bundle(spec_path)(fileset=globs("*"))
                            ])
-    # Call should be should be successful.
+    # Call should be successful.
     app.payload.fingerprint()
 
   def test_rel_path_with_glob_fails(self):

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -258,7 +258,7 @@ class BundleTest(BaseTest):
 
     fingerprint_before = calc_fingerprint()
     os.mkdir(os.path.join(self.build_root, spec_path, 'folder_one'))
-    self.assertEquals(fingerprint_before, calc_fingerprint())
+    self.assertEqual(fingerprint_before, calc_fingerprint())
     self.create_file(os.path.join(spec_path, 'three.xml'))
     self.assertNotEqual(fingerprint_before, calc_fingerprint())
 

--- a/tests/python/pants_test/source/test_wrapped_globs.py
+++ b/tests/python/pants_test/source/test_wrapped_globs.py
@@ -125,6 +125,14 @@ class FilesetRelPathWrapperTest(BaseTest):
       """))
     self.context().scan()
 
+  def test_glob_with_folder_with_only_folders(self):
+    self.add_to_build_file('z/BUILD', dedent("""
+      java_library(name="z", sources=globs("*", exclude=["BUILD"]))
+      """))
+    graph = self.context().scan()
+    self.assertEqual([],
+                     list(graph.get_target_from_spec('z').sources_relative_to_source_root()))
+
   def test_glob_exclude_doesnt_modify_exclude_array(self):
     self.add_to_build_file('y/BUILD', dedent("""
       list_of_files = ["fleem.java"]


### PR DESCRIPTION
I've discovered `fingerprint` method fails on `jvm_app` targets because of pants `globs` implementation returns folders which are not hashable. I think it's fair enough to return only files in `globs`/`rglobs`/`zglobs` implementations for `BUILD` files. This PR contains tests for both `jvm_app` fingerprint and `globs` behaviour + fix for it.