### PR TITLE
Get rid of the "Skipped X files" messages from isort output.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,3 +7,4 @@ indent=2
 lines_after_imports=2
 known_first_party=internal_backend,pants,pants_test
 default_section=THIRDPARTY
+not_skip=__init__.py

--- a/contrib/.isort.cfg
+++ b/contrib/.isort.cfg
@@ -7,3 +7,4 @@ indent=2
 lines_after_imports=2
 known_first_party=pants.contrib
 default_section=THIRDPARTY
+not_skip=__init__.py

--- a/examples/.isort.cfg
+++ b/examples/.isort.cfg
@@ -7,3 +7,4 @@ indent=2
 lines_after_imports=2
 known_first_party=example
 default_section=THIRDPARTY
+not_skip=__init__.py


### PR DESCRIPTION
isort skips __init__.py by default, leading to these confusing messages:
The casual reader will wonder what got skipped, and why, and whether it's OK.

This change to our .isort.cfg files ensures that isort doesn't skip
__init__.py files.  All ours are empty anyway, so isort will do nothing
with them, but this gets rid of those distracting messages.