### PR TITLE
Fix GoFetch and test.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
@@ -107,15 +107,24 @@ class GoFetch(GoTask):
 
     return None, None, None
 
+  _META_IMPORT_REGEX = re.compile(r"""
+      <meta
+          \s+
+          name=['"]go-import['"]
+          \s+
+          content=['"](?P<root>[^\s]+)\s+(?P<vcs>[^\s]+)\s+(?P<url>[^\s]+)['"]
+          \s*
+      >""",
+      flags=re.VERBOSE)
+
   @classmethod
   def _find_meta_tag(cls, page_html):
     """Returns the content of the meta tag if found inside of the provided HTML."""
 
-    meta_import_regex = re.compile(r'<meta\s+name="go-import"\s+content="(?P<root>[^\s]+)\s+(?P<vcs>[^\s]+)\s+(?P<url>[^\s]+)"\s*>')
-    matched = meta_import_regex.search(page_html)
+    matched = cls._META_IMPORT_REGEX.search(page_html)
     if matched:
       return matched.groups()
-    return None
+    return None, None, None
 
   def _transitive_download_remote_libs(self, go_remote_libs, all_known_addresses=None):
     """Recursively attempt to resolve / download all remote transitive deps of go_remote_libs.

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -139,7 +139,9 @@ class GoFetchTest(TaskTestBase):
         }
         self._init_dep_graph_files(src, zipdir, dep_graph)
 
+        self.set_options_for_scope('source', source_roots={'3rdparty/go': ['go_remote']})
         r1 = self.target('3rdparty/go/localzip/r1')
+
         context = self._create_fetch_context(zipdir)
         go_fetch = self.create_task(context)
         undeclared_deps = go_fetch._transitive_download_remote_libs({r1})
@@ -159,6 +161,7 @@ class GoFetchTest(TaskTestBase):
         }
         self._init_dep_graph_files(src, zipdir, dep_graph)
 
+        self.set_options_for_scope('source', source_roots={'3rdparty/go': ['go_remote']})
         r1 = self.target('3rdparty/go/localzip/r1')
         r2 = self.target('3rdparty/go/localzip/r2')
 
@@ -180,6 +183,7 @@ class GoFetchTest(TaskTestBase):
         }
         self._init_dep_graph_files(src, zipdir, dep_graph)
 
+        self.set_options_for_scope('source', source_roots={'3rdparty/go': ['go_remote']})
         r1 = self.target('3rdparty/go/localzip/r1')
         r2 = self.target('3rdparty/go/localzip/r2')
 
@@ -254,4 +258,4 @@ class GoFetchTest(TaskTestBase):
     go_fetch = self.create_task(self.context())
     meta_tag_content = go_fetch._find_meta_tag(test_html)
 
-    self.assertEqual(meta_tag_content, None)
+    self.assertEqual(meta_tag_content, (None, None, None))


### PR DESCRIPTION
The `GoFetch._find_meta_tag` function was broken in return type and the
`GoFetchTest` failed to arrange a correct 3rdparty source root.  Fix both.

https://rbcommons.com/s/twitter/r/3888/