### PR TITLE
Improve stderr handling for ProcessManager.get_subprocess_output().

### DIFF
--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -269,15 +269,19 @@ class ProcessManager(ProcessMetadataManager):
     return self._socket or self.read_metadata_by_name(self._name, 'socket', self._socket_type)
 
   @classmethod
-  def get_subprocess_output(cls, *args):
+  def get_subprocess_output(cls, command, ignore_stderr=True, **kwargs):
     """Get the output of an executed command.
 
-    :param *args: An iterable representing the command to execute (e.g. ['ls', '-al']).
+    :param command: An iterable representing the command to execute (e.g. ['ls', '-al']).
+    :param ignore_stderr: Whether or not to ignore stderr output vs interleave it with stdout.
     :raises: `ProcessManager.ExecutionError` on `OSError` or `CalledProcessError`.
     :returns: The output of the command.
     """
+    if ignore_stderr is False:
+      kwargs.setdefault('stderr', subprocess.STDOUT)
+
     try:
-      return subprocess.check_output(*args, stderr=subprocess.STDOUT)
+      return subprocess.check_output(command, **kwargs)
     except (OSError, subprocess.CalledProcessError) as e:
       subprocess_output = getattr(e, 'output', '').strip()
       raise cls.ExecutionError(str(e), subprocess_output)

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -7,6 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import errno
 import os
+import subprocess
+import sys
 from contextlib import contextmanager
 
 import mock
@@ -175,6 +177,14 @@ class TestProcessManager(BaseTest):
   def test_get_subprocess_output(self):
     test_str = '333'
     self.assertEqual(self.pm.get_subprocess_output(['echo', '-n', test_str]), test_str)
+
+  def test_get_subprocess_output_interleaved(self):
+    cmd_payload = 'import sys; ' + 'sys.stderr.write("9"); sys.stdout.write("3"); ' * 3
+    cmd = [sys.executable, '-c', cmd_payload]
+
+    self.assertEqual(self.pm.get_subprocess_output(cmd), '333')
+    self.assertEqual(self.pm.get_subprocess_output(cmd, ignore_stderr=False), '939393')
+    self.assertEqual(self.pm.get_subprocess_output(cmd, stderr=subprocess.STDOUT), '939393')
 
   def test_get_subprocess_output_oserror_exception(self):
     with self.assertRaises(self.pm.ExecutionError):


### PR DESCRIPTION
Fixes #3591.