### PR TITLE
Fixup `PythonChrootTest.test_thrift_issues_2005`.

### DIFF
--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -201,7 +201,9 @@ class PythonChrootTest(BaseTest):
         self.assertEqual('Hello World!', stdout.strip())
 
         if inspect_chroot:
-          inspect_chroot(python_chroot)
+          # Snap a clean copy of the chroot with just the chroots added files.
+          chroot = pex_builder.clone().path()
+          inspect_chroot(chroot)
 
   def test_thrift(self):
     with self.do_test_thrift():
@@ -232,9 +234,9 @@ class PythonChrootTest(BaseTest):
     # PythonThriftLibrary's thrift files as well as its transitive dependencies thrift files.
     # We test here that the generated chroot only contains 1 copy of each thrift stub in the face
     # of transitive thrift deps.
-    def inspect_chroot(python_chroot):
+    def inspect_chroot(chroot):
       all_constants_files = set()
-      for root, _, files in os.walk(python_chroot.path()):
+      for root, _, files in os.walk(chroot):
         all_constants_files.update(os.path.join(root, f) for f in files if f == 'constants.py')
 
       # If core/constants.py was included in test/ we'd have 2 copies of core/constants.py plus


### PR DESCRIPTION
Previously, the test walked a pex chroot to do a tally of files.  This
approach was flawed since a pex chroot object rooted at a (temporary)
path can have files under the root that are not owned by the chroot
object. In order for the chroot object to own a file, it has to be added
via its API.  Its just these files that make it into a frozen pex.  In
the case of pants pex chroots, the chroot dir is used as a convenient
temp-dir base behind pex's back (files added to the temp-dirs are not
added to the pex chroot object).  This change fixes the chroot
inspection code to act against a clean copy of the chroot object's view
of the chroot.

This addresses #3288 

https://rbcommons.com/s/twitter/r/3774/