### PR TITLE
Separate out parsing specs from making list of requests

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/CompositeRequestRunner.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/CompositeRequestRunner.java
@@ -17,9 +17,9 @@ import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
 
 /**
- * A JUnit {@link Request} that is composed of a list of {@link Request}s.
+ * A JUnit Runner that handles a list of {@link Request}s.
  */
-public class CompositeRequest extends ParentRunner<Request> {
+public class CompositeRequestRunner extends ParentRunner<Request> {
 
   private final List<Request> requests;
 
@@ -28,7 +28,7 @@ public class CompositeRequest extends ParentRunner<Request> {
    * @param requests List of requests to be composed of.
    * @throws InitializationError
    */
-  public CompositeRequest(List<Request> requests) throws InitializationError {
+  public CompositeRequestRunner(List<Request> requests) throws InitializationError {
     // Note: this works for now, Suite constructor also calls super(null), but it may break some
     // point in future, in which case fall back to implementing Runner may be necessary.
     super(null);
@@ -75,5 +75,4 @@ public class CompositeRequest extends ParentRunner<Request> {
       eachNotifier.addFailure(e);
     }
   }
-
 }

--- a/src/java/org/pantsbuild/tools/junit/impl/Concurrency.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Concurrency.java
@@ -1,5 +1,11 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 package org.pantsbuild.tools.junit.impl;
 
+/**
+ * Describes the type of concurrency desired when running a batch of tests.
+ */
 public enum Concurrency {
   SERIAL(false, false),
   PARALLEL_CLASSES(true, false),

--- a/src/java/org/pantsbuild/tools/junit/impl/ConcurrentCompositeRequestRunner.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConcurrentCompositeRequestRunner.java
@@ -13,11 +13,11 @@ import org.junit.runners.model.Statement;
 /**
  * A Runner for running composite requests in a concurrent fashion.
  */
-public class ConcurrentCompositeRequest extends CompositeRequest {
+public class ConcurrentCompositeRequestRunner extends CompositeRequestRunner {
 
   private final ConcurrentRunnerScheduler runnerScheduler;
 
-  public ConcurrentCompositeRequest(List<Request> requests, Concurrency defaultConcurrency,
+  public ConcurrentCompositeRequestRunner(List<Request> requests, Concurrency defaultConcurrency,
       int numThreads)
       throws InitializationError {
     super(requests);

--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -4,27 +4,6 @@
 package org.pantsbuild.tools.junit.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.ByteArrayOutputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -34,7 +13,26 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
-
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.junit.runner.Computer;
 import org.junit.runner.Description;
@@ -51,7 +49,6 @@ import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 import org.kohsuke.args4j.spi.StringArrayOptionHandler;
-
 import org.pantsbuild.args4j.InvalidCmdLineArgumentException;
 import org.pantsbuild.tools.junit.withretry.AllDefaultPossibilitiesBuilderWithRetry;
 
@@ -328,8 +325,6 @@ public class ConsoleRunnerImpl {
     ALL, FAILURE_ONLY, NONE
   }
 
-  private static final Pattern METHOD_PARSER = Pattern.compile("^([^#]+)#([^#]+)$");
-
   private final boolean failFast;
   private final OutputMode outputMode;
   private final boolean xmlReport;
@@ -340,6 +335,7 @@ public class ConsoleRunnerImpl {
   private final int testShard;
   private final int numTestShards;
   private final int numRetries;
+  private final boolean useExperimentalRunner;
   private final SwappableStream<PrintStream> swappableOut;
   private final SwappableStream<PrintStream> swappableErr;
 
@@ -354,6 +350,7 @@ public class ConsoleRunnerImpl {
       int testShard,
       int numTestShards,
       int numRetries,
+      boolean useExperimentalRunner,
       PrintStream out,
       PrintStream err) {
 
@@ -374,18 +371,12 @@ public class ConsoleRunnerImpl {
     this.numRetries = numRetries;
     this.swappableOut = new SwappableStream<PrintStream>(out);
     this.swappableErr = new SwappableStream<PrintStream>(err);
+    this.useExperimentalRunner = useExperimentalRunner;
   }
 
-  void run(Iterable<String> tests) {
+  void run(Collection<String> tests) {
     System.setOut(new PrintStream(swappableOut));
     System.setErr(new PrintStream(swappableErr));
-
-    List<Request> requests =
-        parseRequests(swappableOut.getOriginal(), swappableErr.getOriginal(), tests);
-
-    if (numTestShards > 0) {
-      requests = setFilterForTestShard(requests);
-    }
 
     JUnitCore core = new JUnitCore();
     final AbortableListener abortableListener = new AbortableListener(failFast) {
@@ -424,20 +415,22 @@ public class ConsoleRunnerImpl {
     final Thread abnormalExitHook =
         createAbnormalExitHook(abortableListener, swappableOut.getOriginal());
     Runtime.getRuntime().addShutdownHook(abnormalExitHook);
+
     int failures = 0;
     try {
-      if (this.parallelThreads > 1) {
-        ConcurrentCompositeRequest request = new ConcurrentCompositeRequest(
-            requests, this.defaultConcurrency, this.parallelThreads);
-        failures = core.run(request).getFailureCount();
+      List<Spec> parsedTests = new SpecParser(tests).parse();
+
+      if (useExperimentalRunner) {
+        failures = runExperimental(parsedTests, core);
       } else {
-        for (Request request : requests) {
-          Result result = core.run(request);
-          failures += result.getFailureCount();
-        }
+        failures = runLegacy(parsedTests, core);
       }
-    } catch (InitializationError initializationError) {
+    } catch (SpecException e) {
       failures = 1;
+      swappableErr.getOriginal().println("Error parsing specs: " + e.getMessage());
+    } catch (InitializationError e) {
+      failures = 1;
+      swappableErr.getOriginal().println("Error initializing JUnit: " + e.getMessage());
     } finally {
       // If we're exiting via a thrown exception, we'll get a better message by letting it
       // propagate than by halt()ing.
@@ -469,7 +462,38 @@ public class ConsoleRunnerImpl {
     return abnormalExitHook;
   }
 
-  private List<Request> parseRequests(PrintStream out, PrintStream err, Iterable<String> specs) {
+  private int runExperimental(List<Spec> parsedTests, JUnitCore core)
+      throws InitializationError {
+    Preconditions.checkArgument(!parsedTests.isEmpty());
+    Preconditions.checkNotNull(core);
+
+    throw new InitializationError("Experimental Runner: Not Implemented");
+  }
+
+  private int runLegacy(List<Spec> parsedTests, JUnitCore core) throws InitializationError {
+    List<Request> requests =
+        legacyParseRequests(swappableOut.getOriginal(), swappableErr.getOriginal(), parsedTests);
+
+    if (numTestShards > 0) {
+      requests = setFilterForTestShard(requests);
+    }
+
+    if (this.parallelThreads > 1) {
+      ConcurrentCompositeRequestRunner request = new ConcurrentCompositeRequestRunner(
+          requests, this.defaultConcurrency, this.parallelThreads);
+      return core.run(request).getFailureCount();
+    }
+
+    int failures = 0;
+    for (Request request : requests) {
+      Result result = core.run(request);
+      failures += result.getFailureCount();
+    }
+    return failures;
+  }
+
+  private List<Request> legacyParseRequests(PrintStream out, PrintStream err,
+      List<Spec> specs) {
     /**
      * Datatype representing an individual test method.
      */
@@ -484,34 +508,13 @@ public class ConsoleRunnerImpl {
     }
     Set<TestMethod> testMethods = Sets.newLinkedHashSet();
     Set<Class<?>> classes = Sets.newLinkedHashSet();
-    for (String spec : specs) {
-      Matcher matcher = METHOD_PARSER.matcher(spec);
-      try {
-        if (matcher.matches()) {
-          Class<?> testClass = loadClass(matcher.group(1));
-          if (isTest(testClass)) {
-            String method = matcher.group(2);
-            testMethods.add(new TestMethod(testClass, method));
-          }
-        } else {
-          Class<?> testClass = loadClass(spec);
-          if (isTest(testClass)) {
-            classes.add(testClass);
-          }
+    for (Spec spec: specs) {
+      if (spec.getMethods().isEmpty()) {
+        classes.add(spec.getSpecClass());
+      } else {
+        for (String method : spec.getMethods()) {
+          testMethods.add(new TestMethod(spec.getSpecClass(), method));
         }
-      } catch (NoClassDefFoundError e) {
-        notFoundError(spec, out, e);
-      } catch (ClassNotFoundException e) {
-        notFoundError(spec, out, e);
-      } catch (LinkageError e) {
-        // Any of a number of runtime linking errors can occur when trying to load a class,
-        // fail with the test spec so the class failing to link is known.
-        notFoundError(spec, out, e);
-      // See the comment below for justification.
-      } catch (RuntimeException e) {
-        // The class may fail with some variant of RTE in its static initializers, trap these
-        // and dump the bad spec in question to help narrow down issue.
-        notFoundError(spec, out, e);
       }
     }
     List<Request> requests = Lists.newArrayList();
@@ -625,12 +628,6 @@ public class ConsoleRunnerImpl {
     return filteredRequests;
   }
 
-  private void notFoundError(String spec, PrintStream out, Throwable t) {
-    out.printf("FATAL: Error during test discovery for %s: %s\n", spec, t);
-    throw new RuntimeException(
-        "Classloading error during test discovery for spec '%s'".format(spec), t);
-  }
-
   /**
    * Launcher for JUnitConsoleRunner.
    *
@@ -738,6 +735,10 @@ public class ConsoleRunnerImpl {
                 metaVar = "TESTS",
                 handler = StringArrayOptionHandler.class)
       private String[] tests = {};
+
+      @Option(name="-use-experimental-runner",
+          usage="Use the experimental runner that has support for parallel methods")
+      private boolean useExperimentalRunner = false;
     }
 
     Options options = new Options();
@@ -766,6 +767,7 @@ public class ConsoleRunnerImpl {
             options.testShard,
             options.numTestShards,
             options.numRetries,
+            options.useExperimentalRunner,
             System.out,
             System.err);
 
@@ -810,46 +812,12 @@ public class ConsoleRunnerImpl {
     return Concurrency.PARALLEL_CLASSES;
   }
 
-  public static final Predicate<Constructor<?>> IS_PUBLIC_CONSTRUCTOR =
-      new Predicate<Constructor<?>>() {
-        @Override public boolean apply(Constructor<?> constructor) {
-          return Modifier.isPublic(constructor.getModifiers());
-        }
-      };
-
   private static final Predicate<Method> IS_ANNOTATED_TEST_METHOD = new Predicate<Method>() {
     @Override public boolean apply(Method method) {
       return Modifier.isPublic(method.getModifiers())
           && method.isAnnotationPresent(org.junit.Test.class);
     }
   };
-
-  private static boolean isTest(final Class<?> clazz) {
-    // Must be a public concrete class to be a runnable junit Test.
-    if (clazz.isInterface()
-        || Modifier.isAbstract(clazz.getModifiers())
-        || !Modifier.isPublic(clazz.getModifiers())) {
-      return false;
-    }
-
-    // The class must have some public constructor to be instantiated by the runner being used
-    if (!Iterables.any(Arrays.asList(clazz.getConstructors()), IS_PUBLIC_CONSTRUCTOR)) {
-      return false;
-    }
-
-    // Support junit 3.x Test hierarchy.
-    if (junit.framework.Test.class.isAssignableFrom(clazz)) {
-      return true;
-    }
-
-    // Support classes using junit 4.x custom runners.
-    if (clazz.isAnnotationPresent(RunWith.class)) {
-      return true;
-    }
-
-    // Support junit 4.x @Test annotated methods.
-    return Iterables.any(Arrays.asList(clazz.getMethods()), IS_ANNOTATED_TEST_METHOD);
-  }
 
   private static void exit(int code) {
     exitStatus = code;

--- a/src/java/org/pantsbuild/tools/junit/impl/Spec.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Spec.java
@@ -1,0 +1,56 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.pantsbuild.junit.annotations.TestParallel;
+import org.pantsbuild.junit.annotations.TestSerial;
+
+/**
+ * Represents a parsed test spec from the junit-runner command line.
+ */
+class Spec {
+  private final Class<?> clazz;
+  private final Set<String> methods;
+
+  public Spec(Class<?> clazz) {
+    Preconditions.checkNotNull(clazz);
+    this.clazz = clazz;
+    this.methods = new LinkedHashSet<String>();
+  }
+
+  public String getSpecName() {
+    return this.clazz.getName();
+  }
+
+  public Class<?> getSpecClass() {
+    return this.clazz;
+  }
+
+  public void addMethod(String method) {
+    Preconditions.checkNotNull(method);
+    methods.add(method);
+  }
+
+  /**
+   * @return either the Concurrency value specified by the class annotation or the default
+   * concurrency setting passed in the parameter.
+   */
+  public Concurrency getConcurrency(Concurrency defaultConcurrency) {
+    if (clazz.isAnnotationPresent(TestSerial.class)) {
+      return Concurrency.SERIAL;
+    } else if (clazz.isAnnotationPresent(TestParallel.class)) {
+      return Concurrency.PARALLEL_CLASSES;
+    }
+    return defaultConcurrency;
+  }
+
+  public Collection<String> getMethods() {
+    return ImmutableList.copyOf(methods);
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/impl/SpecException.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/SpecException.java
@@ -1,0 +1,19 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+class SpecException extends Exception {
+
+  public SpecException(String spec, String message) {
+    super(formatMessage(spec, message));
+  }
+
+  public SpecException(String spec, String message, Throwable t) {
+    super(formatMessage(spec, message), t);
+  }
+
+  private static String formatMessage(String spec, String message) {
+    return String.format("FATAL: Error parsing spec %s: %s",spec, message);
+  }
+}

--- a/src/java/org/pantsbuild/tools/junit/impl/SpecParser.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/SpecParser.java
@@ -1,0 +1,184 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.runner.RunWith;
+
+/**
+ * Takes strings passed to the command line representing packages or individual methods
+ * and returns a parsed Spec.  Each Spec represents a single class, so individual methods
+ * are added into each spec
+ */
+class SpecParser {
+  private final Iterable<String> testSpecStrings;
+  private final Map<Class<?>, Spec> specs = new LinkedHashMap<Class<?>, Spec>();
+  private final Set<String> classNamesInSpecs = new HashSet<String>();
+
+  /**
+   * Parses the list of incoming test specs from the command line.
+   * <p>
+   * Expects a list of string specs which can be represented as one of:
+   * <ul>
+   *   <li>package.className</li>
+   *   <li>package.className#methodName</li>
+   * </ul>
+   * Note that each class or method will only be executed once, no matter how many times it is
+   * present in the list.
+   * </p>
+   * <p>
+   * It is illegal to pass a spec with just the className if there are also individual methods
+   * present in the list within the same class.
+   * </p>
+   */
+  // TODO(zundel): This could easily be extended to allow a regular expression in the spec
+  public SpecParser(Iterable<String> testSpecStrings) {
+    Preconditions.checkArgument(!Iterables.isEmpty(testSpecStrings));
+    this.testSpecStrings = testSpecStrings;
+  }
+
+  /**
+   * Parse the specs passed in to the constructor.
+   * @return List of parsed specs
+   * @throws SpecException
+   */
+  public List<Spec> parse() throws SpecException {
+    for (String specString : testSpecStrings) {
+      if (specString.indexOf('#') >= 0) {
+        addMethod(specString);
+        continue;
+      }
+      // The specString is expected to be the same as the fully qualified class name
+      if (classNamesInSpecs.contains(specString)) {
+        Spec spec = getOrCreateSpec(specString, specString);
+        if (!spec.getMethods().isEmpty()) {
+          throw new SpecException(specString,
+              "Request for entire class already requesting individual methods");
+        }
+        continue;
+      }
+      getOrCreateSpec(specString, specString);
+    }
+    return ImmutableList.copyOf(specs.values());
+  }
+
+  /**
+   * Creates or returns an existing Spec that corresponds to the className parameter.
+   *
+   * @param className The class name already parsed out of specString
+   * @param specString  A spec string described in {@link SpecParser}
+   * @return a Spec instance on success, null if this spec string should be ignored
+   * @throws SpecException if the method passed in is not an executable test method
+   */
+  private Spec getOrCreateSpec(String className, String specString) throws SpecException {
+    try {
+      Class<?> clazz = getClass().getClassLoader().loadClass(className);
+      if (!isTest(clazz)) {
+        return null;
+      }
+      if (!specs.containsKey(clazz)) {
+        specs.put(clazz, new Spec(clazz));
+        classNamesInSpecs.add(className);
+      }
+      return specs.get(clazz);
+    } catch (ClassNotFoundException e) {
+      throw new SpecException(specString,
+          String.format("Class %s not found in classpath.", className), e);
+    } catch (NoClassDefFoundError e) {
+      throw new SpecException(specString,
+          String.format("Class %s not found in classpath.", className), e);
+    } catch (LinkageError e) {
+      // Any of a number of runtime linking errors can occur when trying to load a class,
+      // fail with the test spec so the class failing to link is known.
+      throw new SpecException(specString,
+          String.format("Error linking %s.", className), e);
+      // See the comment below for justification.
+    } catch (RuntimeException e) {
+      // The class may fail with some variant of RTE in its static initializers, trap these
+      // and dump the bad spec in question to help narrow down issue.
+      throw new SpecException(specString,
+          String.format("Error initializing %s.",className), e);
+    }
+  }
+
+  public static final Predicate<Constructor<?>> IS_PUBLIC_CONSTRUCTOR =
+      new Predicate<Constructor<?>>() {
+        @Override public boolean apply(Constructor<?> constructor) {
+          return Modifier.isPublic(constructor.getModifiers());
+        }
+      };
+
+  private static final Predicate<Method> IS_ANNOTATED_TEST_METHOD =
+      new Predicate<Method>() {
+        @Override public boolean apply(Method method) {
+          return Modifier.isPublic(method.getModifiers())
+              && method.isAnnotationPresent(org.junit.Test.class);
+        }
+      };
+
+  private static boolean isTest(final Class<?> clazz) {
+    // Must be a public concrete class to be a runnable junit Test.
+    if (clazz.isInterface()
+        || Modifier.isAbstract(clazz.getModifiers())
+        || !Modifier.isPublic(clazz.getModifiers())) {
+      return false;
+    }
+
+    // The class must have some public constructor to be instantiated by the runner being used
+    if (!Iterables.any(Arrays.asList(clazz.getConstructors()), IS_PUBLIC_CONSTRUCTOR)) {
+      return false;
+    }
+
+    // Support junit 3.x Test hierarchy.
+    if (junit.framework.Test.class.isAssignableFrom(clazz)) {
+      return true;
+    }
+
+    // Support classes using junit 4.x custom runners.
+    if (clazz.isAnnotationPresent(RunWith.class)) {
+      return true;
+    }
+
+    // Support junit 4.x @Test annotated methods.
+    return Iterables.any(Arrays.asList(clazz.getMethods()), IS_ANNOTATED_TEST_METHOD);
+  }
+
+  /**
+   * Handle a spec that looks like package.className#methodName
+   */
+  public void addMethod(String specString) throws SpecException {
+    String[] results = specString.split("#");
+    if (results.length != 2) {
+      throw new SpecException(specString, "Expected only one # in spec");
+    }
+    String className = results[0];
+    String methodName = results[1];
+
+    Spec spec = getOrCreateSpec(className, specString);
+    boolean found = false;
+    for (Method clazzMethod : spec.getSpecClass().getMethods()) {
+      if (clazzMethod.getName().equals(methodName)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      throw new SpecException(specString,
+          String.format("Method %s not found in class %s", methodName, className));
+    }
+    spec.addMethod(methodName);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/AnnotationOverrideClass.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/AnnotationOverrideClass.java
@@ -1,0 +1,16 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.pantsbuild.junit.annotations.TestParallel;
+import org.pantsbuild.junit.annotations.TestSerial;
+
+/**
+ * Tests the annotation override behavior.
+ * {@link TestSerial} should override all other annotations.
+ */
+@TestParallel
+@TestSerial
+public class AnnotationOverrideClass {
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -205,7 +205,60 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
         "SerialTest1 SerialTest2"
             + " -default-concurrency SERIAL -parallel-threads 4"));
     assertEquals("stest1 stest2", TestRegistry.getCalledTests());
+  }
 
+  @Test
+  public void testMockJUnit3Test() throws Exception {
+    ConsoleRunnerImpl.main(asArgsArray("MockJUnit3Test"));
+    assertEquals("mju3t1", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testMockRunWithTest() throws Exception {
+    ConsoleRunnerImpl.main(asArgsArray("MockRunWithTest"));
+    assertEquals("mrwt1-bar mrwt1-foo", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testNotATestNoPublicConstructor() throws Exception {
+    // This class contains no public constructor. The test runner should ignore
+    ConsoleRunnerImpl.main(asArgsArray("NotATestNoPublicConstructor"));
+    assertEquals("", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testNotATestPrivateClass() throws Exception {
+    // This class is private. The test runner should ignore
+    ConsoleRunnerImpl.main(asArgsArray("NotATestPrivateClass$PrivateClass"));
+    assertEquals("", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testNotATestNoRunnableMethods() throws Exception {
+    // This class has no runnable methods. The test runner should ignore
+    ConsoleRunnerImpl.main(asArgsArray("NotATestNoRunnableMethods"));
+    assertEquals("", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testNotATestNonzeroArgConstructor() throws Exception {
+    // This class doesn't have a zero args public constructor, test runner should ignore
+    ConsoleRunnerImpl.main(asArgsArray("NotATestNonzeroArgConstructor"));
+    assertEquals("", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testNotATestAbstractClass() throws Exception {
+    // This class is abstract, test runner should ignore
+    ConsoleRunnerImpl.main(asArgsArray("NotATestAbstractClass"));
+    assertEquals("", TestRegistry.getCalledTests());
+  }
+
+  @Test
+  public void testNotATestInterface() throws Exception {
+    // This class is abstract, test runner should ignore
+    ConsoleRunnerImpl.main(asArgsArray("NotATestInterface"));
+    assertEquals("", TestRegistry.getCalledTests());
   }
 
   @Test

--- a/tests/java/org/pantsbuild/tools/junit/impl/ParallelAnnotatedClass.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ParallelAnnotatedClass.java
@@ -1,0 +1,10 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.pantsbuild.junit.annotations.TestParallel;
+
+@TestParallel
+public class ParallelAnnotatedClass {
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
@@ -1,0 +1,135 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.pantsbuild.tools.junit.lib.MockJUnit3Test;
+import org.pantsbuild.tools.junit.lib.MockRunWithTest;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SpecParserTest {
+  private static final String DUMMY_CLASS_NAME =
+      "org.pantsbuild.tools.junit.impl.UnannotatedTestClass";
+  private static final String DUMMY_METHOD_NAME = "testMethod";
+
+  @Test public void testEmptySpecsThrows() {
+    try {
+      SpecParser parser = new SpecParser(new ArrayList<String>());
+      fail("Expected Exception");
+    } catch (Throwable expected) {
+    }
+  }
+
+  @Test public void testParserClass() throws Exception {
+    SpecParser parser = new SpecParser(ImmutableList.of(DUMMY_CLASS_NAME));
+    List<Spec> specs = parser.parse();
+    assertEquals(1, specs.size());
+    Spec spec = specs.get(0);
+    assertEquals(UnannotatedTestClass.class,spec.getSpecClass());
+    assertEquals(DUMMY_CLASS_NAME, spec.getSpecName());
+    assertEquals(0, spec.getMethods().size());
+  }
+
+  @Test public void testParserMethod() throws Exception {
+    String specString = DUMMY_CLASS_NAME + "#" + DUMMY_METHOD_NAME;
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    List<Spec> specs = parser.parse();
+    assertEquals(1, specs.size());
+    Spec spec = specs.get(0);
+    assertEquals(UnannotatedTestClass.class, spec.getSpecClass());
+    assertEquals(DUMMY_CLASS_NAME, spec.getSpecName());
+    assertEquals(ImmutableList.of(DUMMY_METHOD_NAME), spec.getMethods());
+  }
+
+  @Test public void testMethodDupsClass() throws Exception {
+    String specString = DUMMY_CLASS_NAME + "#" + DUMMY_METHOD_NAME;
+    SpecParser parser = new SpecParser(ImmutableList.of(DUMMY_CLASS_NAME, specString));
+    try {
+      parser.parse();
+    } catch (SpecException expected) {
+      assertThat(expected.getMessage(),
+          containsString("Request for entire class already requesting individual methods"));
+    }
+  }
+
+  @Test public void testBadSpec() {
+    String specString = DUMMY_CLASS_NAME + "#" + DUMMY_METHOD_NAME + "#" + "foo";
+    SpecParser parser = new SpecParser(ImmutableList.of(DUMMY_CLASS_NAME, specString));
+    try {
+      parser.parse();
+    } catch (SpecException expected) {
+      assertThat(expected.getMessage(),
+          containsString("Expected only one # in spec"));
+    }
+  }
+
+  @Test public void testMissingClass() {
+    String specString = "org.foo.bar.Baz" ;
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    try {
+      parser.parse();
+    } catch (SpecException expected) {
+      assertThat(expected.getMessage(),
+          containsString("Class org.foo.bar.Baz not found"));
+    }
+  }
+
+  @Test public void testMissingMethod() {
+    String specString = DUMMY_CLASS_NAME + "#doesNotExist";
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    try {
+      parser.parse();
+    } catch (SpecException expected) {
+      assertThat(expected.getMessage(),
+          containsString("Method doesNotExist not found in class"));
+    }
+  }
+
+  private void assertNoSpecs(String className) throws Exception {
+    String specString = "org.pantsbuild.tools.junit.lib." + className;
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    List<Spec> specs = parser.parse();
+    assertTrue(specs.isEmpty());
+  }
+
+  /**
+   * These are all classes/interfaces, but aren't test classes. Pants will pass in all the classes
+   * and interfaces it finds, but if they get passed down to the BlockJUnit4Runner, the runner
+   * will throw an InitializationError
+   *
+   * @throws Exception
+   */
+  @Test public void testNotATest() throws Exception {
+    assertNoSpecs("NotATestAbstractClass");
+    assertNoSpecs("NotATestInterface");
+    assertNoSpecs("NotATestNonzeroArgConstructor");
+    assertNoSpecs("NotATestNoPublicConstructor");
+    assertNoSpecs("NotATestNoRunnableMethods");
+    assertNoSpecs("NotATestPrivateClass");
+  }
+
+  @Test public void testJUnit3() throws Exception {
+    String specString = "org.pantsbuild.tools.junit.lib.MockJUnit3Test";
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    List<Spec> specs = parser.parse();
+    assertEquals(1, specs.size());
+    assertEquals(MockJUnit3Test.class, specs.get(0).getSpecClass());
+  }
+
+  @Test public void testRunWith() throws Exception {
+    String specString = "org.pantsbuild.tools.junit.lib.MockRunWithTest";
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    List<Spec> specs = parser.parse();
+    assertEquals(1, specs.size());
+    assertEquals(MockRunWithTest.class, specs.get(0).getSpecClass());
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/SpecTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/SpecTest.java
@@ -1,0 +1,48 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SpecTest {
+
+  @Test public void testAddMethod() throws Exception {
+    Spec spec = new Spec(UnannotatedTestClass.class);
+    assertEquals(UnannotatedTestClass.class, spec.getSpecClass());
+    assertEquals("org.pantsbuild.tools.junit.impl.UnannotatedTestClass",
+        spec.getSpecName());
+    assertEquals(ImmutableList.of(), spec.getMethods());
+    spec.addMethod("testMethod");
+    assertEquals(ImmutableList.of("testMethod"), spec.getMethods());
+    spec.addMethod("foo");
+    assertEquals(ImmutableList.of("testMethod", "foo"), spec.getMethods());
+  }
+
+  @Test public void testDefaultConcurrency() {
+    Spec spec = new Spec(UnannotatedTestClass.class);
+    assertEquals(Concurrency.SERIAL, spec.getConcurrency(Concurrency.SERIAL));
+    assertEquals(Concurrency.PARALLEL_CLASSES, spec.getConcurrency(Concurrency.PARALLEL_CLASSES));
+    assertEquals(Concurrency.PARALLEL_METHODS, spec.getConcurrency(Concurrency.PARALLEL_METHODS));
+    assertEquals(Concurrency.PARALLEL_BOTH, spec.getConcurrency(Concurrency.PARALLEL_BOTH));
+  }
+
+  @Test public void testAnnotatedConcurrency() {
+    Spec spec = new Spec(ParallelAnnotatedClass.class);
+    assertEquals(Concurrency.PARALLEL_CLASSES, spec.getConcurrency(Concurrency.PARALLEL_BOTH));
+    assertEquals(Concurrency.PARALLEL_CLASSES, spec.getConcurrency(Concurrency.PARALLEL_CLASSES));
+    assertEquals(Concurrency.PARALLEL_CLASSES, spec.getConcurrency(Concurrency.PARALLEL_METHODS));
+    assertEquals(Concurrency.PARALLEL_CLASSES, spec.getConcurrency(Concurrency.SERIAL));
+  }
+
+  @Test public void testAnnotationPrecedence() {
+    Spec spec = new Spec(AnnotationOverrideClass.class);
+    assertEquals(Concurrency.SERIAL, spec.getConcurrency(Concurrency.PARALLEL_BOTH));
+    assertEquals(Concurrency.SERIAL, spec.getConcurrency(Concurrency.PARALLEL_CLASSES));
+    assertEquals(Concurrency.SERIAL, spec.getConcurrency(Concurrency.PARALLEL_METHODS));
+    assertEquals(Concurrency.SERIAL, spec.getConcurrency(Concurrency.SERIAL));
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/impl/UnannotatedTestClass.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/UnannotatedTestClass.java
@@ -1,0 +1,14 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.impl;
+
+import org.junit.Test;
+
+/**
+ * For use in other test methods
+ */
+public class UnannotatedTestClass {
+  @Test public void testMethod() {
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/MockJUnit3Test.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/MockJUnit3Test.java
@@ -1,0 +1,14 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+import junit.framework.TestCase;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public class MockJUnit3Test extends TestCase {
+  public void testMju3t1() { TestRegistry.registerTestCall("mju3t1"); }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/MockRunWithTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/MockRunWithTest.java
@@ -1,0 +1,35 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+@RunWith(Parameterized.class)
+public class MockRunWithTest {
+  private String parameter;
+
+  @Parameters
+  public static List<String> data() {
+    return Arrays.asList("foo", "bar");
+  }
+
+  public MockRunWithTest(String parameter) {
+    this.parameter = parameter;
+  }
+
+  @Test
+  public void mrwt1() {
+    TestRegistry.registerTestCall("mrwt1-" + parameter);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/NotATestAbstractClass.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/NotATestAbstractClass.java
@@ -1,0 +1,15 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.tools.junit.lib;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public abstract class NotATestAbstractClass {
+
+  // abstract class, so the test shouldn't be invoked
+  public void natac1() {
+    TestRegistry.registerTestCall("natac1");
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/NotATestInterface.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/NotATestInterface.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.tools.junit.lib;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public interface NotATestInterface {
+
+  // interface only so the test shouldn't be invoked
+  public void natif1();
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/NotATestNoPublicConstructor.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/NotATestNoPublicConstructor.java
@@ -1,0 +1,19 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public class NotATestNoPublicConstructor {
+
+  private NotATestNoPublicConstructor() {
+  }
+
+  // No public constructor for this class, so the test shouldn't be invoked
+  public void natnpc1() {
+    TestRegistry.registerTestCall("natnpc1");
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/NotATestNoRunnableMethods.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/NotATestNoRunnableMethods.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public class NotATestNoRunnableMethods {
+  private NotATestNoRunnableMethods() {
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/NotATestNonzeroArgConstructor.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/NotATestNonzeroArgConstructor.java
@@ -1,0 +1,19 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public class NotATestNonzeroArgConstructor {
+  public NotATestNonzeroArgConstructor(String ignored) {
+  }
+
+  // No zero arg public constructor for this class, so the test shouldn't be invoked
+  public void natnac1() {
+    TestRegistry.registerTestCall("natnac1");
+  }
+
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/NotATestPrivateClass.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/NotATestPrivateClass.java
@@ -1,0 +1,17 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public class NotATestPrivateClass {
+  // If the runner is invoked with this private class name, it should just be ignored
+  static private class PrivateClass {
+    public void pc1() {
+      TestRegistry.registerTestCall("pc1");
+    }
+  }
+}


### PR DESCRIPTION
Essentially, a Yak shave for adding support for an experimental test runner.

 - Rename classes that are ParentRunner subclasses
 - Create a class that parses and validates command line specs for tests
 - Add tests for annotation overrides
 - Add a flag to the runner to turn on an experimental test runner (for future use)