### PR TITLE
Set useful jvm_options defaults.

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -39,16 +39,16 @@ python_tests(
 )
 
 python_tests(
-  name='thrift_linter_test',
+  name='thrift_linter',
   sources=['test_thrift_linter.py'],
   dependencies=[
-     '3rdparty/python:mock',
-     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_linter',
-     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_util',
-     'src/python/pants/backend/codegen/targets:java',
-     'src/python/pants/build_graph',
-     'tests/python/pants_test/tasks:task_test_base',
-     'tests/python/pants_test/testutils:mock_logger',
+    '3rdparty/python:mock',
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_linter',
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_util',
+    'src/python/pants/backend/codegen/targets:java',
+    'src/python/pants/build_graph',
+    'tests/python/pants_test/tasks:task_test_base',
+    'tests/python/pants_test/testutils:mock_logger',
   ],
 )
 

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -15,10 +15,6 @@ class JarTool(JvmToolMixin, Subsystem):
   options_scope = 'jar-tool'
 
   @classmethod
-  def get_jvm_options_default(cls, bootstrap_option_values):
-    return ['-Xmx64M']
-
-  @classmethod
   def register_options(cls, register):
     super(JarTool, cls).register_options(register)
     cls.register_jvm_tool(register,

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -21,11 +21,14 @@ class JVM(Subsystem):
   """
   options_scope = 'jvm'
 
+  options_default = ['-Xmx1g', '-XX:MaxPermSize=256m', '-Dfile.encoding=UTF8']
+
   @classmethod
   def register_options(cls, register):
     super(JVM, cls).register_options(register)
     # TODO(benjy): Options to specify the JVM version?
     register('--options', type=list, metavar='<option>...',
+             default=cls.options_default,
              help='Run with these extra JVM options.')
     register('--program-args', type=list, metavar='<arg>...',
              help='Run with these extra program args.')

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -58,7 +58,7 @@ class JvmToolMixin(object):
                                     See src/python/pants/options/options_bootstrapper.py for
                                     details.
     """
-    return []
+    return ['-Xmx1g', '-XX:MaxPermSize=256m', '-Dfile.encoding=UTF8']
 
   @classmethod
   def register_options(cls, register):

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -466,6 +466,7 @@ python_tests(
   name = 'jvm_run',
   sources = ['test_jvm_run.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/subsystems:jvm',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jvm_run',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -9,6 +9,7 @@ import os
 import re
 from contextlib import contextmanager
 
+from pants.backend.jvm.subsystems.jvm import JVM
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jvm_run import JvmRun
 from pants.util.contextutil import pushd, temporary_dir
@@ -56,5 +57,5 @@ class JvmRunTest(JvmTaskTestBase):
   def _match_cmdline_regex(self, cmdline, main):
     # Original classpath is embedded in the manifest file of a synthetic jar, just verify
     # classpath is a singleton jar here.
-    m = re.search(r'java -cp [^:]*\.jar {}'.format(main), cmdline)
+    m = re.search(r'java {} -cp [^:]*\.jar {}'.format(' '.join(JVM.options_default), main), cmdline)
     return m is not None

--- a/tests/python/pants_test/jvm/subsystems/test_jvm.py
+++ b/tests/python/pants_test/jvm/subsystems/test_jvm.py
@@ -16,7 +16,7 @@ create_JVM = functools.partial(create_subsystem, JVM)
 
 def test_options_default():
   jvm = create_JVM()
-  assert [] == jvm.get_jvm_options()
+  assert jvm.options_default == jvm.get_jvm_options()
 
 
 def test_options_simple():
@@ -62,7 +62,7 @@ def test_implicit_via_debug_port():
 
 def test_explicit_debug_args():
   jvm = create_JVM(debug_args=['fred'])
-  assert ['fred'] == jvm.get_jvm_options()
+  assert jvm.options_default + ['fred'] == jvm.get_jvm_options()
 
 
 def test_explicit_debug_args_with_options():


### PR DESCRIPTION
- Sets the defaults for the JVM subsystem and also for the
  JvmToolMixin.  They are currently the same values, but
  I don't use a common constant, to emphasize the unrelatedness
  of those two things.  And indeed we may well want them to have
  different default values in the future.

- The default value was derived from looking at various existing
  pants.inis, and from common sense - these days all non-trivial
  JVM binaries need to at least set -Xmx.

- Also removes an odd choice of default for JarTool. All current
  users override it anyway, to a much larget -Xmx setting, so
  I'm not sure how that 64m number was arrived at. It's
  evidently far too low in practice.

Note that all current shops set their jvm_options in pants.ini,
so this shouldn't affect any existing usage. But it will allow
new repos to get up and running without having to think about
JVM memory issues for a bit.