### PR TITLE
Allow for using the native engine from-source in another repo

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -36,8 +36,13 @@ readonly CACHE_TARGET_DIR=${CACHE_ROOT}/bin/native-engine/${OS_ID}
 
 function calculate_current_hash() {
   # Cached and unstaged files, with ignored files excluded.
-  git ls-files -c -o --exclude-standard ${NATIVE_ROOT} | \
-    git hash-object -t blob --stdin-paths | fingerprint_data
+  # NB: We fork a subshell because one or both of `ls-files`/`hash-object` are
+  # sensitive to the CWD, and the `--work-tree` option doesn't seem to resolve that.
+  (
+   cd ${REPO_ROOT}
+   git ls-files -c -o --exclude-standard "${NATIVE_ROOT}" | \
+      git hash-object -t blob --stdin-paths | fingerprint_data
+  )
 }
 
 function ensure_build_prerequisites() {


### PR DESCRIPTION
### Problem

Currently, running the pantsbuild/pants repo from source in another repo (ie, `cd ${other_repo}; ../pantsbuild/pants list ::`) is broken due to use of relative paths in file fingerprinting. We use this workflow internally to iterate on new unreleased pants code.

### Solution

Execute file fingerprinting in a subshell that cds to the buildroot of pantsbuild/pants. Note that using the `git --work-tree` option didn't work... possible due to reads of `.gitignore` files ignoring that option.