### PR TITLE
Leverage default targets throughout pants BUILDs.

### DIFF
--- a/3rdparty/jvm/com/google/auto/value/BUILD
+++ b/3rdparty/jvm/com/google/auto/value/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jar_library(name='value',
+jar_library(
   jars=[
     jar(org='com.google.auto.value', name='auto-value', rev='1.1'),
   ],

--- a/3rdparty/jvm/commons-io/BUILD
+++ b/3rdparty/jvm/commons-io/BUILD
@@ -1,5 +1,4 @@
 jar_library(
-  name='commons-io',
   jars=[
     jar(org='commons-io', name='commons-io', rev='2.4'),
   ],

--- a/contrib/android/examples/src/android/example_library/BUILD
+++ b/contrib/android/examples/src/android/example_library/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 android_library(
-  name='example_library',
   manifest='AndroidManifest.xml',
   libraries=['contrib/android/examples/3rdparty/android:android-support-v4'],
   include_patterns=[

--- a/contrib/android/examples/src/android/hello/BUILD
+++ b/contrib/android/examples/src/android/hello/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 android_binary(
-  name='hello',
   sources=rglobs('src/*.java'),
   manifest='AndroidManifest.xml',
   dependencies = [

--- a/contrib/android/examples/src/android/hello_with_library/BUILD
+++ b/contrib/android/examples/src/android/hello_with_library/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 android_binary(
-  name='hello_with_library',
   sources=rglobs('main/src/*.java'),
   manifest='main/AndroidManifest.xml',
   dependencies = [

--- a/contrib/cpp/examples/src/cpp/calcsqrt/BUILD
+++ b/contrib/cpp/examples/src/cpp/calcsqrt/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 cpp_binary(
-  name='calcsqrt',
   sources=['main.cc'],
   libraries=['m'],
 )

--- a/contrib/cpp/examples/src/cpp/example/hello/BUILD
+++ b/contrib/cpp/examples/src/cpp/example/hello/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 cpp_library(
-  name='hello',
   sources=[
     'hello.cc',
     'hello.h',

--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='targets',
   sources=[
     'cpp_binary.py',
     'cpp_library.py',

--- a/contrib/cpp/src/python/pants/contrib/cpp/tasks/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/tasks/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='tasks',
   sources=[
     'cpp_compile.py',
     'cpp_binary_create.py',

--- a/contrib/cpp/src/python/pants/contrib/cpp/toolchain/BUILD
+++ b/contrib/cpp/src/python/pants/contrib/cpp/toolchain/BUILD
@@ -3,7 +3,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='toolchain',
   sources=[
     'cpp_toolchain.py',
   ],

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/BUILD
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='tasks',
   sources=[
     'findbugs.py',
   ],

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='tasks',
   sources=['test_findbugs.py'],
   dependencies=[
     'contrib/findbugs/src/python/pants/contrib/findbugs/tasks:tasks',

--- a/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='subsystems',
   sources=globs('*.py'),
   dependencies=[
     '3rdparty/python:requests',

--- a/contrib/go/src/python/pants/contrib/go/targets/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/targets/BUILD
@@ -1,5 +1,4 @@
 target(
-  name='targets',
   dependencies=[
     ':go_binary',
     ':go_library',

--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -1,5 +1,4 @@
 target(
-  name='tasks',
   dependencies=[
     ':go_binary_create',
     ':go_buildgen',

--- a/contrib/node/examples/3rdparty/node/babel-loader/BUILD
+++ b/contrib/node/examples/3rdparty/node/babel-loader/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='babel-loader',
   version='5.3.2'
 )

--- a/contrib/node/examples/3rdparty/node/babel/BUILD
+++ b/contrib/node/examples/3rdparty/node/babel/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='babel',
   version='5.8.23'
 )

--- a/contrib/node/examples/3rdparty/node/css-loader/BUILD
+++ b/contrib/node/examples/3rdparty/node/css-loader/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='css-loader',
   version='0.17.0'
 )

--- a/contrib/node/examples/3rdparty/node/mocha/BUILD
+++ b/contrib/node/examples/3rdparty/node/mocha/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='mocha',
   version='2.3.0'
 )

--- a/contrib/node/examples/3rdparty/node/null-loader/BUILD
+++ b/contrib/node/examples/3rdparty/node/null-loader/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='null-loader',
   version='0.1.1'
 )

--- a/contrib/node/examples/3rdparty/node/react/BUILD
+++ b/contrib/node/examples/3rdparty/node/react/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='react',
   version='0.13.3'
 )

--- a/contrib/node/examples/3rdparty/node/style-loader/BUILD
+++ b/contrib/node/examples/3rdparty/node/style-loader/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='style-loader',
   version='0.12.3'
 )

--- a/contrib/node/examples/3rdparty/node/webpack/BUILD
+++ b/contrib/node/examples/3rdparty/node/webpack/BUILD
@@ -1,4 +1,3 @@
 node_remote_module(
-  name='webpack',
   version='1.12.0'
 )

--- a/contrib/node/examples/src/node/preinstalled-project/BUILD
+++ b/contrib/node/examples/src/node/preinstalled-project/BUILD
@@ -2,7 +2,6 @@
 # an alternative Node module resolver.
 
 node_preinstalled_module(
-  name='preinstalled-project',
   sources=globs('package.json', 'src/*.js', 'test/*.js'),
   dependencies_archive_url=
     'https://dl.bintray.com/pantsbuild/node-preinstalled-modules/node_modules.tar.gz'

--- a/contrib/node/examples/src/node/server-project/BUILD
+++ b/contrib/node/examples/src/node/server-project/BUILD
@@ -3,7 +3,6 @@
 # package.json enough to get this benefit without any duplication.
 
 node_module(
-  name='server-project',
   sources=globs('package.json', 'checkarg', 'src/*.js', 'test/*.js'),
   dependencies=[
     'contrib/node/examples/3rdparty/node/babel',

--- a/contrib/node/examples/src/node/web-build-tool/BUILD
+++ b/contrib/node/examples/src/node/web-build-tool/BUILD
@@ -1,5 +1,4 @@
 node_module(
-  name='web-build-tool',
   sources=globs('package.json','web-build-tool','webpack.config.base.js'),
   dependencies=[
     'contrib/node/examples/3rdparty/node/babel-loader',

--- a/contrib/node/examples/src/node/web-component-button/BUILD
+++ b/contrib/node/examples/src/node/web-component-button/BUILD
@@ -1,5 +1,4 @@
 node_module(
-  name='web-component-button',
   sources=globs('package.json', 'webpack.config.js', 'src/*', 'test/*'),
   dependencies=[
     'contrib/node/examples/3rdparty/node/mocha',

--- a/contrib/node/examples/src/node/web-project/BUILD
+++ b/contrib/node/examples/src/node/web-project/BUILD
@@ -1,5 +1,4 @@
 node_module(
-  name='web-project',
   sources=globs('package.json', 'webpack.config.js', 'src/*', 'test/*'),
   dependencies=[
     'contrib/node/examples/3rdparty/node/mocha',

--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name='resolvers',
   dependencies=[
     ':npm_resolver',
     ':node_preinstalled_module_resolver',

--- a/contrib/node/src/python/pants/contrib/node/targets/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/targets/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name='targets',
   dependencies=[
     ':node_module',
     ':node_preinstalled_module',

--- a/contrib/node/src/python/pants/contrib/node/tasks/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name='tasks',
   dependencies=[
     ':node_repl',
     ':node_resolve',

--- a/contrib/python/src/python/pants/contrib/python/isort/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/isort/BUILD
@@ -1,5 +1,4 @@
 python_binary(
-  name='isort',
   source='isort.py',
   dependencies=[
     '3rdparty/python:isort',

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='checkstyle',
   sources=globs('*.py'),
   dependencies=[
     'contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle:all',

--- a/contrib/scalajs/examples/src/scala/org/pantsbuild/scalajs/example/factfinder/BUILD
+++ b/contrib/scalajs/examples/src/scala/org/pantsbuild/scalajs/example/factfinder/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-scala_js_binary(name='factfinder',
+scala_js_binary(
   dependencies=[
     'examples/src/scala/org/pantsbuild/example/fact:fact-js',
   ],

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/BUILD
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/subsystems/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'subsystems',
   dependencies = [
     'contrib/node/src/python/pants/contrib/node/subsystems/resolvers:node_resolver_base',
     'src/python/pants/option',

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/targets/BUILD
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/targets/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'targets',
   dependencies = [
     'contrib/node/src/python/pants/contrib/node/targets:node_module',
     'contrib/scalajs/src/python/pants/contrib/scalajs/subsystems',

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/BUILD
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'tasks',
   dependencies = [
     'contrib/scalajs/src/python/pants/contrib/scalajs/targets',
     'src/python/pants/backend/jvm/tasks/jvm_compile:zinc',

--- a/contrib/scalajs/tests/scala/org/pantsbuild/scalajs/example/factfinder/BUILD
+++ b/contrib/scalajs/tests/scala/org/pantsbuild/scalajs/example/factfinder/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='factfinder',
+junit_tests(
   dependencies=[
     '3rdparty:guava',
     '3rdparty:junit',

--- a/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
+++ b/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
@@ -1,5 +1,4 @@
 java_thrift_library(
-  name='android_generator',
   sources=['struct.thrift'],
   compiler='scrooge',
   language='android',

--- a/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/dummy_generator/BUILD
+++ b/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/dummy_generator/BUILD
@@ -1,5 +1,4 @@
 java_thrift_library(
-  name='dummy_generator',
   sources=['dummy.thrift'],
   compiler='scrooge',
   language='android',

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='tasks',
   dependencies=[
     ':scrooge_gen',
     ':thrift_linter',

--- a/examples/src/antlr/org/pantsbuild/example/exp/BUILD
+++ b/examples/src/antlr/org/pantsbuild/example/exp/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-target(name='exp',
+target(
   dependencies=[
     ':exp_antlr3',
     ':exp_antlr4',

--- a/examples/src/java/org/pantsbuild/example/annotation/example/BUILD
+++ b/examples/src/java/org/pantsbuild/example/annotation/example/BUILD
@@ -3,7 +3,7 @@
 #
 #  Example of annotation_processor() target
 
-java_library(name='example',
+java_library(
   sources=['Example.java'],
   # Is used by an annotation processor.
   scope='compile',

--- a/examples/src/java/org/pantsbuild/example/annotation/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/annotation/main/BUILD
@@ -3,7 +3,7 @@
 #
 #  Example for annotation_processor() target
 
-jvm_binary(name='main',
+jvm_binary(
   source='Main.java',
   main='org.pantsbuild.example.annotation.main.Main',
   basename = 'annotation-example',

--- a/examples/src/java/org/pantsbuild/example/annotation/processor/BUILD
+++ b/examples/src/java/org/pantsbuild/example/annotation/processor/BUILD
@@ -3,7 +3,7 @@
 #
 #  Example of annotation_processor() target
 
-annotation_processor(name='processor',
+annotation_processor(
   sources=['ExampleProcessor.java'],
   processors=['org.pantsbuild.example.annotation.processor.ExampleProcessor'],
   dependencies=[

--- a/examples/src/java/org/pantsbuild/example/antlr3/BUILD
+++ b/examples/src/java/org/pantsbuild/example/antlr3/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='antlr3',
+jvm_binary(
   source='ExampleAntlr3.java',
   main='org.pantsbuild.example.antlr3.ExampleAntlr3',
   dependencies=[

--- a/examples/src/java/org/pantsbuild/example/antlr4/BUILD
+++ b/examples/src/java/org/pantsbuild/example/antlr4/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='antlr4',
+jvm_binary(
   source='ExampleAntlr4.java',
   main='org.pantsbuild.example.antlr4.ExampleAntlr4',
   dependencies=[

--- a/examples/src/java/org/pantsbuild/example/autovalue/BUILD
+++ b/examples/src/java/org/pantsbuild/example/autovalue/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='autovalue',
+jvm_binary(
   main = 'org.pantsbuild.example.autovalue.AutoValueMain',
   dependencies = [
     ':autovalue-lib',

--- a/examples/src/java/org/pantsbuild/example/hello/simple/BUILD
+++ b/examples/src/java/org/pantsbuild/example/hello/simple/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name = 'simple',
+jvm_binary(
   source = 'HelloWorld.java',
   main = 'org.pantsbuild.example.hello.simple.HelloWorld',
 )

--- a/examples/src/java/org/pantsbuild/example/java_sources/BUILD
+++ b/examples/src/java/org/pantsbuild/example/java_sources/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name = 'java_sources',
+java_library(
   sources = globs('*.java'),
   dependencies = [
    'examples/src/scala/org/pantsbuild/example/scala_with_java_sources',

--- a/examples/src/java/org/pantsbuild/example/jaxb/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/jaxb/main/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='main',
+jvm_binary(
   basename='jaxb-example',
   dependencies=[
     'examples/src/java/org/pantsbuild/example/jaxb/reader',

--- a/examples/src/java/org/pantsbuild/example/jaxb/reader/BUILD
+++ b/examples/src/java/org/pantsbuild/example/jaxb/reader/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='reader',
+java_library(
   dependencies=[
     'examples/src/resources/org/pantsbuild/example/jaxb',
   ],

--- a/examples/src/java/org/pantsbuild/example/make_it_rain/BUILD
+++ b/examples/src/java/org/pantsbuild/example/make_it_rain/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='make_it_rain',
+java_library(
   sources=['MakeItRain.java',],
   dependencies=[
     '3rdparty:thrift-0.9.2',

--- a/examples/src/java/org/pantsbuild/example/protobuf/distance/BUILD
+++ b/examples/src/java/org/pantsbuild/example/protobuf/distance/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='distance',
+jvm_binary(
   basename='protobuf-example',
   dependencies=[
     'examples/src/protobuf/org/pantsbuild/example/distance',

--- a/examples/src/java/org/pantsbuild/example/protobuf/imports/BUILD
+++ b/examples/src/java/org/pantsbuild/example/protobuf/imports/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='imports',
+jvm_binary(
   basename='protobuf-imports-example',
   dependencies=[
     'examples/src/protobuf/org/pantsbuild/example/imports',

--- a/examples/src/java/org/pantsbuild/example/protobuf/unpacked_jars/BUILD
+++ b/examples/src/java/org/pantsbuild/example/protobuf/unpacked_jars/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='unpacked_jars',
+jvm_binary(
   basename='protobuf-unpacked-jars-example',
   source='ExampleProtobufExternalArchive.java',
   main='org.pantsbuild.example.protobuf.unpacked_jars.ExampleProtobufExternalArchive',

--- a/examples/src/java/org/pantsbuild/example/wire/element/BUILD
+++ b/examples/src/java/org/pantsbuild/example/wire/element/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='element',
+jvm_binary(
   basename='wire-element-example',
   dependencies=[
     '3rdparty:wire-runtime',

--- a/examples/src/java/org/pantsbuild/example/wire/roots/BUILD
+++ b/examples/src/java/org/pantsbuild/example/wire/roots/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='roots',
+jvm_binary(
   basename='wire-roots-example',
   dependencies=[
     'examples/src/wire/org/pantsbuild/example/roots',

--- a/examples/src/java/org/pantsbuild/example/wire/temperatureservice/BUILD
+++ b/examples/src/java/org/pantsbuild/example/wire/temperatureservice/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='temperatureservice',
+jvm_binary(
   basename='wire-temperature-example',
   dependencies=[
     '3rdparty:wire-runtime',

--- a/examples/src/protobuf/org/pantsbuild/example/distance/BUILD
+++ b/examples/src/protobuf/org/pantsbuild/example/distance/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_protobuf_library(name='distance',
+java_protobuf_library(
   sources=['distances.proto',],
 )

--- a/examples/src/protobuf/org/pantsbuild/example/imports/BUILD
+++ b/examples/src/protobuf/org/pantsbuild/example/imports/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_protobuf_library(name='imports',
+java_protobuf_library(
   sources=['test_imports.proto',],
   imports=[
     '3rdparty:protobuf-test-import',

--- a/examples/src/protobuf/org/pantsbuild/example/unpacked_jars/BUILD
+++ b/examples/src/protobuf/org/pantsbuild/example/unpacked_jars/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-remote_sources(name='unpacked_jars',
+remote_sources(
   dest=java_protobuf_library,
   sources_target=':external-source',
 )

--- a/examples/src/python/example/hello/greet/BUILD
+++ b/examples/src/python/example/hello/greet/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(name='greet',
+python_library(
   dependencies=[
     '3rdparty/python:ansicolors',
   ],

--- a/examples/src/python/example/hello/main/BUILD
+++ b/examples/src/python/example/hello/main/BUILD
@@ -3,7 +3,7 @@
 
 # Like Hello world, but built with Pants.
 
-python_binary(name='main',
+python_binary(
   dependencies=[
     'examples/src/python/example/hello/greet:greet',
   ],

--- a/examples/src/resources/org/pantsbuild/example/hello/BUILD
+++ b/examples/src/resources/org/pantsbuild/example/hello/BUILD
@@ -1,3 +1,3 @@
-resources(name='hello',
+resources(
   sources=['world.txt'],
 )

--- a/examples/src/resources/org/pantsbuild/example/jaxb/BUILD
+++ b/examples/src/resources/org/pantsbuild/example/jaxb/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jaxb_library(name='jaxb',
+jaxb_library(
   sources=globs('*.xsd'),
   package='org.pantsbuild.example.jaxb.api',
 )

--- a/examples/src/resources/org/pantsbuild/example/names/BUILD
+++ b/examples/src/resources/org/pantsbuild/example/names/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(name='names',
+resources(
   sources=['simple.xml'],
 )

--- a/examples/src/scala/org/pantsbuild/example/fact/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/fact/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # A pure scala library, with no Java or 3rdparty dependencies.
-scala_library(name='fact',
+scala_library(
   sources=globs('*.scala'),
 )
 scala_js_library(name='fact-js',

--- a/examples/src/scala/org/pantsbuild/example/hello/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/hello/BUILD
@@ -1,7 +1,7 @@
 #This is a dummy build file for Intellij Plugin integration test.
 #Please do not remove this BUILD file
 
-target(name='hello',
+target(
   dependencies = [
    'examples/src/scala/org/pantsbuild/example/hello/exe:exe',
   ]

--- a/examples/src/scala/org/pantsbuild/example/hello/exe/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/hello/exe/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='exe',
+jvm_binary(
   dependencies=[
     'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome',
   ],

--- a/examples/src/scala/org/pantsbuild/example/hello/welcome/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/hello/welcome/BUILD
@@ -3,7 +3,7 @@
 
 # Seq-friendly wrapper for Java "greet" library: greet everything in a seq.
 
-scala_library(name='welcome',
+scala_library(
   dependencies=[
     'examples/src/java/org/pantsbuild/example/hello/greet:greet',
   ],

--- a/examples/src/scala/org/pantsbuild/example/scala_with_java_sources/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/scala_with_java_sources/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-scala_library(name = 'scala_with_java_sources',
+scala_library(
   sources = ['Greet.scala'],
   java_sources=[
     'examples/src/java/org/pantsbuild/example/java_sources',

--- a/examples/src/scala/org/pantsbuild/example/styleissue/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/styleissue/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-scala_library(name = 'styleissue',
+scala_library(
   sources = ['StyleIssue.scala'],
 )

--- a/examples/src/wire/org/pantsbuild/example/element/BUILD
+++ b/examples/src/wire/org/pantsbuild/example/element/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_wire_library(name='element',
+java_wire_library(
   sources=[
     'elements.proto', # Order matters here.
     'compound.proto',

--- a/examples/src/wire/org/pantsbuild/example/roots/BUILD
+++ b/examples/src/wire/org/pantsbuild/example/roots/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_wire_library(name='roots',
+java_wire_library(
   sources=[
     'foo.proto',
     'bar.proto',

--- a/examples/src/wire/org/pantsbuild/example/temperature/BUILD
+++ b/examples/src/wire/org/pantsbuild/example/temperature/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_wire_library(name='temperature',
+java_wire_library(
   sources=['temperatures.proto',],
 
   # For service stub generation:

--- a/examples/tests/java/org/pantsbuild/example/hello/greet/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/hello/greet/BUILD
@@ -3,7 +3,7 @@
 
 # Test the Hello World example's "greet" library
 
-junit_tests(name='greet',
+junit_tests(
   sources=globs('*.java'),
   dependencies=[
     'examples/src/java/org/pantsbuild/example/hello/greet',

--- a/examples/tests/java/org/pantsbuild/example/usejaxb/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/usejaxb/BUILD
@@ -3,7 +3,7 @@
 
 # Shows java working with jaxb generations.
 
-junit_tests(name='usejaxb',
+junit_tests(
   sources=['UseJaxbTest.java',],
   dependencies=[
     '3rdparty:junit',

--- a/examples/tests/java/org/pantsbuild/example/useproto/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/useproto/BUILD
@@ -3,7 +3,7 @@
 
 # Tests functionality of protoc generating java code.
 
-junit_tests(name='useproto',
+junit_tests(
   sources=['UseProtoTest.java',],
   dependencies=[
     '3rdparty:junit',

--- a/examples/tests/java/org/pantsbuild/example/useprotoimports/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/useprotoimports/BUILD
@@ -3,7 +3,7 @@
 
 # Tests functionality of protoc generating java code, using 'imports' parameter.
 
-junit_tests(name='useprotoimports',
+junit_tests(
   sources=['UseImportsTest.java',],
   dependencies=[
     '3rdparty:junit',

--- a/examples/tests/java/org/pantsbuild/example/usethrift/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/usethrift/BUILD
@@ -3,7 +3,7 @@
 
 # This doesn't test much. It shows Pants-ly using Thrift from Java, though.
 
-junit_tests(name='usethrift',
+junit_tests(
   sources=['UseThriftTest.java',],
   dependencies=[
     '3rdparty:junit',

--- a/examples/tests/java/org/pantsbuild/example/usewire/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/usewire/BUILD
@@ -3,7 +3,7 @@
 
 # Tests functionality of wire generating java code.
 
-junit_tests(name='usewire',
+junit_tests(
   sources=['UseWireTest.java',],
   dependencies=[
     '3rdparty:junit',

--- a/examples/tests/python/example_test/hello/greet/BUILD
+++ b/examples/tests/python/example_test/hello/greet/BUILD
@@ -3,7 +3,7 @@
 
 # The greet library doesn't do much, but we should still test it
 
-python_tests(name='greet',
+python_tests(
   dependencies=[
     'examples/src/python/example/hello/greet:greet',
     ':prep',

--- a/examples/tests/scala/org/pantsbuild/example/hello/welcome/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/hello/welcome/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='welcome',
+junit_tests(
   dependencies=[
     'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome',
     '3rdparty:junit',

--- a/pants-plugins/tests/python/internal_backend_test/sitegen/BUILD
+++ b/pants-plugins/tests/python/internal_backend_test/sitegen/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='sitegen',
   sources=['test_sitegen.py'],
   dependencies=[
     'pants-plugins/3rdparty/python:beautifulsoup4',

--- a/pants-plugins/tests/python/internal_backend_test/utilities/BUILD
+++ b/pants-plugins/tests/python/internal_backend_test/utilities/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='utilities',
   sources=globs('*.py'),
   dependencies=[
     'pants-plugins/src/python/internal_backend/utilities:plugin',

--- a/src/docs/BUILD
+++ b/src/docs/BUILD
@@ -200,6 +200,7 @@ page(
 )
 
 page(
+  name='docs',
   source='docs.md',
 )
 

--- a/src/docs/BUILD
+++ b/src/docs/BUILD
@@ -200,7 +200,6 @@ page(
 )
 
 page(
-  name='docs',
   source='docs.md',
 )
 

--- a/src/java/com/sun/tools/javac/api/BUILD
+++ b/src/java/com/sun/tools/javac/api/BUILD
@@ -3,7 +3,6 @@
 
 
 java_library(
-  name='api',
   sources=globs('*.java'),
   dependencies=[
   ],

--- a/src/java/org/pantsbuild/args4j/BUILD
+++ b/src/java/org/pantsbuild/args4j/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='args4j',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:args4j',

--- a/src/java/org/pantsbuild/junit/annotations/BUILD
+++ b/src/java/org/pantsbuild/junit/annotations/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='annotations',
   provides=artifact(
     org='org.pantsbuild',
     name='junit-runner-annotations',

--- a/src/java/org/pantsbuild/testing/BUILD
+++ b/src/java/org/pantsbuild/testing/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='testing',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:easymock',

--- a/src/java/org/pantsbuild/tools/jar/BUILD
+++ b/src/java/org/pantsbuild/tools/jar/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='jar',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:args4j',

--- a/src/java/org/pantsbuild/tools/junit/BUILD
+++ b/src/java/org/pantsbuild/tools/junit/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='junit',
   provides=artifact(
     org='org.pantsbuild',
     name='junit-runner',

--- a/src/java/org/pantsbuild/tools/junit/withretry/BUILD
+++ b/src/java/org/pantsbuild/tools/junit/withretry/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='withretry',
   provides=artifact(
     org='org.pantsbuild',
     name='junit-runner-withretry',

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 target(
-  name='pants',
   dependencies=[
     'src/python/pants/bin:pants',
   ],

--- a/src/python/pants/backend/docgen/targets/BUILD
+++ b/src/python/pants/backend/docgen/targets/BUILD
@@ -3,7 +3,6 @@
 
 
 python_library(
-  name = 'targets',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/base:payload',

--- a/src/python/pants/backend/docgen/tasks/BUILD
+++ b/src/python/pants/backend/docgen/tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'tasks',
   sources = globs('*.py'),
   resource_targets = [
     ':resources',

--- a/src/python/pants/backend/graph_info/tasks/BUILD
+++ b/src/python/pants/backend/graph_info/tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'tasks',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/base:build_environment',

--- a/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
+++ b/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import copy
+import os
 
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.base.exceptions import TargetDefinitionException
@@ -112,13 +113,16 @@ class ManagedJarLibraries(object):
   def __init__(self, parse_context):
     self._parse_context = parse_context
 
-  def __call__(self, name, artifacts=None, **kwargs):
+  def __call__(self, name=None, artifacts=None, **kwargs):
     """
-    :param string name: The name of the generated managed_jar_dependencies() target.
+    :param string name: The optional name of the generated managed_jar_dependencies() target.
     :param artifacts: List of `jar <#jar>`_\s or specs to jar_library targets with pinned versions.
       Versions are pinned per (org, name, classifier, ext) artifact coordinate (excludes, etc are
       ignored for the purposes of pinning).
     """
+    # Support the default target name protocol.
+    if name is None:
+      name = os.path.basename(self._parse_context.rel_path)
     management = self._parse_context.create_object('managed_jar_dependencies',
                                                    name=name,
                                                    artifacts=artifacts,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -57,7 +57,6 @@ python_library(
 )
 
 python_library(
-  name = 'jvm_compile',
   sources = ['jvm_compile.py'],
   dependencies = [
     ':compile_context',

--- a/src/python/pants/backend/jvm/zinc/BUILD
+++ b/src/python/pants/backend/jvm/zinc/BUILD
@@ -1,5 +1,4 @@
 python_library(
-  name = 'zinc',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python:six',

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='bin',
   sources=globs('*.py', exclude=['options_initializer.py',
                                  'extension_loader.py',
                                  'plugin_resolver.py']),

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -3,7 +3,6 @@
 
 
 python_library(
-  name = 'build_graph',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',

--- a/src/python/pants/cache/BUILD
+++ b/src/python/pants/cache/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'cache',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python:requests',

--- a/src/python/pants/core_tasks/BUILD
+++ b/src/python/pants/core_tasks/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='core_tasks',
   sources=globs('*.py'),
   resource_targets=[':templates',],
   dependencies=[

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -38,7 +38,6 @@ python_library(
 )
 
 python_library(
-  name='engine',
   sources=['engine.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',

--- a/src/python/pants/fs/BUILD
+++ b/src/python/pants/fs/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'fs',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/util:contextutil',

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -53,7 +53,6 @@ python_library(
 # However the targets in this BUILD file (and elsewhere) are probably too fine-grained anyway, so
 # we may just solve this possible confusion by refactoring out some stuff and unifying the rest.
 python_library(
-  name = 'goal',
   sources = ['goal.py'],
   dependencies = [
     ':error',

--- a/src/python/pants/help/BUILD
+++ b/src/python/pants/help/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='help',
   sources=globs('*.py'),
   dependencies=[
     'src/python/pants/base:build_environment',

--- a/src/python/pants/invalidation/BUILD
+++ b/src/python/pants/invalidation/BUILD
@@ -3,7 +3,6 @@
 
 
 python_library(
-  name = 'invalidation',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/base:hash_utils',

--- a/src/python/pants/ivy/BUILD
+++ b/src/python/pants/ivy/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'ivy',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='distribution',
   sources=[ 'distribution.py' ],
   resource_targets=[
     ':resources',

--- a/src/python/pants/logging/BUILD
+++ b/src/python/pants/logging/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='logging',
   sources=globs('*.py'),
   dependencies=[
     'src/python/pants/util:dirutil',

--- a/src/python/pants/net/BUILD
+++ b/src/python/pants/net/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'net',
   sources = rglobs('*.py'),
   dependencies = [
     '3rdparty/python:requests',

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='option',
   sources=globs('*.py'),
   dependencies=[
     '3rdparty/python:ansicolors',

--- a/src/python/pants/process/BUILD
+++ b/src/python/pants/process/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'process',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python:fasteners',

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='reporting',
   sources=globs('*.py', exclude=[['report.py']]),
   resource_targets=[
     ':reporting_resources',

--- a/src/python/pants/scm/BUILD
+++ b/src/python/pants/scm/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'scm',
   sources = ['scm.py'],
   dependencies = [
     'src/python/pants/util:contextutil',

--- a/src/python/pants/source/BUILD
+++ b/src/python/pants/source/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='source',
   sources=globs('*.py'),
   dependencies=[
     '3rdparty/python:six',

--- a/src/python/pants/stats/BUILD
+++ b/src/python/pants/stats/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'stats',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/subsystem',

--- a/src/python/pants/subsystem/BUILD
+++ b/src/python/pants/subsystem/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name = 'subsystem',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',

--- a/src/python/pants/task/BUILD
+++ b/src/python/pants/task/BUILD
@@ -3,7 +3,6 @@
 
 
 python_library(
-  name = 'task',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/base:build_environment',

--- a/src/scala/org/pantsbuild/zinc/BUILD
+++ b/src/scala/org/pantsbuild/zinc/BUILD
@@ -1,5 +1,4 @@
 scala_library(
-  name='zinc',
   provides=scala_artifact(
     org='org.pantsbuild',
     name='zinc',

--- a/src/scala/org/pantsbuild/zinc/cache/BUILD
+++ b/src/scala/org/pantsbuild/zinc/cache/BUILD
@@ -1,5 +1,4 @@
 scala_library(
-  name='cache',
   provides=scala_artifact(
     org='org.pantsbuild',
     name='zinc-cache',

--- a/src/scala/org/pantsbuild/zinc/logging/BUILD
+++ b/src/scala/org/pantsbuild/zinc/logging/BUILD
@@ -1,5 +1,4 @@
 scala_library(
-  name='logging',
   provides=scala_artifact(
     org='org.pantsbuild',
     name='zinc-logging',

--- a/src/scala/sbt/compiler/javac/BUILD
+++ b/src/scala/sbt/compiler/javac/BUILD
@@ -1,5 +1,4 @@
 scala_library(
-  name='javac',
   provides=scala_artifact(
     org='org.pantsbuild',
     name='zinc-sbt-compiler-javac',

--- a/src/scala/sbt/inc/BUILD
+++ b/src/scala/sbt/inc/BUILD
@@ -1,5 +1,4 @@
 scala_library(
-  name='inc',
   provides=scala_artifact(
     org='org.pantsbuild',
     name='zinc-sbt-inc',

--- a/testprojects/3rdparty/checkstyle/BUILD
+++ b/testprojects/3rdparty/checkstyle/BUILD
@@ -1,6 +1,7 @@
 # Duped from root (but with a slightly different version) for tests which
 # assert that using different JVM tools for a task invalidates any unchanged targets.
-jar_library(name = 'checkstyle',
-            jars = [
-              jar(org = 'com.puppycrawl.tools', name = 'checkstyle', rev = '5.7'),
-            ])
+jar_library(
+  jars = [
+    jar(org = 'com.puppycrawl.tools', name = 'checkstyle', rev = '5.7'),
+  ]
+)

--- a/testprojects/3rdparty/managed/BUILD
+++ b/testprojects/3rdparty/managed/BUILD
@@ -2,7 +2,7 @@
 # and jar libraries.
 # It also serves as a very simple example of how it might be used.
 
-managed_jar_libraries(name='managed',
+managed_jar_libraries(
   artifacts=[
     jar('info.cukes', 'cucumber-core', '1.2.4'),
     jar('org.eclipse.jetty', 'jetty-jsp', '9.2.9.v20150224'),

--- a/testprojects/maven_layout/junit_resource_collision/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-target(name='junit_resource_collision',
+target(
   dependencies=[
     'testprojects/maven_layout/junit_resource_collision/onedir/src/test/java',
     'testprojects/maven_layout/junit_resource_collision/twodir/src/test/java',

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='java',
+junit_tests(
   sources=[
     'org/pantsbuild/duplicates/FirstTest.java'
   ],

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(name='resources',
+resources(
   sources=['org/pantsbuild/duplicates/textfile.txt'],
 )

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='java',
+junit_tests(
   sources=[
     'org/pantsbuild/duplicates/SecondTest.java'
   ],

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(name='resources',
+resources(
   sources=['org/pantsbuild/duplicates/textfile.txt'],
 )

--- a/testprojects/maven_layout/maven_and_pants/src/main/java/org/pantsbuild/example/BUILD
+++ b/testprojects/maven_layout/maven_and_pants/src/main/java/org/pantsbuild/example/BUILD
@@ -5,7 +5,7 @@ java_library(name='lib',
   sources = ['HelloMavenAndPants.java'],
 )
 
-jvm_binary(name='example',
+jvm_binary(
   basename = 'hello-maven-and-pants',
   main = 'org.pantsbuild.example.HelloMavenAndPants',
   dependencies = [':lib'],

--- a/testprojects/maven_layout/resource_collision/example_a/src/main/java/org/pantsbuild/duplicateres/examplea/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_a/src/main/java/org/pantsbuild/duplicateres/examplea/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='examplea',
+jvm_binary(
   main='org.pantsbuild.duplicateres.examplea.Main',
   dependencies=[
     ':lib',

--- a/testprojects/maven_layout/resource_collision/example_a/src/main/resources/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_a/src/main/resources/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(name='resources',
+resources(
   sources=['org/pantsbuild/duplicateres/duplicated_resource.txt'],
 )

--- a/testprojects/maven_layout/resource_collision/example_a/src/test/java/org/pantsbuild/duplicateres/examplea/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_a/src/test/java/org/pantsbuild/duplicateres/examplea/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name='examplea',
   sources=['ExampleATest.java'],
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/maven_layout/resource_collision/example_b/src/main/java/org/pantsbuild/duplicateres/exampleb/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_b/src/main/java/org/pantsbuild/duplicateres/exampleb/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='exampleb',
+jvm_binary(
   main='org.pantsbuild.duplicateres.exampleb.Main',
   dependencies=[':lib'],
 )

--- a/testprojects/maven_layout/resource_collision/example_b/src/main/resources/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_b/src/main/resources/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(name='resources',
+resources(
   sources=['org/pantsbuild/duplicateres/duplicated_resource.txt'],
 )

--- a/testprojects/maven_layout/resource_collision/example_b/src/test/java/org/pantsbuild/duplicateres/exampleb/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_b/src/test/java/org/pantsbuild/duplicateres/exampleb/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name='exampleb',
   sources=['ExampleBTest.java'],
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/maven_layout/resource_collision/example_c/src/main/java/org/pantsbuild/duplicateres/examplec/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_c/src/main/java/org/pantsbuild/duplicateres/examplec/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='examplec',
+jvm_binary(
   main='org.pantsbuild.duplicateres.examplec.Main',
   dependencies=[
     ':lib',

--- a/testprojects/maven_layout/resource_collision/example_c/src/main/resources/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_c/src/main/resources/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(name='resources',
+resources(
   sources=['org/pantsbuild/duplicateres/duplicated_resource.txt'],
 )

--- a/testprojects/maven_layout/resource_collision/example_c/src/test/java/org/pantsbuild/duplicateres/examplec/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_c/src/test/java/org/pantsbuild/duplicateres/examplec/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name='examplec',
   sources=['ExampleCTest.java'],
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/maven_layout/resource_collision/lib/src/main/java/org/pantsbuild/duplicateres/lib/BUILD
+++ b/testprojects/maven_layout/resource_collision/lib/src/main/java/org/pantsbuild/duplicateres/lib/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='lib',
+java_library(
   sources=['CheckRes.java']
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/main/BUILD
@@ -3,7 +3,7 @@
 #
 #  Test project for resource mapping feature
 
-jvm_binary(name='main',
+jvm_binary(
   source='Main.java',
   main='org.pantsbuild.testproject.annotation.main.Main',
   basename = 'annotation-example',

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processor/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processor/BUILD
@@ -3,7 +3,7 @@
 #
 #  annotation_processor() target to test resource mapping
 
-annotation_processor(name='processor',
+annotation_processor(
   sources=globs('*.java'),
   processors=['org.pantsbuild.testproject.annotation.processor.ResourceMappingProcessor'],
   dependencies=[

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/hellomaker/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name = 'hellomaker',
   sources = globs('*.java'),
   dependencies = [],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/main/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-jvm_binary(name='main',
+jvm_binary(
   source = 'Main.java',
   main = 'org.pantsbuild.testproject.annotation.processorwithdep.Main',
   basename = 'processorwithdep-main',

--- a/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/annotation/processorwithdep/processor/BUILD
@@ -3,7 +3,7 @@
 #
 #  annotation_processor() target to test generating java code
 
-annotation_processor(name = 'processor',
+annotation_processor(
   sources = globs('*.java'),
   processors = ['org.pantsbuild.testproject.annotation.processorwithdep.processor.ProcessorWithDep'],
   dependencies = [

--- a/testprojects/src/java/org/pantsbuild/testproject/bench/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/bench/BUILD
@@ -1,6 +1,7 @@
-benchmark(name='bench',
-          dependencies=[':caliper'],
-          sources=['CaliperBench.java'])
+benchmark(
+  dependencies=[':caliper'],
+  sources=['CaliperBench.java']
+)
 
 jar_library(
   name= 'caliper',

--- a/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_app(name='bundle',
+jvm_app(
   basename = 'bundle-example',
   binary=':bundle-bin',
   bundles=[

--- a/testprojects/src/java/org/pantsbuild/testproject/cwdexample/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/cwdexample/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='cwdexample',
+jvm_binary(
   basename='cwd-example',
   source='ExampleCwd.java',
   main='org.pantsbuild.testproject.cwdexample.ExampleCwd',

--- a/testprojects/src/java/org/pantsbuild/testproject/deployexcludes/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/deployexcludes/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='deployexcludes',
+jvm_binary(
   main='org.pantsbuild.testproject.deployexcludes.DeployExcludesMain',
   dependencies=[
     ':lib',

--- a/testprojects/src/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
@@ -3,7 +3,6 @@
 
 # see test_idea_integration.py
 java_library(
-  name='code',
   sources = ['Code.java'],
   resources=[
       'testprojects/src/resources/org/pantsbuild/testproject/idearesourcesonly:resource',

--- a/testprojects/src/java/org/pantsbuild/testproject/idearesourcesonly/resources_only/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/idearesourcesonly/resources_only/BUILD
@@ -3,6 +3,5 @@
 
 # see test_idea_integration.py
 resources(
-  name='resources_only',
   sources=['README.md'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/inccompile/libwithjettydep/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/inccompile/libwithjettydep/BUILD
@@ -1,5 +1,4 @@
 java_library(
-  name='libwithjettydep',
   sources=globs('*.java'),
   dependencies=[
     'testprojects/3rdparty/jetty:jetty-jsp',

--- a/testprojects/src/java/org/pantsbuild/testproject/inccompile/libwithjettyserver/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/inccompile/libwithjettyserver/BUILD
@@ -1,5 +1,4 @@
 java_library(
-  name='libwithjettyserver',
   sources=globs('*.java'),
   dependencies=[
     'testprojects/3rdparty/jetty:jetty-server',

--- a/testprojects/src/java/org/pantsbuild/testproject/intransitive/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/intransitive/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='intransitive',
+jvm_binary(
   source='A.java',
   main='org.pantsbuild.testproject.intransitive.A',
   dependencies=[

--- a/testprojects/src/java/org/pantsbuild/testproject/jarversionincompatibility/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/jarversionincompatibility/BUILD
@@ -7,8 +7,7 @@ target(name='alongside-16',
                     ])
 
 
-java_library(name='jarversionincompatibility',
-             sources=['DependsOnRateLimiter.java'],
+java_library(sources=['DependsOnRateLimiter.java'],
              dependencies=[':guava-15'])
 
 

--- a/testprojects/src/java/org/pantsbuild/testproject/javadepsonscala/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/javadepsonscala/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='javadepsonscala',
+java_library(
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject/javadepsonscala'
   ],

--- a/testprojects/src/java/org/pantsbuild/testproject/javasources/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/javasources/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='javasources',
+java_library(
   sources=rglobs('*.java'),
   dependencies=[
     'testprojects/src/scala/org/pantsbuild/testproject/javasources',

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/failing/tests/org/pantsbuild/tmp/tests/BUILD
@@ -1,4 +1,4 @@
-target(name='tests',
+target(
   dependencies=[
     ':one',
     ':two',

--- a/testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/junit/mixed/tests/org/pantsbuild/tmp/tests/BUILD
@@ -1,4 +1,4 @@
-java_tests(name='tests',
+java_tests(
   sources=[
     'AllTestsBase.java',
     'AllTests.java',

--- a/testprojects/src/java/org/pantsbuild/testproject/jvmprepcommand/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/jvmprepcommand/BUILD
@@ -3,7 +3,7 @@
 
 # Integration tests for the jvm_prep_command() target
 
-java_library(name='jvmprepcommand',
+java_library(
   sources=globs('*.java'),
 )
 

--- a/testprojects/src/java/org/pantsbuild/testproject/missing_sources/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missing_sources/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-target(name='missing_sources',
+target(
   dependencies=[':ant'],
 )
 

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='missingdepswhitelist',
+java_library(
   sources=rglobs('*.java'),
   dependencies=[
     'testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet',

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist2/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdepswhitelist2/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='missingdepswhitelist2',
+java_library(
   sources=rglobs('*.java'),
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='missingdirectdepswhitelist',
+java_library(
   sources=rglobs('*.java'),
   dependencies=[
     'testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist2'

--- a/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist2/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingdirectdepswhitelist2/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='missingdirectdepswhitelist2',
+java_library(
   sources=rglobs('*.java'),
   dependencies=['testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet']
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='missingjardepswhitelist',
   sources=rglobs('*.java'),
   dependencies=[
     'testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist2',

--- a/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist2/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist2/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name='missingjardepswhitelist2',
   sources=rglobs('*.java'),
   dependencies=[
     '3rdparty:guava',

--- a/testprojects/src/java/org/pantsbuild/testproject/nocache/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/nocache/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='nocache',
+java_library(
   sources = ['Hello.java'],
   no_cache = True
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/packageinfo/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/packageinfo/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='packageinfo',
+java_library(
   sources=rglobs('*.java')
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/printversion/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/printversion/BUILD
@@ -1,4 +1,4 @@
-jvm_binary(name='printversion',
+jvm_binary(
   main='org.pantsbuild.testproject.printversion.PrintVersion',
   basename='printversion',
   source='PrintVersion.java',

--- a/testprojects/src/java/org/pantsbuild/testproject/proto-ordering/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/proto-ordering/BUILD
@@ -3,6 +3,6 @@
 
 # This is here to test a common use-case in maven-style directory structures, wherein targets in
 # root directories exist purely to consolidate targets in other locations.
-target(name='proto-ordering',
+target(
   dependencies=['testprojects/src/protobuf/org/pantsbuild/testproject/proto-ordering:protos'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='greet',
+java_library(
   dependencies=[],
   sources=globs('*.java'),
   provides=artifact(

--- a/testprojects/src/java/org/pantsbuild/testproject/publish/hello/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/publish/hello/main/BUILD
@@ -3,7 +3,7 @@
 
 # Like Hello World, but built with Pants.
 
-jvm_app(name='main',
+jvm_app(
   basename = 'hello-example',
   dependencies = [
     ':main-bin'

--- a/testprojects/src/java/org/pantsbuild/testproject/shading/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shading/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='shading',
+jvm_binary(
   main='org.pantsbuild.testproject.shading.Main',
   basename='shading',
   dependencies=[

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='shadingdep',
+jvm_binary(
   main='org.pantsbuild.testproject.shadingdep.Dependency',
   basename='shadingdep',
   dependencies=[

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/otherpackage/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/otherpackage/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='otherpackage',
+java_library(
   sources=globs('*.java'),
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/shadingdep/subpackage/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/shadingdep/subpackage/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='subpackage',
+java_library(
   sources=globs('*.java'),
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java6/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='java6',
+jvm_binary(
   main='org.pantsbuild.testproject.targetlevels.java6.Six',
   platform='java6',
   dependencies=[':lib'],

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='java7',
+jvm_binary(
   source='Seven.java',
   main='org.pantsbuild.testproject.targetlevels.java7.Seven',
   platform='java7',

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7on6/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java7on6/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='java7on6',
+jvm_binary(
   source='SevenOnSix.java',
   main='org.pantsbuild.testproject.targetlevels.java7on6.SevenOnSix',
   platform='java7',

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java8/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/java8/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='java8',
+jvm_binary(
   source='Eight.java',
   main='org.pantsbuild.testproject.targetlevels.java8.Eight',
   platform='java8',

--- a/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/targetlevels/unspecified/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='unspecified',
+jvm_binary(
   main='org.pantsbuild.testproject.targetlevels.unspecified.Unspecified',
   dependencies=[
     ':java6',

--- a/testprojects/src/java/org/pantsbuild/testproject/thriftdeptest/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/thriftdeptest/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  name = 'thriftdeptest',
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild/testproject:thrift-java',
   ],

--- a/testprojects/src/java/org/pantsbuild/testproject/unicode/cucumber/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/unicode/cucumber/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_library(name='cucumber',
+java_library(
   sources=globs('*.java'),
   dependencies = [
     # This dependency is only used for an annotation, which zinc's analysis will not report.

--- a/testprojects/src/java/org/pantsbuild/testproject/unicode/main/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/unicode/main/BUILD
@@ -3,7 +3,7 @@
 
 # Demonstrates compiling code with a unicode classes
 
-jvm_binary(name = 'main',
+jvm_binary(
   basename = 'unicode-testproject',
   dependencies = [
     'testprojects/src/java/org/pantsbuild/testproject/unicode/cucumber',

--- a/testprojects/src/java/org/pantsbuild/testproject/utf8proto/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/utf8proto/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-jvm_binary(name='utf8proto',
+jvm_binary(
   basename='utf8proto-example',
   dependencies=[
     'testprojects/src/protobuf/org/pantsbuild/testproject/utf8proto',

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/distance/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/distance/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_protobuf_library(name='distance',
+java_protobuf_library(
   sources=globs('*.proto'),
   provides=artifact(
     org='org.pantsbuild.testproject.protobuf',

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/proto-ordering/a/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/proto-ordering/a/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_protobuf_library(name='a',
+java_protobuf_library(
   sources=['testproto1.proto', 'testproto2.proto',],
   imports=['3rdparty:protobuf-test-import',],
 )

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/proto-ordering/b/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/proto-ordering/b/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_protobuf_library(name='b',
+java_protobuf_library(
   sources=['zestproto3.proto', 'testproto4.proto',],
 )

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/utf8proto/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/utf8proto/BUILD
@@ -1,6 +1,6 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-java_protobuf_library(name='utf8proto',
+java_protobuf_library(
   sources=globs('*.proto'),
 )

--- a/testprojects/src/python/sources/BUILD
+++ b/testprojects/src/python/sources/BUILD
@@ -1,4 +1,4 @@
-python_library(name='sources',
+python_library(
   sources=globs('*.py'),
   resources=globs('*.txt'),
 )

--- a/testprojects/src/resources/org/pantsbuild/testproject/ordering/BUILD
+++ b/testprojects/src/resources/org/pantsbuild/testproject/ordering/BUILD
@@ -1,3 +1,3 @@
-resources(name='ordering',
+resources(
   sources=['p', 'a', 'n', 't', 's', 'b', 'u', 'i', 'l', 'd', 'p', 'a', 'n', 't', 's'],
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/badscalastyle/BUILD
@@ -1,3 +1,3 @@
-scala_library(name='badscalastyle',
+scala_library(
   sources=globs('*')
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/compilation_failure/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/compilation_failure/BUILD
@@ -1,4 +1,3 @@
 scala_library(
-  name='compilation_failure',
   sources=globs('*.scala'),
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/custom_scala_platform/BUILD
@@ -2,6 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  name='custom_scala_platform',
   sources=['Hello.scala'],
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/emptyscala/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/emptyscala/BUILD
@@ -1,3 +1,3 @@
-scala_library(name='emptyscala',
+scala_library(
   sources=globs('*'),
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscala/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javadepsonscala/BUILD
@@ -2,6 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  name = 'javadepsonscala',
   sources = rglobs('*.scala')
 )

--- a/testprojects/src/scala/org/pantsbuild/testproject/javasources/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/javasources/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  name = 'javasources',
   java_sources=[
     'testprojects/src/java/org/pantsbuild/testproject/javasources',
     'testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet:greet'

--- a/testprojects/src/scala/org/pantsbuild/testproject/publish/classifiers/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/publish/classifiers/BUILD
@@ -1,4 +1,4 @@
-scala_library(name='classifiers',
+scala_library(
   provides=scala_artifact(
     org='org.pantsbuild.testproject.publish',
     name='classifiers',

--- a/testprojects/src/scala/org/pantsbuild/testproject/publish/hello/welcome/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/publish/hello/welcome/BUILD
@@ -3,7 +3,7 @@
 
 # Seq-friendly wrapper for Java "greet" library: greet everything in a seq.
 
-scala_library(name='welcome',
+scala_library(
   dependencies=[
     'testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet:greet',
   ],

--- a/testprojects/src/scala/org/pantsbuild/testproject/scalac/plugin/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/scalac/plugin/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-scalac_plugin(name='plugin',
+scalac_plugin(
   plugin='hello_scalac',
   classname='org.pantsbuild.testproject.scalac.plugin.HelloScalac',
   sources=['HelloScalac.scala'],

--- a/testprojects/src/scala/org/pantsbuild/testproject/scaladepsonboth/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/scaladepsonboth/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  name = 'scaladepsonboth',
   sources = rglobs('*.scala'),
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject/javasources',

--- a/testprojects/src/scala/org/pantsbuild/testproject/thriftdeptest/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/thriftdeptest/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  name = 'thriftdeptest',
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild/testproject:thrift-java',
   ],

--- a/testprojects/src/scala/org/pantsbuild/testproject/unicode/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/unicode/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-target(name='unicode',
+target(
   dependencies=[
     'testprojects/src/scala/org/pantsbuild/testproject/unicode/shapeless',
   ],

--- a/testprojects/src/scala/org/pantsbuild/testproject/unicode/shapeless/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/unicode/shapeless/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-scala_library(name='shapeless',
+scala_library(
   sources=globs('*.scala'),
   dependencies = [
     '3rdparty:shapeless',

--- a/testprojects/src/scala/org/pantsbuild/testproject/unicode/unicodedep/consumer/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/unicode/unicodedep/consumer/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  name='consumer',
   sources=globs('*.scala'),
   dependencies = [
     'testprojects/src/scala/org/pantsbuild/testproject/unicode/unicodedep/provider',

--- a/testprojects/src/scala/org/pantsbuild/testproject/unicode/unicodedep/provider/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/unicode/unicodedep/provider/BUILD
@@ -2,6 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 scala_library(
-  name='provider',
   sources=globs('*.scala'),
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/annotation/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/annotation/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-junit_tests(name='annotation',
+junit_tests(
   sources=globs('*'),
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='cucumber',
+junit_tests(
   sources=[
     'BadnamesTest.java',
     'CukeTest.java',

--- a/testprojects/tests/java/org/pantsbuild/testproject/cwdexample/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cwdexample/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='cwdexample',
+junit_tests(
   sources=['CwdTest.java'],
   dependencies=[
     '3rdparty:guava',

--- a/testprojects/tests/java/org/pantsbuild/testproject/empty/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/empty/BUILD
@@ -1,5 +1,4 @@
 # These sources intentionally missing.
 java_tests(
-  name='empty',
   sources=globs('*.java'),
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/htmlreport/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/htmlreport/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='htmlreport',
+junit_tests(
   sources=['HtmlReportTest.java'],
   dependencies=[
     '3rdparty:junit'

--- a/testprojects/tests/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
@@ -3,7 +3,6 @@
 
 # see test_idea_integration.py
 junit_tests(
-  name='code',
   sources=['TestCode.java'],
   resources=[
       'testprojects/tests/resources/org/pantsbuild/testproject/idearesourcesonly:resource',

--- a/testprojects/tests/java/org/pantsbuild/testproject/idearesourcesonly/resources_only/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/idearesourcesonly/resources_only/BUILD
@@ -3,6 +3,5 @@
 
 # see test_idea_integration.py
 resources(
-  name='resources_only',
   sources=['README.md'],
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/ivyclassifier/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/ivyclassifier/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='ivyclassifier',
+junit_tests(
   sources=['IvyClassifierTest.java'],
   resources=[
     'testprojects/tests/resources/org/pantsbuild/testproject/ivyclassifier',

--- a/testprojects/tests/java/org/pantsbuild/testproject/matcher/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/matcher/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-junit_tests(name='matcher',
+junit_tests(
   sources=['MatcherTest.java'],
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/tests/java/org/pantsbuild/testproject/parallel/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/parallel/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='parallel',
+junit_tests(
   sources=globs('ParallelTest*.java'),
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/tests/java/org/pantsbuild/testproject/parallelclassesandmethods/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/parallelclassesandmethods/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='parallelclassesandmethods',
+junit_tests(
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/tests/java/org/pantsbuild/testproject/parallelmethods/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/parallelmethods/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='parallelmethods',
+junit_tests(
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/tests/java/org/pantsbuild/testproject/testjvms/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/testjvms/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-target(name='testjvms',
+target(
   dependencies=[
     ':six',
     ':seven',

--- a/testprojects/tests/java/org/pantsbuild/testproject/unicode/cucumber/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/unicode/cucumber/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='cucumber',
+junit_tests(
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/workdirs/onedir/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='onedir',
+junit_tests(
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:junit',

--- a/testprojects/tests/python/pants/constants_only/BUILD
+++ b/testprojects/tests/python/pants/constants_only/BUILD
@@ -1,5 +1,4 @@
 python_tests(
-  name = 'constants_only',
   sources = ['test_constants_only.py'],
   dependencies = [
     'testprojects/src/thrift/org/pantsbuild/constants_only:py-test-thrift',

--- a/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/BUILD
+++ b/testprojects/tests/resources/org/pantsbuild/testproject/cucumber/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resources(name='cucumber',
+resources(
   sources=[
     'badnames.feature',
     'demo.feature',

--- a/testprojects/tests/resources/org/pantsbuild/testproject/ivyclassifier/BUILD
+++ b/testprojects/tests/resources/org/pantsbuild/testproject/ivyclassifier/BUILD
@@ -2,6 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 resources(
-  name='ivyclassifier',
   sources=['example.avsc']
 )

--- a/testprojects/tests/scala/org/pantsbuild/testproject/cp-directories/BUILD
+++ b/testprojects/tests/scala/org/pantsbuild/testproject/cp-directories/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name = 'cp-directories',
   dependencies = [
     '3rdparty:junit',
     '3rdparty:scalatest',

--- a/tests/java/org/pantsbuild/args4j/BUILD
+++ b/tests/java/org/pantsbuild/args4j/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name='args4j',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:args4j',

--- a/tests/java/org/pantsbuild/testing/BUILD
+++ b/tests/java/org/pantsbuild/testing/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name='testing',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:easymock',

--- a/tests/java/org/pantsbuild/tools/jar/BUILD
+++ b/tests/java/org/pantsbuild/tools/jar/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
-  name='jar',
   sources=globs('*.java'),
   dependencies=[
     '3rdparty:args4j',

--- a/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/reports/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'reports',
   sources = ['test_junit_html_report.py'],
   dependencies = [
     'src/python/pants/backend/jvm/tasks:reports',

--- a/tests/python/pants_test/backend/jvm/zinc/BUILD
+++ b/tests/python/pants_test/backend/jvm/zinc/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'zinc',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/backend/jvm/zinc',

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -55,7 +55,6 @@ python_tests(
 )
 
 python_tests(
-  name = 'build_graph',
   sources = ['test_build_graph.py'],
   dependencies = [
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -96,7 +96,6 @@ python_tests(
 )
 
 python_tests(
-  name='engine',
   sources=['test_engine.py'],
   dependencies=[
     'src/python/pants/base:cmd_line_spec_parser',

--- a/tests/python/pants_test/fs/BUILD
+++ b/tests/python/pants_test/fs/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'fs',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/fs',

--- a/tests/python/pants_test/java/distribution/BUILD
+++ b/tests/python/pants_test/java/distribution/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'distribution',
   sources = ['test_distribution.py'],
   dependencies = [
     'src/python/pants/base:revision',

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='logging',
   sources=globs('*.py'),
   dependencies=[
     '3rdparty/python:six',

--- a/tests/python/pants_test/net/http/BUILD
+++ b/tests/python/pants_test/net/http/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'http',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python:mock',

--- a/tests/python/pants_test/option/util/BUILD
+++ b/tests/python/pants_test/option/util/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='util',
   sources=globs('*.py'),
   dependencies=[
     'src/python/pants/option',

--- a/tests/python/pants_test/process/BUILD
+++ b/tests/python/pants_test/process/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'process',
   sources = globs('*.py'),
   dependencies = [
     '3rdparty/python:mock',

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'reporting',
   sources = ['test_linkify.py'],
   dependencies = [
     'src/python/pants/reporting',

--- a/tests/python/pants_test/stats/BUILD
+++ b/tests/python/pants_test/stats/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'stats',
   sources = globs('*.py'),
   dependencies = [
     'src/python/pants/stats',

--- a/tests/python/pants_test/subsystem/BUILD
+++ b/tests/python/pants_test/subsystem/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='subsystem',
   sources=['test_subsystem.py'],
   dependencies=[
     'src/python/pants/option',

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -32,7 +32,6 @@ python_tests(
 )
 
 python_tests(
-  name='task',
   sources=['test_task.py'],
   dependencies=[
     'src/python/pants/build_graph',

--- a/tests/resources/org/pantsbuild/tools/jar/BUILD
+++ b/tests/resources/org/pantsbuild/tools/jar/BUILD
@@ -2,6 +2,5 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 resources(
-  name='jar',
   sources=globs('*.jar'),
 )

--- a/tests/scala/org/pantsbuild/zinc/BUILD
+++ b/tests/scala/org/pantsbuild/zinc/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='zinc',
+junit_tests(
   dependencies=[
     '3rdparty/jvm/com/typesafe/sbt:incremental-compiler',
     '3rdparty:junit',

--- a/tests/scala/org/pantsbuild/zinc/logging/BUILD
+++ b/tests/scala/org/pantsbuild/zinc/logging/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-junit_tests(name='logging',
+junit_tests(
   dependencies=[
     '3rdparty:guava',
     '3rdparty:junit',

--- a/zinc/BUILD
+++ b/zinc/BUILD
@@ -1,5 +1,4 @@
 jvm_binary(
-  name='zinc',
   basename='zinc',
   main='org.pantsbuild.zinc.Main',
   dependencies=[


### PR DESCRIPTION
Add support for the default name protocol to managed_jar_dependencies to
support this cleanup sweep.

https://rbcommons.com/s/twitter/r/4287/