### PR TITLE
Fix ng-killall by swallowing psutil exceptions in filter

### DIFF
--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -49,16 +49,17 @@ class ProcessGroup(object):
                           metadata_base_dir=self._metadata_base_dir)
 
   def iter_processes(self, proc_filter=None):
-    if proc_filter:
-      def filter(o):
-        with swallow_psutil_exceptions():
-          return proc_filter(o)
-    else:
-      filter = lambda x: True
+    """Yields processes from psutil.process_iter with an optional filter and swallows psutil errors.
 
-    with swallow_psutil_exceptions():
-      for proc in (x for x in psutil.process_iter() if filter(x)):
-        yield proc
+    If a psutil exception is raised during execution of the filter, that process will not be
+    yielded but subsequent process will. On the other hand, if psutil.process_iter raises
+    an exception, no more processes will be yielded.
+    """
+    with swallow_psutil_exceptions():  # process_iter may raise
+      for proc in psutil.process_iter():
+        with swallow_psutil_exceptions():  # proc_filter may raise
+          if (proc_filter is None) or proc_filter(proc):
+            yield proc
 
   def iter_instances(self, *args, **kwargs):
     for item in self.iter_processes(*args, **kwargs):

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -49,9 +49,15 @@ class ProcessGroup(object):
                           metadata_base_dir=self._metadata_base_dir)
 
   def iter_processes(self, proc_filter=None):
-    proc_filter = proc_filter or (lambda x: True)
+    if proc_filter:
+      def filter(o):
+        with swallow_psutil_exceptions():
+          return proc_filter(o)
+    else:
+      filter = lambda x: True
+
     with swallow_psutil_exceptions():
-      for proc in (x for x in psutil.process_iter() if proc_filter(x)):
+      for proc in (x for x in psutil.process_iter() if filter(x)):
         yield proc
 
   def iter_instances(self, *args, **kwargs):

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -52,7 +52,7 @@ class ProcessGroup(object):
     """Yields processes from psutil.process_iter with an optional filter and swallows psutil errors.
 
     If a psutil exception is raised during execution of the filter, that process will not be
-    yielded but subsequent process will. On the other hand, if psutil.process_iter raises
+    yielded but subsequent processes will. On the other hand, if psutil.process_iter raises
     an exception, no more processes will be yielded.
     """
     with swallow_psutil_exceptions():  # process_iter may raise


### PR DESCRIPTION
ng-killall will fail to kill nailguns if there is a process earlier in the process list that has attributes that can't be accessed.

This patch wraps ProcessManager.process_iter's filter with a exception swallow call which allows it to continue if the filter calls a psutil error causing method.