### PR TITLE
Decode Watchman file event filenames to UTF-8.

### DIFF
--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -67,9 +67,9 @@ class SchedulerService(PantsService):
     try:
       subscription, is_initial_event, files = (event['subscription'],
                                                event['is_fresh_instance'],
-                                               event['files'])
-    except KeyError:
-      self._logger.warn('invalid watchman event: %s', event)
+                                               [f.decode('utf-8') for f in event['files']])
+    except (KeyError, UnicodeDecodeError) as e:
+      self._logger.warn('%r raised by invalid watchman event: %s', e, event)
       return
 
     self._logger.debug('processing {} files for subscription {} (first_event={})'

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -111,5 +111,6 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
       for line in read_pantsd_log(workdir):
         print(line)
 
+      # Assert there were no warnings or errors thrown in the pantsd log.
       for line in read_pantsd_log(workdir):
-        self.assertNotIn('raised by invalid watchman event: ', line)
+        self.assertNotRegexpMatches(line, r'^[WE].*')

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -26,12 +26,11 @@ class PantsDaemonMonitor(ProcessManager):
     assert self._pid is not None and self.is_dead(), 'pantsd should be stopped!'
 
 
-def print_pantsd_log(workdir):
+def read_pantsd_log(workdir):
   # Surface the pantsd log for easy viewing via pytest's `-s` (don't capture stdio) option.
-  print('pantsd.log:\n')
   with open('{}/pantsd/pantsd.log'.format(workdir)) as f:
     for line in f:
-      print(line, end='')
+      yield line.strip()
 
 
 class TestPantsDaemonIntegration(PantsRunIntegrationTest):
@@ -68,7 +67,9 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
 
       checker.assert_stopped()
-      print_pantsd_log(workdir)
+
+      for line in read_pantsd_log(workdir):
+        print(line)
 
   def test_pantsd_run_with_watchman(self):
     with self.temporary_workdir() as workdir_base:
@@ -106,4 +107,9 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
 
       checker.assert_stopped()
-      print_pantsd_log(workdir)
+
+      for line in read_pantsd_log(workdir):
+        print(line)
+
+      for line in read_pantsd_log(workdir):
+        self.assertNotIn('raised by invalid watchman event: ', line)


### PR DESCRIPTION
Fixes #3524.

Relates to https://github.com/facebook/watchman/wiki/Better-Unicode-handling-plan