### PR TITLE
Move the custom javac option to the Java subsystem.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -27,6 +27,7 @@ python_library(
   sources = ['java.py'],
   dependencies = [
     ':zinc_language_mixin',
+    'src/python/pants/backend/jvm/subsystems:jvm_tool_mixin',
     'src/python/pants/build_graph',
     'src/python/pants/option',
     'src/python/pants/subsystem',

--- a/src/python/pants/backend/jvm/subsystems/java.py
+++ b/src/python/pants/backend/jvm/subsystems/java.py
@@ -5,13 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.subsystems.zinc_language_mixin import ZincLanguageMixin
 from pants.build_graph.address import Address
 from pants.option.custom_types import target_option
 from pants.subsystem.subsystem import Subsystem
 
 
-class Java(ZincLanguageMixin, Subsystem):
+class Java(JvmToolMixin, ZincLanguageMixin, Subsystem):
   """A subsystem to encapsulate compile-time settings and features for the Java language.
 
   Runtime options are captured by the JvmPlatform subsystem.
@@ -21,10 +22,38 @@ class Java(ZincLanguageMixin, Subsystem):
   @classmethod
   def register_options(cls, register):
     super(Java, cls).register_options(register)
+    # This target, if specified, serves as both a tool (for compiling java code) and a
+    # dependency (for javac plugins).  See below for the different methods for accessing
+    # classpath entries (in the former case) or target specs (in the latter case).
+    #
+    # Javac plugins can access basically all of the compiler internals, so we don't shade anything.
+    # Hence the unspecified main= argument. This tool is optional, hence the empty classpath list.
+    cls.register_jvm_tool(register,
+                          'javac',
+                          classpath=[],
+                          help='Java compiler to use.  If unspecified, we use the compiler '
+                               'embedded in the Java distribution we run on.')
+
     register('--compiler-plugin-deps', advanced=True, type=list, member_type=target_option,
              fingerprint=True,
              help='Requested javac plugins will be found in these targets, as well as in any '
                   'dependencies of the targets being compiled.')
+
+  @classmethod
+  def global_javac_spec(cls, buildgraph):
+    """Returns a target spec for the java compiler library, useable as a dependency.
+
+    If no javac library is specified, will return None.  The caller must handle
+    this case by defaulting to the JDK's tools.jar.  We can't provide a spec for that
+    jar here because it would create a circular dependency between this subsystem and JVM targets.
+
+    :param pants.build_graph.build_graph.BuildGraph buildgraph: buildgraph object.
+    :return: a target spec or None
+    """
+    javac_spec = cls.global_instance().javac_spec()
+    if buildgraph.contains_address(Address.parse(javac_spec)):
+      return javac_spec
+    return None
 
   @classmethod
   def global_plugin_dependency_specs(cls):
@@ -38,17 +67,38 @@ class Java(ZincLanguageMixin, Subsystem):
     else:
       return []
 
+  @classmethod
+  def global_javac_classpath(cls, products):
+    """Returns a classpath entry for the java compiler library, useable as a tool.
+
+    If no javac library is specified, will return an empty list.  The caller must handle
+    this case by defaulting to the JDK's tools.jar.  We can't provide that jar here
+    because we'd have to know about a Distribution.
+    """
+    return cls.global_instance().javac_classpath(products)
+
   def __init__(self, *args, **kwargs):
     super(Java, self).__init__(*args, **kwargs)
     opts = self.get_options()
-    # TODO: This check is a continuation of the hack that allows tests to pass without caring
+
+    # TODO: These checks are a continuation of the hack that allows tests to pass without caring
     # about this subsystem.
+    if hasattr(opts, 'javac') and opts.javac:
+      self._javac_spec = opts.javac
+    else:
+      self._javac_spec = None
     if hasattr(opts, 'compiler_plugin_deps'):
-      # Parse the specs in order to normalize them, so we can do string comparisons on them.
-      self._dependency_specs = [Address.parse(spec).spec
-                                for spec in self.get_options().compiler_plugin_deps]
+      # Parse the specs in order to normalize them, so we can do string comparisons on them in
+      # JvmTarget in order to avoid creating self-referencing deps.
+      self._dependency_specs = [Address.parse(spec).spec for spec in opts.compiler_plugin_deps]
     else:
       self._dependency_specs = []
 
   def plugin_dependency_specs(self):
     return self._dependency_specs
+
+  def javac_spec(self):
+    return self._javac_spec
+
+  def javac_classpath(self, products):
+    self.tool_classpath_from_products(products, 'javac', self.options_scope)

--- a/src/python/pants/backend/jvm/subsystems/java.py
+++ b/src/python/pants/backend/jvm/subsystems/java.py
@@ -101,4 +101,4 @@ class Java(JvmToolMixin, ZincLanguageMixin, Subsystem):
     return self._javac_spec
 
   def javac_classpath(self, products):
-    self.tool_classpath_from_products(products, 'javac', self.options_scope)
+    return self.tool_classpath_from_products(products, 'javac', self.options_scope)

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -173,8 +173,8 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, Subsystem):
     :param pants.build_graph.build_graph.BuildGraph buildgraph: buildgraph object.
     :return a target spec:
     """
-    return ScalaPlatform.global_instance()._library_target_spec(buildgraph, 'scalac',
-                                                                cls._create_compiler_jardep)
+    return cls.global_instance()._library_target_spec(buildgraph, 'scalac',
+                                                      cls._create_compiler_jardep)
 
   @classmethod
   def runtime_library_target_spec(cls, buildgraph):
@@ -185,8 +185,8 @@ class ScalaPlatform(JvmToolMixin, ZincLanguageMixin, Subsystem):
     :param pants.build_graph.build_graph.BuildGraph buildgraph: buildgraph object.
     :return a target spec:
     """
-    return ScalaPlatform.global_instance()._library_target_spec(buildgraph, 'scala-library',
-                                                                cls._create_runtime_jardep)
+    return cls.global_instance()._library_target_spec(buildgraph, 'scala-library',
+                                                      cls._create_runtime_jardep)
 
   def _library_target_spec(self, buildgraph, key, create_jardep_func):
     if self.version == 'custom':

--- a/src/python/pants/backend/jvm/targets/BUILD
+++ b/src/python/pants/backend/jvm/targets/BUILD
@@ -61,6 +61,7 @@ python_library(
   dependencies = [
     '3rdparty/python:six',
     ':jvm',
+    'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
   ],

--- a/src/python/pants/backend/jvm/targets/javac_plugin.py
+++ b/src/python/pants/backend/jvm/targets/javac_plugin.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.tools_jar import ToolsJar
 from pants.build_graph.address import Address
@@ -12,6 +13,17 @@ from pants.build_graph.address import Address
 
 class JavacPlugin(JavaLibrary):
   """A Java compiler plugin."""
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JavacPlugin, cls).subsystem_dependencies() + (Java,)
+
+  @classmethod
+  def _tools_jar_spec(cls, buildgraph):
+    synthetic_address = Address.parse('//:tools-jar-synthetic')
+    if not buildgraph.contains_address(synthetic_address):
+      buildgraph.inject_synthetic_target(synthetic_address, ToolsJar)
+    return synthetic_address.spec
 
   def __init__(self, classname=None, plugin=None, *args, **kwargs):
 
@@ -31,11 +43,8 @@ class JavacPlugin(JavaLibrary):
   def traversable_dependency_specs(self):
     for spec in super(JavacPlugin, self).traversable_dependency_specs:
       yield spec
-    yield self._tools_jar_spec(self._build_graph)
-
-  @classmethod
-  def _tools_jar_spec(cls, buildgraph):
-    synthetic_address = Address.parse('//:tools-jar-synthetic')
-    if not buildgraph.contains_address(synthetic_address):
-      buildgraph.inject_synthetic_target(synthetic_address, ToolsJar)
-    return synthetic_address.spec
+    javac_spec = Java.global_javac_spec(self._build_graph)
+    if javac_spec is None:
+      yield self._tools_jar_spec(self._build_graph)
+    else:
+      yield javac_spec

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -106,6 +106,7 @@ python_library(
     ':analysis_parser',
     ':analysis_tools',
     ':jvm_compile',
+    'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:scala_platform',
     'src/python/pants/backend/jvm/subsystems:shader',
     'src/python/pants/backend/jvm/targets:java',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -12,6 +12,7 @@ import textwrap
 from contextlib import closing
 from xml.etree import ElementTree
 
+from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.subsystems.shader import Shader
@@ -180,14 +181,6 @@ class BaseZincCompile(JvmCompile):
                   'This is unset by default, because it is generally a good precaution to cache '
                   'only clean/cold builds.')
 
-    # Javac plugins can access basically all of the compiler internals, so we don't shade anything.
-    # Hence the unspecified main= argument. This tool is optional, hence the empty classpath list.
-    cls.register_jvm_tool(register,
-                          'javac',
-                          classpath=[],
-                          help='Java compiler to use.  If unspecified, we use the compiler '
-                               'embedded in the Java distribution we run Zinc on.')
-
     cls.register_jvm_tool(register,
                           'zinc',
                           classpath=[
@@ -273,9 +266,9 @@ class BaseZincCompile(JvmCompile):
     return self.tool_classpath('zinc')
 
   def javac_classpath(self):
-    # Note that if this classpath is empty then Zinc will use the javac from
+    # Note that if this classpath is empty then Zinc will automatically use the javac from
     # the JDK it was invoked with.
-    return self.tool_classpath('javac')
+    return Java.global_javac_classpath(self.context.products)
 
   def scalac_classpath(self):
     return ScalaPlatform.global_instance().compiler_classpath(self.context.products)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -183,7 +183,7 @@ class ZincCompileIntegrationTest(BaseCompileIT):
       with self.temporary_cachedir() as cachedir:
         pants_run = self.run_test_compile(
             workdir, cachedir, 'examples/src/java/org/pantsbuild/example/hello/main',
-            extra_args=['--compile-zinc-javac=testprojects/3rdparty/javactool:custom_javactool_for_testing'],
+            extra_args=['--java-javac=testprojects/3rdparty/javactool:custom_javactool_for_testing'],
             clean_all=True
         )
         self.assertNotEquals(0, pants_run.returncode)  # Our custom javactool always fails.


### PR DESCRIPTION
It was initially an option on ZincCompile.  But putting it on Java
allows us to have plugins depend on the custom javac instead of
always depending on the JDK's tools.jar.  This solves mismatch
issues where we depend on the regular tools.jar when compiling
a plugin, but then that plugin runs against the custom javac.

No one is currently using this option (which was only introduced
a week ago) so no need for a deprecation cycle.