### PR TITLE
Provide a better error message when target `dependencies` is passed a…

### DIFF
--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -170,12 +170,12 @@ class BuildFileAddressMapper(object):
     :returns: A new Address instance.
     :rtype: :class:`pants.build_graph.address.BuildFileAddress`
     """
-    spec_path, name = parse_spec(spec, relative_to=relative_to)
-    address = Address(spec_path, name)
     try:
+      spec_path, name = parse_spec(spec, relative_to=relative_to)
+      address = Address(spec_path, name)
       build_file_address, _ = self.resolve(address)
       return build_file_address
-    except AddressLookupError as e:
+    except (ValueError, AddressLookupError) as e:
       raise self.InvalidBuildFileReference('{message}\n  when translating spec {spec}'
                                            .format(message=e, spec=spec))
 

--- a/src/python/pants/build_graph/target_addressable.py
+++ b/src/python/pants/build_graph/target_addressable.py
@@ -53,6 +53,11 @@ class TargetAddressable(Addressable):
     self._name = kwargs['name']
     self._dependency_specs = self._kwargs.pop('dependencies', [])
 
+    if not isinstance(self.dependency_specs, (list, set, tuple)):
+      msg = ('dependencies passed to Target constructors must be a sequence of strings, received {}'
+             .format(type(self.dependency_specs)))
+      raise TargetDefinitionException(target=self, msg=msg)
+
     for dep_spec in self.dependency_specs:
       if not isinstance(dep_spec, string_types):
         msg = ('dependencies passed to Target constructors must be strings.  {dep_spec} is not'

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -73,6 +73,9 @@ class BuildFileAddressMapperTest(BaseTest):
                                  '^.*/non-existent-path does not contain any BUILD files.'
                                  '\s+when translating spec //non-existent-path:a'):
       self.address_mapper.spec_to_address('//non-existent-path:a')
+    with self.assertRaisesRegexp(BuildFileAddressMapper.InvalidBuildFileReference,
+                                 '^Spec : has no name part\s+when translating spec :'):
+      self.address_mapper.spec_to_address(':')
 
   def test_raises_address_not_in_one_build_file(self):
     self.add_to_build_file('BUILD', 'target(name="foo")')
@@ -113,6 +116,14 @@ class BuildFileAddressMapperTest(BaseTest):
     self.assertIsInstance(BuildFileAddressMapper.InvalidBuildFileReference(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.InvalidAddressError(), AddressLookupError)
     self.assertIsInstance(BuildFileAddressMapper.BuildFileScanError(), AddressLookupError)
+
+  def test_raises_wrong_dependencies_type(self):
+    self.add_to_build_file('BUILD', 'target(name="foo", dependencies="bar")')
+    address = Address.parse(':foo')
+    with self.assertRaisesRegexp(AddressLookupError,
+                                 '^Invalid target.*foo.*.'
+                                 'dependencies passed to Target constructors must be a sequence of strings'):
+      self.address_mapper.resolve(address)
 
 
 class BuildFileAddressMapperWithIgnoreTest(BaseTest):


### PR DESCRIPTION
… string, not a list

Previously, a target of the form:

```
target(name='foo', dependencies=':bar')
```

was parsed as the dependencies ':', 'b', 'a', 'r'.  Now we check to see that dependencies
is a list, set, or tuple.  Pants exited cryptically with the error:

```
Exception caught: (<type 'exceptions.ValueError'>)
  ...
  File "/Users/zundel/Src/Pants/src/python/pants/build_graph/address.py", line 84, in parse_spec
    check_target_name(target_name)
  File "/Users/zundel/Src/Pants/src/python/pants/build_graph/address.py", line 71, in check_target_name
    raise ValueError('Spec {spec} has no name part'.format(spec=spec))

Exception message: Spec : has no name part
```

With no path to the BUILD file or indication of which target was wrong.

Also, catch spec parsing error and convert to AddressLookupError to at least get a path to error if something
like this slips through again.