### PR TITLE
Filter inactive goals from `Goal.all`.

### DIFF
--- a/src/docs/dev_tasks.md
+++ b/src/docs/dev_tasks.md
@@ -52,6 +52,15 @@ goal `foo`, use `Goal.by_name('foo').install`. You can install more than
 one task in a goal; e.g., there are separate tasks to run Java tests and
 Python tests; but both are in the `test` goal.
 
+Generally you'll be installing your task into an existing goal like `test`,
+`fmt` or `compile`. You can find most of these goals and their purpose by
+running the `./pants goals` command; however, some goals of a general nature
+are installed by pants without tasks and are thus hidden from `./pants goals`
+output. The `buildgen` goal is an example of this, reserving a slot for tasks
+that can auto-generate BUILD files for various languages; none of which are
+installed by default. You can hunt for these by searching for `Goal.register`
+calls in `src/python/pants/core_tasks/register.py`.
+
 Products: How one Task consumes the output of another
 ---------------------------------------------------
 

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -35,8 +35,15 @@ class Goal(object):
     register tasks on.
 
     :API: public
+
+    :param string name: The name of the goal; ie: the way to specify it on the command line.
+    :param string description: A description of the tasks in the goal do.
+    :return: The freshly registered goal.
+    :rtype: :class:`_Goal`
     """
-    cls.by_name(name)._description = description
+    goal = cls.by_name(name)
+    goal._description = description
+    return goal
 
   @classmethod
   def by_name(cls, name):
@@ -72,7 +79,7 @@ class Goal(object):
 
     :API: public
     """
-    return [pair[1] for pair in sorted(Goal._goal_by_name.items())]
+    return [goal for _, goal in sorted(Goal._goal_by_name.items()) if goal.active]
 
   @classmethod
   def subsystems(cls):
@@ -231,6 +238,16 @@ class _Goal(object):
       if issubclass(task_type, typ):
         return True
     return False
+
+  @property
+  def active(self):
+    """Return `True` if this goal has tasks installed.
+
+    Some goals are installed in pants core without associated tasks in anticipation of plugins
+    providing tasks that implement the goal being installed. If no such plugins are installed, the
+    goal may be inactive in the repo.
+    """
+    return len(self._task_type_by_name) > 0
 
   def __repr__(self):
     return self.name

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -75,7 +75,7 @@ class Goal(object):
 
   @staticmethod
   def all():
-    """Returns all registered goals, sorted alphabetically by name.
+    """Returns all active registered goals, sorted alphabetically by name.
 
     :API: public
     """

--- a/tests/python/pants_test/core_tasks/BUILD
+++ b/tests/python/pants_test/core_tasks/BUILD
@@ -29,6 +29,8 @@ python_tests(
   dependencies = [
     'src/python/pants/core_tasks',
     'src/python/pants/goal',
+    'src/python/pants/goal:task_registrar',
+    'src/python/pants/task',
     'tests/python/pants_test/tasks:task_test_base',
   ],
 )

--- a/tests/python/pants_test/core_tasks/test_list_goals.py
+++ b/tests/python/pants_test/core_tasks/test_list_goals.py
@@ -9,17 +9,26 @@ from unittest import expectedFailure
 
 from pants.core_tasks.list_goals import ListGoals
 from pants.goal.goal import Goal
+from pants.goal.task_registrar import TaskRegistrar
+from pants.task.task import Task
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase
 
 
 class ListGoalsTest(ConsoleTaskTestBase):
+  class NoopTask(Task):
+    def execute(self):
+      pass
+
   _INSTALLED_HEADER = 'Installed goals:'
   _UNDOCUMENTED_HEADER = 'Undocumented goals:'
   _LIST_GOALS_NAME = 'goals'
   _LIST_GOALS_DESC = 'List available goals.'
+  _LIST_GOALS_TASK = TaskRegistrar('list-goals', NoopTask)
   _LLAMA_NAME = 'llama'
   _LLAMA_DESC = 'With such handsome fiber, no wonder everyone loves Llamas.'
+  _LLAMA_TASK = TaskRegistrar('winamp', NoopTask)
   _ALPACA_NAME = 'alpaca'
+  _ALPACA_TASK = TaskRegistrar('alpaca', NoopTask)
 
   @classmethod
   def task_type(cls):
@@ -29,20 +38,24 @@ class ListGoalsTest(ConsoleTaskTestBase):
     Goal.clear()
     self.assert_console_output(self._INSTALLED_HEADER)
 
-    Goal.register(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC)
+    # Goals with no tasks should always be elided.
+    list_goals_goal = Goal.register(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC)
+    self.assert_console_output(self._INSTALLED_HEADER)
+
+    list_goals_goal.install(self._LIST_GOALS_TASK)
     self.assert_console_output(
       self._INSTALLED_HEADER,
       '  {0}: {1}'.format(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC),
     )
 
-    Goal.register(self._LLAMA_NAME, self._LLAMA_DESC)
+    Goal.register(self._LLAMA_NAME, self._LLAMA_DESC).install(self._LLAMA_TASK)
     self.assert_console_output(
       self._INSTALLED_HEADER,
       '  {0}: {1}'.format(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC),
       '  {0}: {1}'.format(self._LLAMA_NAME, self._LLAMA_DESC),
     )
 
-    Goal.register(self._ALPACA_NAME, description='')
+    Goal.register(self._ALPACA_NAME, description='').install(self._ALPACA_TASK)
     self.assert_console_output(
       self._INSTALLED_HEADER,
       '  {0}: {1}'.format(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC),
@@ -52,14 +65,16 @@ class ListGoalsTest(ConsoleTaskTestBase):
   def test_list_goals_all(self):
     Goal.clear()
 
-    Goal.register(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC)
+    Goal.register(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC).install(self._LIST_GOALS_TASK)
+
+    # Goals with no tasks should always be elided.
     Goal.register(self._LLAMA_NAME, self._LLAMA_DESC)
-    Goal.register(self._ALPACA_NAME, description='')
+
+    Goal.register(self._ALPACA_NAME, description='').install(self._ALPACA_TASK)
 
     self.assert_console_output(
       self._INSTALLED_HEADER,
       '  {0}: {1}'.format(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC),
-      '  {0}: {1}'.format(self._LLAMA_NAME, self._LLAMA_DESC),
       '',
       self._UNDOCUMENTED_HEADER,
       '  {0}'.format(self._ALPACA_NAME),
@@ -72,9 +87,8 @@ class ListGoalsTest(ConsoleTaskTestBase):
   def test_list_goals_graph(self):
     Goal.clear()
 
-
-    Goal.register(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC)
-    Goal.register(self._LLAMA_NAME, self._LLAMA_DESC)
+    Goal.register(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC).install(self._LIST_GOALS_TASK)
+    Goal.register(self._LLAMA_NAME, self._LLAMA_DESC).install(self._LLAMA_TASK)
     Goal.register(self._ALPACA_NAME, description='')
 
     self.assert_console_output(


### PR DESCRIPTION
Introduce the concept of a goal's `active` status.  Most goals are in
fact active (have at least 1 task installed), but some may not if there
are no plugins providing tasks to the goal installed.

https://rbcommons.com/s/twitter/r/4298/