### PR TITLE
Add 'transitve' and 'scope' attributes to export of target

### DIFF
--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -168,6 +168,26 @@ The following is an abbreviated export file from a command in the pants repo:
 
 # Export Format Changes
 
+## 1.0.8
+
+Conditionally added 'transitive' and 'scope' fields to target
+
+## 1.0.7
+
+Added 'test_platform' to target and 'preferred_jvm_distributions' section
+
+## 1.0.6
+
+Added 'is_synthetic' field to target
+
+## 1.0.5
+
+Added 'id' to target
+
+## 1.0.4
+
+If a target class is registered under multiple aliases returns the last one
+
 ## 1.0.3
 
 Added information about jdk settings

--- a/src/python/pants/backend/project_info/tasks/export.py
+++ b/src/python/pants/backend/project_info/tasks/export.py
@@ -56,7 +56,7 @@ class ExportTask(IvyTaskMixin, PythonTask):
   #
   # Note format changes in src/docs/export.md and update the Changelog section.
   #
-  DEFAULT_EXPORT_VERSION = '1.0.7'
+  DEFAULT_EXPORT_VERSION = '1.0.8'
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -199,13 +199,16 @@ class ExportTask(IvyTaskMixin, PythonTask):
         # NB: is_code_gen should be removed when export format advances to 1.1.0 or higher
         'is_code_gen': current_target.is_codegen,
         'is_synthetic': current_target.is_synthetic,
-        'pants_target_type': self._get_pants_target_alias(type(current_target))
+        'pants_target_type': self._get_pants_target_alias(type(current_target)),
       }
 
       if not current_target.is_synthetic:
         info['globs'] = current_target.globs_relative_to_buildroot()
         if self.get_options().sources:
           info['sources'] = list(current_target.sources_relative_to_buildroot())
+
+      info['transitive'] = current_target.transitive
+      info['scope'] =str(current_target.scope)
 
       if isinstance(current_target, PythonRequirementLibrary):
         reqs = current_target.payload.get_field_value('requirements', set())

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -94,6 +94,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
+  timeout = 120,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -217,7 +217,8 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
 
   def test_version(self):
     result = self.execute_export_json('project_info:first')
-    self.assertEqual('1.0.7', result['version'])
+    # If you have to update this test, make sure export.md is updated with changelog notes
+    self.assertEqual('1.0.8', result['version'])
 
   def test_sources(self):
     self.set_options(sources=True)
@@ -277,7 +278,9 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
            'package_prefix': 'this.is.a.source'
          },
       ],
+      'scope' : 'default',
       'target_type': 'SOURCE',
+      'transitive' : True,
       'pants_target_type': 'scala_library',
       'platform': 'java6',
     }

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -253,3 +253,12 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
       python_target = json_data['targets']['src/python/pants/backend/python/targets:python']
       self.assertIsNotNone(python_target)
       self.assertEquals(default_interpreter, python_target['python_interpreter'])
+
+  def test_intranstive_and_scope(self):
+    with self.temporary_workdir() as workdir:
+      test_path = 'testprojects/maven_layout/provided_patching/one/src/main/java'
+      test_target = '{}:common'.format(test_path)
+      json_data = self.run_export(test_target, workdir)
+      synthetic_target = '{}:shadow-unstable-intransitive-1'.format(test_path)
+      self.assertEquals(False, json_data['targets'][synthetic_target]['transitive'])
+      self.assertEquals('compile test', json_data['targets'][synthetic_target]['scope'])


### PR DESCRIPTION
These attributes were introduced in https://rbcommons.com/s/twitter/r/3582/

Testing Done:
Updated unit tests, added integration test
CI build: https://travis-ci.org/pantsbuild/pants/builds/128830195

Bugs closed: 3386

Reviewed at https://rbcommons.com/s/twitter/r/3845/