### PR TITLE
[engine] Minor perf: use _kwargs in Struct._key

### DIFF
--- a/src/python/pants/engine/struct.py
+++ b/src/python/pants/engine/struct.py
@@ -259,8 +259,9 @@ class Struct(Serializable, SerializableFactory, Validatable):
     return object.__getattribute__(self, item)
 
   def _key(self):
-    if self.address:
-      return self.address
+    address = self._kwargs.get('address', None)
+    if address:
+      return address
     else:
       def hashable(value):
         if isinstance(value, dict):


### PR DESCRIPTION
Problem
-------
Struct._key is called ~460k times running list in the pants repo. The @property machinery invoked for self.address ends up taking ~3-5% of time.

Solution
--------
Inline the _kwargs.get call for address in this specific case.

Another more invasive solution would be to set __dict__ to _kwargs, but that would have other effects that we might not want.