### PR TITLE
Implement options scope name deprecation.

### DIFF
--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -76,7 +76,6 @@ class OptionValueContainer(object):
     else:
       return default
 
-
   def update(self, other):
     """Set other's values onto this object.
 

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -68,14 +68,6 @@ class OptionValueContainer(object):
     :rtype: bool
     """
     return self.get_rank(key) in (RankedValue.NONE, RankedValue.HARDCODED)
-  #
-  # def update(self, attrs):
-  #   """Set attr values on this object from the data in attrs.
-  #
-  #   :param dict|OptionValueContainer attrs: The key/value attrs to set on this object.
-  #   """
-  #   for k, v in attrs.items():
-  #     self._set(k, v)
 
   def get(self, key, default=None):
     # Support dict-like dynamic access.  See also __getitem__ below.
@@ -83,6 +75,17 @@ class OptionValueContainer(object):
       return self._get_underlying_value(key)
     else:
       return default
+
+
+  def update(self, other):
+    """Set other's values onto this object.
+
+    For each key, highest ranked value wins. In a tie, other's value wins.
+
+    :param OptionValueContainer other: Augment our values with this object's values.
+    """
+    for k, v in other._value_map.items():
+      self._set(k, v)
 
   def _get_underlying_value(self, key):
     # Note that the key may exist with a value of None, so we can't just
@@ -111,16 +114,6 @@ class OptionValueContainer(object):
       # We set values from outer scopes before values from inner scopes, so
       # in case of equal rank we overwrite. That way that the inner scope value wins.
       self._value_map[key] = value
-
-  def augment(self, other):
-    """Set other's values onto this object.
-
-    For each key, highest ranked value wins. In a tie, other's value wins.
-
-    :param OptionValueContainer other: Augment our values with this object's values.
-    """
-    for k, v in other._value_map.items():
-      self._set(k, v)
 
   # Support natural dynamic access, e.g., opts[foo] is more idiomatic than getattr(opts, 'foo').
   def __getitem__(self, key):

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -27,6 +27,14 @@ class OptionValueContainer(object):
   def __init__(self):
     self._value_map = {}  # key -> either raw value or RankedValue wrapping the raw value.
 
+  def get_explicit_keys(self):
+    """Returns the keys for any values that were set explicitly (via flag, config, or env var)."""
+    ret = []
+    for k, v in self._value_map.items():
+      if v.rank > RankedValue.HARDCODED:
+        ret.append(k)
+    return ret
+
   def get_rank(self, key):
     """Returns the rank of the value at the specified key.
 
@@ -60,11 +68,14 @@ class OptionValueContainer(object):
     :rtype: bool
     """
     return self.get_rank(key) in (RankedValue.NONE, RankedValue.HARDCODED)
-
-  def update(self, attrs):
-    """Set attr values on this object from the data in the attrs dict."""
-    for k, v in attrs.items():
-      self._set(k, v)
+  #
+  # def update(self, attrs):
+  #   """Set attr values on this object from the data in attrs.
+  #
+  #   :param dict|OptionValueContainer attrs: The key/value attrs to set on this object.
+  #   """
+  #   for k, v in attrs.items():
+  #     self._set(k, v)
 
   def get(self, key, default=None):
     # Support dict-like dynamic access.  See also __getitem__ below.
@@ -100,6 +111,16 @@ class OptionValueContainer(object):
       # We set values from outer scopes before values from inner scopes, so
       # in case of equal rank we overwrite. That way that the inner scope value wins.
       self._value_map[key] = value
+
+  def augment(self, other):
+    """Set other's values onto this object.
+
+    For each key, highest ranked value wins. In a tie, other's value wins.
+
+    :param OptionValueContainer other: Augment our values with this object's values.
+    """
+    for k, v in other._value_map.items():
+      self._set(k, v)
 
   # Support natural dynamic access, e.g., opts[foo] is more idiomatic than getattr(opts, 'foo').
   def __getitem__(self, key):

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -19,6 +19,13 @@ class Optionable(AbstractClass):
   options_scope = None
   options_scope_category = None
 
+  # Subclasses may override these to specify a deprecated former name for this Optionable's scope.
+  # Option values can be read from the deprecated scope, but a deprecation warning will be issued.
+  # The deprecation warning becomes an error at the given Pants version (which must therefore be
+  # a valid semver).
+  deprecated_options_scope = None
+  deprecated_options_scope_removal_version = None
+
   @classmethod
   def get_scope_info(cls):
     """Returns a ScopeInfo instance representing this Optionable's options scope."""

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -299,7 +299,7 @@ class Options(object):
                       'Use scope {} instead (options: {})'.format(scope, ', '.join(explicit_keys)))
         # Note that a deprecated val will take precedence over a val of equal rank.
         # This makes the code a bit neater.
-        values.augment(deprecated_vals)
+        values.update(deprecated_vals)
 
     # Record the value derivation.
     for option in values:

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import copy
 import sys
 
+from pants.base.deprecated import warn_or_error
 from pants.option.arg_splitter import GLOBAL_SCOPE, ArgSplitter
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.option.option_util import is_list_option
@@ -69,14 +70,20 @@ class Options(object):
     """Expand a set of scopes to include all enclosing scopes.
 
     E.g., if the set contains `foo.bar.baz`, ensure that it also contains `foo.bar` and `foo`.
+
+    Also adds any deprecated scopes.
     """
     ret = {GlobalOptionsRegistrar.get_scope_info()}
-    for scope_info in scope_infos:
-      ret.add(scope_info)
+    original_scopes = set()
+    for si in scope_infos:
+      ret.add(si)
+      original_scopes.add(si.scope)
+      if si.deprecated_scope:
+        ret.add(ScopeInfo(si.deprecated_scope, si.category, si.optionable_cls))
+        original_scopes.add(si.deprecated_scope)
 
-    original_scopes = {si.scope for si in scope_infos}
-    for scope_info in scope_infos:
-      scope = scope_info.scope
+    for si in scope_infos:
+      scope = si.scope
       while scope != '':
         if scope not in original_scopes:
           ret.add(ScopeInfo(scope, ScopeInfo.INTERMEDIATE))
@@ -231,6 +238,9 @@ class Options(object):
   def register(self, scope, *args, **kwargs):
     """Register an option in the given scope."""
     self.get_parser(scope).register(*args, **kwargs)
+    deprecated_scope = self.known_scope_to_info[scope].deprecated_scope
+    if deprecated_scope:
+      self.get_parser(deprecated_scope).register(*args, **kwargs)
 
   def registration_function_for_optionable(self, optionable_class):
     """Returns a function for registering options on the given scope."""
@@ -273,10 +283,32 @@ class Options(object):
     # Now add our values.
     flags_in_scope = self._scope_to_flags.get(scope, [])
     self._parser_hierarchy.get_parser_by_scope(scope).parse_args(flags_in_scope, values)
-    self._values_by_scope[scope] = values
+
+    # If we're the new name of a deprecated scope, also get values from that scope (but we
+    # take precedence).
+    deprecated_scope = self.known_scope_to_info[scope].deprecated_scope
+    # Note that deprecated_scope and scope share the same Optionable class, so deprecated_scope's
+    # Optionable has a deprecated_options_scope equal to deprecated_scope. Therefore we must
+    # check that scope != deprecated_scope to prevent infinite recursion.
+    if deprecated_scope is not None and scope != deprecated_scope:
+      deprecated_vals = self.for_scope(deprecated_scope)
+      explicit_keys = deprecated_vals.get_explicit_keys()
+      if explicit_keys:
+        warn_or_error(self.known_scope_to_info[scope].deprecated_scope_removal_version,
+                      'scope {}'.format(deprecated_scope),
+                      'Use scope {} instead (options: {})'.format(scope, ', '.join(explicit_keys)))
+        # Note that a deprecated val will take precedence over a val of equal rank.
+        # This makes the code a bit neater.
+        values.augment(deprecated_vals)
+
+    # Record the value derivation.
     for option in values:
       self._option_tracker.record_option(scope=scope, option=option, value=values[option],
                                          rank=values.get_rank(option))
+
+    # Cache the values.
+    self._values_by_scope[scope] = values
+
     return values
 
   def get_fingerprintable_for_scope(self, scope):

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -19,7 +19,18 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
 
   @property
   def description(self):
-    return self.optionable_cls.get_description() if self.optionable_cls else ''
+    return self._optionable_cls_attr('get_description', lambda: '')()
+
+  @property
+  def deprecated_scope(self):
+    return self._optionable_cls_attr('deprecated_options_scope')
+
+  @property
+  def deprecated_scope_removal_version(self):
+    return self._optionable_cls_attr('deprecated_options_scope_removal_version')
+
+  def _optionable_cls_attr(self, name, default=None):
+    return getattr(self.optionable_cls, name) if self.optionable_cls else default
 
 
 # Allow the optionable_cls to default to None.


### PR DESCRIPTION
Allows an Optionable to specify that its current scope is
a new name for an older, deprecated scope.

Takes option values from both scopes, but issues a warning if
any values were explicitly specified on the old scope.

Note: Removes an update() method on OptionValueContainer that was
never used.  Adds instead an augment() method with similar semantics,
but that takes an OptionValueContainer instead of an attr dict.