### PR TITLE
Buffer the ConsoleRunner's use of stdio.

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closeables;
 import com.google.common.io.Files;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -791,8 +792,9 @@ public class ConsoleRunnerImpl {
             options.numTestShards,
             options.numRetries,
             options.useExperimentalRunner,
-            System.out,
-            System.err);
+            // NB: Buffering yields ~factor of 100 speedups for output-heavy tests.
+            new PrintStream(new BufferedOutputStream(System.out)),
+            new PrintStream(new BufferedOutputStream(System.err)));
 
     List<String> tests = Lists.newArrayList();
     for (String test : options.tests) {

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerTest.java
@@ -34,7 +34,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
@@ -163,6 +162,8 @@ public class ConsoleRunnerTest extends ConsoleRunnerTestBase {
 
       invokeConsoleRunner("MockTest4 -parallel-threads 1 -xmlreport");
       Assert.assertEquals("test41 test42", TestRegistry.getCalledTests());
+
+      System.out.flush();
       String output = outContent.toString();
       assertThat(output, containsString("test41"));
       assertThat(output, containsString("start test42"));


### PR DESCRIPTION
This results in drastic speed gains for tests that do alot of stdio.

https://rbcommons.com/s/twitter/r/4101/