### PR TITLE
shading cobertura jars to get rid of the logging jar conflict with opinionated frameworks like dropwizard

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
@@ -28,7 +28,7 @@ class Cobertura(Coverage):
 
   @classmethod
   def register_options(cls, register, register_jvm_tool):
-    slf4j_jar = JarDependency(org='org.slf4j', name='slf4j-simple', rev='1.7.5')
+    slf4j_jar = JarDependency(org='org.slf4j', name='slf4j-api', rev='1.7.5')
 
     register('--coverage-cobertura-include-classes', advanced=True, type=list,
              help='Regex patterns passed to cobertura specifying which classes should be '


### PR DESCRIPTION
I have tested this on a local sample dropwizard project and it works.
