### PR TITLE
Peiyu/make scm project tree pickable wip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,13 +81,13 @@ env:
 
 
 before_script: |
-  git --version
   ./build-support/bin/ci-sync.sh
   ./build-support/bin/install-android-sdk.sh
 
 script: |
   uname -a
   java -version
+  git --version
   ./build-support/bin/ci.sh -x ${CI_FLAGS}
 
 # We accept the default travis-ci email author+comitter notification

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ env:
 
 
 before_script: |
+  git --version
   ./build-support/bin/ci-sync.sh
   ./build-support/bin/install-android-sdk.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,6 @@ before_script: |
 script: |
   uname -a
   java -version
-  git --version
   ./build-support/bin/ci.sh -x ${CI_FLAGS}
 
 # We accept the default travis-ci email author+comitter notification

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -36,6 +36,7 @@ python_library(
   sources = ['scm_project_tree.py'],
   dependencies = [
     ':project_tree',
+    'src/python/pants/util:memo',
   ]
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -36,7 +36,6 @@ python_library(
   sources = ['scm_project_tree.py'],
   dependencies = [
     ':project_tree',
-    'src/python/pants/util:memo',
   ]
 )
 

--- a/src/python/pants/base/scm_project_tree.py
+++ b/src/python/pants/base/scm_project_tree.py
@@ -11,6 +11,7 @@ import os
 from types import NoneType
 
 from pants.base.project_tree import PTSTAT_DIR, PTSTAT_FILE, PTSTAT_LINK, ProjectTree
+from pants.util.memo import memoized
 
 
 logger = logging.getLogger(__name__)
@@ -21,8 +22,12 @@ class ScmProjectTree(ProjectTree):
     super(ScmProjectTree, self).__init__(build_root)
     self._scm = scm
     self._rev = rev
-    self._reader = scm.repo_reader(rev)
     self._scm_worktree = os.path.realpath(scm.worktree)
+
+  @memoized
+  def _reader(self):
+    """Make this memoized such that `ScmProjectTree` is pickable."""
+    return self._scm.repo_reader(self._rev)
 
   def _scm_relpath(self, build_root_relpath):
     return os.path.relpath(os.path.join(self.build_root, build_root_relpath), self._scm_worktree)

--- a/src/python/pants/base/scm_project_tree.py
+++ b/src/python/pants/base/scm_project_tree.py
@@ -24,6 +24,7 @@ class ScmProjectTree(ProjectTree):
     self._rev = rev
     self._scm_worktree = os.path.realpath(scm.worktree)
 
+  @property
   @memoized
   def _reader(self):
     """Make this memoized such that `ScmProjectTree` is pickable."""

--- a/src/python/pants/base/scm_project_tree.py
+++ b/src/python/pants/base/scm_project_tree.py
@@ -98,6 +98,17 @@ class ScmProjectTree(ProjectTree):
       (self._scm == other._scm) and
       (self._rev == other._rev))
 
+  def __getstate__(self):
+    odict = self.__dict__.copy()
+    del odict['_reader']
+    return odict
+
+  def __setstate__(self, dict):
+    scm = dict['_scm']
+    rev = dict['_rev']
+    self.__dict__.update(dict)
+    self._reader = scm.repo_reader(rev)
+
   def __ne__(self, other):
     return not self.__eq__(other)
 

--- a/src/python/pants/base/scm_project_tree.py
+++ b/src/python/pants/base/scm_project_tree.py
@@ -11,7 +11,6 @@ import os
 from types import NoneType
 
 from pants.base.project_tree import PTSTAT_DIR, PTSTAT_FILE, PTSTAT_LINK, ProjectTree
-from pants.util.memo import memoized
 
 
 logger = logging.getLogger(__name__)
@@ -24,10 +23,6 @@ class ScmProjectTree(ProjectTree):
     self._rev = rev
     self._reader = scm.repo_reader(rev)
     self._scm_worktree = os.path.realpath(scm.worktree)
-
-  @memoized
-  def _reader(self):
-    return self._scm.repo_reader(self._rev)
 
   def _scm_relpath(self, build_root_relpath):
     return os.path.relpath(os.path.join(self.build_root, build_root_relpath), self._scm_worktree)

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -94,7 +94,6 @@ class Git(Scm):
     worktree:  The path to the git repository working tree directory (typically '.').
     remote:    The default remote to use.
     branch:    The default remote branch to use.
-    log:       A log object that supports debug, info, and warn methods.
     """
     super(Scm, self).__init__()
 

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 import StringIO
 import subprocess
@@ -26,6 +27,9 @@ NUL = ensure_binary('\0')
 SPACE = ensure_binary(' ')
 NEWLINE = ensure_binary('\n')
 EMPTY_STRING = ensure_binary("")
+
+
+logger = logging.getLogger(__name__)
 
 
 class Git(Scm):
@@ -82,7 +86,7 @@ class Git(Scm):
     if result != 0:
       raise raise_type(failure_msg or '{} failed with exit code {}'.format(' '.join(cmd), result))
 
-  def __init__(self, binary='git', gitdir=None, worktree=None, remote=None, branch=None, log=None):
+  def __init__(self, binary='git', gitdir=None, worktree=None, remote=None, branch=None):
     """Creates a git scm proxy that assumes the git repository is in the cwd by default.
 
     binary:    The path to the git binary to use, 'git' by default.
@@ -99,12 +103,6 @@ class Git(Scm):
     self._gitdir = os.path.realpath(gitdir) if gitdir else os.path.join(self._worktree, '.git')
     self._remote = remote
     self._branch = branch
-
-    if log:
-      self._log = log
-    else:
-      import logging
-      self._log = logging.getLogger(__name__)
 
   def current_rev_identifier(self):
     return 'HEAD'
@@ -210,12 +208,12 @@ class Git(Scm):
       self._check_call(['rebase', 'FETCH_HEAD'], raise_type=Scm.LocalException)
     except Scm.LocalException as e:
       if leave_clean:
-        self._log.debug('Cleaning up after failed rebase')
+        logger.debug('Cleaning up after failed rebase')
         try:
           self._check_call(['rebase', '--abort'], raise_type=Scm.LocalException)
         except Scm.LocalException as abort_exc:
-          self._log.debug('Failed to up after failed rebase')
-          self._log.debug(traceback.format_exc(abort_exc))
+          logger.debug('Failed to up after failed rebase')
+          logger.debug(traceback.format_exc(abort_exc))
           # But let the original exception propagate, since that's the more interesting one
       raise e
 
@@ -276,7 +274,7 @@ class Git(Scm):
     return [self._gitcmd, '--git-dir=' + self._gitdir, '--work-tree=' + self._worktree] + args
 
   def _log_call(self, cmd):
-    self._log.debug('Executing: ' + ' '.join(cmd))
+    logger.debug('Executing: ' + ' '.join(cmd))
 
   def repo_reader(self, rev):
     return GitRepositoryReader(self, rev)

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -16,7 +16,7 @@ python_tests(
     ':scheduler_test_base',
     'src/python/pants/engine/exp:fs',
     'src/python/pants/engine/exp:nodes',
-    'tests/python/pants_test/util:git_util',
+    'tests/python/pants_test/testutils:git_util',
   ]
 )
 

--- a/tests/python/pants_test/engine/exp/BUILD
+++ b/tests/python/pants_test/engine/exp/BUILD
@@ -16,6 +16,7 @@ python_tests(
     ':scheduler_test_base',
     'src/python/pants/engine/exp:fs',
     'src/python/pants/engine/exp:nodes',
+    'tests/python/pants_test/util:git_util',
   ]
 )
 

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -20,6 +20,7 @@ from pants.util.contextutil import environment_as
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants.util.meta import AbstractClass
 from pants_test.engine.exp.scheduler_test_base import SchedulerTestBase
+from pants_test.testutils.git_util import Version, git_version
 
 
 class FSTestBase(SchedulerTestBase, AbstractClass):
@@ -114,6 +115,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('4.txt'), Stats),
       ])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_file(self):
     self.assert_fsnodes(Files, ['c.ln/2'], [
         (Link('c.ln'), ReadLink),
@@ -169,6 +171,7 @@ class PosixFSTest(unittest.TestCase, FSTestBase):
     yield self.mk_fs_tree(build_root_src)
 
 
+@unittest.skipIf(git_version() < Version('1.7.10'), 'The GitTest requires git >= 1.7.10.')
 class GitFSTest(unittest.TestCase, FSTestBase):
 
   @contextmanager

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -57,7 +57,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
                 if type(n) is FilesystemNode]
     self.assertEquals(set((n.subject, n.product) for n in fs_nodes), set(subject_product_pairs))
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_literal(self):
     self.assert_walk(Files, ['4.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/1.txt', 'a/b/2'], ['a/b/1.txt', 'a/b/2'])
@@ -66,7 +66,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/3.txt'], ['a/3.txt'])
     self.assert_walk(Files, ['z.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_literal_directory(self):
     self.assert_walk(Dirs, ['c.ln'], ['a/b'])
     self.assert_walk(Dirs, ['a'], ['a'])
@@ -74,7 +74,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Dirs, ['z'], [])
     self.assert_walk(Dirs, ['4.txt', 'a/3.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_siblings(self):
     self.assert_walk(Files, ['*.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/*.txt'], ['a/b/1.txt'])
@@ -82,7 +82,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/b/*'], ['a/b/1.txt', 'a/b/2'])
     self.assert_walk(Files, ['*/0.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive(self):
     self.assert_walk(Files, ['**/*.txt.ln'], ['4.txt'])
     self.assert_walk(Files, ['**/*.txt'], ['a/3.txt', 'a/b/1.txt'])
@@ -90,14 +90,14 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['*', '**/*'], ['a/3.txt', 'a/b/1.txt', '4.txt', 'a/b/2'])
     self.assert_walk(Files, ['**/*.zzz'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive_directory(self):
     self.assert_walk(Dirs, ['*'], ['a', 'a/b'])
     self.assert_walk(Dirs, ['*/*'], ['a/b'])
     self.assert_walk(Dirs, ['**/*'], ['a/b'])
     self.assert_walk(Dirs, ['*/*/*'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_literal(self):
     self.assert_content(['4.txt'], {'4.txt': 'four\n'})
     self.assert_content(['a/4.txt.ln'], {'4.txt': 'four\n'})
@@ -108,12 +108,13 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     with self.assertRaises(Exception):
       self.assert_content(['a/b'], {'a/b': 'nope\n'})
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_file(self):
     self.assert_fsnodes(Files, ['4.txt'], [
         (Path('4.txt'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_file(self):
     self.assert_fsnodes(Files, ['c.ln/2'], [
         (Link('c.ln'), ReadLink),
@@ -129,7 +130,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/b/1.txt'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_dir(self):
     self.assert_fsnodes(Files, ['*/2'], [
         # Glob the root.
@@ -149,7 +150,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/2'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_file(self):
     self.assert_fsnodes(Files, ['d.ln/b/*.txt'], [
         # NB: Needs to stat every path on the way down to track whether

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -57,6 +57,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
                 if type(n) is FilesystemNode]
     self.assertEquals(set((n.subject, n.product) for n in fs_nodes), set(subject_product_pairs))
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_walk_literal(self):
     self.assert_walk(Files, ['4.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/1.txt', 'a/b/2'], ['a/b/1.txt', 'a/b/2'])
@@ -65,6 +66,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/3.txt'], ['a/3.txt'])
     self.assert_walk(Files, ['z.txt'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_walk_literal_directory(self):
     self.assert_walk(Dirs, ['c.ln'], ['a/b'])
     self.assert_walk(Dirs, ['a'], ['a'])
@@ -72,6 +74,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Dirs, ['z'], [])
     self.assert_walk(Dirs, ['4.txt', 'a/3.txt'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_walk_siblings(self):
     self.assert_walk(Files, ['*.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/*.txt'], ['a/b/1.txt'])
@@ -79,6 +82,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/b/*'], ['a/b/1.txt', 'a/b/2'])
     self.assert_walk(Files, ['*/0.txt'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_walk_recursive(self):
     self.assert_walk(Files, ['**/*.txt.ln'], ['4.txt'])
     self.assert_walk(Files, ['**/*.txt'], ['a/3.txt', 'a/b/1.txt'])
@@ -86,12 +90,14 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['*', '**/*'], ['a/3.txt', 'a/b/1.txt', '4.txt', 'a/b/2'])
     self.assert_walk(Files, ['**/*.zzz'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_walk_recursive_directory(self):
     self.assert_walk(Dirs, ['*'], ['a', 'a/b'])
     self.assert_walk(Dirs, ['*/*'], ['a/b'])
     self.assert_walk(Dirs, ['**/*'], ['a/b'])
     self.assert_walk(Dirs, ['*/*/*'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_files_content_literal(self):
     self.assert_content(['4.txt'], {'4.txt': 'four\n'})
     self.assert_content(['a/4.txt.ln'], {'4.txt': 'four\n'})
@@ -107,6 +113,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('4.txt'), Stats),
       ])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_nodes_symlink_file(self):
     self.assert_fsnodes(Files, ['c.ln/2'], [
         (Link('c.ln'), ReadLink),
@@ -122,6 +129,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/b/1.txt'), Stats),
       ])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_nodes_symlink_globbed_dir(self):
     self.assert_fsnodes(Files, ['*/2'], [
         # Glob the root.
@@ -141,6 +149,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/2'), Stats),
       ])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3189')
   def test_nodes_symlink_globbed_file(self):
     self.assert_fsnodes(Files, ['d.ln/b/*.txt'], [
         # NB: Needs to stat every path on the way down to track whether

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import subprocess
 import unittest
 from abc import abstractmethod
 from contextlib import contextmanager
@@ -15,9 +14,6 @@ from pants.base.scm_project_tree import ScmProjectTree
 from pants.engine.exp.fs import (Dir, DirectoryListing, Dirs, FileContent, Files, Link, Path,
                                  PathGlobs, ReadLink, Stat, Stats)
 from pants.engine.exp.nodes import FilesystemNode
-from pants.scm.git import Git
-from pants.util.contextutil import environment_as
-from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants.util.meta import AbstractClass
 from pants_test.engine.exp.scheduler_test_base import SchedulerTestBase
 from pants_test.testutils.git_util import Version, git_version, initialize_repo
@@ -179,5 +175,3 @@ class GitFSTest(unittest.TestCase, FSTestBase):
     worktree = self.mk_fs_tree(build_root_src).build_root
     with initialize_repo(worktree) as git_repo:
       yield ScmProjectTree(worktree, git_repo, 'HEAD')
-
-    safe_rmtree(worktree)

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -81,7 +81,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/b/*'], ['a/b/1.txt', 'a/b/2'])
     self.assert_walk(Files, ['*/0.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive(self):
     self.assert_walk(Files, ['**/*.txt.ln'], ['4.txt'])
     self.assert_walk(Files, ['**/*.txt'], ['a/3.txt', 'a/b/1.txt'])
@@ -95,7 +94,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Dirs, ['**/*'], ['a/b'])
     self.assert_walk(Dirs, ['*/*/*'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_literal(self):
     self.assert_content(['4.txt'], {'4.txt': 'four\n'})
     self.assert_content(['a/4.txt.ln'], {'4.txt': 'four\n'})
@@ -176,3 +174,11 @@ class GitFSTest(unittest.TestCase, FSTestBase):
     worktree = self.mk_fs_tree(build_root_src).build_root
     with initialize_repo(worktree) as git_repo:
       yield ScmProjectTree(worktree, git_repo, 'HEAD')
+
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
+  def test_walk_recursive(self):
+    super(GitFSTest, self).test_walk_recursive()
+
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
+  def test_files_content_literal(self):
+    super(GitFSTest, self).test_files_content_literal()

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -115,7 +115,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('4.txt'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_file(self):
     self.assert_fsnodes(Files, ['c.ln/2'], [
         (Link('c.ln'), ReadLink),

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -16,7 +16,7 @@ from pants.engine.exp.fs import (Dir, DirectoryListing, Dirs, FileContent, Files
 from pants.engine.exp.nodes import FilesystemNode
 from pants.util.meta import AbstractClass
 from pants_test.engine.exp.scheduler_test_base import SchedulerTestBase
-from pants_test.testutils.git_util import Version, git_version, initialize_repo
+from pants_test.testutils.git_util import MIN_REQUIRED_GIT_VERSION, git_version, initialize_repo
 
 
 class FSTestBase(SchedulerTestBase, AbstractClass):
@@ -166,7 +166,8 @@ class PosixFSTest(unittest.TestCase, FSTestBase):
     yield self.mk_fs_tree(build_root_src)
 
 
-@unittest.skipIf(git_version() < Version('1.7.10'), 'The GitTest requires git >= 1.7.10.')
+@unittest.skipIf(git_version() < MIN_REQUIRED_GIT_VERSION,
+                 'The GitTest requires git >= {}.'.format(MIN_REQUIRED_GIT_VERSION))
 class GitFSTest(unittest.TestCase, FSTestBase):
 
   @contextmanager

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -6,23 +6,29 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import shutil
+import subprocess
 import unittest
 from abc import abstractmethod
+from contextlib import contextmanager
 
 from pants.base.scm_project_tree import ScmProjectTree
 from pants.engine.exp.fs import (Dir, DirectoryListing, Dirs, FileContent, Files, Link, Path,
                                  PathGlobs, ReadLink, Stat, Stats)
 from pants.engine.exp.nodes import FilesystemNode
 from pants.scm.git import Git
+from pants.util.contextutil import environment_as
+from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants.util.meta import AbstractClass
 from pants_test.engine.exp.scheduler_test_base import SchedulerTestBase
 
 
-class FSTestBase(SchedulerTestBase, AbstractClass):
+class FSTestBase(AbstractClass, SchedulerTestBase):
 
-  _build_root_src = os.path.join(os.path.dirname(__file__), 'examples/fs_test')
+  _original_src = os.path.join(os.path.dirname(__file__), 'examples/fs_test')
 
   @abstractmethod
+  @contextmanager
   def mk_project_tree(self, build_root_src):
     """Construct a ProjectTree for the given src path."""
     pass
@@ -31,31 +37,31 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     return PathGlobs.create_from_specs(ftype, relative_to, filespecs)
 
   def assert_walk(self, ftype, filespecs, files):
-    project_tree = self.mk_project_tree(self._build_root_src)
-    scheduler, storage = self.mk_scheduler(project_tree=project_tree)
-    result = self.execute(scheduler, storage, Stat, self.specs(ftype, '', *filespecs))[0]
-    self.assertEquals(set(files), set([p.path for p in result]))
+    with self.mk_project_tree(self._original_src) as project_tree:
+      scheduler, storage = self.mk_scheduler(project_tree=project_tree)
+      result = self.execute(scheduler, storage, Stat, self.specs(ftype, '', *filespecs))[0]
+      self.assertEquals(set(files), set([p.path for p in result]))
 
   def assert_content(self, filespecs, expected_content):
-    project_tree = self.mk_project_tree(self._build_root_src)
-    scheduler, storage = self.mk_scheduler(project_tree=project_tree)
-    result = self.execute(scheduler, storage, FileContent, self.specs(Files, '', *filespecs))[0]
-    def validate(e):
-      self.assertEquals(type(e), FileContent)
-      return True
-    actual_content = {f.path: f.content for f in result if validate(f)}
-    self.assertEquals(expected_content, actual_content)
+    with self.mk_project_tree(self._original_src) as project_tree:
+      scheduler, storage = self.mk_scheduler(project_tree=project_tree)
+      result = self.execute(scheduler, storage, FileContent, self.specs(Files, '', *filespecs))[0]
+      def validate(e):
+        self.assertEquals(type(e), FileContent)
+        return True
+      actual_content = {f.path: f.content for f in result if validate(f)}
+      self.assertEquals(expected_content, actual_content)
 
   def assert_fsnodes(self, ftype, filespecs, subject_product_pairs):
-    project_tree = self.mk_project_tree(self._build_root_src)
-    scheduler, storage = self.mk_scheduler(project_tree=project_tree)
-    request = self.execute_request(scheduler, storage, Stat, self.specs(ftype, '', *filespecs))
+    with self.mk_project_tree(self._original_src) as project_tree:
+      scheduler, storage = self.mk_scheduler(project_tree=project_tree)
+      request = self.execute_request(scheduler, storage, Stat, self.specs(ftype, '', *filespecs))
 
-    # Validate that FilesystemNodes for exactly the given subjects are reachable under this
-    # request.
-    fs_nodes = [n for ((n, _), _) in scheduler.product_graph.walk(roots=request.roots)
-                if type(n) is FilesystemNode]
-    self.assertEquals(set((n.subject, n.product) for n in fs_nodes), set(subject_product_pairs))
+      # Validate that FilesystemNodes for exactly the given subjects are reachable under this
+      # request.
+      fs_nodes = [n for ((n, _), _) in scheduler.product_graph.walk(roots=request.roots)
+                  if type(n) is FilesystemNode]
+      self.assertEquals(set((n.subject, n.product) for n in fs_nodes), set(subject_product_pairs))
 
   def test_walk_literal(self):
     self.assert_walk(Files, ['4.txt'], ['4.txt'])
@@ -65,6 +71,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/3.txt'], ['a/3.txt'])
     self.assert_walk(Files, ['z.txt'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_literal_directory(self):
     self.assert_walk(Dirs, ['c.ln'], ['a/b'])
     self.assert_walk(Dirs, ['a'], ['a'])
@@ -72,6 +79,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Dirs, ['z'], [])
     self.assert_walk(Dirs, ['4.txt', 'a/3.txt'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_siblings(self):
     self.assert_walk(Files, ['*.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/*.txt'], ['a/b/1.txt'])
@@ -79,6 +87,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/b/*'], ['a/b/1.txt', 'a/b/2'])
     self.assert_walk(Files, ['*/0.txt'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive(self):
     self.assert_walk(Files, ['**/*.txt.ln'], ['4.txt'])
     self.assert_walk(Files, ['**/*.txt'], ['a/3.txt', 'a/b/1.txt'])
@@ -86,27 +95,32 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['*', '**/*'], ['a/3.txt', 'a/b/1.txt', '4.txt', 'a/b/2'])
     self.assert_walk(Files, ['**/*.zzz'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive_directory(self):
     self.assert_walk(Dirs, ['*'], ['a', 'a/b'])
     self.assert_walk(Dirs, ['*/*'], ['a/b'])
     self.assert_walk(Dirs, ['**/*'], ['a/b'])
     self.assert_walk(Dirs, ['*/*/*'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_literal(self):
     self.assert_content(['4.txt'], {'4.txt': 'four\n'})
     self.assert_content(['a/4.txt.ln'], {'4.txt': 'four\n'})
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_directory(self):
     with self.assertRaises(Exception):
       self.assert_content(['a/b/'], {'a/b/': 'nope\n'})
     with self.assertRaises(Exception):
       self.assert_content(['a/b'], {'a/b': 'nope\n'})
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_file(self):
     self.assert_fsnodes(Files, ['4.txt'], [
         (Path('4.txt'), Stats),
       ])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_file(self):
     self.assert_fsnodes(Files, ['c.ln/2'], [
         (Link('c.ln'), ReadLink),
@@ -122,6 +136,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/b/1.txt'), Stats),
       ])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_dir(self):
     self.assert_fsnodes(Files, ['*/2'], [
         # Glob the root.
@@ -141,6 +156,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/2'), Stats),
       ])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_file(self):
     self.assert_fsnodes(Files, ['d.ln/b/*.txt'], [
         # NB: Needs to stat every path on the way down to track whether
@@ -155,15 +171,26 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
       ])
 
 
-class PosixFSTest(unittest.TestCase, FSTestBase):
+class PosixFSTest(FSTestBase):
 
+  @contextmanager
   def mk_project_tree(self, build_root_src):
-    return self.mk_fs_tree(build_root_src)
+    yield self.mk_fs_tree(build_root_src)
 
 
-# TODO: See https://github.com/pantsbuild/pants/issues/3281
-@unittest.expectedFailure
 class GitFSTest(unittest.TestCase, FSTestBase):
 
+  @contextmanager
   def mk_project_tree(self, build_root_src):
-    return ScmProjectTree(build_root_src, Git(worktree=build_root_src), 'HEAD')
+    gitdir = safe_mkdtemp()
+    worktree = self.mk_fs_tree(self._original_src).build_root
+    with environment_as(GIT_DIR=gitdir, GIT_WORK_TREE=worktree):
+      subprocess.check_call(['git', 'init'])
+      for file in ['4.txt', 'a', 'c.ln', 'd.ln']:
+        subprocess.check_call(['git', 'add', file])
+      subprocess.check_call(['git', 'commit', '-am', 'Add files.'])
+
+      yield ScmProjectTree(build_root_src, Git(gitdir=gitdir, worktree=worktree), 'HEAD')
+
+    safe_rmtree(gitdir)
+    safe_rmtree(worktree)

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import shutil
 import subprocess
 import unittest
 from abc import abstractmethod
@@ -85,6 +84,7 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
     self.assert_walk(Files, ['a/b/*'], ['a/b/1.txt', 'a/b/2'])
     self.assert_walk(Files, ['*/0.txt'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive(self):
     self.assert_walk(Files, ['**/*.txt.ln'], ['4.txt'])
     self.assert_walk(Files, ['**/*.txt'], ['a/3.txt', 'a/b/1.txt'])
@@ -98,6 +98,7 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
     self.assert_walk(Dirs, ['**/*'], ['a/b'])
     self.assert_walk(Dirs, ['*/*/*'], [])
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_literal(self):
     self.assert_content(['4.txt'], {'4.txt': 'four\n'})
     self.assert_content(['a/4.txt.ln'], {'4.txt': 'four\n'})

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -161,8 +161,6 @@ class PosixFSTest(unittest.TestCase, FSTestBase):
     return self.mk_fs_tree(build_root_src)
 
 
-# TODO: See https://github.com/pantsbuild/pants/issues/3189
-@unittest.expectedFailure
 class GitFSTest(unittest.TestCase, FSTestBase):
 
   def mk_project_tree(self, build_root_src):

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -181,6 +181,8 @@ class GitFSTest(unittest.TestCase, FSTestBase):
     worktree = self.mk_fs_tree(build_root_src).build_root
     with environment_as(GIT_DIR=gitdir, GIT_WORK_TREE=worktree):
       subprocess.check_call(['git', 'init'])
+      subprocess.check_call(['git', 'config', 'user.email', 'you@example.com'])
+      subprocess.check_call(['git', 'config', 'user.name', 'Your Name'])
       for file in ['4.txt', 'a', 'c.ln', 'd.ln']:
         subprocess.check_call(['git', 'add', file])
       subprocess.check_call(['git', 'commit', '-am', 'Add project files.'])

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -22,7 +22,7 @@ from pants.util.meta import AbstractClass
 from pants_test.engine.exp.scheduler_test_base import SchedulerTestBase
 
 
-class FSTestBase(AbstractClass, SchedulerTestBase):
+class FSTestBase(SchedulerTestBase, AbstractClass):
 
   _original_src = os.path.join(os.path.dirname(__file__), 'examples/fs_test')
 
@@ -162,7 +162,7 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
       ])
 
 
-class PosixFSTest(FSTestBase):
+class PosixFSTest(unittest.TestCase, FSTestBase):
 
   @contextmanager
   def mk_project_tree(self, build_root_src):

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -57,7 +57,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
                 if type(n) is FilesystemNode]
     self.assertEquals(set((n.subject, n.product) for n in fs_nodes), set(subject_product_pairs))
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_literal(self):
     self.assert_walk(Files, ['4.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/1.txt', 'a/b/2'], ['a/b/1.txt', 'a/b/2'])
@@ -66,7 +65,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/3.txt'], ['a/3.txt'])
     self.assert_walk(Files, ['z.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_literal_directory(self):
     self.assert_walk(Dirs, ['c.ln'], ['a/b'])
     self.assert_walk(Dirs, ['a'], ['a'])
@@ -74,7 +72,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Dirs, ['z'], [])
     self.assert_walk(Dirs, ['4.txt', 'a/3.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_siblings(self):
     self.assert_walk(Files, ['*.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/*.txt'], ['a/b/1.txt'])
@@ -82,7 +79,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['a/b/*'], ['a/b/1.txt', 'a/b/2'])
     self.assert_walk(Files, ['*/0.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive(self):
     self.assert_walk(Files, ['**/*.txt.ln'], ['4.txt'])
     self.assert_walk(Files, ['**/*.txt'], ['a/3.txt', 'a/b/1.txt'])
@@ -90,14 +86,12 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     self.assert_walk(Files, ['*', '**/*'], ['a/3.txt', 'a/b/1.txt', '4.txt', 'a/b/2'])
     self.assert_walk(Files, ['**/*.zzz'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive_directory(self):
     self.assert_walk(Dirs, ['*'], ['a', 'a/b'])
     self.assert_walk(Dirs, ['*/*'], ['a/b'])
     self.assert_walk(Dirs, ['**/*'], ['a/b'])
     self.assert_walk(Dirs, ['*/*/*'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_literal(self):
     self.assert_content(['4.txt'], {'4.txt': 'four\n'})
     self.assert_content(['a/4.txt.ln'], {'4.txt': 'four\n'})
@@ -108,13 +102,11 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
     with self.assertRaises(Exception):
       self.assert_content(['a/b'], {'a/b': 'nope\n'})
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_file(self):
     self.assert_fsnodes(Files, ['4.txt'], [
         (Path('4.txt'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_file(self):
     self.assert_fsnodes(Files, ['c.ln/2'], [
         (Link('c.ln'), ReadLink),
@@ -130,7 +122,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/b/1.txt'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_dir(self):
     self.assert_fsnodes(Files, ['*/2'], [
         # Glob the root.
@@ -150,7 +141,6 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
         (Path('a/2'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_file(self):
     self.assert_fsnodes(Files, ['d.ln/b/*.txt'], [
         # NB: Needs to stat every path on the way down to track whether
@@ -171,6 +161,8 @@ class PosixFSTest(unittest.TestCase, FSTestBase):
     return self.mk_fs_tree(build_root_src)
 
 
+# TODO: See https://github.com/pantsbuild/pants/issues/3281
+@unittest.expectedFailure
 class GitFSTest(unittest.TestCase, FSTestBase):
 
   def mk_project_tree(self, build_root_src):

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -174,12 +174,14 @@ class GitFSTest(unittest.TestCase, FSTestBase):
   @contextmanager
   def mk_project_tree(self, build_root_src):
     gitdir = safe_mkdtemp()
+
+    # Use mk_fs_tree only to feed the files for the git repo, not using its FileSystemProjectTree.
     worktree = self.mk_fs_tree(build_root_src).build_root
     with environment_as(GIT_DIR=gitdir, GIT_WORK_TREE=worktree):
       subprocess.check_call(['git', 'init'])
       for file in ['4.txt', 'a', 'c.ln', 'd.ln']:
         subprocess.check_call(['git', 'add', file])
-      subprocess.check_call(['git', 'commit', '-am', 'Add files.'])
+      subprocess.check_call(['git', 'commit', '-am', 'Add project files.'])
 
       yield ScmProjectTree(worktree, Git(gitdir=gitdir, worktree=worktree), 'HEAD')
 

--- a/tests/python/pants_test/engine/exp/test_fs.py
+++ b/tests/python/pants_test/engine/exp/test_fs.py
@@ -71,7 +71,6 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
     self.assert_walk(Files, ['a/3.txt'], ['a/3.txt'])
     self.assert_walk(Files, ['z.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_literal_directory(self):
     self.assert_walk(Dirs, ['c.ln'], ['a/b'])
     self.assert_walk(Dirs, ['a'], ['a'])
@@ -79,7 +78,6 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
     self.assert_walk(Dirs, ['z'], [])
     self.assert_walk(Dirs, ['4.txt', 'a/3.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_siblings(self):
     self.assert_walk(Files, ['*.txt'], ['4.txt'])
     self.assert_walk(Files, ['a/b/*.txt'], ['a/b/1.txt'])
@@ -87,7 +85,6 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
     self.assert_walk(Files, ['a/b/*'], ['a/b/1.txt', 'a/b/2'])
     self.assert_walk(Files, ['*/0.txt'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive(self):
     self.assert_walk(Files, ['**/*.txt.ln'], ['4.txt'])
     self.assert_walk(Files, ['**/*.txt'], ['a/3.txt', 'a/b/1.txt'])
@@ -95,32 +92,27 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
     self.assert_walk(Files, ['*', '**/*'], ['a/3.txt', 'a/b/1.txt', '4.txt', 'a/b/2'])
     self.assert_walk(Files, ['**/*.zzz'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_walk_recursive_directory(self):
     self.assert_walk(Dirs, ['*'], ['a', 'a/b'])
     self.assert_walk(Dirs, ['*/*'], ['a/b'])
     self.assert_walk(Dirs, ['**/*'], ['a/b'])
     self.assert_walk(Dirs, ['*/*/*'], [])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_literal(self):
     self.assert_content(['4.txt'], {'4.txt': 'four\n'})
     self.assert_content(['a/4.txt.ln'], {'4.txt': 'four\n'})
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_files_content_directory(self):
     with self.assertRaises(Exception):
       self.assert_content(['a/b/'], {'a/b/': 'nope\n'})
     with self.assertRaises(Exception):
       self.assert_content(['a/b'], {'a/b': 'nope\n'})
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_file(self):
     self.assert_fsnodes(Files, ['4.txt'], [
         (Path('4.txt'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_file(self):
     self.assert_fsnodes(Files, ['c.ln/2'], [
         (Link('c.ln'), ReadLink),
@@ -136,7 +128,6 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
         (Path('a/b/1.txt'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_dir(self):
     self.assert_fsnodes(Files, ['*/2'], [
         # Glob the root.
@@ -156,7 +147,6 @@ class FSTestBase(AbstractClass, SchedulerTestBase):
         (Path('a/2'), Stats),
       ])
 
-  @unittest.skip('https://github.com/pantsbuild/pants/issues/3281')
   def test_nodes_symlink_globbed_file(self):
     self.assert_fsnodes(Files, ['d.ln/b/*.txt'], [
         # NB: Needs to stat every path on the way down to track whether
@@ -183,14 +173,14 @@ class GitFSTest(unittest.TestCase, FSTestBase):
   @contextmanager
   def mk_project_tree(self, build_root_src):
     gitdir = safe_mkdtemp()
-    worktree = self.mk_fs_tree(self._original_src).build_root
+    worktree = self.mk_fs_tree(build_root_src).build_root
     with environment_as(GIT_DIR=gitdir, GIT_WORK_TREE=worktree):
       subprocess.check_call(['git', 'init'])
       for file in ['4.txt', 'a', 'c.ln', 'd.ln']:
         subprocess.check_call(['git', 'add', file])
       subprocess.check_call(['git', 'commit', '-am', 'Add files.'])
 
-      yield ScmProjectTree(build_root_src, Git(gitdir=gitdir, worktree=worktree), 'HEAD')
+      yield ScmProjectTree(worktree, Git(gitdir=gitdir, worktree=worktree), 'HEAD')
 
     safe_rmtree(gitdir)
     safe_rmtree(worktree)

--- a/tests/python/pants_test/scm/BUILD
+++ b/tests/python/pants_test/scm/BUILD
@@ -9,6 +9,6 @@ python_tests(
     'src/python/pants/scm:git',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
-    'tests/python/pants_test/util:git_util',
+    'tests/python/pants_test/testutils:git_util',
   ]
 )

--- a/tests/python/pants_test/scm/BUILD
+++ b/tests/python/pants_test/scm/BUILD
@@ -9,5 +9,6 @@ python_tests(
     'src/python/pants/scm:git',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'tests/python/pants_test/util:git_util',
   ]
 )

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -6,12 +6,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import re
 import subprocess
 import types
 import unittest
 from contextlib import contextmanager
-from itertools import izip_longest
 from textwrap import dedent
 from unittest import skipIf
 
@@ -19,19 +17,7 @@ from pants.scm.git import Git
 from pants.scm.scm import Scm
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import chmod_plus_x, safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree, touch
-
-
-class Version(object):
-
-  def __init__(self, text):
-    self._components = map(int, text.split('.'))
-
-  def __cmp__(self, other):
-    for ours, theirs in izip_longest(self._components, other._components, fillvalue=0):
-      difference = cmp(ours, theirs)
-      if difference != 0:
-        return difference
-    return 0
+from pants_test.testutils.git_util import Version, git_version
 
 
 class VersionTest(unittest.TestCase):
@@ -53,16 +39,6 @@ class VersionTest(unittest.TestCase):
     self.assertTrue(Version('1.6.22') > Version('1.6.2'))
     self.assertTrue(Version('1.6.22') > Version('1.6.21'))
     self.assertTrue(Version('1.6.22') > Version('1.6.21.3'))
-
-
-def git_version():
-  """Get a Version() based on installed command-line git's version"""
-  process = subprocess.Popen(['git', '--version'], stdout=subprocess.PIPE)
-  (stdout, stderr) = process.communicate()
-  assert process.returncode == 0, "Failed to determine git version."
-  # stdout is like 'git version 1.9.1.598.g9119e8b\n'  We want '1.9.1.598'
-  matches = re.search(r'\s(\d+(?:\.\d+)*)[\s\.]', stdout)
-  return Version(matches.group(1))
 
 
 @skipIf(git_version() < Version('1.7.10'), 'The GitTest requires git >= 1.7.10.')

--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -17,35 +17,16 @@ from pants.scm.git import Git
 from pants.scm.scm import Scm
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import chmod_plus_x, safe_mkdir, safe_mkdtemp, safe_open, safe_rmtree, touch
-from pants_test.testutils.git_util import Version, git_version
+from pants_test.testutils.git_util import MIN_REQUIRED_GIT_VERSION, git_version
 
 
-class VersionTest(unittest.TestCase):
-
-  def test_equal(self):
-    self.assertEqual(Version('1'), Version('1.0.0.0'))
-    self.assertEqual(Version('1.0'), Version('1.0.0.0'))
-    self.assertEqual(Version('1.0.0'), Version('1.0.0.0'))
-    self.assertEqual(Version('1.0.0.0'), Version('1.0.0.0'))
-
-  def test_less(self):
-    self.assertTrue(Version('1.6') < Version('2'))
-    self.assertTrue(Version('1.6') < Version('1.6.1'))
-    self.assertTrue(Version('1.6') < Version('1.10'))
-
-  def test_greater(self):
-    self.assertTrue(Version('1.6.22') > Version('1'))
-    self.assertTrue(Version('1.6.22') > Version('1.6'))
-    self.assertTrue(Version('1.6.22') > Version('1.6.2'))
-    self.assertTrue(Version('1.6.22') > Version('1.6.21'))
-    self.assertTrue(Version('1.6.22') > Version('1.6.21.3'))
-
-
-@skipIf(git_version() < Version('1.7.10'), 'The GitTest requires git >= 1.7.10.')
+@skipIf(git_version() < MIN_REQUIRED_GIT_VERSION,
+        'The GitTest requires git >= {}.'.format(MIN_REQUIRED_GIT_VERSION))
 class GitTest(unittest.TestCase):
 
   @staticmethod
   def init_repo(remote_name, remote):
+    # TODO (peiyu) clean this up, use `git_util.initialize_repo`.
     subprocess.check_call(['git', 'init'])
     subprocess.check_call(['git', 'config', 'user.email', 'you@example.com'])
     subprocess.check_call(['git', 'config', 'user.name', 'Your Name'])

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -25,4 +25,7 @@ python_library(
   sources = [
     'git_util.py',
   ],
+  dependencies = [
+    'src/python/pants/scm:git',
+  ],
 )

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -19,3 +19,10 @@ python_library(
     'src/python/pants/util:contextutil',
   ],
 )
+
+python_library(
+  name = 'git_util',
+  sources = [
+    'git_util.py',
+  ],
+)

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -26,6 +26,7 @@ python_library(
     'git_util.py',
   ],
   dependencies = [
+    'src/python/pants/base:revision',
     'src/python/pants/scm:git',
   ],
 )

--- a/tests/python/pants_test/testutils/git_util.py
+++ b/tests/python/pants_test/testutils/git_util.py
@@ -8,24 +8,14 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import re
 import subprocess
 from contextlib import contextmanager
-from itertools import izip_longest
 
+from pants.base.revision import Revision
 from pants.scm.git import Git
 from pants.util.contextutil import environment_as
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 
 
-class Version(object):
-
-  def __init__(self, text):
-    self._components = map(int, text.split('.'))
-
-  def __cmp__(self, other):
-    for ours, theirs in izip_longest(self._components, other._components, fillvalue=0):
-      difference = cmp(ours, theirs)
-      if difference != 0:
-        return difference
-    return 0
+MIN_REQUIRED_GIT_VERSION = Revision.semver('1.7.10')
 
 
 def git_version():
@@ -35,7 +25,7 @@ def git_version():
   assert process.returncode == 0, "Failed to determine git version."
   # stdout is like 'git version 1.9.1.598.g9119e8b\n'  We want '1.9.1.598'
   matches = re.search(r'\s(\d+(?:\.\d+)*)[\s\.]', stdout)
-  return Version(matches.group(1))
+  return Revision.lenient(matches.group(1))
 
 
 @contextmanager

--- a/tests/python/pants_test/testutils/git_util.py
+++ b/tests/python/pants_test/testutils/git_util.py
@@ -1,0 +1,33 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import re
+import subprocess
+from itertools import izip_longest
+
+
+class Version(object):
+
+  def __init__(self, text):
+    self._components = map(int, text.split('.'))
+
+  def __cmp__(self, other):
+    for ours, theirs in izip_longest(self._components, other._components, fillvalue=0):
+      difference = cmp(ours, theirs)
+      if difference != 0:
+        return difference
+    return 0
+
+
+def git_version():
+  """Get a Version() based on installed command-line git's version"""
+  process = subprocess.Popen(['git', '--version'], stdout=subprocess.PIPE)
+  (stdout, stderr) = process.communicate()
+  assert process.returncode == 0, "Failed to determine git version."
+  # stdout is like 'git version 1.9.1.598.g9119e8b\n'  We want '1.9.1.598'
+  matches = re.search(r'\s(\d+(?:\.\d+)*)[\s\.]', stdout)
+  return Version(matches.group(1))


### PR DESCRIPTION
Two things to make `ScmProjectTree` picklable in #3189 :

* `_reader`, `GitRepositoryReader` contains a `Popen` instance. This review marks it `@memoized` so it is saved by memoized.
* `_scm`, `Git` contains a logger, this review moves the logger to the module.

Also added is to initialize Git FS for test, only two tests fail now, created https://github.com/pantsbuild/pants/issues/3281 to address separately.