### PR TITLE
Deprecate the default_backend_packages option.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -35,13 +35,8 @@ pythonpath: [
     "%(buildroot)s/pants-plugins/src/python",
   ]
 
-backend_packages: [
-    "pants.backend.graph_info",
+backend_packages: +[
     "pants.backend.docgen",
-    "pants.backend.python",
-    "pants.backend.jvm",
-    "pants.backend.codegen",
-    "pants.backend.project_info",
     "internal_backend.optional",
     "internal_backend.repositories",
     "internal_backend.sitegen",

--- a/src/python/pants/bin/options_initializer.py
+++ b/src/python/pants/bin/options_initializer.py
@@ -11,6 +11,7 @@ import sys
 import pkg_resources
 
 from pants.base.build_environment import pants_version
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import BuildConfigurationError
 from pants.bin.extension_loader import load_backends_and_plugins
 from pants.bin.plugin_resolver import PluginResolver
@@ -149,6 +150,20 @@ class OptionsInitializer(object):
 
     # Conditionally load backends/plugins and materialize a `BuildConfiguration` object.
     if not self._has_build_configuration():
+      missing = (set(global_bootstrap_options.default_backend_packages).difference(
+                 global_bootstrap_options.backend_packages))
+      deprecated_conditional(
+          lambda: len(missing) > 0,
+          '1.3.0',
+          'default_backend_packages option',
+          'You are relying on the following backends being listed in the deprecated '
+          'default_backend_packages option: {}.\n  '
+          'This is probably because you are overwriting the value of the backend_packages option '
+          'in your pants.ini, instead of appending to it.\n  To get rid of this message, change '
+          'backend_packages: [...] to backend_packages: +[...] in your pants.ini.'.format(
+              ', '.join(missing))
+      )
+
       backends = (global_bootstrap_options.default_backend_packages +
                   global_bootstrap_options.backend_packages)
       build_configuration = self._load_plugins(self._working_set,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -61,9 +61,19 @@ class GlobalOptionsRegistrar(Optionable):
              help='Cache resolved plugin requirements here.')
 
     register('--backend-packages', advanced=True, type=list,
+             default=['pants.backend.graph_info',
+                      'pants.backend.python',
+                      'pants.backend.jvm',
+                      'pants.backend.codegen',
+                      'pants.backend.project_info'],
              help='Load backends from these packages that are already on the path. '
                   'Add contrib and custom backends to this list.')
     register('--default-backend-packages', advanced=True, type=list,
+             removal_version='1.3.0',
+             removal_hint='All backends must be specified using the backend_packages option. '
+                          'That option has the same defaults as this one, and you can append'
+                          'and filter those using +[...] and -[...] syntax, as described here: '
+                          'http://www.pantsbuild.org/options.html#list-options.',
              default=['pants.backend.graph_info',
                       'pants.backend.python',
                       'pants.backend.jvm',


### PR DESCRIPTION
We don't need it now that we can append and filter list options.
Repos can modify the backend_packages option directly.