### PR TITLE
Refactor memoization of the global distribution locator.

### DIFF
--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -552,14 +552,6 @@ class DistributionLocator(Subsystem):
     """
 
   @classmethod
-  @memoized_method
-  def _locator(cls):
-    environment = _UnknownEnvironment(_EnvVarEnvironment(),
-                                      _LinuxEnvironment.standard(),
-                                      _OSXEnvironment.standard())
-    return cls.global_instance()._create_locator(environment)
-
-  @classmethod
   def cached(cls, minimum_version=None, maximum_version=None, jdk=False):
     """Finds a java distribution that meets the given constraints and returns it.
 
@@ -576,9 +568,10 @@ class DistributionLocator(Subsystem):
     :raises: :class:`Distribution.Error` if no suitable java distribution could be found.
     """
     try:
-      return cls._locator().locate(minimum_version=minimum_version,
-                                   maximum_version=maximum_version,
-                                   jdk=jdk)
+      return cls.global_instance()._locator().locate(
+          minimum_version=minimum_version,
+          maximum_version=maximum_version,
+          jdk=jdk)
     except _Locator.Error as e:
       raise cls.Error('Problem locating a java distribution: {}'.format(e))
 
@@ -605,6 +598,10 @@ class DistributionLocator(Subsystem):
     """
     return self._normalized_jdk_paths
 
+  @memoized_method
+  def _locator(self):
+    return self._create_locator()
+
   @memoized_property
   def _normalized_jdk_paths(self):
     normalized = {}
@@ -627,14 +624,16 @@ class DistributionLocator(Subsystem):
                      .format(os_name))
     return self._normalized_jdk_paths.get(os_name, ())
 
-  def _create_locator(self, distribution_environment):
+  def _create_locator(self):
     homes = self._get_explicit_jdk_paths()
-    environment = _UnknownEnvironment(_ExplicitEnvironment(*homes), distribution_environment)
+    environment = _UnknownEnvironment(
+        _ExplicitEnvironment(*homes),
+        _UnknownEnvironment(
+            _EnvVarEnvironment(),
+            _LinuxEnvironment.standard(),
+            _OSXEnvironment.standard()
+        )
+    )
     return _Locator(environment,
                     self.get_options().minimum_version,
                     self.get_options().maximum_version)
-
-  # Exposed for tests.
-  def _reset(self):
-    self._locator.clear()
-    self._normalized_jdk_paths.clear()

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -165,11 +165,12 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
                         JvmPlatformSettings('1.6', '1.6', ['-Xfoo:bar']))
 
   def test_java_home_extraction(self):
-    _, source, _, target, foo, bar, composite, single = tuple(ZincCompile._get_zinc_arguments(
-      JvmPlatformSettings('1.7', '1.7', [
-        'foo', 'bar', 'foo:$JAVA_HOME/bar:$JAVA_HOME/foobar', '$JAVA_HOME',
-      ])
-    ))
+    with subsystem_instance(DistributionLocator):
+      _, source, _, target, foo, bar, composite, single = tuple(ZincCompile._get_zinc_arguments(
+        JvmPlatformSettings('1.7', '1.7', [
+          'foo', 'bar', 'foo:$JAVA_HOME/bar:$JAVA_HOME/foobar', '$JAVA_HOME',
+        ])
+      ))
 
     self.assertEquals('-C1.7', source)
     self.assertEquals('-C1.7', target)
@@ -223,9 +224,8 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
             }
           }
         }
-        with subsystem_instance(DistributionLocator, **path_options) as locator:
+        with subsystem_instance(DistributionLocator, **path_options):
           yield paths
-          locator._reset()
 
     # Completely missing a usable distribution.
     with fake_distribution_locator(far_future_version):

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -430,10 +430,7 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
                                        non_strict_home
                                      ]
                                    })
-        with subsystem_instance(DistributionLocator) as locator:
-          locator._reset()  # Make sure we get a fresh read from the options set just above.
-          self.addCleanup(locator._reset)  # And make sure we we clean up the values we cache.
-
+        with subsystem_instance(DistributionLocator):
           export_json = self.execute_export_json()
           self.assertEqual({'strict': strict_home, 'non_strict': non_strict_home},
                            export_json['preferred_jvm_distributions']['java9999'])

--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -27,6 +27,7 @@ python_tests(
     'src/python/pants/binaries:binary_util',
     'src/python/pants/binaries:thrift_util',
     'src/python/pants/ivy',
+    'src/python/pants/java/distribution',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:base_test',

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -26,6 +26,7 @@ from pants.binaries.binary_util import BinaryUtil
 from pants.binaries.thrift_binary import ThriftBinary
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
+from pants.java.distribution.distribution import DistributionLocator
 from pants.util.contextutil import temporary_dir
 from pants_test.base_test import BaseTest
 from pants_test.subsystem.subsystem_util import subsystem_instance
@@ -46,8 +47,13 @@ class PythonChrootTest(BaseTest):
 
   @contextmanager
   def dumped_chroot(self, targets):
+    # TODO(benjy): We shouldn't need to mention DistributionLocator here, as IvySubsystem
+    # declares it as a dependency. However if we don't then test_antlr() below fails on
+    # uninitialized options for that subsystem.  Hopefully my pending (as of 9/2016) change
+    # to clean up how we initialize and create instances of subsystems in tests will make
+    # this problem go away.
     self.context(for_subsystems=[PythonRepos, PythonSetup, IvySubsystem,
-                                 ThriftBinary.Factory, BinaryUtil.Factory])
+                                 DistributionLocator, ThriftBinary.Factory, BinaryUtil.Factory])
     python_repos = PythonRepos.global_instance()
     ivy_bootstrapper = Bootstrapper(ivy_subsystem=IvySubsystem.global_instance())
     thrift_binary_factory = ThriftBinary.Factory.global_instance().create

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -18,11 +18,7 @@ from pants_test.subsystem.subsystem_util import subsystem_instance
 @contextmanager
 def _distribution_locator(**options):
   with subsystem_instance(DistributionLocator, **options) as locator:
-    locator._reset()  # Force a fresh locator.
-    try:
-      yield locator
-    finally:
-      locator._reset()  # And make sure we we clean up the values we cache.
+    yield locator
 
 
 def _get_two_distributions():


### PR DESCRIPTION
Previously it was memoized on the DistributionLocator class.
This meant that it survived resetting the subsystem instances
in tests, and required a special, non-obvious workaround.

Now we memoize it on the subsystem instance, so it gets cleaned
up when the subsystem is reset.  This change therefore also gets
rid of the workaround, which makes some tests simpler.

This change also adds subsystem initialization to a test that
needed it (unclear how that test worked before, possibly it
implicitly relied on some unclean state from a previous test).

It also removes the argument to _create_locator(), since it was
never used in practice.