### PR TITLE
Cache `dep-usage.jvm` results and provide ability to use cached results in analysis summary

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -16,7 +16,7 @@ from pants.backend.jvm.tasks.jvm_dependency_analyzer import JvmDependencyAnalyze
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
-from pants.util.dirutil import fast_relpath, safe_mkdir
+from pants.util.dirutil import fast_relpath
 from pants.util.fileutil import create_size_estimators
 
 
@@ -167,7 +167,6 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
           node = self.create_dep_usage_node(target, get_buildroot(),
                                             classes_by_source, runtime_classpath, product_deps_by_src)
           vt = target_to_vts[target]
-          safe_mkdir(vt.results_dir)
           with open(_nodes_json(target), mode='w') as fp:
             json.dump(node.to_cacheable_dict(), fp, indent=2, sort_keys=True)
           vt.update()

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -58,6 +58,7 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
              help='Output destination. When unset, outputs to <stdout>.')
     register('--use-cached', action='store_true',
              help='Use cached data for class products usages between targets, '
+                  'in this case `resolve` and `compile` steps are skipped, '
                   'useful for calculating analysis for a lot of targets,'
                   'results can differ from direct execution because 3rdparty libraries resolve is context-aware.')
 

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -16,7 +16,7 @@ from pants.backend.jvm.tasks.jvm_dependency_analyzer import JvmDependencyAnalyze
 from pants.base.build_environment import get_buildroot
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
-from pants.util.dirutil import fast_relpath
+from pants.util.dirutil import fast_relpath, safe_mkdir
 from pants.util.fileutil import create_size_estimators
 
 
@@ -56,13 +56,23 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
              help='Score all targets in the build graph transitively.')
     register('--output-file', type=str,
              help='Output destination. When unset, outputs to <stdout>.')
+    register('--use-cached', action='store_true',
+             help='Use cached data for class products usages between targets, '
+                  'useful for calculating analysis for a lot of targets,'
+                  'results can differ from direct execution because 3rdparty libraries resolve is context-aware.')
 
   @classmethod
   def prepare(cls, options, round_manager):
-    super(JvmDependencyUsage, cls).prepare(options, round_manager)
-    round_manager.require_data('classes_by_source')
-    round_manager.require_data('runtime_classpath')
-    round_manager.require_data('product_deps_by_src')
+    if not options.use_cached:
+      super(JvmDependencyUsage, cls).prepare(options, round_manager)
+      round_manager.require_data('classes_by_source')
+      round_manager.require_data('runtime_classpath')
+      round_manager.require_data('product_deps_by_src')
+    else:
+      # We want to have synthetic targets in build graph to deserialize nodes properly.
+      round_manager.require_data('java')
+      round_manager.require_data('scala')
+      round_manager.require_data('deferred_sources')
 
   @classmethod
   def skip(cls, options):
@@ -70,9 +80,8 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
     return False
 
   def execute(self):
-    targets = (self.context.targets() if self.get_options().transitive
-               else self.context.target_roots)
-    graph = self.create_dep_usage_graph(targets, get_buildroot())
+    graph = self.create_dep_usage_graph(self.context.targets() if self.get_options().transitive
+                                        else self.context.target_roots)
     output_file = self.get_options().output_file
     if output_file:
       self.context.log.info('Writing dependency usage to {}'.format(output_file))
@@ -81,6 +90,10 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
     else:
       sys.stdout.write(b'\n')
       self._render(graph, sys.stdout)
+
+  @classmethod
+  def implementation_version(cls):
+    return super(JvmDependencyUsage, cls).implementation_version() + [('JvmDependencyUsage', 4)]
 
   def _render(self, graph, fh):
     chunks = graph.to_summary() if self.get_options().summary else graph.to_json()
@@ -131,53 +144,104 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
     # Generators don't implement len.
     return sum(1 for _ in contents)
 
-  def create_dep_usage_graph(self, targets, buildroot):
+  def create_dep_usage_graph(self, targets):
     """Creates a graph of concrete targets, with their sum of products and dependencies.
 
     Synthetic targets contribute products and dependencies to their concrete target.
     """
+    with self.invalidated(targets,
+                          invalidate_dependents=True) as invalidation_check:
+      target_to_vts = {}
+      for vts in invalidation_check.all_vts:
+        target_to_vts[vts.target] = vts
 
-    # Initialize all Nodes.
-    classes_by_source = self.context.products.get_data('classes_by_source')
-    runtime_classpath = self.context.products.get_data('runtime_classpath')
-    product_deps_by_src = self.context.products.get_data('product_deps_by_src')
+      def _nodes_json(target):
+        return os.path.join(target_to_vts[target].results_dir, 'node.json')
+
+      if not self.get_options().use_cached:
+        classes_by_source = self.context.products.get_data('classes_by_source')
+        runtime_classpath = self.context.products.get_data('runtime_classpath')
+        product_deps_by_src = self.context.products.get_data('product_deps_by_src')
+
+        def calculating_node_creator(target):
+          node = self.create_dep_usage_node(target, get_buildroot(),
+                                            classes_by_source, runtime_classpath, product_deps_by_src)
+          vt = target_to_vts[target]
+          safe_mkdir(vt.results_dir)
+          with open(_nodes_json(target), mode='w') as fp:
+            json.dump(node.to_cacheable_dict(), fp, indent=2, sort_keys=True)
+          vt.update()
+          return node
+
+        node_creator = calculating_node_creator
+      else:
+        def cached_node_creator(target):
+          if target_to_vts[target].valid and os.path.exists(_nodes_json(target)):
+            try:
+              with open(_nodes_json(target)) as fp:
+                return Node.from_cacheable_dict(json.load(fp),
+                                                lambda spec: self.context.resolve(spec).__iter__().next())
+            except Exception:
+              self.context.log.warn("Can't deserialize json for target {}".format(target))
+              return Node(target.concrete_derived_from)
+          else:
+            self.context.log.warn("No cache entry for {}".format(target))
+            return Node(target.concrete_derived_from)
+
+        node_creator = cached_node_creator
+
+      return DependencyUsageGraph(self.create_dep_usage_nodes(targets, node_creator),
+                                  self.size_estimators[self.get_options().size_estimator])
+
+  def create_dep_usage_nodes(self, targets, node_creator):
     nodes = dict()
     for target in targets:
       if not self._select(target):
         continue
       # Create or extend a Node for the concrete version of this target.
       concrete_target = target.concrete_derived_from
-      products_total = self._count_products(runtime_classpath, target)
-      node = nodes.get(concrete_target)
-      if not node:
-        node = nodes.setdefault(concrete_target, Node(concrete_target))
-      node.add_derivation(target, products_total)
-
-      # Record declared Edges.
-      for dep_tgt in self._resolve_aliases(target):
-        derived_from = dep_tgt.concrete_derived_from
-        if self._select(derived_from):
-          node.add_edge(Edge(is_declared=True, products_used=set()), derived_from)
-
-      # Record the used products and undeclared Edges for this target. Note that some of
-      # these may be self edges, which are considered later.
-      target_product_deps_by_src = product_deps_by_src.get(target, dict())
-      for src in target.sources_relative_to_buildroot():
-        for product_dep in target_product_deps_by_src.get(os.path.join(buildroot, src), []):
-          for dep_tgt in self.targets_by_file.get(product_dep, []):
-            derived_from = dep_tgt.concrete_derived_from
-            if not self._select(derived_from):
-              continue
-            is_declared = self._is_declared_dep(target, dep_tgt)
-            normalized_deps = self._normalize_product_dep(buildroot, classes_by_source, product_dep)
-            node.add_edge(Edge(is_declared=is_declared, products_used=normalized_deps), derived_from)
+      node = node_creator(target)
+      if concrete_target in nodes:
+        nodes[concrete_target].combine(node)
+      else:
+        nodes[concrete_target] = node
 
     # Prune any Nodes with 0 products.
     for concrete_target, node in nodes.items()[:]:
       if node.products_total == 0:
         nodes.pop(concrete_target)
 
-    return DependencyUsageGraph(nodes, self.size_estimators[self.get_options().size_estimator])
+    return nodes
+
+  def cache_target_dirs(self):
+    return True
+
+  def create_dep_usage_node(self, target, buildroot, classes_by_source, runtime_classpath, product_deps_by_src):
+    concrete_target = target.concrete_derived_from
+    products_total = self._count_products(runtime_classpath, target)
+    node = Node(concrete_target)
+    node.add_derivation(target, products_total)
+
+    # Record declared Edges.
+    for dep_tgt in self._resolve_aliases(target):
+      derived_from = dep_tgt.concrete_derived_from
+      if self._select(derived_from):
+        node.add_edge(Edge(is_declared=True, products_used=set()), derived_from)
+
+    # Record the used products and undeclared Edges for this target. Note that some of
+    # these may be self edges, which are considered later.
+    target_product_deps_by_src = product_deps_by_src.get(target, dict())
+    for src in target.sources_relative_to_buildroot():
+      for product_dep in target_product_deps_by_src.get(os.path.join(buildroot, src), []):
+        for dep_tgt in self.targets_by_file.get(product_dep, []):
+          derived_from = dep_tgt.concrete_derived_from
+          if not self._select(derived_from):
+            continue
+          is_declared = self._is_declared_dep(target, dep_tgt)
+          normalized_deps = self._normalize_product_dep(buildroot, classes_by_source, product_dep)
+          node.add_edge(Edge(is_declared=is_declared, products_used=normalized_deps), derived_from)
+
+    return node
 
 
 class Node(object):
@@ -195,6 +259,37 @@ class Node(object):
   def add_edge(self, edge, dest):
     self.dep_edges[dest] += edge
 
+  def combine(self, other_node):
+    assert other_node.concrete_target == self.concrete_target
+    self.products_total += other_node.products_total
+    self.derivations.update(other_node.derivations)
+    self.dep_edges.update(other_node.dep_edges)
+
+  def to_cacheable_dict(self):
+    edges = {}
+    for dest in self.dep_edges:
+      edges[dest.address.spec] = {
+        'products_used': list(self.dep_edges[dest].products_used),
+        'is_declared': self.dep_edges[dest].is_declared,
+      }
+    return {
+      'target': self.concrete_target.address.spec,
+      'products_total': self.products_total,
+      'derivations': [derivation.address.spec for derivation in self.derivations],
+      'dep_edges': edges
+    }
+
+  @staticmethod
+  def from_cacheable_dict(cached_dict, target_resolve_func):
+    res = Node(target_resolve_func(cached_dict['target']))
+    res.products_total = cached_dict['products_total']
+    res.derivations.update([target_resolve_func(spec) for spec in cached_dict['derivations']])
+    for edge in cached_dict['dep_edges']:
+      res.dep_edges[target_resolve_func(edge)] = Edge(
+        is_declared=cached_dict['dep_edges'][edge]['is_declared'],
+        products_used=set(cached_dict['dep_edges'][edge]['products_used']))
+    return res
+
 
 class Edge(object):
   """Record a set of used products, and a boolean indicating that a depedency edge was declared."""
@@ -210,7 +305,6 @@ class Edge(object):
 
 
 class DependencyUsageGraph(object):
-
   def __init__(self, nodes, size_estimator):
     self._nodes = nodes
     self._size_estimator = size_estimator
@@ -271,6 +365,7 @@ class DependencyUsageGraph(object):
   def to_json(self):
     """Outputs the entire graph."""
     res_dict = {}
+
     def gen_dep_edge(node, edge, dep_tgt):
       return {
         'target': dep_tgt.address.spec,
@@ -278,11 +373,12 @@ class DependencyUsageGraph(object):
         'products_used': len(edge.products_used),
         'products_used_ratio': self._used_ratio(dep_tgt, edge),
       }
+
     for node in self._nodes.values():
       res_dict[node.concrete_target.address.spec] = {
-          'cost': self._cost(node.concrete_target),
-          'cost_transitive': self._trans_cost(node.concrete_target),
-          'products_total': node.products_total,
-          'dependencies': [gen_dep_edge(node, edge, dep_tgt) for dep_tgt, edge in node.dep_edges.items()]
-        }
+        'cost': self._cost(node.concrete_target),
+        'cost_transitive': self._trans_cost(node.concrete_target),
+        'products_total': node.products_total,
+        'dependencies': [gen_dep_edge(node, edge, dep_tgt) for dep_tgt, edge in node.dep_edges.items()]
+      }
     yield json.dumps(res_dict, indent=2, sort_keys=True)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage_integration.py
@@ -14,7 +14,12 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class TestJvmDependencyUsageIntegration(PantsRunIntegrationTest):
 
-  def _run_dep_usage(self, workdir, target, clean_all=False, extra_args=None):
+  def _run_dep_usage(self, workdir, target, clean_all=False, extra_args=None, cachedir=None):
+    if cachedir:
+      config = {'cache.dep-usage.jvm': {'write_to': [cachedir], 'read_from': [cachedir]}}
+    else:
+      config = {}
+
     with temporary_dir() as outdir:
       outfile = os.path.join(outdir, 'out.json')
       args = [
@@ -26,7 +31,7 @@ class TestJvmDependencyUsageIntegration(PantsRunIntegrationTest):
         args.insert(0, 'clean-all')
 
       # Run, and then parse the report from json.
-      self.assert_success(self.run_pants_with_workdir(args, workdir))
+      self.assert_success(self.run_pants_with_workdir(args, workdir, config))
       with open(outfile) as f:
         return json.load(f)
 
@@ -43,4 +48,27 @@ class TestJvmDependencyUsageIntegration(PantsRunIntegrationTest):
 
       # Confirm that usage is non-zero, and that the reports match.
       self._assert_non_zero_usage(run_two)
-      self.assertEquals(run_one, run_two)
+      self.assertEqual(run_one, run_two)
+
+  def test_use_cached_without_cache_not_fail(self):
+    target = 'testprojects/src/java/org/pantsbuild/testproject/unicode/main'
+    with self.temporary_workdir() as workdir:
+      # Should be successful.
+      run_one = self._run_dep_usage(workdir, target, clean_all=True, extra_args=['--dep-usage-jvm-use-cached'])
+      run_two = self._run_dep_usage(workdir, target, clean_all=False)
+
+      self.assertNotEqual(run_one, run_two)
+
+  def test_use_cached_results_should_be_equal_to_direct(self):
+    target = 'testprojects/src/java/org/pantsbuild/testproject/unicode/main'
+    with self.temporary_cachedir() as cachedir:
+      with self.temporary_workdir() as workdir:
+        run_one = self._run_dep_usage(workdir, target, clean_all=True, cachedir=cachedir)
+
+      with self.temporary_workdir() as workdir:
+        run_two = self._run_dep_usage(workdir, target, clean_all=True, cachedir=cachedir,
+                                      extra_args=['--dep-usage-jvm-use-cached'])
+
+      # Confirm that usage is non-zero, and that the reports match.
+      self._assert_non_zero_usage(run_two)
+      self.assertEqual(run_one, run_two)


### PR DESCRIPTION
Current implementation of `dep-usage.jvm` working slow for big target's sets mainly because it require compilation results of all targets in analysis, which led to a lot of compilation or to retrieve a lot of data from build cache. Alternatively it's possible to cache `dep-usage.jvm` results for each target and use them to build analysis summary. 

This RB adding build cache support for `dep-usage.jvm`. However using cached results is disabled by default and supported via `--use-cached` flag. 

There are couple of reasons for this behavior: 
- It's impossible to fallback to direct version in case of values absence in the cache. To decrease execution time we want not to require `runtime_classpath` product for analysis, and therefore it's impossible to ask for this data while task execution.
- Cached results can differ from direct results because we are ignoring 3rd party libraries resolved versions in a cache key. This information most likely not affect the analysis summary, but in some rear cases it can.