### PR TITLE
Update the source_ami for Jenkins slave packer config.

### DIFF
--- a/build-support/aws/ec2/packer/jenkins-slave.json
+++ b/build-support/aws/ec2/packer/jenkins-slave.json
@@ -2,7 +2,7 @@
   "builders": [{
     "type": "amazon-ebs",
     "region": "us-east-1",
-    "source_ami": "ami-840910ee",
+    "source_ami": "ami-ddf13fb0",
     "instance_type": "r3.xlarge",
     "ssh_username": "ubuntu",
     "ami_name": "pantsbuild-jenkins-slave.{{timestamp}}"


### PR DESCRIPTION
- This is the same ubuntu ec2 image prefix
  (ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server)
  but updated to the 20160627 tag, image id
  ami-ddf13fb0.
- The previous image seemed to suffer from an upstream
  bug where the apt cache would fail to update on the
  first run, failing the packer run.
