### PR TITLE
Bump default wheel version to latest.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -24,4 +24,4 @@ setproctitle==1.1.10
 setuptools==5.4.1
 six>=1.9.0,<2
 thrift==0.9.1
-wheel==0.24.0
+wheel==0.29.0

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -25,7 +25,7 @@ class PythonSetup(Subsystem):
              help='The interpreter requirement string for this python environment.')
     register('--setuptools-version', advanced=True, default='5.4.1',
              help='The setuptools version for this python environment.')
-    register('--wheel-version', advanced=True, default='0.24.0',
+    register('--wheel-version', advanced=True, default='0.29.0',
              help='The wheel version for this python environment.')
     register('--platforms', advanced=True, type=list, default=['current'],
              help='The wheel version for this python environment.')


### PR DESCRIPTION
In particular, this picks up python 3.5 fixes for tagging.
See the release notes here: https://pypi.python.org/pypi/wheel

https://rbcommons.com/s/twitter/r/4116/