### PR TITLE
Make `cargo build --release` the default for native engine bootstrapping.

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -19,7 +19,10 @@ readonly NATIVE_ENGINE_VERSION_RESOURCE="${REPO_ROOT}/src/python/pants/engine/su
 
 # N.B. Set $MODE to "debug" to generate a binary with debugging symbols.
 readonly MODE="release"
-readonly MODE_FLAG="--${MODE}"
+case "$MODE" in
+  debug) MODE_FLAG="" ;;
+  *) MODE_FLAG="--release" ;;
+esac
 
 readonly CACHE_ROOT=${XDG_CACHE_HOME:-$HOME/.cache}/pants
 readonly CACHE_TARGET_DIR=${CACHE_ROOT}/bin/native-engine/${OS_ID}

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -28,10 +28,9 @@ readonly CACHE_ROOT=${XDG_CACHE_HOME:-$HOME/.cache}/pants
 readonly CACHE_TARGET_DIR=${CACHE_ROOT}/bin/native-engine/${OS_ID}
 
 function calculate_current_hash() {
-  # Cached and unstaged files, with ignored files excluded + $MODE mixed in.
+  # Cached and unstaged files, with ignored files excluded.
   git ls-files -c -o --exclude-standard ${NATIVE_ROOT} | \
-    git hash-object -t blob --stdin-paths | \
-      awk -v MODE="$MODE" '{print $1 "\n" MODE}' | fingerprint_data
+    git hash-object -t blob --stdin-paths | fingerprint_data
 }
 
 function ensure_build_prerequisites() {

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -15,10 +15,11 @@ source ${REPO_ROOT}/build-support/common.sh
 source ${REPO_ROOT}/build-support/bin/native/detect_os.sh
 
 readonly NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
-readonly MODE=debug
-readonly MODE_FLAG=
-
 readonly NATIVE_ENGINE_VERSION_RESOURCE="${REPO_ROOT}/src/python/pants/engine/subsystem/native_engine_version"
+
+# N.B. Set $MODE to "debug" to generate a binary with debugging symbols.
+readonly MODE="release"
+readonly MODE_FLAG="--${MODE}"
 
 readonly CACHE_ROOT=${XDG_CACHE_HOME:-$HOME/.cache}/pants
 readonly CACHE_TARGET_DIR=${CACHE_ROOT}/bin/native-engine/${OS_ID}

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -18,7 +18,7 @@ readonly NATIVE_ROOT="${REPO_ROOT}/src/rust/engine"
 readonly NATIVE_ENGINE_VERSION_RESOURCE="${REPO_ROOT}/src/python/pants/engine/subsystem/native_engine_version"
 
 # N.B. Set $MODE to "debug" to generate a binary with debugging symbols.
-readonly MODE="release"
+readonly MODE="${MODE:-release}"
 case "$MODE" in
   debug) MODE_FLAG="" ;;
   *) MODE_FLAG="--release" ;;
@@ -28,9 +28,10 @@ readonly CACHE_ROOT=${XDG_CACHE_HOME:-$HOME/.cache}/pants
 readonly CACHE_TARGET_DIR=${CACHE_ROOT}/bin/native-engine/${OS_ID}
 
 function calculate_current_hash() {
-  # Cached and unstaged files, with ignored files excluded.
+  # Cached and unstaged files, with ignored files excluded + $MODE mixed in.
   git ls-files -c -o --exclude-standard ${NATIVE_ROOT} | \
-    git hash-object -t blob --stdin-paths | fingerprint_data
+    git hash-object -t blob --stdin-paths | \
+      awk -v MODE="$MODE" '{print $1 "\n" MODE}' | fingerprint_data
 }
 
 function ensure_build_prerequisites() {


### PR DESCRIPTION
### Problem

Currently, the native engine binary is created with `cargo build` sans the `--release` flag, which implicitly generates a non-optimized (read: slow) binary.

### Solution

Set the default `$MODE` to "release" and plumb `$MODE_FLAG` to result in `cargo build --release` for the default case.

### Result

Benchmarking before and after indicate a >2x performance boost (19m->9m).