### PR TITLE
Upgrade cloc to 1.66.

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/cloc.py
+++ b/src/python/pants/backend/graph_info/tasks/cloc.py
@@ -26,7 +26,7 @@ class CountLinesOfCode(ConsoleTask):
   @classmethod
   def register_options(cls, register):
     super(CountLinesOfCode, cls).register_options(register)
-    register('--version', advanced=True, fingerprint=True, default='1.64', help='Version of cloc.')
+    register('--version', advanced=True, fingerprint=True, default='1.66', help='Version of cloc.')
     register('--transitive', type=bool, fingerprint=True, default=True,
              help='Operate on the transitive dependencies of the specified targets.  '
                   'Unset to operate only on the specified targets.')


### PR DESCRIPTION
This gets cloc working with modern perl.

https://rbcommons.com/s/twitter/r/3820/