### PR TITLE
Do not traverse the dependees of regexp excluded targets in ChangedCa…

### DIFF
--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -396,3 +396,16 @@ class WhatChangedTestWithIgnorePatterns(WhatChangedTestBasic):
       'root/src/py/a:alpha',
       workspace=self.workspace(files=['root/src/py/a/b/c', 'root/src/py/a/d', 'root/src/py/1/2'])
     )
+
+
+class WhatChangedTestWithExcludeRegexp(WhatChangedTestBasic):
+  def test_exclude_regexp_with_dependees(self):
+    # Both `b` and its dependee `a` are excluded, because the explicit exclusion of
+    # `b` also implies that its direct dependees aren't traversed.
+    self.assert_console_output(
+      options={
+        'include_dependees': 'direct',
+        'exclude_target_regexp': ['root/src/py/dependency_tree/b:b'],
+      },
+      workspace=self.workspace(files=['root/src/py/dependency_tree/b/b.py'])
+    )


### PR DESCRIPTION
…lculator.

Suppose that A depends on B.  If B's source is changed and we call
`./pants test-changed --include-dependees=direct`, then both
B and A will be tested.  If we exclude B using `exclude_target_regexp`,
A is still tested even though the only path to it via changed targets
is through B.

In all circumstances where a user excludes a target specifically for
test-changed, they probably intend to also exclude dependees that
would have been brought in by the excluded target.  This patch
changes the behavior of ChangeCalculator to match that
expectation.