### PR TITLE
Fix unicode parsing of ini files.

### DIFF
--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -9,6 +9,7 @@ import six
 
 from pants.option.errors import ParseError
 from pants.util.eval import parse_expression
+from pants.util.strutil import ensure_text
 
 
 def dict_option(s):
@@ -131,6 +132,8 @@ class ListValueComponent(object):
            member_type.
     :rtype: `ListValueComponent`
     """
+    if isinstance(value, six.string_types):
+      value = ensure_text(value)
     if isinstance(value, cls):  # Ensure idempotency.
       action = value.action
       val = value.val


### PR DESCRIPTION
We encountered an annoying problem upgrading pants in our repo.
Apparently we had a unicode left-quotation mark (\u2018) inside a
line comment. The line comment happened to be in a list. This
caused the option parsing to fail when trying to call
`value.startswith('[')`, which generated a cryptic error about not
being able to decode the string with ascii. This was especially
troublesome because there was no indication of which option the
error was in (and trying to get python to print out the string
caused it to fail with the same error just trying to format the
string for inclusion in a print message).