### PR TITLE
Update the setup.py description.

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -13,7 +13,7 @@ python_library(
   name='pants-packaged',
   provides=pants_setup_py(
     name='pantsbuild.pants',
-    description='A bottom-up build tool.',
+    description='A scalable build tool for large, complex, heterogeneous repos.',
     namespace_packages=['pants', 'pants.backend'],
   ).with_binaries(
     pants='src/python/pants/bin:pants',


### PR DESCRIPTION
"A bottom-up build tool" isn't particularly descriptive, and it
appears on all our PyPI releases.

I'm open to alternative phrasing, this is my best suggestion so far.