### PR TITLE
dep-usage: create edge only for those direct or transitive dependencies.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -177,7 +177,8 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
     """
     def creator(target):
       node = self.create_dep_usage_node(target, get_buildroot(),
-                                        classes_by_source, runtime_classpath, product_deps_by_src)
+                                        classes_by_source, runtime_classpath, product_deps_by_src,
+                                        self._compute_transitive_deps_by_target())
       vt = target_to_vts[target]
       with open(self.nodes_json(vt.results_dir), mode='w') as fp:
         json.dump(node.to_cacheable_dict(), fp, indent=2, sort_keys=True)
@@ -231,7 +232,8 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
   def cache_target_dirs(self):
     return True
 
-  def create_dep_usage_node(self, target, buildroot, classes_by_source, runtime_classpath, product_deps_by_src):
+  def create_dep_usage_node(self, target, buildroot, classes_by_source, runtime_classpath, product_deps_by_src,
+                            transitive_deps_by_target):
     concrete_target = target.concrete_derived_from
     products_total = self._count_products(runtime_classpath, target)
     node = Node(concrete_target)
@@ -251,6 +253,9 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
         for dep_tgt in self.targets_by_file.get(product_dep, []):
           derived_from = dep_tgt.concrete_derived_from
           if not self._select(derived_from):
+            continue
+          # Create edge only for those direct or transitive dependencies.
+          if not derived_from in transitive_deps_by_target.get(concrete_target):
             continue
           is_declared = self._is_declared_dep(target, dep_tgt)
           normalized_deps = self._normalize_product_dep(buildroot, classes_by_source, product_dep)

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_usage.py
@@ -254,7 +254,9 @@ class JvmDependencyUsage(JvmDependencyAnalyzer):
           derived_from = dep_tgt.concrete_derived_from
           if not self._select(derived_from):
             continue
-          # Create edge only for those direct or transitive dependencies.
+          # Create edge only for those direct or transitive dependencies in order to
+          # disqualify irrelevant targets that happen to share some file in sources,
+          # not uncommon when globs especially rglobs is used.
           if not derived_from in transitive_deps_by_target.get(concrete_target):
             continue
           is_declared = self._is_declared_dep(target, dep_tgt)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
@@ -120,7 +120,7 @@ class TestJvmDependencyUsage(TaskTestBase):
     product_deps_by_src[t4] = {'d.java': ['a.class']}
     graph = self.create_graph(dep_usage, [t1, t2, t3, t4])
 
-    # Not creating edge for t2 even it provides a.class that t4 depends on
+    # Not creating edge for t2 even it provides a.class that t4 depends on.
     self.assertFalse(t2 in graph._nodes[t4].dep_edges)
     # t4 depends on a.class from t1 transitively through t3.
     self.assertEqual(graph._nodes[t4].dep_edges[t1].products_used, set(['a.class']))

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_dependency_usage.py
@@ -104,14 +104,40 @@ class TestJvmDependencyUsage(TaskTestBase):
 
     self._cover_output(graph)
 
+  def test_overlapping_globs(self):
+    t1 = self.make_java_target(spec=':t1', sources=['a.java'])
+    t2 = self.make_java_target(spec=':t2', sources=['a.java', 'b.java'])
+    t3 = self.make_java_target(spec=':t3', sources=['c.java'], dependencies=[t1])
+    t4 = self.make_java_target(spec=':t4', sources=['d.java'], dependencies=[t3])
+    self.set_options(strict_deps=False)
+    dep_usage, product_deps_by_src = self._setup({
+        t1: ['a.class'],
+        t2: ['a.class', 'b.class'],
+        t3: ['c.class'],
+        t4: ['d.class'],
+    })
+    product_deps_by_src[t3] = {'c.java': ['a.class']}
+    product_deps_by_src[t4] = {'d.java': ['a.class']}
+    graph = self.create_graph(dep_usage, [t1, t2, t3, t4])
+
+    # Not creating edge for t2 even it provides a.class that t4 depends on
+    self.assertFalse(t2 in graph._nodes[t4].dep_edges)
+    # t4 depends on a.class from t1 transitively through t3.
+    self.assertEqual(graph._nodes[t4].dep_edges[t1].products_used, set(['a.class']))
+    self.assertFalse(graph._nodes[t4].dep_edges[t1].is_declared)
+    self.assertEqual(graph._nodes[t4].dep_edges[t3].products_used, set([]))
+    self.assertTrue(graph._nodes[t4].dep_edges[t3].is_declared)
+
   def create_graph(self, task, targets):
     classes_by_source = task.context.products.get_data('classes_by_source')
     runtime_classpath = task.context.products.get_data('runtime_classpath')
     product_deps_by_src = task.context.products.get_data('product_deps_by_src')
+    transitive_deps_by_target = task._compute_transitive_deps_by_target()
 
     def node_creator(target):
       return task.create_dep_usage_node(target, '',
-                                        classes_by_source, runtime_classpath, product_deps_by_src)
+                                        classes_by_source, runtime_classpath, product_deps_by_src,
+                                        transitive_deps_by_target)
 
     return DependencyUsageGraph(task.create_dep_usage_nodes(targets, node_creator),
                                 task.size_estimators[task.get_options().size_estimator])


### PR DESCRIPTION
Discovered this while working on using dep-usage to clean up twitter internal
build files, when a source file belongs to more than one target, say `:a` and
`:b` both contain `A.java`, not uncommon when globs especially rglobs is used.
`:d` depends on `A.java` implicitly through `:c`, which further depends on
`:a`, in this case, only `:a` should be marked as undeclared dependency.
Marking `:b` as undeclared dependency can potentially introduce circular
dependency, in this example, say `:b` also depends on `:c`.

This review applies the smae check used by `JvmDependencyCheck` also in
`JvmDependencyUsage`.