### PR TITLE
Use `JarBuilder` to build jars.

### DIFF
--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from abc import abstractmethod
 from collections import OrderedDict
-from zipfile import ZIP_DEFLATED, ZIP_STORED
+from zipfile import ZIP_DEFLATED
 
 from pants.util.contextutil import open_tar, open_zip
 from pants.util.dirutil import safe_walk
@@ -129,9 +129,8 @@ TAR = TarArchiver('w:', 'tar')
 TGZ = TarArchiver('w:gz', 'tar.gz')
 TBZ2 = TarArchiver('w:bz2', 'tar.bz2')
 ZIP = ZipArchiver(ZIP_DEFLATED, 'zip')
-JAR = ZipArchiver(ZIP_STORED, 'jar')
 
-_ARCHIVER_BY_TYPE = OrderedDict(tar=TAR, tgz=TGZ, tbz2=TBZ2, zip=ZIP, jar=JAR)
+_ARCHIVER_BY_TYPE = OrderedDict(tar=TAR, tgz=TGZ, tbz2=TBZ2, zip=ZIP)
 
 TYPE_NAMES = frozenset(_ARCHIVER_BY_TYPE.keys())
 

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -75,10 +75,14 @@ python_tests(
   sources = ['test_bundle_create.py'],
   dependencies = [
     ':jvm_binary_task_test_base',
+    'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:bundle_create',
+    'src/python/pants/backend/jvm/tasks:classpath_util',
     'src/python/pants/backend/jvm:jar_dependency_utils',
+    'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
   ]
 )
 

--- a/tests/python/pants_test/testutils/BUILD
+++ b/tests/python/pants_test/testutils/BUILD
@@ -14,10 +14,6 @@ python_library(
   sources = [
     'file_test_util.py',
   ],
-  dependencies = [
-    'src/python/pants/fs',
-    'src/python/pants/util:contextutil',
-  ],
 )
 
 python_library(

--- a/tests/python/pants_test/testutils/file_test_util.py
+++ b/tests/python/pants_test/testutils/file_test_util.py
@@ -7,9 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pants.fs.archive import ZIP
-from pants.util.contextutil import temporary_dir
-
 
 def exact_files(directory, ignore_links=False):
   """Returns the relative files contained in the directory.
@@ -68,27 +65,4 @@ def check_symlinks(directory, symlinks=True):
       p = os.path.join(root, f)
       if symlinks ^ os.path.islink(p):
         return False
-  return True
-
-
-def check_zip_file_content(zip_file, expected_files):
-  """Check zip file contains expected files as well as verify their contents are as expected.
-
-  :API: public
-
-  :param zip_file: Path to the zip file.
-  :param expected_files: A map from file path included in the zip to its content. Set content
-    to `None` to skip checking.
-  :return:
-  """
-  with temporary_dir() as workdir:
-    ZIP.extract(zip_file, workdir)
-    if not contains_exact_files(workdir, expected_files.keys()):
-      return False
-
-    for rel_path in expected_files:
-      path = os.path.join(workdir, rel_path)
-      if expected_files[rel_path] and not check_file_content(path, expected_files[rel_path]):
-        return False
-
   return True


### PR DESCRIPTION
Previously the python zipfile library was used, leading to missing
directory entries.  Fix the existing test to cover this.

https://rbcommons.com/s/twitter/r/3851/