### PR TITLE
Making the permissions of the local artifact cache configurable.

### DIFF
--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -79,6 +79,8 @@ class CacheSetup(Subsystem):
              help='number of seconds before pinger times out')
     register('--pinger-tries', advanced=True, type=int, default=2,
              help='number of times pinger tries a cache')
+    register('--write-permissions', advanced=True, type=str, default=None,
+             help='Permissions to use when writing artifacts to a local cache, in octal.')
 
   @classmethod
   def create_cache_factory_for_task(cls, task, pinger=None, resolver=None):
@@ -148,7 +150,7 @@ class CacheFactory(object):
   def get_write_cache(self):
     """Returns the write cache for this setup, creating it if necessary.
 
-    Returns None if no read cache is configured.
+    Returns None if no write cache is configured.
     """
     if self._options.write_to and not self._write_cache:
       cache_spec = self._resolve(self._sanitize_cache_spec(self._options.write_to))
@@ -251,7 +253,8 @@ class CacheFactory(object):
       self._log.debug('{0} {1} local artifact cache at {2}'
                       .format(self._stable_name, action, path))
       return LocalArtifactCache(artifact_root, path, compression,
-                                self._options.max_entries_per_target)
+                                self._options.max_entries_per_target,
+                                permissions=self._options.write_permissions)
 
     def create_remote_cache(remote_spec, local_cache):
       urls = self.get_available_urls(remote_spec.split('|'))

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -62,7 +62,7 @@ def stdio_as(stdout, stderr, stdin=None):
 
 
 @contextmanager
-def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
+def temporary_dir(root_dir=None, cleanup=True, suffix=str(), permissions=None):
   """
     A with-context that creates a temporary directory.
 
@@ -71,9 +71,12 @@ def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
     You may specify the following keyword args:
     :param string root_dir: The parent directory to create the temporary directory.
     :param bool cleanup: Whether or not to clean up the temporary directory.
+    :param int permissions: If provided, sets the directory permissions to this mode.
   """
   path = tempfile.mkdtemp(dir=root_dir, suffix=suffix)
   try:
+    if permissions is not None:
+      os.chmod(path, permissions)
     yield path
   finally:
     if cleanup:
@@ -81,7 +84,7 @@ def temporary_dir(root_dir=None, cleanup=True, suffix=str()):
 
 
 @contextmanager
-def temporary_file_path(root_dir=None, cleanup=True, suffix=''):
+def temporary_file_path(root_dir=None, cleanup=True, suffix='', permissions=None):
   """
     A with-context that creates a temporary file and returns its path.
 
@@ -91,13 +94,13 @@ def temporary_file_path(root_dir=None, cleanup=True, suffix=''):
     :param str root_dir: The parent directory to create the temporary file.
     :param bool cleanup: Whether or not to clean up the temporary file.
   """
-  with temporary_file(root_dir, cleanup=cleanup, suffix=suffix) as fd:
+  with temporary_file(root_dir, cleanup=cleanup, suffix=suffix, permissions=permissions) as fd:
     fd.close()
     yield fd.name
 
 
 @contextmanager
-def temporary_file(root_dir=None, cleanup=True, suffix=''):
+def temporary_file(root_dir=None, cleanup=True, suffix='', permissions=None):
   """
     A with-context that creates a temporary file and returns a writeable file descriptor to it.
 
@@ -109,9 +112,12 @@ def temporary_file(root_dir=None, cleanup=True, suffix=''):
                        mkstemp() does not put a dot between the file name and the suffix;
                        if you need one, put it at the beginning of suffix.
                        See :py:class:`tempfile.NamedTemporaryFile`.
+    :param int permissions: If provided, sets the file to use these permissions.
   """
   with tempfile.NamedTemporaryFile(suffix=suffix, dir=root_dir, delete=False) as fd:
     try:
+      if permissions is not None:
+        os.chmod(fd.name, permissions)
       yield fd
     finally:
       if cleanup:

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -175,3 +175,10 @@ class ContextutilTest(unittest.TestCase):
 
     self.assertEquals(sys.stdout, old_stdout)
     self.assertEquals(sys.stderr, old_stderr)
+
+  def test_permissions(self):
+    with temporary_file(permissions=0700) as f:
+      self.assertEquals(0700, os.stat(f.name)[0] & 0777)
+
+    with temporary_dir(permissions=0644) as path:
+      self.assertEquals(0644, os.stat(path)[0] & 0777)


### PR DESCRIPTION
We ran into some internal problems due to the permissions of files
created for the local artifact cache being 0600 instead of 0644.