### PR TITLE
minor: fix deployjar help

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -35,9 +35,10 @@ class BundleCreate(JvmBinaryTask):
     super(BundleCreate, cls).register_options(register)
     register('--deployjar', action='store_true', default=False,
              fingerprint=True,
-             help="Expand 3rdparty jars into loose classfiles in the bundle's root dir. "
-                  "If unset, the root will contain internal classfiles only, and 3rdparty jars "
-                  "will go into the bundle's libs dir.")
+             help="Expand all 3rdparty and internal jars into loose classfiles in the bundle's"
+                  "root dir. If unset, all jars will go into the bundle's libs directory,"
+                  "the root will only contain a synthetic jar with its manifest's Class-Path "
+                  "set to those jars.")
     register('--archive', choices=list(archive.TYPE_NAMES),
              fingerprint=True,
              help='Create an archive of this type from the bundle.')

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -35,10 +35,10 @@ class BundleCreate(JvmBinaryTask):
     super(BundleCreate, cls).register_options(register)
     register('--deployjar', action='store_true', default=False,
              fingerprint=True,
-             help="Expand all 3rdparty and internal jars into loose classfiles in the bundle's "
-                  "root dir. If unset, all jars will go into the bundle's libs directory, "
-                  "the root will only contain a synthetic jar with its manifest's Class-Path "
-                  "set to those jars.")
+             help="Pack all 3rdparty and internal jar classfiles into a single deployjar in "
+                  "the bundle's root dir. If unset, all jars will go into the bundle's libs "
+                  "directory, the root will only contain a synthetic jar with its manifest's "
+                  "Class-Path set to those jars.")
     register('--archive', choices=list(archive.TYPE_NAMES),
              fingerprint=True,
              help='Create an archive of this type from the bundle.')

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -35,8 +35,8 @@ class BundleCreate(JvmBinaryTask):
     super(BundleCreate, cls).register_options(register)
     register('--deployjar', action='store_true', default=False,
              fingerprint=True,
-             help="Expand all 3rdparty and internal jars into loose classfiles in the bundle's"
-                  "root dir. If unset, all jars will go into the bundle's libs directory,"
+             help="Expand all 3rdparty and internal jars into loose classfiles in the bundle's "
+                  "root dir. If unset, all jars will go into the bundle's libs directory, "
                   "the root will only contain a synthetic jar with its manifest's Class-Path "
                   "set to those jars.")
     register('--archive', choices=list(archive.TYPE_NAMES),


### PR DESCRIPTION
Fix outdated help for bundle deployjar.

Since https://rbcommons.com/s/twitter/r/3133/, the behavior is
- for deployjar no change, still contains all class files, internal and 3rdparty
- for no-deployjar, it's one synthetic jar + libs of both internal and 3rdparty jars