### PR TITLE
Update binary_util OS map for OSX Sierra.

### DIFF
--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -33,6 +33,7 @@ _DEFAULT_PATH_BY_ID = {
   ('darwin', '13'): ('mac', '10.9'),
   ('darwin', '14'): ('mac', '10.10'),
   ('darwin', '15'): ('mac', '10.11'),
+  ('darwin', '16'): ('mac', '10.12'),
 }
 
 


### PR DESCRIPTION
This is in anticipation of posting the rebuilt
binaries for 10.12, with this as a follow up after
those land.