### PR TITLE
Add a timeout to scalajs tests

### DIFF
--- a/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
+++ b/contrib/scalajs/tests/python/pants_test/contrib/scalajs/tasks/BUILD
@@ -8,4 +8,5 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},
+  timeout=180,
 )


### PR DESCRIPTION
Failed on me locally trying to run a release