### PR TITLE
Fix isort to run `./pants fmt.isort` once.

### DIFF
--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,4 +33,9 @@ do
   esac
 done
 
-./pants changed | xargs -I {} ./pants fmt.isort {} -- ${isort_args[@]}
+to_sort=$(mktemp -t changed.isort.XXXXX)
+trap "rm -f ${to_sort}" EXIT
+if [[ "$(./pants changed | tee ${to_sort})" != "" ]]
+then
+  ./pants -q --target-spec-file=${to_sort} fmt.isort -- ${isort_args[@]}
+fi


### PR DESCRIPTION
This change preserves the skip-fast behavior of the `xargs -I` approach
when there are no targets with changed files.

https://rbcommons.com/s/twitter/r/4297/