### PR TITLE
Remove warnings from the release process.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -77,12 +77,17 @@ function execute_packaged_pants_with_internal_backends() {
   PANTS_PYTHON_REPOS_REPOS="['${ROOT}/dist']" pants \
     --no-verify-config \
     --pythonpath="['pants-plugins/src/python']" \
-    --backend-packages="[ \
-        'pants.backend.docgen', \
-        'internal_backend.optional', \
-        'internal_backend.repositories', \
-        'internal_backend.sitegen', \
-        'internal_backend.utilities', \
+    --backend-packages="[\
+        'pants.backend.codegen',\
+        'pants.backend.docgen',\
+        'pants.backend.graph_info',\
+        'pants.backend.jvm',\
+        'pants.backend.project_info',\
+        'pants.backend.python',\
+        'internal_backend.optional',\
+        'internal_backend.repositories',\
+        'internal_backend.sitegen',\
+        'internal_backend.utilities',\
       ]" \
     "$@"
 }

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -67,7 +67,7 @@ function run_local_pants() {
 
 # When we do (dry-run) testing, we need to run the packaged pants.
 # It doesn't have internal backend plugins so when we execute it
-# at the repo build root, the root pants.ini will ask it load
+# at the repo build root, the root pants.ini will ask it to load
 # internal backend packages and their dependencies which it doesn't have,
 # and it'll fail. To solve that problem, we load the internal backend package
 # dependencies into the pantsbuild.pants venv.


### PR DESCRIPTION
This dogfoods the current state of `--default-backend-packages` and
`--backend-packages` to explicitly list all backend packages needed in
the packaged pants with internal backends contrib plugin testing
environment.

https://rbcommons.com/s/twitter/r/4119/