### PR TITLE
Fix `compute_hashes` for `Page` target type

### DIFF
--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.base.payload import Payload
-from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes
+from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes, stable_json_sha1
 from pants.build_graph.target import Target
 
 
@@ -64,7 +64,7 @@ class Page(Target):
 
   class ProvidesTupleField(tuple, PayloadField):
     def _compute_fingerprint(self):
-      return combine_hashes(artifact.fingerprint() for artifact in self)
+      return combine_hashes([stable_json_sha1(artifact.config) for artifact in self])
 
   def __init__(self,
                address=None,

--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -30,6 +30,9 @@ class WikiArtifact(object):
     self.wiki = wiki
     self.config = kwargs
 
+  def fingerprint(self):
+    return combine_hashes([self.wiki.fingerprint(), stable_json_sha1(self.config)])
+
 
 class Wiki(object):
   """Identifies a wiki where pages can be published."""
@@ -40,6 +43,10 @@ class Wiki(object):
     """
     self.name = name
     self.url_builder = url_builder
+
+  def fingerprint(self):
+    # TODO: url_builder is not a part of fingerprint.
+    return stable_json_sha1(self.name)
 
 
 class Page(Target):
@@ -64,7 +71,7 @@ class Page(Target):
 
   class ProvidesTupleField(tuple, PayloadField):
     def _compute_fingerprint(self):
-      return combine_hashes([stable_json_sha1(artifact.config) for artifact in self])
+      return combine_hashes(artifact.fingerprint() for artifact in self)
 
   def __init__(self,
                address=None,

--- a/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
+++ b/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
@@ -93,3 +93,7 @@ This is the second readme file! Isn't it exciting?
     # the 'README.md' page)
     address = Address.parse('src/docs:readme2', relative_to=get_buildroot())
     self.assertEquals(p._build_graph.get_target(address), self.target('src/docs:readme2'))
+
+  def test_wiki_page_fingerprint(self):
+    # Call should be successful.
+    self.target('src/docs:readme').payload.fingerprint()

--- a/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
+++ b/tests/python/pants_test/backend/docgen/targets/test_wiki_page.py
@@ -94,6 +94,24 @@ This is the second readme file! Isn't it exciting?
     address = Address.parse('src/docs:readme2', relative_to=get_buildroot())
     self.assertEquals(p._build_graph.get_target(address), self.target('src/docs:readme2'))
 
-  def test_wiki_page_fingerprint(self):
-    # Call should be successful.
-    self.target('src/docs:readme').payload.fingerprint()
+  def test_wiki_page_fingerprinting(self):
+    def create_page_target(space):
+      self.reset_build_graph()
+      self.create_file('src/docs/BUILD')
+      self.add_to_build_file('src/docs', dedent("""
+        page(name='readme3',
+          source='README.md',
+          provides=[
+            wiki_artifact(
+              wiki=confluence,
+              space='~""" + space + """',
+              title='test_page3',
+            ),
+          ],
+        )
+      """))
+      return self.target('src/docs:readme3')
+
+    fingerprint_before = create_page_target('space1').payload.fingerprint()
+    self.assertEqual(fingerprint_before, create_page_target('space1').payload.fingerprint())
+    self.assertNotEqual(fingerprint_before, create_page_target('space2').payload.fingerprint())


### PR DESCRIPTION
I've discovered `fingerprint` method fails on `Page` targets because `WikiArtifact` doesn't contain `fingerprint` method. This PR contains tests for `WikiArtifact` payload fingerprint and fix for it.