### PR TITLE
Remove unused config_section from codegen tasks.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -80,11 +80,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
         try:
           dependencies.update(self.context.resolve(depspec))
         except AddressLookupError as e:
-          raise AddressLookupError('{message}\n  referenced from gen.scrooge key: '
-                                   'gen->deps->{category} in pants.ini'.format(
-                                      message=e,
-                                      category=category
-                                    ))
+          raise AddressLookupError('{}\n  referenced from {} scope'.format(e, self.options_scope))
     return deps
 
   def execute_codegen(self, target, target_workdir):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -24,8 +24,6 @@ from twitter.common.collections import OrderedSet
 from pants.contrib.scrooge.tasks.thrift_util import calculate_compile_sources
 
 
-_CONFIG_SECTION = 'scrooge-gen'
-
 _TARGET_TYPE_FOR_LANG = dict(scala=ScalaLibrary, java=JavaLibrary, android=JavaLibrary)
 
 
@@ -63,10 +61,6 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     self._thrift_defaults = ThriftDefaults.global_instance()
     self._depinfo = None
 
-  @property
-  def config_section(self):
-    return _CONFIG_SECTION
-
   # TODO(benjy): Use regular os-located tmpfiles, as we do everywhere else.
   def _tempname(self):
     # don't assume the user's cwd is buildroot
@@ -86,10 +80,9 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
         try:
           dependencies.update(self.context.resolve(depspec))
         except AddressLookupError as e:
-          raise AddressLookupError('{message}\n  referenced from [{section}] key: '
+          raise AddressLookupError('{message}\n  referenced from gen.scrooge key: '
                                    'gen->deps->{category} in pants.ini'.format(
                                       message=e,
-                                      section=_CONFIG_SECTION,
                                       category=category
                                     ))
     return deps

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -20,8 +20,6 @@ class ThriftLintError(Exception):
 class ThriftLinter(NailgunTask):
   """Print linter warnings for thrift files."""
 
-  _CONFIG_SECTION = 'thrift-linter'
-
   @staticmethod
   def _is_thrift(target):
     return target.is_thrift
@@ -47,10 +45,6 @@ class ThriftLinter(NailgunTask):
   def product_types(cls):
     # Declare the product of this goal. Gen depends on thrift-linter.
     return ['thrift-linter']
-
-  @property
-  def config_section(self):
-    return self._CONFIG_SECTION
 
   @property
   def cache_target_dirs(self):
@@ -90,7 +84,6 @@ class ThriftLinter(NailgunTask):
       config_args.extend(['--include-path', p])
 
     args = config_args + list(paths)
-
 
 
     # If runjava returns non-zero, this marks the workunit as a


### PR DESCRIPTION
I thought that we had banned tasks from arbitrary config
reads. We had a couple tasks internally that still
defined (but did not use) the config_section method.
I removed them and thought I would do the same for upstream.