### PR TITLE
Allow attaching a `prep_command` to several goals.

### DIFF
--- a/src/python/pants/build_graph/prep_command.py
+++ b/src/python/pants/build_graph/prep_command.py
@@ -5,10 +5,12 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.base.deprecated import warn_or_error
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.build_graph.target import Target
+from pants.util.memo import memoized_property
 
 
 class PrepCommand(Target):
@@ -28,21 +30,21 @@ class PrepCommand(Target):
   _goals=frozenset()
 
   @staticmethod
-  def add_goal(goal):
+  def add_allowed_goal(goal):
     """Add a named goal to the list of valid goals for the 'goal' parameter."""
     PrepCommand._goals = frozenset(list(PrepCommand._goals) + [goal])
 
   @classmethod
   def reset(cls):
     """Used for testing purposes to reset state."""
-    cls._goals=frozenset()
+    cls._goals = frozenset()
 
   @staticmethod
-  def goals():
+  def allowed_goals():
     return PrepCommand._goals
 
-  def __init__(self, prep_executable=None, prep_args=None, payload=None, prep_environ=False,
-               goal=None, **kwargs):
+  def __init__(self, address=None, payload=None, prep_executable=None, prep_args=None,
+               prep_environ=False, goal=None, goals=None, **kwargs):
     """
     :API: public
 
@@ -52,21 +54,44 @@ class PrepCommand(Target):
       a \\\\0-separated list of key=value pairs to insert into the environment.
       Note that this will pollute the environment for all future tests, so
       avoid it if at all possible.
-    :param goal: Pants goal to run this command in [test, binary or compile]. If not specified,
-                 runs in the 'test' goal.
+    :param goal: (deprecated) Pants goal to run this command in [test, binary or compile]. If not
+      specified, runs in the 'test' goal.
+    :param goals: One or more pants goals to run this command in [test, binary or compile]. If not
+      specified, runs in the 'test' goal.
     """
-    payload = payload or Payload()
-    goal = goal or 'test'
+    def raise_bad_target(msg):
+      raise TargetDefinitionException(address.spec, msg)
 
+    if not prep_executable:
+      raise_bad_target('prep_executable must be specified.')
+    if goal and goals:
+      raise_bad_target('Either `goal` or `goals` (preferred) should be specified, but not both.')
+
+    if goals:
+      goals = sorted(goals)
+    elif goal:
+      warn_or_error('1.5.0', 'goal', hint='Use `goals=[{!r}]` instead.'.format(goal))
+      goals = [goal]
+    else:
+      goals = ['test']
+
+    bad_goals = set(goals) - self.allowed_goals()
+    if bad_goals:
+      raise_bad_target('Got unrecognized goal{maybe_pluralize} {unrecognized}. '
+                       'Goal must be one of {allowed}.'
+                       .format(maybe_pluralize='' if len(bad_goals) == 1 else 's',
+                               unrecognized=', '.join(sorted(bad_goals)),
+                               allowed=self.allowed_goals()))
+
+    payload = payload or Payload()
     payload.add_fields({
-      'goal': PrimitiveField(goal),
+      'goals': PrimitiveField(goals),
       'prep_command_executable': PrimitiveField(prep_executable),
       'prep_command_args': PrimitiveField(prep_args or []),
       'prep_environ': PrimitiveField(prep_environ),
     })
-    super(PrepCommand, self).__init__(payload=payload, **kwargs)
-    if not prep_executable:
-      raise TargetDefinitionException(self, 'prep_executable must be specified.')
-    if goal not in self.goals():
-      raise TargetDefinitionException(self, 'Got goal "{}". Goal must be one of {}.'.format(
-          goal, self.goals()))
+    super(PrepCommand, self).__init__(address=address, payload=payload, **kwargs)
+
+  @memoized_property
+  def goals(self):
+    return frozenset(self.payload.get_field_value('goals'))

--- a/src/python/pants/core_tasks/run_prep_command.py
+++ b/src/python/pants/core_tasks/run_prep_command.py
@@ -36,18 +36,18 @@ class RunPrepCommandBase(Task):
     goal validation in PrepCommand before the build graph is parsed.
     """
     super(RunPrepCommandBase, cls).register_options(register)
-    PrepCommand.add_goal(cls.goal)
+    PrepCommand.add_allowed_goal(cls.goal)
 
   @classmethod
   def runnable_prep_cmd(cls, tgt):
-    return isinstance(tgt, PrepCommand) and tgt.payload.get_field_value('goal') == cls.goal
+    return isinstance(tgt, PrepCommand) and cls.goal in tgt.goals
 
   def execute(self):
-    if self.goal not in PrepCommand.goals():
-      raise  AssertionError('Got goal "{}". Expected goal to be one of {}'.format(
+    if self.goal not in PrepCommand.allowed_goals():
+      raise AssertionError('Got goal "{}". Expected goal to be one of {}'.format(
           self.goal, PrepCommand.goals()))
 
-    targets = self.context.targets(postorder=True,  predicate=self.runnable_prep_cmd)
+    targets = self.context.targets(postorder=True, predicate=self.runnable_prep_cmd)
     Cmdline = namedtuple('Cmdline', ['cmdline', 'environ'])
 
     def make_cmdline(target):

--- a/tests/python/pants_test/core_tasks/test_run_prep_command.py
+++ b/tests/python/pants_test/core_tasks/test_run_prep_command.py
@@ -26,12 +26,12 @@ class FakeRunPrepCommand(RunPrepCommandBase):
 class RunPrepCommandTest(TaskTestBase):
 
   def setUp(self):
-    super (RunPrepCommandTest, self).setUp()
+    super(RunPrepCommandTest, self).setUp()
     # This is normally taken care of in RunPrepCommandBase.register_options() when running pants,
     # but these don't get called in testing unless you call `self.create_task()`.
     # Some of these unit tests need to create targets before creating the task.
-    PrepCommand.add_goal('test')
-    PrepCommand.add_goal('binary')
+    PrepCommand.add_allowed_goal('test')
+    PrepCommand.add_allowed_goal('binary')
 
   def tearDown(self):
     PrepCommand.reset()
@@ -94,21 +94,45 @@ class RunPrepCommandTest(TaskTestBase):
       task = self.create_task(context=context, workdir='')
       task.execute()
 
-  def test_valid_target(self):
-    self.make_target('foo', PrepCommand, prep_executable='foo.sh')
+  def test_valid_target_default_goals(self):
+    prep_command = self.make_target('foo', PrepCommand, prep_executable='foo.sh')
+    self.assertEquals(frozenset(['test']), prep_command.goals)
 
-  def test_invalid_target(self):
+  def test_valid_target_single_goal(self):
+    prep_command = self.make_target('foo', PrepCommand, prep_executable='foo.sh', goal='binary')
+    self.assertEquals(frozenset(['binary']), prep_command.goals)
+
+  def test_valid_target_multiple_goals(self):
+    prep_command = self.make_target('foo', PrepCommand, prep_executable='foo.sh',
+                                    goals=['binary', 'test'])
+    self.assertEquals(frozenset(['binary', 'test']), prep_command.goals)
+
+  def test_invalid_target_no_executable(self):
     with self.assertRaisesRegexp(TargetDefinitionException,
                                  r'prep_executable must be specified'):
       self.make_target('foo', PrepCommand,)
 
+  def test_invalid_target_unrecognized_goal(self):
     with self.assertRaisesRegexp(TargetDefinitionException,
-                                 r'.*Got goal "baloney". Goal must be one of.*'):
+                                 r'.*Got unrecognized goal baloney. Goal must be one of.*'):
       self.make_target('foo', PrepCommand, prep_executable='foo.sh', goal='baloney')
+
+  def test_invalid_target_unrecognized_goals(self):
+    with self.assertRaisesRegexp(TargetDefinitionException,
+                                 r'.*Got unrecognized goals baloney, malarkey. '
+                                 r'Goal must be one of.*'):
+      self.make_target('foo', PrepCommand, prep_executable='foo.sh',
+                       goals=['baloney', 'malarkey', 'test'])
+
+  def test_invalid_target_goal_and_goals(self):
+    with self.assertRaisesRegexp(TargetDefinitionException,
+                                 r'.*Either `goal` or `goals` \(preferred\) should be specified.*'):
+      self.make_target('foo', PrepCommand, prep_executable='foo.sh', goal='binary', goals=['test'])
 
   def test_runnable_prep_cmd(self):
     test_prep_cmd = self.make_target('test-prep-cmd', PrepCommand, prep_executable='foo.sh')
-    binary_prep_cmd = self.make_target('binary-prep-cmd', PrepCommand, prep_executable='foo.sh', goal='binary')
+    binary_prep_cmd = self.make_target('binary-prep-cmd', PrepCommand, prep_executable='foo.sh',
+                                       goal='binary')
     not_a_prep_cmd = self.make_target('not-a-prep-cmd', Target)
     task = self.create_task(context=self.context())
 


### PR DESCRIPTION
Previously only a single goal could be specified leading to copy/paste
boilerplate targets and most likely a target aggregator when the
`prep_command` needed to be run in multiple goals with no common
ancestor. This change adds the `goals` kwarg to `prep_command` and
deprecates `goal` to allow reduction of boilerplate.

https://rbcommons.com/s/twitter/r/4317