### PR TITLE
Clean up junit xml report file location logic.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -366,6 +366,7 @@ python_library(
     'src/python/pants/util:argutil',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:desktop',
+    'src/python/pants/util:iterators',
     'src/python/pants/util:strutil',
     'src/python/pants/util:xml_parser',
   ],

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -51,7 +51,11 @@ python_library(
 python_library(
   name = 'filtering',
   sources = ['filtering.py'],
-  dependencies = [],
+)
+
+python_library(
+  name = 'iterators',
+  sources = ['iterators.py'],
 )
 
 python_library(

--- a/src/python/pants/util/iterators.py
+++ b/src/python/pants/util/iterators.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+
+try:
+  from itertools import accumulate  # Present in python3 stdlib.
+except ImportError:
+  import operator
+
+
+  def accumulate(items, func=operator.add):
+    """Reduce items yielding the initial item and then each reduced value after that.
+
+    :param items: A possibly empty iterable.
+    :param func: A binary operator that can combine items.
+    :returns: An iterator over the first item if any and subsequent applications of `func` to the
+              running "total".
+    """
+    iterator = iter(items)
+    try:
+      total = next(iterator)
+    except StopIteration:
+      return  # The items iterable is empty.`
+    yield total
+    for item in iterator:
+      total = func(total, item)
+      yield total

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -59,6 +59,14 @@ python_tests(
 )
 
 python_tests(
+  name = 'iterators',
+  sources = ['test_iterators.py'],
+  dependencies = [
+    'src/python/pants/util:iterators',
+  ]
+)
+
+python_tests(
   name = 'memo',
   sources = ['test_memo.py'],
   dependencies = [

--- a/tests/python/pants_test/util/test_iterators.py
+++ b/tests/python/pants_test/util/test_iterators.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.util.iterators import accumulate
+
+
+class AccumulateTest(unittest.TestCase):
+  def test_empty(self):
+    self.assertEqual([], list(accumulate(())))
+
+  def test_single(self):
+    self.assertEqual([42], list(accumulate((42,))))
+
+  def test_nominal(self):
+    self.assertEqual([1, 2, 3], list(accumulate((1, 1, 1))))
+
+  def test_heterogeneous(self):
+    self.assertEqual([1, '11', '111'], list(accumulate((1, 1, 1),
+                                                       func=lambda x, y: str(x) + str(y))))


### PR DESCRIPTION
This introduces a backport of itertools.accumulate and then uses it to
make the logic of scanning from more specific nested class report files
to less specific (containing class) ones a bit more coherent.

https://rbcommons.com/s/twitter/r/4211