### PR TITLE
Fix errors due to iterating over None-types in ivy resolve.

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -487,7 +487,7 @@ class IvyFetchResolveResult(IvyResolveResult):
     self._frozen_resolutions = frozen_resolutions
 
   def _jar_dependencies_for_target(self, conf, target):
-    return self._frozen_resolutions[conf].target_to_resolved_coordinates.get(target)
+    return self._frozen_resolutions[conf].target_to_resolved_coordinates.get(target, ())
 
 
 NO_RESOLVE_RUN_RESULT = IvyResolveResult([], {}, None, {})


### PR DESCRIPTION
IvyFetchResolveResult._jar_dependencies_for_target was returning
None instead of an empty iterable, which was breaking the for-loop
in IvyInfo.get_resolved_jars_for_coordinates.

This makes _jar_dependencies_for_target return an empty tuple
instead of None.