### PR TITLE
Require python 2.7.11 under Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ cache:
 language: python
 
 python:
-  - "2.7"
+  - "2.7.11"
 
 install:
   - pip --quiet install coveralls
@@ -86,6 +86,7 @@ before_script: |
 
 script: |
   uname -a
+  python --version
   java -version
   ./build-support/bin/ci.sh -x ${CI_FLAGS}
 

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -10,6 +10,9 @@ use_nailgun: False
 # overhead.
 worker_count: 4
 
-
 [test.pytest]
 options: ['--duration=3']
+
+[python-setup]
+# Stable execution of new engine tests requires at least python 2.7.11.
+interpreter_requirement: CPython>=2.7.11,<3


### PR DESCRIPTION
This stabilizes new engine tests.

https://rbcommons.com/s/twitter/r/3759/