### PR TITLE
Un-publish the `jar` goal.

### DIFF
--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -171,7 +171,6 @@ def register_goals():
   task(name='scaladoc', action=ScaladocGen).install('doc')
 
   # Bundling.
-  Goal.register('jar', 'Create a JAR file.')
   task(name='create', action=JarCreate).install('jar')
   detect_duplicates = task(name='dup', action=DuplicateDetector)
 


### PR DESCRIPTION
This leaves the `jar.create` task installed and the `jar` goal
addressable from the command line, but no longer advertises the goal
since it's really not intended as-is for end users to invoke directly.