### PR TITLE
Scalafmt

### DIFF
--- a/build-support/scalafmt/config
+++ b/build-support/scalafmt/config
@@ -1,0 +1,12 @@
+--maxColumn 100
+--javaDocs
+--alignStripMarginStrings false
+--alignByOpenParenCallSite false
+--alignByOpenParenDefnSite false
+--continuationIndentCallSite 4
+--continuationIndentDefnSite 4
+--spacesInImportCurlyBraces false
+--allowNewlineBeforeColonInMassiveReturnTypes true
+--binPackParentConstructors false
+--spaceAfterTripleEquals true
+--alignByArrowEnumeratorGenerator true

--- a/pants.ini
+++ b/pants.ini
@@ -118,6 +118,8 @@ deps: ["3rdparty:thrift-0.9.2"]
 [compile.checkstyle]
 configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 
+[test.scalafmt]
+configuration: %(pants_supportdir)s/scalafmt/config
 
 [compile.findbugs]
 max_rank: 4

--- a/pants.ini
+++ b/pants.ini
@@ -120,6 +120,7 @@ configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 
 [test.scalafmt]
 configuration: %(pants_supportdir)s/scalafmt/config
+skip: True
 
 [compile.findbugs]
 max_rank: 4

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -60,6 +60,7 @@ from pants.backend.jvm.tasks.run_jvm_prep_command import (RunBinaryJvmPrepComman
                                                           RunTestJvmPrepCommand)
 from pants.backend.jvm.tasks.scala_repl import ScalaRepl
 from pants.backend.jvm.tasks.scaladoc_gen import ScaladocGen
+from pants.backend.jvm.tasks.scalafmt import ScalaFmt
 from pants.backend.jvm.tasks.unpack_jars import UnpackJars
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.goal import Goal
@@ -188,6 +189,7 @@ def register_goals():
   task(name='jvm-dirty', action=JvmRun, serialize=False).install('run-dirty')
   task(name='scala', action=ScalaRepl, serialize=False).install('repl')
   task(name='scala-dirty', action=ScalaRepl, serialize=False).install('repl-dirty')
+  task(name='scalafmt', action=ScalaFmt, serialize=False).install('test')
   task(name='test-jvm-prep-command', action=RunTestJvmPrepCommand).install('test', first=True)
   task(name='binary-jvm-prep-command', action=RunBinaryJvmPrepCommand).install('binary', first=True)
   task(name='compile-jvm-prep-command', action=RunCompileJvmPrepCommand).install('compile', first=True)

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -37,6 +37,7 @@ python_library(
     ':run_jvm_prep_command',
     ':scala_repl',
     ':scaladoc_gen',
+    ':scalafmt',
     ':scalastyle',
     ':unpack_jars',
     'src/python/pants/backend/jvm/tasks/jvm_compile:all',
@@ -604,6 +605,15 @@ python_library(
     'src/python/pants/java/distribution',
     'src/python/pants/util:memo',
   ],
+)
+
+python_library(
+  name = 'scalafmt',
+  sources = ['scalafmt.py'],
+  dependencies = [
+    'src/python/pants/base:exceptions',
+    'src/python/pants/task',
+  ]
 )
 
 python_library(

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
@@ -611,8 +611,10 @@ python_library(
   name = 'scalafmt',
   sources = ['scalafmt.py'],
   dependencies = [
+    ':nailgun_task',
     'src/python/pants/base:exceptions',
-    'src/python/pants/task',
+    'src/python/pants/build_graph',
+    'src/python/pants/option',
   ]
 )
 

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -43,12 +43,10 @@ class ScalaFmt(NailgunTask):
     sources = self.calculate_sources(targets)
 
     if sources:
-      files = ""
-      for source in sources:
-        files = files + source + ','
+      files = ",".join(sources)
 
-      configFile = self.get_options().configuration
-      args = ['--test', '--config', configFile, '--files', files]
+      config_file = self.get_options().configuration
+      args = ['--test', '--config', config_file, '--files', files]
 
       result = self.runjava(classpath=self.tool_classpath('scalafmt'),
                    main=self._SCALAFMT_MAIN,
@@ -56,9 +54,9 @@ class ScalaFmt(NailgunTask):
                    workunit_name='scalafmt')
 
       if result != 0:
-        scalafmtCmd = 'scalafmt -i --config {} --files {}'.format(configFile, files)
-        raise TaskError('Scalafmt failed with exit code {} to fix run: `{}`'.format(result, scalafmtCmd), exit_code=result)
-  
+        scalafmt_cmd = 'scalafmt -i --config {} --files {}'.format(config_file, files)
+        raise TaskError('Scalafmt failed with exit code {} to fix run: `{}`'.format(result, scalafmt_cmd), exit_code=result)
+
   def get_non_synthetic_scala_targets(self, targets):
     return filter(
       lambda target: isinstance(target, Target)
@@ -67,7 +65,7 @@ class ScalaFmt(NailgunTask):
       targets)
 
   def calculate_sources(self, targets):
-    sources = set() 
+    sources = set()
     for target in targets:
       sources.update(source for source in target.sources_relative_to_buildroot()
                       if source.endswith(self._SCALA_SOURCE_EXTENSION))

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.exceptions import TaskError
+from pants.option.custom_types import file_option
+
+
+class ScalaFmt(NailgunTask):
+  """Checks Scala code matches scalafmt style.
+
+  :API: public
+  """
+  _SCALAFMT_MAIN = 'org.scalafmt.cli.Cli'
+  _SCALA_SOURCE_EXTENSION = '.scala'
+
+  @classmethod
+  def register_options(cls, register):
+    super(ScalaFmt, cls).register_options(register)
+    register('--skip', type=bool, fingerprint=True, help='Skip checkstyle')
+    register('--configuration', advanced=True, type=file_option, fingerprint=True,
+              help='Path to scalafmt config file.')
+    cls.register_jvm_tool(register,
+                          'scalafmt',
+                          classpath=[
+                          JarDependency(org='com.geirsson',
+                                        name='scalafmt-cli_2.11',
+                                        rev='0.2.11')
+                          ])
+
+  def execute(self):
+    """Runs Scalafmt on all found Scala Source Files."""
+    if self.get_options().skip:
+      return
+
+    sources = self.calculate_sources(self.context.targets())
+
+    if sources:
+      files = ""
+      for source in sources:
+        files = files + source + ','
+
+      configFile = self.get_options().configuration
+      args = ['--test', '--config', configFile, '--files', files]
+
+      result = self.runjava(classpath=self.tool_classpath('scalafmt'),
+                   main=self._SCALAFMT_MAIN,
+                   args=args,
+                   workunit_name='scalafmt')
+
+      if result != 0:
+        scalafmtCmd = 'scalafmt -i --config {} --files {}'.format(configFile, files)
+        raise TaskError('Scalafmt failed with exit code {} to fix run: `{}`'.format(result, scalafmtCmd), exit_code=result)
+  
+  def calculate_sources(self, targets):
+    sources = set() 
+    for target in targets:
+      sources.update(source for source in target.sources_relative_to_buildroot()
+                      if source.endswith(self._SCALA_SOURCE_EXTENSION))
+    return sources

--- a/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BUILD
@@ -1,0 +1,3 @@
+scala_library(name='badscalastyle',
+  sources=globs('*')
+)

--- a/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BadScalaStyle.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BadScalaStyle.scala
@@ -1,0 +1,18 @@
+// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.badscalastyle
+
+/**
+ * These comments are formmated incorrectly
+ * and the parameter list is too long for one line
+ */
+case class ScalaStyle(one: String,two: String,three: String,four: String,
+    five: String,six: String,seven: String,eight: String,  nine: String)
+
+class Person(name: String,age: Int,astrologicalSign: String,
+    shoeSize: Int,
+    favoriteColor: java.awt.Color) {
+  def getAge:Int={return age}
+  def sum(longvariablename: List[String]): Int = {longvariablename.map(_.toInt).foldLeft(0)(_ + _)}
+}

--- a/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BadScalaStyle.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BadScalaStyle.scala
@@ -1,4 +1,4 @@
-// Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 package org.pantsbuild.testproject.badscalastyle

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -586,6 +586,17 @@ python_tests(
 )
 
 python_tests(
+  name = 'scalafmt',
+  sources = ['test_scalafmt.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm/tasks:scalafmt',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+  timeout = 120,
+)
+
+python_tests(
   name = 'scalastyle',
   sources = ['test_scalastyle.py'],
   dependencies = [

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -593,7 +593,6 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
-  timeout = 120,
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+TEST_DIR = 'testprojects/src/scala/org/pantsbuild/testproject'
+
+
+class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
+  def test_scalafmt_fail(self):
+    target = '{}:badScalaStyle'.format(TEST_DIR)
+    #test should fail because of style error
+    failing_test = self.run_pants(['test', target])
+    self.assert_failure(failing_test)
+
+  # def test_scalafmt_success(self):
+  #   #Verifies that checked in Scala testprojects pass scalafmt"
+  #   for project in ('emptyscala', 'scalac'):
+  #     target = '{}/{}::'.format(TEST_DIR, project)
+  #     #test should pass because of style error
+  #     passing_test = self.run_pants(['test', target])
+  #     self.assert_success(passing_test)

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -14,7 +14,7 @@ TEST_DIR = 'testprojects/src/scala/org/pantsbuild/testproject'
 class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
   def test_scalafmt_fail(self):
     target = '{}/badscalastyle::'.format(TEST_DIR)
-    #test should fail because of style error
+    # test should fail because of style error.
     failing_test = self.run_pants(['test', target],
       {'test.scalafmt':{'skip': 'False'}})
 
@@ -22,7 +22,7 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
 
   def test_scalafmt_disabled(self):
     target = '{}/badscalastyle::'.format(TEST_DIR)
-    #test should pass because of scalafmt disabled
+    # test should pass because of scalafmt disabled.
     failing_test = self.run_pants(['test', target],
       {'test.scalafmt':{'skip': 'True'}})
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -13,15 +13,17 @@ TEST_DIR = 'testprojects/src/scala/org/pantsbuild/testproject'
 
 class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
   def test_scalafmt_fail(self):
-    target = '{}:badScalaStyle'.format(TEST_DIR)
+    target = '{}/badscalastyle::'.format(TEST_DIR)
     #test should fail because of style error
-    failing_test = self.run_pants(['test', target])
+    failing_test = self.run_pants(['test', target],
+      {'test.scalafmt':{'skip': 'False'}})
+
     self.assert_failure(failing_test)
 
-  # def test_scalafmt_success(self):
-  #   #Verifies that checked in Scala testprojects pass scalafmt"
-  #   for project in ('emptyscala', 'scalac'):
-  #     target = '{}/{}::'.format(TEST_DIR, project)
-  #     #test should pass because of style error
-  #     passing_test = self.run_pants(['test', target])
-  #     self.assert_success(passing_test)
+  def test_scalafmt_disabled(self):
+    target = '{}/badscalastyle::'.format(TEST_DIR)
+    #test should pass because of scalafmt disabled
+    failing_test = self.run_pants(['test', target],
+      {'test.scalafmt':{'skip': 'True'}})
+
+    self.assert_success(failing_test)


### PR DESCRIPTION
Integrating [Scalafmt](https://github.com/olafurpg/scalafmt) Style Checks into Pants.

The test Target now checks if .scala files conform to the configured Scalafmt settings.  If not the Target run fails.
* Added a ScalaFmt Task, that checks if all .scala files in the target match the Scalafmt config
* Registered ScalaFmt Task to run as part of the test Target
* Added Configuration to pants.ini to read config and to disable the Scalafmt check.  It is currently disabled.
* Added a default Scalafmt config
* Added Scalafmt Integration Test Cases