### PR TITLE
Fix `jvm_app` fingerprinting for bundles with non-existing files.

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_app.py
+++ b/src/python/pants/backend/jvm/targets/jvm_app.py
@@ -167,8 +167,11 @@ class BundleField(tuple, PayloadField):
       buildroot_relative_path = os.path.relpath(abs_path, get_buildroot())
       hasher.update(buildroot_relative_path)
       hasher.update(bundle.filemap[abs_path])
-      with open(abs_path, 'rb') as f:
-        hasher.update(f.read())
+      if os.path.isfile(abs_path):
+        # Update with any additional string to differentiate empty file with non-existing file.
+        hasher.update('e')
+        with open(abs_path, 'rb') as f:
+          hasher.update(f.read())
     return hasher.hexdigest()
 
   def _compute_fingerprint(self):

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -273,14 +273,15 @@ class BundleTest(BaseTest):
                                 _bundle(spec_path)(fileset=['one.xml'])
                               ]).payload.fingerprint()
 
-    fingerprint1 = calc_fingerprint()
+    fingerprint_non_existing_file = calc_fingerprint()
     self.create_file(os.path.join(spec_path, 'one.xml'))
-    fingerprint2 = calc_fingerprint()
-    self.assertNotEqual(fingerprint1, fingerprint2)
+    fingerprint_empty_file = calc_fingerprint()
     self.create_file(os.path.join(spec_path, 'one.xml'), contents='some content')
-    fingerprint3 = calc_fingerprint()
-    self.assertNotEqual(fingerprint1, fingerprint3)
-    self.assertNotEqual(fingerprint2, fingerprint3)
+    fingerprint_file_with_content = calc_fingerprint()
+
+    self.assertNotEqual(fingerprint_empty_file, fingerprint_non_existing_file)
+    self.assertNotEqual(fingerprint_empty_file, fingerprint_file_with_content)
+    self.assertNotEqual(fingerprint_file_with_content, fingerprint_empty_file)
 
   def test_rel_path_with_glob_fails(self):
     # Globs are treated as eager, so rel_path doesn't affect their meaning.

--- a/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jvm_app.py
@@ -262,6 +262,26 @@ class BundleTest(BaseTest):
     self.create_file(os.path.join(spec_path, 'three.xml'))
     self.assertNotEqual(fingerprint_before, calc_fingerprint())
 
+  def test_jvmapp_fingerprinting_with_non_existing_files(self):
+    spec_path = 'y'
+    def calc_fingerprint():
+      self.reset_build_graph()
+      return self.make_target('y:app',
+                              JvmApp,
+                              dependencies=[],
+                              bundles=[
+                                _bundle(spec_path)(fileset=['one.xml'])
+                              ]).payload.fingerprint()
+
+    fingerprint1 = calc_fingerprint()
+    self.create_file(os.path.join(spec_path, 'one.xml'))
+    fingerprint2 = calc_fingerprint()
+    self.assertNotEqual(fingerprint1, fingerprint2)
+    self.create_file(os.path.join(spec_path, 'one.xml'), contents='some content')
+    fingerprint3 = calc_fingerprint()
+    self.assertNotEqual(fingerprint1, fingerprint3)
+    self.assertNotEqual(fingerprint2, fingerprint3)
+
   def test_rel_path_with_glob_fails(self):
     # Globs are treated as eager, so rel_path doesn't affect their meaning.
     # The effect of this is likely to be confusing, so disallow it.


### PR DESCRIPTION
In our repository we have `jvm_app` targets which contain bundles with non-existing files. Use case for this bundles suggests to have this files prepared some other way before you'll `bundle` this `jvm_app`s.

This RB add test on this use case and fixes fingerprint for this bundles.