### PR TITLE
Remove coveralls from CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,13 +78,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -cjlpn 'Various pants self checks'" # (fkmsr)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -106,13 +104,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrcn -u 0/2 'Unit tests for pants and pants-plugins - shard 1'" # (jlp)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -134,13 +130,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrcn -u 1/2 'Unit tests for pants and pants-plugins - shard 2'" # (jlp)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -162,13 +156,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrcjlp 'Python contrib tests'" # (n)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -190,13 +182,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 0/7 'Python integration tests for pants - shard 1'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -218,13 +208,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 1/7 'Python integration tests for pants - shard 2'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -246,13 +234,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 2/7 'Python integration tests for pants - shard 3'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -274,13 +260,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 3/7 'Python integration tests for pants - shard 4'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -302,13 +286,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 4/7 'Python integration tests for pants - shard 5'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -330,13 +312,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 5/7 'Python integration tests for pants - shard 6'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
     - os: linux
@@ -358,13 +338,11 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      install: pip --quiet install coveralls
       env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 6/7 'Python integration tests for pants - shard 7'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
       after_success:
-        - coveralls
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
 script: |-

--- a/src/docs/howto_contribute.md
+++ b/src/docs/howto_contribute.md
@@ -161,14 +161,14 @@ To get your pull request reviewed, you should:
   who should review your change. Running `git log -- $filename` on one or more of the files that
   you changed is a good way to find potential reviewers!
 
-Finally, when the review is ready for attention, add the `reviewable` label: this is the
-signal to committers and contributors that the review is ready for attention. You can see
-a list of all actively `reviewable` reviews [here](https://github.com/pantsbuild/pants/labels/reviewable).
+You can see a list of all actively `reviewable` reviews [here](
+https://github.com/pantsbuild/pants/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20status%3Asuccess).
 
 #### Iterating
 
 If reviewers post any feedback
-([for more information on providing feedback see](https://help.github.com/articles/reviewing-proposed-changes-in-a-pull-request/)),
+([for more information on providing feedback see](
+https://help.github.com/articles/reviewing-proposed-changes-in-a-pull-request/)),
 there might be a few iterations before finally getting a Ship It. As reviewers enter
 feedback, the github page updates; it should also send
 you mail as long as you are `Subscribed` to notifications for the pull request.


### PR DESCRIPTION
It can be re-enabled when it's working, but for now it blocks easy
querying for pull requests that are ready for review.