### PR TITLE
Fix handling of method specs.

### DIFF
--- a/3rdparty/jvm/org/hamcrest/BUILD
+++ b/3rdparty/jvm/org/hamcrest/BUILD
@@ -1,0 +1,17 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jar_library(
+  name='hamcrest-core',
+  jars=[
+    jar(org='org.hamcrest', name='hamcrest-core', rev='1.3'),
+  ],
+)
+
+jar_library(
+  name='hamcrest-library',
+  jars=[
+    jar(org='org.hamcrest', name='hamcrest-library', rev='1.3'),
+  ],
+)
+

--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -452,8 +452,7 @@ public class ConsoleRunnerImpl {
 
     int failures = 0;
     try {
-      List<Spec> parsedTests = new SpecParser(tests).parse();
-
+      Collection<Spec> parsedTests = new SpecParser(tests).parse();
       if (useExperimentalRunner) {
         failures = runExperimental(parsedTests, core);
       } else {
@@ -495,7 +494,7 @@ public class ConsoleRunnerImpl {
     };
   }
 
-  private int runExperimental(List<Spec> parsedTests, JUnitCore core)
+  private int runExperimental(Collection<Spec> parsedTests, JUnitCore core)
       throws InitializationError {
     Preconditions.checkNotNull(core);
 
@@ -527,10 +526,8 @@ public class ConsoleRunnerImpl {
     return core.run(junitComputer, classes).getFailureCount();
   }
 
-  private int runLegacy(List<Spec> parsedTests, JUnitCore core) throws InitializationError {
-    List<Request> requests =
-        legacyParseRequests(swappableOut.getOriginal(), swappableErr.getOriginal(), parsedTests);
-
+  private int runLegacy(Collection<Spec> parsedTests, JUnitCore core) throws InitializationError {
+    List<Request> requests = legacyParseRequests(swappableErr.getOriginal(), parsedTests);
     if (numTestShards > 0) {
       requests = setFilterForTestShard(requests);
     }
@@ -558,9 +555,7 @@ public class ConsoleRunnerImpl {
     return failures;
   }
 
-  private List<Request> legacyParseRequests(PrintStream out, PrintStream err,
-      List<Spec> specs) {
-
+  private List<Request> legacyParseRequests(PrintStream err, Collection<Spec> specs) {
     Set<TestMethod> testMethods = Sets.newLinkedHashSet();
     Set<Class<?>> classes = Sets.newLinkedHashSet();
     for (Spec spec: specs) {

--- a/src/java/org/pantsbuild/tools/junit/impl/Spec.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Spec.java
@@ -3,11 +3,11 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableSet;
+
 import org.pantsbuild.junit.annotations.TestParallel;
 import org.pantsbuild.junit.annotations.TestParallelClassesAndMethods;
 import org.pantsbuild.junit.annotations.TestParallelMethods;
@@ -18,32 +18,40 @@ import org.pantsbuild.junit.annotations.TestSerial;
  */
 class Spec {
   private final Class<?> clazz;
-  private final Set<String> methods;
+  private final ImmutableSet<String> methods;
 
-  public Spec(Class<?> clazz) {
-    Preconditions.checkNotNull(clazz);
-    this.clazz = clazz;
-    this.methods = new LinkedHashSet<String>();
+  Spec(Class<?> clazz) {
+    this(clazz, ImmutableSet.of());
   }
 
-  public String getSpecName() {
+  private Spec(Class<?> clazz, ImmutableSet<String> methods) {
+    this.clazz = Objects.requireNonNull(clazz);
+    this.methods = Objects.requireNonNull(methods);
+  }
+
+  String getSpecName() {
     return this.clazz.getName();
   }
 
-  public Class<?> getSpecClass() {
+  Class<?> getSpecClass() {
     return this.clazz;
   }
 
-  public void addMethod(String method) {
-    Preconditions.checkNotNull(method);
-    methods.add(method);
+  /**
+   * Return a copy of this class spec, but with an additional method.
+   *
+   * @param method The method to add to the class spec.
+   * @return A new spec that includes the added method.
+   */
+  Spec addMethod(String method) {
+    return new Spec(clazz, ImmutableSet.<String>builder().addAll(methods).add(method).build());
   }
 
   /**
    * @return either the Concurrency value specified by the class annotation or the default
    * concurrency setting passed in the parameter.
    */
-  public Concurrency getConcurrency(Concurrency defaultConcurrency) {
+  Concurrency getConcurrency(Concurrency defaultConcurrency) {
     if (clazz.isAnnotationPresent(TestSerial.class)) {
       return Concurrency.SERIAL;
     } else if (clazz.isAnnotationPresent(TestParallel.class)) {
@@ -57,6 +65,6 @@ class Spec {
   }
 
   public Collection<String> getMethods() {
-    return ImmutableList.copyOf(methods);
+    return methods;
   }
 }

--- a/src/java/org/pantsbuild/tools/junit/impl/Spec.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Spec.java
@@ -43,7 +43,7 @@ class Spec {
    * @param method The method to add to the class spec.
    * @return A new spec that includes the added method.
    */
-  Spec addMethod(String method) {
+  Spec withMethod(String method) {
     return new Spec(clazz, ImmutableSet.<String>builder().addAll(methods).add(method).build());
   }
 

--- a/src/java/org/pantsbuild/tools/junit/impl/SpecException.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/SpecException.java
@@ -3,17 +3,17 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-class SpecException extends Exception {
+class SpecException extends RuntimeException {
 
-  public SpecException(String spec, String message) {
+  SpecException(String spec, String message) {
     super(formatMessage(spec, message));
   }
 
-  public SpecException(String spec, String message, Throwable t) {
+  SpecException(String spec, String message, Throwable t) {
     super(formatMessage(spec, message), t);
   }
 
   private static String formatMessage(String spec, String message) {
-    return String.format("FATAL: Error parsing spec '%s': %s",spec, message);
+    return String.format("FATAL: Error parsing spec '%s': %s", spec, message);
   }
 }

--- a/src/java/org/pantsbuild/tools/junit/impl/SpecParser.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/SpecParser.java
@@ -113,7 +113,7 @@ class SpecParser {
     spec.ifPresent(s -> {
       for (Method clazzMethod : s.getSpecClass().getMethods()) {
         if (clazzMethod.getName().equals(methodName)) {
-          Spec specWithMethod = s.addMethod(methodName);
+          Spec specWithMethod = s.withMethod(methodName);
           specs.put(s.getSpecClass(), specWithMethod);
           return;
         }

--- a/src/java/org/pantsbuild/tools/junit/impl/SpecParser.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/SpecParser.java
@@ -3,20 +3,15 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.junit.runner.RunWith;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Iterables;
 
 /**
  * Takes strings passed to the command line representing packages or individual methods
@@ -25,8 +20,8 @@ import org.junit.runner.RunWith;
  */
 class SpecParser {
   private final Iterable<String> testSpecStrings;
-  private final Map<Class<?>, Spec> specs = new LinkedHashMap<Class<?>, Spec>();
-  private final Set<String> classNamesInSpecs = new HashSet<String>();
+  private final LoadingCache<Class<?>, Spec> specs =
+      CacheBuilder.newBuilder().build(CacheLoader.from(Spec::new));
 
   /**
    * Parses the list of incoming test specs from the command line.
@@ -45,34 +40,32 @@ class SpecParser {
    * </p>
    */
   // TODO(zundel): This could easily be extended to allow a regular expression in the spec
-  public SpecParser(Iterable<String> testSpecStrings) {
+  SpecParser(Iterable<String> testSpecStrings) {
     Preconditions.checkArgument(!Iterables.isEmpty(testSpecStrings));
     this.testSpecStrings = testSpecStrings;
   }
 
   /**
    * Parse the specs passed in to the constructor.
+   *
    * @return List of parsed specs
-   * @throws SpecException
+   * @throws SpecException when there is a problem parsing specs
    */
-  public List<Spec> parse() throws SpecException {
+  Collection<Spec> parse() throws SpecException {
     for (String specString : testSpecStrings) {
       if (specString.indexOf('#') >= 0) {
         addMethod(specString);
-        continue;
+      } else {
+        Optional<Spec> spec = getOrCreateSpec(specString, specString);
+        spec.ifPresent(s -> {
+          if (specs.asMap().containsKey(s.getSpecClass()) && !s.getMethods().isEmpty()) {
+            throw new SpecException(specString,
+                "Request for entire class already requesting individual methods");
+          }
+        });
       }
-      // The specString is expected to be the same as the fully qualified class name
-      if (classNamesInSpecs.contains(specString)) {
-        Spec spec = getOrCreateSpec(specString, specString);
-        if (!spec.getMethods().isEmpty()) {
-          throw new SpecException(specString,
-              "Request for entire class already requesting individual methods");
-        }
-        continue;
-      }
-      getOrCreateSpec(specString, specString);
     }
-    return ImmutableList.copyOf(specs.values());
+    return specs.asMap().values();
   }
 
   /**
@@ -80,24 +73,18 @@ class SpecParser {
    *
    * @param className The class name already parsed out of specString
    * @param specString  A spec string described in {@link SpecParser}
-   * @return a Spec instance on success, null if this spec string should be ignored
+   * @return a present Spec instance on success, absent if this spec string should be ignored
    * @throws SpecException if the method passed in is not an executable test method
    */
-  private Spec getOrCreateSpec(String className, String specString) throws SpecException {
+  private Optional<Spec> getOrCreateSpec(String className, String specString) throws SpecException {
     try {
       Class<?> clazz = getClass().getClassLoader().loadClass(className);
-      if (!Util.isTestClass(clazz)) {
-        return null;
+      if (Util.isTestClass(clazz)) {
+        return Optional.of(specs.getUnchecked(clazz));
+      } else {
+        return Optional.empty();
       }
-      if (!specs.containsKey(clazz)) {
-        specs.put(clazz, new Spec(clazz));
-        classNamesInSpecs.add(className);
-      }
-      return specs.get(clazz);
-    } catch (ClassNotFoundException e) {
-      throw new SpecException(specString,
-          String.format("Class %s not found in classpath.", className), e);
-    } catch (NoClassDefFoundError e) {
+    } catch (ClassNotFoundException | NoClassDefFoundError e) {
       throw new SpecException(specString,
           String.format("Class %s not found in classpath.", className), e);
     } catch (LinkageError e) {
@@ -117,7 +104,7 @@ class SpecParser {
   /**
    * Handle a spec that looks like package.className#methodName
    */
-  public void addMethod(String specString) throws SpecException {
+  private void addMethod(String specString) throws SpecException {
     String[] results = specString.split("#");
     if (results.length != 2) {
       throw new SpecException(specString, "Expected only one # in spec");
@@ -125,18 +112,18 @@ class SpecParser {
     String className = results[0];
     String methodName = results[1];
 
-    Spec spec = getOrCreateSpec(className, specString);
-    boolean found = false;
-    for (Method clazzMethod : spec.getSpecClass().getMethods()) {
-      if (clazzMethod.getName().equals(methodName)) {
-        found = true;
-        break;
+    Optional<Spec> spec = getOrCreateSpec(className, specString);
+    spec.ifPresent(s -> {
+      for (Method clazzMethod : s.getSpecClass().getMethods()) {
+        if (clazzMethod.getName().equals(methodName)) {
+          Spec specWithMethod = s.addMethod(methodName);
+          specs.put(s.getSpecClass(), specWithMethod);
+          return;
+        }
       }
-    }
-    if (!found) {
+      // TODO(John Sirois): Introduce an Either type to make this function total.
       throw new SpecException(specString,
           String.format("Method %s not found in class %s", methodName, className));
-    }
-    spec.addMethod(methodName);
+    });
   }
 }

--- a/testprojects/tests/java/org/pantsbuild/testproject/matcher/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/matcher/BUILD
@@ -6,5 +6,6 @@ junit_tests(name='matcher',
   sources=['MatcherTest.java'],
   dependencies=[
     '3rdparty:junit',
+    '3rdparty/jvm/org/hamcrest:hamcrest-library',
   ],
 )

--- a/tests/java/org/pantsbuild/tools/junit/impl/BUILD
+++ b/tests/java/org/pantsbuild/tools/junit/impl/BUILD
@@ -14,6 +14,5 @@ java_tests(
     'tests/java/org/pantsbuild/tools/junit/lib:test-dep',
   ],
   sources=globs('*Test.java'),
-  strict_deps=False,
   timeout=180,
 )

--- a/tests/java/org/pantsbuild/tools/junit/impl/BUILD
+++ b/tests/java/org/pantsbuild/tools/junit/impl/BUILD
@@ -4,6 +4,13 @@
 java_tests(
   name='junit',
   dependencies=[
+    '3rdparty:guava',
+    '3rdparty:junit',
+    '3rdparty/jvm/commons-io',
+    '3rdparty/jvm/org/hamcrest:hamcrest-core',
+    '3rdparty/jvm/org/hamcrest:hamcrest-library',
+    'src/java/org/pantsbuild/junit/annotations',
+    'src/java/org/pantsbuild/tools/junit',
     'tests/java/org/pantsbuild/tools/junit/lib:test-dep',
   ],
   sources=globs('*Test.java'),

--- a/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
@@ -3,38 +3,37 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
 import org.junit.Test;
 import org.pantsbuild.tools.junit.lib.MockJUnit3Test;
 import org.pantsbuild.tools.junit.lib.MockRunWithTest;
 import org.pantsbuild.tools.junit.lib.UnannotatedTestClass;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class SpecParserTest {
   private static final String DUMMY_CLASS_NAME =
       "org.pantsbuild.tools.junit.lib.UnannotatedTestClass";
   private static final String DUMMY_METHOD_NAME = "testMethod";
 
-  @Test public void testEmptySpecsThrows() {
-    try {
-      SpecParser parser = new SpecParser(new ArrayList<String>());
-      fail("Expected Exception");
-    } catch (Throwable expected) {
-    }
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmptySpecsThrows() {
+    new SpecParser(new ArrayList<>());
   }
 
   @Test public void testParserClass() throws Exception {
     SpecParser parser = new SpecParser(ImmutableList.of(DUMMY_CLASS_NAME));
-    List<Spec> specs = parser.parse();
-    assertEquals(1, specs.size());
-    Spec spec = specs.get(0);
+    Collection<Spec> specs = parser.parse();
+    Spec spec = Iterables.getOnlyElement(specs);
     assertEquals(UnannotatedTestClass.class,spec.getSpecClass());
     assertEquals(DUMMY_CLASS_NAME, spec.getSpecName());
     assertEquals(0, spec.getMethods().size());
@@ -43,12 +42,11 @@ public class SpecParserTest {
   @Test public void testParserMethod() throws Exception {
     String specString = DUMMY_CLASS_NAME + "#" + DUMMY_METHOD_NAME;
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
-    List<Spec> specs = parser.parse();
-    assertEquals(1, specs.size());
-    Spec spec = specs.get(0);
+    Collection<Spec> specs = parser.parse();
+    Spec spec = Iterables.getOnlyElement(specs);
     assertEquals(UnannotatedTestClass.class, spec.getSpecClass());
     assertEquals(DUMMY_CLASS_NAME, spec.getSpecName());
-    assertEquals(ImmutableList.of(DUMMY_METHOD_NAME), spec.getMethods());
+    assertThat(spec.getMethods(), contains(DUMMY_METHOD_NAME));
   }
 
   @Test public void testMethodDupsClass() throws Exception {
@@ -98,7 +96,7 @@ public class SpecParserTest {
   private void assertNoSpecs(String className) throws Exception {
     String specString = "org.pantsbuild.tools.junit.lib." + className;
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
-    List<Spec> specs = parser.parse();
+    Collection<Spec> specs = parser.parse();
     assertTrue(specs.isEmpty());
   }
 
@@ -106,10 +104,8 @@ public class SpecParserTest {
    * These are all classes/interfaces, but aren't test classes. Pants will pass in all the classes
    * and interfaces it finds, but if they get passed down to the BlockJUnit4Runner, the runner
    * will throw an InitializationError
-   *
-   * @throws Exception
    */
-  @Test public void testNotATest() throws Exception {
+  @Test public void testNotATestClassSpec() throws Exception {
     assertNoSpecs("NotATestAbstractClass");
     assertNoSpecs("NotATestInterface");
     assertNoSpecs("NotATestNonzeroArgConstructor");
@@ -118,19 +114,26 @@ public class SpecParserTest {
     assertNoSpecs("NotATestPrivateClass");
   }
 
+  @Test public void testNotATestMethodSpec() throws Exception {
+    String specString = "org.pantsbuild.tools.junit.lib.NotATestInterface#natif1";
+    SpecParser parser = new SpecParser(ImmutableList.of(specString));
+    Collection<Spec> specs = parser.parse();
+    assertTrue(specs.isEmpty());
+  }
+
   @Test public void testJUnit3() throws Exception {
     String specString = "org.pantsbuild.tools.junit.lib.MockJUnit3Test";
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
-    List<Spec> specs = parser.parse();
-    assertEquals(1, specs.size());
-    assertEquals(MockJUnit3Test.class, specs.get(0).getSpecClass());
+    Collection<Spec> specs = parser.parse();
+    Spec spec = Iterables.getOnlyElement(specs);
+    assertEquals(MockJUnit3Test.class, spec.getSpecClass());
   }
 
   @Test public void testRunWith() throws Exception {
     String specString = "org.pantsbuild.tools.junit.lib.MockRunWithTest";
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
-    List<Spec> specs = parser.parse();
-    assertEquals(1, specs.size());
-    assertEquals(MockRunWithTest.class, specs.get(0).getSpecClass());
+    Collection<Spec> specs = parser.parse();
+    Spec spec = Iterables.getOnlyElement(specs);
+    assertEquals(MockRunWithTest.class, spec.getSpecClass());
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/impl/SpecTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/SpecTest.java
@@ -21,9 +21,9 @@ public class SpecTest {
     assertEquals("org.pantsbuild.tools.junit.lib.UnannotatedTestClass",
         spec.getSpecName());
     assertThat(spec.getMethods(), emptyCollectionOf(String.class));
-    Spec specWithMethodAdded = spec.addMethod("testMethod");
+    Spec specWithMethodAdded = spec.withMethod("testMethod");
     assertThat(specWithMethodAdded.getMethods(), contains("testMethod"));
-    assertThat(specWithMethodAdded.addMethod("foo").getMethods(), contains("testMethod", "foo"));
+    assertThat(specWithMethodAdded.withMethod("foo").getMethods(), contains("testMethod", "foo"));
   }
 
   @Test public void testDefaultConcurrency() {

--- a/tests/java/org/pantsbuild/tools/junit/impl/SpecTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/SpecTest.java
@@ -3,13 +3,15 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.pantsbuild.tools.junit.lib.AnnotationOverrideClass;
 import org.pantsbuild.tools.junit.lib.ParallelAnnotatedClass;
 import org.pantsbuild.tools.junit.lib.UnannotatedTestClass;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class SpecTest {
 
@@ -18,11 +20,10 @@ public class SpecTest {
     assertEquals(UnannotatedTestClass.class, spec.getSpecClass());
     assertEquals("org.pantsbuild.tools.junit.lib.UnannotatedTestClass",
         spec.getSpecName());
-    assertEquals(ImmutableList.of(), spec.getMethods());
-    spec.addMethod("testMethod");
-    assertEquals(ImmutableList.of("testMethod"), spec.getMethods());
-    spec.addMethod("foo");
-    assertEquals(ImmutableList.of("testMethod", "foo"), spec.getMethods());
+    assertThat(spec.getMethods(), emptyCollectionOf(String.class));
+    Spec specWithMethodAdded = spec.addMethod("testMethod");
+    assertThat(specWithMethodAdded.getMethods(), contains("testMethod"));
+    assertThat(specWithMethodAdded.addMethod("foo").getMethods(), contains("testMethod", "foo"));
   }
 
   @Test public void testDefaultConcurrency() {

--- a/tests/java/org/pantsbuild/tools/junit/lib/BUILD
+++ b/tests/java/org/pantsbuild/tools/junit/lib/BUILD
@@ -7,7 +7,7 @@ java_library(
     '3rdparty/jvm/com/squareup/burst:burst-junit4',
     '3rdparty:guava',
     '3rdparty:junit',
-    '3rdparty/jvm/commons-io',
+    '3rdparty/jvm/org/hamcrest:hamcrest-core',
     'src/java/org/pantsbuild/junit/annotations',
     'src/java/org/pantsbuild/tools/junit',
   ],


### PR DESCRIPTION
Previously the method spec handling code did not guard against non-test
classes and would throw an NPE. This change adds a failing test and
fixes the handling to deal with `Optional`. The `Spec` class is made
immutable in the process to improve the code's ability to be reasoned
about.

https://rbcommons.com/s/twitter/r/4258/