### PR TITLE
Validate scope name components.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetchers.py
@@ -172,7 +172,9 @@ class Fetchers(Subsystem):
   def subsystem_dependencies(cls):
     return tuple(f for f in set(cls._FETCHERS.values()) if issubclass(f, Subsystem))
 
-  options_scope = 'fetchers'
+  options_scope = 'go-fetchers'
+  deprecated_options_scope = 'fetchers'
+  deprecated_options_scope_removal_version = '1.2.0'
 
   @classmethod
   def register_options(cls, register):
@@ -280,7 +282,9 @@ class ArchiveFetcher(Fetcher, Subsystem):
     def rev(self, rev):
       return rev or self.default_rev
 
-  options_scope = 'archive-fetcher'
+  options_scope = 'go-archive-fetcher'
+  deprecated_options_scope = 'archive-fetcher'
+  deprecated_options_scope_removal_version = '1.2.0'
 
   _DEFAULT_MATCHERS = {
     r'bitbucket\.org/(?P<user>[^/]+)/(?P<repo>[^/]+)':
@@ -437,7 +441,9 @@ class GopkgInFetcher(Fetcher, Subsystem):
   `go help importpath` so we are forced to implement their re-direction protocol instead of using
   the more general <meta/> tag protocol.
   """
-  options_scope = 'gopkg.in'
+  options_scope = 'gopkg-in'
+  deprecated_options_scope = 'gopkg.in'
+  deprecated_options_scope_removal_version = '1.2.0'
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
@@ -66,10 +66,10 @@ class PrefixesTest(unittest.TestCase):
 
   @contextmanager
   def fetcher(self, import_path):
-    with subsystem_instance(Fetchers, **{'fetchers' : {
+    with subsystem_instance(Fetchers, **{'go-fetchers' : {
           'mapping' : {'.*': 'ArchiveFetcher'},
           },
-        'archive-fetcher' : {
+        'go-archive-fetcher' : {
           'matchers' : {'.*': ('', None, 0)},
           'prefixes' :['foo', 'bar/baz'],
         }}) as fetchers:

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_fetch.py
@@ -104,11 +104,11 @@ class GoFetchTest(TaskTestBase):
 
   def _create_fetch_context(self, zipdir):
     """Given a directory of zipfiles, creates a context for GoFetch."""
-    self.set_options_for_scope('fetchers', mapping={r'.*': Fetchers.alias(ArchiveFetcher)})
+    self.set_options_for_scope('go-fetchers', mapping={r'.*': Fetchers.alias(ArchiveFetcher)})
     matcher = ArchiveFetcher.UrlInfo(url_format=os.path.join(zipdir, '\g<zip>.zip'),
                                      default_rev='HEAD',
                                      strip_level=0)
-    self.set_options_for_scope('archive-fetcher', matchers={r'localzip/(?P<zip>[^/]+)': matcher})
+    self.set_options_for_scope('go-archive-fetcher', matchers={r'localzip/(?P<zip>[^/]+)': matcher})
     context = self.context()
     context.products.safe_create_data('go_remote_lib_src', lambda: defaultdict(str))
     return context

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -57,6 +57,7 @@ python_library(
   sources = ['goal.py'],
   dependencies = [
     ':error',
+    'src/python/pants/option',
   ],
 )
 

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.goal.error import GoalError
+from pants.option.optionable import Optionable
 
 
 class Goal(object):
@@ -91,6 +92,7 @@ class _Goal(object):
 
     Create goals only through the Goal.by_name() factory.
     """
+    Optionable.validate_scope_name_component(name)
     self.name = name
     self._description = ''
     self.serialize = False
@@ -132,6 +134,7 @@ class _Goal(object):
       raise GoalError('Can only specify one of first, replace, before or after')
 
     task_name = task_registrar.name
+    Optionable.validate_scope_name_component(task_name)
     options_scope = Goal.scope(self.name, task_name)
 
     # Currently we need to support registering the same task type multiple times in different

--- a/src/python/pants/goal/task_registrar.py
+++ b/src/python/pants/goal/task_registrar.py
@@ -32,7 +32,7 @@ class TaskRegistrar(object):
 
     if dependencies:
       # TODO(John Sirois): kill this warning and the kwarg after a deprecation cycle.
-      print(dedent('''
+      print(dedent("""
           WARNING: Registered dependencies are now ignored and only `Task.product_types`
           and product requirements as expressed in `Task.prepare` are used to
           infer Task dependencies.
@@ -40,7 +40,7 @@ class TaskRegistrar(object):
           Please fix this registration:
             {reg}
             {location}
-          ''').format(reg=self,
+          """).format(reg=self,
                       location=traceback.format_list([traceback.extract_stack()[-2]])[0]),
             file=sys.stderr)
 

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -5,8 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import re
+
 from six import string_types
 
+from pants.base.deprecated import deprecated_conditional
 from pants.option.errors import OptionsError
 from pants.option.scope import ScopeInfo
 from pants.util.meta import AbstractClass
@@ -25,6 +28,20 @@ class Optionable(AbstractClass):
   # a valid semver).
   deprecated_options_scope = None
   deprecated_options_scope_removal_version = None
+
+  _scope_name_component_re = re.compile(r'^(?:[a-z]|[0-9])+(?:-(?:[a-z]|[0-9])+)*$')
+
+  @classmethod
+  def is_valid_scope_name_component(cls, s):
+    return cls._scope_name_component_re.match(s) is not None
+
+  @classmethod
+  def validate_scope_name_component(cls, s):
+    # TODO: turn this deprecation warning into a permanent error after 1.2.0.
+    deprecated_conditional(lambda: not cls.is_valid_scope_name_component(s), '1.2.0',
+                           'options scope {}'.format(s),
+                           'Replace in code with new scope name consisting of dash-separated-words, '
+                           'with words consisting only of lower-case letters and digits.')
 
   @classmethod
   def get_scope_info(cls):

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -29,7 +29,7 @@ class Optionable(AbstractClass):
   deprecated_options_scope = None
   deprecated_options_scope_removal_version = None
 
-  _scope_name_component_re = re.compile(r'^(?:[a-z]|[0-9])+(?:-(?:[a-z]|[0-9])+)*$')
+  _scope_name_component_re = re.compile(r'^(?:[a-z0-9])+(?:-(?:[a-z0-9])+)*$')
 
   @classmethod
   def is_valid_scope_name_component(cls, s):

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -82,7 +82,7 @@ class Options(object):
         ret.add(ScopeInfo(si.deprecated_scope, si.category, si.optionable_cls))
         original_scopes.add(si.deprecated_scope)
 
-    for si in scope_infos:
+    for si in copy.copy(ret):
       scope = si.scope
       while scope != '':
         if scope not in original_scopes:

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -82,6 +82,9 @@ class Options(object):
         ret.add(ScopeInfo(si.deprecated_scope, si.category, si.optionable_cls))
         original_scopes.add(si.deprecated_scope)
 
+    # TODO: Once scope name validation is enforced (so there can be no dots in scope name
+    # components) we can replace this line with `for si in scope_infos:`, because it will
+    # not be possible for a deprecated_scope to introduce any new intermediate scopes.
     for si in copy.copy(ret):
       scope = si.scope
       while scope != '':

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -64,6 +64,7 @@ class Subsystem(SubsystemClientMixin, Optionable):
 
   @classmethod
   def get_scope_info(cls, subscope=None):
+    cls.validate_scope_name_component(cls.options_scope)
     if subscope is None:
       return super(Subsystem, cls).get_scope_info()
     else:

--- a/tests/python/pants_test/option/test_optionable.py
+++ b/tests/python/pants_test/option/test_optionable.py
@@ -37,3 +37,21 @@ class OptionableTest(unittest.TestCase):
     class Indirect(Intermediate):
       options_scope = 'good'
     self.assertEquals('good', Indirect.options_scope)
+
+  def test_is_valid_scope_name_component(self):
+    def check_true(s):
+      self.assertTrue(Optionable.is_valid_scope_name_component(s))
+
+    def check_false(s):
+      self.assertFalse(Optionable.is_valid_scope_name_component(s))
+
+    check_true('foo')
+    check_true('foo-bar0')
+    check_true('foo-bar0-1ba22z')
+
+    check_false('Foo')
+    check_false('fOo')
+    check_false('foo.bar')
+    check_false('foo_bar')
+    check_false('foo--bar')
+    check_false('foo-bar-')

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -1050,3 +1050,19 @@ class OptionsTest(unittest.TestCase):
     self.assertEquals('zz', vals.bar)
     # New scope takes precedence at higher rank.
     self.assertEquals('vv', vals.baz)
+
+  def test_is_valid_scope_name_component(self):
+    def check_true(s):
+      self.assertTrue(Optionable.is_valid_scope_name_component(s))
+
+    def check_false(s):
+      self.assertFalse(Optionable.is_valid_scope_name_component(s))
+
+    check_true('foo')
+    check_true('foo-bar0')
+    check_true('foo-bar0-1ba22z')
+
+    check_false('Foo')
+    check_false('fOo')
+    check_false('foo.bar')
+    check_false('foo_bar')

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -1050,19 +1050,3 @@ class OptionsTest(unittest.TestCase):
     self.assertEquals('zz', vals.bar)
     # New scope takes precedence at higher rank.
     self.assertEquals('vv', vals.baz)
-
-  def test_is_valid_scope_name_component(self):
-    def check_true(s):
-      self.assertTrue(Optionable.is_valid_scope_name_component(s))
-
-    def check_false(s):
-      self.assertFalse(Optionable.is_valid_scope_name_component(s))
-
-    check_true('foo')
-    check_true('foo-bar0')
-    check_true('foo-bar0-1ba22z')
-
-    check_false('Foo')
-    check_false('fOo')
-    check_false('foo.bar')
-    check_false('foo_bar')


### PR DESCRIPTION
Previously we had a scope (gopkg.in) containing a dot. However dots are
used to nest scopes, so this was potentially ambiguous and a bug waiting
to happen (e.g., this only worked because we created an implicit 'gopkg'
parent scope behind the scenes, which isn't what was intended).

Now we forbid dots, and for uniformity we also require lower-case letters
and dashes instead of underscores.

This change deprecates gopkg.in and, while we're at it, a couple of other
go-related scopes.

Note that we currently get warnings about check_published_deps, because of
how its deprecation was implemented. But that hack can go away in the next
release, so this is a very temporary warning.