### PR TITLE
remove dereference:True when extract tarball

### DIFF
--- a/src/python/pants/cache/artifact.py
+++ b/src/python/pants/cache/artifact.py
@@ -96,7 +96,7 @@ class TarballArtifact(Artifact):
     # but decompression times are much faster.
     mode = 'w:gz'
 
-    tar_kwargs = {'dereference': True, 'errorlevel': 2, 'compresslevel': self._compression}
+    tar_kwargs = {'errorlevel': 2, 'compresslevel': self._compression}
 
     with open_tar(self._tarfile, mode, **tar_kwargs) as tarout:
       for path in paths or ():


### PR DESCRIPTION
When tarball artifact is being cached, the extracted tarball are currently dereferenced.  This behavior currently breaks node_module/node_test related targets.  The corresponding issue is https://github.com/pantsbuild/pants/issues/2580.