### PR TITLE
[engine] refine exception output

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -283,20 +283,37 @@ class ProductGraph(object):
     States are probably not sufficient for user output.
     """
     traced = set()
+
     def _format(level, node, state):
-      return '{}Computing {} for {}: {}'.format('  ' * level, node.product.__name__, node.subject, state)
+      return '{}Could not compute {} for {}: {}'.format('  ', node.product.__name__, node.subject, state.exc.message)
+
     def _trace(entry, level):
+      """
+      yield tuple (level, formatted trace)
+      """
       if type(entry.state) in (Noop, Return) or entry in traced:
         return
       traced.add(entry)
-      yield _format(level, entry.node, entry.state)
+      yield (level, _format(level, entry.node, entry.state))
       for dep in entry.cyclic_dependencies:
-        yield _format(level, entry.node, Noop.cycle(entry.node, dep))
+        yield (level, _format(level, entry.node, Noop.cycle(entry.node, dep)))
+
       for dep_entry in entry.dependencies:
-        for l in _trace(dep_entry, level+1):
+        for l in _trace(dep_entry, level + 1):
           yield l
 
-    for line in _trace(self._nodes[root], 1):
+    # Obtain all traces with their level number
+    traces_with_level = list(_trace(self._nodes[root], 1))
+    if not traces_with_level:
+      return
+
+    # Sort the (level, formatted trace) in place by level in desc order.
+    traces_with_level.sort(key=lambda tup: tup[0], reverse=True)
+    max_level = traces_with_level[0][0]
+    # Only yield the max level/leaf trace.
+    for level, line in traces_with_level:
+      if level < max_level:
+        break
       yield line
 
   def visualize(self, roots):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -285,7 +285,7 @@ class ProductGraph(object):
     traced = set()
 
     def _format(level, node, state):
-      return '{}Could not compute {} for {}: {}'.format('  ', node.product.__name__, node.subject, state.exc.message)
+      return '{}Could not compute {} for {}: {}'.format('  ', node.product.__name__, node.subject, state.exc)
 
     def _trace(entry, level):
       """


### PR DESCRIPTION
#Example 1:
```
++++ b/examples/tests/java/org/pantsbuild/example/hello/greet/BUILD
@@ -6,7 +6,7 @@
 junit_tests(name='greet',
   sources=globs('*.java'),
   dependencies=[
-    '3rdparty:junit',
+    '3rdparty:junit123',
     'examples/src/java/org/pantsbuild/example/hello/greet',
   ],

[tw-mbp-yic pants (stacktrace_refine)]$ ./pants --enable-v2-engine list examples/tests/java/org/pantsbuild/example/hello/::
WARN] /Users/yic/workspace/pants/src/python/pants/engine/scheduler.py:288: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
  return '{}Could not compute {} for {}: {}'.format('  ', node.product.__name__, node.subject, state.exc.message)

Exception caught: (<class 'pants.build_graph.address_lookup_error.AddressLookupError'>)
  ...
  File "/Users/yic/workspace/pants/src/python/pants/engine/legacy/graph.py", line 68, in _index
    'Build graph construction failed for {}:\n{}'.format(node.subject, trace))

Exception message: Build graph construction failed for DescendantAddresses(directory='examples/tests/java/org/pantsbuild/example/hello'):
  Could not compute UnhydratedStruct for 3rdparty:junit123: A Struct was not found in namespace 3rdparty for name "junit123". Did you mean one of?:
  3rdparty:jsr305
  3rdparty:scalatest
  3rdparty:junit
  3rdparty:guava-testlib
  ...
```

#Example 2:
```
+++ b/examples/tests/java/org/pantsbuild/example/hello/greet/BUILD
@@ -9,7 +9,7 @@ junit_tests(name='greet',
     '3rdparty:junit',
     'examples/src/java/org/pantsbuild/example/hello/greet',
   ],
-  resources=[
+  resources_dummy=[
     'examples/src/resources/org/pantsbuild/example/hello',
   ],
 )
 
[tw-mbp-yic pants (stacktrace_refine)]$ ./pants --enable-v2-engine list examples/tests/java/org/pantsbuild/example/hello/::
Exception caught: (<class 'pants.build_graph.target.Error'>)
  File "/Users/yic/workspace/pants/src/python/pants/bin/pants_exe.py", line 50, in <module>
    main()
    ...
    cls.global_instance().check_unknown(target, kwargs)
  File "/Users/yic/workspace/pants/src/python/pants/build_graph/target.py", line 183, in check_unknown
    args=''.join('\n  {} = {}'.format(key, value) for key, value in unknown_args.items())

Exception message: Invalid target examples/tests/java/org/pantsbuild/example/hello/greet:greet: JavaTests received unknown arguments: 
  resources_dummy = ['examples/src/resources/org/pantsbuild/example/hello'] 
```