### PR TITLE
Fix issue with python_bundle_create over multiple targets

### DIFF
--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -61,8 +61,8 @@ class PythonBinaryCreate(PythonTask):
         else:
           self.context.log.debug('using cache for {}'.format(vt.target))
 
-        python_pex_product.add(binary, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
-        python_deployable_archive.add(binary, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
+        python_pex_product.add(vt.target, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
+        python_deployable_archive.add(vt.target, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
         self.context.log.debug('created {}'.format(os.path.relpath(pex_path, get_buildroot())))
 
         # Create a copy for pex.

--- a/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_binary_create.py
@@ -54,3 +54,11 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
   def test_deployable_archive_products(self):
     self.test_task.execute()
     self._check_products('bin')
+
+  def test_handles_multiple_binary_targets(self):
+    cbin = self.create_python_binary('src/python/cbin', 'cbin', 'lib.lib:main',
+                                     dependencies=['//src/python/lib'])
+    self.task_context = self.context(target_roots=[self.binary, cbin])
+    self.task_context.run_tracker.run_info = RunInfo(self.run_info_dir)
+    self.create_task(self.task_context).execute()
+    self._check_products('bin')


### PR DESCRIPTION
The python_pex_product was being added to the "binary" variable which was from the previous for loop, so what the pex product actually gets added to is just a random target if there's >1.  This includes a test which demonstrates the problem.
