### PR TITLE
A `remote_sources` target as a better mechanism for from_target.

### DIFF
--- a/examples/src/protobuf/org/pantsbuild/example/unpacked_jars/BUILD
+++ b/examples/src/protobuf/org/pantsbuild/example/unpacked_jars/BUILD
@@ -2,7 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_protobuf_library(name='unpacked_jars',
+  # This uses the legacy deferred sources mechanism.
   sources=from_target(':external-source'),
+)
+
+remote_sources(name='better-unpacked-jars',
+  # This uses the new deferred sources mechanism.
+  dest=java_protobuf_library,
+  sources_target=':external-source',
 )
 
 unpacked_jars(name='external-source',

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:build_file_target_factory',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/base:hash_utils',

--- a/src/python/pants/build_graph/from_target.py
+++ b/src/python/pants/build_graph/from_target.py
@@ -5,9 +5,34 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from textwrap import dedent
+
 import six
 
+from pants.base.deprecated import deprecated
 from pants.build_graph.address import Addresses
+
+
+from_target_deprecation_hint = dedent('''
+    Using sources = from_target() has been deprecated. Try using remote_sources() instead.
+
+    For example, instead of this:
+
+      java_protobuf_library(name='proto',
+        sources=from_target(':other-target'),
+        platform='java7',
+      )
+
+    Try this:
+
+      remote_sources(name='proto',
+        dest=java_protobuf_library,
+        sources_target=':other-target',
+        args=dict(
+          platform='java7',
+        )
+      )
+  ''').strip()
 
 
 class FromTarget(object):
@@ -19,6 +44,7 @@ class FromTarget(object):
   def __init__(self, parse_context):
     self._parse_context = parse_context
 
+  @deprecated(removal_version='1.3.0', hint_message=from_target_deprecation_hint)
   def __call__(self, address):
     """
     :param string address: A target address.

--- a/src/python/pants/build_graph/register.py
+++ b/src/python/pants/build_graph/register.py
@@ -14,6 +14,7 @@ from pants.build_graph.from_target import FromTarget
 from pants.build_graph.intransitive_dependency import (IntransitiveDependencyFactory,
                                                        ProvidedDependencyFactory)
 from pants.build_graph.prep_command import PrepCommand
+from pants.build_graph.remote_sources import RemoteSources
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import ScopedDependencyFactory
@@ -41,6 +42,7 @@ def build_file_aliases():
       'alias': AliasTargetFactory(),
       'prep_command': PrepCommand,
       'resources': Resources,
+      'remote_sources': RemoteSources,
       'target': Target,
     },
     objects={

--- a/src/python/pants/build_graph/remote_sources.py
+++ b/src/python/pants/build_graph/remote_sources.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.base.exceptions import TargetDefinitionException
+from pants.base.payload import Payload
+from pants.base.payload_field import PrimitiveField
+from pants.build_graph.address import Address
+from pants.build_graph.target import Target
+
+
+class RemoteSources(Target):
+  """A target that generates a synthetic target using deferred sources.
+
+  This provides a mechanism for using the contents of a jar as sources for another target. The jar
+  where the sources are specified from is given via the `sources_target` parameter, and the type for
+  the target that should be created with those sources is given via the `dest` parameter. Any
+  additional arguments for the new target go into the `args` parameter.
+  """
+
+  def __init__(self, address=None, payload=None, sources_target=None, dest=None, args=None,
+               **kwargs):
+    """
+    :API: public
+
+    :param string sources_target: The address of the (typically unpacked_jars) target to get sources
+      from.
+    :param dest: The target type of the synthetic target to generate (eg, java_library).
+    :param dict args: Any additional arguments necessary to construct the synthetic destination
+      target (sources and dependencies are supplied automatically).
+    """
+    self.address = address
+    if not sources_target:
+      raise TargetDefinitionException(self, 'You must specify the address of a target to acquire '
+                                            'sources from via the "sources_target" parameter.')
+    if not dest or not hasattr(dest, 'target_types'):
+      raise TargetDefinitionException(self, 'You must specify a target type for the "dest" '
+                                            'parameter.')
+    if len(dest.target_types) != 1:
+      raise TargetDefinitionException(
+        self,
+        'Target alias {} has multiple possible target types {}.'.format(dest, dest.target_types),
+      )
+    dest = dest.target_types[0]
+    self._dest = dest
+    self._dest_args = args
+    payload = payload or Payload()
+    payload.add_fields({
+      'sources_target_spec': PrimitiveField(Address.parse(sources_target,
+                                                          relative_to=address.spec_path).spec),
+      'dest': PrimitiveField(dest.__name__),
+    })
+    super(RemoteSources, self).__init__(address=address, payload=payload, **kwargs)
+
+  @property
+  def traversable_dependency_specs(self):
+    yield self.payload.sources_target_spec
+
+  @property
+  def sources_target(self):
+    return self._build_graph.get_target_from_spec(self.payload.sources_target_spec)
+
+  @property
+  def destination_target_type(self):
+    return self._dest
+
+  @property
+  def destination_target_args(self):
+    return self._dest_args or {}

--- a/src/python/pants/core_tasks/BUILD
+++ b/src/python/pants/core_tasks/BUILD
@@ -7,6 +7,7 @@ python_library(
   resource_targets=[':templates',],
   dependencies=[
     '3rdparty/python:ansicolors',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/base:payload_field',

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -13,6 +13,17 @@ python_tests(
 )
 
 python_tests(
+  name = 'deferred_sources_mapper_integration',
+  sources = ['test_deferred_sources_mapper_integration.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
   name = 'list_goals',
   sources = ['test_list_goals.py'],
   dependencies = [

--- a/tests/python/pants_test/core_tasks/test_deferred_sources_mapper_integration.py
+++ b/tests/python/pants_test/core_tasks/test_deferred_sources_mapper_integration.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import json
+import os
+from textwrap import dedent
+
+from pants.base.build_environment import get_buildroot
+from pants.util.dirutil import safe_open
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class DeferredSourcesMapperIntegration(PantsRunIntegrationTest):
+
+  @classmethod
+  def _emit_targets(cls, workdir):
+    with safe_open(os.path.join(workdir, 'BUILD'), 'w') as f:
+      f.write(dedent("""
+      remote_sources(name='proto-7',
+        dest=java_protobuf_library,
+        sources_target=':external-source',
+        args=dict(
+          platform='java7',
+        ),
+      )
+
+      remote_sources(name='proto-8',
+        dest=java_protobuf_library,
+        sources_target=':external-source',
+        args=dict(
+          platform='java8',
+        ),
+      )
+
+      unpacked_jars(name='external-source',
+        libraries=[':external-source-jars'],
+        include_patterns=[
+          'com/squareup/testing/**/*.proto',
+        ],
+      )
+
+      jar_library(name='external-source-jars',
+        jars=[
+          jar(org='com.squareup.testing.protolib', name='protolib-external-test', rev='0.0.2'),
+        ],
+      )
+      """))
+    return ['{}:proto-{}'.format(os.path.relpath(workdir, get_buildroot()), num) for num in (7, 8)]
+
+  def _configured_pants_run(self, command, workdir):
+    pants_run = self.run_pants_with_workdir(
+      command=command,
+      workdir=workdir,
+      config={
+        'GLOBAL': { 'ignore_patterns': [] },
+        'jvm-platform': {
+          'default_platform': 'java7',
+          'platforms': {
+            'java7': {'source': '7', 'target': '7', 'args': []},
+            'java8': {'source': '8', 'target': '8', 'args': []},
+          },
+        },
+      },
+    )
+    return pants_run
+
+  def test_deferred_sources_gen_successfully(self):
+    with self.temporary_workdir() as workdir:
+      pants_run = self._configured_pants_run(['gen', self._emit_targets(workdir)[0]], workdir)
+      self.assert_success(pants_run)
+
+  def test_deferred_sources_export_successfully(self):
+    with self.temporary_workdir() as workdir:
+      proto7, proto8 = self._emit_targets(workdir)
+      pants_run = self._configured_pants_run(['export', proto7, proto8], workdir)
+      self.assert_success(pants_run)
+      export_data = json.loads(pants_run.stdout_data)
+
+      synthetic_proto_libraries = []
+      for target in export_data['targets'].values():
+        if target['is_synthetic'] and target['pants_target_type'] == 'java_protobuf_library':
+          synthetic_proto_libraries.append(target)
+
+      self.assertEqual(2, len(synthetic_proto_libraries),
+                       'Got unexpected number of synthetic proto libraries.')
+
+      synthetic7, synthetic8 = sorted(synthetic_proto_libraries, key=lambda t: t['platform'])
+
+      self.assertIn('proto-7', synthetic7['id'])
+      self.assertIn('proto-8', synthetic8['id'])
+      self.assertEqual('java7', synthetic7['platform'])
+      self.assertEqual('java8', synthetic8['platform'])


### PR DESCRIPTION
Stu suggested in https://rbcommons.com/s/twitter/r/3830/ that we
overhaul the deferred sources system to generate synthetic targets
instead. This should eliminate a lot of special casing we've been
having to do around deferred sources, since we can use the same
logic that was already handling synthetic targets created from
generated code.

This change adds the `remote_sources` target as a replacement for
the `from_target` object, however it does not remote the existing
functionality of `from_target`. We can remove `from_target` in a
later (breaking) change.

In the mean time, I added an option to `deferred_sources_mapper`
to throw an exception if `from_target` is used, which will allow
individual users to eliminate their own usage of `from_target` in
favor of the more robust `remote_sources`.