### PR TITLE
Support for transitioning to making all backends opt-in.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -37,6 +37,12 @@ pythonpath: [
   ]
 
 backend_packages: [
+    "pants.backend.graph_info",
+    "pants.backend.docgen",
+    "pants.backend.python",
+    "pants.backend.jvm",
+    "pants.backend.codegen",
+    "pants.backend.project_info",
     "internal_backend.optional",
     "internal_backend.repositories",
     "internal_backend.sitegen",

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -104,6 +104,7 @@ def deprecated_conditional(predicate,
 
   :param () -> bool predicate: A function that returns True if the deprecation warning should be on.
   :param string removal_version: The pants version which will remove the deprecated functionality.
+  :param string entity_description: A description of the deprecated entity.
   :param string hint_message: An optional hint pointing to alternatives to the deprecation.
   :param int stacklevel: How far up in the stack do we go to find the calling fn to report
   :raises DeprecationApplicationError if the deprecation is applied improperly.

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -16,6 +16,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:cmd_line_spec_parser',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:file_system_project_tree',
     'src/python/pants/base:scm_project_tree',

--- a/src/python/pants/bin/extension_loader.py
+++ b/src/python/pants/bin/extension_loader.py
@@ -33,7 +33,7 @@ def load_backends_and_plugins(plugins, working_set, backends, build_configuratio
   :param list<str> backends: Source backends to load (see `load_build_configuration_from_source`).
   """
   build_configuration = build_configuration or BuildConfiguration()
-  load_build_configuration_from_source(build_configuration, additional_backends=backends or [])
+  load_build_configuration_from_source(build_configuration, backends)
   load_plugins(build_configuration, plugins or [], working_set)
   return build_configuration
 
@@ -93,35 +93,19 @@ def load_plugins(build_configuration, plugins, working_set):
     loaded[dist.as_requirement().key] = dist
 
 
-def load_build_configuration_from_source(build_configuration, additional_backends=None):
+def load_build_configuration_from_source(build_configuration, backends=None):
   """Installs pants backend packages to provide BUILD file symbols and cli goals.
 
   :param BuildConfiguration build_configuration: The BuildConfiguration (for adding aliases).
-  :param additional_backends: An optional list of additional packages to load backends from.
+  :param backends: An optional list of additional packages to load backends from.
   :raises: :class:``pants.base.exceptions.BuildConfigurationError`` if there is a problem loading
     the build configuration.
   """
-  # Note: pants.core_tasks must be first in this list, as it registers various stubs
-  # that other tasks can use for scheduling against.
-  #
-  # TODO: Allow repos to opt in to any backend (but not to core_tasks, which must always
-  # be loaded).  Note that some backends use targets from other backends in their own BUILD files,
-  # e.g., pants.backend.python uses the page() target type from pants.backend.docgen.  So we must
-  # ensure that depended-on backends are loaded first. We do so manually here, but when making these
-  # opt-in we'll require a facility for loading dependent backends in the right order.
-  #
-  # TODO: Consider replacing the "backend" nomenclature here. For example, pants.build_graph and
+  # pants.build_graph and pants.core_task must always be loaded, and before any other backends.
+  # TODO: Consider replacing the "backend" nomenclature here. pants.build_graph and
   # pants.core_tasks aren't really backends.
-  backend_packages = ['pants.build_graph',
-                      'pants.core_tasks',
-                      'pants.backend.graph_info',
-                      'pants.backend.docgen',
-                      'pants.backend.python',
-                      'pants.backend.jvm',
-                      'pants.backend.codegen',
-                      'pants.backend.project_info']
-
-  for backend_package in OrderedSet(backend_packages + (additional_backends or [])):
+  backend_packages = OrderedSet(['pants.build_graph', 'pants.core_tasks'] + (backends or []))
+  for backend_package in backend_packages:
     load_backend(build_configuration, backend_package)
 
 

--- a/src/python/pants/bin/options_initializer.py
+++ b/src/python/pants/bin/options_initializer.py
@@ -11,6 +11,7 @@ import sys
 import pkg_resources
 
 from pants.base.build_environment import pants_version
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import BuildConfigurationError
 from pants.bin.extension_loader import load_backends_and_plugins
 from pants.bin.plugin_resolver import PluginResolver
@@ -85,8 +86,16 @@ class OptionsInitializer(object):
 
     # Load plugins and backends.
     plugins = global_bootstrap_options.plugins
-    backend_packages = global_bootstrap_options.backend_packages
-    build_configuration = load_backends_and_plugins(plugins, working_set, backend_packages)
+    deprecated_conditional(
+        lambda: not set(global_bootstrap_options.default_backend_packages).issubset(
+            global_bootstrap_options.backend_packages),
+        '1.3.0',
+        '--default-backend-packages',
+        'Add the backends you need to --backend-packages instead. If in doubt, add all of them. '
+        'In the future there will be no default backends.')
+    backends = (global_bootstrap_options.default_backend_packages +
+                global_bootstrap_options.backend_packages)
+    build_configuration = load_backends_and_plugins(plugins, working_set, backends)
 
     # Now that plugins and backends are loaded, we can gather the known scopes.
     known_scope_infos = [GlobalOptionsRegistrar.get_scope_info()]

--- a/src/python/pants/bin/options_initializer.py
+++ b/src/python/pants/bin/options_initializer.py
@@ -91,8 +91,10 @@ class OptionsInitializer(object):
             global_bootstrap_options.backend_packages),
         '1.3.0',
         '--default-backend-packages',
-        'Add the backends you need to --backend-packages instead. If in doubt, add all of them. '
-        'In the future there will be no default backends.')
+        'Add the backends you need to --backend-packages instead. To see available backends run: '
+        './pants help-advanced | grep default-backend-packages | egrep -o -m1 "default: [^)]+" . '
+        'In the future there will be no default backends, and all backends will have to be opted '
+        'into via --backend packages.')
     backends = (global_bootstrap_options.default_backend_packages +
                 global_bootstrap_options.backend_packages)
     build_configuration = load_backends_and_plugins(plugins, working_set, backends)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -62,6 +62,18 @@ class GlobalOptionsRegistrar(Optionable):
 
     register('--backend-packages', advanced=True, type=list,
              help='Load backends from these packages that are already on the path.')
+    register('--default-backend-packages', advanced=True, type=list,
+             default=['pants.backend.graph_info',
+                      'pants.backend.docgen',
+                      'pants.backend.python',
+                      'pants.backend.jvm',
+                      'pants.backend.codegen',
+                      'pants.backend.project_info'],
+             removal_version='1.3.0',
+             removal_hint='Add the backends you need to --backend-packages instead. If in doubt,'
+                          'add all of them.  In the future there will be no default backends.',
+             help='Temporary helper option to ease the transition to requiring repos to '
+                  'opt-in to any needed backend.')
 
     register('--pants-bootstrapdir', advanced=True, metavar='<dir>', default=get_pants_cachedir(),
              help='Use this dir for global cache.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -70,8 +70,12 @@ class GlobalOptionsRegistrar(Optionable):
                       'pants.backend.codegen',
                       'pants.backend.project_info'],
              removal_version='1.3.0',
-             removal_hint='Add the backends you need to --backend-packages instead. If in doubt,'
-                          'add all of them.  In the future there will be no default backends.',
+             removal_hint='Add the backends you need to --backend-packages instead.  To see '
+                          'available backends run: '
+                          './pants help-advanced | grep default-backend-packages | egrep -o -m1 '
+                          '"default: [^)]+" . '
+                          'In the future there will be no default backends and all backends will'
+                          'have to be opted into via --backend packages.',
              help='Temporary helper option to ease the transition to requiring repos to '
                   'opt-in to any needed backend.')
 

--- a/tests/python/pants_test/bin/test_extension_loader.py
+++ b/tests/python/pants_test/bin/test_extension_loader.py
@@ -296,7 +296,7 @@ class LoaderTest(unittest.TestCase):
     def reg_alias():
       return BuildFileAliases(targets={'override-alias': DummyTarget2})
     self.working_set.add(self.get_mock_plugin('pluginalias', '0.0.1', alias=reg_alias))
-    plugins=['pluginalias==0.0.1'];
+    plugins=['pluginalias==0.0.1']
     aliases = BuildFileAliases(targets={'override-alias': DummyTarget})
     with self.create_register(build_file_aliases=lambda: aliases) as backend_module:
       backends=[backend_module]


### PR DESCRIPTION
Replaces the hard-coded list of backends with an already-deprecated
option.  A deprecation warning will issue if that option's values
aren't repeated in --backend-packages.

This allows repos to opt out of currently hard-coded backends,
by removing them from --default-backend-packages.  The deprecation
messages encourage repos to explicitly list the backends they
want in --backend-packages, in advance of switching to an entirely
opt-in system.

In short: this change allows repos to opt out, a future change
will require repos to opt in.