### PR TITLE
Make pinger.py check https as well as https.

### DIFF
--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -54,7 +54,7 @@ python_library(
   name = 'delay_server',
   sources = ['delay_server.py'],
   dependencies = [
-  '3rdparty/python:six',
+    '3rdparty/python:six',
   ]
 )
 
@@ -65,7 +65,7 @@ python_tests(
     'src/python/pants/cache',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test/cache:delay_server',
-  ]
+  ],
 )
 
 python_tests(


### PR DESCRIPTION
Our remote artifact cache serves over HTTPS, which the RESTful
artifact cache ostensibly supports, but the Pinger which decides
what URLs are good was only checking HTTP.

This simply makes the pinger check both HTTP and HTTPS.