### PR TITLE
Bug fix: antlr gen output directory is deleted

### DIFF
--- a/src/python/pants/backend/codegen/tasks/antlr_gen.py
+++ b/src/python/pants/backend/codegen/tasks/antlr_gen.py
@@ -124,7 +124,7 @@ class AntlrGen(SimpleCodegenTask, NailgunTask):
     package_dir = os.path.join(target_workdir, package_dir_rel)
     safe_mkdir(package_dir)
     for root, dirs, files in os.walk(target_workdir, topdown = False):
-      if root == package_dir_rel:
+      if root == package_dir:
         # This path is already in the correct location
         continue
       for f in files:
@@ -134,7 +134,7 @@ class AntlrGen(SimpleCodegenTask, NailgunTask):
         )
       for d in dirs:
         full_dir = os.path.join(root, d)
-        if not os.listdir(full_dir):
+        if not os.listdir(full_dir) and full_dir != package_dir:
           os.rmdir(full_dir)
 
   def _scrub_generated_timestamps(self, target_workdir):


### PR DESCRIPTION
#3787  has both src and dst under the same common directory to be walked, it also tries to do the move and delete in the same loop.

Because of some missing checks (fixed in this rb), if the dst directory is visited first (in alphabetically order) when it is still empty, dst directory will be deleted, and we see 

```
OSError: [Errno 2] No such file or directory
```

when later trying to move files into this non-existent directory.

To repro, change in test_antlr_gen.py

```
   PARTS = {'srcroot': 'testprojects/src/antlr',
-           'dir': 'this/is/a/directory',
+           'dir': 'here/is/a/directory',
            'name': 'smoke',
            'prefix': 'SMOKE'}
```

will force destination directory to be visited first, i.e, `BUILD_ROOT/stable/this/is/a/directory` vs
`BUILD_ROOT/stable/testprojects/src/antlr/this/is/a/directory`, w/o fix would fail and with fix would pass.

cc @lexspoon
