### PR TITLE
Allow the buildroot to be a source root.

### DIFF
--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -346,6 +346,8 @@ class SourceRootTrie(object):
 
   def _do_add_pattern(self, pattern, langs, category):
     keys = pattern.split(os.path.sep)
+    if keys[-1] == '':
+      keys = keys[:-1]
     node = self._root
     for key in keys:
       child = node.children.get(key)  # Can't use get_child, as we don't want to wildcard-match.
@@ -373,6 +375,6 @@ class SourceRootTrie(object):
           node = child
           j += 1
       if node.is_terminal:
-        return self._source_root_factory.create(os.path.join(*keys[1:j]), langs, node.category)
+        return self._source_root_factory.create(os.path.join(*keys[1:j]) if j > 1 else '', langs, node.category)
       # Otherwise, try the next value of i.
     return None

--- a/tests/python/pants_test/source/test_source_root.py
+++ b/tests/python/pants_test/source/test_source_root.py
@@ -95,13 +95,29 @@ class SourceRootTest(BaseTest):
     self.assertEquals(root('src/go/src', ('go',)),
                       trie.find('src/go/src/foo/bar/baz.go'))
 
-  def test_source_root_at_buildroot(self):
-    # Test root at repo root.
+  def test_fixed_source_root_at_buildroot(self):
     trie = SourceRootTrie(SourceRootFactory({}))
     trie.add_fixed('', ('proto',))
 
     self.assertEquals(('', ('proto',), UNKNOWN),
                       trie.find('foo/proto/bar/baz.proto'))
+
+  def test_source_root_pattern_at_buildroot(self):
+    trie = SourceRootTrie(SourceRootFactory({}))
+    trie.add_pattern('*')
+
+    self.assertEquals(('java', ('java',), UNKNOWN),
+                      trie.find('java/bar/baz.proto'))
+
+  def test_invalid_patterns(self):
+    trie = SourceRootTrie(SourceRootFactory({}))
+    # Bad normalization.
+    self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_fixed('foo/bar/', ('bar',)))
+    self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_pattern('foo//*', ('java',)))
+    self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_pattern('foo/*/', ('java',)))
+
+    # Asterisk in fixed pattern.
+    self.assertRaises(SourceRootTrie.InvalidPath, lambda: trie.add_fixed('src/*', ('java',)))
 
   def test_trie_traversal(self):
     trie = SourceRootTrie(SourceRootFactory({}))

--- a/tests/python/pants_test/source/test_source_root.py
+++ b/tests/python/pants_test/source/test_source_root.py
@@ -95,6 +95,14 @@ class SourceRootTest(BaseTest):
     self.assertEquals(root('src/go/src', ('go',)),
                       trie.find('src/go/src/foo/bar/baz.go'))
 
+  def test_source_root_at_buildroot(self):
+    # Test root at repo root.
+    trie = SourceRootTrie(SourceRootFactory({}))
+    trie.add_fixed('', ('proto',))
+
+    self.assertEquals(('', ('proto',), UNKNOWN),
+                      trie.find('foo/proto/bar/baz.proto'))
+
   def test_trie_traversal(self):
     trie = SourceRootTrie(SourceRootFactory({}))
     trie.add_pattern('foo1/bar1/baz1')


### PR DESCRIPTION
This is of limited use, because it would require all
languages in your repo to be rooted at the buildroot.
But I did encounter one such case (involving .proto files,
which Google now recommends be imported relative to the
buildroot), so might as well support it.

TODO: This brings to the fore the fact that source root
      computation is not dependent on the target type.
      If it were (e.g., java_library would only match build roots
      that are registered against 'java') then you could have
      .protos rooted at the buildroot but java in src/java etc.
      See https://github.com/pantsbuild/pants/issues/4093.