### PR TITLE
bootstrap ivy option

### DIFF
--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -136,18 +136,19 @@ class Bootstrapper(object):
       return cp
 
   def _bootstrap_ivy(self, bootstrap_jar_path):
+    options = self._ivy_subsystem.get_options()
     if not os.path.exists(bootstrap_jar_path):
       with temporary_file() as bootstrap_jar:
         fetcher = Fetcher()
         checksummer = fetcher.ChecksumListener(digest=hashlib.sha1())
         try:
-          logger.info('\nDownloading {}'.format(self._ivy_subsystem.get_options().bootstrap_jar_url))
+          logger.info('\nDownloading {}'.format(options.bootstrap_jar_url))
           # TODO: Capture the stdout of the fetcher, instead of letting it output
           # to the console directly.
-          fetcher.download(self._ivy_subsystem.get_options().bootstrap_jar_url,
+          fetcher.download(options.bootstrap_jar_url,
                            listener=fetcher.ProgressListener().wrap(checksummer),
                            path_or_fd=bootstrap_jar,
-                           timeout_secs=self._ivy_subsystem.get_options().bootstrap_fetch_timeout_secs)
+                           timeout_secs=options.bootstrap_fetch_timeout_secs)
           logger.info('sha1: {}'.format(checksummer.checksum))
           bootstrap_jar.close()
           touch(bootstrap_jar_path)
@@ -156,6 +157,6 @@ class Bootstrapper(object):
           raise self.Error('Problem fetching the ivy bootstrap jar! {}'.format(e))
 
     return Ivy(bootstrap_jar_path,
-               ivy_settings=self._ivy_subsystem.get_options().ivy_settings,
-               ivy_cache_dir=self._ivy_subsystem.get_options().cache_dir,
+               ivy_settings=options.bootstrap_ivy_settings or options.ivy_settings,
+               ivy_cache_dir=options.cache_dir,
                extra_jvm_options=self._ivy_subsystem.extra_jvm_options())

--- a/src/python/pants/ivy/ivy_subsystem.py
+++ b/src/python/pants/ivy/ivy_subsystem.py
@@ -42,6 +42,8 @@ class IvySubsystem(Subsystem):
              help='Directory to store artifacts retrieved by Ivy.')
     register('--ivy-settings', advanced=True,
              help='Location of XML configuration file for Ivy settings.')
+    register('--bootstrap-ivy-settings', advanced=True,
+             help='Bootstrap Ivy XML configuration file.')
 
   @classmethod
   def subsystem_dependencies(cls):


### PR DESCRIPTION
Fixes #3174 
https://rbcommons.com/s/twitter/r/3700/

Use a separate Ivy settings for bootstrapping Ivy itself. This way you can get external resolvers (like the S3 one in that issue) and avoid the chicken-and-egg problem.