### PR TITLE
Process 0.0.80 deprecation removals.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -101,15 +101,6 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, Subsystem):
                   '"custom" as the --version, custom build targets can be specified in the targets '
                   'for //:scalac and //:scala-library ')
 
-    register('--runtime', advanced=True, type=list, default=['//:scala-library'],
-             help='Target specs pointing to the scala runtime libraries.',
-             deprecated_version='0.0.75', removal_version='0.0.80',
-             deprecated_hint='Option is no longer used, --version is used to specify the major '
-                             'version. The runtime is created based on major version. '
-                             'The runtime target will be defined at the address //:scala-library '
-                             'unless it is overriden by the option --runtime-spec and a --version '
-                             'is set to custom.')
-
     register('--runtime-spec', advanced=True, default='//:scala-library',
              help='Address to be used for custom scala runtime.')
 

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -123,9 +123,6 @@ python_library(
 python_library(
   name = 'python_requirement',
   sources = ['python_requirement.py'],
-  dependencies = [
-    'src/python/pants/base:deprecated',
-  ]
 )
 
 python_library(

--- a/src/python/pants/backend/python/python_requirement.py
+++ b/src/python/pants/backend/python/python_requirement.py
@@ -7,13 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pkg_resources import Requirement
 
-from pants.base.deprecated import deprecated_conditional
-
-
-def _always_build(python, platform):
-  """Top level function is picklable."""
-  return True
-
 
 class PythonRequirement(object):
   """Pants wrapper around pkg_resources.Requirement
@@ -38,19 +31,13 @@ class PythonRequirement(object):
   :API: public
   """
 
-  def __init__(self, requirement, name=None, repository=None, version_filter=None, use_2to3=False,
-               compatibility=None):
-    deprecated_conditional(lambda: version_filter is not None, '0.0.80',
-                           'version_filter using lambda function is no longer supported.')
-
-    # TODO(wickman) Allow PythonRequirements to be specified using pip-style vcs or url identifiers,
-    # e.g. git+https or just http://...
+  def __init__(self, requirement, name=None, repository=None, use_2to3=False, compatibility=None):
+    # TODO(wickman) Allow PythonRequirements to be specified using pip-style vcs or url
+    # identifiers, e.g. git+https or just http://...
     self._requirement = Requirement.parse(requirement)
     self._repository = repository
     self._name = name or self._requirement.project_name
     self._use_2to3 = use_2to3
-    # Temporary workaround to allow pickling before we fully deprecate version_filter.
-    self._version_filter = version_filter or _always_build
     # TODO(wickman) Unify this with PythonTarget .compatibility
     self.compatibility = compatibility or ['']
 
@@ -58,7 +45,7 @@ class PythonRequirement(object):
     """
     :API: public
     """
-    return self._version_filter(python, platform)
+    return True
 
   @property
   def use_2to3(self):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -140,13 +140,6 @@ class GlobalOptionsRegistrar(Optionable):
              metavar='<regexp>',
              help='Exclude targets that match these regexes.',
              recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
-    register('--spec-excludes', advanced=True, type=list,
-             default=[register.bootstrap.pants_workdir],
-             deprecated_hint='Use --ignore-patterns instead. Use .gitignore syntax for each item, '
-                             'to simulate old behavior prefix each item with "/".',
-             deprecated_version='0.0.75', removal_version='0.0.80',
-             help='Ignore these paths when evaluating the command-line target specs.  Useful with '
-                  '::, to avoid descending into unneeded directories.')
     register('--ignore-patterns', advanced=True, type=list, fromfile=True,
              default=['.*'],
              help='Patterns for ignoring files when reading BUILD files. '

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -26,9 +26,9 @@ class Options(object):
   The value in global scope of option '--foo-bar' (registered in global scope) will be selected
   in the following order:
     - The value of the --foo-bar flag in global scope.
-    - The value of the PANTS_DEFAULT_FOO_BAR environment variable.
+    - The value of the PANTS_GLOBAL_FOO_BAR environment variable.
     - The value of the PANTS_FOO_BAR environment variable.
-    - The value of the foo_bar key in the [DEFAULT] section of pants.ini.
+    - The value of the foo_bar key in the [GLOBAL] section of pants.ini.
     - The hard-coded value provided at registration time.
     - None.
 
@@ -39,11 +39,11 @@ class Options(object):
     - The value of the --foo-bar flag in global scope.
     - The value of the PANTS_COMPILE_JAVA_FOO_BAR environment variable.
     - The value of the PANTS_COMPILE_FOO_BAR environment variable.
-    - The value of the PANTS_DEFAULT_FOO_BAR environment variable.
+    - The value of the PANTS_GLOBAL_FOO_BAR environment variable.
     - The value of the PANTS_FOO_BAR environment variable.
     - The value of the foo_bar key in the [compile.java] section of pants.ini.
     - The value of the foo_bar key in the [compile] section of pants.ini.
-    - The value of the foo_bar key in the [DEFAULT] section of pants.ini.
+    - The value of the foo_bar key in the [GLOBAL] section of pants.ini.
     - The hard-coded value provided at registration time.
     - None.
 
@@ -55,7 +55,7 @@ class Options(object):
     - The value of the PANTS_COMPILE_FOO_BAR environment variable.
     - The value of the foo_bar key in the [compile.java] section of pants.ini.
     - The value of the foo_bar key in the [compile] section of pants.ini.
-    - The value of the foo_bar key in the [DEFAULT] section of pants.ini
+    - The value of the foo_bar key in the [GLOBAL] section of pants.ini
       (because of automatic config file fallback to that section).
     - The hard-coded value provided at registration time.
     - None.

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -494,8 +494,7 @@ class Parser(object):
       # itself starts with 'pants-' then we also allow simply FOO. E.g., PANTS_WORKDIR instead of
       # PANTS_PANTS_WORKDIR or PANTS_GLOBAL_PANTS_WORKDIR. We take the first specified value we
       # find, in this order: PANTS_GLOBAL_FOO, PANTS_FOO, FOO.
-      env_vars = ['PANTS_DEFAULT_{0}'.format(udest),  # Temporary, until deprecation is complete.
-                  'PANTS_GLOBAL_{0}'.format(udest), 'PANTS_{0}'.format(udest)]
+      env_vars = ['PANTS_GLOBAL_{0}'.format(udest), 'PANTS_{0}'.format(udest)]
       if udest.startswith('PANTS_'):
         env_vars.append(udest)
     else:
@@ -507,8 +506,6 @@ class Parser(object):
     if self._env:
       for env_var in env_vars:
         if env_var in self._env:
-          deprecated_conditional(lambda: env_var == 'PANTS_DEFAULT_{0}'.format(udest), '0.0.80',
-                                 'Use PANTS_GLOBAL_{0} instead of PANTS_DEFAULT_{0}'.format(udest))
           env_val_str = expand(self._env.get(env_var))
           env_details = 'from env var {}'.format(env_var)
           break


### PR DESCRIPTION
Options:

`--scala-platform-runtime`:
Option is no longer used, `--version` is used to specify the major
version. The runtime is created based on major version. The runtime
target will be defined at the address `//:scala-library` unless it is
overriden by the option `--runtime-spec` and a `--version` is set to
custom.

`--spec-excludes`:
Use `--ignore-patterns` instead. Use .gitignore syntax for each item, to
simulate old behavior prefix each item with "/".

`PANTS_DEFAULT_*`:
Use `PANTS_GLOBAL_*` instead of `PANTS_DEFAULT_*`

BUILD Files:

`python_requirement(..., version_filter)`:
The `version_filter` argument has been removed with no replacement.

https://rbcommons.com/s/twitter/r/3639/