### PR TITLE
Revert "Revert "Generate 32 bit native engine binaries.""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -70,6 +69,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -90,7 +90,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -98,6 +97,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -118,7 +118,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -126,6 +125,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -146,7 +146,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -154,6 +153,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -174,7 +174,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -182,6 +181,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -202,7 +202,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -210,6 +209,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -230,7 +230,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -238,6 +237,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -258,7 +258,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -266,6 +265,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -286,7 +286,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -294,6 +293,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -314,7 +314,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -322,6 +321,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:
@@ -342,7 +342,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      # These are needed to run the Android SDK tools.
       addons:
         apt:
           packages:
@@ -350,6 +349,7 @@ matrix:
             - lib32z1
             - lib32z1-dev
             - oracle-java6-installer
+            - gcc-multilib
       language: python
       python: "2.7.12"
       before_install:

--- a/build-support/bin/native/generate-bintray-manifest.sh
+++ b/build-support/bin/native/generate-bintray-manifest.sh
@@ -2,11 +2,12 @@
 
 readonly REPO_ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../../.. && pwd -P)
 
-# Exports:
+# Indirectly exports:
 # + LIB_EXTENSION: The extension of native libraries.
 # + OS_NAME: The name of the OS as seen by pants.
 # + OS_ID: The ID of the current OS as seen by pants.
-source ${REPO_ROOT}/build-support/bin/native/detect_os.sh
+# Exposes `build_native_code` for building target-specific native engine binaries.
+source ${REPO_ROOT}/build-support/bin/native/bootstrap.sh
 
 # Bump this when there is a new OSX released:
 readonly OSX_MAX_VERSION=12
@@ -74,12 +75,16 @@ EOF
 }
 
 function emit_linux_files() {
-  # TODO(John Sirois): We should either have a 32 bit linux node, or use docker to get this or
-  # use rustup to install a 32 bit rust platfrm and generate a second binary.
+  native_engine_32="$(build_native_code i686-unknown-linux-gnu)"
+  native_engine_64="$(build_native_code x86_64-unknown-linux-gnu)"
   cat << EOF >> ${REPO_ROOT}/native-engine.bintray.json
     {
-      "includePattern": "${CACHE_TARGET_DIR}/${OS_ID}/${NATIVE_ENGINE_VERSION}/native-engine",
-      "uploadPattern": "build-support/bin/native-engine/${OS_ID}/${NATIVE_ENGINE_VERSION}/native-engine"
+      "includePattern": "${native_engine_32}",
+      "uploadPattern": "build-support/bin/native-engine/linux/i386/${NATIVE_ENGINE_VERSION}/native-engine"
+    },
+    {
+      "includePattern": "${native_engine_64}",
+      "uploadPattern": "build-support/bin/native-engine/linux/x86_64/${NATIVE_ENGINE_VERSION}/native-engine"
     }
 EOF
 }


### PR DESCRIPTION
This reverts commit 23f05de3ba6f8c08dfbb9035ceeed48953110fa0.

In addition, `gcc-multilib` is installed in the Travis-CI linux shards
to enable cross-compiling a 32 bit native-engine binary on those nodes.