### PR TITLE
logs kill server info when creating server

### DIFF
--- a/src/python/pants/core_tasks/reporting_server_run.py
+++ b/src/python/pants/core_tasks/reporting_server_run.py
@@ -53,5 +53,6 @@ class ReportingServerRun(QuietTaskMixin, Task):
 
       logger.info('Launched server with pid {pid} at http://localhost:{port}'
                   .format(pid=manager.pid, port=manager.socket))
+      logger.info('To kill, run ./pants killserver')
 
     self._maybe_open(manager.socket)


### PR DESCRIPTION
added helpful instructions on how to kill server info when new server is created