### PR TITLE
Make checkstyle's options filename-agnostic.

### DIFF
--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from textwrap import dedent
 
+from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_file
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -75,7 +76,7 @@ class FindBugsTest(PantsRunIntegrationTest):
 
   def test_exclude(self):
     cmd = ['compile', 'contrib/findbugs/tests/java/org/pantsbuild/contrib/findbugs:all']
-    with temporary_file() as exclude_file:
+    with temporary_file(root_dir=get_buildroot()) as exclude_file:
       exclude_file.write(dedent("""\
         <?xml version="1.0" encoding="UTF-8"?>
         <FindBugsFilter>
@@ -98,7 +99,7 @@ class FindBugsTest(PantsRunIntegrationTest):
 
   def test_error(self):
     cmd = ['compile', 'contrib/findbugs/tests/java/org/pantsbuild/contrib/findbugs:all']
-    with temporary_file() as exclude_file:
+    with temporary_file(root_dir=get_buildroot()) as exclude_file:
       exclude_file.write(dedent("""\
         <?xml version="1.0" encoding="UTF-8"?>
         <FindBugsFilter>

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -13,7 +13,7 @@ from pants.backend.jvm.subsystems.shader import Shader
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
-from pants.option.custom_types import file_option
+from pants.option.custom_types import dict_with_files_option, file_option
 from pants.process.xargs import Xargs
 from pants.util.dirutil import safe_open
 
@@ -37,7 +37,8 @@ class Checkstyle(NailgunTask):
              help='Skip checkstyle.')
     register('--configuration', advanced=True, type=file_option, fingerprint=True,
              help='Path to the checkstyle configuration file.')
-    register('--properties', advanced=True, type=dict, default={}, fingerprint=True,
+    register('--properties', advanced=True, type=dict_with_files_option, default={},
+             fingerprint=True,
              help='Dictionary of property mappings to use for checkstyle.properties.')
     register('--confs', advanced=True, type=list, default=['default'],
              help='One or more ivy configurations to resolve for this target.')

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -68,6 +68,17 @@ def file_option(s):
   return s
 
 
+def dict_with_files_option(s):
+  """Same as 'dict', but fingerprints the file contents of any values which are file paths.
+
+  For any value which matches the path of a file on disk, the file path is not fingerprinted -- only
+  its contents.
+
+  :API: public
+  """
+  return dict_option(s)
+
+
 def _convert(val, acceptable_types):
   """Ensure that val is one of the acceptable types, converting it if needed.
 

--- a/src/python/pants/option/option_util.py
+++ b/src/python/pants/option/option_util.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.option.custom_types import list_option
+from pants.option.custom_types import dict_with_files_option, list_option
 
 
 def is_list_option(kwargs):
@@ -14,4 +14,4 @@ def is_list_option(kwargs):
 
 
 def is_dict_option(kwargs):
-  return kwargs.get('type') == dict
+  return kwargs.get('type') in (dict, dict_with_files_option)

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -6,9 +6,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import json
+import os
 from hashlib import sha1
 
-from pants.option.custom_types import file_option, target_option
+from pants.base.build_environment import get_buildroot
+from pants.option.custom_types import dict_with_files_option, file_option, target_option
 
 
 def stable_json_dumps(obj):
@@ -47,6 +49,8 @@ class OptionsFingerprinter(object):
       return self._fingerprint_target_specs(option_val)
     elif option_type == file_option:
       return self._fingerprint_files(option_val)
+    elif option_type == dict_with_files_option:
+      return self._fingerprint_dict_with_files(option_val)
     else:
       return self._fingerprint_primitives(option_val)
 
@@ -61,15 +65,58 @@ class OptionsFingerprinter(object):
           hasher.update(h)
     return hasher.hexdigest()
 
+  def _assert_in_buildroot(self, filepath):
+    """Raises an error if the given filepath isn't in the buildroot.
+
+    Returns the normalized, absolute form of the path.
+    """
+    filepath = os.path.normpath(filepath)
+    root = get_buildroot()
+    if not os.path.abspath(filepath) == filepath:
+      # If not absolute, assume relative to the build root.
+      return os.path.join(root, filepath)
+    else:
+      if '..' in os.path.relpath(filepath, root).split(os.path.sep):
+        # The path wasn't in the buildroot. This is an error because it violates the pants being
+        # hermetic.
+        raise ValueError('Received a file_option that was not inside the build root:\n'
+                         '  file_option: {filepath}\n'
+                         '  build_root:  {buildroot}\n'
+                         .format(filepath=filepath, buildroot=root))
+      return filepath
+
   def _fingerprint_files(self, filepaths):
-    """Returns a fingerprint of the given filepaths and their contents."""
+    """Returns a fingerprint of the given filepaths and their contents.
+
+    This assumes the files are small enough to be read into memory.
+    """
     hasher = sha1()
     # Note that we don't sort the filepaths, as their order may have meaning.
     for filepath in filepaths:
-      hasher.update(filepath)
+      filepath = self._assert_in_buildroot(filepath)
+      hasher.update(os.path.relpath(filepath, get_buildroot()))
       with open(filepath, 'rb') as f:
         hasher.update(f.read())
     return hasher.hexdigest()
 
   def _fingerprint_primitives(self, val):
     return stable_json_sha1(val)
+
+  def _fingerprint_dict_with_files(self, option_val):
+    """Returns a fingerprint of the given dictionary containing file paths.
+
+    Any value which is a file path which exists on disk will be fingerprinted by that file's
+    contents rather than by its path.
+
+    This assumes the files are small enough to be read into memory.
+    """
+    # Dicts are wrapped in singleton lists. See the "For simplicity..." comment in `fingerprint()`.
+    option_val = option_val[0]
+    return stable_json_sha1({k: self._expand_possible_file_value(v) for k, v in option_val.items()})
+
+  def _expand_possible_file_value(self, value):
+    """If the value is a file, returns its contents. Otherwise return the original value."""
+    if value and os.path.isfile(str(value)):
+      with open(value, 'r') as f:
+        return f.read()
+    return value

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -116,6 +116,7 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
+  timeout = 120,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -5,9 +5,13 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import json
 import os
+import shutil
+from contextlib import contextmanager
 from textwrap import dedent
 
+from pants.base.build_environment import get_buildroot
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_cached
 
@@ -28,19 +32,19 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
   @ensure_cached(expected_num_artifacts=2)
   def test_config_invalidates_targets(self, cache_args):
     with self.temporary_workdir() as workdir:
-      with temporary_dir() as tmp:
+      with temporary_dir(root_dir=get_buildroot()) as tmp:
         configs = [
-            dedent("""
+          dedent("""
               <module name="TreeWalker">
                 <property name="tabWidth" value="2"/>
               </module>"""),
-            dedent("""
+          dedent("""
               <module name="TreeWalker">
                 <module name="LineLength">
                   <property name="max" value="100"/>
                 </module>
               </module>""")
-          ]
+        ]
 
         for config in configs:
           # Ensure that even though the config files have the same name, their
@@ -48,12 +52,194 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
           config_file = os.path.join(tmp, 'config.xml')
           self._create_config_file(config_file, config)
           args = [
-              'clean-all',
-              'compile.checkstyle',
-              cache_args,
-              'examples/src/java/org/pantsbuild/example/hello/simple',
-              '--compile-checkstyle-configuration={}'.format(config_file)
-            ]
+            'clean-all',
+            'compile.checkstyle',
+            cache_args,
+            'examples/src/java/org/pantsbuild/example/hello/simple',
+            '--compile-checkstyle-configuration={}'.format(config_file)
+          ]
+          pants_run = self.run_pants_with_workdir(args, workdir)
+          self.assert_success(pants_run)
+
+  @ensure_cached(expected_num_artifacts=2)
+  def test_config_name_invalidates_targets(self, cache_args):
+    with self.temporary_workdir() as workdir:
+      with temporary_dir(root_dir=get_buildroot()) as tmp:
+        config_names = ['one.xml', 'two.xml']
+        config = dedent("""
+          <module name="TreeWalker">
+            <property name="tabWidth" value="2"/>
+          </module>""")
+
+        for config_name in config_names:
+          # Ensure that even though the config files have the same name, their contents will
+          # invalidate the targets.
+          config_file = os.path.join(tmp, config_name)
+          self._create_config_file(config_file, config)
+          args = [
+            'compile.checkstyle',
+            cache_args,
+            'examples/src/java/org/pantsbuild/example/hello/simple',
+            '--compile-checkstyle-configuration={}'.format(config_file)
+          ]
+          pants_run = self.run_pants_with_workdir(args, workdir)
+          self.assert_success(pants_run)
+
+  @contextmanager
+  def _temporary_buildroot(self, files_to_copy, current_root=None):
+    if current_root is None:
+      current_root = get_buildroot()
+    files_to_copy = set(files_to_copy)
+    files_to_copy.update(f for f in os.listdir(current_root)
+                         if f.endswith('.ini') or f.startswith('BUILD'))
+    files_to_copy.update((
+      'pants',
+      '3rdparty',
+      'build-support',
+      'contrib',
+      'pants-plugins',
+      'src',
+    ))
+    with temporary_dir() as temp_root:
+      temp_root = os.path.normpath(temp_root)
+      for path in files_to_copy:
+        src = os.path.join(current_root, path)
+        dst = os.path.join(temp_root, path)
+        if os.path.isdir(path):
+          shutil.copytree(src, dst)
+        else:
+          shutil.copyfile(src, dst)
+      current = os.getcwd()
+      try:
+        os.chdir(temp_root)
+        temp_root = os.getcwd()
+        yield temp_root
+      finally:
+        os.chdir(current)
+
+  def _temporary_buildroots(self, files_to_copy=None, current_root=None, iterations=2):
+    while iterations:
+      with self._temporary_buildroot(files_to_copy, current_root) as root:
+        yield root
+      iterations -= 1
+
+  @ensure_cached(expected_num_artifacts=1)
+  def test_config_buildroot_does_not_invalidate_targets(self, cache_args):
+    previous_names = set()
+    for buildroot in self._temporary_buildroots(['examples']):
+      with self.temporary_workdir() as workdir:
+        tmp = os.path.join(buildroot, 'tmp')
+        os.mkdir(tmp)
+        config = dedent("""
+          <module name="TreeWalker">
+            <property name="tabWidth" value="2"/>
+          </module>""")
+
+        # Ensure that even though the config files have the same name, their
+        # contents will invalidate the targets.
+        config_file = os.path.join(tmp, 'one.xml')
+        self.assertNotIn(config_file, previous_names)
+        previous_names.add(config_file)
+        self._create_config_file(config_file, config)
+        args = [
+          'compile.checkstyle',
+          cache_args,
+          'examples/src/java/org/pantsbuild/example/hello/simple',
+          '--compile-checkstyle-configuration={}'.format(config_file),
+        ]
+        pants_run = self.run_pants_with_workdir(args, workdir)
+        self.assert_success(pants_run)
+
+  @ensure_cached(expected_num_artifacts=1)
+  def test_properties_file_names_does_not_invalidates_targets(self, cache_args):
+    with self.temporary_workdir() as workdir:
+      with temporary_dir(root_dir=get_buildroot()) as tmp:
+        suppression_names = ['one-supress.xml', 'two-supress.xml']
+        suppression_data = dedent("""
+          <?xml version="1.0"?>
+          <!DOCTYPE suppressions PUBLIC
+              "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+              "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+          <suppressions>
+            <suppress files=".*/bad-files/.*\.java" checks=".*"/>
+          </suppressions>
+          """).strip()
+
+        for suppression_name in suppression_names:
+          suppression_file = os.path.join(tmp, suppression_name)
+          self._create_config_file(suppression_file, suppression_data)
+          properties = {
+            'checkstyle.suppression.files': suppression_file,
+          }
+          args = [
+            'compile.checkstyle',
+            cache_args,
+            'examples/src/java/org/pantsbuild/example/hello/simple',
+            "--compile-checkstyle-properties={}".format(json.dumps(properties)),
+          ]
+          pants_run = self.run_pants_with_workdir(args, workdir)
+          self.assert_success(pants_run)
+
+  @ensure_cached(expected_num_artifacts=2)
+  def test_properties_file_contents_invalidates_targets(self, cache_args):
+    with self.temporary_workdir() as workdir:
+      with temporary_dir(root_dir=get_buildroot()) as tmp:
+        suppression_files = [
+          dedent("""
+            <?xml version="1.0"?>
+            <!DOCTYPE suppressions PUBLIC
+                "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+                "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+            <suppressions>
+              <suppress files=".*/bad-files/.*\.java" checks=".*"/>
+            </suppressions>
+          """).strip(),
+          dedent("""
+            <?xml version="1.0"?>
+            <!DOCTYPE suppressions PUBLIC
+                "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+                "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+            <suppressions>
+              <suppress files=".*/bad-files/.*\.java" checks=".*"/>
+              <suppress files=".*/really-bad-files/.*\.java" checks=".*"/>
+            </suppressions>
+          """).strip(),
+        ]
+
+        for suppressions in suppression_files:
+          suppression_file = os.path.join(tmp, 'suppressions.xml')
+          self._create_config_file(suppression_file, suppressions)
+          properties = {
+            'checkstyle.suppression.files': suppression_file,
+          }
+          args = [
+            'compile.checkstyle',
+            cache_args,
+            'examples/src/java/org/pantsbuild/example/hello/simple',
+            "--compile-checkstyle-properties={}".format(json.dumps(properties)),
+          ]
+          pants_run = self.run_pants_with_workdir(args, workdir)
+          self.assert_success(pants_run)
+
+  @ensure_cached(expected_num_artifacts=2)
+  def test_properties_nonfile_values_invalidates_targets(self, cache_args):
+    with self.temporary_workdir() as workdir:
+      with temporary_dir(root_dir=get_buildroot()):
+        values = ['this-is-not-a-file', '37']
+
+        for value in values:
+          properties = {
+            'my.value': value,
+          }
+          args = [
+            'compile.checkstyle',
+            cache_args,
+            'examples/src/java/org/pantsbuild/example/hello/simple',
+            "--compile-checkstyle-properties={}".format(json.dumps(properties)),
+          ]
           pants_run = self.run_pants_with_workdir(args, workdir)
           self.assert_success(pants_run)
 

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -5,10 +5,13 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
+
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.option.custom_types import dict_option, file_option, list_option, target_option
 from pants.option.options_fingerprinter import OptionsFingerprinter
+from pants.util.contextutil import temporary_dir
 from pants_test.base_test import BaseTest
 
 
@@ -71,6 +74,12 @@ class OptionsFingerprinterTest(BaseTest):
     self.assertNotEquals(fp1, fp2)
     self.assertNotEquals(fp1, fp3)
     self.assertNotEquals(fp2, fp3)
+
+  def test_fingerprint_file_outside_buildroot(self):
+    with temporary_dir() as tmp:
+      outside_buildroot = self.create_file(os.path.join(tmp, 'foobar'), contents='foobar')
+      with self.assertRaises(ValueError):
+        self.options_fingerprinter.fingerprint(file_option, outside_buildroot)
 
   def test_fingerprint_file_list(self):
     f1, f2, f3 = (self.create_file(f, contents=c) for (f, c) in


### PR DESCRIPTION
See issue: https://github.com/pantsbuild/pants/issues/3555

We were getting excessive cache invalidation in our shared build
cache for checkstyle, because it was fingerprinting the absolute
paths to the configuration files. There's really no reason for
checkstyle to care about the names of the files containing rules
and suppressions, all it should care about are the file contents.
This change enforces that.