### PR TITLE
Have all JvmToolMixins share the same --jvm-options option registration.

### DIFF
--- a/contrib/android/src/python/pants/contrib/android/tasks/dx_compile.py
+++ b/contrib/android/src/python/pants/contrib/android/tasks/dx_compile.py
@@ -49,8 +49,6 @@ class DxCompile(AndroidTask, NailgunTask):
     super(DxCompile, cls).register_options(register)
     register('--build-tools-version',
              help='Create the dex file using this version of the Android build tools.')
-    register('--jvm-options', type=list, metavar='<option>...',
-             help='Run dx with these JVM options.')
 
   @classmethod
   def product_types(cls):

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_link.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/scala_js_link.py
@@ -28,8 +28,6 @@ class ScalaJSLink(NailgunTask):
              help='Perform all optimizations; this is generally only useful for deployments.')
     register('--check-ir', type=bool, fingerprint=True,
              help='Perform (relatively costly) validity checks of IR before linking it.')
-    register('--jvm-options', type=list, metavar='<option>...', advanced=True,
-             help='Run with these extra jvm options.')
     # TODO: revisit after https://rbcommons.com/s/twitter/r/3225/
     cls.register_jvm_tool(register, 'scala-js-cli', main=cls._SCALA_JS_CLI_MAIN)
 

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -40,8 +40,6 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     register('--verbose', type=bool, help='Emit verbose output.')
     register('--strict', fingerprint=True, type=bool,
              help='Enable strict compilation.')
-    register('--jvm-options', default=[], advanced=True, type=list,
-             help='Use these jvm options when running Scrooge.')
     register('--service-deps', default={}, advanced=True, type=dict,
              help='A map of language to targets to add as dependencies of '
                   'synthetic thrift libraries that contain services.')

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -39,8 +39,6 @@ class ThriftLinter(NailgunTask):
                   'this value if it is set.')
     register('--linter-args', default=[], advanced=True, type=list, fingerprint=True,
              help='Additional options passed to the linter.')
-    register('--jvm-options', type=list, metavar='<option>...', advanced=True,
-             help='Run with these extra jvm options.')
     cls.register_jvm_tool(register, 'scrooge-linter')
 
   @classmethod

--- a/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
+++ b/contrib/spindle/src/python/pants/contrib/spindle/tasks/spindle_gen.py
@@ -32,13 +32,6 @@ class SpindleGen(NailgunTask):
   def register_options(cls, register):
     super(SpindleGen, cls).register_options(register)
     register(
-      '--jvm-options',
-      default=[],
-      advanced=True,
-      type=list,
-      help='Use these jvm options when running Spindle.',
-    )
-    register(
       '--runtime-dependency',
       default=['3rdparty:spindle-runtime'],
       advanced=True,

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -15,11 +15,12 @@ class JarTool(JvmToolMixin, Subsystem):
   options_scope = 'jar-tool'
 
   @classmethod
+  def get_jvm_options_default(cls, bootstrap_option_values):
+    return ['-Xmx64M']
+
+  @classmethod
   def register_options(cls, register):
     super(JarTool, cls).register_options(register)
-    # TODO: All jvm tools will need this option, so might as well have register_jvm_tool add it?
-    register('--jvm-options', advanced=True, type=list, default=['-Xmx64M'],
-             help='Run the jar tool with these JVM options.')
     cls.register_jvm_tool(register,
                           'jar-tool',
                           classpath=[

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -50,6 +50,24 @@ class JvmToolMixin(object):
   _jvm_tools = []  # List of JvmTool objects.
 
   @classmethod
+  def get_jvm_options_default(cls, bootstrap_option_values):
+    """Subclasses may override to provide different defaults for their JVM options.
+
+    :param bootstrap_option_values: The values of the "bootstrap options" (e.g., pants_workdir).
+                                    Implementations can use these when generating the default.
+                                    See src/python/pants/options/options_bootstrapper.py for
+                                    details.
+    """
+    return []
+
+  @classmethod
+  def register_options(cls, register):
+    super(JvmToolMixin, cls).register_options(register)
+    register('--jvm-options', type=list,  advanced=True, metavar='<option>...',
+             default=cls.get_jvm_options_default(register.bootstrap),
+             help='Run with these JVM options.')
+
+  @classmethod
   def register_jvm_tool(cls,
                         register,
                         key,

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -41,8 +41,6 @@ class Checkstyle(NailgunTask):
              help='Dictionary of property mappings to use for checkstyle.properties.')
     register('--confs', advanced=True, type=list, default=['default'],
              help='One or more ivy configurations to resolve for this target.')
-    register('--jvm-options', advanced=True, type=list, metavar='<option>...',
-             help='Run checkstyle with these extra jvm options.')
     register('--include-user-classpath', type=bool, fingerprint=True,
              help='Add the user classpath to the checkstyle classpath')
     cls.register_jvm_tool(register,

--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -338,8 +338,6 @@ class JarPublish(ScmPublishMixin, JarTask):
                   'Or: --restart-at=src/java/com/twitter/common/base')
     register('--ivy_settings', advanced=True, default=None,
              help='Specify a custom ivysettings.xml file to be used when publishing.')
-    register('--jvm-options', advanced=True, type=list,
-             help='Use these jvm options when running Ivy.')
     register('--repos', advanced=True, type=dict,
              help='Settings for repositories that can be pushed to. See '
                   'https://pantsbuild.github.io/publish.html for details.')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -92,13 +92,10 @@ class JvmCompile(NailgunTaskBase):
   @classmethod
   def register_options(cls, register):
     super(JvmCompile, cls).register_options(register)
-    register('--jvm-options', advanced=True, type=list,
-             default=list(cls.get_jvm_options_default(register.bootstrap)),
-             help='Run the compiler with these JVM options.')
 
     register('--args', advanced=True, type=list,
              default=list(cls.get_args_default(register.bootstrap)), fingerprint=True,
-             help='Pass these args to the compiler.')
+             help='Pass these extra args to the compiler.')
 
     register('--confs', advanced=True, type=list, default=['default'],
              help='Compile for these Ivy confs.')

--- a/src/python/pants/backend/jvm/tasks/jvm_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_task.py
@@ -13,6 +13,17 @@ from pants.task.task import Task
 
 
 class JvmTask(Task):
+  """Base class for tasks that whose explicit user-facing purpose is to run code in a JVM.
+
+  Examples are run.jvm, test.junit, repl.scala.  These tasks (and end users) can configure
+  the JVM options, args etc. via the JVM subsystem scoped to the task.
+
+  Note that this is distinct from tasks that happen to run code in a JVM as an implementation
+  detail, such as compile.java, checkstyle, etc.  Hypothetically at least, you could imagine
+  a Java compiler written in a non-JVM language, and then compile.java might not need to
+  run JVM code at all.  In practice that is highly unlikely, but the distinction is still
+  important.  Those JVM-tool-using tasks mix in `pants.backend.jvm.tasks.JvmToolTaskMixin`.
+  """
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_tool_task_mixin.py
@@ -12,6 +12,14 @@ from pants.task.task import TaskBase
 class JvmToolTaskMixin(JvmToolMixin, TaskBase):
   """A JvmToolMixin specialized for mixing in to Tasks.
 
+  Tasks that mix this in are those that run code in a JVM as an implementation detail of
+  their operation. Examples are compile.java, checkstyle etc.  This is distinct from tasks
+  whose explicit purpose is to run code in a JVM, such as test.junit or jvm.run.  Those
+  tasks extend `pants.backend.jvm.tasks.JvmTask`.
+
+  Note that this mixin is typically used by extending `pants.backend.jvm.tasks.NailgunTask`
+  rather than being mixed in directly.
+
   :API: public
   """
 

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -76,8 +76,6 @@ class Scalastyle(NailgunTask):
              help='Path to optional scalastyle excludes file. Each line is a regex. (Blank lines '
                   'and lines starting with \'#\' are ignored.) A file is skipped if its path '
                   '(relative to the repo root) matches any of these regexes.')
-    register('--jvm-options', type=list, metavar='<option>...', advanced=True,
-             help='Run scalastyle with these extra jvm options.')
     # TODO: Use the task's log level instead of this separate verbosity knob.
     register('--verbose', type=bool,
              help='Enable verbose scalastyle output.')


### PR DESCRIPTION
It was pointlessly repeated everywhere. We retain the ability to set
different defaults for different subclasses.

Also clarify the distinction between JvmTask and JvmToolTaskMixin in comments.