### PR TITLE
Make a copy of jvm_options before mutating it

### DIFF
--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -96,7 +96,7 @@ class Ivy(object):
   def runner(self, jvm_options=None, args=None, executor=None):
     """Creates an ivy commandline client runner for the given args."""
     args = args or []
-    jvm_options = jvm_options or []
+    options = list(jvm_options) if jvm_options else []
     executor = executor or SubprocessExecutor(DistributionLocator.cached())
     if not isinstance(executor, Executor):
       raise ValueError('The executor argument must be an Executor instance, given {} of type {}'.format(
@@ -107,11 +107,11 @@ class Ivy(object):
       # ivysettings.xml.  Ideally we'd support either simple -caches or these hand-crafted cases
       # instead of just hand-crafted.  Clean this up by taking over ivysettings.xml and generating
       # it from BUILD constructs.
-      jvm_options += ['-Divy.cache.dir={}'.format(self._ivy_cache_dir)]
+      options += ['-Divy.cache.dir={}'.format(self._ivy_cache_dir)]
 
     if self._ivy_settings and '-settings' not in args:
       args = ['-settings', self._ivy_settings] + args
 
-    jvm_options += self._extra_jvm_options
+    options += self._extra_jvm_options
     return executor.runner(classpath=self._classpath, main='org.apache.ivy.Main',
-                           jvm_options=jvm_options, args=args)
+                           jvm_options=options, args=args)

--- a/src/python/pants/ivy/ivy.py
+++ b/src/python/pants/ivy/ivy.py
@@ -96,22 +96,22 @@ class Ivy(object):
   def runner(self, jvm_options=None, args=None, executor=None):
     """Creates an ivy commandline client runner for the given args."""
     args = args or []
-    options = list(jvm_options) if jvm_options else []
-    executor = executor or SubprocessExecutor(DistributionLocator.cached())
-    if not isinstance(executor, Executor):
-      raise ValueError('The executor argument must be an Executor instance, given {} of type {}'.format(
-                         executor, type(executor)))
+    if self._ivy_settings and '-settings' not in args:
+      args = ['-settings', self._ivy_settings] + args
 
+    options = list(jvm_options) if jvm_options else []
     if self._ivy_cache_dir and '-cache' not in args:
       # TODO(John Sirois): Currently this is a magic property to support hand-crafted <caches/> in
       # ivysettings.xml.  Ideally we'd support either simple -caches or these hand-crafted cases
       # instead of just hand-crafted.  Clean this up by taking over ivysettings.xml and generating
       # it from BUILD constructs.
       options += ['-Divy.cache.dir={}'.format(self._ivy_cache_dir)]
-
-    if self._ivy_settings and '-settings' not in args:
-      args = ['-settings', self._ivy_settings] + args
-
     options += self._extra_jvm_options
+
+    executor = executor or SubprocessExecutor(DistributionLocator.cached())
+    if not isinstance(executor, Executor):
+      raise ValueError('The executor argument must be an Executor instance, given {} of type {}'.format(
+                         executor, type(executor)))
+
     return executor.runner(classpath=self._classpath, main='org.apache.ivy.Main',
                            jvm_options=options, args=args)


### PR DESCRIPTION
Noticed this while I turned debug level logging for publish.jar:

```
Executing: /.../java ... -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache -Divy.cache.dir=/Users/peiyu/.ivy2/limiter/cache ...
-cp ../../.ivy2/limiter/cache/org.apache.ivy/ivy/jars/ivy-2.5.0.alpha_20150115120000.jar:../../.ivy2/limiter/cache/fm.last.ivy.plugins/ivysvnresolver/jars/ivysvnresolver-2.2.0.jar:../../.ivy2/limiter/cache/org.tmatesoft.svnkit/svnkit/jars/svnkit-1.3.8.jar:../../.ivy2/limiter/cache/de.regnis.q.sequence/sequence-library/jars/sequence-library-1.0.2.jar:../../.ivy2/limiter/cache/net.java.dev.jna/jna/jars/jna-3.4.0.jar:../../.ivy2/limiter/cache/com.trilead/trilead-ssh2/jars/trilead-ssh2-1.0.0-build215.jar:../../.ivy2/limiter/cache/org.tmatesoft.sqljet/sqljet/jars/sqljet-1.1.2.jar:../../.ivy2/limiter/cache/org.antlr/antlr-runtime/jars/antlr-runtime-3.4.jar org.apache.ivy.Main -settings /Users/peiyu/workspace/source/.pants.d/publish/jar/ivysettings.xml -ivy /Users/peiyu/workspace/source/.pants.d/publish/jar/ivy.xml -deliverto /Users/peiyu/workspace/source/.pants.d/publish/jar/ivy.xml.unused -publish publish_local -publishpattern /Users/peiyu/workspace/source/.pants.d/publish/jar/[organisation]/[module]/[artifact]-[revision](-[classifier]).[ext] -revision 20160708055447-20ffb54 -m2compatible -verbose -overwrite args={'stderr': <pants.util.rwbuf.FileBackedRWBuf object at 0x11821af10>, 'stdout': <pants.util.rwbuf.FileBackedRWBuf object at 0x11821aed0>} at cwd=/Users/peiyu/workspace/source
```