### PR TITLE
Upgrade default go from 1.6.1 to 1.6.2.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -32,7 +32,7 @@ class GoDistribution(object):
       register('--supportdir', advanced=True, default='bin/go',
                help='Find the go distributions under this dir.  Used as part of the path to lookup '
                     'the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', advanced=True, default='1.6.1',
+      register('--version', advanced=True, default='1.6.2',
                help='Go distribution version.  Used as part of the path to lookup the distribution '
                     'with --binary-util-baseurls and --pants-bootstrapdir')
 


### PR DESCRIPTION
Release information can be found here:
  https://golang.org/doc/devel/release.html#go1.6.minor
  https://github.com/golang/go/issues?q=milestone%3AGo1.6.2

https://rbcommons.com/s/twitter/r/3755/