### PR TITLE
Execute traces for all non-Return values

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -20,7 +20,7 @@ from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.addressable import Addresses, Collection
 from pants.engine.fs import Files, FilesDigest, PathGlobs
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, SourcesField, TargetAdaptor
-from pants.engine.nodes import Return, State, Throw
+from pants.engine.nodes import Return
 from pants.engine.selectors import Select, SelectDependencies, SelectProjection
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper
 from pants.util.dirutil import fast_relpath

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -77,12 +77,10 @@ class LegacyBuildGraph(BuildGraph):
 
     # Index the ProductGraph.
     for node, state in roots.items():
-      if type(state) is Throw:
+      if type(state) is not Return:
         trace = '\n'.join(self._scheduler.trace())
         raise AddressLookupError(
             'Build graph construction failed for {}:\n{}'.format(node, trace))
-      elif type(state) is not Return:
-        State.raise_unrecognized(state)
       if type(state.value) is not HydratedTargets:
         raise TypeError('Expected roots to hold {}; got: {}'.format(
           HydratedTargets, type(state.value)))


### PR DESCRIPTION
### Problem

Currently, `Noop`s are not returned across the native boundary, and thus aren't traced during a failure. Noops can occur for a few reasons, but the most user-facing of those reasons are build graph cycles.

### Solution

Rather than executing traces only when we see a Throw, execute it in all non-Return cases, which handles Noops and other unexpected conditions.