### PR TITLE
Cull buildgraph edge traversals that will be nooped anyway because they've already been handled.

### DIFF
--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -55,6 +55,10 @@ class BuildGraph(AbstractClass):
       self._worked = set()
       self._expanded = set()
 
+    def expanded_or_worked(self, vertex):
+      """Returns True if the vertex has been expanded or worked."""
+      return vertex in self._expanded or vertex in self._worked
+
     def do_work_once(self, vertex):
       """Returns True exactly once for the given vertex."""
       if vertex in self._worked:
@@ -309,19 +313,28 @@ class BuildGraph(AbstractClass):
     walker = self.DepthAwareWalk if leveled_predicate else self.DepthAgnosticWalk
     walk = walker()
     def _walk_rec(addr, level=0):
+      # If we've followed an edge to this address, stop recursing.
       if not walk.expand_once(addr, level):
         return
+
       target = self._target_by_address[addr]
+
       if predicate and not predicate(target):
         return
-      if not postorder and walk.do_work_once(target):
+
+      if not postorder and walk.do_work_once(addr):
         work(target)
+
       for dep_address in self._target_dependencies_by_address[addr]:
+        if walk.expanded_or_worked(dep_address):
+          continue
         if not leveled_predicate \
                 or leveled_predicate(self._target_by_address[dep_address], level):
           _walk_rec(dep_address, level + 1)
-      if postorder and walk.do_work_once(target):
+
+      if postorder and walk.do_work_once(addr):
         work(target)
+
     for address in addresses:
       _walk_rec(address)
 
@@ -417,14 +430,18 @@ class BuildGraph(AbstractClass):
     to_walk = deque((0, addr) for addr in addresses)
     while len(to_walk) > 0:
       level, address = to_walk.popleft()
-      target = self._target_by_address[address]
-      if not walk.expand_once(target, level):
+
+      if not walk.expand_once(address, level):
         continue
+
+      target = self._target_by_address[address]
       if predicate and not predicate(target):
         continue
-      if walk.do_work_once(target):
+      if walk.do_work_once(address):
         ordered_closure.add(target)
       for addr in self._target_dependencies_by_address[address]:
+        if walk.expanded_or_worked(addr):
+          continue
         if not leveled_predicate or leveled_predicate(self._target_by_address[addr], level):
           to_walk.append((level + 1, addr))
     return ordered_closure

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -339,9 +339,8 @@ class BuildGraphTest(BaseTest):
           seen_targets[target] += 1
           return True
 
-        self.assertEquals(set(expected), set(func([t.address for t in roots],
-                                                  predicate=predicate_sees,
-                                                  **kwargs)))
+        result = func([t.address for t in roots], predicate=predicate_sees, **kwargs)
+        self.assertEquals(set(expected), set(result))
         if any(ct > 1 for ct in seen_targets.values()):
           self.fail('func {} visited {} more than once.'.format(
             func,

--- a/tests/python/pants_test/build_graph/test_build_graph.py
+++ b/tests/python/pants_test/build_graph/test_build_graph.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from collections import defaultdict
+
 import six
 
 from pants.backend.jvm.targets.jar_dependency import JarDependency
@@ -332,7 +334,19 @@ class BuildGraphTest(BaseTest):
 
     def check_funcs(expected, roots, **kwargs):
       for func in subgraph_funcs:
-        self.assertEquals(set(expected), set(func([t.address for t in roots], **kwargs)))
+        seen_targets = defaultdict(lambda: 0)
+        def predicate_sees(target):
+          seen_targets[target] += 1
+          return True
+
+        self.assertEquals(set(expected), set(func([t.address for t in roots],
+                                                  predicate=predicate_sees,
+                                                  **kwargs)))
+        if any(ct > 1 for ct in seen_targets.values()):
+          self.fail('func {} visited {} more than once.'.format(
+            func,
+            ', '.join(t.address for t, ct in seen_targets.items() if ct > 1))
+          )
 
     def only_roots(_, __):
       # This is a silly constraint, because it effectively turns the transitive subgraph functions

--- a/tests/python/pants_test/build_graph/test_scopes.py
+++ b/tests/python/pants_test/build_graph/test_scopes.py
@@ -70,6 +70,8 @@ class ScopedClosureTest(BaseTest):
                             respect_intransitive)
     self.assert_closure_bfs(expected_targets, roots, include_scopes, exclude_scopes,
                             respect_intransitive)
+    self.assert_closure_dfs(expected_targets, roots, include_scopes, exclude_scopes,
+                            respect_intransitive, postorder=True)
 
   def assert_closure_bfs(self, expected_targets, roots, include_scopes=None, exclude_scopes=None,
                      respect_intransitive=True, ordered=False):
@@ -84,13 +86,14 @@ class ScopedClosureTest(BaseTest):
     self.assertEquals(set_type(expected_targets), bfs_result)
 
   def assert_closure_dfs(self, expected_targets, roots, include_scopes=None, exclude_scopes=None,
-                     respect_intransitive=True, ordered=False):
+                     respect_intransitive=True, ordered=False, postorder=None):
     set_type = OrderedSet if ordered else set
     result = set_type(Target.closure_for_targets(
       target_roots=roots,
       include_scopes=include_scopes,
       exclude_scopes=exclude_scopes,
       respect_intransitive=respect_intransitive,
+      postorder=postorder
     ))
     self.assertEquals(set_type(expected_targets), result)
 
@@ -117,6 +120,7 @@ class ScopedClosureTest(BaseTest):
     self.assert_closure({b_intransitive, a}, {b_intransitive})
     self.assert_closure({e, d, a, c}, {e, d})
     self.assert_closure_dfs([d, c, b_intransitive, a], [d, c], ordered=True)
+    self.assert_closure_dfs([c, d, a, b_intransitive], [d, c], ordered=True, postorder=True)
     self.assert_closure_bfs([d, c, b_intransitive, a], [d, c], ordered=True)
     self.assert_closure({a, b_intransitive, d, c}, {d}, respect_intransitive=False)
 

--- a/tests/python/pants_test/build_graph/test_scopes.py
+++ b/tests/python/pants_test/build_graph/test_scopes.py
@@ -65,6 +65,25 @@ class ScopesTest(BaseTest):
 class ScopedClosureTest(BaseTest):
 
   def assert_closure(self, expected_targets, roots, include_scopes=None, exclude_scopes=None,
+                     respect_intransitive=True):
+    self.assert_closure_dfs(expected_targets, roots, include_scopes, exclude_scopes,
+                            respect_intransitive)
+    self.assert_closure_bfs(expected_targets, roots, include_scopes, exclude_scopes,
+                            respect_intransitive)
+
+  def assert_closure_bfs(self, expected_targets, roots, include_scopes=None, exclude_scopes=None,
+                     respect_intransitive=True, ordered=False):
+    set_type = OrderedSet if ordered else set
+    bfs_result = set_type(Target.closure_for_targets(
+      target_roots=roots,
+      include_scopes=include_scopes,
+      exclude_scopes=exclude_scopes,
+      respect_intransitive=respect_intransitive,
+      bfs=True
+    ))
+    self.assertEquals(set_type(expected_targets), bfs_result)
+
+  def assert_closure_dfs(self, expected_targets, roots, include_scopes=None, exclude_scopes=None,
                      respect_intransitive=True, ordered=False):
     set_type = OrderedSet if ordered else set
     result = set_type(Target.closure_for_targets(
@@ -97,7 +116,8 @@ class ScopedClosureTest(BaseTest):
     self.assert_closure({c, b_intransitive, a}, {c})
     self.assert_closure({b_intransitive, a}, {b_intransitive})
     self.assert_closure({e, d, a, c}, {e, d})
-    self.assert_closure([d, c, b_intransitive, a], [d, c], ordered=True)
+    self.assert_closure_dfs([d, c, b_intransitive, a], [d, c], ordered=True)
+    self.assert_closure_bfs([d, c, b_intransitive, a], [d, c], ordered=True)
     self.assert_closure({a, b_intransitive, d, c}, {d}, respect_intransitive=False)
 
   def test_intransitive_diamond(self):


### PR DESCRIPTION
The current behavior will traverse more edges than necessary, which hurts performance when you have large numbers of common dependencies.

This skips traversing dependencies if they have already been visited.