### PR TITLE
Fix the SetupPy target ownership check.

### DIFF
--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -135,7 +135,8 @@ class ExportedTargetDependencyCalculator(AbstractClass):
     """Identifies targets that need to be exported (are internal targets owning source code).
 
     :param target: The target to identify.
-    :returns: `True` if the given `target` should be exported if a dependent target is exported.
+    :returns: `True` if the given `target` owns files that should be included in exported packages
+              when the target is a member of an exported target's dependency graph.
     """
 
   @abstractmethod

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -229,14 +229,13 @@ class ExportedTargetDependencyCalculator(AbstractClass):
     owner_by_owned_python_target = OrderedDict()
 
     def collect_potentially_owned_python_targets(current):
-      if (current != exported_target) and self.requires_export(current):
-        owner_by_owned_python_target[current] = None  # We can't know the owner in the 1st pass.
+      owner_by_owned_python_target[current] = None  # We can't know the owner in the 1st pass.
       return (current == exported_target) or not self.is_exported(current)
 
     self._walk(exported_target, collect_potentially_owned_python_targets)
 
     for owned in owner_by_owned_python_target:
-      if not self.is_exported(owned):
+      if self.requires_export(owned) and not self.is_exported(owned):
         potential_owners = set()
         for potential_owner in self._ancestor_iterator.iter_target_siblings_and_ancestors(owned):
           if self.is_exported(potential_owner) and owned in self._closure(potential_owner):
@@ -272,7 +271,7 @@ class ExportedTargetDependencyCalculator(AbstractClass):
           reduced_dependencies.add(current)
         else:
           reduced_dependencies.add(owner)
-        return owner == exported_target
+        return owner == exported_target or not self.requires_export(current)
 
     self._walk(exported_target, collect_reduced_dependencies)
     return reduced_dependencies

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -310,7 +310,7 @@ class TestSetupPy(PythonTaskTestBase):
 
   def test_ambiguous_owner(self):
     self.create_python_library(relpath='foo/bar', name='bar')
-    self.create_file(relpath=self.build_path('foo'), contents=dedent("""
+    self.add_to_build_file('foo', dedent("""
     python_library(
       name='foo1',
       dependencies=[
@@ -340,7 +340,7 @@ class TestSetupPy(PythonTaskTestBase):
       self.dependency_calculator.reduced_dependencies(self.target('foo:foo2'))
 
   @contextmanager
-  def extracted_sdist(src, sdist, expected_prefix, collect_suffixes=None):
+  def extracted_sdist(self, sdist, expected_prefix, collect_suffixes=None):
     collect_suffixes = collect_suffixes or ('.py',)
 
     def collect(path):
@@ -556,8 +556,8 @@ class TestSetupPy(PythonTaskTestBase):
           self.assertEqual('test.exported==0.0.0', fp.read().strip())
 
   def test_prep_command_case(self):
-    PrepCommand.add_goal('compile')
-    PrepCommand.add_goal('test')
+    PrepCommand.add_allowed_goal('compile')
+    PrepCommand.add_allowed_goal('test')
     self.add_to_build_file('build-support/thrift',
                            dedent("""
                            prep_command(

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py.py
@@ -21,6 +21,7 @@ from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.tasks.setup_py import SetupPy
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.prep_command import PrepCommand
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.fs.archive import TGZ
@@ -45,8 +46,10 @@ class TestSetupPy(PythonTaskTestBase):
 
   @property
   def alias_groups(self):
-    resources = BuildFileAliases(targets={'resources': Resources})
-    return super(TestSetupPy, self).alias_groups.merge(resources)
+    extra_aliases = BuildFileAliases(targets={'prep_command': PrepCommand,
+                                              'resources': Resources,
+                                              'target': Target})
+    return super(TestSetupPy, self).alias_groups.merge(extra_aliases)
 
   def create_dependencies(self, depmap):
     target_map = {}
@@ -551,6 +554,56 @@ class TestSetupPy(PythonTaskTestBase):
         self.assertTrue(os.path.exists(requirements))
         with open(requirements) as fp:
           self.assertEqual('test.exported==0.0.0', fp.read().strip())
+
+  def test_prep_command_case(self):
+    PrepCommand.add_goal('compile')
+    PrepCommand.add_goal('test')
+    self.add_to_build_file('build-support/thrift',
+                           dedent("""
+                           prep_command(
+                             name='prepare_binary_compile',
+                             goal='compile',
+                             prep_executable='/bin/true',
+                           )
+
+                           prep_command(
+                             name='prepare_binary_test',
+                             goal='test',
+                             prep_executable='/bin/true',
+                           )
+
+                           target(
+                             name='prepare_binary',
+                             dependencies=[
+                               ':prepare_binary_compile',
+                               ':prepare_binary_test',
+                             ],
+                           )
+                           """))
+    prepare_binary_compile = self.make_target(spec='build-support/thrift:prepare_binary_compile',
+                                              target_type=PrepCommand,
+                                              prep_executable='/bin/true',
+                                              goal='compile')
+    prepare_binary_test = self.make_target(spec='build-support/thrift:prepare_binary_test',
+                                           target_type=PrepCommand,
+                                           prep_executable='/bin/true',
+                                           goal='test')
+    self.make_target(spec='build-support/thrift:prepare_binary',
+                     dependencies=[
+                       prepare_binary_compile,
+                       prepare_binary_test
+                     ])
+
+    pants = self.create_python_library(
+      relpath='src/python/pants',
+      name='pants',
+      provides="setup_py(name='pants', version='0.0.0')",
+      dependencies=[
+        'build-support/thrift:prepare_binary'
+      ]
+    )
+    with self.run_execute(pants) as created:
+      self.assertEqual([pants], created.keys())
 
 
 def test_detect_namespace_packages():


### PR DESCRIPTION
Previously the check was too restrictive and considered targets that did
not own files when the single publish ownership check is only intended
to prevent publishing the same file in more than one package.

https://rbcommons.com/s/twitter/r/4315/