### PR TITLE
Caitie/scalafmt update

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -119,11 +119,9 @@ deps: ["3rdparty:thrift-0.9.2"]
 configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 
 [compile.scalafmt]
-configuration: %(pants_supportdir)s/scalafmt/config
 skip: True
 
 [fmt.scalafmt]
-configuration: %(pants_supportdir)s/scalafmt/config
 skip: True
 
 [compile.findbugs]

--- a/pants.ini
+++ b/pants.ini
@@ -122,6 +122,10 @@ configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 configuration: %(pants_supportdir)s/scalafmt/config
 skip: True
 
+[fmt.scalafmt]
+configuration: %(pants_supportdir)s/scalafmt/config
+skip: True
+
 [compile.findbugs]
 max_rank: 4
 fail_on_error: True

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -60,7 +60,7 @@ from pants.backend.jvm.tasks.run_jvm_prep_command import (RunBinaryJvmPrepComman
                                                           RunTestJvmPrepCommand)
 from pants.backend.jvm.tasks.scala_repl import ScalaRepl
 from pants.backend.jvm.tasks.scaladoc_gen import ScaladocGen
-from pants.backend.jvm.tasks.scalafmt import ScalaFmt
+from pants.backend.jvm.tasks.scalafmt import ScalaFmtCheckFormat, ScalaFmtFormat
 from pants.backend.jvm.tasks.unpack_jars import UnpackJars
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.goal import Goal
@@ -189,7 +189,8 @@ def register_goals():
   task(name='jvm-dirty', action=JvmRun, serialize=False).install('run-dirty')
   task(name='scala', action=ScalaRepl, serialize=False).install('repl')
   task(name='scala-dirty', action=ScalaRepl, serialize=False).install('repl-dirty')
-  task(name='scalafmt', action=ScalaFmt, serialize=False).install('compile', first=True)
+  task(name='scalafmt', action=ScalaFmtCheckFormat, serialize=False).install('compile', first=True)
+  task(name='scalafmt', action=ScalaFmtFormat, serialize=False).install('fmt')
   task(name='test-jvm-prep-command', action=RunTestJvmPrepCommand).install('test', first=True)
   task(name='binary-jvm-prep-command', action=RunBinaryJvmPrepCommand).install('binary', first=True)
   task(name='compile-jvm-prep-command', action=RunCompileJvmPrepCommand).install('compile', first=True)

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -619,6 +619,7 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/option',
+    'src/python/pants/util:meta',
   ]
 )
 

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -51,7 +51,6 @@ class ScalaFmt(NailgunTask, AbstractClass):
     if sources:
       files = ",".join(sources)
 
-      print("Running Scalafmt with Args: {} ".format(self.get_command_args(files)))
       result = self.runjava(classpath=self.tool_classpath('scalafmt'),
                    main=self._SCALAFMT_MAIN,
                    args=self.get_command_args(files),
@@ -108,9 +107,6 @@ class ScalaFmtCheckFormat(ScalaFmt):
     if config_file!= None:
       args.extend(['--config', config_file])
 
-    print("Check Format")
-    print(self.get_options().configuration)
-
     return args
 
   def process_results(self, result):
@@ -121,9 +117,9 @@ class ScalaFmtCheckFormat(ScalaFmt):
 class ScalaFmtFormat(ScalaFmt):
   """This Task reads all scala files in the target and emits
   the source in a standard style as specified by the configuration
-  file.   
+  file.
 
-  This task mutates the underlying flies.  
+  This task mutates the underlying flies.
 
   :API: public
   """

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -16,8 +16,8 @@ from pants.util.meta import AbstractClass
 
 
 class ScalaFmt(NailgunTask, AbstractClass):
-  """Abstract class to run ScalaFmt commands.  
-  
+  """Abstract class to run ScalaFmt commands.
+
   Classes that inherit from this should override get_command_args and
   process_results to run different scalafmt commands
 
@@ -63,8 +63,8 @@ class ScalaFmt(NailgunTask, AbstractClass):
   def get_command_args(self, config_file, files):
     """Returns the arguments used to run Scalafmt command.
 
-    The return value should be an array of strings.  For 
-    example, to run the Scalafmt help command: 
+    The return value should be an array of strings.  For
+    example, to run the Scalafmt help command:
     ['--help']
     """
 
@@ -72,7 +72,7 @@ class ScalaFmt(NailgunTask, AbstractClass):
   def process_results(self, result):
     """This method processes the results of the scalafmt command.
 
-    No return value is expected.  If an error occurs running 
+    No return value is expected.  If an error occurs running
     Scalafmt raising a TaskError is recommended.
     """
 
@@ -93,9 +93,9 @@ class ScalaFmt(NailgunTask, AbstractClass):
 
 class ScalaFmtCheckFormat(ScalaFmt):
   """This Task checks that all scala files in the target are formatted
-  correctly.  
+  correctly.
 
-  If the files are not formatted correctly are not an error is raised 
+  If the files are not formatted correctly are not an error is raised
   including the command to run to format the files correctly
 
   :API: public

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -13,8 +13,9 @@ from pants.option.custom_types import file_option
 
 
 class ScalaFmt(NailgunTask):
-  """ScalaFmt base class executes the help command.  Classes
-  that inherit from this should override get_command_args and
+  """ScalaFmt base class executes the help command.  
+  
+  Classes that inherit from this should override get_command_args and
   process_results to run different scalafmt commands
 
   :API: public
@@ -56,8 +57,10 @@ class ScalaFmt(NailgunTask):
       self.process_results(result)
 
   def get_command_args(self, config_file, files):
-    """Gets the arguments for running Scalafmt"""
-    """Base class just runs help command"""
+    """Gets the arguments for running Scalafmt
+    
+    Base class just runs help command
+    """
     return ['--help']
 
   def process_results(self, result):
@@ -81,15 +84,16 @@ class ScalaFmt(NailgunTask):
 
 class ScalaFmtCheckFormat(ScalaFmt):
   """This Task checks that all scala files in the target are formatted
-  correctly.  If they are not an error is raised including the command
-  to run to format the files correctly
+  correctly.  
+
+  If the files are not formatted correctly are not an error is raised 
+  including the command to run to format the files correctly
 
   :API: public
   """
 
   def get_command_args(self, config_file, files):
-    """If no config file is specified use default scalafmt config"""
-
+    # If no config file is specified use default scalafmt config.
     args = ['--test', '--files', files]
     if config_file != None:
       args.extend(['--config', config_file])
@@ -97,20 +101,19 @@ class ScalaFmtCheckFormat(ScalaFmt):
     return args
 
   def process_results(self, result):
-    """Processes the results of running the scalafmt command"""
+    # Processes the results of running the scalafmt command.
     if result != 0:
       raise TaskError('Scalafmt failed with exit code {} to fix run: `./pants fmt <targets>`'.format(result), exit_code=result)
 
 
 class ScalaFmtFormat(ScalaFmt):
-  """This Task formats all scala files in the targets
+  """This Task formats all scala files in the targets.
 
   :API: public
   """
 
   def get_command_args(self, config_file, files):
-    """If no config file is specified use default scalafmt config"""
-
+    # If no config file is specified use default scalafmt config.
     args = ['-i', '--files', files]
     if config_file != None:
       args.extend(['--config', config_file])
@@ -118,7 +121,7 @@ class ScalaFmtFormat(ScalaFmt):
     return args
 
   def process_results(self, result):
-    """Processes the results of running the scalafmt command"""
+    # Processes the results of running the scalafmt command.
     if result != 0:
       raise TaskError('Scalafmt failed to format files', exit_code=result)
 

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -5,15 +5,18 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from abc import abstractproperty
+
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
 from pants.build_graph.target import Target
 from pants.option.custom_types import file_option
+from pants.util.meta import AbstractClass
 
 
-class ScalaFmt(NailgunTask):
-  """ScalaFmt base class executes the help command.  
+class ScalaFmt(NailgunTask, AbstractClass):
+  """Abstract class to run ScalaFmt commands.  
   
   Classes that inherit from this should override get_command_args and
   process_results to run different scalafmt commands
@@ -26,8 +29,8 @@ class ScalaFmt(NailgunTask):
   @classmethod
   def register_options(cls, register):
     super(ScalaFmt, cls).register_options(register)
-    register('--skip', type=bool, fingerprint=True, help='Skip Scalafmt Check')
-    register('--configuration', advanced=True, type=file_option, fingerprint=True,
+    register('--skip', type=bool, fingerprint=False, help='Skip Scalafmt Check')
+    register('--configuration', advanced=True, type=file_option, fingerprint=False,
               help='Path to scalafmt config file, if not specified default scalafmt config used')
     cls.register_jvm_tool(register,
                           'scalafmt',
@@ -56,16 +59,22 @@ class ScalaFmt(NailgunTask):
 
       self.process_results(result)
 
+  @abstractproperty
   def get_command_args(self, config_file, files):
-    """Gets the arguments for running Scalafmt
-    
-    Base class just runs help command
-    """
-    return ['--help']
+    """Returns the arguments used to run Scalafmt command.
 
+    The return value should be an array of strings.  For 
+    example, to run the Scalafmt help command: 
+    ['--help']
+    """
+
+  @abstractproperty
   def process_results(self, result):
-    if result != 0:
-      raise TaskError('Failed to run Scalafmt', exit_code=result)
+    """This method processes the results of the scalafmt command.
+
+    No return value is expected.  If an error occurs running 
+    Scalafmt raising a TaskError is recommended.
+    """
 
   def get_non_synthetic_scala_targets(self, targets):
     return filter(

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -51,16 +51,16 @@ class ScalaFmt(NailgunTask, AbstractClass):
     if sources:
       files = ",".join(sources)
 
-      config_file = self.get_options().configuration
+      print("Running Scalafmt with Args: {} ".format(self.get_command_args(files)))
       result = self.runjava(classpath=self.tool_classpath('scalafmt'),
                    main=self._SCALAFMT_MAIN,
-                   args=self.get_command_args(config_file, files),
+                   args=self.get_command_args(files),
                    workunit_name='scalafmt')
 
       self.process_results(result)
 
   @abstractproperty
-  def get_command_args(self, config_file, files):
+  def get_command_args(self, files):
     """Returns the arguments used to run Scalafmt command.
 
     The return value should be an array of strings.  For
@@ -95,36 +95,44 @@ class ScalaFmtCheckFormat(ScalaFmt):
   """This Task checks that all scala files in the target are formatted
   correctly.
 
-  If the files are not formatted correctly are not an error is raised
+  If the files are not formatted correctly an error is raised
   including the command to run to format the files correctly
 
   :API: public
   """
 
-  def get_command_args(self, config_file, files):
+  def get_command_args(self, files):
     # If no config file is specified use default scalafmt config.
+    config_file = self.get_options().configuration
     args = ['--test', '--files', files]
-    if config_file != None:
+    if config_file!= None:
       args.extend(['--config', config_file])
+
+    print("Check Format")
+    print(self.get_options().configuration)
 
     return args
 
   def process_results(self, result):
-    # Processes the results of running the scalafmt command.
     if result != 0:
-      raise TaskError('Scalafmt failed with exit code {} to fix run: `./pants fmt <targets>`'.format(result), exit_code=result)
+      raise TaskError('Scalafmt failed with exit code {} to fix run: `./pants fmt <targets>` config{}'.format(result, self.get_options().configuration), exit_code=result)
 
 
 class ScalaFmtFormat(ScalaFmt):
-  """This Task formats all scala files in the targets.
+  """This Task reads all scala files in the target and emits
+  the source in a standard style as specified by the configuration
+  file.   
+
+  This task mutates the underlying flies.  
 
   :API: public
   """
 
-  def get_command_args(self, config_file, files):
+  def get_command_args(self, files):
     # If no config file is specified use default scalafmt config.
+    config_file = self.get_options().configuration
     args = ['-i', '--files', files]
-    if config_file != None:
+    if config_file!= None:
       args.extend(['--config', config_file])
 
     return args

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -13,8 +13,9 @@ from pants.option.custom_types import file_option
 
 
 class ScalaFmt(NailgunTask):
-  """ScalaFmt base class executes the help command.  Classes that inherit from this 
-  should override get_command_args and process_results to run different scalafmt commands
+  """ScalaFmt base class executes the help command.  Classes
+  that inherit from this should override get_command_args and
+  process_results to run different scalafmt commands
 
   :API: public
   """
@@ -79,9 +80,9 @@ class ScalaFmt(NailgunTask):
 
 
 class ScalaFmtCheckFormat(ScalaFmt):
-  """This Task checks that all scala files in the target are formatted 
-  correctly.  If they are not an error is raised including the command to
-  run to format the files correctly
+  """This Task checks that all scala files in the target are formatted
+  correctly.  If they are not an error is raised including the command
+  to run to format the files correctly
 
   :API: public
   """
@@ -97,7 +98,7 @@ class ScalaFmtCheckFormat(ScalaFmt):
 
   def process_results(self, result):
     """Processes the results of running the scalafmt command"""
-    if result != 0:       
+    if result != 0:
       raise TaskError('Scalafmt failed with exit code {} to fix run: `./pants fmt <targets>`'.format(result), exit_code=result)
 
 

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -594,6 +594,7 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:scalafmt',
     'tests/python/pants_test:int-test',
   ],
+  timeout=120,
   tags = {'integration'},
 )
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -36,7 +36,7 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
     contents = f.read()
     f.close()
 
-    # format an incorrectly formatted file.  
+    # format an incorrectly formatted file.
     target = '{}/badscalastyle::'.format(TEST_DIR)
     fmt_result = self.run_pants(['fmt', target],
       {'fmt.scalafmt':{'skip': 'False'}})

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -29,13 +29,28 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
     self.assert_success(failing_test)
 
   def test_scalafmt_format(self):
+
+    # take a snapshot of the file which we can write out 
+    # after the test finishes executing. 
+    test_file_name = '{}/badscalastyle/BadScalaStyle.scala'.format(TEST_DIR)
+    f = open(test_file_name, 'r')
+    contents = f.read()
+    f.close()
+
+
     target = '{}/badscalastyle::'.format(TEST_DIR)
-    fmtResult = self.run_pants(['fmt', target],
+    fmt_result = self.run_pants(['fmt', target],
       {'fmt.scalafmt':{'skip': 'False'}})
 
-    self.assert_success(fmtResult)
+    self.assert_success(fmt_result)
 
-    testFmt = self.run_pants(['compile', target],
+    test_fmt= self.run_pants(['compile', target],
       {'compile.scalafmt':{'skip': 'False'}})
 
-    self.assert_success(testFmt)
+    self.assert_success(test_fmt)
+
+    # restore the file to its original state
+    f = open(test_file_name, 'w')
+    f.write(contents)
+    f.close()
+

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -17,31 +17,28 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
     # test should fail because of style error.
     failing_test = self.run_pants(['compile', target],
       {'compile.scalafmt':{'skip':'False'}})
-  
     self.assert_failure(failing_test)
   
   def test_scalafmt_fail(self):
     target = '{}/badscalastyle::'.format(TEST_DIR)
     # test should fail because of style error.
     failing_test = self.run_pants(['compile', target],
-      {'compile.scalafmt':{'skip':'False', 
+      {'compile.scalafmt':{'skip':'False',
       'configuration':'%(pants_supportdir)s/scalafmt/config'}})
-  
     self.assert_failure(failing_test)
-  
+
   def test_scalafmt_disabled(self):
     target = '{}/badscalastyle::'.format(TEST_DIR)
     # test should pass because of scalafmt disabled.
     failing_test = self.run_pants(['compile', target],
       {'compile.scalafmt': {'skip':'True'}})
-
     self.assert_success(failing_test)
-  
+
   def test_scalafmt_format_default_config(self):
     self.format_file_and_verify_fmt({'skip':'False'})
-  
+
   def test_scalafmt_format(self):
-    self.format_file_and_verify_fmt({'skip':'False', 
+    self.format_file_and_verify_fmt({'skip':'False',
       'configuration':'%(pants_supportdir)s/scalafmt/config'})
 
   def format_file_and_verify_fmt(self, options):

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -12,23 +12,39 @@ TEST_DIR = 'testprojects/src/scala/org/pantsbuild/testproject'
 
 
 class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
+  def test_scalafmt_fail_default_config(self):
+    target = '{}/badscalastyle::'.format(TEST_DIR)
+    # test should fail because of style error.
+    failing_test = self.run_pants(['compile', target],
+      {'compile.scalafmt':{'skip':'False'}})
+  
+    self.assert_failure(failing_test)
+  
   def test_scalafmt_fail(self):
     target = '{}/badscalastyle::'.format(TEST_DIR)
     # test should fail because of style error.
     failing_test = self.run_pants(['compile', target],
-      {'compile.scalafmt':{'skip': 'False'}})
-
+      {'compile.scalafmt':{'skip':'False', 
+      'configuration':'%(pants_supportdir)s/scalafmt/config'}})
+  
     self.assert_failure(failing_test)
-
+  
   def test_scalafmt_disabled(self):
     target = '{}/badscalastyle::'.format(TEST_DIR)
     # test should pass because of scalafmt disabled.
     failing_test = self.run_pants(['compile', target],
-      {'compile.scalafmt':{'skip': 'True'}})
+      {'compile.scalafmt': {'skip':'True'}})
 
     self.assert_success(failing_test)
-
+  
+  def test_scalafmt_format_default_config(self):
+    self.format_file_and_verify_fmt({'skip':'False'})
+  
   def test_scalafmt_format(self):
+    self.format_file_and_verify_fmt({'skip':'False', 
+      'configuration':'%(pants_supportdir)s/scalafmt/config'})
+
+  def format_file_and_verify_fmt(self, options):
     # take a snapshot of the file which we can write out
     # after the test finishes executing.
     test_file_name = '{}/badscalastyle/BadScalaStyle.scala'.format(TEST_DIR)
@@ -38,17 +54,14 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
 
     # format an incorrectly formatted file.
     target = '{}/badscalastyle::'.format(TEST_DIR)
-    fmt_result = self.run_pants(['fmt', target],
-      {'fmt.scalafmt':{'skip': 'False'}})
+    fmt_result = self.run_pants(['fmt', target], {'fmt.scalafmt':options})
     self.assert_success(fmt_result)
 
     # verify that the compile check not passes.
-    test_fmt= self.run_pants(['compile', target],
-      {'compile.scalafmt':{'skip': 'False'}})
+    test_fmt = self.run_pants(['compile', target], {'compile.scalafmt':options})
     self.assert_success(test_fmt)
 
     # restore the file to its original state.
     f = open(test_file_name, 'w')
     f.write(contents)
     f.close()
-

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -29,27 +29,25 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
     self.assert_success(failing_test)
 
   def test_scalafmt_format(self):
-
-    # take a snapshot of the file which we can write out 
-    # after the test finishes executing. 
+    # take a snapshot of the file which we can write out
+    # after the test finishes executing.
     test_file_name = '{}/badscalastyle/BadScalaStyle.scala'.format(TEST_DIR)
     f = open(test_file_name, 'r')
     contents = f.read()
     f.close()
 
-
+    # format an incorrectly formatted file.  
     target = '{}/badscalastyle::'.format(TEST_DIR)
     fmt_result = self.run_pants(['fmt', target],
       {'fmt.scalafmt':{'skip': 'False'}})
-
     self.assert_success(fmt_result)
 
+    # verify that the compile check not passes.
     test_fmt= self.run_pants(['compile', target],
       {'compile.scalafmt':{'skip': 'False'}})
-
     self.assert_success(test_fmt)
 
-    # restore the file to its original state
+    # restore the file to its original state.
     f = open(test_file_name, 'w')
     f.write(contents)
     f.close()

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -27,3 +27,15 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
       {'compile.scalafmt':{'skip': 'True'}})
 
     self.assert_success(failing_test)
+
+  def test_scalafmt_format(self):
+    target = '{}/badscalastyle::'.format(TEST_DIR)
+    fmtResult = self.run_pants(['fmt', target],
+      {'fmt.scalafmt':{'skip': 'False'}})
+
+    self.assert_success(fmtResult)
+
+    testFmt = self.run_pants(['compile', target],
+      {'compile.scalafmt':{'skip': 'False'}})
+
+    self.assert_success(testFmt)


### PR DESCRIPTION
Adds scalafmt formatting to the fmt command for scala files.  

Refactored ScalaFmt class into a base class, with two sub classes ScalaFmtCheckFormat (checks if files are formatted correctly) and ScalaFmtFormat (formats the files).  

Both of these are currently turned off in pants.ini.  