### PR TITLE
Skip flaky pytest timeout failure ITs.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import time
+import unittest
 
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
@@ -21,6 +22,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
                                 'testprojects/tests/python/pants/timeout:exceeds_timeout'])
     self.assert_success(pants_run)
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3255')
   def test_pytest_run_timeout_fails(self):
     start = time.time()
     pants_run = self.run_pants(['clean-all',
@@ -41,6 +43,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     # Ensure that the timeout message triggered.
     self.assertIn("FAILURE: Timeout of 1 seconds reached", pants_run.stdout_data)
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3255')
   def test_pytest_run_timeout_cant_terminate(self):
     start = time.time()
     terminate_wait = 2


### PR DESCRIPTION
The `test_pytest_run_timeout_cant_terminate` test is causing the
pantsbuild-osx/pants Travis-CI job to go red roughly 50% of the time.
Local testing of this skip application found
`test_pytest_run_timeout_fails` also failing intermittently on my
machine so a skip is applied to that similarly fragile test as well.

https://rbcommons.com/s/twitter/r/3748/