### PR TITLE
Upgrade default go to 1.7.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -32,7 +32,7 @@ class GoDistribution(object):
       register('--supportdir', advanced=True, default='bin/go',
                help='Find the go distributions under this dir.  Used as part of the path to lookup '
                     'the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', advanced=True, default='1.6.3',
+      register('--version', advanced=True, default='1.7',
                help='Go distribution version.  Used as part of the path to lookup the distribution '
                     'with --binary-util-baseurls and --pants-bootstrapdir')
 


### PR DESCRIPTION
This release folds the x/net context package into the core, adds support
for test and benchmark hierarchies and finalizes vendoring as an
official toolchain feature.

Release notes are here: https://golang.org/doc/go1.7

https://rbcommons.com/s/twitter/r/4195/