### PR TITLE
Allow updating dict option values instead of replacing them.

### DIFF
--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -73,8 +73,11 @@ class HelpInfoExtracter(object):
     if typ == list:
       default_str = '[{}]'.format(','.join(["'{}'".format(s) for s in default]))
     elif typ == dict:
-      default_str = '{{ {} }}'.format(
-        ','.join(["'{}':'{}'".format(k, v) for k, v in default.items()]))
+      if default:
+        default_str = '{{ {} }}'.format(
+          ','.join(["'{}':'{}'".format(k, v) for k, v in default.items()]))
+      else:
+        default_str = '{}'
     elif typ == str:
       default_str = "'{}'".format(default).replace('\n', ' ')
     else:

--- a/src/python/pants/option/option_util.py
+++ b/src/python/pants/option/option_util.py
@@ -11,3 +11,7 @@ from pants.option.custom_types import list_option
 def is_list_option(kwargs):
   return (kwargs.get('action') == 'append' or kwargs.get('type') == list or
           kwargs.get('type') == list_option)
+
+
+def is_dict_option(kwargs):
+  return kwargs.get('type') == dict

--- a/tests/python/pants_test/help/test_help_info_extracter.py
+++ b/tests/python/pants_test/help/test_help_info_extracter.py
@@ -91,8 +91,7 @@ class HelpInfoExtracterTest(unittest.TestCase):
     do_test(['--foo'], {'type': int}, 'None')
     do_test(['--foo'], {'type': int, 'default': 42}, '42')
     do_test(['--foo'], {'type': list}, '[]')
-    # TODO: Change this if we switch the implicit default to {}.
-    do_test(['--foo'], {'type': dict}, 'None')
+    do_test(['--foo'], {'type': dict}, '{}')
 
   def test_deprecated(self):
     kwargs = {'removal_version': '999.99.9', 'removal_hint': 'do not use this'}

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -17,7 +17,7 @@ class CustomTypesTest(unittest.TestCase):
 
   def _do_test(self, expected_val, s):
     if isinstance(expected_val, dict):
-      val = dict_option(s)
+      val = dict_option(s).val
     elif isinstance(expected_val, (list, tuple)):
       val = list_option(s).val
     else:


### PR DESCRIPTION
Similarly to list options, this is done by preceding the dict
literal with a '+'.

This allows, e.g., adding new Go matcher patterns in pants.ini
without having to copy the default ones.

This implementation is simpler than that of list options, because
lists have the added complication of interpreting --foo=bar as
--foo=+[bar], which is irrelevant here.