### PR TITLE
Point Node preinstalled-project at a better URL.

### DIFF
--- a/contrib/node/examples/src/node/preinstalled-project/BUILD
+++ b/contrib/node/examples/src/node/preinstalled-project/BUILD
@@ -4,8 +4,8 @@
 node_preinstalled_module(
   name='preinstalled-project',
   sources=globs('package.json', 'src/*.js', 'test/*.js'),
-  dependencies_archive_url=('https://raw.githubusercontent.com/pantsbuild/'
-    'node-preinstalled-modules/master/node_modules.tar.gz')
+  dependencies_archive_url=
+    'https://dl.bintray.com/pantsbuild/node-preinstalled-modules/node_modules.tar.gz'
 )
 
 node_test(


### PR DESCRIPTION
The bintray repo is not subject to the rate-limiting of the github
serving and is generally designed for the job.

https://rbcommons.com/s/twitter/r/3710/