### PR TITLE
Remove all calls to create_subsystem() in tests.

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/BUILD
@@ -7,7 +7,6 @@ python_tests(
   dependencies=[
     'contrib/scrooge/src/python/pants/contrib/scrooge/tasks:java_thrift_library_fingerprint_strategy',
     'src/python/pants/backend/codegen/subsystems:thrift_defaults',
-    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.backend.codegen.subsystems.thrift_defaults import ThriftDefaults
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import create_subsystem
 
 from pants.contrib.scrooge.tasks.java_thrift_library_fingerprint_strategy import \
   JavaThriftLibraryFingerprintStrategy
@@ -21,8 +20,10 @@ class JavaThriftLibraryFingerprintStrategyTest(BaseTest):
               'rpc_style': 'async'}
 
   def create_strategy(self, option_values):
-    thrift_defaults = create_subsystem(ThriftDefaults, **option_values)
-    return JavaThriftLibraryFingerprintStrategy(thrift_defaults)
+    self.context(for_subsystems=[ThriftDefaults], options={
+      ThriftDefaults.options_scope: option_values
+    })
+    return JavaThriftLibraryFingerprintStrategy(ThriftDefaults.global_instance())
 
   def test_fp_diffs_due_to_option(self):
     option_values = {'compiler': 'scrooge',

--- a/src/python/pants/binaries/thrift_binary.py
+++ b/src/python/pants/binaries/thrift_binary.py
@@ -24,7 +24,7 @@ class ThriftBinary(object):
 
     @classmethod
     def subsystem_dependencies(cls):
-      return (BinaryUtil.Factory,)
+      return super(ThriftBinary.Factory, cls).subsystem_dependencies() + (BinaryUtil.Factory,)
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -171,8 +171,8 @@ class Subsystem(SubsystemClientMixin, Optionable):
 
     TODO: We'd like that to be true of Tasks some day. Subsystems will help with that.
 
-    Task code should call scoped_instance() or global_instance() to get a subsystem instance.
-    Tests can call this constructor directly though.
+    Code should call scoped_instance() or global_instance() to get a subsystem instance.
+    It should not invoke this constructor directly.
 
     :API: public
     """

--- a/tests/python/pants_test/backend/codegen/subsystems/BUILD
+++ b/tests/python/pants_test/backend/codegen/subsystems/BUILD
@@ -8,7 +8,6 @@ python_tests(
     'src/python/pants/backend/codegen/subsystems:thrift_defaults',
     'src/python/pants/backend/codegen/targets:java',
     'src/python/pants/build_graph',
-    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/backend/codegen/subsystems/test_thrift_defaults.py
+++ b/tests/python/pants_test/backend/codegen/subsystems/test_thrift_defaults.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import functools
 import uuid
 from contextlib import contextmanager
 
@@ -13,11 +12,14 @@ from pants.backend.codegen.subsystems.thrift_defaults import ThriftDefaults
 from pants.backend.codegen.targets.java_thrift_library import JavaThriftLibrary
 from pants.build_graph.target import Target
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import create_subsystem
 
 
 class TestThriftDefaults(BaseTest):
-  create_thrift_defaults = functools.partial(create_subsystem, ThriftDefaults)
+  def create_thrift_defaults(self, **options):
+    self.context(for_subsystems=[ThriftDefaults], options={
+      ThriftDefaults.options_scope: options
+    })
+    return ThriftDefaults.global_instance()
 
   @contextmanager
   def invalid_fixtures(self):

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -117,7 +117,6 @@ python_tests(
     'src/python/pants/backend/project_info/tasks:ide_gen',
     'src/python/pants/source',
     'tests/python/pants_test:base_test',
-    'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_ide_gen.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_ide_gen.py
@@ -8,17 +8,21 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.backend.project_info.tasks.ide_gen import Project, SourceSet
 from pants.source.source_root import SourceRootConfig
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import create_subsystem
 
 
 class IdeGenTest(BaseTest):
-
   def test_collapse_source_root(self):
-    source_roots = create_subsystem(SourceRootConfig, source_roots={
-      '/src/java': [],
-      '/tests/java': [],
-      '/some/other': []
-    }, unmatched='fail').get_source_roots()
+    self.context(for_subsystems=[SourceRootConfig], options={
+      SourceRootConfig.options_scope: {
+        'source_roots': {
+          '/src/java': [],
+          '/tests/java': [],
+          '/some/other': []
+        },
+        'unmatched': 'fail'
+      }
+    })
+    source_roots = SourceRootConfig.global_instance().get_source_roots()
     source_set_list = []
     self.assertEquals([], Project._collapse_by_source_root(source_roots, source_set_list))
 

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -19,20 +19,15 @@ python_tests(
   dependencies=[
     '3rdparty/python:pex',
     'src/python/pants/backend/codegen/targets:python',
-
-    # TODO(John Sirois): XXX this dep needs to be fixed.  All pants/java utility code needs to live
-    # in pants java since non-jvm backends depend on it to run things.
-    'src/python/pants/backend/jvm/subsystems:jvm',
-
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python:python_chroot',
     'src/python/pants/backend/python:python_requirement',
     'src/python/pants/backend/python:python_setup',
+    'src/python/pants/binaries:binary_util',
     'src/python/pants/binaries:thrift_util',
     'src/python/pants/ivy',
     'src/python/pants/util:contextutil',
-    'src/python/pants/source',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:base_test',
   ]

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -15,9 +15,6 @@ from pex.platforms import Platform
 
 from pants.backend.codegen.targets.python_antlr_library import PythonAntlrLibrary
 from pants.backend.codegen.targets.python_thrift_library import PythonThriftLibrary
-# TODO(John Sirois): XXX this dep needs to be fixed.  All pants/java utility code needs to live
-# in pants java since non-jvm backends depend on it to run things.
-from pants.backend.jvm.subsystems.jvm import JVM
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.python_chroot import PythonChroot
 from pants.backend.python.python_requirement import PythonRequirement
@@ -25,13 +22,13 @@ from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.binaries.binary_util import BinaryUtil
 from pants.binaries.thrift_binary import ThriftBinary
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants.source.source_root import SourceRootConfig
 from pants.util.contextutil import temporary_dir
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import create_subsystem, subsystem_instance
+from pants_test.subsystem.subsystem_util import subsystem_instance
 
 
 def test_get_current_platform():
@@ -49,35 +46,36 @@ class PythonChrootTest(BaseTest):
 
   @contextmanager
   def dumped_chroot(self, targets):
-    python_repos = create_subsystem(PythonRepos)
+    self.context(for_subsystems=[PythonRepos, PythonSetup, IvySubsystem,
+                                 ThriftBinary.Factory, BinaryUtil.Factory])
+    python_repos = PythonRepos.global_instance()
+    ivy_bootstrapper = Bootstrapper(ivy_subsystem=IvySubsystem.global_instance())
+    thrift_binary_factory = ThriftBinary.Factory.global_instance().create
 
-    with subsystem_instance(IvySubsystem) as ivy_subsystem:
-      ivy_bootstrapper = Bootstrapper(ivy_subsystem=ivy_subsystem)
+    interpreter_cache = PythonInterpreterCache(self.python_setup, python_repos)
+    interpreter_cache.setup()
+    interpreters = list(interpreter_cache.matched_interpreters([
+      self.python_setup.interpreter_requirement
+    ]))
+    self.assertGreater(len(interpreters), 0)
+    interpreter = interpreters[0]
 
-      with subsystem_instance(ThriftBinary.Factory) as thrift_binary_factory:
-        interpreter_cache = PythonInterpreterCache(self.python_setup, python_repos)
-        interpreter_cache.setup()
-        interpreters = list(interpreter_cache.matched_interpreters([
-          self.python_setup.interpreter_requirement]))
-        self.assertGreater(len(interpreters), 0)
-        interpreter = interpreters[0]
+    with temporary_dir() as chroot:
+      pex_builder = PEXBuilder(path=chroot, interpreter=interpreter)
 
-        with temporary_dir() as chroot:
-          pex_builder = PEXBuilder(path=chroot, interpreter=interpreter)
-
-          python_chroot = PythonChroot(python_setup=self.python_setup,
-                                       python_repos=python_repos,
-                                       ivy_bootstrapper=ivy_bootstrapper,
-                                       thrift_binary_factory=thrift_binary_factory.create,
-                                       interpreter=interpreter,
-                                       builder=pex_builder,
-                                       targets=targets,
-                                       platforms=['current'])
-          try:
-            python_chroot.dump()
-            yield pex_builder, python_chroot
-          finally:
-            python_chroot.delete()
+      python_chroot = PythonChroot(python_setup=self.python_setup,
+                                   python_repos=python_repos,
+                                   ivy_bootstrapper=ivy_bootstrapper,
+                                   thrift_binary_factory=thrift_binary_factory,
+                                   interpreter=interpreter,
+                                   builder=pex_builder,
+                                   targets=targets,
+                                   platforms=['current'])
+      try:
+        python_chroot.dump()
+        yield pex_builder, python_chroot
+      finally:
+        python_chroot.delete()
 
   def test_antlr(self):
     self.create_file(relpath='src/antlr/word/word.g', contents=dedent("""
@@ -127,83 +125,70 @@ class PythonChrootTest(BaseTest):
                               source='main.py',
                               dependencies=[antlr_target, antlr3])
 
-    # TODO(John Sirois): This hacks around a direct but undeclared dependency
-    # `pants.java.distribution.distribution.Distribution` gained in
-    # https://rbcommons.com/s/twitter/r/2657
-    # Remove this once proper Subsystem dependency chains are re-established.
-    with subsystem_instance(JVM):
-      # TODO(benjy): This hacks around PythonChroot's dependency on source roots.
-      # See do_test_thrift() for more details. Remove this when we have a better way.
-      with subsystem_instance(SourceRootConfig):
-        with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
-          pex_builder.set_entry_point('test.main:word_up')
-          pex_builder.freeze()
-          pex = python_chroot.pex()
+    with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
+      pex_builder.set_entry_point('test.main:word_up')
+      pex_builder.freeze()
+      pex = python_chroot.pex()
 
-          process = pex.run(blocking=False, stdout=subprocess.PIPE)
-          stdout, _ = process.communicate()
+      process = pex.run(blocking=False, stdout=subprocess.PIPE)
+      stdout, _ = process.communicate()
 
-          self.assertEqual(0, process.returncode)
-          self.assertEqual(['Hello', ' ', 'World!'], stdout.splitlines())
+      self.assertEqual(0, process.returncode)
+      self.assertEqual(['Hello', ' ', 'World!'], stdout.splitlines())
 
   @contextmanager
   def do_test_thrift(self, inspect_chroot=None):
-    # TODO(benjy): This hacks around PythonChroot's dependency on source roots.
-    # Most tests get SourceRoot functionality set up for them by their test context.
-    # However PythonChroot isn't a task and doesn't use context. Rather it accesses source roots
-    # directly via Target.target_base.  Remove this when we have a better way.
-    with subsystem_instance(SourceRootConfig):
-      self.create_file(relpath='src/thrift/core/identifiers.thrift', contents=dedent("""
-        namespace py core
+    self.create_file(relpath='src/thrift/core/identifiers.thrift', contents=dedent("""
+      namespace py core
 
-        const string HELLO = "Hello"
-        const string WORLD = "World!"
-      """))
-      core_const = self.make_target(spec='src/thrift/core',
-                                    target_type=PythonThriftLibrary,
-                                    sources=['identifiers.thrift'])
+      const string HELLO = "Hello"
+      const string WORLD = "World!"
+    """))
+    core_const = self.make_target(spec='src/thrift/core',
+                                  target_type=PythonThriftLibrary,
+                                  sources=['identifiers.thrift'])
 
-      self.create_file(relpath='src/thrift/test/const.thrift', contents=dedent("""
-        namespace py test
+    self.create_file(relpath='src/thrift/test/const.thrift', contents=dedent("""
+      namespace py test
 
-        include "core/identifiers.thrift"
+      include "core/identifiers.thrift"
 
-        const list<string> MESSAGE = [identifiers.HELLO, identifiers.WORLD]
-      """))
-      test_const = self.make_target(spec='src/thrift/test',
-                                    target_type=PythonThriftLibrary,
-                                    sources=['const.thrift'],
-                                    dependencies=[core_const])
+      const list<string> MESSAGE = [identifiers.HELLO, identifiers.WORLD]
+    """))
+    test_const = self.make_target(spec='src/thrift/test',
+                                  target_type=PythonThriftLibrary,
+                                  sources=['const.thrift'],
+                                  dependencies=[core_const])
 
-      self.create_file(relpath='src/python/test/main.py', contents=dedent("""
-        from test.constants import MESSAGE
+    self.create_file(relpath='src/python/test/main.py', contents=dedent("""
+      from test.constants import MESSAGE
 
 
-        def say_hello():
-          print(' '.join(MESSAGE))
-      """))
-      binary = self.make_target(spec='src/python/test',
-                                target_type=PythonBinary,
-                                source='main.py',
-                                dependencies=[test_const])
+      def say_hello():
+        print(' '.join(MESSAGE))
+    """))
+    binary = self.make_target(spec='src/python/test',
+                              target_type=PythonBinary,
+                              source='main.py',
+                              dependencies=[test_const])
 
-      yield binary, test_const
+    yield binary, test_const
 
-      with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
-        pex_builder.set_entry_point('test.main:say_hello')
-        pex_builder.freeze()
-        pex = python_chroot.pex()
+    with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
+      pex_builder.set_entry_point('test.main:say_hello')
+      pex_builder.freeze()
+      pex = python_chroot.pex()
 
-        process = pex.run(blocking=False, stdout=subprocess.PIPE)
-        stdout, _ = process.communicate()
+      process = pex.run(blocking=False, stdout=subprocess.PIPE)
+      stdout, _ = process.communicate()
 
-        self.assertEqual(0, process.returncode)
-        self.assertEqual('Hello World!', stdout.strip())
+      self.assertEqual(0, process.returncode)
+      self.assertEqual('Hello World!', stdout.strip())
 
-        if inspect_chroot:
-          # Snap a clean copy of the chroot with just the chroots added files.
-          chroot = pex_builder.clone().path()
-          inspect_chroot(chroot)
+      if inspect_chroot:
+        # Snap a clean copy of the chroot with just the chroots added files.
+        chroot = pex_builder.clone().path()
+        inspect_chroot(chroot)
 
   def test_thrift(self):
     with self.do_test_thrift():

--- a/tests/python/pants_test/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/jvm/subsystems/BUILD
@@ -6,6 +6,6 @@ python_tests(
   sources=['test_jvm.py'],
   dependencies=[
     'src/python/pants/backend/jvm/subsystems:jvm',
-    'tests/python/pants_test/subsystem:subsystem_utils',
+    'tests/python/pants_test:base_test',
   ]
 )

--- a/tests/python/pants_test/jvm/subsystems/test_jvm.py
+++ b/tests/python/pants_test/jvm/subsystems/test_jvm.py
@@ -5,86 +5,79 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import functools
-
 from pants.backend.jvm.subsystems.jvm import JVM
-from pants_test.subsystem.subsystem_util import create_subsystem
+from pants_test.base_test import BaseTest
 
 
-create_JVM = functools.partial(create_subsystem, JVM)
+class TestJvm(BaseTest):
+  def create_JVM(self, **kwargs):
+    # Note: don't be confused by the fact that the JVM subsystem happens to have an option
+    # named 'options', which we set in several tests below.  We name this method's arguments
+    # kwargs instead of options to reduce this confusion.
+    self.context(for_subsystems=[JVM], options={
+      JVM.options_scope: kwargs
+    })
+    return JVM.global_instance()
 
+  def test_options_default(self):
+    jvm = self.create_JVM()
+    assert jvm.options_default == jvm.get_jvm_options()
 
-def test_options_default():
-  jvm = create_JVM()
-  assert jvm.options_default == jvm.get_jvm_options()
+  def test_options_simple(self):
+    jvm = self.create_JVM(options=['-ea'])
+    assert ['-ea'] == jvm.get_jvm_options()
 
+  def test_options_single_complex(self):
+    jvm = self.create_JVM(options=['-ea "-cp mono.jar" -server'])
+    assert ['-ea', '-cp mono.jar', '-server'] == jvm.get_jvm_options()
 
-def test_options_simple():
-  jvm = create_JVM(options=['-ea'])
-  assert ['-ea'] == jvm.get_jvm_options()
+  def test_options_multiple(self):
+    jvm = self.create_JVM(options=['-ea', '"-cp mono.jar"', '-server'])
+    assert ['-ea', '-cp mono.jar', '-server'] == jvm.get_jvm_options()
 
+  def test_explicit_debug(self):
+    jvm = self.create_JVM(debug=True)
+    assert '-Xdebug' in jvm.get_jvm_options()
 
-def test_options_single_complex():
-  jvm = create_JVM(options=['-ea "-cp mono.jar" -server'])
-  assert ['-ea', '-cp mono.jar', '-server'] == jvm.get_jvm_options()
+  def test_explicit_debug_with_options(self):
+    jvm = self.create_JVM(options=['-ea'], debug=True)
+    assert '-ea' in jvm.get_jvm_options()
+    assert '-Xdebug' in jvm.get_jvm_options()
 
+  def test_implicit_via_debug_port(self):
+    jvm = self.create_JVM(debug_port=1137)
+    jvm_options = jvm.get_jvm_options()
 
-def test_options_multiple():
-  jvm = create_JVM(options=['-ea', '"-cp mono.jar"', '-server'])
-  assert ['-ea', '-cp mono.jar', '-server'] == jvm.get_jvm_options()
+    assert '-Xdebug' in jvm_options
 
+    jdwp_options = None
+    for option in jvm_options:
+      if option.startswith('-Xrunjdwp:'):
+        jdwp_options = dict(kv.split('=', 1) for kv in option.replace('-Xrunjdwp:', '').split(','))
+        assert 'address' in jdwp_options
+        assert '1137' in jdwp_options['address']
+    assert jdwp_options is not None, 'Expected jdwp options to be present specifying the debug port.'
 
-def test_explicit_debug():
-  jvm = create_JVM(debug=True)
-  assert '-Xdebug' in jvm.get_jvm_options()
+  def test_explicit_debug_args(self):
+    jvm = self.create_JVM(debug_args=['fred'])
+    assert jvm.options_default + ['fred'] == jvm.get_jvm_options()
 
+  def test_explicit_debug_args_with_options(self):
+    jvm = self.create_JVM(options=['-ea'], debug_args=['fred'])
+    assert sorted(['-ea', 'fred']) == sorted(jvm.get_jvm_options())
 
-def test_explicit_debug_with_options():
-  jvm = create_JVM(options=['-ea'], debug=True)
-  assert '-ea' in jvm.get_jvm_options()
-  assert '-Xdebug' in jvm.get_jvm_options()
+  def test_args_default(self):
+    jvm = self.create_JVM()
+    assert [] == jvm.get_program_args()
 
+  def test_args_single_simple(self):
+    jvm = self.create_JVM(program_args=['a'])
+    assert ['a'] == jvm.get_program_args()
 
-def test_implicit_via_debug_port():
-  jvm = create_JVM(debug_port=1137)
-  jvm_options = jvm.get_jvm_options()
+  def test_args_single_complex(self):
+    jvm = self.create_JVM(program_args=['a "b c" d'])
+    assert ['a', 'b c', 'd'] == jvm.get_program_args()
 
-  assert '-Xdebug' in jvm_options
-
-  jdwp_options = None
-  for option in jvm_options:
-    if option.startswith('-Xrunjdwp:'):
-      jdwp_options = dict(kv.split('=', 1) for kv in option.replace('-Xrunjdwp:', '').split(','))
-      assert 'address' in jdwp_options
-      assert '1137' in jdwp_options['address']
-  assert jdwp_options is not None, 'Expected jdwp options to be present specifying the debug port.'
-
-
-def test_explicit_debug_args():
-  jvm = create_JVM(debug_args=['fred'])
-  assert jvm.options_default + ['fred'] == jvm.get_jvm_options()
-
-
-def test_explicit_debug_args_with_options():
-  jvm = create_JVM(options=['-ea'], debug_args=['fred'])
-  assert sorted(['-ea', 'fred']) == sorted(jvm.get_jvm_options())
-
-
-def test_args_default():
-  jvm = create_JVM()
-  assert [] == jvm.get_program_args()
-
-
-def test_args_single_simple():
-  jvm = create_JVM(program_args=['a'])
-  assert ['a'] == jvm.get_program_args()
-
-
-def test_args_single_complex():
-  jvm = create_JVM(program_args=['a "b c" d'])
-  assert ['a', 'b c', 'd'] == jvm.get_program_args()
-
-
-def test_args_multiple():
-  jvm = create_JVM(program_args=['a', '"b c"', 'd'])
-  assert ['a', 'b c', 'd'] == jvm.get_program_args()
+  def test_args_multiple(self):
+    jvm = self.create_JVM(program_args=['a', '"b c"', 'd'])
+    assert ['a', 'b c', 'd'] == jvm.get_program_args()

--- a/tests/python/pants_test/python/BUILD
+++ b/tests/python/pants_test/python/BUILD
@@ -53,6 +53,6 @@ python_tests(
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python:python_setup',
     'src/python/pants/util:contextutil',
-    'tests/python/pants_test/subsystem:subsystem_utils',
+    'tests/python/pants_test:base_test',
   ],
 )

--- a/tests/python/pants_test/source/BUILD
+++ b/tests/python/pants_test/source/BUILD
@@ -7,7 +7,6 @@ python_tests(
   dependencies = [
     'src/python/pants/source',
     'tests/python/pants_test:base_test',
-    'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
 

--- a/tests/python/pants_test/source/test_source_root.py
+++ b/tests/python/pants_test/source/test_source_root.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.source.source_root import SourceRoot, SourceRootConfig, SourceRootFactory, SourceRootTrie
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import create_subsystem
 
 
 class SourceRootTest(BaseTest):
@@ -135,7 +134,10 @@ class SourceRootTest(BaseTest):
     }
     options.update(self.options[''])  # We need inherited values for pants_workdir etc.
 
-    source_roots = create_subsystem(SourceRootConfig, **options).get_source_roots()
+    self.context(for_subsystems=[SourceRootConfig], options={
+      SourceRootConfig.options_scope: options
+    })
+    source_roots = SourceRootConfig.global_instance().get_source_roots()
     # Ensure that we see any manually added roots.
     source_roots.add_source_root('fixed/root/jvm', ('java', 'scala'))
     source_roots.all_roots()

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -15,6 +15,7 @@ python_library(
   name='subsystem_utils',
   sources=['subsystem_util.py'],
   dependencies=[
+    'src/python/pants/base:deprecated',
     'src/python/pants/subsystem',
     'tests/python/pants_test/option/util',
   ],

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from contextlib import contextmanager
 
+from pants.base.deprecated import deprecated
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem import Subsystem
@@ -14,6 +15,7 @@ from pants_test.option.util.fakes import (create_option_values_for_optionable,
                                           create_options_for_optionables)
 
 
+@deprecated('1.4.0', "Use BaseTest.context()'s for_subsystems and options args.")
 def create_subsystem(subsystem_type, scope='test-scope', **options):
   """Creates a Subsystem for test.
 


### PR DESCRIPTION
This is the first of several changes I have planned to
clean up how we create subsystem instances in tests.

Today it's chaos - we have at least three different ways (two
helper functions and via the test context).  And these interact
in bad ways. For example, one of the methods may reset
the subsystem state before another has had a chance to work.

Furthermore, instantiating a subsystem instance directly
by providing it with its option values is not always
a well-defined operation.  For example, some subsystems
depend on other subsystems, and this method skips initializing
those other subsystems entirely.

The best way to get a subsystem instance in a test is to
initialize that subsystem type via self.context(for_subsystems=...).
You can then also pass in options to set on the subsystem
and any of its dependencies.  This way you can also control
whether you configure and use the global instance or some
scoped instance.

It may seem a little clunkier, but this is usually what's
happening behind the scenes anyway, and at least this way
it's explicit, and any options conflicts are exposed early.

Future changes will remove the subsystem_instance() method too.