### PR TITLE
Reset subsystem state for integration tests.

### DIFF
--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -50,6 +50,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/fs',
+    'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/testutils:file_test_util',

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -18,6 +18,7 @@ from colors import strip_color
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.fs.archive import ZIP
+from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open
 from pants_test.testutils.file_test_util import check_symlinks, contains_exact_files
@@ -91,6 +92,11 @@ class PantsRunIntegrationTest(unittest.TestCase):
       return True
     except OSError:
       return False
+
+  def setUp(self):
+    super(PantsRunIntegrationTest, self).setUp()
+    # Some integration tests rely on clean subsystem state (e.g., to set up a DistributionLocator).
+    Subsystem.reset()
 
   def temporary_workdir(self, cleanup=True):
     # We can hard-code '.pants.d' here because we know that will always be its value


### PR DESCRIPTION
Some integration tests initialize a DistributionLocator
(e.g., test_distribution_integration.py, test_shader_integration.py).

They currently rely on the subsystem_instance() contextmanager to
clean up that state, but that method is going away (because it
can destroy state needed outside the context).

This pre-cleanup helps prevent weird errors due to interactions between
unrelated tests that happened to run in a certain order in a single
process, typically on CI.