### PR TITLE
added JSON option for pants options

### DIFF
--- a/src/python/pants/core_tasks/explain_options_task.py
+++ b/src/python/pants/core_tasks/explain_options_task.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import json
+
 from colors import black, blue, cyan, green, magenta, red, white
 
 from pants.base.revision import Revision
@@ -34,7 +36,8 @@ class ExplainOptionsTask(ConsoleTask):
              help='Only show values that overrode defaults.')
     register('--skip-inherited', type=bool, default=True,
              help='Do not show inherited options, unless their values differ from their parents.')
-    register('--json', type=bool, default=False, help='Prints the output in JSON format.')
+    register('--output-format', choices=['text', 'json'], default='text',
+             help='Specify the format options will be printed.')
 
   def _scope_filter(self, scope):
     pattern = self.get_options().scope
@@ -63,7 +66,12 @@ class ExplainOptionsTask(ConsoleTask):
     if rank == RankedValue.FLAG: return magenta
     return black
 
-  def _format_scope(self, scope, option):
+  def _format_scope(self, scope, option, no_color=False):
+    if no_color:
+      return '{scope}{option}'.format(
+        scope='{}.'.format(scope) if scope else '',
+        option=option,
+      )
     scope_color = cyan if self.get_options().colors else lambda x: x
     option_color = blue if self.get_options().colors else lambda x: x
     return '{scope}{option}'.format(
@@ -74,15 +82,16 @@ class ExplainOptionsTask(ConsoleTask):
   def _format_record(self, record):
     value_color = green if self.get_options().colors else lambda x: x
     rank_color = self._rank_color(record.rank)
-    formatted_value = rank_color(value_color(str(record.value)))
+    simple_value = str(record.value)
+    formatted_value = value_color(simple_value)
     simple_rank = RankedValue.get_rank_name(record.rank)
     formatted_rank = '(from {rank}{details})'.format(
       rank=simple_rank,
       details=rank_color(' {}'.format(record.details)) if record.details else '',
     )
-    if self.get_options().json:
-      return formatted_value, rank_color(simple_rank)
-    else:
+    if self.is_json():
+      return simple_value.replace('\n', ''), simple_rank
+    elif self.is_text():
       return '{value} {rank}'.format(
         value=formatted_value,
         rank=formatted_rank,
@@ -110,10 +119,16 @@ class ExplainOptionsTask(ConsoleTask):
     except AttributeError:
       return None, None
 
+  def is_json(self):
+    return self.get_options().output_format == 'json'
+
+  def is_text(self):
+    return self.get_options().output_format == 'text'
+
   def console_output(self, targets):
     self._force_option_parsing()
-    if self.get_options().json:
-      yield '{'
+    if self.is_json():
+      output_map = {}
     for scope, options in sorted(self.context.options.tracker.option_history_by_scope.items()):
       if not self._scope_filter(scope):
         continue
@@ -132,17 +147,22 @@ class ExplainOptionsTask(ConsoleTask):
           parent_scope, parent_value = self._get_parent_scope_option(scope, option)
           if parent_scope is not None and parent_value == history.latest.value:
             continue
-        if self.get_options().json:
+        if self.is_json():
           opt_vals = self._format_record(history.latest)
-          yield "  '{}': {{value: '{}', source: '{}'}},".format(
-            self._format_scope(scope, option),
-            opt_vals[0],
-            opt_vals[1],)
-        else:
+          scope_key = self._format_scope(scope, option, True)
+          inner_map = dict(value=opt_vals[0], source=opt_vals[1])
+          output_map[scope_key] = inner_map
+        elif self.is_text():
           yield '{} = {}'.format(self._format_scope(scope, option),
                                  self._format_record(history.latest))
         if self.get_options().show_history:
+          history_list = []
           for line in self._show_history(history):
-            yield line
-    if self.get_options().json:
-      yield '}'
+            if self.is_text():
+              yield line
+            elif self.is_json():
+              history_list.append(line.strip())
+          if self.is_json():
+            inner_map["history"] = history_list
+    if self.is_json():
+      yield json.dumps(output_map, indent=2, sort_keys=True)

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -41,7 +41,10 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     pants_run = self.run_pants(['options', '--output-format=json'])
     self.assert_success(pants_run)
     try:
-      json.loads(pants_run.stdout_data)
+      output_map = json.loads(pants_run.stdout_data)
+      self.assertIn("time", output_map)
+      self.assertEquals(output_map["time"]["source"], "HARDCODED")
+      self.assertEquals(output_map["time"]["value"], "False")
     except ValueError:
       self.fail("Invalid JSON output")
 
@@ -49,8 +52,12 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     pants_run = self.run_pants(['options', '--output-format=json', '--show-history'])
     self.assert_success(pants_run)
     try:
-      output = json.loads(pants_run.stdout_data)
-      for _, val in output.items():
+      output_map = json.loads(pants_run.stdout_data)
+      self.assertIn("time", output_map)
+      self.assertEquals(output_map["time"]["source"], "HARDCODED")
+      self.assertEquals(output_map["time"]["value"], "False")
+      self.assertEquals(output_map["time"]["history"], [])
+      for _, val in output_map.items():
         self.assertIn("history", val)
     except ValueError:
       self.fail("Invalid JSON output")

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import json
 import os
 from textwrap import dedent
 
@@ -35,6 +36,24 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     self.assertNotIn('options.scope = options', pants_run.stdout_data)
     self.assertNotIn('options.name = None', pants_run.stdout_data)
     self.assertIn('publish.jar.scm_push_attempts = ', pants_run.stdout_data)
+
+  def test_valid_json(self):
+    pants_run = self.run_pants(['options', '--output-format=json'])
+    self.assert_success(pants_run)
+    try:
+      json.loads(pants_run.stdout_data)
+    except ValueError:
+      self.fail("Invalid JSON output")
+
+  def test_valid_json_with_history(self):
+    pants_run = self.run_pants(['options', '--output-format=json', '--show-history'])
+    self.assert_success(pants_run)
+    try:
+      output = json.loads(pants_run.stdout_data)
+      for _, val in output.items():
+        self.assertIn("history", val)
+    except ValueError:
+      self.fail("Invalid JSON output")
 
   def test_options_option(self):
     pants_run = self.run_pants(['options', '--no-colors', '--name=colors', '--no-skip-inherited'])


### PR DESCRIPTION
added new option for JSON output of Pants options.

Sample:
{
&nbsp;&nbsp;&nbsp;&nbsp;'build_file_rev': {value: 'None', source: 'NONE'},
&nbsp;&nbsp;&nbsp;&nbsp;'cache_key_gen_version': {value: '200', source: 'HARDCODED'},
}
