### PR TITLE
A clear error message for checkstyle misconfiguration.

### DIFF
--- a/src/docs/first_tutorial.md
+++ b/src/docs/first_tutorial.md
@@ -296,7 +296,7 @@ will still compile them since it knows it must compile before it can
 test.
 
     :::bash
-    $ pants test src/java/com/myorg/myproject tests/java/com/myorg/myproject
+    $ ./pants test src/java/com/myorg/myproject tests/java/com/myorg/myproject
 
 **Run a binary**<br>
 Use pants to execute a binary target.  Compiles the code first if it is not up to date.

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -46,15 +46,11 @@ class Checkstyle(NailgunTask):
              help='Add the user classpath to the checkstyle classpath')
     cls.register_jvm_tool(register,
                           'checkstyle',
+                          # Note that checkstyle 7.0 does not run on Java 7 runtimes or below.
                           classpath=[
-                            # Pants still officially supports java 6 as a tool; the supported
-                            # development environment for a pants hacker is based on that.  As
-                            # such, we use 6.1.1 here since its the last checkstyle version
-                            # compiled to java 6.  See the release notes here:
-                            # http://checkstyle.sourceforge.net/releasenotes.html
                             JarDependency(org='com.puppycrawl.tools',
                                           name='checkstyle',
-                                          rev='6.1.1'),
+                                          rev='6.19'),
                           ],
                           main=cls._CHECKSTYLE_MAIN,
                           custom_rules=[
@@ -111,8 +107,12 @@ class Checkstyle(NailgunTask):
         union_classpath.update(jar for conf, jar in runtime_classpath
                                if conf in self.get_options().confs)
 
+    configuration_file = self.get_options().configuration
+    if not configuration_file:
+      raise TaskError('No checkstyle configuration file provided.')
+
     args = [
-      '-c', self.get_options().configuration,
+      '-c', configuration_file,
       '-f', 'plain'
     ]
 


### PR DESCRIPTION
Previously if the --configuration option wasn't specified,
you'd get an opaque error much further down, in a call to maybe_list.