### PR TITLE
Making the permissions of temporary files configurable.

### DIFF
--- a/src/python/pants/core_tasks/BUILD
+++ b/src/python/pants/core_tasks/BUILD
@@ -21,6 +21,7 @@ python_library(
     'src/python/pants/reporting',
     'src/python/pants/task',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:util_config',
   ])
 
 resources(

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -20,6 +20,7 @@ from pants.core_tasks.roots import ListRoots
 from pants.core_tasks.run_prep_command import (RunBinaryPrepCommand, RunCompilePrepCommand,
                                                RunTestPrepCommand)
 from pants.core_tasks.targets_help import TargetsHelp
+from pants.core_tasks.util_config_init import UtilConfigInit
 from pants.core_tasks.what_changed import WhatChanged
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -90,3 +91,6 @@ def register_goals():
 
   # Handle sources that aren't loose files in the repo.
   task(name='deferred-sources', action=DeferredSourcesMapper).install()
+
+  # Configuration initialization.
+  task('util-config', action=UtilConfigInit).install('bootstrap')

--- a/src/python/pants/core_tasks/util_config_init.py
+++ b/src/python/pants/core_tasks/util_config_init.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+
+from pants.task.task import Task
+from pants.util.util_config import UtilConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class UtilConfigInit(Task):
+  """List the repo's registered source roots."""
+
+  @classmethod
+  def register_options(cls, register):
+    for configurable in UtilConfig.configurables.values():
+      register(configurable.name, **configurable.init_parameters)
+
+  def __init__(self, *vargs, **kwargs):
+    super(UtilConfigInit, self).__init__(*vargs, **kwargs)
+    for name, configurable in UtilConfig.configurables.items():
+      option_value = self.get_options()[name]
+      logger.debug('Initializing config option {} = {}.'.format(name, option_value))
+      configurable.set_value(option_value)
+
+  def execute(self):
+    """We don't need to do anything in execute(); all we care about is that the options are copied.
+
+    The options are copied in the init function rather than in execute() to ensure that it happens
+    as soon as possible in the pants application lifecycle.
+    """

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -12,6 +12,7 @@ python_library(
    dependencies = [
      '3rdparty/python:six',
      ':dirutil',
+     ':util_config',
    ],
 )
 
@@ -104,6 +105,11 @@ python_library(
 python_library(
   name = 'timeout',
   sources = ['timeout.py'],
+)
+
+python_library(
+  name = 'util_config',
+  sources = ['util_config.py'],
 )
 
 python_library(

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -18,6 +18,7 @@ from contextlib import closing, contextmanager
 from six import string_types
 
 from pants.util.dirutil import safe_delete
+from pants.util.util_config import UtilConfig
 
 
 @contextmanager
@@ -62,7 +63,7 @@ def stdio_as(stdout, stderr, stdin=None):
 
 
 @contextmanager
-def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
+def temporary_dir(root_dir=None, cleanup=True, suffix=str(), permissions=None):
   """
     A with-context that creates a temporary directory.
 
@@ -71,9 +72,14 @@ def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
     You may specify the following keyword args:
     :param string root_dir: The parent directory to create the temporary directory.
     :param bool cleanup: Whether or not to clean up the temporary directory.
+    :param int permissions: If provided, sets the directory permissions to this mode.
   """
+  if permissions is None:
+    permissions = UtilConfig.get_options().temporary_file_mode
   path = tempfile.mkdtemp(dir=root_dir, suffix=suffix)
   try:
+    if permissions is not None:
+      os.chmod(path, permissions)
     yield path
   finally:
     if cleanup:
@@ -81,7 +87,7 @@ def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
 
 
 @contextmanager
-def temporary_file_path(root_dir=None, cleanup=True, suffix=''):
+def temporary_file_path(root_dir=None, cleanup=True, suffix='', permissions=None):
   """
     A with-context that creates a temporary file and returns its path.
 
@@ -91,13 +97,13 @@ def temporary_file_path(root_dir=None, cleanup=True, suffix=''):
     :param str root_dir: The parent directory to create the temporary file.
     :param bool cleanup: Whether or not to clean up the temporary file.
   """
-  with temporary_file(root_dir, cleanup=cleanup, suffix=suffix) as fd:
+  with temporary_file(root_dir, cleanup=cleanup, suffix=suffix, permissions=permissions) as fd:
     fd.close()
     yield fd.name
 
 
 @contextmanager
-def temporary_file(root_dir=None, cleanup=True, suffix=''):
+def temporary_file(root_dir=None, cleanup=True, suffix='', permissions=None):
   """
     A with-context that creates a temporary file and returns a writeable file descriptor to it.
 
@@ -109,9 +115,14 @@ def temporary_file(root_dir=None, cleanup=True, suffix=''):
                        mkstemp() does not put a dot between the file name and the suffix;
                        if you need one, put it at the beginning of suffix.
                        See :py:class:`tempfile.NamedTemporaryFile`.
+    :param int permissions: If provided, sets the file to use these permissions.
   """
+  if permissions is None:
+    permissions = UtilConfig.get_options().temporary_file_mode
   with tempfile.NamedTemporaryFile(suffix=suffix, dir=root_dir, delete=False) as fd:
     try:
+      if permissions is not None:
+        os.chmod(fd.name, permissions)
       yield fd
     finally:
       if cleanup:

--- a/src/python/pants/util/util_config.py
+++ b/src/python/pants/util/util_config.py
@@ -1,0 +1,77 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import re
+
+
+class UtilConfig(object):
+  """Settings that tweak the behavior of functions in pants.util.
+
+  This cannot directly be a subsystem, because it would introduce a dependency cycle between
+  utilities and subsystems. So instead this is essentially bag of options with reasonable defaults,
+  which a task later initializes. It's a "pretend" subsystem.
+  """
+
+  class Configurable(object):
+    """A configurable value.
+
+    This is used by the UtilConfigInit to create proper options, whose values are later propagated
+    back to this class.
+    """
+
+    __name_cleaner = re.compile(r'[^a-zA-Z0-9]+')
+
+    @classmethod
+    def clean_name(cls, name):
+      return cls.__name_cleaner.sub(' ', name).strip()
+
+    def __init__(self, name, type, help, default=None, advanced=True, parser=None):
+      self.init_parameters = dict(
+        type=type,
+        help=help,
+        default=default,
+        advanced=advanced,
+      )
+      self.parser = parser
+      self.name = name
+      self.current_value = default
+
+    def set_value(self, value):
+      parser = self.parser or (lambda x: x)
+      self.current_value = parser(value)
+
+    @property
+    def variable_name(self):
+      return self.clean_name(self.name).replace(' ', '_')
+
+    def matches(self, name):
+      return self.clean_name(name) == self.clean_name(self.name)
+
+  configurables = {c.variable_name: c for c in [
+    Configurable(name='--temporary-file-mode', type=str,
+                 parser=lambda x: int(x.strip(), base=8) if x else None,
+                 help='The default permissions mode to use when creating temporary fiels and '
+                      'directories.'),
+  ]}
+
+  __instance = None
+
+  @classmethod
+  def get_options(cls):
+    if cls.__instance is None:
+      cls.__instance = cls()
+    return cls.__instance
+
+  def __getattr__(self, name):
+    if name in self.configurables:
+      return self.configurables[name].current_value
+    raise AttributeError('UtilConfig has no such option: {}'.format(name))
+
+  def __setattr__(self, name, value):
+    if name in self.configurables:
+      self.configurables[name].set_value(value)
+    raise AttributeError('UtilConfig has no such option: {}'.format(name))

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -13,6 +13,7 @@ import unittest
 
 from pants.util.contextutil import (Timer, environment_as, open_zip, pushd, stdio_as, temporary_dir,
                                     temporary_file)
+from pants.util.util_config import UtilConfig
 
 
 class ContextutilTest(unittest.TestCase):
@@ -175,3 +176,15 @@ class ContextutilTest(unittest.TestCase):
 
     self.assertEquals(sys.stdout, old_stdout)
     self.assertEquals(sys.stderr, old_stderr)
+
+  def test_permissions(self):
+    with temporary_file(permissions=0700) as f:
+      self.assertEquals(0700, os.stat(f.name)[0] & 0777)
+
+    with temporary_dir(permissions=0030) as path:
+      self.assertEquals(0030, os.stat(path)[0] & 0777)
+
+  def test_permissions_config(self):
+    UtilConfig.configurables['temporary_file_mode'].set_value('705')
+    with temporary_dir() as path:
+      self.assertEquals(0705, os.stat(path)[0] & 0777)


### PR DESCRIPTION
Unintuitively, the file permissions temporary files are created
impact the file permissions of non-temporary files across many
parts of the build process. This is due to the common pattern of
creating temporary files and directories, then moving them over
their ultimate destinations atomically.

We addresses this issue partially in:

  https://rbcommons.com/s/twitter/r/3420/

However, there appear to be other places that this effect crops up.

This patch adds the ability to set default file permissions used
by contextutil when creating temporary files and directories.

Since pretty much everything (including subsystems) depend directly
or indirectly on utils, I was unfortunately not able to just put
these options directly into a subsystem. Instead I made a simple
class that contains configuration values that behaves similarly
to a subsystem, and an associated Task that populates it with data
from the actual options system.