### PR TITLE
Plumb a configurable worker count to thrift linter.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from multiprocessing import cpu_count
+import multiprocessing
 
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
@@ -40,6 +40,8 @@ class ThriftLinter(NailgunTask):
                   'this value if it is set.')
     register('--linter-args', default=[], advanced=True, type=list, fingerprint=True,
              help='Additional options passed to the linter.')
+    register('--worker-count', default=multiprocessing.cpu_count(), advanced=True, type=int,
+             help='Maximum number of workers to use for linter parallelization.')
     cls.register_jvm_tool(register, 'scrooge-linter')
 
   @classmethod
@@ -110,7 +112,7 @@ class ThriftLinter(NailgunTask):
       with self.context.new_workunit('parallel-thrift-linter') as workunit:
         worker_pool = WorkerPool(workunit.parent,
                                  self.context.run_tracker,
-                                 cpu_count())
+                                 self.get_options().worker_count)
 
         scrooge_linter_classpath = self.tool_classpath('scrooge-linter')
         results = []


### PR DESCRIPTION
### Problem

In environments such as CI where `multiprocessing.cpu_count()` can be higher than expected (on the order of 12-24+), the recent thrift linter parallelization can cause a run on heap space within the same nailgun process resulting in OOM errors.

### Solution

Plumb an option to control this via pants.ini.

### Result

Worker count is now configurable.