### PR TITLE
Addresses should only be equal to other addresses

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -195,7 +195,7 @@ class Address(object):
 
   def __eq__(self, other):
     if not isinstance(other, Address):
-      return NotImplemented
+      return False
     return (self._spec_path == other._spec_path and
             self._target_name == other._target_name)
 
@@ -203,10 +203,7 @@ class Address(object):
     return self._hash
 
   def __ne__(self, other):
-    equality = self.__eq__(other)
-    if equality is NotImplemented:
-      return NotImplemented
-    return not equality
+    return not self == other
 
   def __repr__(self):
     return self.spec

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -195,7 +195,7 @@ class Address(object):
 
   def __eq__(self, other):
     if not isinstance(other, Address):
-      return False
+      return NotImplemented
     return (self._spec_path == other._spec_path and
             self._target_name == other._target_name)
 
@@ -203,7 +203,10 @@ class Address(object):
     return self._hash
 
   def __ne__(self, other):
-    return not self.__eq__(other)
+    equality = self.__eq__(other)
+    if equality is NotImplemented:
+      return NotImplemented
+    return not equality
 
   def __repr__(self):
     return self.spec

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -195,7 +195,7 @@ class Address(object):
 
   def __eq__(self, other):
     if not isinstance(other, Address):
-      return NotImplemented
+      return False
     return (self._spec_path == other._spec_path and
             self._target_name == other._target_name)
 

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -109,6 +109,8 @@ class BaseAddressTest(unittest.TestCase):
 
 class AddressTest(BaseAddressTest):
   def test_equivalence(self):
+    self.assertNotEqual("Not really an address", Address('a/b', 'c'))
+
     self.assertEqual(Address('a/b', 'c'), Address('a/b', 'c'))
     self.assertEqual(Address('a/b', 'c'), Address.parse('a/b:c'))
     self.assertEqual(Address.parse('a/b:c'), Address.parse('a/b:c'))


### PR DESCRIPTION
Currently addresses return NotImplemented when other is not an instance of Address. NotImplemented is truthy, so Addresses will equal any non-address.

This changes it to return False, and adds a regression assertion.