### PR TITLE
Fix some bad three-state logic in thrift_linter.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -8,9 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
+from pants.option.ranked_value import RankedValue
 
 from pants.contrib.scrooge.tasks.thrift_util import calculate_compile_sources
-from pants.option.ranked_value import RankedValue
 
 
 class ThriftLintError(Exception):


### PR DESCRIPTION
It was relying on a default of None in a boolean option
to detect if the option was explicitly provided or not.
But we never want boolean options to be None, as three
state logic is pointlessly complicated and a pending
change relies on this).

This change replaces that logic with a proper check.