### PR TITLE
Upgrade to junit-runner 1.0.14.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -21,7 +21,7 @@ class JUnit(JvmToolMixin, Subsystem):
   RUNNER_MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   _LIBRARY_JAR = JarDependency(org='junit', name='junit', rev=LIBRARY_REV)
-  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.13')
+  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.14')
 
   @classmethod
   def register_options(cls, register):

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -24,14 +24,6 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
   def test_java_eight(self):
     self._testjvms('eight')
 
-  @skipIf(is_missing_jvm('1.7'), 'no java 1.7 installation on testing machine')
-  def test_java_seven(self):
-    self._testjvms('seven')
-
-  @skipIf(is_missing_jvm('1.6'), 'no java 1.6 installation on testing machine')
-  def test_java_six(self):
-    self._testjvms('six')
-
   @skipIf(is_missing_jvm('1.8'), 'no java 1.8 installation on testing machine')
   def test_with_test_platform(self):
     self._testjvms('eight-test-platform')


### PR DESCRIPTION
This picks up a fix for [filepath]#[methodname] test specifier handling.

https://rbcommons.com/s/twitter/r/4264/