### PR TITLE
[engine] bug fix: to get/put within the proper context

### DIFF
--- a/src/python/pants/engine/exp/storage.py
+++ b/src/python/pants/engine/exp/storage.py
@@ -27,9 +27,9 @@ from pants.util.meta import AbstractClass
 
 def unpickle_func(value):
   if isinstance(value, six.binary_type):
-    # loads for string-like values
+    # Deserialize string values.
     return pickle.loads(value)
-  # load for file-like value from buffers
+  # Deserialize values with file interface,
   return pickle.load(value)
 
 
@@ -399,7 +399,7 @@ class KeyValueStore(Closable, AbstractClass):
 
     :param key: key in bytestring.
     :param transform: optional function that is applied on the retrieved value from storage
-      before return, since the original value may be only valid within the context.
+      before it is returned, since the original value may be only valid within the context.
     :return: value can be either string-like or file-like, `None` if does not exist.
     """
 

--- a/src/python/pants/engine/exp/storage.py
+++ b/src/python/pants/engine/exp/storage.py
@@ -404,7 +404,7 @@ class KeyValueStore(Closable, AbstractClass):
     """
 
   @abstractmethod
-  def put(self, key, value, transform=lambda x : x):
+  def put(self, key, value):
     """Save the value under a key, but only once.
 
     The write once semantics is specifically provided for the content addressable use case.
@@ -432,10 +432,10 @@ class InMemoryDb(KeyValueStore):
   def get(self, key, transform=lambda x : x):
     return transform(self._storage.get(key))
 
-  def put(self, key, value, transform=lambda x : x):
+  def put(self, key, value):
     if key in self._storage:
       return False
-    self._storage[key] = transform(value)
+    self._storage[key] = value
     return True
 
   def items(self):
@@ -502,10 +502,10 @@ class Lmdb(KeyValueStore):
         return transform(StringIO.StringIO(value))
       return None
 
-  def put(self, key, value, transform=lambda x : x):
+  def put(self, key, value):
     """Returning True if the key/value are actually written to the storage."""
     with self._env.begin(db=self._db, buffers=True, write=True) as txn:
-      return txn.put(key, transform(value), overwrite=False)
+      return txn.put(key, value, overwrite=False)
 
   def items(self):
     with self._env.begin(db=self._db, buffers=True) as txn:

--- a/src/python/pants/engine/exp/storage.py
+++ b/src/python/pants/engine/exp/storage.py
@@ -398,6 +398,8 @@ class KeyValueStore(Closable, AbstractClass):
     """Fetch the value for a given key.
 
     :param key: key in bytestring.
+    :param transform: optional function that is applied on the retrieved value from storage
+      before return, since the original value may be only valid within the context.
     :return: value can be either string-like or file-like, `None` if does not exist.
     """
 

--- a/tests/python/pants_test/engine/exp/test_engine.py
+++ b/tests/python/pants_test/engine/exp/test_engine.py
@@ -46,7 +46,6 @@ class EngineTest(unittest.TestCase):
     engine = LocalSerialEngine(self.scheduler, self.storage, self.cache)
     self.assert_engine(engine)
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3149')
   def test_multiprocess_engine_multi(self):
     with self.multiprocessing_engine() as engine:
       self.assert_engine(engine)
@@ -62,7 +61,6 @@ class EngineTest(unittest.TestCase):
       with self.assertRaises(SerializationError):
         engine.execute(build_request)
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3149')
   def test_rerun_with_cache(self):
     with self.multiprocessing_engine() as engine:
       self.assert_engine(engine)


### PR DESCRIPTION
For #3149  We have two places that `get` and `put` from/to storage are not used within
the proper context.

* StringIO buffer for write, saving buffer to storage happens outside its context.
* lmdb buffer for read, the invalid buffer was used outside transction context.

The earlier attempt is red herring: https://rbcommons.com/s/twitter/r/3751/.

These two behaviors are clearly documented, see [1] and [2].
[1] https://docs.python.org/2/library/stringio.html
[2] https://lmdb.readthedocs.org/en/release/