### PR TITLE
Fix hardcoded pants ignore from 'dist/' to '/dist/'

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -52,8 +52,8 @@ backend_packages: [
     "pants.contrib.spindle",
   ]
 
-# Path patterns to ignore for filesystem operations.
-pants_ignore: [
+# Path patterns to ignore for filesystem operations on top of the builtin patterns.
+pants_ignore: +[
     # All dotfiles.
     '.*',
     # venv directories under build-support.

--- a/pants.ini
+++ b/pants.ini
@@ -54,8 +54,6 @@ backend_packages: [
 
 # Path patterns to ignore for filesystem operations on top of the builtin patterns.
 pants_ignore: +[
-    # All dotfiles.
-    '.*',
     # venv directories under build-support.
     'build-support/*.venv/',
   ]

--- a/pants.ini
+++ b/pants.ini
@@ -55,7 +55,7 @@ backend_packages: [
 # Path patterns to ignore for filesystem operations on top of the builtin patterns.
 pants_ignore: +[
     # venv directories under build-support.
-    'build-support/*.venv/',
+    '/build-support/*.venv/',
   ]
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -148,7 +148,7 @@ class GlobalOptionsRegistrar(Optionable):
              help='Glob patterns for ignoring files when reading BUILD files. '
                   'Use to ignore unneeded directories or BUILD files. '
                   'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')
-    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=[rel_distdir],
+    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=['.*', rel_distdir],
              help='Ignore files that match the specified patterns. '
                   'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore). '
                   'This option is currently experimental.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -140,12 +140,15 @@ class GlobalOptionsRegistrar(Optionable):
              metavar='<regexp>',
              help='Exclude targets that match these regexes.',
              recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
+    # Relative pants_distdir to buildroot. Requires --pants-distdir to be bootstrapped above first.
+    # e.g. '/dist/'
+    rel_distdir = '/{}/'.format(os.path.relpath(register.bootstrap.pants_distdir, get_buildroot()))
     register('--ignore-patterns', advanced=True, type=list, fromfile=True,
-             default=['.*', '/dist', 'bower_components', 'node_modules', '*.egg-info'],
+             default=['.*', rel_distdir, 'bower_components', 'node_modules', '*.egg-info'],
              help='Glob patterns for ignoring files when reading BUILD files. '
                   'Use to ignore unneeded directories or BUILD files. '
                   'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')
-    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=['.*', '/dist'],
+    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=[rel_distdir],
              help='Ignore files that match the specified patterns. '
                   'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore). '
                   'This option is currently experimental.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -145,7 +145,7 @@ class GlobalOptionsRegistrar(Optionable):
              help='Glob patterns for ignoring files when reading BUILD files. '
                   'Use to ignore unneeded directories or BUILD files. '
                   'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')
-    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=['.*', 'dist/'],
+    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=['.*', '/dist'],
              help='Ignore files that match the specified patterns. '
                   'Entries use the gitignore pattern syntax (https://git-scm.com/docs/gitignore). '
                   'This option is currently experimental.')

--- a/tests/python/pants_test/base/pants_ignore_test_base.py
+++ b/tests/python/pants_test/base/pants_ignore_test_base.py
@@ -130,8 +130,8 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/fruit'])
     files_list = self._walk_tree()
 
-    # root level `/fruit` is excluded,
-    # `/grocery/fruit` is included.
+    # root level `/fruit` and its subdirs are excluded.
+    # non root level `/grocery/fruit` is included.
     self.assertEquals(
       self._all_files - {'fruit/apple',
                          'fruit/banana',

--- a/tests/python/pants_test/base/pants_ignore_test_base.py
+++ b/tests/python/pants_test/base/pants_ignore_test_base.py
@@ -126,6 +126,13 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
 
     self.assertEquals(self._all_files - {'apple'}, set(files_list))
 
+  def test_ignore_pattern_leading_and_trailing_slashes(self):
+    self._project_tree = self.mk_project_tree(self.root_dir, ['/apple/'])
+    files_list = self._walk_tree()
+    # Pattern '/apple/' should only exclude directory `/apple`.
+    # File `/apple` is not excluded.
+    self.assertEquals(self._all_files, set(files_list))
+
   def test_ignore_pattern_leading_slash_should_exclude_subdirs(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/fruit'])
     files_list = self._walk_tree()

--- a/tests/python/pants_test/base/pants_ignore_test_base.py
+++ b/tests/python/pants_test/base/pants_ignore_test_base.py
@@ -126,6 +126,22 @@ class PantsIgnoreTestBase(ProjectTreeTestBase):
 
     self.assertEquals(self._all_files - {'apple'}, set(files_list))
 
+  def test_ignore_pattern_leading_slash_should_exclude_subdirs(self):
+    self._project_tree = self.mk_project_tree(self.root_dir, ['/fruit'])
+    files_list = self._walk_tree()
+
+    # root level `/fruit` is excluded,
+    # `/grocery/fruit` is included.
+    self.assertEquals(
+      self._all_files - {'fruit/apple',
+                         'fruit/banana',
+                         'fruit/orange',
+                         'fruit/fruit/apple',
+                         'fruit/fruit/banana',
+                         'fruit/fruit/orange'},
+      set(files_list)
+    )
+
   def test_ignore_pattern_wildcard(self):
     self._project_tree = self.mk_project_tree(self.root_dir, ['/*e'])
     files_list = self._walk_tree()

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -234,3 +234,18 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     # These should be omitted because they have the same value as their super-scope.
     self.assertNotIn('jvm-platform-validate.colors = False', lines)
     self.assertNotIn('resolve.ivy.colors = False', lines)
+
+  def test_pants_ignore_option(self):
+    with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
+      config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
+      with open(config_path, 'w+') as f:
+        f.write(dedent("""
+          [GLOBAL]
+          pants_ignore: +['some/additional/dir']
+        """))
+      pants_run = self.run_pants(['--config-override={}'.format(config_path),
+                                  '--no-colors',
+                                  'options'])
+      self.assert_success(pants_run)
+      self.assertIn("pants_ignore = ['.*', '/dist/', 'some/additional/dir'] (from CONFIG)",
+                    pants_run.stdout_data)

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -241,11 +241,27 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
       with open(config_path, 'w+') as f:
         f.write(dedent("""
           [GLOBAL]
-          pants_ignore: +['some/additional/dir']
+          pants_ignore: +['some/random/dir']
         """))
       pants_run = self.run_pants(['--config-override={}'.format(config_path),
                                   '--no-colors',
                                   'options'])
       self.assert_success(pants_run)
-      self.assertIn("pants_ignore = ['.*', '/dist/', 'some/additional/dir'] (from CONFIG)",
+      self.assertIn("pants_ignore = ['.*', '/dist/', 'some/random/dir'] (from CONFIG)",
+                    pants_run.stdout_data)
+
+  def test_pants_ignore_option_non_default_dist_dir(self):
+    with temporary_dir(root_dir=os.path.abspath('.')) as tempdir:
+      config_path = os.path.relpath(os.path.join(tempdir, 'config.ini'))
+      with open(config_path, 'w+') as f:
+        f.write(dedent("""
+          [GLOBAL]
+          pants_ignore: +['some/random/dir']
+          pants_distdir: some/other/dist/dir
+        """))
+      pants_run = self.run_pants(['--config-override={}'.format(config_path),
+                                  '--no-colors',
+                                  'options'])
+      self.assert_success(pants_run)
+      self.assertIn("pants_ignore = ['.*', '/some/other/dist/dir/', 'some/random/dir'] (from CONFIG)",
                     pants_run.stdout_data)


### PR DESCRIPTION
Earlier `dist/` in pants ignore inadvertently ignores `a/b/c/dist` as well, so this RB corrects so it will only ignore root level `/dist` and its subdirs.