### PR TITLE
Some fixes to make tests more robust around jvm_options.

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -39,16 +39,16 @@ python_tests(
 )
 
 python_tests(
-  name='thrift_linter_test',
+  name='thrift_linter',
   sources=['test_thrift_linter.py'],
   dependencies=[
-     '3rdparty/python:mock',
-     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_linter',
-     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_util',
-     'src/python/pants/backend/codegen/targets:java',
-     'src/python/pants/build_graph',
-     'tests/python/pants_test/tasks:task_test_base',
-     'tests/python/pants_test/testutils:mock_logger',
+    '3rdparty/python:mock',
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_linter',
+    'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:thrift_util',
+    'src/python/pants/backend/codegen/targets:java',
+    'src/python/pants/build_graph',
+    'tests/python/pants_test/tasks:task_test_base',
+    'tests/python/pants_test/testutils:mock_logger',
   ],
 )
 

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -15,10 +15,6 @@ class JarTool(JvmToolMixin, Subsystem):
   options_scope = 'jar-tool'
 
   @classmethod
-  def get_jvm_options_default(cls, bootstrap_option_values):
-    return ['-Xmx64M']
-
-  @classmethod
   def register_options(cls, register):
     super(JarTool, cls).register_options(register)
     cls.register_jvm_tool(register,

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -15,6 +15,10 @@ class JarTool(JvmToolMixin, Subsystem):
   options_scope = 'jar-tool'
 
   @classmethod
+  def get_jvm_options_default(cls, bootstrap_option_values):
+    return ['-Xmx64M']
+
+  @classmethod
   def register_options(cls, register):
     super(JarTool, cls).register_options(register)
     cls.register_jvm_tool(register,

--- a/src/python/pants/backend/jvm/subsystems/jvm.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm.py
@@ -21,11 +21,14 @@ class JVM(Subsystem):
   """
   options_scope = 'jvm'
 
+  options_default = []
+
   @classmethod
   def register_options(cls, register):
     super(JVM, cls).register_options(register)
     # TODO(benjy): Options to specify the JVM version?
     register('--options', type=list, metavar='<option>...',
+             default=cls.options_default,
              help='Run with these extra JVM options.')
     register('--program-args', type=list, metavar='<arg>...',
              help='Run with these extra program args.')

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -466,6 +466,7 @@ python_tests(
   name = 'jvm_run',
   sources = ['test_jvm_run.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/subsystems:jvm',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:jvm_run',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -9,6 +9,7 @@ import os
 import re
 from contextlib import contextmanager
 
+from pants.backend.jvm.subsystems.jvm import JVM
 from pants.backend.jvm.targets.jvm_binary import JvmBinary
 from pants.backend.jvm.tasks.jvm_run import JvmRun
 from pants.util.contextutil import pushd, temporary_dir
@@ -56,5 +57,5 @@ class JvmRunTest(JvmTaskTestBase):
   def _match_cmdline_regex(self, cmdline, main):
     # Original classpath is embedded in the manifest file of a synthetic jar, just verify
     # classpath is a singleton jar here.
-    m = re.search(r'java -cp [^:]*\.jar {}'.format(main), cmdline)
+    m = re.search(r'java {} -cp [^:]*\.jar {}'.format(' '.join(JVM.options_default), main), cmdline)
     return m is not None

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run.py
@@ -57,5 +57,9 @@ class JvmRunTest(JvmTaskTestBase):
   def _match_cmdline_regex(self, cmdline, main):
     # Original classpath is embedded in the manifest file of a synthetic jar, just verify
     # classpath is a singleton jar here.
-    m = re.search(r'java {} -cp [^:]*\.jar {}'.format(' '.join(JVM.options_default), main), cmdline)
+    if JVM.options_default:
+      opts_str = ' '.join(JVM.options_default) + ' '
+    else:
+      opts_str = ''
+    m = re.search(r'java {}-cp [^:]*\.jar {}'.format(opts_str, main), cmdline)
     return m is not None

--- a/tests/python/pants_test/jvm/subsystems/test_jvm.py
+++ b/tests/python/pants_test/jvm/subsystems/test_jvm.py
@@ -16,7 +16,7 @@ create_JVM = functools.partial(create_subsystem, JVM)
 
 def test_options_default():
   jvm = create_JVM()
-  assert [] == jvm.get_jvm_options()
+  assert jvm.options_default == jvm.get_jvm_options()
 
 
 def test_options_simple():
@@ -62,7 +62,7 @@ def test_implicit_via_debug_port():
 
 def test_explicit_debug_args():
   jvm = create_JVM(debug_args=['fred'])
-  assert ['fred'] == jvm.get_jvm_options()
+  assert jvm.options_default + ['fred'] == jvm.get_jvm_options()
 
 
 def test_explicit_debug_args_with_options():


### PR DESCRIPTION
This came out of a discarded change to actually set the jvm_options
to be non-empty. This exposed various issues in tests that assume
that the default jvm_options are empty.

This commit keeps the fixes for those issues, so that if in the future
we do change the jvm_options defaults, the tests will continue to work.