### PR TITLE
Introducing target aliases in BUILD files.

### DIFF
--- a/src/python/pants/build_graph/aliased_target.py
+++ b/src/python/pants/build_graph/aliased_target.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.base.exceptions import TargetDefinitionException
+from pants.build_graph.build_file_aliases import TargetMacro
+from pants.build_graph.target import Target
+
+
+class AliasTarget(Target):
+  """A target that gets replaced by its dependencies."""
+
+
+class AliasTargetMacro(TargetMacro):
+  """Macro for creating target aliases."""
+
+  def __init__(self, parse_context):
+    self._parse_context = parse_context
+
+  def expand(self, name=None, target=None, **kwargs):
+    """
+    :param string name: The name for this alias.
+    :param string target: The address of the destination target.
+    """
+    if name is None:
+      raise TargetDefinitionException('{}:?'.format(self._parse_context.rel_path, name),
+                                      'The alias() must have a name!')
+    if target is None:
+      raise TargetDefinitionException('{}:{}'.format(self._parse_context.rel_path, name),
+                                      'The alias() must have a "target" parameter.')
+    self._parse_context.create_object(
+      AliasTarget,
+      name=name,
+      dependencies=[target] if target else [],
+      **kwargs
+    )
+
+
+class AliasTargetFactory(TargetMacro.Factory):
+  """Creates an alias for a target, so that it can be referred to with another spec.
+
+  Note that this does not current work with deferred source (from_target()); you must still use the
+  target's actual address in that case.
+  """
+
+  @property
+  def target_types(self):
+    return {AliasTarget}
+
+  def macro(self, parse_context):
+    return AliasTargetMacro(parse_context)

--- a/src/python/pants/build_graph/register.py
+++ b/src/python/pants/build_graph/register.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants.base.build_environment import get_buildroot, pants_version
+from pants.build_graph.aliased_target import AliasTargetFactory
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.from_target import FromTarget
 from pants.build_graph.intransitive_dependency import (IntransitiveDependencyFactory,
@@ -37,6 +38,7 @@ class BuildFilePath(object):
 def build_file_aliases():
   return BuildFileAliases(
     targets={
+      'alias': AliasTargetFactory(),
       'prep_command': PrepCommand,
       'resources': Resources,
       'target': Target,

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -19,6 +19,7 @@ from pants.core_tasks.reporting_server_run import ReportingServerRun
 from pants.core_tasks.roots import ListRoots
 from pants.core_tasks.run_prep_command import (RunBinaryPrepCommand, RunCompilePrepCommand,
                                                RunTestPrepCommand)
+from pants.core_tasks.substitute_aliased_targets import SubstituteAliasedTargets
 from pants.core_tasks.targets_help import TargetsHelp
 from pants.core_tasks.what_changed import WhatChanged
 from pants.goal.goal import Goal
@@ -90,3 +91,7 @@ def register_goals():
 
   # Handle sources that aren't loose files in the repo.
   task(name='deferred-sources', action=DeferredSourcesMapper).install()
+
+  # Processing aliased targets has to occur very early.
+  task(name='substitute-aliased-targets', action=SubstituteAliasedTargets).install('bootstrap',
+                                                                                   first=True)

--- a/src/python/pants/core_tasks/substitute_aliased_targets.py
+++ b/src/python/pants/core_tasks/substitute_aliased_targets.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.build_graph.aliased_target import AliasTarget
+from pants.task.task import Task
+
+
+class SubstituteAliasedTargets(Task):
+  """Substitutes AliasedTargets with their dependencies where applicable."""
+
+  def execute(self):
+    # Replace aliased_targets in target_roots with their dependencies. This permits doing things
+    # like running jvm_binaries that you've referenced indirectly via an alias.
+    self._substitute_target_roots()
+
+    # TODO(gmalmquist): Make this work with deferred sources?
+
+    # "Hotwire" every aliased_target's dependencies to the aliased_target's dependees. This provides
+    # a mechanism to indirectly reference targets that have intransitive dependencies.
+    for aliased_target in self.context.targets(lambda t: isinstance(t, AliasTarget)):
+      self._inject_dependencies_into_dependees(aliased_target)
+
+  def _substitute_target_roots(self):
+    original_roots = list(self.context.target_roots)
+    new_roots = []
+    for target in original_roots:
+      new_roots.extend(self._expand(target))
+    self.context._replace_targets(new_roots)
+
+  def _inject_dependencies_into_dependees(self, target):
+    build_graph = self.context.build_graph
+    for dependee in tuple(build_graph.dependents_of(target.address)):
+      for dependency in target.dependencies:
+        build_graph.inject_dependency(dependee, dependency.address)
+
+  def _expand(self, target):
+    self.context.log.debug('expanding {}'.format(target.address.spec))
+    if isinstance(target, AliasTarget):
+      for dep in target.dependencies:
+        for expanded in self._expand(dep):
+          yield expanded
+    else:
+      yield target

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -250,7 +250,7 @@ class Context(object):
     # initialized somewhere, making it now unsafe to replace targets. Thus callers of this method
     # must know what they're doing!
     #
-    # TODO(John Sirois): This currently has 0 uses (outside ContextTest) in pantsbuild/pants and
+    # TODO(John Sirois): This currently has only 1 use (outside ContextTest) in pantsbuild/pants and
     # only 1 remaining known use case in the Foursquare codebase that will be able to go away with
     # the post RoundEngine engine - kill the method at that time.
     self._target_roots = list(target_roots)

--- a/testprojects/src/java/org/pantsbuild/testproject/aliases/AliasedBinaryMain.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/aliases/AliasedBinaryMain.java
@@ -1,0 +1,18 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.testproject.aliases;
+
+/**
+ * Part of an integration test to ensure that jvm_binaries referenced indirectly through an alias()
+ * in a BUILD file can still be executed with ./pants run.
+ *
+ * See tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
+ */
+public class AliasedBinaryMain {
+
+  public static void main(String[] args) {
+    // NB: This message is checked for in an integration test.
+    System.out.println(AliasedBinaryMain.class.getSimpleName() + " is up and running.");
+  }
+
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/aliases/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/aliases/BUILD
@@ -1,0 +1,45 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This is here as part of an integration test for the `alias()` syntax.
+
+alias('convenient', ':inconveniently-named-binary')
+
+jvm_binary(name='inconveniently-named-binary',
+  main='org.pantsbuild.testproject.aliases.AliasedBinaryMain',
+  dependencies=[
+    ':main',
+  ],
+)
+
+java_library(name='main',
+  sources=[
+    'AliasedBinaryMain.java',
+  ],
+)
+
+java_library(name='intransitive-dependency',
+  sources=[
+    'IntransitiveDependency.java',
+  ],
+)
+
+# Using a normal target() here instead of an alias fails, because its dependencies are unable
+# to see the intransitive dep.
+alias('indirection', intransitive(':intransitive-dependency'))
+
+java_library(name='use-intransitive-dependency',
+  sources=[
+    'UseIntransitiveDependency.java',
+  ],
+  dependencies=[
+    ':indirection',
+  ],
+)
+
+jvm_binary(name='run-use-intransitive',
+  main='org.pantsbuild.testproject.aliases.UseIntransitiveDependency',
+  dependencies=[
+    ':use-intransitive-dependency',
+  ],
+)

--- a/testprojects/src/java/org/pantsbuild/testproject/aliases/IntransitiveDependency.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/aliases/IntransitiveDependency.java
@@ -1,0 +1,13 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.testproject.aliases;
+
+/**
+ * Part of an integration test to ensure that target aliases are replaced by their dependencies in
+ * the build graph.
+ *
+ * See tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
+ */
+public class IntransitiveDependency {
+
+}

--- a/testprojects/src/java/org/pantsbuild/testproject/aliases/TEST_NO_NAME
+++ b/testprojects/src/java/org/pantsbuild/testproject/aliases/TEST_NO_NAME
@@ -1,0 +1,8 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This is here as part of an integration test for the `alias()` syntax.
+
+alias(target=':arbitrary-empty-target')
+
+target(name='arbitrary-empty-target')

--- a/testprojects/src/java/org/pantsbuild/testproject/aliases/TEST_NO_TARGET
+++ b/testprojects/src/java/org/pantsbuild/testproject/aliases/TEST_NO_TARGET
@@ -1,0 +1,7 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This is here as part of an integration test for the `alias()` syntax.
+
+alias('missing-target')
+

--- a/testprojects/src/java/org/pantsbuild/testproject/aliases/UseIntransitiveDependency.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/aliases/UseIntransitiveDependency.java
@@ -1,0 +1,25 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+package org.pantsbuild.testproject.aliases;
+
+/**
+ * Part of an integration test to ensure that target aliases are replaced by their dependencies in
+ * the build graph.
+ *
+ * See tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
+ */
+public class UseIntransitiveDependency {
+
+  public static void main(String[] args) {
+    System.out.println("Managed to run this class.");
+  }
+
+  /**
+   * We don't attempt to reference this, because this will assuredly fail at run-time. We just want
+   * to make sure this reference is here at compile-time.
+   */
+  public static void referenceIntransitive() {
+    new IntransitiveDependency();
+  }
+
+}

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -23,14 +23,14 @@ python_tests(
 )
 
 python_tests(
-    name = 'prep_command_integration',
-    sources = ['test_prep_command_integration.py'],
-    dependencies = [
-        'src/python/pants/util:contextutil',
-        'src/python/pants/util:dirutil',
-        'tests/python/pants_test:int-test',
-    ],
-    tags = {'integration'},
+  name = 'prep_command_integration',
+  sources = ['test_prep_command_integration.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
 )
 
 python_tests(
@@ -57,6 +57,15 @@ python_tests(
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ],
+)
+
+python_tests(
+  name = 'substitute_target_aliases_integration',
+  sources = ['test_substitute_target_aliases_integration.py'],
+  dependencies = [
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
 )
 
 python_tests(

--- a/tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
+++ b/tests/python/pants_test/core_tasks/test_substitute_target_aliases_integration.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class AliasTargetIntegrationTest(PantsRunIntegrationTest):
+
+  test_module = 'testprojects/src/java/org/pantsbuild/testproject/aliases'
+
+  def test_jvm_binary_alias(self):
+    test_run = self.run_pants([
+      'run',
+      '{}:convenient'.format(self.test_module),
+    ])
+    self.assert_success(test_run)
+    self.assertIn('AliasedBinaryMain is up and running.', test_run.stdout_data)
+
+  def test_intransitive_target_alias(self):
+    test_run = self.run_pants([
+      'run',
+      '{}:run-use-intransitive'.format(self.test_module),
+    ])
+    self.assert_success(test_run)
+
+  def test_alias_missing_target(self):
+    with self.file_renamed(self.test_module, 'TEST_NO_TARGET', 'BUILD.test'):
+      test_run = self.run_pants(['bootstrap', '{}::'.format(self.test_module)])
+      self.assert_failure(test_run)
+      self.assertIn('must have a "target"', test_run.stderr_data)
+      self.assertIn('aliases:missing-target', test_run.stderr_data)
+
+  def test_alias_missing_name(self):
+    with self.file_renamed(self.test_module, 'TEST_NO_NAME', 'BUILD.test'):
+      test_run = self.run_pants(['bootstrap', '{}::'.format(self.test_module)])
+      self.assert_failure(test_run)
+      self.assertIn('aliases:?', test_run.stderr_data)


### PR DESCRIPTION
This introduces a new object for use in build files: `alias()`.

It can be used like so: `alias('foo', ':bar')` to allow referencing
`':bar'` by the name `':foo'`. This provides both practical and
aesthetic benefits. Aesthetically, it cleans up common constructs:

Eg, in a maven repo:
```
target(name='foobar',
  dependencies=[
    'foobar/src/main/java:lib',
  ],
)
```
becomes simply:
```
alias('foobar', 'foobar/src/main/java:lib')
```

Aliases also behave slightly differently than normal wrapper
targets. The substitution task which processes target aliases
injects alias's dependencies directly into their dependees. This
means that intransitive targets can be referred to via aliases
without breaking their dependencies.

We've been using this extensively at Square as an internal plugin
for a while now, but it seems likely that other folks could benefit
from it.