### PR TITLE
Check that types passed to TypeConstraint inits are in fact types

### DIFF
--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -38,6 +38,9 @@ class TypeConstraint(AbstractClass):
     """
     if not types:
       raise ValueError('Must supply at least one type')
+    if any(not isinstance(t, type) for t in types):
+      raise TypeError('Supplied types must be types. {!r}'.format(types))
+
     self._types = types
 
   @property

--- a/tests/python/pants_test/engine/test_addressable.py
+++ b/tests/python/pants_test/engine/test_addressable.py
@@ -70,6 +70,10 @@ class ExactlyTest(TypeConstraintTestBase):
     self.assertFalse(exactly_a_or_b.satisfied_by(self.BPrime()))
     self.assertFalse(exactly_a_or_b.satisfied_by(self.C()))
 
+  def test_disallows_unsplatted_lists(self):
+    with self.assertRaises(TypeError):
+      Exactly([1])
+
 
 class SubclassesOfTest(TypeConstraintTestBase):
   def test_none(self):


### PR DESCRIPTION
I was adding some type constraints somewhere and didn't splat types. This failed to work because a list is not a type.

This patch adds a validation that raises a TypeError if the types are not types