### PR TITLE
Bump version to avoid version name conflict in pypi

### DIFF
--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -8,6 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.base.revision import Revision
 
 
-VERSION = '1.1.0-rc0'
+VERSION = '1.1.0-pre7'
 
 PANTS_SEMVER = Revision.semver(VERSION)

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -8,6 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.base.revision import Revision
 
 
-VERSION = '1.1.0-pre7'
+VERSION = '1.1.0-rc7'
 
 PANTS_SEMVER = Revision.semver(VERSION)


### PR DESCRIPTION
rc and pre release versions resolve to the same version.  This is a workaround to
unblock people.  A long term solution is being discussed on pants-devel.