### PR TITLE
Turn off all buildcache for integration tests.

### DIFF
--- a/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
+++ b/contrib/cpp/tests/python/pants_test/contrib/cpp/test_cpp_integration.py
@@ -75,12 +75,12 @@ class CppIntegrationTest(PantsRunIntegrationTest):
         '-ldebug',
       ]
 
-      pants_run = self.run_pants(args)
+      pants_run = self.run_pants(args, cache_read=True)
       self.assert_success(pants_run)
       self.assertIn('No cached artifacts', pants_run.stdout_data)
       self.assertIn('Caching artifacts', pants_run.stdout_data)
 
-      pants_run = self.run_pants(args)
+      pants_run = self.run_pants(args, cache_read=True)
       self.assert_success(pants_run)
       self.assertIn('Using cached artifacts', pants_run.stdout_data)
       self.assertNotIn('No cached artifacts', pants_run.stdout_data)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -32,21 +32,21 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   def test_bad_default(self):
     # thrift-linter fails on linter errors.
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-default')]
-    pants_run = self.run_pants(cmd)
+    pants_run = self.run_pants(cmd, cache_read=False)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=True)
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-strict')]
-    pants_run = self.run_pants(cmd)
+    pants_run = self.run_pants(cmd, cache_read=False)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_non_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=False)
     cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-non-strict')]
-    pants_run = self.run_pants(cmd)
+    pants_run = self.run_pants(cmd, cache_read=False)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
@@ -60,7 +60,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   def test_bad_strict_override(self):
     # thrift-linter passes with non-strict command line flag overriding the BUILD section.
     cmd = ['thrift-linter', '--no-strict', self.thrift_test_target('bad-thrift-strict')]
-    pants_run = self.run_pants(cmd)
+    pants_run = self.run_pants(cmd, cache_read=False)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
@@ -84,6 +84,6 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     # a command line non-strict flag is passed.
     cmd = ['thrift-linter', '--no-strict', self.thrift_test_target('bad-thrift-default')]
     pants_ini_config = {'thrift-linter': {'strict': True}}
-    pants_run = self.run_pants(cmd, config=pants_ini_config)
+    pants_run = self.run_pants(cmd, config=pants_ini_config, cache_read=False)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -109,14 +109,14 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
       yield clone_dir
 
-  def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None,
+  def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None, cache_read=True,
                              **kwargs):
-
     args = ['--no-pantsrc',
             '--pants-workdir=' + workdir,
             '--kill-nailguns',
             '--print-exception-stacktrace']
-
+    if not cache_read:
+      args.append('--no-cache-read')
     if config:
       config_data = config.copy()
       ini = ConfigParser.ConfigParser(defaults=config_data.pop('DEFAULT', None))
@@ -142,7 +142,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     return PantsResult(pants_command, proc.returncode, stdout_data.decode("utf-8"),
                        stderr_data.decode("utf-8"), workdir)
 
-  def run_pants(self, command, config=None, stdin_data=None, extra_env=None, **kwargs):
+  def run_pants(self, command, config=None, stdin_data=None, extra_env=None, cache_read=None, **kwargs):
     """Runs pants in a subprocess.
 
     :param list command: A list of command line arguments coming after `./pants`.
@@ -152,10 +152,10 @@ class PantsRunIntegrationTest(unittest.TestCase):
     :returns a tuple (returncode, stdout_data, stderr_data).
     """
     with self.temporary_workdir() as workdir:
-      return self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env, **kwargs)
+      return self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env, cache_read, **kwargs)
 
   @contextmanager
-  def pants_results(self, command, config=None, stdin_data=None, extra_env=None, **kwargs):
+  def pants_results(self, command, config=None, stdin_data=None, extra_env=None, cache_read=None, **kwargs):
     """Similar to run_pants in that it runs pants in a subprocess, but yields in order to give
     callers a chance to do any necessary validations on the workdir.
 
@@ -166,7 +166,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     :returns a tuple (returncode, stdout_data, stderr_data).
     """
     with self.temporary_workdir() as workdir:
-      yield self.run_pants_with_workdir(command, workdir, config, stdin_data, extra_env, **kwargs)
+      yield self.run_pants_with_workdir(command, cache_read, workdir, config, stdin_data, extra_env, cache_read, **kwargs)
 
   def bundle_and_run(self, target, bundle_name, bundle_jar_name=None, bundle_options=None,
                      args=None,


### PR DESCRIPTION
A TEST RUN TO GAUGE HOW MUCH LONGER TESTS TAKE

This turns off the cache for the test run.
Some tests already implicitely rely on the fact that
their integration tests don't read the cache.

My repro on current master is:

PANTS_CONFIG_OVERRIDE=pants.cache.ini ./pants test contrib/scrooge::

The tests fail because it reads the cache, as declared
in pants.ini.cache. The pants_run invocation
declares a --config-files flag, but the option
system concatenates it any files declared by
PANTS_CONFIG_OVERRIDE.

I could be convinced that this should be a flag
but in general I think that shelled runs are being
called because they actually want the test to do
the work. But I can imagine scenarios where you would
want the buildcache for some particular integration
tests. That is not possible with this patch as it stands.