### PR TITLE
[docs] fix broken link to certifi

### DIFF
--- a/src/docs/setup_repo.md
+++ b/src/docs/setup_repo.md
@@ -170,7 +170,7 @@ certificate authorities, if that library is installed.  If you are
 using a virtualenv installation of pants, using `pip
 install certifi` to add the certify package to your pants environment
 might help.  You can also download a .pem bundle from the
-[certifi project page](http://certifi.io/en/latest/) and set
+[certifi project page](https://certifiio.readthedocs.io/en/latest/) and set
 `REQUESTS_CA_BUNDLE` as mentioned below.
 
 If you are using hosts with a self-signed certificate, your


### PR DESCRIPTION
Fixes the link from non-working to working.
