### PR TITLE
Change some option defaults.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -92,7 +92,8 @@ class JvmCompile(NailgunTaskBase):
   @classmethod
   def register_options(cls, register):
     super(JvmCompile, cls).register_options(register)
-    register('--jvm-options', advanced=True, type=list, default=[],
+    register('--jvm-options', advanced=True, type=list,
+             default=list(cls.get_jvm_options_default(register.bootstrap)),
              help='Run the compiler with these JVM options.')
 
     register('--args', advanced=True, type=list,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -84,16 +84,22 @@ class BaseZincCompile(JvmCompile):
     return (AnnotationProcessor, ScalacPlugin)
 
   @classmethod
+  def get_jvm_options_default(cls, bootstrap_option_values):
+    return ('-Duser.timezone=UTC', '-Dfile.encoding=UTF-8', '-Dzinc.analysis.cache.limit=1000',
+            '-Djava.awt.headless=true', '-Xmx2g')
+
+  @classmethod
   def get_args_default(cls, bootstrap_option_values):
-    return ('-S-encoding', '-SUTF-8', '-S-g:vars')
+    return ('-C-encoding', '-CUTF-8', '-S-encoding', '-SUTF-8', '-S-g:vars')
 
   @classmethod
   def get_warning_args_default(cls):
-    return ('-S-deprecation', '-S-unchecked')
+    return ('-C-deprecation', '-C-Xlint:all', '-C-Xlint:-serial', '-C-Xlint:-path',
+            '-S-deprecation', '-S-unchecked', '-S-Xlint')
 
   @classmethod
   def get_no_warning_args_default(cls):
-    return ('-S-nowarn',)
+    return ('-C-nowarn', '-C-Xlint:none', '-S-nowarn', '-S-Xlint:none', )
 
   @classmethod
   def get_fatal_warnings_enabled_args_default(cls):
@@ -199,7 +205,8 @@ class BaseZincCompile(JvmCompile):
     self._processor_info_dir = os.path.join(self.workdir, 'apt-processor-info')
 
     # Validate zinc options.
-    ZincCompile.validate_arguments(self.context.log, self.get_options().whitelisted_args, self._args)
+    ZincCompile.validate_arguments(self.context.log, self.get_options().whitelisted_args,
+                                   self._args)
     # A directory independent of any other classpath which can contain per-target
     # plugin resource files.
     self._plugin_info_dir = os.path.join(self.workdir, 'scalac-plugin-info')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -141,7 +141,7 @@ class GlobalOptionsRegistrar(Optionable):
              help='Exclude targets that match these regexes.',
              recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
     register('--ignore-patterns', advanced=True, type=list, fromfile=True,
-             default=['.*'],
+             default=['.*', '/dist', 'bower_components', 'node_modules', '*.egg-info'],
              help='Patterns for ignoring files when reading BUILD files. '
                   'Use to ignore unneeded directories or BUILD files. '
                   'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')


### PR DESCRIPTION
These are based on common pants.ini configs at Square, Foursquare and Twitter.

The nature of these options is such that changing the default is unlikely to have
adverse impact on anyone not currently setting them explicitly in pants.ini,
and we'd like to make them more useful before we freeze them in 1.0.