### PR TITLE
A flag to add the buildroot to protoc's import path.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -65,8 +65,8 @@ class ProtobufGen(SimpleCodegenTask):
              default=['3rdparty:protobuf-java'])
     register('--import-from-root', type=bool, advanced=True,
              help='If set, add the buildroot to the path protoc searches for imports. '
-                  'This facilitates import paths in .proto files that are relative to the '
-                  'build root, as recommended by the protoc documentation.')
+                  'This enables using import paths relative to the build root in .proto files, '
+                  'as recommended by the protoc documentation.')
 
   # TODO https://github.com/pantsbuild/pants/issues/604 prep start
   @classmethod

--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -63,6 +63,10 @@ class ProtobufGen(SimpleCodegenTask):
              help='Dependencies to bootstrap this task for generating java code.  When changing '
                   'this parameter you may also need to update --version.',
              default=['3rdparty:protobuf-java'])
+    register('--import-from-root', type=bool, advanced=True,
+             help='If set, add the buildroot to the path protoc searches for imports. '
+                  'This facilitates import paths in .proto files that are relative to the '
+                  'build root, as recommended by the protoc documentation.')
 
   # TODO https://github.com/pantsbuild/pants/issues/604 prep start
   @classmethod
@@ -115,6 +119,8 @@ class ProtobufGen(SimpleCodegenTask):
 
     bases = OrderedSet(sources_by_base.keys())
     bases.update(self._proto_path_imports([target]))
+    if self.get_options().import_from_root:
+      bases.add('.')
 
     gen_flag = '--java_out'
 

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_protobuf_library(
+  sources=globs('*.proto'),
+  dependencies=['testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo']
+)

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/bar.proto
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/bar.proto
@@ -1,0 +1,10 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.import_from_buildroot;
+
+import "testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo/foo.proto";
+
+message SomethingElse {
+  optional Something something = 1;
+}

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo/BUILD
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_protobuf_library(
+  sources=globs('*.proto'),
+)

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo/foo.proto
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/foo/foo.proto
@@ -1,0 +1,9 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.import_from_buildroot;
+
+
+message Something {
+  optional string str = 1;
+}

--- a/tests/python/pants_test/backend/codegen/tasks/test_protobuf_gen.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_protobuf_gen.py
@@ -79,4 +79,5 @@ class ProtobufGenTest(TaskTestBase):
     task = self.create_task(context)
     result = task._calculate_sources(target)
     self.assertEquals(1, len(result.keys()))
-    self.assertEquals(OrderedSet(['project/src/main/proto/proto-lib/foo.proto']), result['project/src/main/proto'])
+    self.assertEquals(OrderedSet(['project/src/main/proto/proto-lib/foo.proto']),
+                      result['project/src/main/proto'])

--- a/tests/python/pants_test/backend/codegen/tasks/test_protobuf_integration.py
+++ b/tests/python/pants_test/backend/codegen/tasks/test_protobuf_integration.py
@@ -15,6 +15,12 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class ProtobufIntegrationTest(PantsRunIntegrationTest):
 
+  def test_import_from_buildroot(self):
+    pants_run = self.run_pants(
+      ['gen.protoc', '--import-from-root',
+       'testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar'])
+    self.assert_success(pants_run)
+
   def test_bundle_protobuf_normal(self):
     with self.pants_results(['bundle.jvm',
                               '--deployjar',
@@ -42,10 +48,11 @@ class ProtobufIntegrationTest(PantsRunIntegrationTest):
       out_path = os.path.join(get_buildroot(), 'dist',
                               ('examples.src.java.org.pantsbuild.example.protobuf.imports'
                                '.imports-bundle'))
-      java_run = subprocess.Popen(['java', '-cp', 'protobuf-imports-example.jar',
-                                   'org.pantsbuild.example.protobuf.imports.ExampleProtobufImports'],
-                                  stdout=subprocess.PIPE,
-                                  cwd=out_path)
+      java_run = subprocess.Popen(
+        ['java', '-cp', 'protobuf-imports-example.jar',
+         'org.pantsbuild.example.protobuf.imports.ExampleProtobufImports'],
+        stdout=subprocess.PIPE,
+        cwd=out_path)
       java_retcode = java_run.wait()
       java_out = java_run.stdout.read()
       self.assertEquals(java_retcode, 0)

--- a/tests/python/pants_test/backend/project_info/tasks/test_idea_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_idea_integration.py
@@ -400,6 +400,7 @@ class IdeaIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
   def test_all_targets(self):
     self._idea_test([
       'src::', 'tests::', 'examples::', 'testprojects::',
+      '--gen-protoc-import-from-root',
       # IdeaGen resolves source jars by default, which causes a collision with these targets because
       # they explicitly include jersey.jersey's source jar.
       '--exclude-target-regexp=testprojects/3rdparty/managed:jersey.jersey.sources',

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -82,12 +82,14 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
                           timeout_targets + deliberately_conflicting_targets)
     exclude_opts = map(lambda target: '--exclude-target-regexp={}'.format(target),
                        targets_to_exclude)
-    pants_run = self.pants_test(['testprojects::', '--jvm-platform-default-platform=java7'] + exclude_opts)
+    pants_run = self.pants_test(['testprojects::', '--jvm-platform-default-platform=java7',
+                                 '--gen-protoc-import-from-root'] + exclude_opts)
     self.assert_success(pants_run)
 
   # This is a special case that we split into 2 tests instead of using ensure_engine.
   # The reason is the original test with ensure_engine takes more than 10 minutes in travis ci,
-  # which will cause travis to terminate the build. By spliting, each test finishes in less than 10 min.
+  # which will cause travis to terminate the build. By spliting, each test finishes in less than
+  # 10 min.
   def test_testprojects_v2_engine(self):
     with environment_as(PANTS_ENABLE_V2_ENGINE='true'):
       self.test_testprojects()


### PR DESCRIPTION
  A flag to add the buildroot to protoc's import path.
    
This allows use of Pants in repos adhering to the protobuf
documentation's recommendation of importing relative to the buildroot,
rather than relative to the .proto file's source root (e.g., src/proto).