### PR TITLE
Improve android install robustness.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ cache:
     #   https://github.com/pantsbuild/pants/issues/2485
     - $HOME/.npm
     - $HOME/.android
-    - $SDK_INSTALL_LOCATION
+    - $ANDROID_SDK_INSTALL_LOCATION
     - build-support/isort.venv
     - build-support/pants_dev_deps.venv
 
@@ -56,8 +56,8 @@ install:
 
 env:
   global:
-    - SDK_INSTALL_LOCATION="$HOME/opt/android-sdk-install"
-    - ANDROID_HOME="$SDK_INSTALL_LOCATION/android-sdk-linux"
+    - ANDROID_SDK_INSTALL_LOCATION="$HOME/opt/android-sdk-install"
+    - ANDROID_HOME="$ANDROID_SDK_INSTALL_LOCATION/android-sdk-linux"
     - CXX=g++
     - PANTS_CONFIG_OVERRIDE="['pants.travis-ci.ini']"
     # Credentials for OSX syncing: GH_USER, GH_EMAIL, GH_TOKEN

--- a/build-support/bin/install-android-sdk.sh
+++ b/build-support/bin/install-android-sdk.sh
@@ -4,44 +4,53 @@
 
 # Install the Android SDK for the Pants Android contrib module.
 
-# SDK_INSTALL_LOCATION and ANDROID_HOME set in travis.yaml.
+set -e
+
+# ANDROID_SDK_INSTALL_LOCATION and ANDROID_HOME set in travis.yaml.
 ANDROID_SDK_URL="http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz"
 SDK_FILE=$(basename "$ANDROID_SDK_URL")
+SDK_ARCHIVE_LOCATION="$ANDROID_SDK_INSTALL_LOCATION/$SDK_FILE"
 
 # The debug.keystore has a well-known definition and location.
-KEYSTORE_LOCATION="$HOME"/.android
+KEYSTORE_LOCATION="$HOME/.android"
 
 # Add SDKs as needed.
-declare -a SDK_MODULES=(android-19 \
-                        android-20 \
-                        android-21 \
-                        android-22 \
-                        build-tools-19.1.0 \
-                        extra-android-support \
-                        extra-google-m2repository \
-                        extra-android-m2repository \
-                        platform-tools)
+SDK_MODULES=(
+  android-19
+  android-20
+  android-21
+  android-22
+  build-tools-19.1.0
+  extra-android-support
+  extra-google-m2repository
+  extra-android-m2repository
+  platform-tools
+)
 
-mkdir -p "$SDK_INSTALL_LOCATION"
-mkdir -p "$KEYSTORE_LOCATION"
+FILTER=$(echo ${SDK_MODULES[@]} | tr ' ' ,)
 
+if [[ ! -f "$SDK_ARCHIVE_LOCATION.processed" || "$FILTER" != "$(cat $SDK_ARCHIVE_LOCATION.processed)" ]]; then
+  mkdir -p "$ANDROID_SDK_INSTALL_LOCATION"
+  cd "$ANDROID_SDK_INSTALL_LOCATION"
+  echo "Downloading $ANDROID_SDK_URL..."
+  wget -c "$ANDROID_SDK_URL"
+  tar -xf "$SDK_ARCHIVE_LOCATION"
 
-function join { local IFS="$1"; shift; echo "$*"; }
-MODULE_LIST=$(join , ${SDK_MODULES[@]})
+  echo y | "$ANDROID_HOME/tools/android" update sdk -u --all --filter "$FILTER"
 
-echo "Downloading $ANDROID_SDK_URL..."
-SDK_ARCHIVE_LOCATION="$SDK_INSTALL_LOCATION"/"$SDK_FILE"
+  # Generate well known debug.keystore if the SDK hasn't created it.
+  DEBUG_KEYSTORE="$KEYSTORE_LOCATION/debug.keystore"
+  if [[ ! -f "$DEBUG_KEYSTORE" ]]; then
+    mkdir -p "$KEYSTORE_LOCATION"
+    keytool -genkey -v -keystore "$KEYSTORE_LOCATION/debug.keystore" -alias androiddebugkey -storepass android  \
+      -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+  fi
 
-wget -nc "$ANDROID_SDK_URL" -O "$SDK_ARCHIVE_LOCATION"
-tar -C "$SDK_INSTALL_LOCATION" -xf "$SDK_ARCHIVE_LOCATION"
-
-# Spamming 'y' was failing non-deterministically so sleep between echos.
-( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | \
-    "$ANDROID_HOME"/tools/android update sdk -u --all --filter "$MODULE_LIST"
-
-# Generate well known debug.keystore if the SDK hasn't created it.
-DEBUG_KEYSTORE="$KEYSTORE_LOCATION"/debug.keystore
-if [[ ! -f "$DEBUG_KEYSTORE" ]]; then
-    keytool -genkey -v -keystore "$KEYSTORE_LOCATION"/debug.keystore -alias androiddebugkey -storepass android  \
-        -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Android Debug,O=Android,C=US"
+  # Commit the transaction.
+  echo "$SDK_MODULES" > "$SDK_ARCHIVE_LOCATION.processed"
+else
+  echo "$SDK_ARCHIVE_LOCATION is already installed with modules:"
+  for module in "${SDK_MODULES[@]}"; do
+    echo "  $module"
+  done
 fi

--- a/build-support/bin/install-android-sdk.sh
+++ b/build-support/bin/install-android-sdk.sh
@@ -47,7 +47,7 @@ if [[ ! -f "$SDK_ARCHIVE_LOCATION.processed" || "$FILTER" != "$(cat $SDK_ARCHIVE
   fi
 
   # Commit the transaction.
-  echo "$SDK_MODULES" > "$SDK_ARCHIVE_LOCATION.processed"
+  echo "$FILTER" > "$SDK_ARCHIVE_LOCATION.processed"
 else
   echo "$SDK_ARCHIVE_LOCATION is already installed with modules:"
   for module in "${SDK_MODULES[@]}"; do


### PR DESCRIPTION
This change sets up the script to fail-fast; thus fail Travis-CI more
quickly and clearly when there are android install errrors. It also
succeeds more quickly when the install has already completed successfully
once for a given android sdk tarball and module list.

https://rbcommons.com/s/twitter/r/3725/