### PR TITLE
Mark several tests expectedFailure.

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -30,6 +30,9 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     spec = 'testprojects/tests/java/org/pantsbuild/testproject/testjvms:{}'.format(spec_name)
     self.assert_success(self.run_pants(['clean-all', 'test.junit', '--strict-jvm-version', spec]))
 
+  # See https://github.com/pantsbuild/pants/issues/2894 for details on why this is
+  # marked xfail.
+  @expectedFailure
   @skipIf(missing_jvm('1.8'), 'no java 1.8 installation on testing machine')
   def test_java_eight(self):
     self._testjvms('eight')

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -109,6 +109,10 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       self.assertTrue('com.typesafe.sbt:incremental-compiler' in foo_target.get('excludes'))
       self.assertTrue('org.pantsbuild' in foo_target.get('excludes'))
 
+  # This test fails when the `PANTS_IVY_CACHE_DIR` is set to something that isn't
+  # the default location.  The set cache_dir likely needs to be plumbed down
+  # to the sub-invocation of pants.
+  # https://github.com/pantsbuild/pants/issues/3126
   def test_export_jar_path(self):
     with self.temporary_workdir() as workdir:
       test_target = 'examples/tests/java/org/pantsbuild/example/usethrift:usethrift'
@@ -149,6 +153,10 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       self.assertIsNotNone(scala_lang_lib['sources'])
       self.assertIsNotNone(scala_lang_lib['javadoc'])
 
+  # This test fails when the `PANTS_IVY_CACHE_DIR` is set to something that isn't
+  # the default location.  The set cache_dir likely needs to be plumbed down
+  # to the sub-invocation of pants.
+  # See https://github.com/pantsbuild/pants/issues/3126
   def test_ivy_classifiers(self):
     with self.temporary_workdir() as workdir:
       test_target = 'testprojects/tests/java/org/pantsbuild/testproject/ivyclassifier:ivyclassifier'

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 from unittest import skipIf
 
 from pants.java.distribution.distribution import Distribution, DistributionLocator
@@ -43,7 +44,7 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
         'JDK_HOME': two.home,
       })
       self.assert_success(run)
-      self.assertIn('java.home:{}'.format(one.home), run.stdout_data)
+      self.assertIn('java.home:{}'.format(os.path.realpath(one.home)), run.stdout_data)
 
   @skipIf(get_two_distributions() is None, 'Could not find java 7 and java 8 jvms to test with.')
   def test_jvm_jdk_paths_supercedes_environment_variables(self):


### PR DESCRIPTION
The junit and distribution tests fail when Java 8 is available,
but not the default.  These were likely not running at all in
Travis, but Jenkins has both JDK7 and 8 available, so it exposed
the issues.

The export integration test makes assumptions about subinvocations
of pants that are not correct.  In particular, it assumes that the
default ivy cache path will be used.  This breaks when
PANTS_IVY_CACHE_DIR is set, as in Jenkins CI.