### PR TITLE
Fix a bug in OptionTracker.

### DIFF
--- a/src/python/pants/option/option_tracker.py
+++ b/src/python/pants/option/option_tracker.py
@@ -49,10 +49,7 @@ class OptionTracker(object):
 
     @property
     def was_overridden(self):
-      """A value was overridden if it has rank greater than 'HARDCODED'."""
-      if len(self.values) < 2:
-        return False
-      return self.latest.rank > RankedValue.HARDCODED and self.values[-2].rank > RankedValue.NONE
+      return self.latest.rank > RankedValue.HARDCODED
 
     @property
     def latest(self):

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -40,11 +40,12 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     self.assertNotIn('options.scope = ', pants_run.stdout_data)
 
   def test_options_only_overridden(self):
-    pants_run = self.run_pants(['options', '--no-colors', '--only-overridden'])
+    pants_run = self.run_pants(['options', '--scope=options', '--no-colors', '--only-overridden'])
     self.assert_success(pants_run)
     self.assertIn('options.only_overridden = True', pants_run.stdout_data)
     self.assertIn('options.colors = False', pants_run.stdout_data)
-    self.assertNotIn('options.scope =', pants_run.stdout_data)
+    self.assertIn('options.scope = options', pants_run.stdout_data)
+    self.assertNotIn('options.name =', pants_run.stdout_data)
     self.assertNotIn('from HARDCODED', pants_run.stdout_data)
     self.assertNotIn('from NONE', pants_run.stdout_data)
 
@@ -78,6 +79,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       self.assert_success(pants_run)
       self.assertIn('options.only_overridden = True', pants_run.stdout_data)
       self.assertIn('(from CONFIG in {})'.format(config_path), pants_run.stdout_data)
+      self.assertIn("options.scope = options", pants_run.stdout_data)
 
   def test_options_deprecation_from_config(self):
     with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:


### PR DESCRIPTION
Previously, if an option set in config (for example) had no hardcoded
default then the option tracker wouldn't see it as overridden.

This commit modifies the integration test to expose this problem,
and fixes it.

That said, I assume the previous logic was there for a reason, so
if this change is naive or otherwise wrong - please point it out!