### PR TITLE
Handle values for list options that end with quotes

### DIFF
--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -148,7 +148,11 @@ class ListValueComponent(object):
       val = _convert(value[1:], (list, tuple))
     elif isinstance(value, six.string_types):
       action = cls.EXTEND
-      val = _convert('[r"""{}"""]'.format(value), list)
+      if value.endswith('"'):
+        fmt_str = "[r'''{}''']"
+      else:
+        fmt_str = '[r"""{}"""]'
+      val = _convert(fmt_str.format(value), list)
     else:
       action = cls.EXTEND
       val = _convert('[{}]'.format(value), list)

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -148,11 +148,7 @@ class ListValueComponent(object):
       val = _convert(value[1:], (list, tuple))
     elif isinstance(value, six.string_types):
       action = cls.EXTEND
-      if value.endswith('"'):
-        fmt_str = "[r'''{}''']"
-      else:
-        fmt_str = '[r"""{}"""]'
-      val = _convert(fmt_str.format(value), list)
+      val = [value]
     else:
       action = cls.EXTEND
       val = _convert('[{}]'.format(value), list)

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -48,6 +48,10 @@ class CustomTypesTest(unittest.TestCase):
     self._do_test(['a', 'b', 'c'], "['a', 'b', 'c']")
     self._do_test([1, 2, 3, 4], '[1, 2] + [3, 4]')
     self._do_test([1, 2, 3, 4], '(1, 2) + (3, 4)')
+    self._do_test(['a"'], 'a"')
+    self._do_test(["a'"], "a'")
+    self._do_test(["\"a'"], "\"a'")
+    self._do_test(["'a\""], "'a\"")
 
   def test_unicode_comments(self):
     """We had a bug where unicode characters in comments would cause the option parser to fail.

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -52,6 +52,10 @@ class CustomTypesTest(unittest.TestCase):
     self._do_test(["a'"], "a'")
     self._do_test(["\"a'"], "\"a'")
     self._do_test(["'a\""], "'a\"")
+    self._do_test(['a"""a'], 'a"""a')
+    self._do_test(['1,2'], '1,2')
+    self._do_test([1, 2], '+[1,2]')
+    self._do_test(['\\'], '\\')
 
   def test_unicode_comments(self):
     """We had a bug where unicode characters in comments would cause the option parser to fail.


### PR DESCRIPTION
The current implementation will raise an error if a list option provided using the extend syntax ends with a double quote. This adds code to handle that case.