### PR TITLE
Implicitly provide source products.

### DIFF
--- a/tests/python/pants_test/engine/test_round_engine.py
+++ b/tests/python/pants_test/engine/test_round_engine.py
@@ -142,10 +142,24 @@ class RoundEngineTest(EngineTestBase, BaseTest):
       self.engine.attempt(self._context, self.as_goals('goal1'))
 
   def test_missing_product(self):
-    task =  self.install_task('task1', goal='goal1', required_data=['1'])
+    task = self.install_task('task1', goal='goal1', required_data=['1'])
     self.create_context(for_task_types=task)
     with self.assertRaises(self.engine.MissingProductError):
       self.engine.attempt(self._context, self.as_goals('goal1'))
+
+  def test_implicit_language_products(self):
+    task1 = self.install_task('task1', goal='goal1', required_data=['java'])
+    task2 = self.install_task('task2', goal='goal2', required_data=['scala'])
+    self.create_context(for_task_types=(task1 + task2))
+    self.create_dir('fixed/java')
+    self._context.source_roots.add_source_root('fixed/java', ['java'])
+
+    # Shouldn't raise, as we have a java source root to provide implicit java products.
+    self.engine.attempt(self._context, self.as_goals('goal1'))
+
+    # Should raise, as we do not have a scala source root, or any other source of scala products.
+    with self.assertRaises(self.engine.MissingProductError):
+      self.engine.attempt(self._context, self.as_goals('goal2'))
 
   def test_goal_cycle_direct(self):
     task1 = self.install_task('task1', goal='goal1', required_data=['2'], product_types=['1'])


### PR DESCRIPTION
The ide project gen tasks require the 'java', 'scala' products.
The only reason this works is that the scrooge task happens to
provide those products.  But if we try to deregister the codegen
backend in some repo that doesn't need it, we get a MissingProductError
from the round engine, and a quite unintuitive error message.

This change makes every source root implicitly provide a product
with the same name as that root's language(s).  This makes logical
sense, and also solves the problem above.

While testing this, I noticed an error in how we iterate over all
source roots: We assumed that all fixed source roots come from
the appropriate options. But in fact they might also be added
programmatically.  So this change also fixes that, and adds
appropriate testing.