### PR TITLE
Add a graph-query goal to run advanced queries over targets.

### DIFF
--- a/src/python/pants/backend/graph_info/register.py
+++ b/src/python/pants/backend/graph_info/register.py
@@ -9,6 +9,7 @@ from pants.backend.graph_info.tasks.cloc import CountLinesOfCode
 from pants.backend.graph_info.tasks.dependees import ReverseDepmap
 from pants.backend.graph_info.tasks.filemap import Filemap
 from pants.backend.graph_info.tasks.filter import Filter
+from pants.backend.graph_info.tasks.graph_queries import GraphQueries
 from pants.backend.graph_info.tasks.list_owners import ListOwners
 from pants.backend.graph_info.tasks.listtargets import ListTargets
 from pants.backend.graph_info.tasks.minimal_cover import MinimalCover
@@ -30,3 +31,4 @@ def register_goals():
   task(name='sort', action=SortTargets).install()
   task(name='cloc', action=CountLinesOfCode).install()
   task(name='list-owners', action=ListOwners).install()
+  task(name='graph-query', action=GraphQueries).install()

--- a/src/python/pants/backend/graph_info/tasks/graph_conditions.py
+++ b/src/python/pants/backend/graph_info/tasks/graph_conditions.py
@@ -1,0 +1,254 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import re
+
+
+class GraphCondition(object):
+  """Base class for a predicate that acts on a task context and a target."""
+
+  def accept(self, context, target):
+    """Tests this condition against the given target.
+
+    :param context: The task's context object.
+    :param target: The target to test this condition against.
+    :returns: True or False.
+    """
+    raise NotImplementedError()
+
+  def __call__(self, context, target):
+    """This is just for convenience, delegating to `accept`, allowing for function-like syntax."""
+    return self.accept(context, target)
+
+
+class MetaCondition(GraphCondition):
+  """Base class for conditions with operate on other conditions."""
+
+  @property
+  def subconditions(self):
+    raise NotImplementedError()
+
+  def __iter__(self):
+    return iter(self.subconditions)
+
+  def __len__(self):
+    return len(self.subconditions)
+
+  def __getitem__(self, index):
+    for i, c in enumerate(self.subconditions):
+      if i == index:
+        return c
+    return None
+
+
+class IsType(GraphCondition):
+  """Accepts iff the target is of the given type.
+
+  This uses the human-readable type aliases, eg 'java_library'. This does not respect inheritance;
+  eg, a 'java_library" is not considered to be of type 'target', even though it technically is in
+  the internal class model.
+
+  E.g.: {"type": "java_library"}
+  """
+
+  def __init__(self, type_):
+    self.type_ = type_
+
+  def accept(self, context, target):
+    aliases = context.build_file_parser.registered_aliases().target_types_by_alias
+    # We want to compare the name directly rather than using isinstance(), because we don't actually
+    # want to count subclasses.
+    return any(type(target).__name__ == t.__name__ for t in aliases.get(self.type_))
+
+
+class NameMatches(GraphCondition):
+  """Accepts iff the target's name matches the given regex.
+
+  E.g.: {"name": "^(int-)?test$"}
+  """
+
+  def __init__(self, pattern):
+    self._pattern = re.compile(pattern)
+
+  def accept(self, context, target):
+    return self._pattern.match(target.name)
+
+
+class SpecMatches(GraphCondition):
+  """Accepts iff the target's spec matches the given regex.
+
+  E.g.: {"spec": "^service/.*?:lib$"}
+  """
+
+  def __init__(self, pattern):
+    self._pattern = re.compile(pattern)
+
+  def accept(self, context, target):
+    return self._pattern.match(target.address.spec)
+
+
+class HasSources(GraphCondition):
+  """Accepts iff the target has any sources that match the provided extension.
+
+  E.g.: {"sources": "java"}
+  """
+
+  def __init__(self, extension=None):
+    """
+    :param string extension: File extension of source files (or '' to match all sources).
+    """
+    self.extension = extension or ''
+
+  def accept(self, context, target):
+    return target.has_sources(extension=self.extension)
+
+
+class HasDependency(MetaCondition):
+  """Accepts iff the target has a dependency that matches the given conditions.
+
+  E.g.: {"dependency": {"target": {"name": "lib", "type": "java_library"}, "transitive": false}}
+  """
+
+  def __init__(self, target, transitive=True):
+    """
+    :param dict target: A (possibly recursive) conditions map with identical semantics to the outer
+      map used to check this target. This conditions map will be checked against every dependency.
+    :param transitive: Whether to consider this target's transitive dependencies, or only the direct
+      ones. (Defaults to True)
+    """
+    self.dependency_condition = Conditions(target)
+    self.transitive = transitive
+
+  def accept(self, context, target):
+    if not self.transitive:
+      return any(self.dependency_condition(context, dep) for dep in target.dependencies)
+    return any(self.dependency_condition(context, dep) for dep in target.closure() if dep != target)
+
+  @property
+  def subconditions(self):
+    return [self.dependency_condition]
+
+
+class HasDependee(MetaCondition):
+  """Accepts iff the target has a dependee that matches the given conditions.
+
+  E.g.: {"dependee": {"target": {"name": "test", "type": "java_tests"}, "transitive": false}}
+  """
+
+  def __init__(self, target, transitive=True):
+    """
+    :param dict target: A (possibly recursive) conditions map with identical semantics to the outer
+      map used to check this target. This conditions map will be checked against every dependee.
+    :param transitive: Whether to consider this target's transitive dependees, or only the direct
+      ones. (Defaults to True)
+    """
+    self.dependee_condition = Conditions(target)
+    self.transitive = transitive
+
+  def accept(self, context, target):
+    if not self.transitive:
+      dependees = (context.build_graph.get_target(addr)
+                   for addr in context.build_graph.dependents_of(target.address))
+      return any(self.dependee_condition(context, dep) for dep in dependees)
+    dependees = set()
+    context.build_graph.walk_transitive_dependee_graph([target.address], dependees.add)
+    return any(self.dependee_condition(context, dep) for dep in dependees if dep != target)
+
+  @property
+  def subconditions(self):
+    return [self.dependee_condition]
+
+
+class All(MetaCondition):
+  """Meta-condition that accepts iff all its input conditions accept.
+
+  E.g.: {"all": [{"name": "^test$"}, {"spec": "^service/"}]}
+  """
+
+  def __init__(self, *conditions):
+    self.conditions = map(Conditions, conditions)
+
+  def accept(self, context, target):
+    return all(predicate(context, target) for predicate in self.conditions)
+
+  @property
+  def subconditions(self):
+    return self.conditions
+
+
+class Any(MetaCondition):
+  """Meta-condition that accepts iff any its input conditions accept.
+
+  E.g.: {"any": [{"name": "test"}, {"name": "int-test"}]}
+  """
+
+  def __init__(self, *conditions):
+    self.conditions = map(Conditions, conditions)
+
+  def accept(self, context, target):
+    return any(predicate(context, target) for predicate in self.conditions)
+
+  @property
+  def subconditions(self):
+    return self.conditions
+
+
+class Not(MetaCondition):
+  """Meta-condition that accepts iff its input condition does not accept.
+
+  E.g.: {"not": {"name": "test"}}
+  """
+
+  def __init__(self, **condition):
+    self.condition = Conditions(condition)
+
+  def accept(self, context, target):
+    return not(self.condition(context, target))
+
+  @property
+  def subconditions(self):
+    return [self.condition]
+
+
+class Conditions(object):
+  """Factory for parsing conditions from dicts."""
+
+  conditions_by_alias = {
+    'all': All,
+    'any': Any,
+    'not': Not,
+    'type': IsType,
+    'name': NameMatches,
+    'spec': SpecMatches,
+    'dependency': HasDependency,
+    'dependee': HasDependee,
+    'sources': HasSources,
+  }
+
+  @classmethod
+  def _create_condition(cls, condition_type, value):
+    if isinstance(value, (list, tuple)):
+      return condition_type(*value)
+    if isinstance(value, dict):
+      return condition_type(**value)
+    return condition_type(value)
+
+  def __new__(cls, params):
+    """
+    :param dict params: A dictionary mapping condition names to their parameters.
+    """
+    if isinstance(params, GraphCondition):
+      return params
+    conditions = []
+    for key, value in params.items():
+      if key not in cls.conditions_by_alias:
+        raise ValueError('Invalid condition "{}"; must be one of: {}'
+                         .format(key, ', '.join(sorted(cls.conditions_by_alias))))
+      conditions.append(cls._create_condition(cls.conditions_by_alias[key], value))
+    if len(conditions) == 1:
+      return conditions[0]
+    return All(*conditions)

--- a/src/python/pants/backend/graph_info/tasks/graph_queries.py
+++ b/src/python/pants/backend/graph_info/tasks/graph_queries.py
@@ -1,0 +1,113 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import json
+import os
+
+from pants.backend.graph_info.tasks.graph_conditions import Conditions
+from pants.base.exceptions import TaskError
+from pants.task.console_task import ConsoleTask
+
+
+class GraphQueries(ConsoleTask):
+  """Execute sophisticated queries about the pants target dependency graph.
+
+  The queries must be loaded from JSON-formatted files; they are parsed by Conditions. Queries can
+  be arbitrarily complicated and nested. Here is a simple example that finds untested
+  java_library targets: ::
+
+      {
+        "type": "java_library",
+        "not": {
+          "dependee": {
+            "type": "java_tests"
+          }
+        }
+      }
+
+  Refer to graph_conditions.py for a full list of possible query conditions.
+  """
+
+  class QueryFailed(TaskError):
+    """Raised when a query returns results when it isn't supposed to, or vice-versa."""
+
+  _output_method = {
+    'yaml': '_yaml_output_iter',
+    'json': '_json_output_iter',
+  }
+
+  @classmethod
+  def register_options(cls, register):
+    super(GraphQueries, cls).register_options(register)
+    register('--query-file', advanced=True, type=str, default='{}',
+             help='Json file containing a list or dictionary specifying conditions. '
+                  'For example, to find all junit tests named "int-test", you could use: '
+                  '{"type": "java_tests", "name": "int-test"}. You can specify multiple conditions '
+                  'using a list, eg [{"spec": "^service"}, {"spec": ":lib$"}])')
+    register('--fail-if-empty', action='store_true', default=False,
+             help='Causes this task to fail if the query returns no results.',)
+    register('--fail-if-not-empty', action='store_true', default=False,
+             help='Causes this task to fail if the query returns any results.',)
+    register('--fail-fast-if-not-empty', action='store_true', default=False,
+             help='If --fail-if-not-empty is set, causes the task to fail the first time it finds '
+                  'a target matching the query.',)
+    register('--format', choices=sorted(cls._output_method), default='yaml',
+             help='Controls the output format. If yaml, the output will be "streaming" (each '
+                  'target satisfying the query conditions will be output as it is found)',)
+
+  def __init__(self, *vargs, **kwargs):
+    super(GraphQueries, self).__init__(*vargs, **kwargs)
+
+  def _satisfying_targets_iter(self, predicate, targets):
+    # Using a generator to enable efficient fail-fast behavior, and incremental updates for
+    # human-readable output.
+    found_any = False
+    for target in targets:
+      if predicate(target):
+        if self.get_options().fail_fast_if_not_empty:
+          raise self.QueryFailed('Query unexpectedly returned target: {} (failing fast).'
+                                 .format(target.address.spec))
+        found_any = True
+        yield target
+    if found_any and self.get_options().fail_if_not_empty:
+      raise self.QueryFailed('Query returned targets, when it was not supposed to find any.')
+    if not found_any and self.get_options().fail_if_empty:
+      raise self.QueryFailed('Query found no targets, when it was supposed to find some.')
+
+  def _yaml_output_iter(self, conditions, targets):
+    yield 'targets:'
+    targets = sorted(targets, key=lambda t: t.address.spec)
+    for target in self._satisfying_targets_iter(conditions, targets):
+      yield '  - {}'.format(target.address.spec)
+
+  def _json_output_iter(self, conditions, targets):
+    spec_list = list(t.address.spec for t in self._satisfying_targets_iter(conditions, targets))
+    yield json.dumps(spec_list, sort_keys=True, separators=(', ', ': '))
+
+  def _get_or_load_conditions_data(self):
+    json_path = self.get_options().query_file
+    if json_path:
+      if not os.path.exists(json_path):
+        raise TaskError('Json query file does not exist: {}'.format(json_path))
+      try:
+        with open(json_path, 'r') as f:
+          return json.loads(f.read())
+      except Exception as e:
+        raise TaskError('Unable to load query from json file: {}\n{}'.format(json_path, e))
+    raise TaskError('Json --query-file not provided.')
+
+  def build_conditions(self, conditions=None):
+    if conditions is None:
+      conditions = self._get_or_load_conditions_data()
+    if not isinstance(conditions, list):
+      conditions = [conditions]
+    conditions = map(Conditions, conditions)
+    return lambda target: all(predicate(self.context, target) for predicate in conditions)
+
+  def console_output(self, targets):
+    conditions = self.build_conditions()
+    return getattr(self, self._output_method[self.get_options().format])(conditions, targets)

--- a/testprojects/src/java/org/pantsbuild/testproject/querysubjects/AnotherFile.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/querysubjects/AnotherFile.java
@@ -1,0 +1,10 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.squareup.squarepants.pants_test_app.query_subjects;
+
+public class AnotherFile {
+  public boolean checkMyJavaFile() {
+    return new MyJavaFile().isWorking();
+  }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/querysubjects/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/querysubjects/BUILD
@@ -1,0 +1,25 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='my-java-file',
+  sources=[
+    'MyJavaFile.java',
+  ],
+)
+
+java_library(name='another-file',
+  sources=[
+    'AnotherFile.java',
+  ],
+  dependencies=[
+    ':my-java-file',
+  ],
+)
+
+java_library(name='untested-file',
+  sources=[
+    'UntestedFile.java',
+  ],
+)
+
+target(name='untested-target')

--- a/testprojects/src/java/org/pantsbuild/testproject/querysubjects/MyJavaFile.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/querysubjects/MyJavaFile.java
@@ -1,0 +1,10 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.squareup.squarepants.pants_test_app.query_subjects;
+
+public class MyJavaFile {
+    public boolean isWorking() {
+      return true;
+    }
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/querysubjects/UntestedFile.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/querysubjects/UntestedFile.java
@@ -1,0 +1,7 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.squareup.squarepants.pants_test_app.query_subjects;
+
+public class UntestedFile {
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/querysubjects/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/querysubjects/BUILD
@@ -1,0 +1,22 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_tests(name='my-java-file',
+  sources=[
+    'TestMyJavaFile.java',
+  ],
+  dependencies=[
+    'testprojects/src/java/org/pantsbuild/testproject/querysubjects:my-java-file',
+    '3rdparty:junit',
+  ],
+)
+
+java_tests(name='another-file',
+  sources=[
+    'TestAnotherFile.java',
+  ],
+  dependencies=[
+    'testprojects/src/java/org/pantsbuild/testproject/querysubjects:another-file',
+    '3rdparty:junit',
+  ],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/querysubjects/TestAnotherFile.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/querysubjects/TestAnotherFile.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.squareup.squarepants.pants_test_app.query_subjects;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class TestAnotherFile {
+    @Test public void testAnotherFile() {
+      assertTrue(new AnotherFile().checkMyJavaFile());
+    }
+}

--- a/testprojects/tests/java/org/pantsbuild/testproject/querysubjects/TestMyJavaFile.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/querysubjects/TestMyJavaFile.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package com.squareup.squarepants.pants_test_app.query_subjects;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+public class TestMyJavaFile {
+    @Test public void testMyJavaFile() {
+      assertTrue(new MyJavaFile().isWorking());
+    }
+}

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -64,6 +64,31 @@ python_tests(
 )
 
 python_tests(
+  name = 'graph_queries',
+  sources = ['test_graph_queries.py'],
+  dependencies = [
+    'src/python/pants/backend/graph_info/tasks',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/build_graph',
+    'tests/python/pants_test/tasks:task_test_base',
+  ],
+)
+
+python_tests(
+  name = 'graph_queries_integration',
+  sources = ['test_graph_queries_integration.py'],
+  dependencies = [
+    'src/python/pants/backend/graph_info/tasks',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/build_graph',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
   name = 'listtargets',
   sources = ['test_listtargets.py'],
   dependencies = [

--- a/tests/python/pants_test/backend/graph_info/tasks/test_graph_queries.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_graph_queries.py
@@ -1,0 +1,183 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.graph_info.tasks.graph_conditions import Conditions
+from pants.backend.graph_info.tasks.graph_queries import GraphQueries
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.targets.java_tests import JavaTests
+from pants_test.tasks.task_test_base import TaskTestBase
+
+
+class GraphQueriesTest(TaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return GraphQueries
+
+  def assert_type_name(self, expected_name, obj):
+    self.assertEquals(expected_name, type(obj).__name__)
+
+  def assert_condition(self, expected_type, data):
+    condition = Conditions(data)
+    self.assert_type_name(expected_type, condition)
+    return condition
+
+  def run_query(self, expected_targets, context, query):
+    predicate = Conditions(query)
+    received_targets = {t for t in context.targets() if predicate(context, t)}
+    self.assertEquals(set(expected_targets), received_targets)
+
+  def _lib_tests_context(self):
+    common = self.make_target('common:common', target_type=JavaLibrary)
+    library = self.make_target('foobar:lib', target_type=JavaLibrary, dependencies=[common])
+    tests = self.make_target('raboof:test', target_type=JavaTests, dependencies=[library])
+    context = self.context(target_roots=[library, tests])
+    return common, library, tests, context
+
+  def test_parse_simple_conditions(self):
+    self.assert_condition('IsType', {'type': 'java_library'})
+    self.assert_condition('HasSources', {'sources': ''})
+    self.assert_condition('NameMatches', {'name': ''})
+    self.assert_condition('SpecMatches', {'spec': ''})
+
+  def test_parse_compound_conditions(self):
+    had_dependency_dict = {'dependency': {'target': {'name': 'lib'}}}
+    has_dependee_dict = {'dependee': {'target': {'type': 'java_tests'}}}
+
+    has_dependency = self.assert_condition('HasDependency', had_dependency_dict)
+    has_dependee = self.assert_condition('HasDependee', has_dependee_dict)
+
+    meta_all = self.assert_condition('All', {'all': [had_dependency_dict, has_dependee_dict]})
+    meta_any = self.assert_condition('Any', {'any': [had_dependency_dict, has_dependee_dict]})
+    meta_not = self.assert_condition('Not', {'not': had_dependency_dict})
+
+    self.assert_type_name('NameMatches', has_dependency[0])
+    self.assert_type_name('IsType', has_dependee[0])
+
+    for meta in meta_all, meta_any:
+      self.assert_type_name('HasDependency', meta[0])
+      self.assert_type_name('HasDependee', meta[1])
+      self.assert_type_name('NameMatches', meta[0][0])
+      self.assert_type_name('IsType', meta[1][0])
+
+    self.assert_type_name('HasDependency', meta_not[0])
+
+  def test_name_matches(self):
+    apple = self.make_target('testing-file:apple')
+    orange = self.make_target('testing-file:orange')
+    context = self.context(target_roots=[apple, orange])
+
+    self.run_query(
+      expected_targets=[apple, orange],
+      context=context,
+      query={'name': '.*?a.*'},
+    )
+    self.run_query(
+      expected_targets=[orange],
+      context=context,
+      query={'name': '.*?ng.*'},
+    )
+
+  def test_spec_matches(self):
+    apple = self.make_target('testing-file:apple')
+    orange = self.make_target('testing-path:orange')
+    context = self.context(target_roots=[apple, orange])
+
+    self.run_query(
+      expected_targets=[apple, orange],
+      context=context,
+      query={'spec': '.*?a.*'},
+    )
+    self.run_query(
+      expected_targets=[apple, orange],
+      context=context,
+      query={'spec': '.*?ng.*'},
+    )
+    self.run_query(
+      expected_targets=[apple],
+      context=context,
+      query={'spec': '.*?file:'},
+    )
+    self.run_query(
+      expected_targets=[orange],
+      context=context,
+      query={'spec': '.*?path:'},
+    )
+
+  def test_not(self):
+    common, library, tests, context = self._lib_tests_context()
+
+    self.run_query(
+      expected_targets=[tests, common],
+      context=context,
+      query={'not': {'name': 'lib'}},
+    )
+    self.run_query(
+      expected_targets=[library, common],
+      context=context,
+      query={'not': {'name': 'test'}},
+    )
+
+  def test_has_dependency(self):
+    common, library, tests, context = self._lib_tests_context()
+
+    self.run_query(
+      expected_targets=[library, tests],
+      context=context,
+      query={'dependency': {'target': {'name': 'common'}}},
+    )
+    self.run_query(
+      expected_targets=[library],
+      context=context,
+      query={'dependency': {'target': {'name': 'common'}, 'transitive': False}},
+    )
+
+  def test_has_dependee(self):
+    common, library, tests, context = self._lib_tests_context()
+
+    self.run_query(
+      expected_targets=[common, library],
+      context=context,
+      query={'dependee': {'target': {'name': 'test'}}},
+    )
+    self.run_query(
+      expected_targets=[library],
+      context=context,
+      query={'dependee': {'target': {'name': 'test'}, 'transitive': False}},
+    )
+
+  def test_all(self):
+    common, library, tests, context = self._lib_tests_context()
+
+    self.run_query(
+      expected_targets=[library],
+      context=context,
+      query={'all': [
+        {'dependency': {'target': {'name': 'common'}}},
+        {'dependee': {'target': {'name': 'test'}}},
+      ]},
+    )
+
+  def test_any(self):
+    common, library, tests, context = self._lib_tests_context()
+
+    self.run_query(
+      expected_targets=[common, library, tests],
+      context=context,
+      query={'any': [
+        {'dependency': {'target': {'name': 'common'}}},
+        {'dependee': {'target': {'name': 'test'}}},
+      ]},
+    )
+    self.run_query(
+      expected_targets=[common, library],
+      context=context,
+      query={'any': [
+        {'dependency': {'transitive': False, 'target': {'name': 'common'}}},
+        {'dependee': {'target': {'name': 'test'}}},
+      ]},
+    )

--- a/tests/python/pants_test/backend/graph_info/tasks/test_graph_queries_integration.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_graph_queries_integration.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import json
+import os
+from contextlib import contextmanager
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class GraphQueriesIntegrationTest(PantsRunIntegrationTest):
+  """Integration tests for ./pants graph-queries."""
+
+  def _spec_path(self, src_or_tests, name=''):
+    return 'testprojects/{src}/java/org/pantsbuild/testproject/querysubjects{suffix}'.format(
+      src=src_or_tests,
+      suffix=name,
+    )
+
+  def test_query_subjects_setup(self):
+    # Sanity check to make sure the test project works.
+    self.assert_success(self.run_pants(['test', self._spec_path('src', '::'),
+                                        self._spec_path('tests', '::')]))
+
+  @contextmanager
+  def query_file(self, json_dict):
+    with temporary_dir() as directory:
+      json_file = os.path.join(directory, 'query.json')
+      with open(json_file, 'w') as f:
+        f.write(json.dumps(json_dict))
+      yield json_file
+
+  def run_graph_queries(self, query, args=()):
+    with self.query_file(query) as path:
+      command = ['graph-query', '--query-file={}'.format(path)]
+      command.extend(args)
+      command.append(self._spec_path('src', '::'))
+      command.append(self._spec_path('tests', '::'))
+      return self.run_pants(command)
+
+  def assert_query_returns(self, expected_targets, query, args=()):
+    # First just check to make sure the yaml formatting works.
+    result = self.run_graph_queries(query, ['--format=yaml'] + list(args))
+    self.assert_success(result)
+    # Now do it with Json so we can read the results easily.
+    result = self.run_graph_queries(query, ['--format=json'] + list(args))
+    self.assert_success(result)
+    try:
+      json_result = json.loads(result.stdout_data)
+    except ValueError:
+      raise ValueError('Failed to return valid json! Got: \n----\n{}\n----\n'.format(result))
+    self.assertEquals(set(expected_targets), set(json_result))
+
+  def test_find_both_of_my_java_files(self):
+    self.assert_query_returns(
+      expected_targets=[
+        self._spec_path('src', ':my-java-file'),
+        self._spec_path('tests', ':my-java-file'),
+      ],
+      query={
+        'name': 'my-java-file',
+      },
+    )
+
+  def test_find_java_libraries(self):
+    self.assert_query_returns(
+      expected_targets=[
+        self._spec_path('src', ':my-java-file'),
+        self._spec_path('src', ':another-file'),
+        self._spec_path('src', ':untested-file'),
+      ],
+      query={
+        'type': 'java_library',
+      },
+    )
+
+  def test_find_java_tests(self):
+    self.assert_query_returns(
+      expected_targets=[
+        self._spec_path('tests', ':my-java-file'),
+        self._spec_path('tests', ':another-file'),
+      ],
+      query={
+        'type': 'java_tests',
+      },
+    )
+
+  def test_find_java_libraries_with_tests(self):
+    self.assert_query_returns(
+      expected_targets=[
+        self._spec_path('src', ':my-java-file'),
+        self._spec_path('src', ':another-file'),
+      ],
+      query={
+        'type': 'java_library',
+        'dependee': {'target': {'type': 'java_tests'}},
+      },
+    )
+
+  def test_find_java_libraries_without_tests(self):
+    self.assert_query_returns(
+      expected_targets=[
+        self._spec_path('src', ':untested-file'),
+      ],
+      query={
+        'type': 'java_library',
+        'not': {'dependee': {'target': {'type': 'java_tests'}}},
+      },
+    )
+
+  def test_find_java_libraries_not_dependent_on_my_java_file(self):
+    conditions = [
+      {
+        'not': {'dependency': {'target': {'name': 'my-java-file'}, 'transitive': False}},
+      },
+      # NB: It's kind of silly to excluding all non-java_library types instead of just specifying
+      # that it should be a java_library, but this helps demonstrate the syntax for using multiple
+      # "not" conditions in the same query.
+      {
+        'not': {'type': 'java_tests'},
+      },
+      {
+        'not': {'type': 'jar_library'},
+      },
+      {
+        'not': {'type': 'target'},
+      }
+    ]
+    # Giving a list instead of a dict to --query should implicitly create an "all" condition.
+    implicit_all_query = conditions
+    explicit_all_query = { 'all': conditions }
+
+    for query in implicit_all_query, explicit_all_query:
+      self.assert_query_returns(
+        expected_targets=[
+          self._spec_path('src', ':my-java-file'),
+          self._spec_path('src', ':untested-file'),
+        ],
+        query=query,
+      )
+
+  def test_fail_when_java_libraries_do_not_have_tests(self):
+    result = self.run_graph_queries(
+      query={
+        'type': 'java_library',
+        'not': {'dependee': {'target': {'type': 'java_tests'}}},
+      },
+      args=['--fail-if-not-empty', '--format=yaml'],
+    )
+    self.assert_failure(result)
+    self.assertIn(self._spec_path('src', ':untested-file'), result.stdout_data)
+
+  def test_fail_when_targets_do_not_have_tests(self):
+    result = self.run_graph_queries(
+      query=[
+        {'not': {'type': 'java_tests'}},
+        {'not': {'dependee': {'target': {'type': 'java_tests'}}}},
+      ],
+      args=['--fail-if-not-empty', '--format=yaml'],
+    )
+    self.assert_failure(result)
+    self.assertIn(self._spec_path('src', ':untested-file'), result.stdout_data)
+    self.assertIn(self._spec_path('src', ':untested-target'), result.stdout_data)
+
+  def test_fail_fast_when_targets_do_not_have_tests(self):
+    result = self.run_graph_queries(
+      query=[
+        {'not': {'type': 'java_tests'}},
+        {'not': {'dependee': {'target': {'type': 'java_tests'}}}},
+      ],
+      args=['--fail-fast-if-not-empty', '--format=yaml'],
+    )
+    self.assert_failure(result)
+    self.assertIn(self._spec_path('src', ':untested-file'), result.stdout_data)
+    # We shouldn't get here because the fail-fast will trigger on the above target.
+    self.assertNotIn(self._spec_path('src', ':untested-target'), result, 'We failed, but not fast.')
+
+  def test_fail_if_no_binaries_are_present(self):
+    result = self.run_graph_queries(
+      query={'type': 'jvm_binary'},
+      args=['--fail-if-empty', '--format=yaml'],
+    )
+    self.assert_failure(result)
+    self.assertIn('Query found no targets, when it was supposed to find some.', result.stdout_data)


### PR DESCRIPTION
Now you can run:

```
./pants graph-query --query-file=foo.json ::
```

To get back a list of targets matching criteria based on their
name, spec, target type, dependencies, dependees, and sources.

For example, you can write a query file that looks like:

```
{
  "type": "java_library",
  "not": {
    "dependee": {
      "type": "java_tests"
    }
  }
}
```

To find java libraries without corresponding tests.
If you want to not include integration tests, you could try:

```
{
  "type": "java_library",
  "not": {
    "dependee": {
      "type": "java_tests",
      "not": {
        "name": "int-.*"
      }
    }
  }
}
```
