### PR TITLE
Scrooge gen: Cache resolved scrooge deps

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -28,6 +28,7 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/option',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ],
 )
 

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -226,10 +226,8 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
   @memoized_property
   def _resolved_dep_info(self):
-    if not self._depinfo:
-      self._depinfo = ScroogeGen.DepInfo(self._resolve_deps(self.get_options().service_deps),
-                                         self._resolve_deps(self.get_options().structs_deps))
-    return self._depinfo
+    return ScroogeGen.DepInfo(self._resolve_deps(self.get_options().service_deps),
+                              self._resolve_deps(self.get_options().structs_deps))
 
   @property
   def _copy_target_attributes(self):


### PR DESCRIPTION
The current behavior is that we re-resolve the scrooge dependencies for each thrift target.

This changes scrooge gen so that only the first target created does a resolve and afterwards it is cached.