### PR TITLE
Bump the open file ulimit on OSX.

### DIFF
--- a/.travis.osx.yml
+++ b/.travis.osx.yml
@@ -45,6 +45,9 @@ script: |
   sw_vers
   python --version
   java -version
+  echo "Bumping open file ulimit from `ulimit -n`..."
+  ulimit -n 8192 # This is probably higher than needed, 1024 limits on linux seem to work fine.
+  echo "...to `ulimit -n`"
   ./build-support/bin/ci.sh -x ${CI_FLAGS}
 
 # The `notifications:` configuration will be programatically copied over from `.travis.yml` for


### PR DESCRIPTION
Tests showed the default was 256 previously which appears to be too low
for modern pants as evidenced by CI failures caused by too many open
file handles.

https://rbcommons.com/s/twitter/r/3733/