### PR TITLE
Retry git operations up to 2 times.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,10 @@ def Closure<Void> ciShNodeSpawner(String os, String flags) {
                  host: ${instanceData('public-ipv4')}
         """)
 
-        checkout scm
+        // Avoid failing on transient git issues.
+        retry(2) {
+          checkout scm
+        }
 
         /*
          * Work around various concurrency issues associated with tools that use paths under the


### PR DESCRIPTION
This is intended to avoid shard failures due to flaky git
operations by trying up to 3 total times to get the workspace
fetched up to the right sha.

https://rbcommons.com/s/twitter/r/3841/