### PR TITLE
Cleanup `BinaryUtil`.

### DIFF
--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -22,17 +22,17 @@ from pants.util.osutil import get_os_id
 
 
 _DEFAULT_PATH_BY_ID = {
-  ('linux', 'x86_64'): ['linux', 'x86_64'],
-  ('linux', 'amd64'): ['linux', 'x86_64'],
-  ('linux', 'i386'): ['linux', 'i386'],
-  ('linux', 'i686'): ['linux', 'i386'],
-  ('darwin', '9'): ['mac', '10.5'],
-  ('darwin', '10'): ['mac', '10.6'],
-  ('darwin', '11'): ['mac', '10.7'],
-  ('darwin', '12'): ['mac', '10.8'],
-  ('darwin', '13'): ['mac', '10.9'],
-  ('darwin', '14'): ['mac', '10.10'],
-  ('darwin', '15'): ['mac', '10.11'],
+  ('linux', 'x86_64'): ('linux', 'x86_64'),
+  ('linux', 'amd64'): ('linux', 'x86_64'),
+  ('linux', 'i386'): ('linux', 'i386'),
+  ('linux', 'i686'): ('linux', 'i386'),
+  ('darwin', '9'): ('mac', '10.5'),
+  ('darwin', '10'): ('mac', '10.6'),
+  ('darwin', '11'): ('mac', '10.7'),
+  ('darwin', '12'): ('mac', '10.8'),
+  ('darwin', '13'): ('mac', '10.9'),
+  ('darwin', '14'): ('mac', '10.10'),
+  ('darwin', '15'): ('mac', '10.11'),
 }
 
 
@@ -60,7 +60,7 @@ class BinaryUtil(object):
       register('--fetch-timeout-secs', type=int, default=30, advanced=True,
                help='Timeout in seconds for url reads when fetching binary tools from the '
                     'repos specified by --baseurls')
-      register("--path-by-id", type=dict, advanced=True,
+      register('--path-by-id', type=dict, advanced=True,
                help='Maps output of uname for a machine to a binary search path.  e.g. '
                '{ ("darwin", "15"): ["mac", "10.11"]), ("linux", "arm32"): ["linux", "arm32"] }')
 
@@ -100,22 +100,16 @@ class BinaryUtil(object):
     :returns: Base path used to select the binary file.
     """
     uname_func = uname_func or os.uname
-
-    sysname, _, release, _, machine = uname_func()
-    try:
-      os_id = get_os_id(uname_func=uname_func)
-    except KeyError:
-      os_id = None
-    if os_id is None:
-      raise self.MissingMachineInfo("Pants has no binaries for {}".format(sysname))
+    os_id = get_os_id(uname_func=uname_func)
+    if not os_id:
+      raise self.MissingMachineInfo('Pants has no binaries for {}'.format(' '.join(uname_func())))
 
     try:
       middle_path = self._path_by_id[os_id]
     except KeyError:
-      raise self.MissingMachineInfo(
-        "Update --binaries-path-by-id to find binaries for {sysname} {machine} {release}.".format(
-          sysname=sysname, release=release, machine=machine))
-    return os.path.join(supportdir, *(middle_path + [version, name]))
+      raise self.MissingMachineInfo('Update --binaries-path-by-id to find binaries for {!r}'
+                                    .format(os_id))
+    return os.path.join(supportdir, *(middle_path + (version, name)))
 
   def __init__(self, baseurls, timeout_secs, bootstrapdir, path_by_id=None):
     """Creates a BinaryUtil with the given settings to define binary lookup behavior.
@@ -136,7 +130,7 @@ class BinaryUtil(object):
     self._pants_bootstrapdir = bootstrapdir
     self._path_by_id = _DEFAULT_PATH_BY_ID.copy()
     if path_by_id:
-      self._path_by_id.update(path_by_id)
+      self._path_by_id.update((tuple(k), tuple(v)) for k, v in path_by_id.items())
 
   @contextmanager
   def _select_binary_stream(self, name, binary_path, fetcher=None):

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -32,9 +32,15 @@ def get_os_name():
 
 
 def get_os_id(uname_func=None):
+  """Return an OS identifier sensitive only to its major version.
+
+  :param uname_func: An `os.uname` compliant callable; intended for tests.
+  :returns: a tuple of (OS name, sub identifier) or `None` if the OS is not supported.
+  :rtype: tuple of string, string
+  """
   uname_func = uname_func or os.uname
   sysname, _, release, _, machine = uname_func()
-  os_id = _ID_BY_OS[sysname.lower()]
+  os_id = _ID_BY_OS.get(sysname.lower())
   if os_id:
     return os_id(release, machine)
   return None

--- a/tests/python/pants_test/binaries/BUILD
+++ b/tests/python/pants_test/binaries/BUILD
@@ -6,6 +6,8 @@ python_tests(
   sources=['test_binary_util.py'],
   dependencies=[
     'src/python/pants/binaries:binary_util',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -5,7 +5,12 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
+import re
+
 from pants.binaries.binary_util import BinaryUtil
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_open
 from pants_test.base_test import BaseTest
 
 
@@ -61,24 +66,28 @@ class BinaryUtilTest(BaseTest):
 
   def test_support_url_multi(self):
     """Tests to make sure existing base urls function as expected."""
-    count = 0
-    binary_util = BinaryUtil(
-      baseurls=[
-        'BLATANTLY INVALID URL',
-        'https://dl.bintray.com/pantsbuild/bin/reasonably-invalid-url',
-        'https://dl.bintray.com/pantsbuild/bin/build-support',
-        'https://dl.bintray.com/pantsbuild/bin/build-support',  # Test duplicate entry handling.
-        'https://dl.bintray.com/pantsbuild/bin/another-invalid-url',
-      ],
-      timeout_secs=30,
-      bootstrapdir='/tmp')
-    binary_path = binary_util._select_binary_base_path(supportdir='bin/protobuf',
-                                                       version='2.4.1',
-                                                       name='protoc')
-    with binary_util._select_binary_stream(name='protoc', binary_path=binary_path) as stream:
-      stream()
-      count += 1
-    self.assertEqual(count, 1)
+
+    with temporary_dir() as invalid_local_files, temporary_dir() as valid_local_files:
+      binary_util = BinaryUtil(
+        baseurls=[
+          'BLATANTLY INVALID URL',
+          'https://dl.bintray.com/pantsbuild/bin/reasonably-invalid-url',
+          invalid_local_files,
+          valid_local_files,
+          'https://dl.bintray.com/pantsbuild/bin/another-invalid-url',
+        ],
+        timeout_secs=30,
+        bootstrapdir='/tmp')
+
+      binary_path = binary_util._select_binary_base_path(supportdir='bin/protobuf',
+                                                         version='2.4.1',
+                                                         name='protoc')
+      contents = b'proof'
+      with safe_open(os.path.join(valid_local_files, binary_path), 'wb') as fp:
+        fp.write(contents)
+
+      with binary_util._select_binary_stream(name='protoc', binary_path=binary_path) as stream:
+        self.assertEqual(contents, stream())
 
   def test_support_url_fallback(self):
     """Tests fallback behavior with multiple support baseurls.
@@ -116,7 +125,7 @@ class BinaryUtilTest(BaseTest):
     self.assertEqual(0, len(unseen))  # Make sure we've seen all the SEENs.
 
   def test_select_binary_base_path_linux(self):
-    binary_util =  BinaryUtil([], 0, '/tmp')
+    binary_util = BinaryUtil([], 0, '/tmp')
 
     def uname_func():
       return "linux", "dontcare1", "dontcare2", "dontcare3", "amd64"
@@ -143,8 +152,7 @@ class BinaryUtilTest(BaseTest):
 
     with self.assertRaisesRegexp(BinaryUtil.MissingMachineInfo,
                                  r'Pants has no binaries for vms'):
-      binary_util._select_binary_base_path("supportdir", "name", "version",
-                                           uname_func=uname_func)
+      binary_util._select_binary_base_path("supportdir", "name", "version", uname_func=uname_func)
 
   def test_select_binary_base_path_missing_version(self):
     binary_util = BinaryUtil([], 0, '/tmp')
@@ -152,10 +160,11 @@ class BinaryUtilTest(BaseTest):
     def uname_func():
       return "darwin", "dontcare1", "999.9", "dontcare2", "x86_64"
 
+    os_id = ('darwin', '999')
     with self.assertRaisesRegexp(BinaryUtil.MissingMachineInfo,
-                                 r'Update --binaries-path-by-id to find binaries for darwin x86_64 999\.9\.'):
-      binary_util._select_binary_base_path("supportdir", "name", "version",
-                                           uname_func=uname_func)
+                                 r'Update --binaries-path-by-id to find binaries for '
+                                 r'{}'.format(re.escape(repr(os_id)))):
+      binary_util._select_binary_base_path("supportdir", "name", "version", uname_func=uname_func)
 
   def test_select_binary_base_path_override(self):
     binary_util = BinaryUtil([], 0, '/tmp',


### PR DESCRIPTION
This simplifies some logic and presents more directly useful error
messages as well as firming up the `osutil.get_os_id` contract with
docs and a now-uniform return protocol.

The `test_support_url_multi` test is also simplified to remove the
ineffective dedup test and is sped up and stabilized by switching a real
bintray protoc fetch out for a local file url fetch of a small test
file.

https://rbcommons.com/s/twitter/r/4108/