### PR TITLE
Peiyu/fix engine test hung bug

### DIFF
--- a/src/python/pants/engine/exp/engine.py
+++ b/src/python/pants/engine/exp/engine.py
@@ -162,7 +162,8 @@ def _execute_step(cache_save, debug, process_state, step):
   def execute():
     resolved_request = storage.resolve_request(step)
     result = resolved_request(node_builder)
-    _try_pickle(result)
+    if debug:
+      _try_pickle(result)
     cache_save(step, result)
     return storage.key_for_result(result)
 

--- a/src/python/pants/engine/exp/engine.py
+++ b/src/python/pants/engine/exp/engine.py
@@ -152,9 +152,6 @@ def _execute_step(cache_save, debug, process_state, step):
   Executes the Step for the given node builder and storage, and returns a tuple of step id and
   result or exception. Since step execution is only on cache misses, this also saves result
   to the cache.
-
-  Operations inside the step that might raise exceptions need to be guarded to prevent
-  subprocess from dying.
   """
   node_builder, storage = process_state
   step_id = step.step_id

--- a/src/python/pants/engine/exp/engine.py
+++ b/src/python/pants/engine/exp/engine.py
@@ -156,8 +156,8 @@ def _execute_step(cache_save, debug, process_state, step):
   node_builder, storage = process_state
 
   step_id = step.step_id
-  resolved_request = storage.resolve_request(step)
   try:
+    resolved_request = storage.resolve_request(step)
     result = resolved_request(node_builder)
   except Exception as e:
     # Trap any exception raised by the execution node that bubbles up, and


### PR DESCRIPTION
We intended to catch all subprocesses exceptions, for example the test case
EngineTest.test_multiprocess_unpickleable checks SerializationError, but some
later added code wasn't protected, including [line 159](https://github.com/pantsbuild/pants/blob/f01c2c674c1c2055e6d98e3dea66d00770082a0c/src/python/pants/engine/exp/engine.py#L159) that caused
#3149 test to hang.

This review fixes this by moving everything into the same try block.

This review does not fix the root cause of https://github.com/pantsbuild/pants/issues/3149
but next time it happens the subprocess won't die and will report the
exception back to the engine.