### PR TITLE
Skip flaky test_pytest_run_timeout_cant_terminate.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import time
+import unittest
 
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -41,6 +42,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     # Ensure that the timeout message triggered.
     self.assertIn("FAILURE: Timeout of 1 seconds reached", pants_run.stdout_data)
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3255')
   def test_pytest_run_timeout_cant_terminate(self):
     start = time.time()
     terminate_wait = 2


### PR DESCRIPTION
This is causing the pantsbuild-osx/pants Travis-CI job to go red
roughly 50% of the time.