### PR TITLE
Performance fix for consolidated classpath

### DIFF
--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -69,16 +69,3 @@ class ConsolidateClasspath(JvmBinaryTask):
             # Replace directory classpath entry with its jarpath.
             classpath_products.remove_for_target(vt.target, [(conf, entry.path)])
             classpath_products.add_for_target(vt.target, [(conf, jarpath)])
-
-  def _find_consolidate_classpath_candidates(self, classpath_products, targets):
-    # TODO: investigate if inlining this method will provide enough benefit by reducing calls
-    # to justify not being able to short circuit.  See: https://rbcommons.com/s/twitter/r/4152/
-    targets_with_directory_in_classpath = []
-    for target in targets:
-      entries = classpath_products.get_internal_classpath_entries_for_targets([target])
-      for conf, entry in entries:
-        if ClasspathUtil.is_dir(entry.path):
-          targets_with_directory_in_classpath.append(target)
-          break
-
-    return targets_with_directory_in_classpath

--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -42,20 +42,14 @@ class ConsolidateClasspath(JvmBinaryTask):
     consolidated_classpath = self.context.products.get_data(
       'consolidated_classpath', runtime_classpath.copy)
 
-<<<<<<< ours
     # TODO: use a smarter filter method we should be able to limit the targets a bit more.
     # https://github.com/pantsbuild/pants/issues/3807
-=======
->>>>>>> theirs
     targets_to_consolidate = self.context.targets(**self._target_closure_kwargs)
     self._consolidate_classpath(targets_to_consolidate, consolidated_classpath)
 
   def _consolidate_classpath(self, targets, classpath_products):
     """Convert loose directories in classpath_products into jars. """
-<<<<<<< ours
     # TODO: find a way to not process classpath entries for valid VTs.
-=======
->>>>>>> theirs
 
     # NB: It is very expensive to call to get entries for each target one at a time.
     # For performance reasons we look them all up at once.

--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -42,11 +42,14 @@ class ConsolidateClasspath(JvmBinaryTask):
     consolidated_classpath = self.context.products.get_data(
       'consolidated_classpath', runtime_classpath.copy)
 
+    # TODO: use a smarter filter method we should be able to limit the targets a bit more.
+    # https://github.com/pantsbuild/pants/issues/3807
     targets_to_consolidate = self.context.targets(**self._target_closure_kwargs)
     self._consolidate_classpath(targets_to_consolidate, consolidated_classpath)
 
   def _consolidate_classpath(self, targets, classpath_products):
     """Convert loose directories in classpath_products into jars. """
+    # TODO: find a way to not process classpath entries for valid VTs.
 
     # NB: It is very expensive to call to get entries for each target one at a time.
     # For performance reasons we look them all up at once.

--- a/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
+++ b/src/python/pants/backend/jvm/tasks/consolidate_classpath.py
@@ -42,14 +42,20 @@ class ConsolidateClasspath(JvmBinaryTask):
     consolidated_classpath = self.context.products.get_data(
       'consolidated_classpath', runtime_classpath.copy)
 
+<<<<<<< ours
     # TODO: use a smarter filter method we should be able to limit the targets a bit more.
     # https://github.com/pantsbuild/pants/issues/3807
+=======
+>>>>>>> theirs
     targets_to_consolidate = self.context.targets(**self._target_closure_kwargs)
     self._consolidate_classpath(targets_to_consolidate, consolidated_classpath)
 
   def _consolidate_classpath(self, targets, classpath_products):
     """Convert loose directories in classpath_products into jars. """
+<<<<<<< ours
     # TODO: find a way to not process classpath entries for valid VTs.
+=======
+>>>>>>> theirs
 
     # NB: It is very expensive to call to get entries for each target one at a time.
     # For performance reasons we look them all up at once.


### PR DESCRIPTION
Previously we fetched the classpath entries for each target which was very expensive.  This change fetches them upfront.

Prior to change:

23.419 main:consolidate-classpath
23.414 main:consolidate-classpath:consolidate-classpath

After change:

1.344 main:consolidate-classpath
1.340 main:consolidate-classpath:consolidate-classpath