### PR TITLE
Bump setuptools version.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -23,7 +23,7 @@ pywatchman==1.3.0
 requests>=2.5.0,<2.6
 scandir==1.2
 setproctitle==1.1.10
-setuptools==20.2
+setuptools==20.2.2
 six>=1.9.0,<2
 thrift==0.9.1
 wheel==0.29.0

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -23,7 +23,7 @@ pywatchman==1.3.0
 requests>=2.5.0,<2.6
 scandir==1.2
 setproctitle==1.1.10
-setuptools==20.2.2
+setuptools==20.10.1
 six>=1.9.0,<2
 thrift==0.9.1
 wheel==0.29.0

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -23,7 +23,7 @@ pywatchman==1.3.0
 requests>=2.5.0,<2.6
 scandir==1.2
 setproctitle==1.1.10
-setuptools==5.4.1
+setuptools==20.2
 six>=1.9.0,<2
 thrift==0.9.1
 wheel==0.29.0

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -23,7 +23,7 @@ class PythonSetup(Subsystem):
     super(PythonSetup, cls).register_options(register)
     register('--interpreter-requirement', advanced=True, default='CPython>=2.7,<3',
              help='The interpreter requirement string for this python environment.')
-    register('--setuptools-version', advanced=True, default='20.2.2',
+    register('--setuptools-version', advanced=True, default='20.10.1',
              help='The setuptools version for this python environment.')
     register('--wheel-version', advanced=True, default='0.29.0',
              help='The wheel version for this python environment.')

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -23,7 +23,7 @@ class PythonSetup(Subsystem):
     super(PythonSetup, cls).register_options(register)
     register('--interpreter-requirement', advanced=True, default='CPython>=2.7,<3',
              help='The interpreter requirement string for this python environment.')
-    register('--setuptools-version', advanced=True, default='5.4.1',
+    register('--setuptools-version', advanced=True, default='20.2.2',
              help='The setuptools version for this python environment.')
     register('--wheel-version', advanced=True, default='0.29.0',
              help='The wheel version for this python environment.')

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -8,6 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from packaging.version import Version
 
 
-VERSION = '1.3.0dev2'
+VERSION = '1.3.0.dev2'
 
 PANTS_SEMVER = Version(VERSION)

--- a/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_dependencies.py
@@ -182,7 +182,7 @@ class PythonDependenciesTests(ConsoleTaskTestBase):
       'dependencies:python_inner',
       'dependencies:python_leaf',
       'dependencies:python_inner_with_external',
-      'antlr-python-runtime==3.1.3',
+      'antlr_python_runtime==3.1.3',
       targets=[self.target('dependencies:python_root')]
     )
 
@@ -198,7 +198,7 @@ class PythonDependenciesTests(ConsoleTaskTestBase):
 
   def test_external_dependencies(self):
     self.assert_console_output_ordered(
-      'antlr-python-runtime==3.1.3',
+      'antlr_python_runtime==3.1.3',
       targets=[self.target('dependencies:python_root')],
       options={'external_only': True}
     )
@@ -213,7 +213,7 @@ class PythonDependenciesTests(ConsoleTaskTestBase):
 
   def test_intransitive_external_dependencies(self):
     self.assert_console_output_ordered(
-      'antlr-python-runtime==3.1.3',
+      'antlr_python_runtime==3.1.3',
       targets=[self.target('dependencies:python_root')],
       options={'transitive': False, 'external_only': True}
     )


### PR DESCRIPTION
### Problem

Currently, the version of setuptools used by pants is quite old and does not support [PEP440 local version identifiers](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers). Local version identifiers are useful for appending additional local context onto the end of a requirement version. In the most immediate case, this will enable us and others to suffix pants' own dists with the precise sha they were built from (e.g. `pantsbuild.pants.contrib.go-1.3.0dev2+<SHA>.tar.gz`) in a PEP-440 compliant manner. This functionality is also generally useful for pants users who have to work with python dependencies and resolution.

### Solution

Bump `setuptools` to `20.10.1`, the earliest version in which local version identifiers were supported. Additionally, because of implicit version handling in the newer setuptools the pants version has been made explicitly its canonical version (note the added `.` between `1.3.0` and `dev2`):

```
>>> from packaging.version import Version
>>> Version('1.3.0dev2')
<Version('1.3.0.dev2')>
```

### Result

Pants should now be able to resolve packages with local version identifiers.