### PR TITLE
[bugfix] Fix `remote_sources()` targets dependency injection.

### DIFF
--- a/src/python/pants/core_tasks/deferred_sources_mapper.py
+++ b/src/python/pants/core_tasks/deferred_sources_mapper.py
@@ -110,7 +110,7 @@ class DeferredSourcesMapper(Task):
         **target.destination_target_args
       )
       for dependent in self.context.build_graph.dependents_of(target.address):
-        self.context.build_graph.inject_dependency(dependent.address, synthetic_target.address)
+        self.context.build_graph.inject_dependency(dependent, synthetic_target.address)
 
   def execute(self):
     self.map_deferred_sources()

--- a/tests/python/pants_test/core_tasks/test_deferred_sources_mapper_integration.py
+++ b/tests/python/pants_test/core_tasks/test_deferred_sources_mapper_integration.py
@@ -34,6 +34,14 @@ class DeferredSourcesMapperIntegration(PantsRunIntegrationTest):
         args=dict(
           platform='java8',
         ),
+        dependencies=[
+          ':proto-sources',
+        ],
+      )
+
+      remote_sources(name='proto-sources',
+        dest=resources,
+        sources_target=':external-source',
       )
 
       unpacked_jars(name='external-source',


### PR DESCRIPTION
The deferred sources mapper was failing to inject the dependencies
for the synthetic targets made from `remote_sources()` targets.

This behavior wasn't previously tested, so of course it was broken.
Now it's tested.
