### PR TITLE
Ensure `DistributionLocator` is `_reset` after tests.

### DIFF
--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -428,6 +428,7 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
                                    })
         with subsystem_instance(DistributionLocator) as locator:
           locator._reset()  # Make sure we get a fresh read from the options set just above.
+          self.addCleanup(locator._reset)  # And make sure we we clean up the values we cache.
 
           export_json = self.execute_export_json()
           self.assertEqual({'strict': strict_home, 'non_strict': non_strict_home},

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -19,7 +19,10 @@ from pants_test.subsystem.subsystem_util import subsystem_instance
 def _distribution_locator(**options):
   with subsystem_instance(DistributionLocator, **options) as locator:
     locator._reset()  # Force a fresh locator.
-    yield locator
+    try:
+      yield locator
+    finally:
+      locator._reset()  # And make sure we we clean up the values we cache.
 
 
 def _get_two_distributions():


### PR DESCRIPTION
https://rbcommons.com/s/twitter/r/3832/