### PR TITLE
Fix erroneous deprecated scope warnings.

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -265,7 +265,7 @@ class Options(object):
   def walk_parsers(self, callback):
     self._parser_hierarchy.walk(callback)
 
-  def for_scope(self, scope):
+  def for_scope(self, scope, inherit_from_enclosing_scope=True):
     """Return the option values for the given scope.
 
     Values are attributes of the returned object, e.g., options.foo.
@@ -278,7 +278,7 @@ class Options(object):
       return self._values_by_scope[scope]
 
     # First get enclosing scope's option values, if any.
-    if scope == GLOBAL_SCOPE:
+    if scope == GLOBAL_SCOPE or not inherit_from_enclosing_scope:
       values = OptionValueContainer()
     else:
       values = copy.copy(self.for_scope(enclosing_scope(scope)))
@@ -287,22 +287,25 @@ class Options(object):
     flags_in_scope = self._scope_to_flags.get(scope, [])
     self._parser_hierarchy.get_parser_by_scope(scope).parse_args(flags_in_scope, values)
 
-    # If we're the new name of a deprecated scope, also get values from that scope (but we
-    # take precedence).
+    # If we're the new name of a deprecated scope, also get values from that scope.
     deprecated_scope = self.known_scope_to_info[scope].deprecated_scope
     # Note that deprecated_scope and scope share the same Optionable class, so deprecated_scope's
     # Optionable has a deprecated_options_scope equal to deprecated_scope. Therefore we must
     # check that scope != deprecated_scope to prevent infinite recursion.
     if deprecated_scope is not None and scope != deprecated_scope:
-      deprecated_vals = self.for_scope(deprecated_scope)
-      explicit_keys = deprecated_vals.get_explicit_keys()
+      # Do the deprecation check only on keys that were explicitly set on the deprecated scope
+      # (and not on its enclosing scopes).
+      explicit_keys = self.for_scope(deprecated_scope,
+                                     inherit_from_enclosing_scope=False).get_explicit_keys()
       if explicit_keys:
         warn_or_error(self.known_scope_to_info[scope].deprecated_scope_removal_version,
                       'scope {}'.format(deprecated_scope),
                       'Use scope {} instead (options: {})'.format(scope, ', '.join(explicit_keys)))
+        # Update our values with those of the deprecated scope (now including values inherited
+        # from its enclosing scope).
         # Note that a deprecated val will take precedence over a val of equal rank.
         # This makes the code a bit neater.
-        values.update(deprecated_vals)
+        values.update(self.for_scope(deprecated_scope))
 
     # Record the value derivation.
     for option in values:

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -1109,6 +1109,9 @@ class OptionsTest(unittest.TestCase):
 
     options = Options.create(env={},
                              config=self._create_config({
+                               'GLOBAL': {
+                                 'inherited': 'aa'
+                               },
                                DummyOptionable1.options_scope: {
                                  'foo': 'xx'
                                },
@@ -1126,6 +1129,7 @@ class OptionsTest(unittest.TestCase):
                              args=shlex.split('./pants --new-scope1-baz=vv'),
                              option_tracker=OptionTracker())
 
+    options.register(GLOBAL_SCOPE, '--inherited')
     options.register(DummyOptionable1.options_scope, '--foo')
     options.register(DummyOptionable1.options_scope, '--bar')
     options.register(DummyOptionable1.options_scope, '--baz')
@@ -1134,9 +1138,10 @@ class OptionsTest(unittest.TestCase):
     with self.warnings_catcher() as w:
       vals1 = options.for_scope(DummyOptionable1.options_scope)
 
-    # Check that we got a warning.
+    # Check that we got a warning, but not for the inherited option.
     self.assertEquals(1, len(w))
     self.assertTrue(isinstance(w[0].message, DeprecationWarning))
+    self.assertNotIn('inherited', w[0].message)
 
     # Check values.
     # Deprecated scope takes precedence at equal rank.
@@ -1151,6 +1156,7 @@ class OptionsTest(unittest.TestCase):
     # Check that we got a warning.
     self.assertEquals(1, len(w))
     self.assertTrue(isinstance(w[0].message, DeprecationWarning))
+    self.assertNotIn('inherited', w[0].message)
 
     # Check values.
     self.assertEquals('uu', vals2.qux)


### PR DESCRIPTION
Previously we'd warn about use of a deprecated scope even
if the option in question was merely an inherited value from
the enclosing scope of the deprecated scope.

This change ensures that we only check the options that
were directly set on the deprecated scope.