### PR TITLE
The thrift dep is indirect but required under JDK8.

### DIFF
--- a/examples/tests/java/org/pantsbuild/example/usethrift/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/usethrift/BUILD
@@ -7,6 +7,7 @@ junit_tests(name='usethrift',
   sources=['UseThriftTest.java',],
   dependencies=[
     '3rdparty:junit',
+    '3rdparty:thrift',
     'examples/src/thrift/org/pantsbuild/example/distance:distance-java',
     'examples/src/thrift/org/pantsbuild/example/precipitation:precipitation-java',
   ],

--- a/examples/tests/java/org/pantsbuild/example/usethrift/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/usethrift/BUILD
@@ -7,7 +7,7 @@ junit_tests(name='usethrift',
   sources=['UseThriftTest.java',],
   dependencies=[
     '3rdparty:junit',
-    '3rdparty:thrift',
+    '3rdparty:thrift-0.9.2',
     'examples/src/thrift/org/pantsbuild/example/distance:distance-java',
     'examples/src/thrift/org/pantsbuild/example/precipitation:precipitation-java',
   ],


### PR DESCRIPTION
Discovered here:
  http://jenkins.pantsbuild.org/job/test.pants.multibranch.pipeline/branch/PR-3292/8/execution/node/344/log/

https://rbcommons.com/s/twitter/r/3787/