### PR TITLE
[engine] using memoized to avoid repeated keying and unpickling

### DIFF
--- a/tests/python/pants_test/engine/exp/test_engine.py
+++ b/tests/python/pants_test/engine/exp/test_engine.py
@@ -12,7 +12,7 @@ from contextlib import closing, contextmanager
 from pants.build_graph.address import Address
 from pants.engine.exp.engine import LocalMultiprocessEngine, LocalSerialEngine, SerializationError
 from pants.engine.exp.examples.planners import Classpath, setup_json_scheduler
-from pants.engine.exp.nodes import Node, Return, SelectNode
+from pants.engine.exp.nodes import Return, SelectNode
 from pants.engine.exp.storage import Cache, Storage
 
 


### PR DESCRIPTION
Still for #3066 

This is yet another low hanging fruit but effective caching in Storage.

In my manual testing list 3rdparty::, improvement for cold cache is
about 50%, for fully warmed-up cache, it's sightly slower because of the
extra memoized check cost.

Using memoized is for now, there are various lru_cache implementations
for py2 we could use later, like [1] and [2] or just py3.

[1] https://github.com/repoze/repoze.lru
[2] https://pypi.python.org/pypi/functools32