### PR TITLE
Enforce that an option name isn't registered twice in a scope.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -77,8 +77,8 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
   @classmethod
   def register_options(cls, register):
     super(BootstrapJvmTools, cls).register_options(register)
-    # Must be registered with the shader- prefix, as IvyTaskMixin already registers --jvm-options.
-    # TODO: IvyTaskMixin should probably add an ivy- prefix; there's no reason to privilege it.
+    # Must be registered with the shader- prefix, as JarTask already registers --jvm-options
+    # (indirectly, via NailgunTask).
     register('--shader-jvm-options', type=list, metavar='<option>...',
              help='Run the tool shader with these extra jvm options.')
 

--- a/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py
@@ -66,6 +66,10 @@ class IvyResolveFingerprintStrategy(FingerprintStrategy):
 class IvyTaskMixin(TaskBase):
   """A mixin for Tasks that execute resolves via Ivy.
 
+  Must be mixed in to a task that registers a --jvm-options option (typically by
+  extending NailgunClass).
+  TODO: Get rid of this requirement by registering an --ivy-jvm-options below.
+
   NB: Ivy reports are not relocatable in a cache, and a report must be present in order to
   parse the graph structure of dependencies. Therefore, this mixin explicitly disables the
   cache for its invalidation checks via the `use_cache=False` parameter. Tasks that extend
@@ -87,8 +91,9 @@ class IvyTaskMixin(TaskBase):
   @classmethod
   def register_options(cls, register):
     super(IvyTaskMixin, cls).register_options(register)
-    register('--jvm-options', type=list, metavar='<option>...',
-             help='Run Ivy with these extra jvm options.')
+    # TODO: Register an --ivy-jvm-options here and use that, instead of the --jvm-options
+    # registered by the task we mix into. That task may have intended those options for some
+    # other JVM run than the Ivy one.
     register('--soft-excludes', type=bool, advanced=True,
              help='If a target depends on a jar that is excluded by another target '
                   'resolve this jar anyway')

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -105,6 +105,10 @@ class ExportTask(IvyTaskMixin, PythonTask):
              help='Causes libraries with javadocs to be output.')
     register('--sources', type=bool,
              help='Causes sources to be output.')
+    # Required by IvyTaskMixin.
+    # TODO: Remove this once IvyTaskMixin registers an --ivy-jvm-options option.
+    register('--jvm-options', type=list, metavar='<option>...',
+             help='Run Ivy with these extra jvm options.')
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -48,6 +48,8 @@ InvalidMemberType = mk_registration_error('member_type {member_type} not allowed
 MemberTypeNotAllowed = mk_registration_error('member_type not allowed on option with type {type_}. '
                                              'It may only be specified if type=list.')
 NoOptionNames = mk_registration_error('No option names provided.')
+OptionAlreadyRegistered = mk_registration_error('An option with this name was already registered '
+                                                'on this scope.')
 OptionNameDash = mk_registration_error('Option name must begin with a dash.')
 OptionNameDoubleDash = mk_registration_error('Long option name must begin with a double-dash.')
 RecursiveSubsystemOption = mk_registration_error("Subsystem option cannot specify 'recursive'. "

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -21,9 +21,9 @@ from pants.option.custom_types import (ListValueComponent, dict_option, file_opt
                                        target_list_option, target_option)
 from pants.option.errors import (BooleanOptionNameWithNo, DeprecatedOptionError, FrozenRegistration,
                                  ImplicitValIsNone, InvalidKwarg, InvalidMemberType,
-                                 MemberTypeNotAllowed, NoOptionNames, OptionNameDash,
-                                 OptionNameDoubleDash, ParseError, RecursiveSubsystemOption,
-                                 Shadowing)
+                                 MemberTypeNotAllowed, NoOptionNames, OptionAlreadyRegistered,
+                                 OptionNameDash, OptionNameDoubleDash, ParseError,
+                                 RecursiveSubsystemOption, Shadowing)
 from pants.option.option_util import is_list_option
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo
@@ -362,6 +362,9 @@ class Parser(object):
         existing_scope = self._parent_parser._existing_scope(arg)
         if existing_scope is not None:
           raise Shadowing(self.scope, arg, outer_scope=self._scope_str(existing_scope))
+    for arg in args:
+      if arg in self._known_args:
+        raise OptionAlreadyRegistered(self.scope, arg)
     self._known_args.update(args)
 
   def _check_deprecated(self, dest, kwargs):

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -18,9 +18,9 @@ from pants.option.config import Config
 from pants.option.custom_types import file_option, target_option
 from pants.option.errors import (BooleanOptionNameWithNo, DeprecatedOptionError, FrozenRegistration,
                                  ImplicitValIsNone, InvalidKwarg, InvalidMemberType,
-                                 MemberTypeNotAllowed, NoOptionNames, OptionNameDash,
-                                 OptionNameDoubleDash, ParseError, RecursiveSubsystemOption,
-                                 Shadowing)
+                                 MemberTypeNotAllowed, NoOptionNames, OptionAlreadyRegistered,
+                                 OptionNameDash, OptionNameDoubleDash, ParseError,
+                                 RecursiveSubsystemOption, Shadowing)
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_tracker import OptionTracker
 from pants.option.options import Options
@@ -996,3 +996,12 @@ class OptionsTest(unittest.TestCase):
 
     self.assertEqual(99, options.for_global_scope().b)
     self.assertTrue(options.for_global_scope().store_true_flag)
+
+  def test_double_registration(self):
+    options = Options.create(env={},
+                             config=self._create_config({}),
+                             known_scope_infos=OptionsTest._known_scope_infos,
+                             args=shlex.split('./pants'),
+                             option_tracker=OptionTracker())
+    options.register(GLOBAL_SCOPE, '--foo-bar')
+    self.assertRaises(OptionAlreadyRegistered, lambda: options.register(GLOBAL_SCOPE, '--foo-bar'))


### PR DESCRIPTION
Amazingly, we didn't check for this before.

This commit fixes one case where we actually did this. The fix requires a
bit of a hack in export.py, but there's a TODO to fix that.