### PR TITLE
[checkstyle] enable globally disabling style rules

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -69,6 +69,8 @@ class PythonCheckStyleTask(PythonTask):
              help='Takes a XML file where specific rules on specific files will be skipped.')
     register('--fail', fingerprint=True, default=True, action='store_true',
              help='Prevent test failure but still produce output for problems.')
+    register('--ignore', fingerprint=True, default=[], type=list,
+             help='Disable messages with the following codes. eg. ["T1234", ... ].')
 
   @classmethod
   def supports_passthru_args(cls):
@@ -114,12 +116,18 @@ class PythonCheckStyleTask(PythonTask):
           yield nit
           continue
 
+        elif self._should_ignore_nit(nit):
+          continue
+
         nit_slice = python_file.line_range(nit._line_number)
         for line_number in range(nit_slice.start, nit_slice.stop):
           if noqa_line_filter(python_file, line_number):
             break
           else:
             yield nit
+
+  def _should_ignore_nit(self, nit):
+    return nit.code in self.options.ignore
 
   def check_file(self, filename):
     """Process python file looking for indications of problems.

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_noqa.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_noqa.py
@@ -24,11 +24,11 @@ class RageSubsystem(PluginSubsystemBase):
 
 class Rage(CheckstylePlugin):
   """Dummy Checkstyle plugin that hates everything"""
-
+  rage_code = 'T999'
   def nits(self):
     """Return Nits for everything you see."""
     for line_no, _ in self.python_file.enumerate():
-      yield self.error('T999', 'I hate everything!', line_no)
+      yield self.error(self.rage_code, 'I hate everything!', line_no)
 
 
 @pytest.fixture()
@@ -89,3 +89,13 @@ class TestPyStyleTask(PythonTaskTestBase):
     """Verify Whole file filters are applied correctly"""
     nits = list(self.style_check.get_nits(self.no_qa_file))
     self.assertEqual(0, len(nits), 'Expected zero nits since entire file should be ignored')
+
+  def test_ignore_option_ignores_error_codes(self):
+    self.style_check.options.ignore = [Rage.rage_code]
+    nits = list(self.style_check.get_nits(self.no_qa_line))
+    self.assertEqual(0, len(nits), 'Expected zero nits since this nit type was ignored')
+
+  def test_ignore_option_ignores_error_codes(self):
+    self.style_check.options.ignore = ['NOT_A_REAL_CODE']
+    nits = list(self.style_check.get_nits(self.no_qa_line))
+    self.assertEqual(1, len(nits), 'Expected a nit since this nit type was not ignored')


### PR DESCRIPTION
- a new option `--ignore`, matching nit codes from any plugins in use

For discussion:
- another approach would be to make this flag mandatory for all checkers & implement it in all of them. To be most useful however, this would be best if nit-reporting also printed which plugin was the source of a particular nit -- which would require plugins to be aware of the name that they are registered with (making this a larger patch) 
