### PR TITLE
Catch null target value in junit_run.py

### DIFF
--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -50,8 +50,7 @@ def pants_setup_py(name, description, additional_classifiers=None, **kwargs):
       'Topic :: Software Development :: Build Tools']
   classifiers = OrderedSet(standard_classifiers + (additional_classifiers or []))
 
-  #notes = PantsReleases.global_instance().notes_for_version(PANTS_SEMVER)
-  notes = ""
+  notes = PantsReleases.global_instance().notes_for_version(PANTS_SEMVER)
 
   return PythonArtifact(
       name=name,

--- a/pants-plugins/src/python/internal_backend/utilities/register.py
+++ b/pants-plugins/src/python/internal_backend/utilities/register.py
@@ -50,7 +50,8 @@ def pants_setup_py(name, description, additional_classifiers=None, **kwargs):
       'Topic :: Software Development :: Build Tools']
   classifiers = OrderedSet(standard_classifiers + (additional_classifiers or []))
 
-  notes = PantsReleases.global_instance().notes_for_version(PANTS_SEMVER)
+  #notes = PantsReleases.global_instance().notes_for_version(PANTS_SEMVER)
+  notes = ""
 
   return PythonArtifact(
       name=name,

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -463,7 +463,8 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
                 test = _Test(classname=testcase.getAttribute('classname'),
                              methodname=testcase.getAttribute('name'))
                 target = test_registry.get_owning_target(test)
-                failed_targets[target].add(test)
+                if target and test:
+                  failed_targets[target].add(test)
         except (XmlParser.XmlError, ValueError) as e:
           self.context.log.error('Error parsing test result file {0}: {1}'.format(path, e))
 


### PR DESCRIPTION
In the logic that is used to print a summary of results, we were seeing an exception being thrown for trying to index the value 'null' in failed_targets.  In one of our tests that uses cucumber or another library that re-writes the classname, we're getting a null value back from `test_registry.get_owning_target(test)` which then causes an exception to be thrown. 

This patch is against the 1.2.x branch.  I haven't confirmed if this is an issue in master - the code is different.