### PR TITLE
Bump pex and setuptools to latest.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ mock==1.3.0
 packaging==16.7
 pathspec==0.3.4
 pep8==1.6.2
-pex==1.1.13
+pex==1.1.16
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4
@@ -23,7 +23,7 @@ pywatchman==1.3.0
 requests>=2.5.0,<2.6
 scandir==1.2
 setproctitle==1.1.10
-setuptools==20.10.1
+setuptools==30.0.0
 six>=1.9.0,<2
 thrift==0.9.1
 wheel==0.29.0

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -23,7 +23,7 @@ class PythonSetup(Subsystem):
     super(PythonSetup, cls).register_options(register)
     register('--interpreter-requirement', advanced=True, default='CPython>=2.7,<3',
              help='The interpreter requirement string for this python environment.')
-    register('--setuptools-version', advanced=True, default='20.10.1',
+    register('--setuptools-version', advanced=True, default='30.0.0',
              help='The setuptools version for this python environment.')
     register('--wheel-version', advanced=True, default='0.29.0',
              help='The wheel version for this python environment.')


### PR DESCRIPTION
### Problem

Pants uses an old version of setuptools (as of last week, 5.x and currently at 20.x). We'd like to modernize our consumption of this lib as composed with pex to stay current with improvements, bugfixes, etc around working with python requirements and resolution.

### Solution

This change consumes a new version of pex which extends the higher end of the setuptools requirement range to permit usage of the latest version of setuptools (30.0.0) and also bumps the setuptools dep to the latest.

### Result

Tested this end-to-end in both pants' and Twitter's monorepo with clean results.