### PR TITLE
Adding section to describe building multiplatform python binaries wit…

### DIFF
--- a/examples/src/python/example/3rdparty_py.md
+++ b/examples/src/python/example/3rdparty_py.md
@@ -24,7 +24,7 @@ into many directories.)
 **pip-style requirements.txt:**
 
 To define some third-party dependencies, use a
-<a pantsref="bdict_python_requirements">python_requirements</a> in your `BUILD`
+<a pantsref="bdict_python_requirements">`python_requirements`</a> in your `BUILD`
 file and make a pip `requirements.txt` file in the same directory.
 
 E.g, your `3rdparty/python/BUILD` file might look like:
@@ -69,3 +69,27 @@ Then in your Python code, you can `import` from that package:
 
     :::python
     from colors import green
+
+Managing dependencies for multiple platforms
+----------------------
+
+If you're building a python binary for use on multiple platforms, you might have 3rd-party
+dependencies that rely on platform-specific code. In addition to specifying the platforms
+with which your binary is intended to be compatible in the `platform` field of your
+<a pantsref="bdict_python_binary">`python_binary`</a> target, you may need to make
+<a href="https://pip.pypa.io/en/stable/reference/pip_wheel/">wheel</a> files for each platform
+available at build time.
+
+You can store these files on the web formatted in a link detection-friendly format or locally in
+your repo relative to the build root. If you opt for the latter method under version control, you may
+want to use <a href="https://git-lfs.github.com/">git-lfs</a> or similar to avoid storing large binaries
+in your repository.
+
+In either case, you will need to specify the repo location in pants.ini, as a URL or a local path like so:
+
+```
+[python-repos]
+repos: [
+  "%(buildroot)s/3rdparty/python/wheelhouse/"
+]
+```

--- a/examples/src/python/example/3rdparty_py.md
+++ b/examples/src/python/example/3rdparty_py.md
@@ -75,21 +75,21 @@ Managing dependencies for multiple platforms
 
 If you're building a python binary for use on multiple platforms, you might have 3rd-party
 dependencies that rely on platform-specific code. In addition to specifying the platforms
-with which your binary is intended to be compatible in the `platform` field of your
-<a pantsref="bdict_python_binary">`python_binary`</a> target, you may need to make
-<a href="https://pip.pypa.io/en/stable/reference/pip_wheel/">wheel</a> files for each platform
-available at build time.
+with which your binary is intended to be compatible in the `platforms` field of your
+<a pantsref="bdict_python_binary">`python_binary`</a> target, you will need to make
+<a href="https://pip.pypa.io/en/stable/reference/pip_wheel/">wheel</a> files for each package
+and platform available at build time.
 
-You can store these files on the web formatted in a link detection-friendly format or locally in
-your repo relative to the build root. If you opt for the latter method under version control, you may
-want to use <a href="https://git-lfs.github.com/">git-lfs</a> or similar to avoid storing large binaries
-in your repository.
-
-In either case, you will need to specify the repo location in pants.ini, as a URL or a local path like so:
+Pants will look for those files in the location specified in the
+[[`python-repos`|pants('src/docs:setup_repo')#redirecting-python-requirements-to-other-servers]] field
+in pants.ini. It can understand either a simple local directory of .whl files or a "find links"-friendly
+webpage of links formatted like so:
 
 ```
-[python-repos]
-repos: [
-  "%(buildroot)s/3rdparty/python/wheelhouse/"
-]
+<a href="x.whl">x.whl</a>
 ```
+
+If you opt for the local directory method under version control, you may want to use
+<a href="https://git-lfs.github.com/">git-lfs</a> or similar to avoid storing large binaries in your
+repository. If you opt for a hosted solution, <a href="https://pages.github.com/">Github pages</a> may
+be helpful.

--- a/src/docs/setup_repo.md
+++ b/src/docs/setup_repo.md
@@ -250,3 +250,11 @@ For python repos, you need to override the following settings in pants.ini:
         "https://pypi.python.org/simple/"
       ]
 
+You can also reference a local repo relative to your project's build root with this pattern:
+
+    :::ini
+    [python-repos]
+    repos: [
+        "%(buildroot)s/repo_path"
+      ]
+


### PR DESCRIPTION
### Problem

I asked in the pantsbuild slack about patterns for making wheel files available at build time for multi-platform python binaries and chatted with folks about the best way to store and reference wheel files. There's not much official existing documentation about multi-platform python binaries.

### Solution

I added a section to the "Python 3rdparty Pattern" page describing where I ended up, drawing in part from @ericzundel's stack overflow post on the topic (http://stackoverflow.com/questions/34979100/pants-includes-os-x-specific-python-wheels)

### Result

This is purely a documentation change.