### PR TITLE
Recover compile-zinc-name-hashing option to follow deprecation cycle

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -155,6 +155,11 @@ class BaseZincCompile(JvmCompile):
   @classmethod
   def register_options(cls, register):
     super(BaseZincCompile, cls).register_options(register)
+    register('--name-hashing', advanced=True, type=bool, fingerprint=True,
+             removal_hint='Name hashing is required for operation in zinc 1.0.0-X: this '
+                          'option no longer has any effect.',
+             removal_version='1.4.0',
+             help='Use zinc name hashing.')
     register('--whitelisted-args', advanced=True, type=dict,
              default={
                '-S.*': False,


### PR DESCRIPTION
### Problem

https://rbcommons.com/s/twitter/r/4342 removed `compile-zinc-name-hashing` before marking it as `deprecated` first. It's not supported by zinc/zinc wrapper but still should follow the proper deprecation cycle

### Solution

Add it back with a deprecation warning.

### Result

```
--[no-]compile-zinc-name-hashing (default: False)
    Use zinc name hashing.
    DEPRECATED. will be removed in version: 1.4.0.
    Name hashing is required for operation in zinc 1.0.0-X: this option no longer has any effect.
```