### PR TITLE
Allow specification of an alternate javac location.

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -52,7 +52,6 @@ jar_library(name='commons-lang',
               jar(org='commons-lang', name='commons-lang', rev='2.5'),
             ])
 
-
 jar_library(name='cucumber-java',
             jars=[
               jar(org='info.cukes', name='cucumber-java', rev='1.1.7'),
@@ -126,6 +125,11 @@ target(name='thrift-0.6.1',
 ###############
 # Test support
 #
+
+jar_library(name='custom_javactool_for_testing',
+            jars=[
+              jar('org.pantsbuild', 'custom_javactool_for_testing', '0.0.1')
+            ])
 
 jar_library(name='easymock',
             jars=[

--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -126,11 +126,6 @@ target(name='thrift-0.6.1',
 # Test support
 #
 
-jar_library(name='custom_javactool_for_testing',
-            jars=[
-              jar('org.pantsbuild', 'custom_javactool_for_testing', '0.0.1')
-            ])
-
 jar_library(name='easymock',
             jars=[
               jar('org.easymock', 'easymock', '3.3.1')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
@@ -13,11 +13,6 @@ from pants.util.contextutil import temporary_dir
 
 class AnalysisTools(object):
   """Analysis manipulation methods required by JvmCompile."""
-  # Note: The value string isn't the same as the symbolic name for legacy reasons:
-  # We changed the name of the var, but didn't want to invalidate all cached artifacts just
-  # for that reason.
-  # TODO: If some future change requires us to invalidate all cached artifacts for some good reason
-  # (by bumping GLOBAL_CACHE_KEY_GEN_VERSION), we can use that opportunity to change this string.
   _PANTS_BUILDROOT_PLACEHOLDER = b'/_PANTS_BUILDROOT_PLACEHOLDER'
   _PANTS_WORKDIR_PLACEHOLDER = b'/_PANTS_WORKDIR_PLACEHOLDER'
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -28,7 +28,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
-from pants.java.distribution.distribution import Distribution, DistributionLocator
+from pants.java.distribution.distribution import DistributionLocator
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_open
 from pants.util.memo import memoized_method, memoized_property
@@ -154,6 +154,7 @@ class BaseZincCompile(JvmCompile):
     # ...also, as of sbt 0.13.9, it is significantly slower for cold builds.
     register('--name-hashing', advanced=True, type=bool, fingerprint=True,
              help='Use zinc name hashing.')
+
     register('--whitelisted-args', advanced=True, type=dict,
              default={
                '-S.*': False,
@@ -178,6 +179,14 @@ class BaseZincCompile(JvmCompile):
              help='When set, the results of incremental compiles will be written to the cache. '
                   'This is unset by default, because it is generally a good precaution to cache '
                   'only clean/cold builds.')
+
+    # Javac plugins can access basically all of the compiler internals, so we don't shade anything.
+    # Hence the unspecified main= argument. This tool is optional, hence the empty classpath list.
+    cls.register_jvm_tool(register,
+                          'javac',
+                          classpath=[],
+                          help='Java compiler to use.  If unspecified, we use the compiler '
+                               'embedded in the Java distribution we run Zinc on.')
 
     cls.register_jvm_tool(register,
                           'zinc',
@@ -242,13 +251,6 @@ class BaseZincCompile(JvmCompile):
   def __init__(self, *args, **kwargs):
     super(BaseZincCompile, self).__init__(*args, **kwargs)
     self.set_distribution(jdk=True)
-    try:
-      # Zinc uses com.sun.tools.javac.Main for in-process java compilation.
-      # If not present Zinc attempts to spawn an external javac, but we want to keep
-      # everything in our selected distribution, so we don't allow it to do that.
-      self._tools_jar = self.dist.find_libs(['tools.jar'])
-    except Distribution.Error as e:
-      raise TaskError(e)
 
     # A directory to contain per-target subdirectories with apt processor info files.
     self._processor_info_dir = os.path.join(self.workdir, 'apt-processor-info')
@@ -268,9 +270,14 @@ class BaseZincCompile(JvmCompile):
                          get_buildroot(), self.get_options().pants_workdir)
 
   def zinc_classpath(self):
-    return self.tool_classpath('zinc') + self._tools_jar
+    return self.tool_classpath('zinc')
 
-  def compiler_classpath(self):
+  def javac_classpath(self):
+    # Note that if this classpath is empty then Zinc will use the javac from
+    # the JDK it was invoked with.
+    return self.tool_classpath('javac')
+
+  def scalac_classpath(self):
     return ScalaPlatform.global_instance().compiler_classpath(self.context.products)
 
   def extra_compile_time_classpath_elements(self):
@@ -328,7 +335,7 @@ class BaseZincCompile(JvmCompile):
 
     zinc_args.extend(['-compiler-interface', self.tool_jar('compiler-interface')])
     zinc_args.extend(['-sbt-interface', self.tool_jar('sbt-interface')])
-    zinc_args.extend(['-scala-path', ':'.join(self.compiler_classpath())])
+    zinc_args.extend(['-scala-path', ':'.join(self.scalac_classpath())])
 
     zinc_args.extend(self.javac_plugin_args(javac_plugins_to_exclude))
     zinc_args.extend(self.scalac_plugin_args)
@@ -344,7 +351,19 @@ class BaseZincCompile(JvmCompile):
     else:
       zinc_args.extend(self.get_options().fatal_warnings_disabled_args)
 
-    jvm_options = list(self._jvm_options)
+    jvm_options = []
+
+    if self.javac_classpath():
+      # Make the custom javac classpath the first thing on the bootclasspath, to ensure that
+      # it's the one javax.tools.ToolProvider.getSystemJavaCompiler() loads.
+      # It will probably be loaded even on the regular classpath: If not found on the bootclasspath,
+      # getSystemJavaCompiler() constructs a classloader that loads from the JDK's tools.jar.
+      # That classloader will first delegate to its parent classloader, which will search the
+      # regular classpath.  However it's harder to guarantee that our javac will preceed any others
+      # on the classpath, so it's safer to prefix it to the bootclasspath.
+      jvm_options.extend(['-Xbootclasspath/p:{}'.format(':'.join(self.javac_classpath()))])
+
+    jvm_options.extend(self._jvm_options)
 
     zinc_args.extend(sources)
 

--- a/src/python/pants/backend/jvm/tasks/nailgun_task.py
+++ b/src/python/pants/backend/jvm/tasks/nailgun_task.py
@@ -63,11 +63,11 @@ class NailgunTaskBase(JvmToolTaskMixin, TaskBase):
       return NailgunExecutor(self._identity,
                              self._executor_workdir,
                              classpath,
-                             self._dist,
+                             self.dist,
                              connect_timeout=self.get_options().nailgun_timeout_seconds,
                              connect_attempts=self.get_options().nailgun_connect_attempts)
     else:
-      return SubprocessExecutor(self._dist)
+      return SubprocessExecutor(self.dist)
 
   def runjava(self, classpath, main, jvm_options=None, args=None, workunit_name=None,
               workunit_labels=None, workunit_log_config=None):

--- a/testprojects/3rdparty/javactool/BUILD
+++ b/testprojects/3rdparty/javactool/BUILD
@@ -1,0 +1,8 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Used for integration tests of using custom javac jars.
+jar_library(name='custom_javactool_for_testing',
+            jars=[
+              jar('org.pantsbuild', 'custom_javactool_for_testing', '0.0.1')
+            ])

--- a/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_incomplete_custom_scala.py
@@ -113,7 +113,6 @@ class IncompleteCustomScalaIntegrationTest(PantsRunIntegrationTest):
       pants_run = self.pants_run(
         options=['--scala-platform-version=custom', '--scala-platform-suffix-version=2.11']
       )
-      print('XXXXXXXXXXXXXXX {}'.format(pants_run.stdout_data))
       self.assert_failure(pants_run)
       assert "Unable to bootstrap tool: 'scalac'" in pants_run.stdout_data
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -20,6 +20,7 @@ python_tests(
   sources=['test_zinc_compile_integration.py'],
   dependencies=[
     'src/python/pants/build_graph',
+    'tests/python/pants_test/backend/jvm/tasks:missing_jvm_check',
     'tests/python/pants_test/backend/jvm/tasks/jvm_compile:base_compile_integration_test',
   ],
   tags = {'integration'},

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -174,3 +174,15 @@ class ZincCompileIntegrationTest(BaseCompileIT):
                               expected_files=['PrintVersion.class'],
                               extra_args=['--no-compile-zinc-capture-classpath']) as found:
       self.assertFalse(classpath_filename in found)
+
+  def test_custom_javac(self):
+    with self.temporary_workdir() as workdir:
+      with self.temporary_cachedir() as cachedir:
+        pants_run = self.run_test_compile(
+            workdir, cachedir, 'examples/src/java/org/pantsbuild/example/hello/main',
+            extra_args=['--compile-zinc-javac=3rdparty:custom_javactool_for_testing'],
+            clean_all=True
+        )
+        self.assertNotEquals(0, pants_run.returncode)  # Our custom javactool always fails.
+        self.assertIn('Pants caused Zinc to load a custom JavacTool', pants_run.stdout_data)
+

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -6,10 +6,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+from unittest import skipIf
 
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants_test.backend.jvm.tasks.jvm_compile.base_compile_integration_test import BaseCompileIT
+from pants_test.backend.jvm.tasks.missing_jvm_check import is_missing_jvm
 
 
 class ZincCompileIntegrationTest(BaseCompileIT):
@@ -175,14 +177,14 @@ class ZincCompileIntegrationTest(BaseCompileIT):
                               extra_args=['--no-compile-zinc-capture-classpath']) as found:
       self.assertFalse(classpath_filename in found)
 
+  @skipIf(is_missing_jvm('1.8'), 'no java 1.8 installation on testing machine')
   def test_custom_javac(self):
     with self.temporary_workdir() as workdir:
       with self.temporary_cachedir() as cachedir:
         pants_run = self.run_test_compile(
             workdir, cachedir, 'examples/src/java/org/pantsbuild/example/hello/main',
-            extra_args=['--compile-zinc-javac=3rdparty:custom_javactool_for_testing'],
+            extra_args=['--compile-zinc-javac=testprojects/3rdparty/javactool:custom_javactool_for_testing'],
             clean_all=True
         )
         self.assertNotEquals(0, pants_run.returncode)  # Our custom javactool always fails.
         self.assertIn('Pants caused Zinc to load a custom JavacTool', pants_run.stdout_data)
-


### PR DESCRIPTION
Currently we always use the javac embedded in the JDK
we're using to run zinc.

This change supports experimenting with unreleased compiler
versions without having to also build and run an unreleased,
and possibly unstable, runtime, which would be a much riskier
prospect.

Specifically, this allows running the (relatively stable but still
unreleased) javac 9 compiler on a Java 8 runtime, something that
Bazel currently supports for various reasons.

- Also remove a comment that was obsoleted long ago,
  in b15a7cbb to be precise.

- Also fix a couple of references to a non-public member of a
  base class.