### PR TITLE
Fix dead apidocs link for guava.

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -22,7 +22,7 @@ jar_library(name='args4j',
 jar_library(name='guava',
             jars=[
               jar('com.google.guava', 'guava', '18.0',
-                  apidocs='http://docs.guava-libraries.googlecode.com/git-history/v18.0/javadoc/'),
+                  apidocs='http://google.github.io/guava/releases/18.0/api/docs/')
             ])
 
 jar_library(name='jansi',


### PR DESCRIPTION
This eliminates a `./pants doc` warning of the form:
  javadoc: warning - Error fetching URL: http://docs.guava-libraries...

https://rbcommons.com/s/twitter/r/4037/