### PR TITLE
[engine] clean up non in-memory storage usage, only needed for LocalMultiprocessEngine

### DIFF
--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -80,7 +80,7 @@ class EngineInitializer(object):
     return spec_roots
 
   @staticmethod
-  def setup_legacy_graph(path_ignore_patterns, storage=None):
+  def setup_legacy_graph(path_ignore_patterns):
     """Construct and return the components necessary for LegacyBuildGraph construction.
 
     :param list path_ignore_patterns: A list of path ignore patterns for FileSystemProjectTree,
@@ -90,7 +90,8 @@ class EngineInitializer(object):
     """
 
     build_root = get_buildroot()
-    storage = storage or Storage.create(debug=False)
+    # Creates an in-memory storage for `LocalSerialEngine`
+    storage = Storage.create(debug=False)
     project_tree = FileSystemProjectTree(build_root, path_ignore_patterns)
     symbol_table_cls = LegacySymbolTable
 

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -80,16 +80,17 @@ class EngineInitializer(object):
     return spec_roots
 
   @staticmethod
-  def setup_legacy_graph(path_ignore_patterns):
+  def setup_legacy_graph(path_ignore_patterns, storage=None):
     """Construct and return the components necessary for LegacyBuildGraph construction.
 
     :param list path_ignore_patterns: A list of path ignore patterns for FileSystemProjectTree,
                                       usually taken from the `--pants-ignore` global option.
+    :param Storage storage: storage instance to construct the engine.
     :returns: A tuple of (scheduler, engine, symbol_table_cls, build_graph_cls).
     """
 
     build_root = get_buildroot()
-    storage = Storage.create(debug=False)
+    storage = storage or Storage.create(debug=False)
     project_tree = FileSystemProjectTree(build_root, path_ignore_patterns)
     symbol_table_cls = LegacySymbolTable
 
@@ -106,7 +107,7 @@ class EngineInitializer(object):
       create_graph_tasks(address_mapper, symbol_table_cls)
     )
 
-    scheduler = LocalScheduler(dict(), tasks, storage, project_tree)
+    scheduler = LocalScheduler(dict(), tasks, project_tree)
     engine = LocalSerialEngine(scheduler, storage)
 
     return LegacyGraphHelper(scheduler, engine, symbol_table_cls, LegacyBuildGraph)

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -85,13 +85,10 @@ class EngineInitializer(object):
 
     :param list path_ignore_patterns: A list of path ignore patterns for FileSystemProjectTree,
                                       usually taken from the `--pants-ignore` global option.
-    :param Storage storage: storage instance to construct the engine.
     :returns: A tuple of (scheduler, engine, symbol_table_cls, build_graph_cls).
     """
 
     build_root = get_buildroot()
-    # Creates an in-memory storage for `LocalSerialEngine`
-    storage = Storage.create(debug=False)
     project_tree = FileSystemProjectTree(build_root, path_ignore_patterns)
     symbol_table_cls = LegacySymbolTable
 
@@ -109,7 +106,7 @@ class EngineInitializer(object):
     )
 
     scheduler = LocalScheduler(dict(), tasks, project_tree)
-    engine = LocalSerialEngine(scheduler, storage)
+    engine = LocalSerialEngine(scheduler, Storage.create(debug=False))
 
     return LegacyGraphHelper(scheduler, engine, symbol_table_cls, LegacyBuildGraph)
 

--- a/src/python/pants/engine/engine.py
+++ b/src/python/pants/engine/engine.py
@@ -125,10 +125,6 @@ class Engine(AbstractClass):
 class LocalSerialEngine(Engine):
   """An engine that runs tasks locally and serially in-process."""
 
-  def __init__(self, scheduler, storage=None, cache=None):
-    storage = storage or Storage.create(in_memory=True)
-    super(LocalSerialEngine, self).__init__(scheduler, storage, cache)
-
   def reduce(self, execution_request):
     node_builder = self._scheduler.node_builder()
     for step_batch in self._scheduler.schedule(execution_request):
@@ -206,7 +202,7 @@ class LocalMultiprocessEngine(Engine):
                           be used.
     :param bool debug: `True` to turn on pickling error debug mode (slower); True by default.
     """
-    # Explicitly create a lmdb storage that's only needed by LocalMultiprocessEngine.
+    # This is the only place where non in-memory storage is needed, create one if not specified.
     storage = storage or Storage.create(in_memory=False)
     super(LocalMultiprocessEngine, self).__init__(scheduler, storage, cache)
     self._pool_size = pool_size if pool_size and pool_size > 0 else 2 * multiprocessing.cpu_count()

--- a/src/python/pants/engine/engine.py
+++ b/src/python/pants/engine/engine.py
@@ -124,6 +124,9 @@ class Engine(AbstractClass):
 
 class LocalSerialEngine(Engine):
   """An engine that runs tasks locally and serially in-process."""
+  def __init__(self, scheduler, storage=None, cache=None):
+    storage = storage or Storage.create(in_memory=True)
+    super(LocalSerialEngine, self).__init__(scheduler, storage, cache)
 
   def reduce(self, execution_request):
     node_builder = self._scheduler.node_builder()
@@ -202,6 +205,8 @@ class LocalMultiprocessEngine(Engine):
                           be used.
     :param bool debug: `True` to turn on pickling error debug mode (slower); True by default.
     """
+    # Explicitly create a lmdb storage that's only needed by LocalMultiprocessEngine.
+    storage = storage or Storage.create(in_memory=False)
     super(LocalMultiprocessEngine, self).__init__(scheduler, storage, cache)
     self._pool_size = pool_size if pool_size and pool_size > 0 else 2 * multiprocessing.cpu_count()
 

--- a/src/python/pants/engine/engine.py
+++ b/src/python/pants/engine/engine.py
@@ -124,6 +124,7 @@ class Engine(AbstractClass):
 
 class LocalSerialEngine(Engine):
   """An engine that runs tasks locally and serially in-process."""
+
   def __init__(self, scheduler, storage=None, cache=None):
     storage = storage or Storage.create(in_memory=True)
     super(LocalSerialEngine, self).__init__(scheduler, storage, cache)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -449,7 +449,7 @@ class StepResult(datatype('Step', ['state'])):
 class LocalScheduler(object):
   """A scheduler that expands a ProductGraph by executing user defined tasks."""
 
-  def __init__(self, goals, tasks, storage, project_tree, graph_lock=None, graph_validator=None):
+  def __init__(self, goals, tasks, project_tree, graph_lock=None, graph_validator=None):
     """
     :param goals: A dict from a goal name to a product type. A goal is just an alias for a
            particular (possibly synthetic) product.

--- a/src/python/pants/engine/storage.py
+++ b/src/python/pants/engine/storage.py
@@ -139,7 +139,7 @@ class Storage(Closable):
   LMDB_KEY_MAPPINGS_DB_NAME = b'_key_mappings_'
 
   @classmethod
-  def create(cls, path=None, in_memory=False, debug=True, protocol=None):
+  def create(cls, path=None, in_memory=True, debug=True, protocol=None):
     """Create a content addressable Storage backed by a key value store.
 
     :param path: If in_memory=False, the path to store the database in.

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -510,4 +510,4 @@ def setup_json_scheduler(build_root, debug=True):
     )
 
   project_tree = FileSystemProjectTree(build_root)
-  return LocalScheduler(goals, tasks, storage, project_tree, None, GraphValidator(symbol_table_cls)), storage
+  return LocalScheduler(goals, tasks, project_tree, None, GraphValidator(symbol_table_cls)), storage

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -22,7 +22,6 @@ from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import LocalScheduler
 from pants.engine.selectors import (Select, SelectDependencies, SelectLiteral, SelectProjection,
                                     SelectVariant)
-from pants.engine.storage import Storage
 from pants.engine.struct import HasStructs, Struct, StructWithDeps, Variants
 from pants.util.meta import AbstractClass
 from pants.util.objects import datatype
@@ -403,14 +402,11 @@ class ExampleTable(SymbolTable):
             'inferred_scala': ScalaInferredDepsSources}
 
 
-def setup_json_scheduler(build_root, debug=True):
+def setup_json_scheduler(build_root):
   """Return a build graph and scheduler configured for BLD.json files under the given build root.
 
-  :rtype A tuple of :class:`pants.engine.scheduler.LocalScheduler`,
-    :class:`pants.engine.storage.Storage`.
+  :rtype :class:`pants.engine.scheduler.LocalScheduler`
   """
-
-  storage = Storage.create(debug=debug)
 
   symbol_table_cls = ExampleTable
 
@@ -510,4 +506,4 @@ def setup_json_scheduler(build_root, debug=True):
     )
 
   project_tree = FileSystemProjectTree(build_root)
-  return LocalScheduler(goals, tasks, project_tree, None, GraphValidator(symbol_table_cls)), storage
+  return LocalScheduler(goals, tasks, project_tree, None, GraphValidator(symbol_table_cls))

--- a/tests/python/pants_test/engine/examples/visualizer.py
+++ b/tests/python/pants_test/engine/examples/visualizer.py
@@ -32,7 +32,7 @@ def visualize_execution_graph(scheduler, storage, request):
 
 def visualize_build_request(build_root, goals, subjects):
   scheduler = setup_json_scheduler(build_root)
-  storage = Storage.create(debug=True, in_memory=False)
+  storage = Storage.create(debug=True)
 
   execution_request = scheduler.build_request(goals, subjects)
   # NB: Calls `reduce` independently of `execute`, in order to render a graph before validating it.

--- a/tests/python/pants_test/engine/examples/visualizer.py
+++ b/tests/python/pants_test/engine/examples/visualizer.py
@@ -19,7 +19,7 @@ from pants.util.contextutil import temporary_file_path
 from pants_test.engine.examples.planners import setup_json_scheduler
 
 
-def visualize_execution_graph(scheduler, storage, request):
+def visualize_execution_graph(scheduler, request):
   with temporary_file_path(cleanup=False, suffix='.dot') as dot_file:
     scheduler.visualize_graph_to_file(request.roots, dot_file)
     print('dot file saved to: {}'.format(dot_file))
@@ -32,15 +32,14 @@ def visualize_execution_graph(scheduler, storage, request):
 
 def visualize_build_request(build_root, goals, subjects):
   scheduler = setup_json_scheduler(build_root)
-  storage = Storage.create(debug=True)
 
   execution_request = scheduler.build_request(goals, subjects)
   # NB: Calls `reduce` independently of `execute`, in order to render a graph before validating it.
-  engine = LocalSerialEngine(scheduler, storage)
+  engine = LocalSerialEngine(scheduler, Storage.create(debug=True))
   engine.start()
   try:
     engine.reduce(execution_request)
-    visualize_execution_graph(scheduler, storage, execution_request)
+    visualize_execution_graph(scheduler, execution_request)
   finally:
     engine.close()
 

--- a/tests/python/pants_test/engine/examples/visualizer.py
+++ b/tests/python/pants_test/engine/examples/visualizer.py
@@ -14,6 +14,7 @@ from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.binaries import binary_util
 from pants.engine.engine import LocalSerialEngine
 from pants.engine.fs import Files, PathGlobs
+from pants.engine.storage import Storage
 from pants.util.contextutil import temporary_file_path
 from pants_test.engine.examples.planners import setup_json_scheduler
 
@@ -30,7 +31,9 @@ def visualize_execution_graph(scheduler, storage, request):
 
 
 def visualize_build_request(build_root, goals, subjects):
-  scheduler, storage = setup_json_scheduler(build_root)
+  scheduler = setup_json_scheduler(build_root)
+  storage = Storage.create(debug=True, in_memory=False)
+
   execution_request = scheduler.build_request(goals, subjects)
   # NB: Calls `reduce` independently of `execute`, in order to render a graph before validating it.
   engine = LocalSerialEngine(scheduler, storage)

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -14,7 +14,6 @@ from pants.engine.fs import create_fs_tasks
 from pants.engine.nodes import Return
 from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import LocalScheduler
-from pants.engine.storage import Storage
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 
@@ -49,18 +48,15 @@ class SchedulerTestBase(object):
   def mk_scheduler(self,
                    tasks=None,
                    goals=None,
-                   storage=None,
-                   project_tree=None,
-                   symbol_table_cls=EmptyTable):
+                   project_tree=None):
     """Creates a Scheduler with "native" tasks already included, and the given additional tasks."""
     goals = goals or dict()
     tasks = tasks or []
-    storage = storage or Storage.create(in_memory=True)
     project_tree = project_tree or self.mk_fs_tree()
 
     tasks = list(tasks) + create_fs_tasks()
-    scheduler = LocalScheduler(goals, tasks, storage, project_tree)
-    return scheduler, storage
+    scheduler = LocalScheduler(goals, tasks, project_tree)
+    return scheduler
 
   def execute_request(self, scheduler, storage, product, *subjects):
     """Creates, runs, and returns an ExecutionRequest for the given product and subjects."""

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -19,8 +19,9 @@ from pants_test.engine.examples.planners import Classpath, setup_json_scheduler
 class EngineTest(unittest.TestCase):
   def setUp(self):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
-    self.scheduler, self.storage = setup_json_scheduler(build_root, debug=True)
-    self.cache = Cache.create(Storage.create())
+    self.scheduler = setup_json_scheduler(build_root)
+    storage = Storage.create(debug=True, in_memory=False)
+    self.cache = Cache.create(storage=storage)
 
     self.java = Address.parse('src/java/codegen/simple')
 

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -20,8 +20,8 @@ class EngineTest(unittest.TestCase):
   def setUp(self):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
     self.scheduler = setup_json_scheduler(build_root)
-    storage = Storage.create(debug=True, in_memory=False)
-    self.cache = Cache.create(storage=storage)
+    self.storage = Storage.create(debug=True, in_memory=False)
+    self.cache = Cache.create(storage=self.storage)
 
     self.java = Address.parse('src/java/codegen/simple')
 

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -14,7 +14,6 @@ from pants.base.scm_project_tree import ScmProjectTree
 from pants.engine.fs import (Dir, DirectoryListing, Dirs, FileContent, Files, Link, Path, PathGlobs,
                              ReadLink, Stat, Stats)
 from pants.engine.nodes import FilesystemNode
-from pants.engine.storage import Storage
 from pants.util.meta import AbstractClass
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.testutils.git_util import MIN_REQUIRED_GIT_VERSION, git_version, initialize_repo
@@ -36,13 +35,13 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
   def assert_walk(self, ftype, filespecs, files):
     with self.mk_project_tree(self._original_src) as project_tree:
       scheduler = self.mk_scheduler(project_tree=project_tree)
-      result = self.execute(scheduler, Storage.create(), Stat, self.specs(ftype, '', *filespecs))[0]
+      result = self.execute(scheduler, Stat, self.specs(ftype, '', *filespecs))[0]
       self.assertEquals(set(files), set([p.path for p in result]))
 
   def assert_content(self, filespecs, expected_content):
     with self.mk_project_tree(self._original_src) as project_tree:
       scheduler = self.mk_scheduler(project_tree=project_tree)
-      result = self.execute(scheduler, Storage.create(), FileContent, self.specs(Files, '', *filespecs))[0]
+      result = self.execute(scheduler, FileContent, self.specs(Files, '', *filespecs))[0]
       def validate(e):
         self.assertEquals(type(e), FileContent)
         return True
@@ -52,7 +51,7 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
   def assert_fsnodes(self, ftype, filespecs, subject_product_pairs):
     with self.mk_project_tree(self._original_src) as project_tree:
       scheduler = self.mk_scheduler(project_tree=project_tree)
-      request = self.execute_request(scheduler, Storage.create(), Stat, self.specs(ftype, '', *filespecs))
+      request = self.execute_request(scheduler, Stat, self.specs(ftype, '', *filespecs))
 
       # Validate that FilesystemNodes for exactly the given subjects are reachable under this
       # request.

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -14,6 +14,7 @@ from pants.base.scm_project_tree import ScmProjectTree
 from pants.engine.fs import (Dir, DirectoryListing, Dirs, FileContent, Files, Link, Path, PathGlobs,
                              ReadLink, Stat, Stats)
 from pants.engine.nodes import FilesystemNode
+from pants.engine.storage import Storage
 from pants.util.meta import AbstractClass
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.testutils.git_util import MIN_REQUIRED_GIT_VERSION, git_version, initialize_repo
@@ -34,14 +35,14 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
 
   def assert_walk(self, ftype, filespecs, files):
     with self.mk_project_tree(self._original_src) as project_tree:
-      scheduler, storage = self.mk_scheduler(project_tree=project_tree)
-      result = self.execute(scheduler, storage, Stat, self.specs(ftype, '', *filespecs))[0]
+      scheduler = self.mk_scheduler(project_tree=project_tree)
+      result = self.execute(scheduler, Storage.create(), Stat, self.specs(ftype, '', *filespecs))[0]
       self.assertEquals(set(files), set([p.path for p in result]))
 
   def assert_content(self, filespecs, expected_content):
     with self.mk_project_tree(self._original_src) as project_tree:
-      scheduler, storage = self.mk_scheduler(project_tree=project_tree)
-      result = self.execute(scheduler, storage, FileContent, self.specs(Files, '', *filespecs))[0]
+      scheduler = self.mk_scheduler(project_tree=project_tree)
+      result = self.execute(scheduler, Storage.create(), FileContent, self.specs(Files, '', *filespecs))[0]
       def validate(e):
         self.assertEquals(type(e), FileContent)
         return True
@@ -50,8 +51,8 @@ class FSTestBase(SchedulerTestBase, AbstractClass):
 
   def assert_fsnodes(self, ftype, filespecs, subject_product_pairs):
     with self.mk_project_tree(self._original_src) as project_tree:
-      scheduler, storage = self.mk_scheduler(project_tree=project_tree)
-      request = self.execute_request(scheduler, storage, Stat, self.specs(ftype, '', *filespecs))
+      scheduler = self.mk_scheduler(project_tree=project_tree)
+      request = self.execute_request(scheduler, Storage.create(), Stat, self.specs(ftype, '', *filespecs))
 
       # Validate that FilesystemNodes for exactly the given subjects are reachable under this
       # request.

--- a/tests/python/pants_test/engine/test_graph.py
+++ b/tests/python/pants_test/engine/test_graph.py
@@ -16,7 +16,6 @@ from pants.engine.graph import ResolvedTypeMismatchError, create_graph_tasks
 from pants.engine.mapper import AddressMapper, ResolveError
 from pants.engine.nodes import Noop, Return, Throw
 from pants.engine.parser import SymbolTable
-from pants.engine.storage import Storage
 from pants.engine.struct import HasStructs, Struct, StructWithDeps
 from pants_test.engine.examples.parsers import (JsonParser, PythonAssignmentsParser,
                                                 PythonCallbacksParser)
@@ -91,10 +90,6 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
 
   def setUp(self):
     super(GraphTestBase, self).setUp()
-    self.storage = Storage.create()
-
-  def tearDown(self):
-    self.storage.close()
 
   def create(self, build_pattern=None, parser_cls=None, inline=False):
     symbol_table_cls = TestTable
@@ -114,7 +109,7 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
   def _populate(self, scheduler, address):
     """Perform an ExecutionRequest to parse the given Address into a Struct."""
     request = scheduler.execution_request([self._product], [address])
-    LocalSerialEngine(scheduler, self.storage).reduce(request)
+    LocalSerialEngine(scheduler).reduce(request)
     root_entries = scheduler.root_entries(request).items()
     self.assertEquals(1, len(root_entries))
     return root_entries[0]

--- a/tests/python/pants_test/engine/test_graph.py
+++ b/tests/python/pants_test/engine/test_graph.py
@@ -91,7 +91,7 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
 
   def setUp(self):
     super(GraphTestBase, self).setUp()
-    self.storage = Storage.create(in_memory=True)
+    self.storage = Storage.create()
 
   def tearDown(self):
     self.storage.close()
@@ -105,10 +105,7 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
 
     tasks = create_graph_tasks(address_mapper, symbol_table_cls)
     project_tree = self.mk_fs_tree(os.path.join(os.path.dirname(__file__), 'examples'))
-    scheduler, _ = self.mk_scheduler(tasks=tasks,
-                                     storage=self.storage,
-                                     project_tree=project_tree,
-                                     symbol_table_cls=symbol_table_cls)
+    scheduler = self.mk_scheduler(tasks=tasks, project_tree=project_tree)
     return scheduler
 
   def create_json(self):

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -21,7 +21,6 @@ from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, Diffe
                                  DuplicateNameError, ResolveError, UnaddressableObjectError)
 from pants.engine.nodes import Throw
 from pants.engine.parser import SymbolTable
-from pants.engine.storage import Storage
 from pants.engine.struct import HasStructs, Struct
 from pants.util.dirutil import safe_open
 from pants_test.engine.examples.parsers import JsonParser
@@ -159,7 +158,6 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
   def setUp(self):
     # Set up a scheduler that supports address mapping.
     symbol_table_cls = TargetTable
-    self.storage = Storage.create()
     address_mapper = AddressMapper(symbol_table_cls=symbol_table_cls,
                                    parser_cls=JsonParser,
                                    build_pattern=r'.+\.BUILD.json$')
@@ -175,12 +173,9 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
                              configurations=['//a', Struct(embedded='yes')],
                              type_alias='target')
 
-  def tearDown(self):
-    self.storage.close()
-
   def resolve(self, spec):
     request = self.scheduler.execution_request([UnhydratedStruct], [spec])
-    result = LocalSerialEngine(self.scheduler, self.storage).execute(request)
+    result = LocalSerialEngine(self.scheduler).execute(request)
     if result.error:
       raise result.error
 

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -159,7 +159,7 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
   def setUp(self):
     # Set up a scheduler that supports address mapping.
     symbol_table_cls = TargetTable
-    self.storage = Storage.create(in_memory=True)
+    self.storage = Storage.create()
     address_mapper = AddressMapper(symbol_table_cls=symbol_table_cls,
                                    parser_cls=JsonParser,
                                    build_pattern=r'.+\.BUILD.json$')
@@ -167,10 +167,7 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
 
     project_tree = self.mk_fs_tree(os.path.join(os.path.dirname(__file__), 'examples/mapper_test'))
     self.build_root = project_tree.build_root
-    self.scheduler, _ = self.mk_scheduler(tasks=tasks,
-                                          project_tree=project_tree,
-                                          storage=self.storage,
-                                          symbol_table_cls=symbol_table_cls)
+    self.scheduler = self.mk_scheduler(tasks=tasks, project_tree=project_tree)
 
     self.a_b = Address.parse('a/b')
     self.a_b_target = Target(name='b',

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -17,7 +17,6 @@ from pants.engine.nodes import (ConflictingProducersError, DependenciesNode, Ret
                                 Throw, Waiting)
 from pants.engine.scheduler import (CompletedNodeException, IncompleteDependencyException,
                                     ProductGraph)
-from pants.engine.storage import Storage
 from pants.util.contextutil import temporary_dir
 from pants_test.engine.examples.planners import (ApacheThriftJavaConfiguration, Classpath, GenGoal,
                                                  Jar, JavaSources, ThriftSources,
@@ -29,9 +28,8 @@ class SchedulerTest(unittest.TestCase):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
     self.spec_parser = CmdLineSpecParser(build_root)
     self.scheduler = setup_json_scheduler(build_root)
-    self.storage = Storage.create(debug=True)
     self.pg = self.scheduler.product_graph
-    self.engine = LocalSerialEngine(self.scheduler, self.storage)
+    self.engine = LocalSerialEngine(self.scheduler)
 
     self.guava = Address.parse('3rdparty/jvm:guava')
     self.thrift = Address.parse('src/thrift/codegen/simple')

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -29,7 +29,7 @@ class SchedulerTest(unittest.TestCase):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
     self.spec_parser = CmdLineSpecParser(build_root)
     self.scheduler = setup_json_scheduler(build_root)
-    self.storage = Storage.create(debug=True, in_memory=False)
+    self.storage = Storage.create(debug=True)
     self.pg = self.scheduler.product_graph
     self.engine = LocalSerialEngine(self.scheduler, self.storage)
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -17,6 +17,7 @@ from pants.engine.nodes import (ConflictingProducersError, DependenciesNode, Ret
                                 Throw, Waiting)
 from pants.engine.scheduler import (CompletedNodeException, IncompleteDependencyException,
                                     ProductGraph)
+from pants.engine.storage import Storage
 from pants.util.contextutil import temporary_dir
 from pants_test.engine.examples.planners import (ApacheThriftJavaConfiguration, Classpath, GenGoal,
                                                  Jar, JavaSources, ThriftSources,
@@ -27,7 +28,8 @@ class SchedulerTest(unittest.TestCase):
   def setUp(self):
     build_root = os.path.join(os.path.dirname(__file__), 'examples', 'scheduler_inputs')
     self.spec_parser = CmdLineSpecParser(build_root)
-    self.scheduler, self.storage = setup_json_scheduler(build_root)
+    self.scheduler = setup_json_scheduler(build_root)
+    self.storage = Storage.create(debug=True, in_memory=False)
     self.pg = self.scheduler.product_graph
     self.engine = LocalSerialEngine(self.scheduler, self.storage)
 

--- a/tests/python/pants_test/engine/test_storage.py
+++ b/tests/python/pants_test/engine/test_storage.py
@@ -23,7 +23,7 @@ class StorageTest(unittest.TestCase):
   class SomeException(Exception): pass
 
   def setUp(self):
-    self.storage = Storage.create(in_memory=True)
+    self.storage = Storage.create()
     self.result = StepResult(state='something')
     self.request = StepRequest(step_id=123, node='some node',
                                dependencies={'some dep': 'some state',
@@ -113,7 +113,7 @@ class CacheTest(unittest.TestCase):
 
   def setUp(self):
     """Setup cache as well as request and result."""
-    self.storage = Storage.create(in_memory=True)
+    self.storage = Storage.create()
     self.cache = Cache.create(storage=self.storage)
     request = StepRequest(step_id=123, node='some node',
                                dependencies={'some dep': 'some state',


### PR DESCRIPTION
This review serves for two purposes:

1. Use `in_memory` as default because `lmdb` is only useful for
   `LocalMultiprocessEngine` which is still experimental.
2. By using `lmdb` only when appropriate would hopefully solve #3510
   that we suspect to do with excessive `lmdb` usage (not closing files)