### PR TITLE
Mimic an issue report in https://github.com/pantsbuild/pants/issues/3…

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/AbortableListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AbortableListener.java
@@ -3,6 +3,7 @@
 
 package org.pantsbuild.tools.junit.impl;
 
+import com.google.common.base.Throwables;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -24,6 +25,17 @@ abstract class AbortableListener extends ForwardingListener {
   AbortableListener(boolean failFast) {
     this.failFast = failFast;
     addListener(result.createListener());
+  }
+
+  @Override public void testRunFinished(Result result) throws Exception {
+    try {
+      super.testRunFinished(result);
+    } catch (Throwable t) {
+      // See https://github.com/pantsbuild/pants/issues/3638, without this debug stmt the runner
+      // fails without printing out any errors
+      System.err.println(Throwables.getStackTraceAsString(t));
+      Throwables.propagate(t);
+    }
   }
 
   @Override

--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -36,6 +36,7 @@ import org.junit.runner.Result;
 import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
 import org.junit.runners.model.InitializationError;
 import org.kohsuke.args4j.Argument;
 import org.kohsuke.args4j.CmdLineException;
@@ -56,6 +57,8 @@ public class ConsoleRunnerImpl {
   private static boolean callSystemExitOnFinish = true;
   /** Intended to be used in unit testing this class */
   private static int exitStatus;
+  /** Intended to be used in unit testing this class */
+  private static RunListener testListener = null;
 
   /**
    * A stream that allows its underlying output to be swapped.
@@ -395,6 +398,10 @@ public class ConsoleRunnerImpl {
       AntJunitXmlReportListener xmlReportListener =
           new AntJunitXmlReportListener(outdir, streamCapturingListener);
       abortableListener.addListener(xmlReportListener);
+    }
+
+    if (testListener != null) {
+      abortableListener.addListener(testListener);
     }
 
     // TODO: Register all listeners to core instead of to abortableListener because
@@ -849,5 +856,9 @@ public class ConsoleRunnerImpl {
 
   public static void setExitStatus(int v) {
     exitStatus = v;
+  }
+
+  public static void addTestListener(RunListener listener) {
+    testListener = listener;
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -5,11 +5,13 @@ package org.pantsbuild.tools.junit.impl;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
 import org.pantsbuild.tools.junit.lib.AnnotatedParallelClassesAndMethodsTest1;
 import org.pantsbuild.tools.junit.lib.AnnotatedParallelMethodsTest1;
 import org.pantsbuild.tools.junit.lib.AnnotatedParallelTest1;
@@ -28,9 +30,11 @@ import org.pantsbuild.tools.junit.lib.SerialTest1;
 import org.pantsbuild.tools.junit.lib.TestRegistry;
 
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
@@ -160,9 +164,9 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
       invokeConsoleRunner("MockTest4 -parallel-threads 1 -xmlreport");
       Assert.assertEquals("test41 test42", TestRegistry.getCalledTests());
       String output = outContent.toString();
-      assertThat(output, CoreMatchers.containsString("test41"));
-      assertThat(output, CoreMatchers.containsString("start test42"));
-      assertThat(output, CoreMatchers.containsString("end test42"));
+      assertThat(output, containsString("test41"));
+      assertThat(output, containsString("start test42"));
+      assertThat(output, containsString("end test42"));
     } finally {
       System.setOut(stdout);
       System.setErr(stderr);
@@ -180,9 +184,9 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
 
     String testClassName = MockTest4.class.getCanonicalName();
     String output = FileUtils.readFileToString(new File(outdir, testClassName + ".out.txt"));
-    assertThat(output, CoreMatchers.containsString("test41"));
-    assertThat(output, CoreMatchers.containsString("start test42"));
-    assertThat(output, CoreMatchers.containsString("end test42"));
+    assertThat(output, containsString("test41"));
+    assertThat(output, containsString("start test42"));
+    assertThat(output, containsString("end test42"));
   }
 
   @Test
@@ -402,5 +406,31 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
         ConsoleRunnerImpl.computeConcurrencyOption(null, false));
     assertEquals(Concurrency.PARALLEL_CLASSES,
         ConsoleRunnerImpl.computeConcurrencyOption(null, true));
+  }
+
+  /**
+   * This test reproduces a problem reported in https://github.com/pantsbuild/pants/issues/3638
+   *
+   * It is intended to show that when the test mechanism breaks catastrophically, you see console
+   * output. Verify this is working by manual inspection running this test in IntellIJ.
+   * We don't have a way to capture the console output here, but we could reproduce this
+   * test in a pants integration test once the fix gets released as a new JUnit runner.
+   */
+  @Test
+  public void testRunFinishFailed() throws Exception {
+
+    class AbortInTestRunFinishedListener extends RunListener {
+      @Override public void testRunFinished(Result result) throws Exception {
+        throw new IOException("Bogus IOException");
+      }
+    }
+
+    ConsoleRunnerImpl.addTestListener(new AbortInTestRunFinishedListener());
+
+    try {
+      invokeConsoleRunner("MockTest1");
+      fail("Expected a runtime exception");
+    } catch (RuntimeException expected) {
+    }
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestBase.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/ConsoleRunnerTestBase.java
@@ -83,6 +83,7 @@ public abstract class ConsoleRunnerTestBase {
   public void setUp() {
     ConsoleRunnerImpl.setCallSystemExitOnFinish(false);
     ConsoleRunnerImpl.setExitStatus(0);
+    ConsoleRunnerImpl.addTestListener(null);
     TestRegistry.reset();
   }
 
@@ -90,6 +91,7 @@ public abstract class ConsoleRunnerTestBase {
   public void tearDown() {
     ConsoleRunnerImpl.setCallSystemExitOnFinish(true);
     ConsoleRunnerImpl.setExitStatus(0);
+    ConsoleRunnerImpl.addTestListener(null);
   }
 
   /**


### PR DESCRIPTION
…638 where

a failure from testRunFinished() in a listener aborts the test but otherwise gives no error messages.