### PR TITLE
[jvm-compile][test] Add test explicitly checking classpath for z.jars

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/test_zinc_compile_integration.py
@@ -178,3 +178,16 @@ class ZincCompileIntegrationTest(BaseCompileIT):
 
 class ZincCompileIntegrationWithZjars(ZincCompileIntegrationTest):
   _EXTRA_TASK_ARGS = ['--compile-zinc-use-classpath-jars']
+
+  def test_classpath_includes_jars_when_use_jars_enabled(self):
+    target_spec = 'examples/src/java/org/pantsbuild/example/hello/main'
+    classpath_filename = 'examples.src.java.org.pantsbuild.example.hello.main.main-bin.txt'
+
+    with self.do_test_compile(target_spec,
+      expected_files=[classpath_filename],
+      extra_args=['--compile-zinc-capture-classpath']) as found:
+
+      found_classpath_file = self.get_only(found, classpath_filename)
+      with open(found_classpath_file, 'r') as f:
+        contents = f.read()
+        self.assertIn('z.jar', contents)


### PR DESCRIPTION
While working on https://rbcommons.com/s/twitter/r/4198, I thought I saw that --use-classpath-jars wasn't being respected for modifying the compile classpath. I wrote this test to check and it passed.