### PR TITLE
Fix #3132: `./pants changed` doesn't fail on changed invalid `BUILD` files

### DIFF
--- a/src/python/pants/build_graph/source_mapper.py
+++ b/src/python/pants/build_graph/source_mapper.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from collections import defaultdict
 
-from pants.build_graph.address_lookup_error import AddressLookupError
+from pants.build_graph.build_file_address_mapper import BuildFileAddressMapper
 from pants.source.payload_fields import DeferredSourcesField
 
 
@@ -48,7 +48,7 @@ class SpecSourceMapper(SourceMapper):
       path = os.path.dirname(path)
       try:
         result.extend(self._find_targets_for_source(source, path))
-      except AddressLookupError:
+      except BuildFileAddressMapper.BuildFileScanError:
         pass
       if self._stop_after_match and len(result) > 0:
         break
@@ -128,7 +128,7 @@ class LazySourceMapper(SourceMapper):
       if path not in self._mapped_paths:
         try:
           self._map_sources_from_spec_path(path)
-        except AddressLookupError:
+        except BuildFileAddressMapper.BuildFileScanError:
           pass
         self._mapped_paths.add(path)
       elif not self._stop_after_match:

--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -16,6 +16,7 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.scala_jar_dependency import ScalaJarDependency
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.backend.python.targets.python_library import PythonLibrary
+from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.from_target import FromTarget
 from pants.build_graph.resources import Resources
@@ -224,6 +225,13 @@ class WhatChangedTest(WhatChangedTestBasic):
       'root/src/py/a:beta',
       workspace=self.workspace(files=['root/src/py/a/BUILD'])
     )
+
+  def test_broken_build_file(self):
+    with self.assertRaises(AddressLookupError):
+      self.add_to_build_file('root/src/py/a', dedent("""
+        //
+      """))
+      self.assert_console_output(workspace=self.workspace(files=['root/src/py/a/BUILD']))
 
   def test_resource_changed(self):
     self.assert_console_output(


### PR DESCRIPTION
This PR fixes an issue #3132: "pants changed" should fail but does not on changed invalid BUILD file.