### PR TITLE
Add public API markers to targets and base tasks used by 4qs plugins.

### DIFF
--- a/src/python/pants/backend/codegen/targets/python_thrift_library.py
+++ b/src/python/pants/backend/codegen/targets/python_thrift_library.py
@@ -9,7 +9,10 @@ from pants.backend.python.targets.python_target import PythonTarget
 
 
 class PythonThriftLibrary(PythonTarget):
-  """A Python library generated from Thrift IDL files."""
+  """A Python library generated from Thrift IDL files.
+
+  :API: public
+  """
 
   def __init__(self, **kwargs):
     """

--- a/src/python/pants/backend/jvm/targets/jarable.py
+++ b/src/python/pants/backend/jvm/targets/jarable.py
@@ -12,7 +12,10 @@ from pants.util.meta import AbstractClass
 
 
 class Jarable(AbstractClass):
-  """A mixin that identifies a target as one that can provide a jar."""
+  """A mixin that identifies a target as one that can provide a jar.
+
+  :API: public
+  """
 
   @abstractproperty
   def identifier(self):

--- a/src/python/pants/backend/jvm/targets/jvm_app.py
+++ b/src/python/pants/backend/jvm/targets/jvm_app.py
@@ -185,6 +185,8 @@ class JvmApp(Target):
   self-contained artifact suitable for deployment on some other machine.
   The artifact contains the executable jar, its dependencies, and
   extra files like config files, startup scripts, etc.
+
+  :API: public
   """
 
   def __init__(self, name=None, payload=None, binary=None, bundles=None, basename=None, **kwargs):

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -33,6 +33,8 @@ class Jar(object):
   Upon construction the jar is conceptually opened for writes.  The write methods are called to
   add to the jar's contents and then changes are finalized with a call to close.  If close is not
   called the staged changes will be lost.
+
+  :API: public
   """
 
   class Error(Exception):
@@ -326,7 +328,10 @@ class JarTask(NailgunTask):
 class JarBuilderTask(JarTask):
 
   class JarBuilder(AbstractClass):
-    """A utility to aid in adding the classes and resources associated with targets to a jar."""
+    """A utility to aid in adding the classes and resources associated with targets to a jar.
+
+    :API: public
+    """
 
     @staticmethod
     def _add_agent_manifest(agent, manifest):

--- a/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
@@ -22,6 +22,10 @@ from pants.util.memo import memoized_property
 
 
 class JvmBinaryTask(JarBuilderTask):
+  """Encapsulates operations to build or update JvmBinary jars.
+
+  :API: public
+  """
 
   @staticmethod
   def is_binary(target):

--- a/src/python/pants/backend/jvm/tasks/scala_repl.py
+++ b/src/python/pants/backend/jvm/tasks/scala_repl.py
@@ -16,6 +16,11 @@ from pants.task.repl_task_mixin import ReplTaskMixin
 
 
 class ScalaRepl(JvmToolTaskMixin, ReplTaskMixin, JvmTask):
+  """Operations to create or launch Scala repls.
+
+  :API: public
+  """
+
   _RUNNER_MAIN = 'org.pantsbuild.tools.runner.PantsRunner'
 
   @classmethod

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -22,6 +22,8 @@ class PythonBinary(PythonTarget):
   scripts that contain a complete Python environment capable of
   running the target. For more information about pex files see
   http://pantsbuild.github.io/python-readme.html#how-pex-files-work.
+
+  :API: public
   """
 
   # TODO(wickman) Consider splitting pex options out into a separate PexInfo builder that can be

--- a/src/python/pants/backend/python/targets/python_requirement_library.py
+++ b/src/python/pants/backend/python/targets/python_requirement_library.py
@@ -13,7 +13,10 @@ from pants.build_graph.target import Target
 
 
 class PythonRequirementLibrary(Target):
-  """A set of pip requirements."""
+  """A set of pip requirements.
+
+  :API: public
+  """
 
   def __init__(self, payload=None, requirements=None, **kwargs):
     """

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -19,7 +19,10 @@ from pants.util.memo import memoized_property
 
 
 class PythonTarget(Target):
-  """Base class for all Python targets."""
+  """Base class for all Python targets.
+
+  :API: public
+  """
 
   def __init__(self,
                address=None,

--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -26,10 +26,7 @@ class DefaultFingerprintHashingMixin(object):
 
 
 class FingerprintStrategy(AbstractClass):
-  """A helper object for doing per-task, finer grained invalidation of Targets.
-
-  :API: public
-  """
+  """A helper object for doing per-task, finer grained invalidation of Targets."""
 
   @abstractmethod
   def compute_fingerprint(self, target):

--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -26,7 +26,10 @@ class DefaultFingerprintHashingMixin(object):
 
 
 class FingerprintStrategy(AbstractClass):
-  """A helper object for doing per-task, finer grained invalidation of Targets."""
+  """A helper object for doing per-task, finer grained invalidation of Targets.
+
+  :API: public
+  """
 
   @abstractmethod
   def compute_fingerprint(self, target):

--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -21,6 +21,8 @@ from pants.util.dirutil import safe_mkdir
 class Ivy(object):
   """Encapsulates the ivy cli taking care of the basic invocation letting you just worry about the
   args to pass to the cli itself.
+
+  :API: public
   """
 
   class Error(Exception):


### PR DESCRIPTION
The targets are sefl explanatory - we consume products of these
targets in plugin tasks. The fingerprint strategy is a core tool
in a task developer's toolbox.

If the task involves jvm code, then it may need do jar operations,
this exposes as public some of those tasks.

Ivy is marked public because it provides a custom exception that
doesn't inherit from anything descriptive - Ivy.Error is just an
Exception. We publish jars with a custom pom-publish task - where
every jar has a common version. Catching Ivy failures required
catching Ivy.Error.