### PR TITLE
[engine] Skip re-creating copy of address if no variants

### DIFF
--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -436,7 +436,9 @@ def _extract_variants(address, variants_str):
 
 
 def parse_variants(address):
-  target_name, _, variants_str = address.target_name.partition('@')
+  target_name, at_sign, variants_str = address.target_name.partition('@')
+  if not at_sign:
+    return address, None
   variants = _extract_variants(address, variants_str) if variants_str else None
   normalized_address = Address(spec_path=address.spec_path, target_name=target_name)
   return normalized_address, variants


### PR DESCRIPTION
The current parse_variants constructs a new address regardless of whether there were variants or not within the address. This adds a check that returns early if there was no at sign in the
target_name, ie that the split target_name is equal to the original.