### PR TITLE
Fixup `PEP8Error` to carry lines.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pep8.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pep8.py
@@ -13,7 +13,8 @@ from pants.contrib.python.checks.tasks.checkstyle.common import CheckstylePlugin
 class PEP8Error(Nit):
   def __init__(self, python_file, code, line_number, text):
     line_range = python_file.line_range(line_number)
-    super(PEP8Error, self).__init__(code, Nit.ERROR, python_file, text, line_range)
+    lines = python_file.lines[line_range]
+    super(PEP8Error, self).__init__(code, Nit.ERROR, python_file, text, line_range, lines)
 
 
 class PantsReporter(pep8.BaseReport):

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/plugin_test_base.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/plugin_test_base.py
@@ -45,10 +45,12 @@ class CheckstylePluginTestBase(unittest.TestCase):
     plugin = self.get_plugin(file_content)
     nits = list(plugin.nits())
     self.assertEqual(1, len(nits), 'Expected single nit, got: {}'.format(nits))
-    self.assertEqual(expected_code, nits[0].code)
-    self.assertEqual(expected_severity, nits[0].severity)
+    nit = nits[0]
+    self.assertEqual(expected_code, nit.code)
+    self.assertEqual(expected_severity, nit.severity)
     if expected_line_number is not None:
-      self.assertEqual(expected_line_number, nits[0].line_number)
+      self.assertEqual(expected_line_number, nit.line_number)
+    return nit
 
   def assertNoNits(self, file_content):
     plugin = self.get_plugin(file_content)

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_pep8.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_pep8.py
@@ -28,3 +28,14 @@ class PEP8CheckerTest(CheckstylePluginTestBase):
 
   def test_pep8_line_length(self):
     self.assertNit('# Longer than 10.\n', 'E501', expected_line_number='001')
+
+  def test_pep8_nit_lines(self):
+    # Pep8 supports `# noqa` for certain checks, but not all, whereas the higher level pants checker
+    # always supports `# noqa` no matter the provenance of the check, iff the check has a relevant
+    # line marked `# noqa`.
+    #
+    # This test verifies that E221 does not respect `# noqa` at the pep8 check level, but that the
+    # resulting nit does have an appropriate set of lines for the higher-level pants checker
+    # `# noqa` support.
+    nit = self.assertNit('A  = "Longer than 10."  # noqa\n', 'E221', expected_line_number='001')
+    self.assertEqual(['A  = "Longer than 10."  # noqa'], nit.lines)


### PR DESCRIPTION
This plumbing was missed in https://rbcommons.com/s/twitter/r/3647 and
it is needed to enable the higher-level `# noqa` support provided by
`checker.py`

https://rbcommons.com/s/twitter/r/3806/