### PR TITLE
Fixed bugs in Go thrift generation with services

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
@@ -63,7 +63,7 @@ class GoThriftGen(SimpleCodegenTask):
 
   @memoized_property
   def _service_deps(self):
-    service_deps = self.get_options().service_deps
+    service_deps = self.get_options().get('service_deps')
     return list(self.resolve_deps(service_deps)) if service_deps else self._deps
 
   SERVICE_PARSER = re.compile(r'^\s*service\s+(?:[^\s{]+)')

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_workspace_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_workspace_task.py
@@ -9,7 +9,7 @@ import os
 from itertools import chain
 
 from pants.base.build_environment import get_buildroot
-from pants.util.dirutil import safe_mkdir
+from pants.util.dirutil import safe_mkdir, safe_mkdir_for
 
 from pants.contrib.go.targets.go_target import GoTarget
 from pants.contrib.go.tasks.go_task import GoTask
@@ -74,8 +74,10 @@ class GoWorkspaceTask(GoTask):
 
     Adds the symlinks to the source files to required_links.
     """
-    source_iter = (os.path.join(get_buildroot(), src)
-                   for src in go_local_src.sources_relative_to_buildroot())
+    source_list = [os.path.join(get_buildroot(), src)
+                   for src in go_local_src.sources_relative_to_buildroot()]
+    rel_path = go_local_src.rel_path_relative_to_buildroot()
+    source_iter = ((source, os.path.relpath(source, rel_path)) for source in source_list)
     return self._symlink_lib(gopath, go_local_src, source_iter, required_links)
 
   def _symlink_remote_lib(self, gopath, go_remote_lib, required_links):
@@ -93,14 +95,15 @@ class GoWorkspaceTask(GoTask):
         # We grab any file since a go package might have .go, .c, .cc, etc files - all needed for
         # installation.
         if os.path.isfile(remote_src):
-          yield remote_src
+          yield (remote_src, os.path.basename(path))
     return self._symlink_lib(gopath, go_remote_lib, source_iter(), required_links)
 
   def _symlink_lib(self, gopath, lib, source_iter, required_links):
     src_dir = os.path.join(gopath, 'src', lib.import_path)
     safe_mkdir(src_dir)
-    for path in source_iter:
-      src_link = os.path.join(src_dir, os.path.basename(path))
+    for path, dest in source_iter:
+      src_link = os.path.join(src_dir, dest)
+      safe_mkdir_for(src_link)
       if not os.path.islink(src_link):
         os.symlink(path, src_link)
       required_links.add(src_link)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_workspace_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_workspace_task.py
@@ -76,8 +76,8 @@ class GoWorkspaceTask(GoTask):
     """
     source_list = [os.path.join(get_buildroot(), src)
                    for src in go_local_src.sources_relative_to_buildroot()]
-    rel_path = go_local_src.rel_path_relative_to_buildroot()
-    source_iter = ((source, os.path.relpath(source, rel_path)) for source in source_list)
+    rel_list = go_local_src.sources_relative_to_target_base()
+    source_iter = zip(source_list, rel_list)
     return self._symlink_lib(gopath, go_local_src, source_iter, required_links)
 
   def _symlink_remote_lib(self, gopath, go_remote_lib, required_links):

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen_integration.py
@@ -27,6 +27,10 @@ class GoThriftGenIntegrationTest(PantsRunIntegrationTest):
             struct Duck {
               1: optional string quack,
             }
+
+            service Feeder {
+              void feed(1:Duck duck),
+            }
             """).strip())
       with safe_open(os.path.join(srcdir, 'src/thrift/thrifttest/BUILD'), 'w') as fp:
         fp.write(dedent("""
@@ -42,8 +46,9 @@ class GoThriftGenIntegrationTest(PantsRunIntegrationTest):
 
             import "thrifttest/duck"
 
-            func whatevs() string {
+            func whatevs(f duck.Feeder) string {
               d := duck.NewDuck()
+              f.Feed(d)
               return d.GetQuack()
             }
             """).strip())
@@ -87,7 +92,9 @@ class GoThriftGenIntegrationTest(PantsRunIntegrationTest):
                             target_dir.replace(os.path.sep, '.'), 'current')
 
         self.assertEquals(sorted(['src/go/thrifttest/duck/constants.go',
-                                  'src/go/thrifttest/duck/ttypes.go']),
+                                  'src/go/thrifttest/duck/ttypes.go',
+                                  'src/go/thrifttest/duck/feeder.go',
+                                  'src/go/thrifttest/duck/feeder-remote/feeder-remote.go']),
                           sorted(exact_files(root)))
 
   def test_go_thrift_gen_and_compile(self):

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -560,6 +560,12 @@ class Target(AbstractTarget):
     """
     return self._sources_field.filespec
 
+  def rel_path_relative_to_buildroot(self):
+    """
+    :API: public
+    """
+    return self.payload.sources.rel_path
+
   @property
   def derived_from(self):
     """Returns the target this target was derived from.

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -560,11 +560,11 @@ class Target(AbstractTarget):
     """
     return self._sources_field.filespec
 
-  def rel_path_relative_to_buildroot(self):
+  def sources_relative_to_target_base(self):
     """
     :API: public
     """
-    return self.payload.sources.rel_path
+    return self.payload.sources.sources
 
   @property
   def derived_from(self):


### PR DESCRIPTION
Previously Pants would fail to work correctly for Go projects which tried to use Thrift services.  This fixes two bugs related to that, and modifies a test to fail without these changes:

1) service_deps: the old way of accessing it raises an exception if service_deps is not found, but clearly None is expected when not found.  The `get` function fixes this.

2) directory structure when symlinking files.  Previously, the basename was always used as the place where the files were supposed to go.  However, thrift generates a directory structure with services, and that is lost, leading to compile issues.  But making `source_iter` contain a tuple of `(source, relative_path_of_destination)`, we fix this issue.