### PR TITLE
Remove arbitrary JVM memory setting for jar-tool.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -15,10 +15,6 @@ class JarTool(JvmToolMixin, Subsystem):
   options_scope = 'jar-tool'
 
   @classmethod
-  def get_jvm_options_default(cls, bootstrap_option_values):
-    return ['-Xmx64M']
-
-  @classmethod
   def register_options(cls, register):
     super(JarTool, cls).register_options(register)
     cls.register_jvm_tool(register,

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -23,7 +23,7 @@ class JVM(Subsystem):
 
   # Broken out here instead of being inlined in the registration stanza,
   # because various tests may need to access these.
-  options_default = []
+  options_default = ['-Xmx256m']
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -58,7 +58,7 @@ class JvmToolMixin(object):
                                     See src/python/pants/options/options_bootstrapper.py for
                                     details.
     """
-    return []
+    return ['-Xmx256m']
 
   @classmethod
   def register_options(cls, register):


### PR DESCRIPTION
Everything else defaults to the JVM's defaults (apart from ZincCompile,
which is known to need a lot of RAM). It seems odd to single out jar-tool
for a very low default, especially since all major Pants users override
this in pants.ini to a much higher number.