### PR TITLE
normalize filespec exclude usage

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -232,9 +232,9 @@ class PathGlobs(datatype('PathGlobs', ['dependencies'])):
       if not specs:
         continue
       res = pattern_cls.to_filespec(specs)
-      excludes = res.get('excludes')
-      if excludes:
-        raise ValueError('Excludes not supported for PathGlobs. Got: {}'.format(excludes))
+      exclude = res.get('exclude')
+      if exclude:
+        raise ValueError('Excludes not supported for PathGlobs. Got: {}'.format(exclude))
       new_specs = res.get('globs', None)
       if new_specs:
         filespecs.update(new_specs)

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -204,16 +204,16 @@ class BaseGlobs(Locatable, AbstractClass):
       raise AssertionError('Could not construct PathGlobs from {}'.format(sources))
 
   @staticmethod
-  def _filespec_for_excludes(raw_excludes, spec_path):
-    if isinstance(raw_excludes, string_types):
-      raise ValueError('Excludes of type `{}` are not supported: got "{}"'
-                       .format(type(raw_excludes).__name__, raw_excludes))
+  def _filespec_for_exclude(raw_exclude, spec_path):
+    if isinstance(raw_exclude, string_types):
+      raise ValueError('Exclude type `{}` is not supported: got "{}"'
+                       .format(type(raw_exclude).__name__, raw_exclude))
 
     excluded_patterns = []
-    for raw_exclude in raw_excludes:
-      exclude_filespecs = BaseGlobs.from_sources_field(raw_exclude, spec_path).filespecs
+    for raw_element in raw_exclude:
+      exclude_filespecs = BaseGlobs.from_sources_field(raw_element, spec_path).filespecs
       if exclude_filespecs.get('exclude', []):
-        raise ValueError('Nested excludes are not supported: got {}'.format(raw_excludes))
+        raise ValueError('Nested excludes are not supported: got {}'.format(raw_element))
       excluded_patterns.extend(exclude_filespecs.get('globs', []))
     return {'globs': excluded_patterns}
 
@@ -228,8 +228,8 @@ class BaseGlobs(Locatable, AbstractClass):
   def __init__(self, *patterns, **kwargs):
     raw_spec_path = kwargs.pop('spec_path')
     self._file_globs = self.legacy_globs_class.to_filespec(patterns).get('globs', [])
-    raw_excludes = kwargs.pop('exclude', [])
-    self._excluded_file_globs = self._filespec_for_excludes(raw_excludes, raw_spec_path).get('globs', [])
+    raw_exclude = kwargs.pop('exclude', [])
+    self._excluded_file_globs = self._filespec_for_exclude(raw_exclude, raw_spec_path).get('globs', [])
     self._spec_path = raw_spec_path
 
     # `follow_links=True` is the default behavior for wrapped globs, so we pop the old kwarg

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -206,7 +206,7 @@ class BaseGlobs(Locatable, AbstractClass):
   @staticmethod
   def _filespec_for_exclude(raw_exclude, spec_path):
     if isinstance(raw_exclude, string_types):
-      raise ValueError('Exclude type `{}` is not supported: got "{}"'
+      raise ValueError('Excludes of type `{}` are not supported: got "{}"'
                        .format(type(raw_exclude).__name__, raw_exclude))
 
     excluded_patterns = []

--- a/tests/python/pants_test/source/test_wrapped_globs.py
+++ b/tests/python/pants_test/source/test_wrapped_globs.py
@@ -234,6 +234,19 @@ class FilesetWithSpecTest(BaseTest):
     with self.assertRaises(ValueError):
       EagerFilesetWithSpec('foo', {'globs':['notfoo/a.txt']}, files=['files'], file_hashes={})
 
+  def test_lazy_fileset_with_spec_fails_if_exclude_filespec_not_prefixed_by_relroot(self):
+    with self.assertRaises(ValueError):
+      LazyFilesetWithSpec('foo',
+                          {'globs': [], 'exclude': [{'globs': ['notfoo/a.txt']}]},
+                          lambda: ['foo/a.txt'])
+
+  def test_eager_fileset_with_spec_fails_if_exclude_filespec_not_prefixed_by_relroot(self):
+    with self.assertRaises(ValueError):
+      EagerFilesetWithSpec('foo',
+                           {'globs': [], 'exclude': [{'globs': ['notfoo/a.txt']}]},
+                           files=['files'],
+                           file_hashes={})
+
   def test_iter_relative_paths(self):
     efws = EagerFilesetWithSpec('test_root', {'globs': []}, files=['a', 'b', 'c'], file_hashes={})
     result = list(efws.iter_relative_paths())


### PR DESCRIPTION
Sometimes we use exclude and sometimes we use excludes. It looks like there might be bugs do to that.

This patch ensures all of the glob and filespec related exclude names use exclude and not excludes.