### PR TITLE
Fix warnings about AliasTarget not having a BUILD alias.

### DIFF
--- a/src/python/pants/build_graph/aliased_target.py
+++ b/src/python/pants/build_graph/aliased_target.py
@@ -33,6 +33,7 @@ class AliasTargetMacro(TargetMacro):
                                       'The alias() must have a "target" parameter.')
     self._parse_context.create_object(
       AliasTarget,
+      type_alias='alias_target',
       name=name,
       dependencies=[target] if target else [],
       **kwargs


### PR DESCRIPTION
Before:

    ```
    ~/Src/Pants ./pants export --output-file=/tmp/foobar
    testprojects/src/java/org/pantsbuild/testproject/aliases::
    WARN]
    AliasTarget(BuildFileAddress(BuildFile(testprojects/src/java/org/pantsbuild/testproject/aliases/BUILD,
    FileSystemProjectTree(/Users/gmalmquist/Src/Pants)), convenient)) has no
    BUILD alias, suggesting a broken macro that does not assign one.
    WARN]
    AliasTarget(BuildFileAddress(BuildFile(testprojects/src/java/org/pantsbuild/testproject/aliases/BUILD,
    FileSystemProjectTree(/Users/gmalmquist/Src/Pants)), indirection)) has
    no BUILD alias, suggesting a broken macro that does not assign one.

    ~/Src/Pants
    ```

After:

    ```
    ~/Src/Pants ./pants export --output-file=/tmp/foobar
    testprojects/src/java/org/pantsbuild/testproject/aliases::

    ~/Src/Pants
    ```