### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
@@ -312,7 +312,7 @@ class CheckSyntaxError(Exception):
     line_range = slice(self._syntax_error.lineno, self._syntax_error.lineno + 1)
     lines = OffByOneList(self._blob.split('\n'))
     # NB: E901 is the SyntaxError PEP8 code.
-    # See:http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+    # See:https://pep8.readthedocs.io/en/latest/intro.html#error-codes
     return Nit('E901', Nit.ERROR, self.filename,
                'SyntaxError: {error}'.format(error=self._syntax_error.msg),
                line_range=line_range, lines=lines)

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pep8_subsystem.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pep8_subsystem.py
@@ -11,7 +11,7 @@ from pants.contrib.python.checks.tasks.checkstyle.plugin_subsystem_base import P
 class PEP8Subsystem(PluginSubsystemBase):
   options_scope = 'pycheck-pep8'
 
-  # Code reference is here: http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+  # Code reference is here: https://pep8.readthedocs.io/en/latest/intro.html#error-codes
   DEFAULT_IGNORE_CODES = (
     # continuation_line_indentation
     'E121', # continuation line under-indented for hanging indent

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pyflakes.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pyflakes.py
@@ -14,7 +14,7 @@ class FlakeError(Nit):
   # TODO(wickman) There is overlap between this and Flake8 -- consider integrating
   # checkstyle plug-ins into the PEP8 tool directly so that this can be inherited
   # by flake8.
-  # Code reference is here: http://flake8.readthedocs.org/en/latest/warnings.html
+  # Code reference is here: https://flake8.readthedocs.io/en/latest/warnings.html
   CLASS_ERRORS = {
     'DuplicateArgument': 'F831',
     'ImportShadowedByLoopVar': 'F402',

--- a/src/docs/announce_201409.md
+++ b/src/docs/announce_201409.md
@@ -65,7 +65,7 @@ Among Pants’s current strengths are:
 -   Support for local and distributed caching.
 -   Especially fast for Scala builds, compared to alternatives.
 -   Builds standalone python executables ([PEX
-    files](http://pex.readthedocs.org/))
+    files](https://pex.readthedocs.io/))
 -   Has a plugin system to add custom features and override stock
     behavior.
 -   Runs on Linux and Mac OS X.

--- a/src/python/pants/engine/storage.py
+++ b/src/python/pants/engine/storage.py
@@ -476,7 +476,7 @@ class Lmdb(KeyValueStore):
   # writemap will use a writeable memory mapping to directly update storage, therefore
   # improves performance. But it may cause filesystems that don’t support sparse files,
   # such as OSX, to immediately preallocate map_size = bytes of underlying storage.
-  # See https://lmdb.readthedocs.org/en/release/#writemap-mode
+  # See https://lmdb.readthedocs.io/en/release/#writemap-mode
   USE_SPARSE_FILES = sys.platform != 'darwin'
 
   @classmethod


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
