### PR TITLE
downgrade pex to 1.1.2

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ mock==1.3.0
 mox==0.5.3
 pathspec==0.3.4
 pep8==1.6.2
-pex==1.1.4
+pex==1.1.2
 psutil==3.1.1
 pyflakes==1.1.0
 Pygments==1.4


### PR DESCRIPTION
There's a bug added in 1.1.3 that prevents eggs with '_'s in their file names in versions from being found