### PR TITLE
Use NailgunTask's Java distribution consistently.

### DIFF
--- a/contrib/android/src/python/pants/contrib/android/tasks/sign_apk.py
+++ b/contrib/android/src/python/pants/contrib/android/tasks/sign_apk.py
@@ -23,6 +23,8 @@ from pants.contrib.android.targets.android_binary import AndroidBinary
 logger = logging.getLogger(__name__)
 
 
+# TODO: Should this be a NailgunTask? Then it can set its self.dist instead of
+# working directly with DistributionLocator.
 class SignApkTask(Task):
   """Sign Android packages with keystores using the jarsigner tool."""
 

--- a/src/python/pants/backend/codegen/tasks/BUILD
+++ b/src/python/pants/backend/codegen/tasks/BUILD
@@ -67,7 +67,6 @@ python_library(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:exceptions',
-    'src/python/pants/java/distribution:distribution',
   ],
 )
 
@@ -133,7 +132,6 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:revision',
-    'src/python/pants/java/distribution',
     'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/backend/codegen/tasks/jaxb_gen.py
+++ b/src/python/pants/backend/codegen/tasks/jaxb_gen.py
@@ -13,7 +13,6 @@ from pants.backend.codegen.tasks.simple_codegen_task import SimpleCodegenTask
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
-from pants.java.distribution.distribution import DistributionLocator
 
 
 class JaxbGen(SimpleCodegenTask, NailgunTask):
@@ -25,13 +24,14 @@ class JaxbGen(SimpleCodegenTask, NailgunTask):
     :param workdir: inherited parameter from Task
     """
     super(JaxbGen, self).__init__(*args, **kwargs)
+    self.set_distribution(jdk=True)
     self.gen_langs = set()
     lang = 'java'
     if self.context.products.isrequired(lang):
       self.gen_langs.add(lang)
 
   def _compile_schema(self, args):
-    classpath = DistributionLocator.cached(jdk=True).find_libs(['tools.jar'])
+    classpath = self.dist.find_libs(['tools.jar'])
     java_main = 'com.sun.tools.internal.xjc.Driver'
     return self.runjava(classpath=classpath, main=java_main, args=args, workunit_name='xjc')
 

--- a/src/python/pants/backend/codegen/tasks/wire_gen.py
+++ b/src/python/pants/backend/codegen/tasks/wire_gen.py
@@ -18,7 +18,6 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunTaskBase
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.java.distribution.distribution import DistributionLocator
 
 
 logger = logging.getLogger(__name__)
@@ -46,10 +45,6 @@ class WireGen(NailgunTaskBase, SimpleCodegenTask):
   @classmethod
   def is_wire_compiler_jar(cls, jar):
     return 'com.squareup.wire' == jar.org and 'wire-compiler' == jar.name
-
-  @classmethod
-  def subsystem_dependencies(cls):
-    return super(WireGen, cls).subsystem_dependencies() + (DistributionLocator,)
 
   def __init__(self, *args, **kwargs):
     """Generates Java files from .proto files using the Wire protobuf compiler."""

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -112,6 +112,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/base:hash_utils',
     'src/python/pants/base:workunit',
+    'src/python/pants/java/distribution',
     'src/python/pants/option',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -25,6 +25,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
+from pants.java.distribution.distribution import Distribution
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_open
 from pants.util.memo import memoized_property
@@ -205,7 +206,7 @@ class BaseZincCompile(JvmCompile):
       # For example com.sun.tools.javac.Main is used for in process java compilation.
       self.set_distribution(jdk=True)
       self._tools_jar = self.dist.find_libs(['tools.jar'])
-    except TaskError:
+    except (TaskError, Distribution.Error):
       self.context.log.info('Failed to locate tools.jar. '
                             'Install a JDK to increase performance of Zinc.')
       self._tools_jar = []

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -20,6 +20,7 @@ from pants.util.dirutil import safe_mkdir, safe_walk
 Jvmdoc = collections.namedtuple('Jvmdoc', ['tool_name', 'product_type'])
 
 
+# TODO: Shouldn't this be a NailgunTask?
 class JvmdocGen(JvmTask):
 
   @classmethod

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -62,6 +62,10 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
     except DistributionLocator.Error as e:
       raise TaskError(e)
 
+  @property
+  def dist(self):
+    return self._dist
+
   def create_java_executor(self):
     """Create java executor that uses this task's ng daemon, if allowed.
 


### PR DESCRIPTION
A few NailgunTasks need the JDK's tools.jar, and were fetching
its path directly via DistributionLocator, instead of using
the distribution it will later execute with.

In practice, today, these all end up being the same distribution.
But in the future, if a particular task restricts its choice of
distribution then we could end up running in one JDK with the
tools.jar of another JDK on our classpath.