### PR TITLE
Fixup `PythonTarget` `resource_targets` docs.

### DIFF
--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -34,19 +34,24 @@ class PythonTarget(Target):
                compatibility=None,
                **kwargs):
     """
-    :param dependencies: Other targets that this target depends on.
+    :param dependencies: The addresses of targets that this target depends on.
       These dependencies may
       be ``python_library``-like targets (``python_library``,
       ``python_thrift_library``, ``python_antlr_library`` and so forth) or
       ``python_requirement_library`` targets.
-    :type dependencies: List of target specs
+    :type dependencies: list of strings
     :param sources: Files to "include". Paths are relative to the
       BUILD file's directory.
     :type sources: ``Fileset`` or list of strings
     :param resources: non-Python resources, e.g. templates, keys, other data
       (it is
       recommended that your application uses the pkgutil package to access these
-      resources in a .zip-module friendly way.)
+      resources in a .zip-module friendly way.) Paths are relative to the BUILD
+      file's directory.
+    :type sources: ``Fileset`` or list of strings
+    :param resource_targets: The addresses of ``resources`` targets this target
+      depends on.
+    :type resource_targets: list of strings
     :param provides:
       The `setup_py <#setup_py>`_ to publish that represents this
       target outside the repo.

--- a/src/python/pants/build_graph/resources.py
+++ b/src/python/pants/build_graph/resources.py
@@ -10,13 +10,12 @@ from pants.build_graph.target import Target
 
 
 class Resources(Target):
-  """JVM resource files.
+  """Resource files.
 
-  Looking for loose files in your application bundle? Those are
-  `bundle <#bundle>`_\s.
+  Looking for loose files in your JVM application bundle? Those are `bundle <#bundle>`_\s.
 
-  Resources are Java-style resources accessible via the ``Class.getResource``
-  and friends API. In the ``jar`` goal, the resource files are placed in the resulting `.jar`.
+  Resources are files included in deployable units like Java jars or Python wheels and accessible
+  via language-specific APIs.
 
   :API: public
   """


### PR DESCRIPTION
This also fixes the `resources` target docs to be language neutral.

https://rbcommons.com/s/twitter/r/4148/