### PR TITLE
Don't exit with number of failures because Java will mod 256 the exitcode so System.exit(512) == System.exit(256) == System.exit(0)

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -449,7 +449,7 @@ public class ConsoleRunnerImpl {
         createUnexpectedExitHook(shutdownListener, swappableOut.getOriginal());
     Runtime.getRuntime().addShutdownHook(unexpectedExitHook);
 
-    int failures = 0;
+    int failures = 1;
     try {
       Collection<Spec> parsedTests = new SpecParser(tests).parse();
       if (useExperimentalRunner) {
@@ -458,17 +458,15 @@ public class ConsoleRunnerImpl {
         failures = runLegacy(parsedTests, core);
       }
     } catch (SpecException e) {
-      failures = 1;
       swappableErr.getOriginal().println("Error parsing specs: " + e.getMessage());
     } catch (InitializationError e) {
-      failures = 1;
       swappableErr.getOriginal().println("Error initializing JUnit: " + e.getMessage());
     } finally {
       // If we're exiting via a thrown exception, we'll get a better message by letting it
       // propagate than by halt()ing.
       Runtime.getRuntime().removeShutdownHook(unexpectedExitHook);
     }
-    exit(failures);
+    exit(failures == 0 ? 0 : 1);
   }
 
   /**

--- a/testprojects/tests/java/org/pantsbuild/testproject/fail256/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/fail256/BUILD
@@ -1,0 +1,10 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+junit_tests(name='fail256',
+  sources=globs('*'),
+  dependencies=[
+    '3rdparty:junit'
+  ],
+)

--- a/testprojects/tests/java/org/pantsbuild/testproject/fail256/Fail256Test.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/fail256/Fail256Test.java
@@ -1,0 +1,32 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.testrule;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class Fail256Test {
+
+  @Parameters
+  public static Object[] data() {
+    Object[] parameters = new Object[256];
+    for (int i = 0; i < 256; i++) {
+      parameters[i] = i;
+    }
+    return parameters;
+  }
+
+  @Parameter
+  public int input;
+
+  @Test
+  public void testFails() {
+    Assert.assertTrue(input < 0);
+  }
+}

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -123,6 +123,14 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
         'testprojects/tests/java/org/pantsbuild/testproject/annotation'])
     self.assert_success(pants_run)
 
+  # Uncomment this test after the junit_runner is updated with exit code fix
+  # def test_junit_test_256_failures(self):
+  #   pants_run = self.run_pants([
+  #     'test',
+  #     'testprojects/tests/java/org/pantsbuild/testproject/fail256'])
+  #   self.assert_failure(pants_run)
+  #   self.assertIn('Failures: 256', pants_run.stdout_data)
+  #
   def test_junit_test_duplicate_resources(self):
     pants_run = self.run_pants([
         'test',


### PR DESCRIPTION
### Problem

If you have a test with 256 failures it will return success

### Solution

Don't System.exit(failureCount)
