### PR TITLE
Fix distribution tests in the face of many javas.

### DIFF
--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -288,7 +288,8 @@ class ExportTask(IvyTaskMixin, PythonTask):
     jvm_distributions = DistributionLocator.global_instance().all_jdk_paths()
     if jvm_distributions:
       deprecated_conditional(lambda: True, '0.0.89',
-                             'jvm_distributions is deprecated in favor of preferred_jvm_distributions.')
+                             'jvm_distributions is deprecated in favor of '
+                             'preferred_jvm_distributions.')
       graph_info['jvm_distributions'] = jvm_distributions
 
     # `jvm_distributions` are static distribution settings from config,

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -598,7 +598,7 @@ class DistributionLocator(Subsystem):
   def all_jdk_paths(self):
     """Get all explicitly configured JDK paths.
 
-    :return: mapping of os  name -> list of jdk_paths
+    :return: mapping of os name -> list of jdk_paths
     :rtype: dict of string -> list of string
     """
     return self._normalized_jdk_paths

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -5,11 +5,13 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import itertools
 import logging
 import os
 import pkgutil
 import plistlib
 import subprocess
+from abc import abstractproperty
 from collections import namedtuple
 from contextlib import contextmanager
 
@@ -19,11 +21,28 @@ from pants.base.revision import Revision
 from pants.java.util import execute_java, execute_java_async
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_dir
-from pants.util.memo import memoized_property
+from pants.util.memo import memoized_method, memoized_property
+from pants.util.meta import AbstractClass
 from pants.util.osutil import OS_ALIASES, normalize_os_name
 
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_java_version(name, version):
+  # Java version strings have been well defined since release 1.3.1 as defined here:
+  #  http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
+  # These version strings comply with semver except that the traditional pre-release semver
+  # slot (the 4th) can be delimited by an _ in the case of update releases of the jdk.
+  # We accommodate that difference here using lenient parsing.
+  # We also accommodate specification versions, which just have major and minor
+  # components; eg: `1.8`.  These are useful when specifying constraints a distribution must
+  # satisfy; eg: to pick any 1.8 java distribution: '1.8' <= version <= '1.8.99'
+  if isinstance(version, string_types):
+    version = Revision.lenient(version)
+  if version and not isinstance(version, Revision):
+    raise ValueError('{} must be a string or a Revision object, given: {}'.format(name, version))
+  return version
 
 
 class Distribution(object):
@@ -34,26 +53,13 @@ class Distribution(object):
   source code or run bytecode that exercise features only available in that version forward.
 
   :API: public
+
+  TODO(John Sirois): This class has a broken API, its not reasonably useful with no methods exposed.
+  Expose reasonable methods: https://github.com/pantsbuild/pants/issues/3263
   """
 
   class Error(Exception):
     """Indicates an invalid java distribution."""
-
-  @staticmethod
-  def _parse_java_version(name, version):
-    # Java version strings have been well defined since release 1.3.1 as defined here:
-    #  http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
-    # These version strings comply with semver except that the traditional pre-release semver
-    # slot (the 4th) can be delimited by an _ in the case of update releases of the jdk.
-    # We accommodate that difference here using lenient parsing.
-    # We also accommodate specification versions, which just have major and minor
-    # components; eg: `1.8`.  These are useful when specifying constraints a distribution must
-    # satisfy; eg: to pick any 1.8 java distribution: '1.8' <= version <= '1.8.99'
-    if isinstance(version, string_types):
-      version = Revision.lenient(version)
-    if version and not isinstance(version, Revision):
-      raise ValueError('{} must be a string or a Revision object, given: {}'.format(name, version))
-    return version
 
   @staticmethod
   def _is_executable(path):
@@ -82,12 +88,11 @@ class Distribution(object):
     self._home = home_path
     self._bin_path = bin_path or (os.path.join(home_path, 'bin') if home_path else '/usr/bin')
 
-    self._minimum_version = self._parse_java_version("minimum_version", minimum_version)
-    self._maximum_version = self._parse_java_version("maximum_version", maximum_version)
+    self._minimum_version = _parse_java_version("minimum_version", minimum_version)
+    self._maximum_version = _parse_java_version("maximum_version", maximum_version)
     self._jdk = jdk
     self._is_jdk = False
     self._system_properties = None
-    self._version = None
     self._validated_binaries = {}
 
   @property
@@ -222,11 +227,9 @@ class Distribution(object):
   def execute_java_async(self, *args, **kwargs):
     return execute_java_async(*args, distribution=self, **kwargs)
 
+  @memoized_method
   def _get_version(self, java):
-    if not self._version:
-      self._version = self._parse_java_version('java.version',
-                                               self._get_system_properties(java)['java.version'])
-    return self._version
+    return _parse_java_version('java.version', self._get_system_properties(java)['java.version'])
 
   def _get_system_properties(self, java):
     if not self._system_properties:
@@ -279,16 +282,8 @@ class Distribution(object):
             self._bin_path, self._minimum_version, self._maximum_version, self._jdk))
 
 
-class DistributionLocator(Subsystem):
-  """Subsystem that knows how to look up a java Distribution.
-
-  :API: public
-  """
-
-  class Error(Distribution.Error):
-    """Error locating a java distribution."""
-
-  class _Location(namedtuple('Location', ['home_path', 'bin_path'])):
+class _DistributionEnvironment(AbstractClass):
+  class Location(namedtuple('Location', ['home_path', 'bin_path'])):
     """Represents the location of a java distribution."""
 
     @classmethod
@@ -309,72 +304,135 @@ class DistributionLocator(Subsystem):
       """
       return cls(home_path=None, bin_path=bin_path)
 
-  options_scope = 'jvm-distributions'
-  _CACHE = {}
-  # The `/usr/lib/jvm` dir is a common target of packages built for redhat and debian as well as
-  # other more exotic distributions.  SUSE uses lib64
-  _JAVA_DIST_DIRS = ['/usr/lib/jvm', '/usr/lib64/jvm']
+  @abstractproperty
+  def jvm_locations(self):
+    """Return the jvm locations discovered in this environment.
+
+    :returns: An iterator over all discovered jvm locations.
+    :rtype: iterator of :class:`DistributionEnvironment.Location`
+    """
+
+
+class _EnvVarEnvironment(_DistributionEnvironment):
+  @property
+  def jvm_locations(self):
+    def env_home(home_env_var):
+      home = os.environ.get(home_env_var)
+      return self.Location.from_home(home) if home else None
+
+    jdk_home = env_home('JDK_HOME')
+    if jdk_home:
+      yield jdk_home
+
+    java_home = env_home('JAVA_HOME')
+    if java_home:
+      yield java_home
+
+    search_path = os.environ.get('PATH')
+    if search_path:
+      for bin_path in search_path.strip().split(os.pathsep):
+        yield self.Location.from_bin(bin_path)
+
+
+class _OSXEnvironment(_DistributionEnvironment):
   _OSX_JAVA_HOME_EXE = '/usr/libexec/java_home'
 
   @classmethod
-  def register_options(cls, register):
-    super(DistributionLocator, cls).register_options(register)
-    human_readable_os_aliases = ', '.join('{}: [{}]'.format(str(key), ', '.join(sorted(val)))
-                                          for key, val in OS_ALIASES.items())
-    register('--paths', advanced=True, type=dict,
-             help='Map of os names to lists of paths to jdks. These paths will be searched before '
-                  'everything else (before the JDK_HOME, JAVA_HOME, PATH environment variables) '
-                  'when locating a jvm to use. The same OS can be specified via several different '
-                  'aliases, according to this map: {}'.format(human_readable_os_aliases))
-    register('--minimum-version', advanced=True, help='Minimum version of the JVM pants will use')
-    register('--maximum-version', advanced=True, help='Maximum version of the JVM pants will use')
+  def standard(cls):
+    return cls(cls._OSX_JAVA_HOME_EXE)
 
-  @memoized_property
-  def _normalized_jdk_paths(self):
-    jdk_paths = self.get_options().paths or {}
-    normalized = {}
-    for name, paths in sorted(jdk_paths.items()):
-      rename = normalize_os_name(name)
-      if rename in normalized:
-        logger.warning('Multiple OS names alias to "{}"; combining results.'.format(rename))
-        normalized[rename].extend(paths)
-      else:
-        normalized[rename] = paths
-    return normalized
+  def __init__(self, osx_java_home_exe):
+    self._osx_java_home_exe = osx_java_home_exe
 
-  def all_jdk_paths(self):
-    """Get all explicitly configured JDK paths.
+  @property
+  def jvm_locations(self):
+    # OSX will have a java_home tool that can be used to locate a unix-compatible java home dir.
+    #
+    # See:
+    #   https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/java_home.1.html
+    #
+    # The `--xml` output looks like so:
+    # <?xml version="1.0" encoding="UTF-8"?>
+    # <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    #                        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    # <plist version="1.0">
+    #   <array>
+    #     <dict>
+    #       ...
+    #       <key>JVMHomePath</key>
+    #       <string>/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home</string>
+    #       ...
+    #     </dict>
+    #     ...
+    #   </array>
+    # </plist>
+    if os.path.exists(self._osx_java_home_exe):
+      try:
+        plist = subprocess.check_output([self._osx_java_home_exe, '--failfast', '--xml'])
+        for distribution in plistlib.readPlistFromString(plist):
+          home = distribution['JVMHomePath']
+          yield self.Location.from_home(home)
+      except subprocess.CalledProcessError:
+        pass
 
-    :return: mapping of os  name -> list of jdk_paths
-    :rtype: dict of string -> list of string
-    """
-    return self._normalized_jdk_paths
 
-  def get_jdk_paths(self, os_name=None):
-    """Get the list of explicitly configured JDK paths for this os.
-
-    :param os_name: Os name to lookup. If None, use the currently detected os name.
-    :return: Paths of explicitly configured JDK's from the --jvm-distribution-paths option
-    :rtype: list of strings
-    """
-    jdk_paths = self._normalized_jdk_paths
-    if not jdk_paths:
-      return ()
-    if os_name is None:
-      os_name = os.uname()[0].lower()
-    os_name = normalize_os_name(os_name)
-    if os_name not in jdk_paths:
-      logger.warning('--jvm-distributions-paths was specified, but has no entry for "{}".'
-                     .format(os_name))
-    return jdk_paths.get(os_name, ())
+class _LinuxEnvironment(_DistributionEnvironment):
+  # The `/usr/lib/jvm` dir is a common target of packages built for redhat and debian as well as
+  # other more exotic distributions.  SUSE uses lib64
+  _STANDARD_JAVA_DIST_DIRS = ('/usr/lib/jvm', '/usr/lib64/jvm')
 
   @classmethod
-  def java_path_locations(cls):
-    for location in cls.global_instance().get_jdk_paths():
-      yield cls._Location.from_home(location)
+  def standard(cls):
+    return cls(*cls._STANDARD_JAVA_DIST_DIRS)
 
-  @classmethod
-  def _scan_constraint_match(cls, minimum_version, maximum_version, jdk):
+  def __init__(self, *java_dist_dirs):
+    if len(java_dist_dirs) == 0:
+      raise ValueError('Expected at least 1 java dist dir.')
+    self._java_dist_dirs = java_dist_dirs
+
+  @property
+  def jvm_locations(self):
+    for java_dist_dir in self._java_dist_dirs:
+      if os.path.isdir(java_dist_dir):
+        for path in os.listdir(java_dist_dir):
+          home = os.path.join(java_dist_dir, path)
+          if os.path.isdir(home):
+            yield self.Location.from_home(home)
+
+
+class _ExplicitEnvironment(_DistributionEnvironment):
+  def __init__(self, *homes):
+    self._homes = homes
+
+  @property
+  def jvm_locations(self):
+    for home in self._homes:
+      yield self.Location.from_home(home)
+
+
+class _UnknownEnvironment(_DistributionEnvironment):
+  def __init__(self, *possible_environments):
+    super(_DistributionEnvironment, self).__init__()
+    if len(possible_environments) < 2:
+      raise ValueError('At least two possible environments must be supplied.')
+    self._possible_environments = possible_environments
+
+  @property
+  def jvm_locations(self):
+    return itertools.chain(*(pe.jvm_locations for pe in self._possible_environments))
+
+
+class _Locator(object):
+  class Error(Distribution.Error):
+    """Error locating a java distribution."""
+
+  def __init__(self, distribution_environment, minimum_version=None, maximum_version=None):
+    self._cache = {}
+    self._distribution_environment = distribution_environment
+    self._minimum_version = minimum_version
+    self._maximum_version = maximum_version
+
+  def _scan_constraint_match(self, minimum_version, maximum_version, jdk):
     """Finds a cached version matching the specified constraints
 
     :param Revision minimum_version: minimum jvm version to look for (eg, 1.7).
@@ -384,7 +442,7 @@ class DistributionLocator(Subsystem):
     :rtype: :class:`pants.java.distribution.Distribution`
     """
 
-    for dist in cls._CACHE.values():
+    for dist in self._cache.values():
       if minimum_version and dist.version < minimum_version:
         continue
       if maximum_version and dist.version > maximum_version:
@@ -393,23 +451,23 @@ class DistributionLocator(Subsystem):
         continue
       return dist
 
-  @classmethod
-  def cached(cls, minimum_version=None, maximum_version=None, jdk=False):
+  def locate(self, minimum_version=None, maximum_version=None, jdk=False):
     """Finds a java distribution that meets the given constraints and returns it.
 
     First looks for a cached version that was previously located, otherwise calls locate().
     :param minimum_version: minimum jvm version to look for (eg, 1.7).
-                            The stricter of this and get_options().minimum_version is used.
+                            The stricter of this and `--jvm-distributions-minimum-version` is used.
     :param maximum_version: maximum jvm version to look for (eg, 1.7.9999).
-                            The stricter of this and get_options().maximum_version is used.
+                            The stricter of this and `--jvm-distributions-maximum-version` is used.
     :param bool jdk: whether the found java distribution is required to have a jdk.
     :return: the Distribution.
-    :rtype: :class:`pants.java.distribution.Distribution`
+    :rtype: :class:`Distribution`
+    :raises: :class:`Distribution.Error` if no suitable java distribution could be found.
     """
 
     def _get_stricter_version(a, b, name, stricter):
-      version_a = Distribution._parse_java_version(name, a)
-      version_b = Distribution._parse_java_version(name, b)
+      version_a = _parse_java_version(name, a)
+      version_b = _parse_java_version(name, b)
       if version_a is None:
         return version_b
       if version_b is None:
@@ -418,52 +476,36 @@ class DistributionLocator(Subsystem):
 
     # take the tighter constraint of method args and subsystem options
     minimum_version = _get_stricter_version(minimum_version,
-                                            cls.global_instance().get_options().minimum_version,
+                                            self._minimum_version,
                                             "minimum_version",
                                             max)
     maximum_version = _get_stricter_version(maximum_version,
-                                            cls.global_instance().get_options().maximum_version,
+                                            self._maximum_version,
                                             "maximum_version",
                                             min)
 
     key = (minimum_version, maximum_version, jdk)
-    dist = cls._CACHE.get(key)
+    dist = self._cache.get(key)
     if not dist:
-      dist = cls._scan_constraint_match(minimum_version, maximum_version, jdk)
+      dist = self._scan_constraint_match(minimum_version, maximum_version, jdk)
       if not dist:
-        dist = cls.locate(minimum_version=minimum_version,
-                          maximum_version=maximum_version,
-                          jdk=jdk)
-      cls._CACHE[key] = dist
+        dist = self._locate(minimum_version=minimum_version,
+                            maximum_version=maximum_version,
+                            jdk=jdk)
+      self._cache[key] = dist
     return dist
 
-  @classmethod
-  def locate(cls, minimum_version=None, maximum_version=None, jdk=False):
+  def _locate(self, minimum_version=None, maximum_version=None, jdk=False):
     """Finds a java distribution that meets any given constraints and returns it.
 
-    Distributions are searched for in the following order:
-     * Paths listed for this operating system in the
-    --jvm-distributions-paths map
-     * JDK_HOME/JAVA_HOME
-     * PATH
-     * Likely locations on the file system such as /usr/lib/jvm
-
-    :raises: Distribution.Error if no suitable java distribution could
-    be found.
     :param minimum_version: minimum jvm version to look for (eg, 1.7).
     :param maximum_version: maximum jvm version to look for (eg, 1.7.9999).
     :param bool jdk: whether the found java distribution is required to have a jdk.
     :return: the located Distribution.
-    :rtype: :class:`pants.java.distribution.Distribution`
+    :rtype: :class:`Distribution`
+    :raises: :class:`Distribution.Error` if no suitable java distribution could be found.
     """
-    def search_path():
-      for location in cls.global_instance().java_path_locations():
-        yield location
-
-      for location in cls._environment_jvm_locations():
-        yield location
-
-    for location in filter(None, search_path()):
+    for location in itertools.chain(self._distribution_environment.jvm_locations):
       try:
         dist = Distribution(home_path=location.home_path,
                             bin_path=location.bin_path,
@@ -485,64 +527,112 @@ class DistributionLocator(Subsystem):
     else:
       error_format = ('Failed to locate a {} distribution with minimum_version {}, '
                       'maximum_version {}')
-    raise cls.Error(error_format.format('JDK' if jdk else 'JRE', minimum_version, maximum_version))
+    raise self.Error(error_format.format('JDK' if jdk else 'JRE', minimum_version, maximum_version))
+
+
+class DistributionLocator(Subsystem):
+  """Subsystem that knows how to look up a java Distribution.
+
+  Distributions are searched for in the following order by default:
+
+  1. Paths listed for this operating system in the `--jvm-distributions-paths` map.
+  2. JDK_HOME/JAVA_HOME
+  3. PATH
+  4. Likely locations on the file system such as `/usr/lib/jvm` on Linux machines.
+
+  :API: public
+  """
+
+  class Error(Distribution.Error):
+    """Error locating a java distribution.
+
+    :API: public
+    """
 
   @classmethod
-  def _linux_java_homes(cls):
-    for java_dist_dir in cls._JAVA_DIST_DIRS:
-      if os.path.isdir(java_dist_dir):
-        for path in os.listdir(java_dist_dir):
-          home = os.path.join(java_dist_dir, path)
-          if os.path.isdir(home):
-            yield cls._Location.from_home(home)
+  @memoized_method
+  def _locator(cls):
+    environment = _UnknownEnvironment(_EnvVarEnvironment(),
+                                      _LinuxEnvironment.standard(),
+                                      _OSXEnvironment.standard())
+    return cls.global_instance()._create_locator(environment)
 
   @classmethod
-  def _osx_java_homes(cls):
-    # OSX will have a java_home tool that can be used to locate a unix-compatible java home dir.
-    #
-    # See:
-    #   https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/java_home.1.html
-    #
-    # The `--xml` output looks like so:
-    # <?xml version="1.0" encoding="UTF-8"?>
-    # <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-    #                        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    # <plist version="1.0">
-    #   <array>
-    #     <dict>
-    #       ...
-    #       <key>JVMHomePath</key>
-    #       <string>/Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home</string>
-    #       ...
-    #     </dict>
-    #     ...
-    #   </array>
-    # </plist>
-    if os.path.exists(cls._OSX_JAVA_HOME_EXE):
-      try:
-        plist = subprocess.check_output([cls._OSX_JAVA_HOME_EXE, '--failfast', '--xml'])
-        for distribution in plistlib.readPlistFromString(plist):
-          home = distribution['JVMHomePath']
-          yield cls._Location.from_home(home)
-      except subprocess.CalledProcessError:
-        pass
+  def cached(cls, minimum_version=None, maximum_version=None, jdk=False):
+    """Finds a java distribution that meets the given constraints and returns it.
+
+    :API: public
+
+    First looks for a cached version that was previously located, otherwise calls locate().
+    :param minimum_version: minimum jvm version to look for (eg, 1.7).
+                            The stricter of this and `--jvm-distributions-minimum-version` is used.
+    :param maximum_version: maximum jvm version to look for (eg, 1.7.9999).
+                            The stricter of this and `--jvm-distributions-maximum-version` is used.
+    :param bool jdk: whether the found java distribution is required to have a jdk.
+    :return: the Distribution.
+    :rtype: :class:`Distribution`
+    :raises: :class:`Distribution.Error` if no suitable java distribution could be found.
+    """
+    try:
+      return cls._locator().locate(minimum_version=minimum_version,
+                                   maximum_version=maximum_version,
+                                   jdk=jdk)
+    except _Locator.Error as e:
+      raise cls.Error('Problem locating a java distribution: {}'.format(e))
+
+  options_scope = 'jvm-distributions'
 
   @classmethod
-  def _environment_jvm_locations(cls):
-    def env_home(home_env_var):
-      home = os.environ.get(home_env_var)
-      return cls._Location.from_home(home) if home else None
+  def register_options(cls, register):
+    super(DistributionLocator, cls).register_options(register)
+    human_readable_os_aliases = ', '.join('{}: [{}]'.format(str(key), ', '.join(sorted(val)))
+                                          for key, val in OS_ALIASES.items())
+    register('--paths', advanced=True, type=dict,
+             help='Map of os names to lists of paths to jdks. These paths will be searched before '
+                  'everything else (before the JDK_HOME, JAVA_HOME, PATH environment variables) '
+                  'when locating a jvm to use. The same OS can be specified via several different '
+                  'aliases, according to this map: {}'.format(human_readable_os_aliases))
+    register('--minimum-version', advanced=True, help='Minimum version of the JVM pants will use')
+    register('--maximum-version', advanced=True, help='Maximum version of the JVM pants will use')
 
-    yield env_home('JDK_HOME')
-    yield env_home('JAVA_HOME')
+  def all_jdk_paths(self):
+    """Get all explicitly configured JDK paths.
 
-    search_path = os.environ.get('PATH')
-    if search_path:
-      for bin_path in search_path.strip().split(os.pathsep):
-        yield cls._Location.from_bin(bin_path)
+    :return: mapping of os  name -> list of jdk_paths
+    :rtype: dict of string -> list of string
+    """
+    return self._normalized_jdk_paths
 
-    for location in cls._linux_java_homes():
-      yield location
+  @memoized_property
+  def _normalized_jdk_paths(self):
+    normalized = {}
+    jdk_paths = self.get_options().paths or {}
+    for name, paths in sorted(jdk_paths.items()):
+      rename = normalize_os_name(name)
+      if rename in normalized:
+        logger.warning('Multiple OS names alias to "{}"; combining results.'.format(rename))
+        normalized[rename].extend(paths)
+      else:
+        normalized[rename] = paths
+    return normalized
 
-    for location in cls._osx_java_homes():
-      yield location
+  def _get_explicit_jdk_paths(self):
+    if not self._normalized_jdk_paths:
+      return ()
+    os_name = normalize_os_name(os.uname()[0].lower())
+    if os_name not in self._normalized_jdk_paths:
+      logger.warning('--jvm-distributions-paths was specified, but has no entry for "{}".'
+                     .format(os_name))
+    return self._normalized_jdk_paths.get(os_name, ())
+
+  def _create_locator(self, distribution_environment):
+    homes = self._get_explicit_jdk_paths()
+    environment = _UnknownEnvironment(_ExplicitEnvironment(*homes), distribution_environment)
+    return _Locator(environment,
+                    self.get_options().minimum_version,
+                    self.get_options().maximum_version)
+
+  # Exposed for tests.
+  def _reset(self):
+    self._locator.clear()
+    self._normalized_jdk_paths.clear()

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -18,7 +18,7 @@ from pants_test.subsystem.subsystem_util import subsystem_instance
 def missing_jvm(version):
   with subsystem_instance(DistributionLocator):
     try:
-      DistributionLocator.locate(minimum_version=version, maximum_version='{}.9999'.format(version))
+      DistributionLocator.cached(minimum_version=version, maximum_version='{}.9999'.format(version))
       return False
     except DistributionLocator.Error:
       return True

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -72,6 +72,8 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/java/distribution',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:osutil',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
     'tests/python/pants_test/backend/python/tasks:interpreter_cache_test_mixin',

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import subprocess
-import tempfile
 import textwrap
 import unittest
 from contextlib import contextmanager
@@ -15,9 +14,11 @@ from contextlib import contextmanager
 from twitter.common.collections import maybe_list
 
 from pants.base.revision import Revision
-from pants.java.distribution.distribution import Distribution, DistributionLocator
-from pants.util.contextutil import environment_as, temporary_dir
-from pants.util.dirutil import chmod_plus_x, safe_open, safe_rmtree, touch
+from pants.java.distribution.distribution import (Distribution, DistributionLocator,
+                                                  _EnvVarEnvironment, _LinuxEnvironment, _Locator,
+                                                  _OSXEnvironment, _UnknownEnvironment)
+from pants.util.contextutil import environment_as, temporary_dir, temporary_file
+from pants.util.dirutil import chmod_plus_x, safe_open, touch
 from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
@@ -46,17 +47,16 @@ class EXE(object):
 
 @contextmanager
 def distribution(files=None, executables=None, java_home=None):
-  with subsystem_instance(DistributionLocator):
-    with temporary_dir() as dist_root:
-      for f in maybe_list(files or ()):
-        touch(os.path.join(dist_root, f))
-      for executable in maybe_list(executables or (), expected_type=EXE):
-        path = os.path.join(dist_root, executable.relpath)
-        with safe_open(path, 'w') as fp:
-          java_home = os.path.join(dist_root, java_home) if java_home else dist_root
-          fp.write(executable.contents(java_home))
-        chmod_plus_x(path)
-      yield dist_root
+  with temporary_dir() as dist_root:
+    for f in maybe_list(files or ()):
+      touch(os.path.join(dist_root, f))
+    for executable in maybe_list(executables or (), expected_type=EXE):
+      path = os.path.join(dist_root, executable.relpath)
+      with safe_open(path, 'w') as fp:
+        java_home = os.path.join(dist_root, java_home) if java_home else dist_root
+        fp.write(executable.contents(java_home))
+      chmod_plus_x(path)
+    yield dist_root
 
 
 @contextmanager
@@ -152,203 +152,159 @@ class DistributionValidationTest(unittest.TestCase):
                        dist.find_libs(['tools.jar', 'rt.jar']))
 
 
-class BaseDistributionLocationTest(unittest.TestCase):
-  def make_tmp_dir(self):
-    tmpdir = tempfile.mkdtemp()
-    self.addCleanup(safe_rmtree, tmpdir)
-    return tmpdir
-
-  def set_up_no_linux_discovery(self, index=0):
-    orig_java_dist_dir = DistributionLocator._JAVA_DIST_DIRS[index]
-
-    def restore_java_dist_dir():
-      DistributionLocator._JAVA_DIST_DIRS[index] = orig_java_dist_dir
-    DistributionLocator._JAVA_DIST_DIRS[index] = self.make_tmp_dir()
-    self.addCleanup(restore_java_dist_dir)
-
-  def set_up_no_osx_discovery(self):
-    osx_java_home_exe = DistributionLocator._OSX_JAVA_HOME_EXE
-
-    def restore_osx_java_home_exe():
-      DistributionLocator._OSX_JAVA_HOME_EXE = osx_java_home_exe
-    DistributionLocator._OSX_JAVA_HOME_EXE = os.path.join(self.make_tmp_dir(), 'java_home')
-    self.addCleanup(restore_osx_java_home_exe)
-
-
-class BaseDistributionLocationEnvOnlyTest(BaseDistributionLocationTest):
+class DistributionEnvLocationTest(unittest.TestCase):
   def setUp(self):
-    self.set_up_no_linux_discovery()
-    self.set_up_no_osx_discovery()
+    super(DistributionEnvLocationTest, self).setUp()
+    self.locator = _Locator(_EnvVarEnvironment())
 
-
-class DistributionEnvLocationTest(BaseDistributionLocationEnvOnlyTest):
   def test_locate_none(self):
     with env():
       with self.assertRaises(Distribution.Error):
-        with subsystem_instance(DistributionLocator):
-          DistributionLocator.locate()
+        self.locator.locate()
 
   def test_locate_java_not_executable(self):
     with distribution(files='bin/java') as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          DistributionLocator.locate()
+          self.locator.locate()
 
   def test_locate_jdk_is_jre(self):
     with distribution(executables=EXE('bin/java')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          DistributionLocator.locate(jdk=True)
+          self.locator.locate(jdk=True)
 
   def test_locate_version_to_low(self):
     with distribution(executables=EXE('bin/java', '1.6.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          DistributionLocator.locate(minimum_version='1.7.0')
+          self.locator.locate(minimum_version='1.7.0')
 
   def test_locate_version_to_high(self):
     with distribution(executables=EXE('bin/java', '1.8.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
         with self.assertRaises(Distribution.Error):
-          DistributionLocator.locate(maximum_version='1.7.999')
+          self.locator.locate(maximum_version='1.7.999')
 
   def test_locate_invalid_jdk_home(self):
     with distribution(executables=EXE('java')) as dist_root:
       with env(JDK_HOME=dist_root):
         with self.assertRaises(Distribution.Error):
-          DistributionLocator.locate()
+          self.locator.locate()
 
   def test_locate_invalid_java_home(self):
     with distribution(executables=EXE('java')) as dist_root:
       with env(JAVA_HOME=dist_root):
         with self.assertRaises(Distribution.Error):
-          DistributionLocator.locate()
+          self.locator.locate()
 
   def test_locate_jre_by_path(self):
     with distribution(executables=EXE('bin/java')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.locate()
+        self.locator.locate()
 
   def test_locate_jdk_by_path(self):
     with distribution(executables=[EXE('bin/java'), EXE('bin/javac')]) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.locate(jdk=True)
+        self.locator.locate(jdk=True)
 
   def test_locate_jdk_via_jre_path(self):
     with distribution(executables=[EXE('jre/bin/java'), EXE('bin/javac')],
                       java_home='jre') as dist_root:
       with env(PATH=os.path.join(dist_root, 'jre', 'bin')):
-        DistributionLocator.locate(jdk=True)
+        self.locator.locate(jdk=True)
 
   def test_locate_version_greater_then_or_equal(self):
     with distribution(executables=EXE('bin/java', '1.7.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.locate(minimum_version='1.6.0')
+        self.locator.locate(minimum_version='1.6.0')
 
   def test_locate_version_less_then_or_equal(self):
     with distribution(executables=EXE('bin/java', '1.7.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.locate(maximum_version='1.7.999')
+        self.locator.locate(maximum_version='1.7.999')
 
   def test_locate_version_within_range(self):
     with distribution(executables=EXE('bin/java', '1.7.0')) as dist_root:
       with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.locate(minimum_version='1.6.0', maximum_version='1.7.999')
+        self.locator.locate(minimum_version='1.6.0', maximum_version='1.7.999')
 
   def test_locate_via_jdk_home(self):
     with distribution(executables=EXE('bin/java')) as dist_root:
       with env(JDK_HOME=dist_root):
-        DistributionLocator.locate()
+        self.locator.locate()
 
   def test_locate_via_java_home(self):
     with distribution(executables=EXE('bin/java')) as dist_root:
       with env(JAVA_HOME=dist_root):
-        DistributionLocator.locate()
+        self.locator.locate()
 
 
-class DistributionLinuxLocationTest(BaseDistributionLocationTest):
-  def setUp(self):
-    self.set_up_no_osx_discovery()
-
+class DistributionLinuxLocationTest(unittest.TestCase):
   @contextmanager
-  def java_dist_dir(self):
+  def locator(self):
     with distribution(executables=EXE('bin/java', version='1')) as jdk1_home:
       with distribution(executables=EXE('bin/java', version='2')) as jdk2_home:
-        with temporary_dir() as java_dist_dir:
-          jdk1_home_link = os.path.join(java_dist_dir, 'jdk1_home')
-          jdk2_home_link = os.path.join(java_dist_dir, 'jdk2_home')
+        with temporary_dir() as java_dist_dir1, temporary_dir() as java_dist_dir2:
+          locator = _Locator(_UnknownEnvironment(_EnvVarEnvironment(),
+                                                 _LinuxEnvironment(java_dist_dir1, java_dist_dir2)))
+          jdk1_home_link = os.path.join(java_dist_dir1, 'jdk1_home')
+          jdk2_home_link = os.path.join(java_dist_dir2, 'jdk2_home')
           os.symlink(jdk1_home, jdk1_home_link)
           os.symlink(jdk2_home, jdk2_home_link)
-
-          original_java_dist_dir = DistributionLocator._JAVA_DIST_DIRS[0]
-          DistributionLocator._JAVA_DIST_DIRS[0] = java_dist_dir
-          try:
-            yield jdk1_home_link, jdk2_home_link
-          finally:
-            DistributionLocator._JAVA_DIST_DIRS[0] = original_java_dist_dir
+          yield locator, jdk1_home_link, jdk2_home_link
 
   def test_locate_jdk1(self):
     with env():
-      with self.java_dist_dir() as (jdk1_home, _):
-        dist = DistributionLocator.locate(maximum_version='1')
+      with self.locator() as (locator, jdk1_home, _):
+        dist = locator.locate(maximum_version='1')
         self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk2(self):
     with env():
-      with self.java_dist_dir() as (_, jdk2_home):
-        dist = DistributionLocator.locate(minimum_version='2')
+      with self.locator() as (locator, _, jdk2_home):
+        dist = locator.locate(minimum_version='2')
         self.assertEqual(jdk2_home, dist.home)
 
   def test_default_to_path(self):
-    with self.java_dist_dir() as (jdk1_home, jdk2_home):
+    with self.locator() as (locator, jdk1_home, jdk2_home):
       with distribution(executables=EXE('bin/java', version='3')) as path_jdk:
         with env(PATH=os.path.join(path_jdk, 'bin')):
-          dist = DistributionLocator.locate(minimum_version='2')
+          dist = locator.locate(minimum_version='2')
           self.assertEqual(path_jdk, dist.home)
-          dist = DistributionLocator.locate(maximum_version='2')
+          dist = locator.locate(maximum_version='2')
           self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk_home_trumps(self):
-    with self.java_dist_dir() as (jdk1_home, jdk2_home):
+    with self.locator() as (locator, jdk1_home, jdk2_home):
       with distribution(executables=EXE('bin/java', version='3')) as jdk_home:
         with env(JDK_HOME=jdk_home):
-          dist = DistributionLocator.locate()
+          dist = locator.locate()
           self.assertEqual(jdk_home, dist.home)
-          dist = DistributionLocator.locate(maximum_version='1.1')
+          dist = locator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
+          dist = locator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
 
   def test_locate_java_home_trumps(self):
-    with self.java_dist_dir() as (jdk1_home, jdk2_home):
+    with self.locator() as (locator, jdk1_home, jdk2_home):
       with distribution(executables=EXE('bin/java', version='3')) as java_home:
         with env(JAVA_HOME=java_home):
-          dist = DistributionLocator.locate()
+          dist = locator.locate()
           self.assertEqual(java_home, dist.home)
-          dist = DistributionLocator.locate(maximum_version='1.1')
+          dist = locator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
+          dist = locator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
 
 
-class DistributionLinuxAltLocationTest(DistributionLinuxLocationTest):
-  def setUp(self):
-    self.set_up_no_linux_discovery(index=1)
-    self.set_up_no_osx_discovery()
-
-
-class DistributionOSXLocationTest(BaseDistributionLocationTest):
-  def setUp(self):
-    self.set_up_no_linux_discovery()
-
+class DistributionOSXLocationTest(unittest.TestCase):
   @contextmanager
   def java_home_exe(self):
     with distribution(executables=EXE('bin/java', version='1')) as jdk1_home:
       with distribution(executables=EXE('bin/java', version='2')) as jdk2_home:
-        with temporary_dir() as tmpdir:
-          osx_java_home_exe = os.path.join(tmpdir, 'java_home')
-          with safe_open(osx_java_home_exe, 'w') as fp:
-            fp.write(textwrap.dedent("""
+        with temporary_file() as osx_java_home_exe:
+          osx_java_home_exe.write(textwrap.dedent("""
                 #!/bin/sh
                 echo '<?xml version="1.0" encoding="UTF-8"?>
                 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -367,121 +323,54 @@ class DistributionOSXLocationTest(BaseDistributionLocationTest):
                 </plist>
                 '
               """.format(jdk1_home=jdk1_home, jdk2_home=jdk2_home)).strip())
-          chmod_plus_x(osx_java_home_exe)
-
-          original_osx_java_home_exe = DistributionLocator._OSX_JAVA_HOME_EXE
-          DistributionLocator._OSX_JAVA_HOME_EXE = osx_java_home_exe
-          try:
-            yield jdk1_home, jdk2_home
-          finally:
-            DistributionLocator._OSX_JAVA_HOME_EXE = original_osx_java_home_exe
+          osx_java_home_exe.close()
+          chmod_plus_x(osx_java_home_exe.name)
+          locator = _Locator(_UnknownEnvironment(_EnvVarEnvironment(),
+                                                 _OSXEnvironment(osx_java_home_exe.name)))
+          yield locator, jdk1_home, jdk2_home
 
   def test_locate_jdk1(self):
     with env():
-      with self.java_home_exe() as (jdk1_home, _):
-        dist = DistributionLocator.locate()
+      with self.java_home_exe() as (locator, jdk1_home, _):
+        dist = locator.locate()
         self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk2(self):
     with env():
-      with self.java_home_exe() as (_, jdk2_home):
-        dist = DistributionLocator.locate(minimum_version='2')
+      with self.java_home_exe() as (locator, _, jdk2_home):
+        dist = locator.locate(minimum_version='2')
         self.assertEqual(jdk2_home, dist.home)
 
   def test_default_to_path(self):
-    with self.java_home_exe() as (jdk1_home, jdk2_home):
+    with self.java_home_exe() as (locator, jdk1_home, jdk2_home):
       with distribution(executables=EXE('bin/java', version='3')) as path_jdk:
         with env(PATH=os.path.join(path_jdk, 'bin')):
-          dist = DistributionLocator.locate(minimum_version='2')
+          dist = locator.locate(minimum_version='2')
           self.assertEqual(path_jdk, dist.home)
-          dist = DistributionLocator.locate(maximum_version='2')
+          dist = locator.locate(maximum_version='2')
           self.assertEqual(jdk1_home, dist.home)
 
   def test_locate_jdk_home_trumps(self):
-    with self.java_home_exe() as (jdk1_home, jdk2_home):
+    with self.java_home_exe() as (locator, jdk1_home, jdk2_home):
       with distribution(executables=EXE('bin/java', version='3')) as jdk_home:
         with env(JDK_HOME=jdk_home):
-          dist = DistributionLocator.locate()
+          dist = locator.locate()
           self.assertEqual(jdk_home, dist.home)
-          dist = DistributionLocator.locate(maximum_version='1.1')
+          dist = locator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
+          dist = locator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
 
   def test_locate_java_home_trumps(self):
-    with self.java_home_exe() as (jdk1_home, jdk2_home):
+    with self.java_home_exe() as (locator, jdk1_home, jdk2_home):
       with distribution(executables=EXE('bin/java', version='3')) as java_home:
         with env(JAVA_HOME=java_home):
-          dist = DistributionLocator.locate()
+          dist = locator.locate()
           self.assertEqual(java_home, dist.home)
-          dist = DistributionLocator.locate(maximum_version='1.1')
+          dist = locator.locate(maximum_version='1.1')
           self.assertEqual(jdk1_home, dist.home)
-          dist = DistributionLocator.locate(minimum_version='1.1', maximum_version='2')
+          dist = locator.locate(minimum_version='1.1', maximum_version='2')
           self.assertEqual(jdk2_home, dist.home)
-
-
-class DistributionCachedTest(BaseDistributionLocationEnvOnlyTest):
-  def setUp(self):
-    super(DistributionCachedTest, self).setUp()
-
-    # Save local cache and then flush so tests get a clean environment.
-    local_cache = DistributionLocator._CACHE
-
-    def restore_cache():
-      DistributionLocator._CACHE = local_cache
-    DistributionLocator._CACHE = {}
-    self.addCleanup(restore_cache)
-
-  def test_cached_good_min(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.cached(minimum_version='1.7.0_25')
-
-  def test_cached_good_max(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.cached(maximum_version='1.7.0_50')
-
-  def test_cached_good_bounds(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        DistributionLocator.cached(minimum_version='1.6.0_35', maximum_version='1.7.0_55')
-
-  def test_cached_too_low(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        with self.assertRaises(Distribution.Error):
-          DistributionLocator.cached(minimum_version='1.7.0_40')
-
-  def test_cached_too_high(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_83')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        with self.assertRaises(Distribution.Error):
-          DistributionLocator.cached(maximum_version='1.7.0_55')
-
-  def test_cached_low_fault(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        with self.assertRaises(Distribution.Error):
-          DistributionLocator.cached(minimum_version='1.7.0_35', maximum_version='1.7.0_55')
-
-  def test_cached_high_fault(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        with self.assertRaises(Distribution.Error):
-          DistributionLocator.cached(minimum_version='1.6.0_00', maximum_version='1.6.0_50')
-
-  def test_cached_conflicting(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        with self.assertRaises(Distribution.Error):
-          DistributionLocator.cached(minimum_version='1.7.0_00', maximum_version='1.6.0_50')
-
-  def test_cached_bad_input(self):
-    with distribution(executables=EXE('bin/java', '1.7.0_33')) as dist_root:
-      with env(PATH=os.path.join(dist_root, 'bin')):
-        with self.assertRaises(ValueError):
-          DistributionLocator.cached(minimum_version=1.7, maximum_version=1.8)
 
 
 def exe_path(name):
@@ -509,12 +398,12 @@ class LiveDistributionTest(unittest.TestCase):
     Distribution(bin_path=os.path.dirname(self.JAVA), maximum_version='999.999.999').validate()
     Distribution(bin_path=os.path.dirname(self.JAVA), minimum_version='1.3.1',
                  maximum_version='999.999.999').validate()
-    with subsystem_instance(DistributionLocator):
-      DistributionLocator.locate(jdk=False)
+    with subsystem_instance(DistributionLocator) as locator:
+      locator.cached(jdk=False)
 
   @unittest.skipIf(not JAVAC, reason='No javac executable on the PATH.')
   def test_validate_live_jdk(self):
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).validate()
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).binary('javap')
-    with subsystem_instance(DistributionLocator):
-      DistributionLocator.locate(jdk=True)
+    with subsystem_instance(DistributionLocator) as locator:
+      locator.cached(jdk=True)

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from contextlib import contextmanager
 from unittest import skipIf
 
 from pants.java.distribution.distribution import Distribution, DistributionLocator
@@ -14,43 +15,51 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
-def get_two_distributions():
-  with subsystem_instance(DistributionLocator):
+@contextmanager
+def _distribution_locator(**options):
+  with subsystem_instance(DistributionLocator, **options) as locator:
+    locator._reset()  # Force a fresh locator.
+    yield locator
+
+
+def _get_two_distributions():
+  with _distribution_locator() as locator:
     try:
-      java7 = DistributionLocator.locate(minimum_version='1.7', maximum_version='1.7.9999')
-      java8 = DistributionLocator.locate(minimum_version='1.8', maximum_version='1.8.9999')
+      java7 = locator.cached(minimum_version='1.7', maximum_version='1.7.9999')
+      java8 = locator.cached(minimum_version='1.8', maximum_version='1.8.9999')
       return java7, java8
     except DistributionLocator.Error:
       return None
 
 
 class DistributionIntegrationTest(PantsRunIntegrationTest):
-
   def _test_two_distributions(self, os_name=None):
-    java7, java8 = get_two_distributions()
+    java7, java8 = _get_two_distributions()
     os_name = os_name or get_os_name()
 
     self.assertNotEqual(java7.home, java8.home)
 
     for (one, two) in ((java7, java8), (java8, java7)):
       target_spec = 'testprojects/src/java/org/pantsbuild/testproject/printversion'
-      run = self.run_pants(['run', target_spec], config={
-        'jvm-distributions': {
-          'paths': {
-            os_name: [one.home],
-          }
-        }
-      }, extra_env={
-        'JDK_HOME': two.home,
-      })
+      run = self.run_pants(['run', target_spec],
+                           config={
+                             'jvm-distributions': {
+                               'paths': {
+                                 os_name: [one.home],
+                               }
+                             }
+                           },
+                           extra_env={
+                             'JDK_HOME': two.home,
+                           })
       self.assert_success(run)
       self.assertIn('java.home:{}'.format(os.path.realpath(one.home)), run.stdout_data)
 
-  @skipIf(get_two_distributions() is None, 'Could not find java 7 and java 8 jvms to test with.')
+  @skipIf(_get_two_distributions() is None, 'Could not find java 7 and java 8 jvms to test with.')
   def test_jvm_jdk_paths_supercedes_environment_variables(self):
     self._test_two_distributions()
 
-  @skipIf(get_two_distributions() is None, 'Could not find java 7 and java 8 jvms to test with.')
+  @skipIf(_get_two_distributions() is None, 'Could not find java 7 and java 8 jvms to test with.')
   def test_jdk_paths_with_aliased_os_names(self):
     # NB(gmalmquist): This test will silently no-op and do nothing if the testing machine is running
     # an esoteric os (eg, windows).
@@ -61,30 +70,31 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
           self._test_two_distributions(other)
 
   def test_no_jvm_restriction(self):
-    with subsystem_instance(DistributionLocator):
-      distribution = DistributionLocator.locate()
-    target_spec = 'testprojects/src/java/org/pantsbuild/testproject/printversion'
-    run = self.run_pants(['run', target_spec])
-    self.assert_success(run)
-    self.assertIn('java.home:{}'.format(distribution.home), run.stdout_data)
+    with _distribution_locator() as locator:
+      distribution = locator.cached()
+      target_spec = 'testprojects/src/java/org/pantsbuild/testproject/printversion'
+      run = self.run_pants(['run', target_spec])
+      self.assert_success(run)
+      self.assertIn('java.home:{}'.format(distribution.home), run.stdout_data)
 
   def test_jvm_meets_min_and_max_distribution(self):
-    with subsystem_instance(DistributionLocator):
-      distribution = DistributionLocator.locate()
-    target_spec = 'testprojects/src/java/org/pantsbuild/testproject/printversion'
-    run = self.run_pants(['run', target_spec], config={
-      'jvm-distributions': {
-        'minimum_version': str(distribution.version),
-        'maximum_version': str(distribution.version)
-      }
-    })
-    self.assert_success(run)
-    self.assertIn('java.home:{}'.format(distribution.home), run.stdout_data)
+    with _distribution_locator() as locator:
+      distribution = locator.cached()
+      target_spec = 'testprojects/src/java/org/pantsbuild/testproject/printversion'
+      run = self.run_pants(['run', target_spec],
+                           config={
+                             'jvm-distributions': {
+                               'minimum_version': str(distribution.version),
+                               'maximum_version': str(distribution.version)
+                             }
+                           })
+      self.assert_success(run)
+      self.assertIn('java.home:{}'.format(distribution.home), run.stdout_data)
 
   def test_impossible_distribution_requirements(self):
-    with subsystem_instance(DistributionLocator) as dist_loader:
+    with _distribution_locator() as locator:
       with self.assertRaisesRegexp(Distribution.Error, "impossible constraints"):
-        dist_loader.cached('2', '1', jdk=False)
+        locator.cached('2', '1', jdk=False)
 
   def _test_jvm_does_not_meet_distribution_requirements(self,
                                                         min_version_arg=None,
@@ -97,9 +107,9 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
         'maximum_version': max_version_option,
       }
     }
-    with subsystem_instance(DistributionLocator, **options) as dist_loader:
+    with _distribution_locator(**options) as locator:
       with self.assertRaises(Distribution.Error):
-        dist_loader.cached(min_version_arg, max_version_arg, jdk=False)
+        locator.cached(minimum_version=min_version_arg, maximum_version=max_version_arg, jdk=False)
 
   # a version less than all other versions
   BOTTOM = '0.00001'
@@ -119,13 +129,17 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
     self._test_jvm_does_not_meet_distribution_requirements(max_version_arg=self.BOTTOM)
 
   def test_min_option_trumps_min_arg(self):
-    self._test_jvm_does_not_meet_distribution_requirements(min_version_arg=self.BOTTOM, min_version_option=self.TOP)
+    self._test_jvm_does_not_meet_distribution_requirements(min_version_arg=self.BOTTOM,
+                                                           min_version_option=self.TOP)
 
   def test_min_arg_trumps_min_option(self):
-    self._test_jvm_does_not_meet_distribution_requirements(min_version_arg=self.TOP, min_version_option=self.BOTTOM)
+    self._test_jvm_does_not_meet_distribution_requirements(min_version_arg=self.TOP,
+                                                           min_version_option=self.BOTTOM)
 
   def test_max_option_trumps_max_arg(self):
-    self._test_jvm_does_not_meet_distribution_requirements(max_version_arg=self.TOP, max_version_option=self.BOTTOM)
+    self._test_jvm_does_not_meet_distribution_requirements(max_version_arg=self.TOP,
+                                                           max_version_option=self.BOTTOM)
 
   def test_max_arg_trumps_max_option(self):
-    self._test_jvm_does_not_meet_distribution_requirements(max_version_arg=self.BOTTOM, max_version_option=self.TOP)
+    self._test_jvm_does_not_meet_distribution_requirements(max_version_arg=self.BOTTOM,
+                                                           max_version_option=self.TOP)


### PR DESCRIPTION
Previously, the distribution test failed on machine with multiple java
distributions installed.  This change re-factors `DistributionLocator`
into a thin factory class that produces a `_Locator` from option values.
This results in a more easily testable system.

This addresses #2894 

https://rbcommons.com/s/twitter/r/3778/