### PR TITLE
Support for optional product requirements.

### DIFF
--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -106,12 +106,15 @@ class IdeGen(IvyTaskMixin, NailgunTask):
   @classmethod
   def prepare(cls, options, round_manager):
     super(IdeGen, cls).prepare(options, round_manager)
+    # We optional_product() instead of require() because there's no guarantee
+    # that anything produces these products (typically only codegen produces them,
+    # because checked-in sources aren't considered products, at least in the old engine).
     if options.python:
-      round_manager.require('python')
+      round_manager.optional_product('python')
     if options.java:
-      round_manager.require('java')
+      round_manager.optional_product('java')
     if options.scala:
-      round_manager.require('scala')
+      round_manager.optional_product('scala')
 
   class Error(TaskError):
     """IdeGen Error."""

--- a/src/python/pants/engine/round_manager.py
+++ b/src/python/pants/engine/round_manager.py
@@ -34,25 +34,53 @@ class RoundManager(object):
 
   def __init__(self, context):
     self._dependencies = set()
+    self._optional_dependencies = set()
     self._context = context
     self._producer_infos_by_product_type = None
-    self._known_langs = set()
 
   def require(self, product_type):
     """Schedules the tasks that produce product_type to be executed before the requesting task.
+
+    There must be at least one task that produces the required product type, or the
+    dependencies will not be satisfied.
 
     :API: public
     """
     self._dependencies.add(product_type)
     self._context.products.require(product_type)
 
+  def optional_product(self, product_type):
+    """Schedules tasks, if any, that produce product_type to be executed before the requesting task.
+
+    There need not be any tasks that produce the required product type.  All this method
+    guarantees is that if there are any then they will be executed before the requesting task.
+
+    :API: public
+    """
+    self._optional_dependencies.add(product_type)
+    self.require(product_type)
+
   def require_data(self, product_type):
     """Schedules the tasks that produce product_type to be executed before the requesting task.
+
+    There must be at least one task that produces the required product type, or the
+    dependencies will not be satisfied.
 
     :API: public
     """
     self._dependencies.add(product_type)
     self._context.products.require_data(product_type)
+
+  def optional_data(self, product_type):
+    """Schedules tasks, if any, that produce product_type to be executed before the requesting task.
+
+    There need not be any tasks that produce the required product type.  All this method
+    guarantees is that if there are any then they will be executed before the requesting task.
+
+    :API: public
+    """
+    self._optional_dependencies.add(product_type)
+    self.require_data(product_type)
 
   def get_dependencies(self):
     """Returns the set of data dependencies as producer infos corresponding to data requirements."""
@@ -64,13 +92,8 @@ class RoundManager(object):
   def _get_producer_infos_by_product_type(self, product_type):
     if self._producer_infos_by_product_type is None:
       self._producer_infos_by_product_type = self._index_products()
-      self._known_langs = set(self._context.source_roots.all_langs())
 
     producer_infos = self._producer_infos_by_product_type[product_type]
-    # Products named for languages ('java', 'scala', 'python' etc.) are special: they represent
-    # source files in those languages, and are implicitly provided by a relevant source root.
-    # They may happen to also be explicitly provided by tasks (e.g., codegen(, but we don't want
-    # to fail with a MissingProductError if not.
-    if not producer_infos and product_type not in self._known_langs:
+    if not producer_infos and product_type not in self._optional_dependencies:
       raise self.MissingProductError("No producers registered for '{0}'".format(product_type))
     return producer_infos

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -126,11 +126,6 @@ class SourceRoots(object):
             yield match  # Found a source root not a prefix of any fixed roots.
           del dirnames[:]  # Don't continue to walk into it.
 
-  def all_langs(self):
-    for root in self.all_roots():
-      for lang in root.langs:
-        yield lang
-
 
 class SourceRootConfig(Subsystem):
   """Configuration for roots of source trees.

--- a/tests/python/pants_test/engine/test_round_engine.py
+++ b/tests/python/pants_test/engine/test_round_engine.py
@@ -42,7 +42,8 @@ class RoundEngineTest(EngineTestBase, BaseTest):
   def construct_action(self, tag):
     return 'construct', tag, self._context
 
-  def record(self, tag, product_types=None, required_data=None, alternate_target_roots=None):
+  def record(self, tag, product_types=None, required_data=None, optional_data=None,
+             alternate_target_roots=None):
 
     class RecordingTask(Task):
       options_scope = tag
@@ -58,8 +59,10 @@ class RoundEngineTest(EngineTestBase, BaseTest):
 
       @classmethod
       def prepare(cls, options, round_manager):
-        for requirement in (required_data or ()):
-          round_manager.require_data(requirement)
+        for product in (required_data or ()):
+          round_manager.require_data(product)
+        for product in (optional_data or ()):
+          round_manager.optional_data(product)
         self.actions.append(self.prepare_action(tag))
 
       def __init__(me, *args, **kwargs):
@@ -72,12 +75,13 @@ class RoundEngineTest(EngineTestBase, BaseTest):
     return RecordingTask
 
   def install_task(self, name, product_types=None, goal=None, required_data=None,
-                   alternate_target_roots=None):
+                   optional_data=None, alternate_target_roots=None):
     """Install a task to goal and return all installed tasks of the goal.
 
     This is needed to initialize tasks' context.
     """
-    task_type = self.record(name, product_types, required_data, alternate_target_roots)
+    task_type = self.record(name, product_types, required_data, optional_data,
+                            alternate_target_roots)
     return super(RoundEngineTest,
                  self).install_task(name=name, action=task_type, goal=goal).task_types()
 
@@ -147,19 +151,11 @@ class RoundEngineTest(EngineTestBase, BaseTest):
     with self.assertRaises(self.engine.MissingProductError):
       self.engine.attempt(self._context, self.as_goals('goal1'))
 
-  def test_implicit_language_products(self):
-    task1 = self.install_task('task1', goal='goal1', required_data=['java'])
-    task2 = self.install_task('task2', goal='goal2', required_data=['scala'])
-    self.create_context(for_task_types=(task1 + task2))
-    self.create_dir('fixed/java')
-    self._context.source_roots.add_source_root('fixed/java', ['java'])
-
-    # Shouldn't raise, as we have a java source root to provide implicit java products.
+  def test_missing_optional_product(self):
+    task = self.install_task('task1', goal='goal1', optional_data=['1'])
+    self.create_context(for_task_types=task)
+    # Shouldn't raise, as the missing product is optional.
     self.engine.attempt(self._context, self.as_goals('goal1'))
-
-    # Should raise, as we do not have a scala source root, or any other source of scala products.
-    with self.assertRaises(self.engine.MissingProductError):
-      self.engine.attempt(self._context, self.as_goals('goal2'))
 
   def test_goal_cycle_direct(self):
     task1 = self.install_task('task1', goal='goal1', required_data=['2'], product_types=['1'])


### PR DESCRIPTION
That is, you can now request products for the purpose of scheduling
in the round manager, but it won't be an error if nothing produces them.

This is then used in ide_gen.py, to request source products ('java',
'python', etc.) This provides an alternative solution to the problem
of failing on missing products when no codegen produces those source
products.  The previous solution (cb78b0ef7bc) was to have source roots
implicitly provide those products.  However this caused performance
issues because we have to scan the filesystem for source roots. This
solution does not have that problem.