### PR TITLE
Plumb fetch timeout through `BinaryUtil`.

### DIFF
--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -155,7 +155,10 @@ class BinaryUtil(object):
       try:
         with temporary_file() as dest:
           fetcher = fetcher or Fetcher(get_buildroot())
-          fetcher.download(url, listener=Fetcher.ProgressListener(), path_or_fd=dest)
+          fetcher.download(url,
+                           listener=Fetcher.ProgressListener(),
+                           path_or_fd=dest,
+                           timeout_secs=self._timeout_secs)
           logger.info('Fetched {name} binary from: {url} .'.format(name=name, url=url))
           downloaded_successfully = True
           dest.seek(0)

--- a/tests/python/pants_test/binaries/BUILD
+++ b/tests/python/pants_test/binaries/BUILD
@@ -5,7 +5,9 @@ python_tests(
   name='binary_util',
   sources=['test_binary_util.py'],
   dependencies=[
+    '3rdparty/python:mock',
     'src/python/pants/binaries:binary_util',
+    'src/python/pants/net',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -55,7 +55,7 @@ class BinaryUtilTest(BaseTest):
     return '{base}/{binary}'.format(base=base, binary=binary)
 
   def test_timeout(self):
-    fetcher = mock.mock.create_autospec(Fetcher, spec_set=True)
+    fetcher = mock.create_autospec(Fetcher, spec_set=True)
     binary_util = BinaryUtil(baseurls=['http://binaries.example.com'],
                              timeout_secs=42,
                              bootstrapdir='/tmp')

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -55,7 +55,7 @@ class BinaryUtilTest(BaseTest):
     return '{base}/{binary}'.format(base=base, binary=binary)
 
   def test_timeout(self):
-    fetcher = mock.mock.create_autospec(Fetcher)
+    fetcher = mock.mock.create_autospec(Fetcher, spec_set=True)
     binary_util = BinaryUtil(baseurls=['http://binaries.example.com'],
                              timeout_secs=42,
                              bootstrapdir='/tmp')


### PR DESCRIPTION
Previously, the option was stored by `BinaryUtil` but not forwarded to
the underlying `Fetcher` it used.

https://rbcommons.com/s/twitter/r/4196/