### PR TITLE
Deprecate the `subsystem_instance` utility function.

### DIFF
--- a/contrib/android/tests/python/pants_test/contrib/android/android_integration_test.py
+++ b/contrib/android/tests/python/pants_test/contrib/android/android_integration_test.py
@@ -9,7 +9,7 @@ import os
 
 from pants.java.distribution.distribution import Distribution, DistributionLocator
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class AndroidIntegrationTest(PantsRunIntegrationTest):
@@ -38,8 +38,8 @@ class AndroidIntegrationTest(PantsRunIntegrationTest):
     else:
       return False
     try:
-      with subsystem_instance(DistributionLocator) as locator:
-        locator.cached(minimum_version=cls.JAVA_MIN, maximum_version=cls.JAVA_MAX)
+      locator = global_subsystem_instance(DistributionLocator)
+      locator.cached(minimum_version=cls.JAVA_MIN, maximum_version=cls.JAVA_MAX)
     except Distribution.Error:
       return False
     return True

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_fetchers.py
@@ -5,23 +5,20 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from contextlib import contextmanager
-
 from pants_test import base_test
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 from pants.contrib.go.subsystems.fetcher_factory import FetcherFactory
 
 
 class FetchersTest(base_test.BaseTest):
-  @contextmanager
   def fetcher(self, import_path):
-    with subsystem_instance(FetcherFactory) as fetcher_factory:
-      yield fetcher_factory.get_fetcher(import_path)
+    fetcher_factory = global_subsystem_instance(FetcherFactory)
+    return fetcher_factory.get_fetcher(import_path)
 
   def check_default(self, import_path, expected_root):
-    with self.fetcher(import_path) as fetcher:
-      self.assertEqual(expected_root, fetcher.root())
+    fetcher = self.fetcher(import_path)
+    self.assertEqual(expected_root, fetcher.root())
 
   def test_default_bitbucket(self):
     self.check_default('bitbucket.org/rj/sqlite3-go',

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_distribution.py
@@ -7,36 +7,34 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import unittest
-from contextlib import contextmanager
 
 from pants.util.contextutil import environment_as
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 from pants.contrib.go.subsystems.go_distribution import GoDistribution
 
 
 class GoDistributionTest(unittest.TestCase):
 
-  @contextmanager
   def distribution(self):
-    with subsystem_instance(GoDistribution.Factory) as factory:
-      yield factory.create()
+    factory = global_subsystem_instance(GoDistribution.Factory)
+    return factory.create()
 
   def test_bootstrap(self):
-    with self.distribution() as go_distribution:
-      go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOROOT'])
-      output = go_cmd.check_output()
-      self.assertEqual(go_distribution.goroot, output.strip())
+    go_distribution = self.distribution()
+    go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOROOT'])
+    output = go_cmd.check_output()
+    self.assertEqual(go_distribution.goroot, output.strip())
 
   def assert_no_gopath(self):
-    with self.distribution() as go_distribution:
-      go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOPATH'])
+    go_distribution = self.distribution()
+    go_cmd = go_distribution.create_go_cmd(cmd='env', args=['GOPATH'])
 
-      self.assertEqual({'GOROOT': go_distribution.goroot, 'GOPATH': ''}, go_cmd.env)
-      self.assertEqual('go', os.path.basename(go_cmd.cmdline[0]))
-      self.assertEqual(['env', 'GOPATH'], go_cmd.cmdline[1:])
-      self.assertRegexpMatches(str(go_cmd), r'^GOROOT=[^ ]+ GOPATH= .*/go env GOPATH')
-      self.assertEqual('', go_cmd.check_output().strip())
+    self.assertEqual({'GOROOT': go_distribution.goroot, 'GOPATH': ''}, go_cmd.env)
+    self.assertEqual('go', os.path.basename(go_cmd.cmdline[0]))
+    self.assertEqual(['env', 'GOPATH'], go_cmd.cmdline[1:])
+    self.assertRegexpMatches(str(go_cmd), r'^GOROOT=[^ ]+ GOPATH= .*/go env GOPATH')
+    self.assertEqual('', go_cmd.check_output().strip())
 
   def test_go_command_no_gopath(self):
     self.assert_no_gopath()
@@ -49,11 +47,11 @@ class GoDistributionTest(unittest.TestCase):
       self.assert_no_gopath()
 
   def test_go_command_gopath(self):
-    with self.distribution() as go_distribution:
-      go_cmd = go_distribution.create_go_cmd(cmd='env', gopath='/tmp/fred', args=['GOROOT'])
+    go_distribution = self.distribution()
+    go_cmd = go_distribution.create_go_cmd(cmd='env', gopath='/tmp/fred', args=['GOROOT'])
 
-      self.assertEqual({'GOROOT': go_distribution.goroot,
-                        'GOPATH': '/tmp/fred'}, go_cmd.env)
-      self.assertEqual('go', os.path.basename(go_cmd.cmdline[0]))
-      self.assertEqual(['env', 'GOROOT'], go_cmd.cmdline[1:])
-      self.assertRegexpMatches(str(go_cmd), r'^GOROOT=[^ ]+ GOPATH=/tmp/fred .*/go env GOROOT$')
+    self.assertEqual({'GOROOT': go_distribution.goroot,
+                      'GOPATH': '/tmp/fred'}, go_cmd.env)
+    self.assertEqual('go', os.path.basename(go_cmd.cmdline[0]))
+    self.assertEqual(['env', 'GOROOT'], go_cmd.cmdline[1:])
+    self.assertRegexpMatches(str(go_cmd), r'^GOROOT=[^ ]+ GOPATH=/tmp/fred .*/go env GOROOT$')

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_compile_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_compile_integration.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 from pants_test.testutils.file_test_util import contains_exact_files
 
 from pants.contrib.go.subsystems.go_distribution import GoDistribution
@@ -22,16 +22,16 @@ class GoCompileIntegrationTest(PantsRunIntegrationTest):
               'contrib/go/examples/src/go/libA']
       pants_run = self.run_pants_with_workdir(args, workdir)
       self.assert_success(pants_run)
-      with subsystem_instance(GoDistribution.Factory) as factory:
-        go_dist = factory.create()
-        goos = go_dist.create_go_cmd('env', args=['GOOS']).check_output().strip()
-        goarch = go_dist.create_go_cmd('env', args=['GOARCH']).check_output().strip()
-        expected_files = set('contrib.go.examples.src.go.{libname}.{libname}/'
-                             'pkg/{goos}_{goarch}/{libname}.a'
-                             .format(libname=libname, goos=goos, goarch=goarch)
-                             for libname in ('libA', 'libB', 'libC', 'libD', 'libE'))
-        self.assertTrue(contains_exact_files(os.path.join(workdir, 'compile', 'go'),
-                                             expected_files, ignore_links=True))
+      factory = global_subsystem_instance(GoDistribution.Factory)
+      go_dist = factory.create()
+      goos = go_dist.create_go_cmd('env', args=['GOOS']).check_output().strip()
+      goarch = go_dist.create_go_cmd('env', args=['GOARCH']).check_output().strip()
+      expected_files = set('contrib.go.examples.src.go.{libname}.{libname}/'
+                           'pkg/{goos}_{goarch}/{libname}.a'
+                           .format(libname=libname, goos=goos, goarch=goarch)
+                           for libname in ('libA', 'libB', 'libC', 'libD', 'libE'))
+      self.assertTrue(contains_exact_files(os.path.join(workdir, 'compile', 'go'),
+                                           expected_files, ignore_links=True))
 
   def test_go_compile_cgo(self):
     args = ['compile', 'contrib/go/examples/src/go/cgo']

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_node_distribution.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_node_distribution.py
@@ -9,64 +9,57 @@ import json
 import os
 import subprocess
 import unittest
-from contextlib import contextmanager
 
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 from pants.contrib.node.subsystems.node_distribution import NodeDistribution
 
 
 class NodeDistributionTest(unittest.TestCase):
 
-  @contextmanager
-  def distribution(self):
-    with subsystem_instance(NodeDistribution.Factory) as factory:
-      yield factory.create()
+  def setUp(self):
+    self.distribution = global_subsystem_instance(NodeDistribution.Factory).create()
 
   def test_bootstrap(self):
-    with self.distribution() as node_distribution:
-      node_cmd = node_distribution.node_command(args=['--version'])
-      output = node_cmd.check_output()
-      self.assertEqual(node_distribution.version, output.strip())
+    node_cmd = self.distribution.node_command(args=['--version'])
+    output = node_cmd.check_output()
+    self.assertEqual(self.distribution.version, output.strip())
 
   def test_node(self):
-    with self.distribution() as node_distribution:
-      node_command = node_distribution.node_command(args=['--interactive'])  # Force a REPL session.
-      repl = node_command.run(stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    node_command = self.distribution.node_command(args=['--interactive'])  # Force a REPL session.
+    repl = node_command.run(stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-      out, err = repl.communicate('console.log("Hello World!")')
-      self.assertEqual('', err)
-      self.assertEqual(0, repl.returncode)
+    out, err = repl.communicate('console.log("Hello World!")')
+    self.assertEqual('', err)
+    self.assertEqual(0, repl.returncode)
 
-      for line in out.splitlines():
-        if line.endswith('Hello World!'):
-          break
-      else:
-        self.fail('Did not find the expected "Hello World!" in the REPL session '
-                  'output:\n{}'.format(out))
+    for line in out.splitlines():
+      if line.endswith('Hello World!'):
+        break
+    else:
+      self.fail('Did not find the expected "Hello World!" in the REPL session '
+                'output:\n{}'.format(out))
 
   def test_npm(self):
-    with self.distribution() as node_distribution:
-      npm_version_flag = node_distribution.npm_command(args=['--version'])
-      raw_version = npm_version_flag.check_output().strip()
+    npm_version_flag = self.distribution.npm_command(args=['--version'])
+    raw_version = npm_version_flag.check_output().strip()
 
-      npm_version_cmd = node_distribution.npm_command(args=['version', '--json'])
-      versions_json = npm_version_cmd.check_output()
-      versions = json.loads(versions_json)
+    npm_version_cmd = self.distribution.npm_command(args=['version', '--json'])
+    versions_json = npm_version_cmd.check_output()
+    versions = json.loads(versions_json)
 
-      self.assertEqual(raw_version, versions['npm'])
+    self.assertEqual(raw_version, versions['npm'])
 
   def test_bin_dir_on_path(self):
-    with self.distribution() as node_distribution:
-      node_cmd = node_distribution.node_command(args=['--eval', 'console.log(process.env["PATH"])'])
+    node_cmd = self.distribution.node_command(args=['--eval', 'console.log(process.env["PATH"])'])
 
-      # Test the case in which we do not pass in env,
-      # which should fall back to env=os.environ.copy()
-      output = node_cmd.check_output().strip()
-      self.assertEqual(node_cmd.bin_dir_path, output.split(os.pathsep)[0])
+    # Test the case in which we do not pass in env,
+    # which should fall back to env=os.environ.copy()
+    output = node_cmd.check_output().strip()
+    self.assertEqual(node_cmd.bin_dir_path, output.split(os.pathsep)[0])
 
-      output = node_cmd.check_output(env={'PATH': '/test/path'}).strip()
-      self.assertEqual(node_cmd.bin_dir_path + os.path.pathsep + '/test/path', output)
+    output = node_cmd.check_output(env={'PATH': '/test/path'}).strip()
+    self.assertEqual(node_cmd.bin_dir_path + os.path.pathsep + '/test/path', output)
 
-      output = node_cmd.check_output(env={'PATH': ''}).strip()
-      self.assertEqual(node_cmd.bin_dir_path, output)
+    output = node_cmd.check_output(env={'PATH': ''}).strip()
+    self.assertEqual(node_cmd.bin_dir_path, output)

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import inspect
 import logging
 from collections import Iterable, namedtuple
 

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -25,10 +25,6 @@ class BuildConfiguration(object):
 
   ParseState = namedtuple('ParseState', ['registered_addressable_instances', 'parse_globals'])
 
-  @staticmethod
-  def _is_subsystem_type(obj):
-    return inspect.isclass(obj) and issubclass(obj, Subsystem)
-
   def __init__(self):
     self._target_by_alias = {}
     self._target_macro_factory_by_alias = {}
@@ -117,7 +113,7 @@ class BuildConfiguration(object):
     """
     if not isinstance(subsystems, Iterable):
       raise TypeError('The subsystems must be an iterable, given {}'.format(subsystems))
-    invalid_subsystems = [s for s in subsystems if not self._is_subsystem_type(s)]
+    invalid_subsystems = [s for s in subsystems if not Subsystem.is_subsystem_type(s)]
     if invalid_subsystems:
       raise TypeError('The following items from the given subsystems are not Subsystem '
                       'subclasses:\n\t{}'.format('\n\t'.join(str(i) for i in invalid_subsystems)))

--- a/src/python/pants/java/distribution/distribution.py
+++ b/src/python/pants/java/distribution/distribution.py
@@ -474,7 +474,7 @@ class _Locator(object):
         return version_a
       return stricter(version_a, version_b)
 
-    # take the tighter constraint of method args and subsystem options
+    # Take the tighter constraint of method args and subsystem options.
     minimum_version = _get_stricter_version(minimum_version,
                                             self._minimum_version,
                                             "minimum_version",

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import inspect
+
 from twitter.common.collections import OrderedSet
 
 from pants.option.optionable import Optionable
@@ -53,6 +55,10 @@ class Subsystem(SubsystemClientMixin, Optionable):
       message = 'Cycle detected:\n\t{}'.format(' ->\n\t'.join(
           '{} scope: {}'.format(subsystem, subsystem.options_scope) for subsystem in cycle))
       super(Subsystem.CycleException, self).__init__(message)
+
+  @classmethod
+  def is_subsystem_type(cls, obj):
+    return inspect.isclass(obj) and issubclass(obj, cls)
 
   @classmethod
   def scoped(cls, optionable):

--- a/tests/python/pants_test/backend/jvm/subsystems/BUILD
+++ b/tests/python/pants_test/backend/jvm/subsystems/BUILD
@@ -44,6 +44,7 @@ python_tests(
   sources=['test_shader_integration.py'],
   dependencies=[
     'src/python/pants/fs',
+    'src/python/pants/java/distribution',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test:int-test',
@@ -58,8 +59,10 @@ python_tests(
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',
+    'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'tests/python/pants_test:base_test',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )

--- a/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_custom_scala.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -14,7 +13,7 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.scalastyle import Scalastyle
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class CustomScalaTest(NailgunTaskTestBase):
@@ -60,40 +59,55 @@ class CustomScalaTest(NailgunTaskTestBase):
         </scalastyle>
       """.format(rule_section_xml=rule_section_xml)))
 
-  @contextmanager
   def scala_platform_setup(self):
     options = {
-      'scala-platform': {
+      ScalaPlatform.options_scope: {
         'version': 'custom',
         'suffix_version': '2.10',
       }
     }
-    with subsystem_instance(ScalaPlatform, **options):
-      self.make_target('//:scalastyle',
-                       JarLibrary,
-                       jars=[JarDependency('org.scalastyle', 'scalastyle_2.10', '0.3.2')]
-      )
+    init_subsystem(ScalaPlatform, options)
 
-      self.make_target('//:scala-repl',
-                 JarLibrary,
-                 jars=[
-                   JarDependency(org = 'org.scala-lang',
-                                 name = 'jline',
-                                 rev = '2.10.5'),
-                   JarDependency(org = 'org.scala-lang',
-                                 name = 'scala-compiler',
-                                 rev = '2.10.5')])
+    self.make_target('//:scalastyle',
+                     JarLibrary,
+                     jars=[JarDependency('org.scalastyle', 'scalastyle_2.10', '0.3.2')]
+    )
 
-      self.make_target('//:scalac',
-                       JarLibrary,
-                       jars=[JarDependency('org.scala-lang', 'scala-compiler', '2.10.5')])
-      yield
+    self.make_target('//:scala-repl',
+               JarLibrary,
+               jars=[
+                 JarDependency(org = 'org.scala-lang',
+                               name = 'jline',
+                               rev = '2.10.5'),
+                 JarDependency(org = 'org.scala-lang',
+                               name = 'scala-compiler',
+                               rev = '2.10.5')])
+
+    self.make_target('//:scalac',
+                     JarLibrary,
+                     jars=[JarDependency('org.scala-lang', 'scala-compiler', '2.10.5')])
 
   def test_custom_lib_spec(self):
-    with self.scala_platform_setup():
-      self.make_target('//:scala-library',
-                       JarLibrary,
-                       jars=[JarDependency('org.scala-lang', 'scala-library', '2.10.5')])
+    self.scala_platform_setup()
+    self.make_target('//:scala-library',
+                     JarLibrary,
+                     jars=[JarDependency('org.scala-lang', 'scala-library', '2.10.5')])
+    scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
+
+    context = self._create_context(
+        scalastyle_config=self._create_scalastyle_config_file(),
+        target_roots=[scala_target]
+    )
+
+    self.execute(context)
+
+  def test_no_custom_target(self):
+    with self.assertRaises(ValueError):
+      # This should raise:
+      # ValueError: Tests must make targets for traversable dependency specs
+      # ahead of them being traversed, ScalaLibrary(a/scala:pass) tried to traverse
+      # //:scala-library-custom which does not exist.
+      self.scala_platform_setup()
       scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
 
       context = self._create_context(
@@ -102,19 +116,3 @@ class CustomScalaTest(NailgunTaskTestBase):
       )
 
       self.execute(context)
-
-  def test_no_custom_target(self):
-    with self.assertRaises(ValueError):
-      # This should raise:
-      # ValueError: Tests must make targets for traversable dependency specs
-      # ahead of them being traversed, ScalaLibrary(a/scala:pass) tried to traverse
-      # //:scala-library-custom which does not exist.
-      with self.scala_platform_setup():
-        scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
-
-        context = self._create_context(
-            scalastyle_config=self._create_scalastyle_config_file(),
-            target_roots=[scala_target]
-        )
-
-        self.execute(context)

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
@@ -6,104 +6,104 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import unittest
-from contextlib import contextmanager
 
 from pants.backend.jvm.jar_dependency_utils import M2Coordinate
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
                                                                     PinnedJarArtifactSet)
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants.subsystem.subsystem import Subsystem
+from pants_test.base_test import BaseTest
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
-class JarDependencyManagementTest(unittest.TestCase):
+class JarDependencyManagementTest(BaseTest):
 
   _coord_any = M2Coordinate('foobar', 'foobar')
   _coord_one = M2Coordinate('foobar', 'foobar', '1.1')
   _coord_two = M2Coordinate('foobar', 'foobar', '1.2')
 
-  @contextmanager
   def _jar_dependency_management(self, **flags):
+    Subsystem.reset()
     options = {
-      'jar-dependency-management': flags,
+      JarDependencyManagement.options_scope: flags,
     }
-    with subsystem_instance(JarDependencyManagement, **options) as manager:
-      yield manager
+    return global_subsystem_instance(JarDependencyManagement, options=options)
 
   def test_conflict_strategy_short_circuits(self):
-    with self._jar_dependency_management(conflict_strategy='FAIL') as manager:
-      manager.resolve_version_conflict(
-        direct_coord=self._coord_any,
-        managed_coord=self._coord_one,
-      )
-      manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_one,
-      )
+    manager = self._jar_dependency_management(conflict_strategy='FAIL')
+    manager.resolve_version_conflict(
+      direct_coord=self._coord_any,
+      managed_coord=self._coord_one,
+    )
+    manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_one,
+    )
 
   def test_conflict_strategy_fail(self):
-    with self._jar_dependency_management(conflict_strategy='FAIL') as manager:
-      with self.assertRaises(JarDependencyManagement.DirectManagedVersionConflict):
-        manager.resolve_version_conflict(
-          direct_coord=self._coord_one,
-          managed_coord=self._coord_two,
-        )
+    manager = self._jar_dependency_management(conflict_strategy='FAIL')
+    with self.assertRaises(JarDependencyManagement.DirectManagedVersionConflict):
+      manager.resolve_version_conflict(
+        direct_coord=self._coord_one,
+        managed_coord=self._coord_two,
+      )
 
   def test_conflict_strategy_use_direct(self):
-    with self._jar_dependency_management(conflict_strategy='USE_DIRECT') as manager:
-      self.assertEquals(self._coord_one, manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_two,
-      ))
-    with self._jar_dependency_management(conflict_strategy='USE_DIRECT',
-                                     suppress_conflict_messages=True) as manager:
-      self.assertEquals(self._coord_one, manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_two,
-      ))
+    manager = self._jar_dependency_management(conflict_strategy='USE_DIRECT')
+    self.assertEquals(self._coord_one, manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_two,
+    ))
+    manager = self._jar_dependency_management(conflict_strategy='USE_DIRECT',
+                                              suppress_conflict_messages=True)
+    self.assertEquals(self._coord_one, manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_two,
+    ))
 
   def test_conflict_strategy_use_managed(self):
-    with self._jar_dependency_management(conflict_strategy='USE_MANAGED') as manager:
-      self.assertEquals(self._coord_two, manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_two,
-      ))
-    with self._jar_dependency_management(conflict_strategy='USE_MANAGED',
-                                     suppress_conflict_messages=True) as manager:
-      self.assertEquals(self._coord_two, manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_two,
-      ))
+    manager = self._jar_dependency_management(conflict_strategy='USE_MANAGED')
+    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_two,
+    ))
+    manager = self._jar_dependency_management(conflict_strategy='USE_MANAGED',
+                                              suppress_conflict_messages=True)
+    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_two,
+    ))
 
   def test_conflict_strategy_use_forced(self):
-    with self._jar_dependency_management(conflict_strategy='USE_DIRECT_IF_FORCED') as manager:
-      self.assertEquals(self._coord_two, manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_two,
-      ))
-      self.assertEquals(self._coord_one, manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_two,
-        force=True,
-      ))
+    manager = self._jar_dependency_management(conflict_strategy='USE_DIRECT_IF_FORCED')
+    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_two,
+    ))
+    self.assertEquals(self._coord_one, manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_two,
+      force=True,
+    ))
 
   def test_conflict_strategy_use_newer(self):
-    with self._jar_dependency_management(conflict_strategy='USE_NEWER') as manager:
-      self.assertEquals(self._coord_two, manager.resolve_version_conflict(
-        direct_coord=self._coord_one,
-        managed_coord=self._coord_two,
-      ))
-      self.assertEquals(self._coord_two, manager.resolve_version_conflict(
-        direct_coord=self._coord_two,
-        managed_coord=self._coord_one,
-      ))
+    manager = self._jar_dependency_management(conflict_strategy='USE_NEWER')
+    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+      direct_coord=self._coord_one,
+      managed_coord=self._coord_two,
+    ))
+    self.assertEquals(self._coord_two, manager.resolve_version_conflict(
+      direct_coord=self._coord_two,
+      managed_coord=self._coord_one,
+    ))
 
   def test_conflict_resolution_input_validation(self):
-    with self._jar_dependency_management() as manager:
-      with self.assertRaises(ValueError):
-        manager.resolve_version_conflict(M2Coordinate('org', 'foo', '1.2'),
-                                         M2Coordinate('com', 'bar', '7.8'))
-      with self.assertRaises(ValueError):
-        manager.resolve_version_conflict(M2Coordinate('org', 'foo', '1.2'),
-                                         M2Coordinate('com', 'bar', '1.2'))
+    manager = self._jar_dependency_management()
+    with self.assertRaises(ValueError):
+      manager.resolve_version_conflict(M2Coordinate('org', 'foo', '1.2'),
+                                       M2Coordinate('com', 'bar', '7.8'))
+    with self.assertRaises(ValueError):
+      manager.resolve_version_conflict(M2Coordinate('org', 'foo', '1.2'),
+                                       M2Coordinate('com', 'bar', '1.2'))
 
 
 class PinnedJarArtifactSetTest(unittest.TestCase):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_jar_dependency_management.py
@@ -22,6 +22,7 @@ class JarDependencyManagementTest(BaseTest):
   _coord_two = M2Coordinate('foobar', 'foobar', '1.2')
 
   def _jar_dependency_management(self, **flags):
+    # Need to reset, because we can get called multiple times in a single test.
     Subsystem.reset()
     options = {
       JarDependencyManagement.options_scope: flags,

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
@@ -14,15 +14,15 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_delete
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class ShaderTest(unittest.TestCase):
   def setUp(self):
     self.jarjar = '/not/really/jarjar.jar'
-    with subsystem_instance(DistributionLocator):
-      executor = SubprocessExecutor(DistributionLocator.cached())
-      self.shader = Shader(jarjar_classpath=[self.jarjar], executor=executor)
+    init_subsystem(DistributionLocator)
+    executor = SubprocessExecutor(DistributionLocator.cached())
+    self.shader = Shader(jarjar_classpath=[self.jarjar], executor=executor)
     self.output_jar = '/not/really/shaded.jar'
 
   def populate_input_jar(self, *entries):

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader_integration.py
@@ -14,11 +14,10 @@ from pants.fs.archive import ZIP
 from pants.java.distribution.distribution import DistributionLocator
 from pants.util.contextutil import temporary_dir
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class ShaderIntegrationTest(PantsRunIntegrationTest):
-
   def test_shader_project(self):
     """Test that the binary target at the ``shading_project`` can be built and run.
 
@@ -48,12 +47,12 @@ class ShaderIntegrationTest(PantsRunIntegrationTest):
     }
 
     path = os.path.join('dist', 'shading.jar')
-    with subsystem_instance(DistributionLocator):
-      execute_java = DistributionLocator.cached(minimum_version='1.6').execute_java
-      self.assertEquals(0, execute_java(classpath=[path],
-                                        main='org.pantsbuild.testproject.shading.Main'))
-      self.assertEquals(0, execute_java(classpath=[path],
-                                        main='org.pantsbuild.testproject.foo.bar.MyNameIsDifferentNow'))
+    init_subsystem(DistributionLocator)
+    execute_java = DistributionLocator.cached(minimum_version='1.6').execute_java
+    self.assertEquals(0, execute_java(classpath=[path],
+                                      main='org.pantsbuild.testproject.shading.Main'))
+    self.assertEquals(0, execute_java(classpath=[path],
+                                      main='org.pantsbuild.testproject.foo.bar.MyNameIsDifferentNow'))
 
     received_classes = set()
     with temporary_dir() as tempdir:

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/BUILD
@@ -68,6 +68,7 @@ python_tests(
   dependencies=[
     'src/python/pants/backend/jvm/tasks/jvm_compile:zinc',
     'src/python/pants/fs',
+    'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:base_test',

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_settings_partitioning.py
@@ -13,10 +13,11 @@ from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import ZincCompile
 from pants.base.revision import Revision
 from pants.java.distribution.distribution import DistributionLocator
+from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method
 from pants.util.osutil import get_os_name, normalize_os_name
 from pants_test.java.distribution.test_distribution import EXE, distribution
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
@@ -165,12 +166,12 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
                         JvmPlatformSettings('1.6', '1.6', ['-Xfoo:bar']))
 
   def test_java_home_extraction(self):
-    with subsystem_instance(DistributionLocator):
-      _, source, _, target, foo, bar, composite, single = tuple(ZincCompile._get_zinc_arguments(
-        JvmPlatformSettings('1.7', '1.7', [
-          'foo', 'bar', 'foo:$JAVA_HOME/bar:$JAVA_HOME/foobar', '$JAVA_HOME',
-        ])
-      ))
+    init_subsystem(DistributionLocator)
+    _, source, _, target, foo, bar, composite, single = tuple(ZincCompile._get_zinc_arguments(
+      JvmPlatformSettings('1.7', '1.7', [
+        'foo', 'bar', 'foo:$JAVA_HOME/bar:$JAVA_HOME/foobar', '$JAVA_HOME',
+      ])
+    ))
 
     self.assertEquals('-C1.7', source)
     self.assertEquals('-C1.7', target)
@@ -218,14 +219,15 @@ class JavaCompileSettingsPartitioningTest(TaskTestBase):
       """
       with fake_distributions(versions) as paths:
         path_options = {
-          'jvm-distributions': {
+          DistributionLocator.options_scope: {
             'paths': {
               os_name: paths,
             }
           }
         }
-        with subsystem_instance(DistributionLocator, **path_options):
-          yield paths
+        Subsystem.reset()
+        init_subsystem(DistributionLocator, options=path_options)
+        yield paths
 
     # Completely missing a usable distribution.
     with fake_distribution_locator(far_future_version):

--- a/tests/python/pants_test/backend/jvm/tasks/missing_jvm_check.py
+++ b/tests/python/pants_test/backend/jvm/tasks/missing_jvm_check.py
@@ -6,13 +6,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.java.distribution.distribution import DistributionLocator
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 def is_missing_jvm(version):
-  with subsystem_instance(DistributionLocator):
-    try:
-      DistributionLocator.cached(minimum_version=version, maximum_version='{}.9999'.format(version))
-      return False
-    except DistributionLocator.Error:
-      return True
+  init_subsystem(DistributionLocator)
+  try:
+    DistributionLocator.cached(minimum_version=version, maximum_version='{}.9999'.format(version))
+    return False
+  except DistributionLocator.Error:
+    return True

--- a/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bootstrap_jvm_tools.py
@@ -19,20 +19,20 @@ from pants.java.executor import SubprocessExecutor
 from pants.task.task import Task
 from pants.util.contextutil import open_zip
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class BootstrapJvmToolsTestBase(JvmToolTaskTestBase):
   @contextmanager
   def execute_tool(self, classpath, main, args=None):
-    with subsystem_instance(DistributionLocator):
-      executor = SubprocessExecutor(DistributionLocator.cached())
-      process = executor.spawn(classpath, main, args=args,
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-      out, err = process.communicate()
-      self.assertEqual(0, process.returncode)
-      self.assertEqual('', err.strip())
-      yield out
+    init_subsystem(DistributionLocator)
+    executor = SubprocessExecutor(DistributionLocator.cached())
+    process = executor.spawn(classpath, main, args=args,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = process.communicate()
+    self.assertEqual(0, process.returncode)
+    self.assertEqual('', err.strip())
+    yield out
 
 
 class BootstrapJvmToolsShadingTest(BootstrapJvmToolsTestBase):

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_resolve.py
@@ -26,7 +26,7 @@ from pants.task.task import Task
 from pants.util.contextutil import temporary_dir, temporary_file_path
 from pants.util.dirutil import safe_delete
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.tasks.task_test_base import TaskTestBase, ensure_cached
 
 
@@ -488,11 +488,9 @@ class IvyResolveFingerprintStrategyTest(TaskTestBase):
 
   def setUp(self):
     super(IvyResolveFingerprintStrategyTest, self).setUp()
-    self._subsystem_scope = subsystem_instance(JarDependencyManagement)
-    self._subsystem_scope.__enter__()
+    init_subsystem(JarDependencyManagement)
 
   def tearDown(self):
-    self._subsystem_scope.__exit__(None, None, None)
     super(IvyResolveFingerprintStrategyTest, self).tearDown()
 
   def set_artifact_set_for(self, managed_jar_target, artifact_set):

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -26,7 +26,7 @@ from pants.build_graph.register import build_file_aliases as register_core
 from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.util.contextutil import temporary_dir, temporary_file, temporary_file_path
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 def coord(org, name, classifier=None, rev=None, ext=None):
@@ -147,8 +147,8 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
   def test_force_override(self):
     jars = list(self.a.payload.jars)
     with temporary_file_path() as ivyxml:
-      with subsystem_instance(JarDependencyManagement):
-        IvyUtils.generate_ivy([self.a], jars=jars, excludes=[], ivyxml=ivyxml, confs=['default'])
+      init_subsystem(JarDependencyManagement)
+      IvyUtils.generate_ivy([self.a], jars=jars, excludes=[], ivyxml=ivyxml, confs=['default'])
 
       doc = ET.parse(ivyxml).getroot()
 
@@ -400,9 +400,6 @@ class IvyUtilsGenerateIvyTest(IvyUtilsTestBase):
     self.set_options_for_scope(IvySubsystem.options_scope,
                                cache_dir='DOES_NOT_EXIST',
                                use_nailgun=False)
-
-    # Hack to initialize Ivy subsystem
-    self.context()
 
     with self.assertRaises(IvyUtils.IvyResolveReportError):
       IvyUtils.parse_xml_report('default', IvyUtils.xml_report_path('INVALID_CACHE_DIR',

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_dependency_management_setup.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from contextlib import contextmanager
-
 from pants.backend.jvm.jar_dependency_utils import M2Coordinate
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
                                                                     JarDependencyManagementSetup)
@@ -17,7 +15,7 @@ from pants.backend.jvm.targets.managed_jar_dependencies import (ManagedJarDepend
 from pants.backend.jvm.targets.unpacked_jars import UnpackedJars
 from pants.build_graph.target import Target
 from pants_test.backend.jvm.tasks.jvm_binary_task_test_base import JvmBinaryTaskTestBase
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
@@ -26,11 +24,9 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
   def task_type(cls):
     return JarDependencyManagementSetup
 
-  @contextmanager
-  def _subsystem(self, **options):
-    scoped_options = {'jar-dependency-management': options}
-    with subsystem_instance(JarDependencyManagement, **scoped_options) as manager:
-      yield manager
+  def _init_manager(self, **jar_dependency_management_options):
+    options = {JarDependencyManagement.options_scope: jar_dependency_management_options}
+    return global_subsystem_instance(JarDependencyManagement, options=options)
 
   def _single_artifact_set(self, manager, targets):
     sets = manager.targets_by_artifact_set(targets)
@@ -52,12 +48,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                      JarDependency(org='foobar', name='foobar'),
                                    ])
     context = self.context(target_roots=[default_target, jar_library])
-    with self._subsystem(default_target='//foo:management') as manager:
-      task = self.create_task(context)
-      task.execute()
-      artifact_set = manager.for_target(jar_library)
-      self.assertFalse(artifact_set is None)
-      self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    manager = self._init_manager(default_target='//foo:management')
+    task = self.create_task(context)
+    task.execute()
+    artifact_set = manager.for_target(jar_library)
+    self.assertFalse(artifact_set is None)
+    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_bad_default(self):
     jar_library = self.make_target(spec='//foo:library',
@@ -66,10 +62,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                      JarDependency(org='foobar', name='foobar'),
                                    ])
     context = self.context(target_roots=[jar_library])
-    with self._subsystem(default_target='//foo:nonexistant'):
-      task = self.create_task(context)
-      with self.assertRaises(JarDependencyManagementSetup.InvalidDefaultTarget):
-        task.execute()
+    self._init_manager(default_target='//foo:nonexistant')
+    task = self.create_task(context)
+    with self.assertRaises(JarDependencyManagementSetup.InvalidDefaultTarget):
+      task.execute()
 
   def test_no_default_target(self):
     # Loading this into the context just to make sure it isn't erroneously used.
@@ -84,11 +80,11 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                      JarDependency(org='foobar', name='foobar'),
                                    ])
     context = self.context(target_roots=[management_target, jar_library])
-    with self._subsystem() as manager:
-      task = self.create_task(context)
-      task.execute()
-      artifact_set = manager.for_target(jar_library)
-      self.assertTrue(artifact_set is None)
+    manager = self._init_manager()
+    task = self.create_task(context)
+    task.execute()
+    artifact_set = manager.for_target(jar_library)
+    self.assertTrue(artifact_set is None)
 
   def test_explicit_target(self):
     management_target = self.make_target(spec='//foo:management',
@@ -103,12 +99,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                    ],
                                    managed_dependencies='//foo:management')
     context = self.context(target_roots=[management_target, jar_library])
-    with self._subsystem() as manager:
-      task = self.create_task(context)
-      task.execute()
-      artifact_set = manager.for_target(jar_library)
-      self.assertFalse(artifact_set is None)
-      self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    manager = self._init_manager()
+    task = self.create_task(context)
+    task.execute()
+    artifact_set = manager.for_target(jar_library)
+    self.assertFalse(artifact_set is None)
+    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_explicit_and_default_target(self):
     default_target = self.make_target(spec='//foo:foobar',
@@ -128,12 +124,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                    ],
                                    managed_dependencies='//foo:management')
     context = self.context(target_roots=[default_target, management_target, jar_library])
-    with self._subsystem(default_target='//foo:management') as manager:
-      task = self.create_task(context)
-      task.execute()
-      artifact_set = manager.for_target(jar_library)
-      self.assertFalse(artifact_set is None)
-      self.assertEquals('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    manager = self._init_manager(default_target='//foo:management')
+    task = self.create_task(context)
+    task.execute()
+    artifact_set = manager.for_target(jar_library)
+    self.assertFalse(artifact_set is None)
+    self.assertEquals('3', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_using_jar_library_address(self):
     pin_jar_library = self.make_target(
@@ -155,12 +151,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                    ],
                                    managed_dependencies='//foo:management')
     context = self.context(target_roots=[management_target, jar_library, pin_jar_library])
-    with self._subsystem() as manager:
-      task = self.create_task(context)
-      task.execute()
-      artifact_set = manager.for_target(jar_library)
-      self.assertFalse(artifact_set is None)
-      self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    manager = self._init_manager()
+    task = self.create_task(context)
+    task.execute()
+    artifact_set = manager.for_target(jar_library)
+    self.assertFalse(artifact_set is None)
+    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_duplicate_coord_error(self):
     management_target = self.make_target(spec='//foo:management',
@@ -170,10 +166,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                            JarDependency(org='foobar', name='foobar', rev='3'),
                                          ])
     context = self.context(target_roots=[management_target])
-    with self._subsystem():
-      task = self.create_task(context)
-      with self.assertRaises(JarDependencyManagementSetup.DuplicateCoordinateError):
-        task.execute()
+    self._init_manager()
+    task = self.create_task(context)
+    with self.assertRaises(JarDependencyManagementSetup.DuplicateCoordinateError):
+      task.execute()
 
   def test_missing_version_error(self):
     management_target = self.make_target(spec='//foo:management',
@@ -182,10 +178,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                            JarDependency(org='foobar', name='foobar'),
                                          ])
     context = self.context(target_roots=[management_target])
-    with self._subsystem():
-      task = self.create_task(context)
-      with self.assertRaises(JarDependencyManagementSetup.MissingVersion):
-        task.execute()
+    self._init_manager()
+    task = self.create_task(context)
+    with self.assertRaises(JarDependencyManagementSetup.MissingVersion):
+      task.execute()
 
   def test_duplicate_coord_error_jar(self):
     jar_library = self.make_target(spec='//foo:library',
@@ -200,10 +196,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                            '//foo:library',
                                          ])
     context = self.context(target_roots=[jar_library, management_target])
-    with self._subsystem():
-      task = self.create_task(context)
-      with self.assertRaises(JarDependencyManagementSetup.DuplicateCoordinateError):
-        task.execute()
+    self._init_manager()
+    task = self.create_task(context)
+    with self.assertRaises(JarDependencyManagementSetup.DuplicateCoordinateError):
+      task.execute()
 
   def test_missing_version_error_jar(self):
     jar_library = self.make_target(spec='//foo:library',
@@ -218,10 +214,10 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                            '//foo:library',
                                          ])
     context = self.context(target_roots=[jar_library, management_target])
-    with self._subsystem():
-      task = self.create_task(context)
-      with self.assertRaises(JarDependencyManagementSetup.MissingVersion):
-        task.execute()
+    self._init_manager()
+    task = self.create_task(context)
+    with self.assertRaises(JarDependencyManagementSetup.MissingVersion):
+      task.execute()
 
   def test_heterogenous_for_targets(self):
     default_target = self.make_target(spec='//foo:management',
@@ -246,13 +242,13 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
                                        ])
     context = self.context(target_roots=[default_target, jar_library1, jar_library2,
                                          unpacked_target])
-    with self._subsystem(default_target='//foo:management') as manager:
-      task = self.create_task(context)
-      task.execute()
-      artifact_set = self._single_artifact_set(manager, [jar_library1, jar_library2,
-                                                         unpacked_target])
-      self.assertFalse(artifact_set is None)
-      self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    manager = self._init_manager(default_target='//foo:management')
+    task = self.create_task(context)
+    task.execute()
+    artifact_set = self._single_artifact_set(manager, [jar_library1, jar_library2,
+                                                       unpacked_target])
+    self.assertFalse(artifact_set is None)
+    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_indirection(self):
     management_target = self.make_target(
@@ -277,12 +273,12 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
       ],
     )
     context = self.context(target_roots=[default_target, jar_library1, management_target])
-    with self._subsystem(default_target='//foo:management') as manager:
-      task = self.create_task(context)
-      task.execute()
-      artifact_set = self._single_artifact_set(manager, [jar_library1])
-      self.assertFalse(artifact_set is None)
-      self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
+    manager = self._init_manager(default_target='//foo:management')
+    task = self.create_task(context)
+    task.execute()
+    artifact_set = self._single_artifact_set(manager, [jar_library1])
+    self.assertFalse(artifact_set is None)
+    self.assertEquals('2', artifact_set[M2Coordinate('foobar', 'foobar')].rev)
 
   def test_invalid_managed_jar_libraries(self):
     target_aliases = {
@@ -344,9 +340,9 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
       self.assertEquals('4', artifact_set[M2Coordinate('fruit', 'apple')].rev)
       self.assertEquals('7', artifact_set[M2Coordinate('foobar', 'foobar', ext='tar')].rev)
 
-    with self._subsystem(default_target='//foo:management') as manager:
-      with self.assertRaises(JarDependencyManagementSetup.IllegalVersionOverride):
-        check_task_execution(manager)
+    manager = self._init_manager(default_target='//foo:management')
+    with self.assertRaises(JarDependencyManagementSetup.IllegalVersionOverride):
+      check_task_execution(manager)
 
   def test_double_dependency_override(self):
     management_target = self.make_target(
@@ -404,6 +400,6 @@ class TestJarDependencyManagementSetup(JvmBinaryTaskTestBase):
       self.assertEquals('4', artifact_set[M2Coordinate('fruit', 'apple')].rev)
       self.assertEquals('7', artifact_set[M2Coordinate('foobar', 'foobar', ext='tar')].rev)
 
-    with self._subsystem(default_target='//foo:management') as manager:
-      with self.assertRaises(JarDependencyManagementSetup.IllegalVersionOverride):
-        check_task_execution(manager)
+    manager = self._init_manager(default_target='//foo:management')
+    with self.assertRaises(JarDependencyManagementSetup.IllegalVersionOverride):
+      check_task_execution(manager)

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run.py
@@ -25,7 +25,7 @@ from pants.util.contextutil import environment_as
 from pants.util.dirutil import safe_file_dump
 from pants.util.timeout import TimeoutReached
 from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class JUnitRunnerTest(JvmToolTaskTestBase):
@@ -156,12 +156,12 @@ class JUnitRunnerTest(JvmToolTaskTestBase):
 
     # Invoke ivy to resolve classpath for junit.
     classpath_file_abs_path = os.path.join(test_abs_path, 'junit.classpath')
-    with subsystem_instance(IvySubsystem) as ivy_subsystem:
-      distribution = DistributionLocator.cached(jdk=True)
-      ivy = Bootstrapper(ivy_subsystem=ivy_subsystem).ivy()
-      ivy.execute(args=['-cachepath', classpath_file_abs_path,
-                        '-dependency', 'junit', 'junit-dep', '4.10'],
-                  executor=SubprocessExecutor(distribution=distribution))
+    ivy_subsystem = global_subsystem_instance(IvySubsystem)
+    distribution = DistributionLocator.cached(jdk=True)
+    ivy = Bootstrapper(ivy_subsystem=ivy_subsystem).ivy()
+    ivy.execute(args=['-cachepath', classpath_file_abs_path,
+                      '-dependency', 'junit', 'junit-dep', '4.10'],
+                executor=SubprocessExecutor(distribution=distribution))
 
     with open(classpath_file_abs_path) as fp:
       classpath = fp.read()

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalastyle.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -17,7 +16,7 @@ from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.scalastyle import FileExcluder, Scalastyle
 from pants.base.exceptions import TaskError
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.tasks.task_test_base import ensure_cached
 
 
@@ -67,23 +66,25 @@ class ScalastyleTest(NailgunTaskTestBase):
 
   def setUp(self):
     super(ScalastyleTest, self).setUp()
-    self.context()  # We don't need the context, but this ensures subsystem option registration.
+    # Default scalastyle config (import grouping rule) and no excludes.
+    init_subsystem(ScalaPlatform, {
+      ScalaPlatform.options_scope: {
+        'version': '2.10'
+      }
+    })
 
   def test_initialize_config_no_config_settings(self):
-    with self.scala_platform_setup():
-      with self.assertRaises(Scalastyle.UnspecifiedConfig):
-        self._create_scalastyle_task(scalastyle_config=None).validate_scalastyle_config()
+    with self.assertRaises(Scalastyle.UnspecifiedConfig):
+      self._create_scalastyle_task(scalastyle_config=None).validate_scalastyle_config()
 
   def test_initialize_config_config_setting_exist_but_invalid(self):
-    with self.scala_platform_setup():
-      with self.assertRaises(Scalastyle.MissingConfig):
-        self._create_scalastyle_task(
-          scalastyle_config='file_does_not_exist.xml').validate_scalastyle_config()
+    with self.assertRaises(Scalastyle.MissingConfig):
+      self._create_scalastyle_task(
+        scalastyle_config='file_does_not_exist.xml').validate_scalastyle_config()
 
   def test_excludes_setting_exists_but_invalid(self):
-    with self.scala_platform_setup():
-      with self.assertRaises(TaskError):
-        FileExcluder('file_does_not_exist.txt', logger)
+    with self.assertRaises(TaskError):
+      FileExcluder('file_does_not_exist.txt', logger)
 
   def test_excludes_parsed_loaded_correctly(self):
     excludes_text = dedent('''
@@ -98,151 +99,143 @@ class ScalastyleTest(NailgunTaskTestBase):
     self.assertFalse(excluder.should_include('com/some/org/y.cpp'))
     self.assertFalse(excluder.should_include('z.py'))
 
-  @contextmanager
-  def scala_platform_setup(self):
-    with subsystem_instance(ScalaPlatform):
-      self.set_options_for_scope(ScalaPlatform.options_scope, version='2.10')
-
-      yield
-
-  @contextmanager
   def custom_scala_platform_setup(self):
-    with subsystem_instance(ScalaPlatform):
-      # We don't need to specify :scalac or :scala-repl since they are never being fetched.
-      self.make_target('//:scalastyle',
-                       JarLibrary,
-                       jars=[JarDependency('org.scalastyle', 'scalastyle_2.10', '0.3.2')],
-      )
-      self.set_options_for_scope(ScalaPlatform.options_scope, version='custom')
+    # We don't need to specify :scalac or :scala-repl since they are never being fetched.
+    self.make_target('//:scala-library',
+                     JarLibrary,
+                     jars=[JarDependency('org.scala-lang', 'scala-library', '2.10')],
+    )
+    self.make_target('//:scalastyle',
+                     JarLibrary,
+                     jars=[JarDependency('org.scalastyle', 'scalastyle_2.10', '0.3.2')],
+    )
 
-      yield
+    init_subsystem(ScalaPlatform, {
+      ScalaPlatform.options_scope: {
+        'version': 'custom'
+      }
+    })
 
   def test_get_non_synthetic_scala_targets(self):
-    with self.scala_platform_setup():
-      # scala_library - should remain.
-      scala_target = self.make_target('a/scala:s', ScalaLibrary, sources=['Source.scala'])
+    # scala_library - should remain.
+    scala_target = self.make_target('a/scala:s', ScalaLibrary, sources=['Source.scala'])
 
-      # scala_library but with java sources - should be filtered
-      scala_target_with_java_source = self.make_target('a/scala_java:sj',
-                                                       ScalaLibrary,
-                                                       sources=['Source.java'])
+    # scala_library but with java sources - should be filtered
+    scala_target_with_java_source = self.make_target('a/scala_java:sj',
+                                                     ScalaLibrary,
+                                                     sources=['Source.java'])
 
-      # java_library - should be filtered
-      java_target = self.make_target('a/java:j', JavaLibrary, sources=['Source.java'])
+    # java_library - should be filtered
+    java_target = self.make_target('a/java:j', JavaLibrary, sources=['Source.java'])
 
-      # synthetic scala_library - should be filtered
-      synthetic_scala_target = self.make_target('a/synthetic_scala:ss',
-                                                ScalaLibrary,
-                                                sources=['SourceGenerated.scala'],
-                                                derived_from=scala_target)
+    # synthetic scala_library - should be filtered
+    synthetic_scala_target = self.make_target('a/synthetic_scala:ss',
+                                              ScalaLibrary,
+                                              sources=['SourceGenerated.scala'],
+                                              derived_from=scala_target)
 
-      result_targets = Scalastyle.get_non_synthetic_scala_targets([java_target,
-                                                                   scala_target,
-                                                                   scala_target_with_java_source,
-                                                                   synthetic_scala_target])
+    result_targets = Scalastyle.get_non_synthetic_scala_targets([java_target,
+                                                                 scala_target,
+                                                                 scala_target_with_java_source,
+                                                                 synthetic_scala_target])
 
-      # Only the scala target should remain
-      self.assertEquals(1, len(result_targets))
-      self.assertEqual(scala_target, result_targets[0])
+    # Only the scala target should remain
+    self.assertEquals(1, len(result_targets))
+    self.assertEqual(scala_target, result_targets[0])
 
   def test_get_non_excluded_scala_sources(self):
-    with self.scala_platform_setup():
-      # this scala target has mixed *.scala and *.java sources.
-      # the *.java source should be filtered out.
-      scala_target_1 = self.make_target('a/scala_1:s1',
-                                        ScalaLibrary,
-                                        sources=['Source1.java', 'Source1.scala'])
+    # this scala target has mixed *.scala and *.java sources.
+    # the *.java source should be filtered out.
+    scala_target_1 = self.make_target('a/scala_1:s1',
+                                      ScalaLibrary,
+                                      sources=['Source1.java', 'Source1.scala'])
 
-      # this scala target has single *.scala source but will be excluded out
-      # by the [scalastyle].[excludes] setting.
-      scala_target_2 = self.make_target('a/scala_2:s2', ScalaLibrary, sources=['Source2.scala'])
+    # this scala target has single *.scala source but will be excluded out
+    # by the [scalastyle].[excludes] setting.
+    scala_target_2 = self.make_target('a/scala_2:s2', ScalaLibrary, sources=['Source2.scala'])
 
-      # Create a custom context so we can manually inject scala targets
-      # with mixed sources in them to test the source filtering logic.
-      context = self._create_context(
-        scalastyle_config=self._create_scalastyle_config_file(),
-        excludes=self._create_scalastyle_excludes_file(['a/scala_2/Source2.scala']),
-        target_roots=[
-          scala_target_1,
-          scala_target_2
-        ]
-      )
+    # Create a custom context so we can manually inject scala targets
+    # with mixed sources in them to test the source filtering logic.
+    context = self._create_context(
+      scalastyle_config=self._create_scalastyle_config_file(),
+      excludes=self._create_scalastyle_excludes_file(['a/scala_2/Source2.scala']),
+      target_roots=[
+        scala_target_1,
+        scala_target_2
+      ]
+    )
 
-      # Remember, we have the extra 'scala-library' dep target.
-      self.assertEqual(3, len(context.targets()))
+    # Remember, we have the extra 'scala-library' dep target.
+    self.assertEqual(3, len(context.targets()))
 
-      # Now create the task and run the scala source and exclusion filtering.
-      task = self.prepare_execute(context)
+    # Now create the task and run the scala source and exclusion filtering.
+    task = self.prepare_execute(context)
 
-      result_sources = task.get_non_excluded_scala_sources(
-        task.create_file_excluder(),
-        task.get_non_synthetic_scala_targets(context.targets()))
+    result_sources = task.get_non_excluded_scala_sources(
+      task.create_file_excluder(),
+      task.get_non_synthetic_scala_targets(context.targets()))
 
-      # Only the scala source from target 1 should remain
-      self.assertEquals(1, len(result_sources))
-      self.assertEqual('a/scala_1/Source1.scala', result_sources[0])
+    # Only the scala source from target 1 should remain
+    self.assertEquals(1, len(result_sources))
+    self.assertEqual('a/scala_1/Source1.scala', result_sources[0])
 
   @ensure_cached(Scalastyle, expected_num_artifacts=1)
   def test_end_to_end_pass(self):
-    # Default scalastyle config (import grouping rule) and no excludes.
-    with self.scala_platform_setup():
-      # Create a scala source that would PASS ImportGroupingChecker rule.
-      self.create_file(
-        relpath='a/scala/pass.scala',
-        contents=dedent("""
-          import java.util
-          object HelloWorld {
-             def main(args: Array[String]) {
-                println("Hello, world!")
-             }
-          }
-        """))
-      scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
+    # Create a scala source that would PASS ImportGroupingChecker rule.
+    self.create_file(
+      relpath='a/scala/pass.scala',
+      contents=dedent("""
+        import java.util
+        object HelloWorld {
+           def main(args: Array[String]) {
+              println("Hello, world!")
+           }
+        }
+      """))
+    scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
 
-      context = self._create_context(scalastyle_config=self._create_scalastyle_config_file(),
-                                     target_roots=[scala_target])
+    context = self._create_context(scalastyle_config=self._create_scalastyle_config_file(),
+                                   target_roots=[scala_target])
 
-      self.execute(context)
+    self.execute(context)
 
   def test_custom_end_to_end_pass(self):
-    # Default scalastyle config (import grouping rule) and no excludes.
-    with self.custom_scala_platform_setup():
-      # Create a scala source that would PASS ImportGroupingChecker rule.
-      self.create_file(
-        relpath='a/scala/pass.scala',
-        contents=dedent("""
-          import java.util
-          object HelloWorld {
-             def main(args: Array[String]) {
-                println("Hello, world!")
-             }
-          }
-        """))
-      scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
+    # Override the default version set in setUp().
+    self.custom_scala_platform_setup()
+    # Create a scala source that would PASS ImportGroupingChecker rule.
+    self.create_file(
+      relpath='a/scala/pass.scala',
+      contents=dedent("""
+        import java.util
+        object HelloWorld {
+           def main(args: Array[String]) {
+              println("Hello, world!")
+           }
+        }
+      """))
+    scala_target = self.make_target('a/scala:pass', ScalaLibrary, sources=['pass.scala'])
 
-      context = self._create_context(scalastyle_config=self._create_scalastyle_config_file(),
-                                     target_roots=[scala_target])
+    context = self._create_context(scalastyle_config=self._create_scalastyle_config_file(),
+                                   target_roots=[scala_target])
 
-      self.execute(context)
+    self.execute(context)
 
   def test_fail(self):
-    # Default scalastyle config (import grouping rule) and no excludes.
-    with self.scala_platform_setup():
-      # Create a scala source that would FAIL ImportGroupingChecker rule.
-      self.create_file(
-        relpath='a/scala/fail.scala',
-        contents=dedent("""
-          import java.io._
-          object HelloWorld {
-             def main(args: Array[String]) {
-                println("Hello, world!")
-             }
-          }
-          import java.util._
-        """))
-      scala_target = self.make_target('a/scala:fail', ScalaLibrary, sources=['fail.scala'])
+    # Create a scala source that would FAIL ImportGroupingChecker rule.
+    self.create_file(
+      relpath='a/scala/fail.scala',
+      contents=dedent("""
+        import java.io._
+        object HelloWorld {
+           def main(args: Array[String]) {
+              println("Hello, world!")
+           }
+        }
+        import java.util._
+      """))
+    scala_target = self.make_target('a/scala:fail', ScalaLibrary, sources=['fail.scala'])
 
-      context = self._create_context(target_roots=[scala_target])
+    context = self._create_context(target_roots=[scala_target])
 
-      with self.assertRaises(TaskError):
-        self.execute(context)
+    with self.assertRaises(TaskError):
+      self.execute(context)

--- a/tests/python/pants_test/backend/project_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/project_info/tasks/BUILD
@@ -60,6 +60,7 @@ python_tests(
   name = 'export',
   sources = ['test_export.py'],
   dependencies = [
+    'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/subsystems:scala_platform',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/targets:jvm',

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.backend.jvm.register import build_file_aliases as register_jvm
+from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.targets.jar_library import JarLibrary
@@ -33,7 +34,7 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import chmod_plus_x, safe_open
 from pants.util.osutil import get_os_name, normalize_os_name
 from pants_test.backend.python.tasks.interpreter_cache_test_mixin import InterpreterCacheTestMixin
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
@@ -49,140 +50,150 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
   def setUp(self):
     super(ExportTest, self).setUp()
 
-    self.set_options_for_scope('jvm-platform',
-                               default_platform='java6',
-                               platforms={
-                                 'java6': {'source': '1.6', 'target': '1.6'}
-                               })
+    # We need an initialized ScalaPlatform in order to make ScalaLibrary targets below.
+    scala_options = {
+      ScalaPlatform.options_scope: {
+        'version': 'custom'
+      }
+    }
+    init_subsystem(ScalaPlatform, scala_options)
 
-    scala_options = {'scala-platform': {'version': 'custom'}}
-    with subsystem_instance(ScalaPlatform, **scala_options):
-      self.make_target(':scala-library',
-                       JarLibrary,
-                       jars=[JarDependency('org.scala-lang', 'scala-library', '2.10.5')])
+    self.make_target(':scala-library',
+                     JarLibrary,
+                     jars=[JarDependency('org.scala-lang', 'scala-library', '2.10.5')])
 
-      self.make_target(
-        'project_info:first',
-        target_type=Target,
-      )
+    self.make_target(
+      'project_info:first',
+      target_type=Target,
+    )
 
-      jar_lib = self.make_target(
-        'project_info:jar_lib',
-        target_type=JarLibrary,
-        jars=[JarDependency('org.apache', 'apache-jar', '12.12.2012')],
-      )
+    jar_lib = self.make_target(
+      'project_info:jar_lib',
+      target_type=JarLibrary,
+      jars=[JarDependency('org.apache', 'apache-jar', '12.12.2012')],
+    )
 
-      self.make_target(
-        'java/project_info:java_lib',
-        target_type=JavaLibrary,
-        sources=['com/foo/Bar.java', 'com/foo/Baz.java'],
-      )
+    self.make_target(
+      'java/project_info:java_lib',
+      target_type=JavaLibrary,
+      sources=['com/foo/Bar.java', 'com/foo/Baz.java'],
+    )
 
-      self.make_target(
-        'project_info:third',
+    self.make_target(
+      'project_info:third',
+      target_type=ScalaLibrary,
+      dependencies=[jar_lib],
+      java_sources=['java/project_info:java_lib'],
+      sources=['com/foo/Bar.scala', 'com/foo/Baz.scala'],
+    )
+
+    self.make_target(
+      'project_info:globular',
+      target_type=ScalaLibrary,
+      dependencies=[jar_lib],
+      java_sources=['java/project_info:java_lib'],
+      sources=['com/foo/*.scala'],
+    )
+
+    self.make_target(
+      'project_info:jvm_app',
+      target_type=JvmApp,
+      dependencies=[jar_lib],
+    )
+
+    self.make_target(
+      'project_info:jvm_target',
+      target_type=ScalaLibrary,
+      dependencies=[jar_lib],
+      sources=['this/is/a/source/Foo.scala', 'this/is/a/source/Bar.scala'],
+    )
+
+    test_resource = self.make_target(
+      'project_info:test_resource',
+      target_type=Resources,
+      sources=['y_resource', 'z_resource'],
+    )
+
+    self.make_target(
+      'project_info:java_test',
+      target_type=JavaTests,
+      dependencies=[jar_lib],
+      sources=['this/is/a/test/source/FooTest.scala'],
+      resources=[test_resource.address.spec],
+    )
+
+    jvm_binary = self.make_target(
+      'project_info:jvm_binary',
+      target_type=JvmBinary,
+      dependencies=[jar_lib],
+    )
+
+    self.make_target(
+      'project_info:top_dependency',
+      target_type=Target,
+      dependencies=[jvm_binary],
+    )
+
+    src_resource = self.make_target(
+      'project_info:resource',
+      target_type=Resources,
+      sources=['a_resource', 'b_resource'],
+    )
+
+    self.make_target(
+        'project_info:target_type',
         target_type=ScalaLibrary,
-        dependencies=[jar_lib],
-        java_sources=['java/project_info:java_lib'],
-        sources=['com/foo/Bar.scala', 'com/foo/Baz.scala'],
-      )
-
-      self.make_target(
-        'project_info:globular',
-        target_type=ScalaLibrary,
-        dependencies=[jar_lib],
-        java_sources=['java/project_info:java_lib'],
-        sources=['com/foo/*.scala'],
-      )
-
-      self.make_target(
-        'project_info:jvm_app',
-        target_type=JvmApp,
-        dependencies=[jar_lib],
-      )
-
-      self.make_target(
-        'project_info:jvm_target',
-        target_type=ScalaLibrary,
-        dependencies=[jar_lib],
-        sources=['this/is/a/source/Foo.scala', 'this/is/a/source/Bar.scala'],
-      )
-
-      test_resource = self.make_target(
-        'project_info:test_resource',
-        target_type=Resources,
-        sources=['y_resource', 'z_resource'],
-      )
-
-      self.make_target(
-        'project_info:java_test',
-        target_type=JavaTests,
-        dependencies=[jar_lib],
-        sources=['this/is/a/test/source/FooTest.scala'],
-        resources=[test_resource.address.spec],
-      )
-
-      jvm_binary = self.make_target(
-        'project_info:jvm_binary',
-        target_type=JvmBinary,
-        dependencies=[jar_lib],
-      )
-
-      self.make_target(
-        'project_info:top_dependency',
-        target_type=Target,
         dependencies=[jvm_binary],
-      )
+        resources=[src_resource.address.spec],
+    )
 
-      src_resource = self.make_target(
-        'project_info:resource',
-        target_type=Resources,
-        sources=['a_resource', 'b_resource'],
-      )
+    self.make_target(
+      'project_info:unrecognized_target_type',
+      target_type=JvmTarget,
+    )
 
-      self.make_target(
-          'project_info:target_type',
-          target_type=ScalaLibrary,
-          dependencies=[jvm_binary],
-          resources=[src_resource.address.spec],
-      )
+    self.add_to_build_file('src/python/x/BUILD', """
+       python_library(name="x", sources=globs("*.py"))
+    """.strip())
 
-      self.make_target(
-        'project_info:unrecognized_target_type',
-        target_type=JvmTarget,
-      )
+    self.add_to_build_file('src/python/y/BUILD', dedent("""
+      python_library(name="y", sources=rglobs("*.py"))
+      python_library(name="y2", sources=rglobs("subdir/*.py"))
+      python_library(name="y3", sources=rglobs("Test*.py"))
+    """))
 
-      self.add_to_build_file('src/python/x/BUILD', '''
-         python_library(name="x", sources=globs("*.py"))
-      '''.strip())
+    self.add_to_build_file('src/python/z/BUILD', """
+      python_library(name="z", sources=zglobs("**/*.py"))
+    """.strip())
 
-      self.add_to_build_file('src/python/y/BUILD', dedent('''
-        python_library(name="y", sources=rglobs("*.py"))
-        python_library(name="y2", sources=rglobs("subdir/*.py"))
-        python_library(name="y3", sources=rglobs("Test*.py"))
-      '''))
+    self.add_to_build_file('src/python/exclude/BUILD', """
+      python_library(name="exclude", sources=globs("*.py", exclude=[['foo.py']]))
+    """.strip())
 
-      self.add_to_build_file('src/python/z/BUILD', '''
-        python_library(name="z", sources=zglobs("**/*.py"))
-      '''.strip())
+    self.add_to_build_file('src/BUILD', """
+      target(name="alias")
+    """.strip())
 
-      self.add_to_build_file('src/python/exclude/BUILD', '''
-        python_library(name="exclude", sources=globs("*.py", exclude=[['foo.py']]))
-      '''.strip())
-
-      self.add_to_build_file('src/BUILD', '''
-        target(name="alias")
-      '''.strip())
-
-  def execute_export(self, *specs):
-    context = self.context(target_roots=[self.target(spec) for spec in specs])
+  def execute_export(self, *specs, **options_overrides):
+    options = {
+      JvmPlatform.options_scope: {
+        'default_platform': 'java6',
+        'platforms': {
+          'java6': {'source': '1.6', 'target': '1.6'}
+        }
+      },
+    }
+    options.update(options_overrides)
+    context = self.context(options=options, target_roots=[self.target(spec) for spec in specs],
+                           for_subsystems=[JvmPlatform])
     context.products.safe_create_data('compile_classpath',
                                       init_func=ClasspathProducts.init_func(self.pants_workdir))
     task = self.create_task(context)
     return list(task.console_output(list(task.context.targets()),
                                     context.products.get_data('compile_classpath')))
 
-  def execute_export_json(self, *specs):
-    return json.loads(''.join(self.execute_export(*specs)))
+  def execute_export_json(self, *specs, **options):
+    return json.loads(''.join(self.execute_export(*specs, **options)))
 
   def test_source_globs_py(self):
     self.set_options(globs=True)
@@ -391,9 +402,9 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
 
   def test_synthetic_target(self):
     # Create a BUILD file then add itself as resources
-    self.add_to_build_file('src/python/alpha/BUILD', '''
+    self.add_to_build_file('src/python/alpha/BUILD', """
         python_library(name="alpha", sources=zglobs("**/*.py"), resources=["BUILD"])
-      '''.strip())
+      """.strip())
 
     result = self.execute_export_json('src/python/alpha')
     # The synthetic resource is synthetic
@@ -414,23 +425,26 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
       yield java_home
 
   def test_preferred_jvm_distributions(self):
-    self.set_options_for_scope('jvm-platform',
-                               default_platform='java9999',
-                               platforms={
-                                 'java9999': {'target': '9999'},
-                                 'java10000': {'target': '10000'}
-                               })
-
     with self.fake_distribution(version='9999') as strict_home:
       with self.fake_distribution(version='10000') as non_strict_home:
-        self.set_options_for_scope('jvm-distributions',
-                                   paths={
-                                     normalize_os_name(get_os_name()): [
-                                       strict_home,
-                                       non_strict_home
-                                     ]
-                                   })
-        with subsystem_instance(DistributionLocator):
-          export_json = self.execute_export_json()
-          self.assertEqual({'strict': strict_home, 'non_strict': non_strict_home},
-                           export_json['preferred_jvm_distributions']['java9999'])
+        options = {
+          JvmPlatform.options_scope: {
+            'default_platform': 'java9999',
+            'platforms': {
+              'java9999': {'target': '9999'},
+              'java10000': {'target': '10000'}
+            }
+          },
+          DistributionLocator.options_scope: {
+            'paths': {
+              normalize_os_name(get_os_name()): [
+                strict_home,
+                non_strict_home
+              ]
+            }
+          }
+        }
+
+        export_json = self.execute_export_json(**options)
+        self.assertEqual({'strict': strict_home, 'non_strict': non_strict_home},
+                         export_json['preferred_jvm_distributions']['java9999'])

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -16,7 +16,7 @@ from pants.base.build_environment import get_buildroot
 from pants.ivy.ivy_subsystem import IvySubsystem
 from pants_test.backend.project_info.tasks.resolve_jars_test_mixin import ResolveJarsTestMixin
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_engine
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
@@ -117,24 +117,24 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
     with self.temporary_workdir() as workdir:
       test_target = 'examples/tests/java/org/pantsbuild/example/usethrift:usethrift'
       json_data = self.run_export(test_target, workdir, load_libs=True)
-      with subsystem_instance(IvySubsystem) as ivy_subsystem:
-        ivy_cache_dir = ivy_subsystem.get_options().cache_dir
-        common_lang_lib_info = json_data.get('libraries').get('junit:junit:4.12')
-        self.assertIsNotNone(common_lang_lib_info)
-        self.assertEquals(
-          common_lang_lib_info.get('default'),
-          os.path.join(ivy_cache_dir, 'junit/junit/jars/junit-4.12.jar')
-        )
-        self.assertEquals(
-          common_lang_lib_info.get('javadoc'),
-          os.path.join(ivy_cache_dir,
-                       'junit/junit/javadocs/junit-4.12-javadoc.jar')
-        )
-        self.assertEquals(
-          common_lang_lib_info.get('sources'),
-          os.path.join(ivy_cache_dir,
-                       'junit/junit/sources/junit-4.12-sources.jar')
-        )
+      ivy_subsystem = global_subsystem_instance(IvySubsystem)
+      ivy_cache_dir = ivy_subsystem.get_options().cache_dir
+      common_lang_lib_info = json_data.get('libraries').get('junit:junit:4.12')
+      self.assertIsNotNone(common_lang_lib_info)
+      self.assertEquals(
+        common_lang_lib_info.get('default'),
+        os.path.join(ivy_cache_dir, 'junit/junit/jars/junit-4.12.jar')
+      )
+      self.assertEquals(
+        common_lang_lib_info.get('javadoc'),
+        os.path.join(ivy_cache_dir,
+                     'junit/junit/javadocs/junit-4.12-javadoc.jar')
+      )
+      self.assertEquals(
+        common_lang_lib_info.get('sources'),
+        os.path.join(ivy_cache_dir,
+                     'junit/junit/sources/junit-4.12-sources.jar')
+      )
 
   def test_dep_map_for_java_sources(self):
     with self.temporary_workdir() as workdir:
@@ -161,26 +161,26 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
     with self.temporary_workdir() as workdir:
       test_target = 'testprojects/tests/java/org/pantsbuild/testproject/ivyclassifier:ivyclassifier'
       json_data = self.run_export(test_target, workdir, load_libs=True)
-      with subsystem_instance(IvySubsystem) as ivy_subsystem:
-        ivy_cache_dir = ivy_subsystem.get_options().cache_dir
-        avro_lib_info = json_data.get('libraries').get('org.apache.avro:avro:1.7.7')
-        self.assertIsNotNone(avro_lib_info)
-        self.assertEquals(
-          avro_lib_info.get('default'),
-          os.path.join(ivy_cache_dir, 'org.apache.avro/avro/jars/avro-1.7.7.jar')
-        )
-        self.assertEquals(
-          avro_lib_info.get('tests'),
-          os.path.join(ivy_cache_dir, 'org.apache.avro/avro/jars/avro-1.7.7-tests.jar')
-        )
-        self.assertEquals(
-          avro_lib_info.get('javadoc'),
-          os.path.join(ivy_cache_dir, 'org.apache.avro/avro/javadocs/avro-1.7.7-javadoc.jar')
-        )
-        self.assertEquals(
-          avro_lib_info.get('sources'),
-          os.path.join(ivy_cache_dir, 'org.apache.avro/avro/sources/avro-1.7.7-sources.jar')
-        )
+      ivy_subsystem = global_subsystem_instance(IvySubsystem)
+      ivy_cache_dir = ivy_subsystem.get_options().cache_dir
+      avro_lib_info = json_data.get('libraries').get('org.apache.avro:avro:1.7.7')
+      self.assertIsNotNone(avro_lib_info)
+      self.assertEquals(
+        avro_lib_info.get('default'),
+        os.path.join(ivy_cache_dir, 'org.apache.avro/avro/jars/avro-1.7.7.jar')
+      )
+      self.assertEquals(
+        avro_lib_info.get('tests'),
+        os.path.join(ivy_cache_dir, 'org.apache.avro/avro/jars/avro-1.7.7-tests.jar')
+      )
+      self.assertEquals(
+        avro_lib_info.get('javadoc'),
+        os.path.join(ivy_cache_dir, 'org.apache.avro/avro/javadocs/avro-1.7.7-javadoc.jar')
+      )
+      self.assertEquals(
+        avro_lib_info.get('sources'),
+        os.path.join(ivy_cache_dir, 'org.apache.avro/avro/sources/avro-1.7.7-sources.jar')
+      )
 
   def test_distributions_and_platforms(self):
     with self.temporary_workdir() as workdir:

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -26,7 +26,7 @@ from pants.fs.archive import TGZ
 from pants.util.contextutil import temporary_dir, temporary_file
 from pants.util.dirutil import safe_mkdir
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class TestSetupPy(PythonTaskTestBase):
@@ -474,9 +474,9 @@ class TestSetupPy(PythonTaskTestBase):
     # `pants.java.distribution.distribution.Distribution` gained in
     # https://rbcommons.com/s/twitter/r/2657
     # Remove this once proper Subsystem dependency chains are re-established.
-    with subsystem_instance(JVM):
-      with self.run_execute(target) as created:
-        self.assertEqual([target], created.keys())
+    init_subsystem(JVM)
+    with self.run_execute(target) as created:
+      self.assertEqual([target], created.keys())
 
   def test_exported_thrift(self):
     self.create_file(relpath='src/thrift/exported/exported.thrift', contents=dedent("""

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -29,7 +29,7 @@ from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.java.distribution.distribution import DistributionLocator
 from pants.util.contextutil import temporary_dir
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 def test_get_current_platform():
@@ -41,8 +41,7 @@ class PythonChrootTest(BaseTest):
 
   def setUp(self):
     # Capture PythonSetup with the real BUILD_ROOT before that is reset to a tmpdir by super.
-    with subsystem_instance(PythonSetup) as python_setup:
-      self.python_setup = python_setup
+    self.python_setup = global_subsystem_instance(PythonSetup)
     super(PythonChrootTest, self).setUp()
 
   @contextmanager

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -13,7 +13,7 @@ from pants.build_graph.address import Address, Addresses
 from pants.build_graph.target import Target
 from pants.source.payload_fields import DeferredSourcesField
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class TestDeferredSourcesTarget(Target):
@@ -68,17 +68,17 @@ class TargetTest(BaseTest):
     self.assertSequenceEqual(['//:foo'], list(target.traversable_dependency_specs))
 
   def test_illegal_kwargs(self):
-    with subsystem_instance(Target.UnknownArguments):
-      with self.assertRaises(Target.UnknownArguments.Error) as cm:
-        self.make_target('foo:bar', Target, foobar='barfoo')
-      self.assertTrue('foobar = barfoo' in str(cm.exception))
-      self.assertTrue('foo:bar' in str(cm.exception))
+    init_subsystem(Target.UnknownArguments)
+    with self.assertRaises(Target.UnknownArguments.Error) as cm:
+      self.make_target('foo:bar', Target, foobar='barfoo')
+    self.assertTrue('foobar = barfoo' in str(cm.exception))
+    self.assertTrue('foo:bar' in str(cm.exception))
 
   def test_unknown_kwargs(self):
     options = {Target.UnknownArguments.options_scope: {'ignored': {'Target': ['foobar']}}}
-    with subsystem_instance(Target.UnknownArguments, **options):
-      target = self.make_target('foo:bar', Target, foobar='barfoo')
-      self.assertFalse(hasattr(target, 'foobar'))
+    init_subsystem(Target.UnknownArguments, options)
+    target = self.make_target('foo:bar', Target, foobar='barfoo')
+    self.assertFalse(hasattr(target, 'foobar'))
 
   def test_target_id_long(self):
     long_path = 'dummy'

--- a/tests/python/pants_test/ivy/test_bootstrapper.py
+++ b/tests/python/pants_test/ivy/test_bootstrapper.py
@@ -10,30 +10,31 @@ import unittest
 
 from pants.ivy.bootstrapper import Bootstrapper
 from pants.ivy.ivy_subsystem import IvySubsystem
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 class BootstrapperTest(unittest.TestCase):
+  def setUp(self):
+    super(BootstrapperTest, self).setUp()
+    init_subsystem(IvySubsystem)
 
   def test_simple(self):
-    with subsystem_instance(IvySubsystem) as ivy_subsystem:
-      bootstrapper = Bootstrapper(ivy_subsystem=ivy_subsystem)
-      ivy = bootstrapper.ivy()
-      self.assertIsNotNone(ivy.ivy_cache_dir)
-      self.assertIsNone(ivy.ivy_settings)
-      bootstrap_jar_path = os.path.join(ivy_subsystem.get_options().pants_bootstrapdir,
-                                        'tools', 'jvm', 'ivy', 'bootstrap.jar')
-      self.assertTrue(os.path.exists(bootstrap_jar_path))
+    ivy_subsystem = IvySubsystem.global_instance()
+    bootstrapper = Bootstrapper(ivy_subsystem=ivy_subsystem)
+    ivy = bootstrapper.ivy()
+    self.assertIsNotNone(ivy.ivy_cache_dir)
+    self.assertIsNone(ivy.ivy_settings)
+    bootstrap_jar_path = os.path.join(ivy_subsystem.get_options().pants_bootstrapdir,
+                                      'tools', 'jvm', 'ivy', 'bootstrap.jar')
+    self.assertTrue(os.path.exists(bootstrap_jar_path))
 
   def test_reset(self):
-    with subsystem_instance(IvySubsystem):
-      bootstrapper1 = Bootstrapper.instance()
-      Bootstrapper.reset_instance()
-      bootstrapper2 = Bootstrapper.instance()
-      self.assertIsNot(bootstrapper1, bootstrapper2)
+    bootstrapper1 = Bootstrapper.instance()
+    Bootstrapper.reset_instance()
+    bootstrapper2 = Bootstrapper.instance()
+    self.assertIsNot(bootstrapper1, bootstrapper2)
 
   def test_default_ivy(self):
-    with subsystem_instance(IvySubsystem):
-      ivy = Bootstrapper.default_ivy()
-      self.assertIsNotNone(ivy.ivy_cache_dir)
-      self.assertIsNone(ivy.ivy_settings)
+    ivy = Bootstrapper.default_ivy()
+    self.assertIsNotNone(ivy.ivy_cache_dir)
+    self.assertIsNone(ivy.ivy_settings)

--- a/tests/python/pants_test/ivy/test_ivy_subsystem.py
+++ b/tests/python/pants_test/ivy/test_ivy_subsystem.py
@@ -9,34 +9,34 @@ import unittest
 
 from pants.ivy.ivy_subsystem import IvySubsystem
 from pants.util.contextutil import environment_as
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class IvySubsystemTest(unittest.TestCase):
 
   def test_parse_proxy_string(self):
-    with subsystem_instance(IvySubsystem) as ivy_subsystem:
-      self.assertEquals(('example.com', 1234),
-                        ivy_subsystem._parse_proxy_string('http://example.com:1234'))
-      self.assertEquals(('secure-example.com', 999),
-                        ivy_subsystem._parse_proxy_string('http://secure-example.com:999'))
-      # trailing slash is ok
-      self.assertEquals(('example.com', 1234),
-                        ivy_subsystem._parse_proxy_string('http://example.com:1234/'))
+    ivy_subsystem = global_subsystem_instance(IvySubsystem)
+    self.assertEquals(('example.com', 1234),
+                      ivy_subsystem._parse_proxy_string('http://example.com:1234'))
+    self.assertEquals(('secure-example.com', 999),
+                      ivy_subsystem._parse_proxy_string('http://secure-example.com:999'))
+    # trailing slash is ok
+    self.assertEquals(('example.com', 1234),
+                      ivy_subsystem._parse_proxy_string('http://example.com:1234/'))
 
   def test_proxy_from_env(self):
-    with subsystem_instance(IvySubsystem) as ivy_subsystem:
-      self.assertIsNone(ivy_subsystem.http_proxy())
-      self.assertIsNone(ivy_subsystem.https_proxy())
+    ivy_subsystem = global_subsystem_instance(IvySubsystem)
+    self.assertIsNone(ivy_subsystem.http_proxy())
+    self.assertIsNone(ivy_subsystem.https_proxy())
 
-      with environment_as(HTTP_PROXY='http://proxy.example.com:456',
-                          HTTPS_PROXY='https://secure-proxy.example.com:789'):
-        self.assertEquals('http://proxy.example.com:456', ivy_subsystem.http_proxy())
-        self.assertEquals('https://secure-proxy.example.com:789', ivy_subsystem.https_proxy())
+    with environment_as(HTTP_PROXY='http://proxy.example.com:456',
+                        HTTPS_PROXY='https://secure-proxy.example.com:789'):
+      self.assertEquals('http://proxy.example.com:456', ivy_subsystem.http_proxy())
+      self.assertEquals('https://secure-proxy.example.com:789', ivy_subsystem.https_proxy())
 
-        self.assertEquals([
-          '-Dhttp.proxyHost=proxy.example.com',
-          '-Dhttp.proxyPort=456',
-          '-Dhttps.proxyHost=secure-proxy.example.com',
-          '-Dhttps.proxyPort=789',
-        ], ivy_subsystem.extra_jvm_options())
+      self.assertEquals([
+        '-Dhttp.proxyHost=proxy.example.com',
+        '-Dhttp.proxyPort=456',
+        '-Dhttps.proxyHost=secure-proxy.example.com',
+        '-Dhttps.proxyPort=789',
+      ], ivy_subsystem.extra_jvm_options())

--- a/tests/python/pants_test/java/distribution/test_distribution.py
+++ b/tests/python/pants_test/java/distribution/test_distribution.py
@@ -19,7 +19,7 @@ from pants.java.distribution.distribution import (Distribution, DistributionLoca
                                                   _OSXEnvironment, _UnknownEnvironment)
 from pants.util.contextutil import environment_as, temporary_dir, temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_open, touch
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class EXE(object):
@@ -398,12 +398,12 @@ class LiveDistributionTest(unittest.TestCase):
     Distribution(bin_path=os.path.dirname(self.JAVA), maximum_version='999.999.999').validate()
     Distribution(bin_path=os.path.dirname(self.JAVA), minimum_version='1.3.1',
                  maximum_version='999.999.999').validate()
-    with subsystem_instance(DistributionLocator) as locator:
-      locator.cached(jdk=False)
+    locator = global_subsystem_instance(DistributionLocator)
+    locator.cached(jdk=False)
 
   @unittest.skipIf(not JAVAC, reason='No javac executable on the PATH.')
   def test_validate_live_jdk(self):
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).validate()
     Distribution(bin_path=os.path.dirname(self.JAVAC), jdk=True).binary('javap')
-    with subsystem_instance(DistributionLocator) as locator:
-      locator.cached(jdk=True)
+    locator = global_subsystem_instance(DistributionLocator)
+    locator.cached(jdk=True)

--- a/tests/python/pants_test/java/distribution/test_distribution_integration.py
+++ b/tests/python/pants_test/java/distribution/test_distribution_integration.py
@@ -12,13 +12,15 @@ from unittest import skipIf
 from pants.java.distribution.distribution import Distribution, DistributionLocator
 from pants.util.osutil import OS_ALIASES, get_os_name
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 @contextmanager
-def _distribution_locator(**options):
-  with subsystem_instance(DistributionLocator, **options) as locator:
-    yield locator
+def _distribution_locator(distribution_locator_options=None):
+  options = {
+    DistributionLocator.options_scope: distribution_locator_options or {}
+  }
+  yield global_subsystem_instance(DistributionLocator, options=options)
 
 
 def _get_two_distributions():
@@ -103,13 +105,11 @@ class DistributionIntegrationTest(PantsRunIntegrationTest):
                                                         max_version_arg=None,
                                                         min_version_option=None,
                                                         max_version_option=None):
-    options = {
-      'jvm-distributions': {
-        'minimum_version': min_version_option,
-        'maximum_version': max_version_option,
-      }
+    distribution_locator_options = {
+      'minimum_version': min_version_option,
+      'maximum_version': max_version_option,
     }
-    with _distribution_locator(**options) as locator:
+    with _distribution_locator(distribution_locator_options) as locator:
       with self.assertRaises(Distribution.Error):
         locator.cached(minimum_version=min_version_arg, maximum_version=max_version_arg, jdk=False)
 

--- a/tests/python/pants_test/pantsd/subsystem/test_pants_daemon_launcher.py
+++ b/tests/python/pants_test/pantsd/subsystem/test_pants_daemon_launcher.py
@@ -5,28 +5,24 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from contextlib import contextmanager
-
 import mock
 
 from pants.pantsd.pants_daemon import PantsDaemon
 from pants.pantsd.subsystem.pants_daemon_launcher import PantsDaemonLauncher
 from pants.pantsd.subsystem.watchman_launcher import WatchmanLauncher
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class PantsDaemonLauncherTest(BaseTest):
   PDL_PATCH_OPTS = dict(autospec=True, spec_set=True, return_value=(None, None))
 
-  @contextmanager
-  def pants_daemon_launcher(self, options=None):
-    options = options or {}
-    with subsystem_instance(PantsDaemonLauncher.Factory, **options) as factory:
-      pdl = factory.create(None)
-      pdl.pantsd = self.mock_pantsd
-      pdl.watchman_launcher = self.mock_watchman_launcher
-      yield pdl
+  def pants_daemon_launcher(self):
+    factory = global_subsystem_instance(PantsDaemonLauncher.Factory)
+    pdl = factory.create(None)
+    pdl.pantsd = self.mock_pantsd
+    pdl.watchman_launcher = self.mock_watchman_launcher
+    return pdl
 
   def setUp(self):
     super(PantsDaemonLauncherTest, self).setUp()
@@ -37,8 +33,8 @@ class PantsDaemonLauncherTest(BaseTest):
   def test_maybe_launch(self, mock_setup_services):
     self.mock_pantsd.is_alive.return_value = False
 
-    with self.pants_daemon_launcher() as pdl:
-      pdl.maybe_launch()
+    pdl = self.pants_daemon_launcher()
+    pdl.maybe_launch()
 
     self.assertGreater(mock_setup_services.call_count, 0)
     self.assertGreater(self.mock_pantsd.is_alive.call_count, 0)
@@ -47,10 +43,10 @@ class PantsDaemonLauncherTest(BaseTest):
   @mock.patch.object(PantsDaemonLauncher, '_setup_services', **PDL_PATCH_OPTS)
   def test_maybe_launch_already_alive(self, mock_setup_services):
     self.mock_pantsd.is_alive.return_value = True
-    options = {'default': {'pantsd_enabled': 'true'}}
+    #options = {'default': {'pantsd_enabled': 'true'}}
 
-    with self.pants_daemon_launcher(options) as pdl:
-      pdl.maybe_launch()
+    pdl = self.pants_daemon_launcher()
+    pdl.maybe_launch()
 
     self.assertEqual(mock_setup_services.call_count, 0)
     self.assertGreater(self.mock_pantsd.is_alive.call_count, 0)

--- a/tests/python/pants_test/pantsd/subsystem/test_subprocess.py
+++ b/tests/python/pants_test/pantsd/subsystem/test_subprocess.py
@@ -5,19 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from contextlib import contextmanager
-
 from pants.pantsd.subsystem.subprocess import Subprocess
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class SubprocessTest(BaseTest):
-  @contextmanager
   def subprocess(self):
-    with subsystem_instance(Subprocess.Factory) as factory:
-      yield factory.create()
+    return global_subsystem_instance(Subprocess.Factory).create()
 
   def test_get_subprocess_dir(self):
-    with self.subprocess() as subprocess:
-      self.assertTrue(subprocess.get_subprocess_dir().endswith('/.pids'))
+    self.assertTrue(self.subprocess().get_subprocess_dir().endswith('/.pids'))

--- a/tests/python/pants_test/pantsd/subsystem/test_watchman_launcher.py
+++ b/tests/python/pants_test/pantsd/subsystem/test_watchman_launcher.py
@@ -5,22 +5,18 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from contextlib import contextmanager
-
 import mock
 
 from pants.pantsd.subsystem.watchman_launcher import WatchmanLauncher
 from pants.pantsd.watchman import Watchman
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class TestWatchmanLauncher(BaseTest):
-  @contextmanager
   def watchman_launcher(self, options=None):
     options = options or {}
-    with subsystem_instance(WatchmanLauncher.Factory, **options) as factory:
-      yield factory.create()
+    return global_subsystem_instance(WatchmanLauncher.Factory, options=options).create()
 
   def create_mock_watchman(self, is_alive):
     mock_watchman = mock.create_autospec(Watchman, spec_set=False)
@@ -31,9 +27,9 @@ class TestWatchmanLauncher(BaseTest):
   def test_maybe_launch(self):
     mock_watchman = self.create_mock_watchman(False)
 
-    with self.watchman_launcher() as wl:
-      wl.watchman = mock_watchman
-      self.assertTrue(wl.maybe_launch())
+    wl = self.watchman_launcher()
+    wl.watchman = mock_watchman
+    self.assertTrue(wl.maybe_launch())
 
     mock_watchman.is_alive.assert_called_once_with()
     mock_watchman.launch.assert_called_once_with()
@@ -41,9 +37,9 @@ class TestWatchmanLauncher(BaseTest):
   def test_maybe_launch_already_alive(self):
     mock_watchman = self.create_mock_watchman(True)
 
-    with self.watchman_launcher() as wl:
-      wl.watchman = mock_watchman
-      self.assertTrue(wl.maybe_launch())
+    wl = self.watchman_launcher()
+    wl.watchman = mock_watchman
+    self.assertTrue(wl.maybe_launch())
 
     mock_watchman.is_alive.assert_called_once_with()
     self.assertFalse(mock_watchman.launch.called)
@@ -52,20 +48,20 @@ class TestWatchmanLauncher(BaseTest):
     mock_watchman = self.create_mock_watchman(False)
     mock_watchman.launch.side_effect = Watchman.ExecutionError('oops!')
 
-    with self.watchman_launcher() as wl:
-      wl.watchman = mock_watchman
-      with self.assertRaises(wl.watchman.ExecutionError):
-        wl.maybe_launch()
+    wl = self.watchman_launcher()
+    wl.watchman = mock_watchman
+    with self.assertRaises(wl.watchman.ExecutionError):
+      wl.maybe_launch()
 
     mock_watchman.is_alive.assert_called_once_with()
     mock_watchman.launch.assert_called_once_with()
 
   def test_watchman_property(self):
-    with self.watchman_launcher() as wl:
-      self.assertIsInstance(wl.watchman, Watchman)
+    wl = self.watchman_launcher()
+    self.assertIsInstance(wl.watchman, Watchman)
 
   def test_watchman_socket_path(self):
     expected_path = '/a/shorter/path'
-    options = {'watchman': {'socket_path': expected_path}}
-    with self.watchman_launcher(options) as wl:
-      self.assertEquals(wl.watchman._sock_file, expected_path)
+    options = {WatchmanLauncher.Factory.options_scope: {'socket_path': expected_path}}
+    wl = self.watchman_launcher(options)
+    self.assertEquals(wl.watchman._sock_file, expected_path)

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -73,7 +73,11 @@ def subsystem_instance(subsystem_type, scope=None, **options):
 
 
 def global_subsystem_instance(subsystem_type, options=None):
-  """Returns the global instance of a subsystem, for use in tests.
+  """Initializes a subsystem, and returns its global instance, for use in tests.
+
+  Note that if the subsystem was already initialized and an instance of it created, then that
+  instance will not be cleared by this function.
+  TODO: Support reset of individual subsystems. See https://github.com/pantsbuild/pants/issues/3856.
 
   :API: public
 
@@ -94,6 +98,10 @@ def init_subsystems(subsystem_types, options=None):
   Does not create an instance.  This function is for setting up subsystems that the code
   under test creates.
 
+  Note that if the subsystem was already initialized and an instance of it created, then that
+  instance will not be cleared by this function.
+  TODO: Support reset of individual subsystems. See https://github.com/pantsbuild/pants/issues/3856.
+
   Note that there is some redundancy between this function and BaseTest.context(for_subsystems=...).
   TODO: Fix that.
 
@@ -109,6 +117,7 @@ def init_subsystems(subsystem_types, options=None):
   for s in subsystem_types:
     if not Subsystem.is_subsystem_type(s):
       raise TypeError('{} is not a subclass of `Subsystem`'.format(s))
+
   optionables = Subsystem.closure(subsystem_types)
   if options:
     allowed_scopes = {o.options_scope for o in optionables}

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -107,11 +107,11 @@ def init_subsystems(subsystem_types, options=None):
                   subsystems they transitively depend on.
   """
   for s in subsystem_types:
-    if not issubclass(s, Subsystem):
+    if not Subsystem.is_subsystem_type(s):
       raise TypeError('{} is not a subclass of `Subsystem`'.format(s))
   optionables = Subsystem.closure(subsystem_types)
   if options:
-    allowed_scopes = set([o.options_scope for o in optionables])
+    allowed_scopes = {o.options_scope for o in optionables}
     for scope in options.keys():
       if scope not in allowed_scopes:
         raise ValueError('`{}` is not the scope of any of these subsystems: {}'.format(

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -15,7 +15,11 @@ from pants_test.option.util.fakes import (create_option_values_for_optionable,
                                           create_options_for_optionables)
 
 
-@deprecated('1.4.0', "Use BaseTest.context()'s for_subsystems and options args.")
+_deprecation_msg = ("Use the for_subsystems and options arguments to BaseTest.context(), or use "
+                    "the methods init_subsystem(), global_subsystem_instance() in this module.")
+
+
+@deprecated('1.4.0', _deprecation_msg)
 def create_subsystem(subsystem_type, scope='test-scope', **options):
   """Creates a Subsystem for test.
 
@@ -35,6 +39,7 @@ def create_subsystem(subsystem_type, scope='test-scope', **options):
 
 
 @contextmanager
+@deprecated('1.4.0', _deprecation_msg)
 def subsystem_instance(subsystem_type, scope=None, **options):
   """Creates a Subsystem instance for test.
 
@@ -65,3 +70,59 @@ def subsystem_instance(subsystem_type, scope=None, **options):
       yield subsystem_type.scoped_instance(ScopedOptionable)
   finally:
     Subsystem.reset()
+
+
+def global_subsystem_instance(subsystem_type, options=None):
+  """Returns the global instance of a subsystem, for use in tests.
+
+  :API: public
+
+  :param type subsystem_type: The subclass of :class:`pants.subsystem.subsystem.Subsystem`
+                              to create.
+  :param options: dict of scope -> (dict of option name -> value).
+                  The scopes may be that of the global instance of the subsystem (i.e.,
+                  subsystem_type.options_scope) and/or the scopes of instances of the
+                  subsystems it transitively depends on.
+  """
+  init_subsystem(subsystem_type, options)
+  return subsystem_type.global_instance()
+
+
+def init_subsystems(subsystem_types, options=None):
+  """Initialize a subsystem for use in tests.
+
+  Does not create an instance.  This function is for setting up subsystems that the code
+  under test creates.
+
+  Note that there is some redundancy between this function and BaseTest.context(for_subsystems=...).
+  TODO: Fix that.
+
+  :API: public
+
+  :param list subsystem_types: The subclasses of :class:`pants.subsystem.subsystem.Subsystem`
+                               to create.
+  :param options: dict of scope -> (dict of option name -> value).
+                  The scopes may be those of the global instances of the subsystems (i.e.,
+                  subsystem_type.options_scope) and/or the scopes of instances of the
+                  subsystems they transitively depend on.
+  """
+  for s in subsystem_types:
+    if not issubclass(s, Subsystem):
+      raise TypeError('{} is not a subclass of `Subsystem`'.format(s))
+  optionables = Subsystem.closure(subsystem_types)
+  if options:
+    allowed_scopes = set([o.options_scope for o in optionables])
+    for scope in options.keys():
+      if scope not in allowed_scopes:
+        raise ValueError('`{}` is not the scope of any of these subsystems: {}'.format(
+            scope, optionables))
+  # Don't trample existing subsystem options, in case a test has set up some
+  # other subsystems in some other way.
+  updated_options = dict(Subsystem._options.items()) if Subsystem._options else {}
+  if options:
+    updated_options.update(options)
+  Subsystem.set_options(create_options_for_optionables(optionables, options=updated_options))
+
+
+def init_subsystem(subsystem_type, options=None):
+  init_subsystems([subsystem_type], options)

--- a/tests/python/pants_test/test_maven_layout.py
+++ b/tests/python/pants_test/test_maven_layout.py
@@ -10,7 +10,7 @@ from pants.backend.jvm.targets.java_tests import JavaTests
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.source.source_root import SourceRootConfig
 from pants_test.base_test import BaseTest
-from pants_test.subsystem.subsystem_util import subsystem_instance
+from pants_test.subsystem.subsystem_util import init_subsystem
 
 
 # Note: There is no longer any special maven_layout directive.  Maven layouts should just
@@ -27,6 +27,7 @@ class MavenLayoutTest(BaseTest):
 
   def setUp(self):
     super(MavenLayoutTest, self).setUp()
+    init_subsystem(SourceRootConfig)
     self.add_to_build_file('projectB/src/test/scala',
                            'junit_tests(name="test", sources=["a/source"])')
 
@@ -34,11 +35,9 @@ class MavenLayoutTest(BaseTest):
                            'java_library(name="test", sources=[])')
 
   def test_layout_here(self):
-    with subsystem_instance(SourceRootConfig):
-      self.assertEqual('projectB/src/test/scala',
-                       self.target('projectB/src/test/scala:test').target_base)
+    self.assertEqual('projectB/src/test/scala',
+                     self.target('projectB/src/test/scala:test').target_base)
 
   def test_subproject_layout(self):
-    with subsystem_instance(SourceRootConfig):
-      self.assertEqual('projectA/subproject/src/main/java',
-                       self.target('projectA/subproject/src/main/java:test').target_base)
+    self.assertEqual('projectA/subproject/src/main/java',
+                     self.target('projectA/subproject/src/main/java:test').target_base)


### PR DESCRIPTION
It was implemented as a contextmanager that resets subsystem
state in __exit__.  However this interacts badly with tests that
use that state outside the context. Several tests have to do
weird balancing acts to get around this.

Instead we introduce a global_subsystem_instance() that simply
inits and returns the global instance of a subsystem. The test
must rely on BaseTest.tearDown to reset state, or it can do so
explicitly itself if it must.

This change allows us to remove various contextmanagers sprinkled
around our tests, that existed only because subsystem_instance
was a contextmanager.  It also allows simplification of several
tests.

This is part 2 of my effort to simplify and standardize how we
create subsystems in tests.  See for part 1:

44be4da8bda29e21061e550b6529a346934b9b0f