### PR TITLE
Fix python 3.5 tests

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -18,7 +18,7 @@ pyflakes==1.1.0
 Pygments==1.4
 pystache==0.5.3
 pytest-cov>=1.8,<1.9
-pytest>=2.6,<2.7
+pytest>=2.9,<2.10
 pywatchman==1.3.0
 requests>=2.5.0,<2.6
 scandir==1.2

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -14,11 +14,9 @@ class PyTest(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(PyTest, cls).register_options(register)
-    register('--requirements', advanced=True, default='pytest>=2.6,<2.7',
+    register('--requirements', advanced=True, default='pytest>=2.9,<2.10',
              help='Requirements string for the pytest library.')
-    # NB, pytest-timeout 1.0.0 introduces a conflicting pytest>=2.8.0 requirement, see:
-    #   https://github.com/pantsbuild/pants/issues/2566
-    register('--timeout-requirements', advanced=True, default='pytest-timeout<1.0.0',
+    register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.0,<1.1',
              help='Requirements string for the pytest-timeout library.')
     register('--cov-requirements', advanced=True, default='pytest-cov>=1.8,<1.9',
              help='Requirements string for the pytest-cov library.')


### PR DESCRIPTION
Pytest 2.6.x is not compatible with Python 3.5. They fixed this in pytest 2.8.

These changes should fix python 3.5 tests on Pants.

This is the error that happens when trying to run any test under python 3.5

```
13:54:34 00:00 [main]
               (To run a reporting server: ./pants server)
13:54:34 00:00   [setup]
13:54:34 00:00     [parse]
               Executing tasks in goals: bootstrap -> imports -> unpack-jars -> deferred-sources -> gen -> jvm-platform-validate -> resolve -> resources -> compile -> test
13:54:34 00:00   [bootstrap]
13:54:34 00:00     [substitute-aliased-targets]
13:54:34 00:00     [jar-dependency-management]
13:54:35 00:01     [bootstrap-jvm-tools]
13:54:35 00:01     [provide-tools-jar]
13:54:35 00:01   [imports]
13:54:35 00:01     [ivy-imports]
13:54:35 00:01   [unpack-jars]
13:54:35 00:01     [unpack-jars]
13:54:35 00:01   [deferred-sources]
13:54:35 00:01     [deferred-sources]
13:54:35 00:01   [gen]
13:54:35 00:01     [thrift]
13:54:35 00:01     [protoc]
13:54:35 00:01     [antlr]
13:54:35 00:01     [ragel]
13:54:35 00:01     [jaxb]
13:54:35 00:01     [wire]
13:54:35 00:01   [jvm-platform-validate]
13:54:35 00:01     [jvm-platform-validate]
13:54:35 00:01   [resolve]
13:54:35 00:01     [ivy]
13:54:35 00:01   [resources]
13:54:35 00:01     [prepare]
13:54:35 00:01     [services]
13:54:35 00:01   [compile]
13:54:35 00:01     [compile-jvm-prep-command]
13:54:35 00:01       [jvm_prep_command]
13:54:35 00:01     [compile-prep-command]
13:54:35 00:01     [compile]
13:54:35 00:01     [zinc]
13:54:35 00:01     [jvm-dep-check]
13:54:35 00:01   [test]
13:54:35 00:01     [test-jvm-prep-command]
13:54:35 00:01       [jvm_prep_command]
13:54:35 00:01     [test-prep-command]
13:54:35 00:01     [test]
13:54:35 00:01     [pytest]
13:54:35 00:01       [run]
                     ============== test session starts ===============
                     platform linux -- Python 3.5.2 -- py-1.4.31 -- pytest-2.6.4
                     plugins: timeout, cov
                     collected 0 items / 1 errors

                     ===================== ERRORS =====================
                      ERROR collecting src/python/echo/tests/echo_test.py
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/py-1.4.31-py2.py3-none-any.whl/py/_path/local.py:650: in pyimport
                         __import__(modname)
                     <frozen importlib._bootstrap>:969: in _find_and_load
                         ???
                     <frozen importlib._bootstrap>:954: in _find_and_load_unlocked
                         ???
                     <frozen importlib._bootstrap>:892: in _find_spec
                         ???
                     <frozen importlib._bootstrap>:873: in _find_spec_legacy
                         ???
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:137: in find_module
                         source_stat, co = _rewrite_test(state, fn_pypath)
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:272: in _rewrite_test
                         rewrite_asserts(tree)
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:330: in rewrite_asserts
                         AssertionRewriter().run(mod)
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:539: in run
                         new.extend(self.visit(child))
                     /usr/lib/python3.5/ast.py:245: in visit
                         return visitor(node)
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:647: in visit_Assert
                         top_condition, explanation = self.visit(assert_.test)
                     /usr/lib/python3.5/ast.py:245: in visit
                         return visitor(node)
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:778: in visit_Compare
                         left_res, left_expl = self.visit(comp.left)
                     /usr/lib/python3.5/ast.py:245: in visit
                         return visitor(node)
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:739: in visit_Call
                         new_func, func_expl = self.visit(call.func)
                     /usr/lib/python3.5/ast.py:245: in visit
                         return visitor(node)
                     .pants.d/python-setup/chroots/c43b733395decf039a1bd7aa7f134bbb2b9b9388/.deps/pytest-2.6.4-py3-none-any.whl/_pytest/assertion/rewrite.py:682: in visit_Name
                         locs = ast.Call(self.builtin("locals"), [], [], None, None)
                     E   TypeError: Call constructor takes either 0 or 3 positional arguments
                     ============ 1 error in 0.09 seconds =============

FAILURE


13:54:35 00:01   [complete]
               FAILURE
```
