### PR TITLE
[engine] model snapshots in validation, make root rules a dict instead of a set

### DIFF
--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -199,7 +199,9 @@ def create_snapshot_singletons(project_tree):
 
 def create_snapshot_intrinsics(project_tree):
   def ptree(func):
-    return functools.partial(func, project_tree, snapshot_directory(project_tree))
+    partial = functools.partial(func, project_tree, snapshot_directory(project_tree))
+    partial.__name__ = '{}_intrinsic'.format(func.__name__)
+    return partial
   return [
       (Snapshot, Files, ptree(create_snapshot_archive)),
     ]
@@ -213,7 +215,9 @@ def create_snapshot_tasks(project_tree):
   uncacheable singleton.
   """
   def ptree(func):
-    return functools.partial(func, project_tree, snapshot_directory(project_tree))
+    partial = functools.partial(func, project_tree, snapshot_directory(project_tree))
+    partial.__name__ = '{}_task'.format(func.__name__)
+    return partial
   return [
       (Snapshot, [Select(Files)], ptree(create_snapshot_archive)),
     ]

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -12,7 +12,8 @@ from textwrap import dedent
 
 from twitter.common.collections import OrderedSet
 
-from pants.engine.addressable import Exactly
+from pants.engine.addressable import Exactly, TypeConstraint
+from pants.engine.isolated_process import SnapshottedProcess, SnapshottedProcessRequest
 from pants.engine.selectors import (Select, SelectDependencies, SelectLiteral, SelectProjection,
                                     SelectVariant, type_or_constraint_repr)
 from pants.util.meta import AbstractClass
@@ -121,7 +122,9 @@ class SingletonRule(datatype('SingletonRule', ['product_type', 'func']), Rule):
     return self.product_type
 
   def __repr__(self):
-    return '{}({})'.format(type(self).__name__, self.product_type.__name__)
+    return '{}({}, {})'.format(type(self).__name__,
+                           self.product_type.__name__,
+                           self.func.__name__)
 
 
 class IntrinsicRule(datatype('IntrinsicRule', ['subject_type', 'product_type', 'func']), Rule):
@@ -136,7 +139,10 @@ class IntrinsicRule(datatype('IntrinsicRule', ['subject_type', 'product_type', '
     return self.product_type
 
   def __repr__(self):
-    return '{}({})'.format(type(self).__name__, self.func.__name__)
+    return '{}(({}, {}), {})'.format(type(self).__name__,
+                                     self.subject_type.__name__,
+                                     self.output_product_type.__name__,
+                                     self.func.__name__)
 
 
 class RuleIndex(datatype('RuleIndex', ['tasks', 'intrinsics', 'singletons'])):
@@ -180,12 +186,15 @@ class RuleIndex(datatype('RuleIndex', ['tasks', 'intrinsics', 'singletons'])):
                         " Rules either extend Rule, or are 3 elem tuples.".format(type(entry)))
 
     intrinsics = dict()
-    for output_type, input_type, func in intrinsic_entries:
-      key = (input_type, output_type)
+    for output_type, subject_type, func in intrinsic_entries:
+      key = (subject_type, output_type)
+      if isinstance(output_type, TypeConstraint):
+        raise Exception( 'wut {}'.format(output_type))
+
       if key in intrinsics:
         raise ValueError('intrinsic provided by {} has already been provided by: {}'.format(
           func.__name__, intrinsics[key]))
-      intrinsics[key] = IntrinsicRule(input_type, output_type, func)
+      intrinsics[key] = IntrinsicRule(subject_type, output_type, func)
 
     singletons = dict()
     for output_type, func in singleton_entries:
@@ -206,13 +215,14 @@ class RuleIndex(datatype('RuleIndex', ['tasks', 'intrinsics', 'singletons'])):
   def all_produced_product_types(self, subject_type):
     intrinsic_products = set(prod for subj, prod in self.intrinsics.keys()
                              if subj == subject_type)
- #   task_products = self.tasks.keys()
+    singleton_products = self.singletons.keys()
+    task_products = self.tasks.keys()
     # Unwrap Exactlys if they only contain one type.
     # TODO exercise w/ a test
-#    task_products = set(t._types[0] if type(t) is Exactly and len(t._types) == 1 else t for t in task_products )
-#    return intrinsic_products.union(set(task_products))
+    task_products = set(t._types[0] if type(t) is Exactly and len(t._types) == 1 else t for t in task_products)
 
-    return intrinsic_products.union(set(self.tasks.keys())).union(set(self.singletons.keys()))
+    return intrinsic_products.union(task_products).union(set(singleton_products))
+#    return intrinsic_products.union(set(self.tasks.keys())).union(set(self.singletons.keys()))
 
   def gen_rules(self, subject_type, product_type):
     # Singletons or intrinsics that provide the requested product for the current subject type.
@@ -243,7 +253,8 @@ class CanBeDependency(object):
 
 
 class RuleGraph(datatype('RuleGraph',
-                         ['root_subject_types',
+                         ['graph_maker',
+                          'root_subject_types',
                           'root_rules',
                           'rule_dependencies',
                           'unfulfillable_rules'])):
@@ -256,30 +267,50 @@ class RuleGraph(datatype('RuleGraph',
   Because in
 
      `root_subject_types` the root subject types this graph was generated with.
-     `root_rules` The rule entries that can produce the root products this graph was generated
-                        with.
+     `root_rules` A map from root rules, ie rules representing the expected selector / subject types
+                  for requests, to the rules that can fulfill them.
      `rule_dependencies` A map from rule entries to the rule entries they depend on.
                          The collections of dependencies are contained by RuleEdges objects.
                          Keys must be subclasses of CanHaveDependencies
                          values must be subclasses of CanBeDependency
      `unfulfillable_rules` A map of rule entries to collections of Diagnostics
-                                 containing the reasons why they were eliminated from the graph.
+                           containing the reasons why they were eliminated from the graph.
 
   """
-  # TODO constructing nodes from the resulting graph.
-  # Possible approach:
-  # - walk out from root nodes, constructing each node.
-  # - when hit a node that can't be constructed yet, ie the subject type changes,
-  #   skip and collect for later.
-  # - inject the constructed nodes into the product graph.
+
+  def dependency_edges_for_rule(self, rule, subject_type):
+    if type(rule) is RootRuleGraphEntry:
+      return self.root_rule_edges(RootRuleGraphEntry(rule.subject_type, rule.selector))
+    else:
+      return self.rule_dependencies.get(RuleGraphEntry(subject_type, rule))
+
+  def is_unfulfillable(self, rule, subject_type):
+    return RuleGraphEntry(subject_type, rule) in self.unfulfillable_rules
+
+  def root_rule_matching(self, subject_type, selector):
+    root_rule = RootRuleGraphEntry(subject_type, selector)
+    if root_rule in self.root_rules:
+      return root_rule
+
+  def new_graph_with_root_for(self, subject_type, selector):
+    return self.graph_maker.new_graph_from_existing(subject_type, selector, self)
+
+  def root_rule_edges(self, root_rule):
+    try:
+      return self.root_rules[root_rule]
+    except KeyError:
+      logger.error('missing root rule {}'.format(root_rule))
+      raise
 
   def error_message(self):
     """Returns a nice error message for errors in the rule graph."""
     collated_errors = defaultdict(lambda : defaultdict(set))
     for rule_entry, diagnostics in self.unfulfillable_rules.items():
       # don't include the root rules in the error
-      # message since they aren't real.
-      if type(rule_entry) is RootRule:
+      # message since they are not part of the task list.
+      # We could include them, but I think we'd want to have a different format, since they
+      # represent the execution requests.
+      if type(rule_entry) is RootRuleGraphEntry:
         continue
       for diagnostic in diagnostics:
         collated_errors[rule_entry.rule][diagnostic.reason].add(diagnostic.subject_type)
@@ -296,14 +327,14 @@ class RuleGraph(datatype('RuleGraph',
 
     def format_messages(rule, subject_types_by_reasons):
       errors = '\n    '.join(sorted('{} with subject types: {}'
-                             .format(reason, ', '.join(sorted(subject_type_str(t) for t in subject_types)))
-                             for reason, subject_types in subject_types_by_reasons.items()))
+                                    .format(reason, ', '.join(sorted(subject_type_str(t) for t in subject_types)))
+                                    for reason, subject_types in subject_types_by_reasons.items()))
       return '{}:\n    {}'.format(rule, errors)
 
     used_rule_lookup = set(rule_entry.rule for rule_entry in self.rule_dependencies.keys())
     formatted_messages = sorted(format_messages(rule, subject_types_by_reasons)
-                               for rule, subject_types_by_reasons in collated_errors.items()
-                               if rule not in used_rule_lookup)
+                                for rule, subject_types_by_reasons in collated_errors.items()
+                                if rule not in used_rule_lookup)
     if not formatted_messages:
       return None
     return 'Rules with errors: {}\n  {}'.format(len(formatted_messages),
@@ -314,20 +345,21 @@ class RuleGraph(datatype('RuleGraph',
       return '{empty graph}'
 
     root_subject_types_str = ', '.join(x.__name__ for x in self.root_subject_types)
-    root_rules_str = ', '.join(sorted(str(r) for r in self.root_rules))
     return dedent("""
               {{
                 root_subject_types: ({},)
-                root_rules: {}
+                root_rules:
+                {}
+                all_rules:
                 {}
               }}""".format(root_subject_types_str,
-                           root_rules_str,
-                           '\n                '.join(self._dependency_strs())
-    )).strip()
+                           '\n                '.join(self._dependency_strs(self.root_rules)),
+                           '\n                '.join(self._dependency_strs(self.rule_dependencies))
+                           )).strip()
 
-  def _dependency_strs(self):
+  def _dependency_strs(self, dependencies):
     return sorted('{} => ({},)'.format(rule, ', '.join(str(d) for d in deps))
-                  for rule, deps in self.rule_dependencies.items())
+                  for rule, deps in dependencies.items())
 
 
 class RuleGraphSubjectIsProduct(datatype('RuleGraphSubjectIsProduct', ['value']), CanBeDependency):
@@ -378,7 +410,7 @@ class RuleGraphEntry(datatype('RuleGraphEntry', ['subject_type', 'rule']),
     return '{} of {}'.format(self.rule, self.subject_type.__name__)
 
 
-class RootRule(datatype('RootRule', ['subject_type', 'selector']), CanHaveDependencies):
+class RootRuleGraphEntry(datatype('RootRule', ['subject_type', 'selector']), CanHaveDependencies):
   """A synthetic rule representing a root selector."""
 
   @property
@@ -457,64 +489,92 @@ class RuleEdges(object):
 class GraphMaker(object):
 
   def __init__(self, rule_index, root_subject_fns):
+    if not root_subject_fns:
+      raise ValueError('root_subject_fns must not be empty')
     self.root_subject_selector_fns = root_subject_fns
     self.rule_index = rule_index
+
+  def new_graph_from_existing(self, root_subject_type, root_selector, existing_graph):
+    root_rule = RootRuleGraphEntry(root_subject_type, root_selector)
+    root_rule_dependency_edges, edges, unfulfillable = self._construct_graph(root_rule,
+                                                                             root_rule_dependency_edges=existing_graph.root_rules,
+                                                                             rule_dependency_edges=existing_graph.rule_dependencies,
+                                                                             unfulfillable_rules=existing_graph.unfulfillable_rules
+                                                                             )
+    root_rule_dependency_edges, edges = self._remove_unfulfillable_rules_and_dependents(root_rule_dependency_edges,
+                                                                                        edges, unfulfillable)
+    return RuleGraph(self,
+                     self.root_subject_selector_fns.keys() + [root_subject_type,],
+                     root_rule_dependency_edges,
+                     edges,
+                     unfulfillable)
 
   def generate_subgraph(self, root_subject, requested_product):
     root_subject_type = type(root_subject)
     root_selector = self.root_subject_selector_fns[root_subject_type](requested_product)
-    root_rules, edges, unfulfillable = self._construct_graph(RootRule(root_subject_type, root_selector))
-    root_rules, edges = self._remove_unfulfillable_rules_and_dependents(root_rules,
-      edges, unfulfillable)
-    return RuleGraph((root_subject_type,), root_rules, edges, unfulfillable)
+    root_rule = RootRuleGraphEntry(root_subject_type, root_selector)
+    root_rule_dependency_edges, edges, unfulfillable = self._construct_graph(root_rule)
+    root_rule_dependency_edges, edges = self._remove_unfulfillable_rules_and_dependents(root_rule_dependency_edges,
+                                                                                        edges, unfulfillable)
+    return RuleGraph(self,
+                     (root_subject_type,),
+                     root_rule_dependency_edges,
+                     edges,
+                     unfulfillable)
 
   def full_graph(self):
     """Produces a full graph based on the root subjects and all of the products produced by rules."""
-    full_root_rules = set()
+    full_root_rule_dependency_edges = dict()
     full_dependency_edges = {}
     full_unfulfillable_rules = {}
     for root_subject_type, selector_fn in self.root_subject_selector_fns.items():
       for product in sorted(self.rule_index.all_produced_product_types(root_subject_type)):
-        beginning_root = RootRule(root_subject_type, selector_fn(product))
+        beginning_root = RootRuleGraphEntry(root_subject_type, selector_fn(product))
         root_dependencies, rule_dependency_edges, unfulfillable_rules = self._construct_graph(
           beginning_root,
-          root_rules=full_root_rules,
+          root_rule_dependency_edges=full_root_rule_dependency_edges,
           rule_dependency_edges=full_dependency_edges,
           unfulfillable_rules=full_unfulfillable_rules
         )
 
-        full_root_rules = set(root_dependencies)
+        full_root_rule_dependency_edges = dict(root_dependencies)
         full_dependency_edges = rule_dependency_edges
         full_unfulfillable_rules = unfulfillable_rules
 
     rules_in_graph = set(entry.rule for entry in full_dependency_edges.keys())
-    rules_eliminated_during_construction = [entry.rule for entry in full_unfulfillable_rules.keys()]
-    rules_used = set(rules_eliminated_during_construction + self.rule_index.intrinsics.values() + self.rule_index.singletons.values())
+    rules_eliminated_during_construction = set(entry.rule
+                                               for entry in full_unfulfillable_rules.keys())
 
     declared_rules = self.rule_index.all_rules()
-    unreachable_rules = declared_rules.difference(rules_in_graph, rules_used)
+    unreachable_rules = declared_rules.difference(rules_in_graph,
+                                                  rules_eliminated_during_construction,
+                                                  # NB Singletons and intrinsics are ignored for
+                                                  #    purposes of reachability.
+                                                  self.rule_index.singletons.values(),
+                                                  self.rule_index.intrinsics.values())
     for rule in sorted(unreachable_rules):
       full_unfulfillable_rules[UnreachableRule(rule)] = [Diagnostic(None, 'Unreachable')]
 
-    full_root_rules, full_dependency_edges = self._remove_unfulfillable_rules_and_dependents(
-      full_root_rules,
+    full_root_rule_dependency_edges, full_dependency_edges = self._remove_unfulfillable_rules_and_dependents(
+      full_root_rule_dependency_edges,
       full_dependency_edges,
       full_unfulfillable_rules)
 
-    return RuleGraph(self.root_subject_selector_fns,
-                         list(full_root_rules),
-                         full_dependency_edges,
-                         full_unfulfillable_rules)
+    return RuleGraph(self,
+                     self.root_subject_selector_fns,
+                     dict(full_root_rule_dependency_edges),
+                     full_dependency_edges,
+                     full_unfulfillable_rules)
 
   def _construct_graph(self,
-                       beginning_rule,
-                       root_rules=None,
-                       rule_dependency_edges=None,
-                       unfulfillable_rules=None):
-    root_rules = set() if root_rules is None else root_rules
+    beginning_rule,
+    root_rule_dependency_edges=None,
+    rule_dependency_edges=None,
+    unfulfillable_rules=None):
+    rules_to_traverse = deque([beginning_rule])
+    root_rule_dependency_edges = dict() if root_rule_dependency_edges is None else root_rule_dependency_edges
     rule_dependency_edges = dict() if rule_dependency_edges is None else rule_dependency_edges
     unfulfillable_rules = dict() if unfulfillable_rules is None else unfulfillable_rules
-    rules_to_traverse = deque([beginning_rule])
 
     def _find_rhs_for_select(subject_type, selector):
       if selector.type_constraint.satisfied_by_type(subject_type):
@@ -522,7 +582,7 @@ class GraphMaker(object):
         return (RuleGraphSubjectIsProduct(subject_type),)
       else:
         return tuple(RuleGraphEntry(subject_type, rule)
-          for rule in self.rule_index.gen_rules(subject_type, selector.product))
+                     for rule in self.rule_index.gen_rules(subject_type, selector.product))
 
     def mark_unfulfillable(rule, subject_type, reason):
       if rule not in unfulfillable_rules:
@@ -531,11 +591,17 @@ class GraphMaker(object):
 
     def add_rules_to_graph(rule, selector_path, dep_rules):
       unseen_dep_rules = [g for g in dep_rules
-                          if g not in rule_dependency_edges and g not in unfulfillable_rules]
+                          if g not in rule_dependency_edges and
+                          g not in unfulfillable_rules and
+                          g not in root_rule_dependency_edges]
       rules_to_traverse.extend(unseen_dep_rules)
-      if type(rule) is RootRule:
-        root_rules.update(dep_rules)
-        return
+      if type(rule) is RootRuleGraphEntry:
+        if rule in root_rule_dependency_edges:
+          root_rule_dependency_edges[rule].add_edges_via(selector_path, dep_rules)
+        else:
+          new_edges = RuleEdges()
+          new_edges.add_edges_via(selector_path, dep_rules)
+          root_rule_dependency_edges[rule] = new_edges
       elif rule not in rule_dependency_edges:
         new_edges = RuleEdges()
         new_edges.add_edges_via(selector_path, dep_rules)
@@ -577,7 +643,7 @@ class GraphMaker(object):
                              selector,
                              (RuleGraphLiteral(selector.subject, selector.product),))
         elif type(selector) is SelectDependencies:
-          initial_selector = selector.dep_product_selector
+          initial_selector = selector.input_product_selector
           initial_rules_or_literals = _find_rhs_for_select(entry.subject_type, initial_selector)
           if not initial_rules_or_literals:
             mark_unfulfillable(entry,
@@ -602,7 +668,7 @@ class GraphMaker(object):
             continue
 
           add_rules_to_graph(entry,
-                             (selector, selector.dep_product_selector),
+                             (selector, selector.input_product_selector),
                              initial_rules_or_literals)
           add_rules_to_graph(entry,
                              (selector, selector.projected_product_selector),
@@ -615,7 +681,7 @@ class GraphMaker(object):
             mark_unfulfillable(entry,
                                entry.subject_type,
                                'no matches for {} when resolving {}'
-                                .format(selector.input_product_selector, selector))
+                               .format(selector.input_product_selector, selector))
             was_unfulfillable = True
             continue
 
@@ -637,14 +703,51 @@ class GraphMaker(object):
                              projected_rules)
         else:
           raise TypeError('Unexpected type of selector: {}'.format(selector))
-      if not was_unfulfillable and entry not in rule_dependency_edges:
+
+      if type(entry.rule) is SnapshottedProcess:
+        # TODO, this is a copy of the SelectDependencies with some changes
+        # Need to come up with a better approach here, but this fixes things
+        # It's also not tested explicitly.
+        snapshot_selector = entry.rule.snapshot_selector
+        initial_selector = entry.rule.snapshot_selector.input_product_selector
+        initial_rules_or_literals = _find_rhs_for_select(SnapshottedProcessRequest, initial_selector)
+        if not initial_rules_or_literals:
+          mark_unfulfillable(entry,
+                             entry.subject_type,
+                             'no matches for {} when resolving {}'
+                             .format(initial_selector, snapshot_selector))
+          was_unfulfillable = True
+        else:
+
+          rules_for_dependencies = []
+          for field_type in snapshot_selector.field_types:
+            rules_for_field_subjects = _find_rhs_for_select(field_type,
+                                                            snapshot_selector.projected_product_selector)
+            rules_for_dependencies.extend(rules_for_field_subjects)
+
+          if not rules_for_dependencies:
+            mark_unfulfillable(entry,
+                               snapshot_selector.field_types,
+                               'no matches for {} when resolving {}'
+                               .format(snapshot_selector.projected_product_selector, snapshot_selector))
+            was_unfulfillable = True
+          else:
+            add_rules_to_graph(entry,
+                               (snapshot_selector, snapshot_selector.input_product_selector),
+                               initial_rules_or_literals)
+            add_rules_to_graph(entry,
+                               (snapshot_selector, snapshot_selector.projected_product_selector),
+                               tuple(rules_for_dependencies))
+
+
+      if not was_unfulfillable:
         # NB: In this case, there are no selectors.
         add_rules_to_graph(entry, None, tuple())
 
-    return root_rules, rule_dependency_edges, unfulfillable_rules
+    return root_rule_dependency_edges, rule_dependency_edges, unfulfillable_rules
 
   def _remove_unfulfillable_rules_and_dependents(self,
-                                                 root_rules,
+                                                 root_rule_dependency_edges,
                                                  rule_dependency_edges,
                                                  unfulfillable_rules):
     """Removes all unfulfillable rules transitively from the roots and the dependency edges.
@@ -665,12 +768,30 @@ class GraphMaker(object):
 
         if dependency_edges.makes_unfulfillable(unfulfillable_entry):
           unfulfillable_rules[current_entry] = [Diagnostic(current_entry.subject_type,
-                                                'depends on unfulfillable {}'.format(unfulfillable_entry))]
+                                                           'depends on unfulfillable {}'.format(unfulfillable_entry))]
           removal_traversal.append(current_entry)
         else:
           rule_dependency_edges[current_entry] = dependency_edges.without_rule(unfulfillable_entry)
 
-    rule_dependency_edges = dict((k, v) for k, v in rule_dependency_edges.items()
-                                 if k not in unfulfillable_rules)
-    root_rules = tuple(r for r in root_rules if r not in unfulfillable_rules)
-    return root_rules, rule_dependency_edges
+      for current_entry, dependency_edges in tuple(root_rule_dependency_edges.items()):
+        if current_entry in unfulfillable_rules:
+          # NB: these are removed at the end
+          continue
+
+        if dependency_edges.makes_unfulfillable(unfulfillable_entry):
+          unfulfillable_rules[current_entry] = [Diagnostic(current_entry.subject_type,
+                                                           'depends on unfulfillable {}'.format(unfulfillable_entry))]
+          removal_traversal.append(current_entry)
+        else:
+          root_rule_dependency_edges[current_entry] = dependency_edges.without_rule(unfulfillable_entry)
+
+    rule_dependency_edges = {k: v for k, v in rule_dependency_edges.items()
+                             if k not in unfulfillable_rules}
+    root_rule_dependency_edges = {k: v for k, v in root_rule_dependency_edges.items()
+                                  if k not in unfulfillable_rules}
+
+    for root_rule, deps in root_rule_dependency_edges.items():
+      for d in deps:
+        if d not in rule_dependency_edges and isinstance(d, RuleGraphEntry):
+          raise ValueError('expected all referenced dependencies to have entries in the graph: {}'.format(d))
+    return root_rule_dependency_edges, rule_dependency_edges

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -123,8 +123,8 @@ class SingletonRule(datatype('SingletonRule', ['product_type', 'func']), Rule):
 
   def __repr__(self):
     return '{}({}, {})'.format(type(self).__name__,
-                           self.product_type.__name__,
-                           self.func.__name__)
+                               self.product_type.__name__,
+                               self.func.__name__)
 
 
 class IntrinsicRule(datatype('IntrinsicRule', ['subject_type', 'product_type', 'func']), Rule):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -18,7 +18,7 @@ from pants.engine.addressable import SubclassesOf
 from pants.engine.fs import PathGlobs, create_fs_intrinsics, generate_fs_subjects
 from pants.engine.isolated_process import create_snapshot_intrinsics, create_snapshot_singletons
 from pants.engine.nodes import Return, Runnable, Throw
-from pants.engine.rules import NodeBuilder, RulesetValidator
+from pants.engine.rules import RuleIndex, RulesetValidator
 from pants.engine.selectors import (Select, SelectDependencies, SelectLiteral, SelectProjection,
                                     SelectVariant, constraint_for)
 from pants.engine.struct import HasProducts, Variants
@@ -111,11 +111,11 @@ class LocalScheduler(object):
     }
     intrinsics = create_fs_intrinsics(project_tree) + create_snapshot_intrinsics(project_tree)
     singletons = create_snapshot_singletons(project_tree)
-    node_builder = NodeBuilder.create(tasks, intrinsics, singletons)
-    RulesetValidator(node_builder, goals, root_selector_fns).validate()
-    self._register_tasks(node_builder.tasks)
-    self._register_intrinsics(node_builder.intrinsics)
-    self._register_singletons(node_builder.singletons)
+    rule_index = RuleIndex.create(tasks, intrinsics, singletons)
+    RulesetValidator(rule_index, goals, root_selector_fns).validate()
+    self._register_tasks(rule_index.tasks)
+    self._register_intrinsics(rule_index.intrinsics)
+    self._register_singletons(rule_index.singletons)
 
   def _to_value(self, obj):
     return self._context.to_value(obj)

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -85,7 +85,7 @@ class SelectVariant(datatype('Variant', ['product', 'variant_key']), Selector):
 
 
 class SelectDependencies(datatype('Dependencies',
-                                  ['product', 'dep_product', 'field_', 'field_types', 'transitive']),
+                                  ['product', 'dep_product', 'field', 'field_types', 'transitive']),
                          Selector):
   """Selects a product for each of the dependencies of a product for the Subject.
 
@@ -97,14 +97,12 @@ class SelectDependencies(datatype('Dependencies',
   `dep_product`.
   """
 
+  DEFAULT_FIELD = 'dependencies'
+
   optional = False
 
-  def __new__(cls, product, dep_product, field=None, field_types=tuple(), transitive=False):
+  def __new__(cls, product, dep_product, field=DEFAULT_FIELD, field_types=tuple(), transitive=False):
     return super(SelectDependencies, cls).__new__(cls, product, dep_product, field, field_types, transitive)
-
-  @property
-  def field(self):
-    return self.field_ or 'dependencies'
 
   @property
   def input_product_selector(self):
@@ -119,12 +117,17 @@ class SelectDependencies(datatype('Dependencies',
       field_types_portion = ', field_types=({},)'.format(', '.join(f.__name__ for f in self.field_types))
     else:
       field_types_portion = ''
+    if self.field is not self.DEFAULT_FIELD:
+      field_name_portion = ', {}'.format(repr(self.field))
+    else:
+      field_name_portion = ''
     return '{}({}, {}{}{}{})'.format(type(self).__name__,
                                      type_or_constraint_repr(self.product),
                                      type_or_constraint_repr(self.dep_product),
-                                     ', {}'.format(repr(self.field_)) if self.field_ else '',
+                                     field_name_portion,
+                                     field_types_portion,
                                      ', transitive=True' if self.transitive else '',
-                                     field_types_portion)
+                                     )
 
 
 class SelectProjection(datatype('Projection', ['product', 'projected_subject', 'fields', 'input_product']), Selector):

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -85,7 +85,7 @@ class SelectVariant(datatype('Variant', ['product', 'variant_key']), Selector):
 
 
 class SelectDependencies(datatype('Dependencies',
-                                  ['product', 'dep_product', 'field', 'field_types', 'transitive']),
+                                  ['product', 'dep_product', 'field_', 'field_types', 'transitive']),
                          Selector):
   """Selects a product for each of the dependencies of a product for the Subject.
 
@@ -97,11 +97,17 @@ class SelectDependencies(datatype('Dependencies',
   `dep_product`.
   """
 
-  def __new__(cls, product, dep_product, field='dependencies', field_types=tuple(), transitive=False):
+  optional = False
+
+  def __new__(cls, product, dep_product, field=None, field_types=tuple(), transitive=False):
     return super(SelectDependencies, cls).__new__(cls, product, dep_product, field, field_types, transitive)
 
   @property
-  def dep_product_selector(self):
+  def field(self):
+    return self.field_ or 'dependencies'
+
+  @property
+  def input_product_selector(self):
     return Select(self.dep_product)
 
   @property
@@ -116,7 +122,7 @@ class SelectDependencies(datatype('Dependencies',
     return '{}({}, {}{}{}{})'.format(type(self).__name__,
                                      type_or_constraint_repr(self.product),
                                      type_or_constraint_repr(self.dep_product),
-                                     ', {}'.format(repr(self.field)) if self.field else '',
+                                     ', {}'.format(repr(self.field_)) if self.field_ else '',
                                      ', transitive=True' if self.transitive else '',
                                      field_types_portion)
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -177,6 +177,7 @@ python_tests(
     'src/python/pants/engine:build_files',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
+    'src/python/pants/engine/legacy:graph',
   ]
 )
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -177,7 +177,6 @@ python_tests(
     'src/python/pants/engine:build_files',
     'src/python/pants/engine:rules',
     'src/python/pants/engine:selectors',
-    'src/python/pants/engine/legacy:graph',
   ]
 )
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -14,7 +14,6 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
 from pants.build_graph.address import Address
 from pants.engine.addressable import Exactly
 from pants.engine.fs import PathGlobs, create_fs_intrinsics, create_fs_tasks
-from pants.engine.graph import create_graph_tasks
 from pants.engine.mapper import AddressMapper
 from pants.engine.rules import GraphMaker, Rule, RuleIndex, RulesetValidator
 from pants.engine.selectors import Select, SelectDependencies, SelectLiteral, SelectProjection

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -88,10 +88,6 @@ class BoringRule(Rule):
   def output_product_type(self):
     return self._output_product_type
 
-  @property
-  def constraint(self):
-    return Exactly(self._output_product_type)
-
   def __repr__(self):
     return '{}({})'.format(type(self).__name__, self.output_product_type.__name__)
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -13,8 +13,8 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
                               SingleAddress)
 from pants.build_graph.address import Address
 from pants.engine.addressable import Exactly
+from pants.engine.build_files import create_graph_tasks
 from pants.engine.fs import PathGlobs, create_fs_intrinsics, create_fs_tasks
-from pants.engine.graph import create_graph_tasks
 from pants.engine.mapper import AddressMapper
 from pants.engine.rules import GraphMaker, Rule, RuleIndex, RulesetValidator
 from pants.engine.selectors import Select, SelectDependencies, SelectLiteral, SelectProjection

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -14,6 +14,7 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
 from pants.build_graph.address import Address
 from pants.engine.addressable import Exactly
 from pants.engine.fs import PathGlobs, create_fs_intrinsics, create_fs_tasks
+from pants.engine.graph import create_graph_tasks
 from pants.engine.mapper import AddressMapper
 from pants.engine.rules import GraphMaker, Rule, RuleIndex, RulesetValidator
 from pants.engine.selectors import Select, SelectDependencies, SelectLiteral, SelectProjection

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -13,8 +13,8 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
                               SingleAddress)
 from pants.build_graph.address import Address
 from pants.engine.addressable import Exactly
-from pants.engine.build_files import create_graph_tasks
 from pants.engine.fs import PathGlobs, create_fs_intrinsics, create_fs_tasks
+from pants.engine.graph import create_graph_tasks
 from pants.engine.mapper import AddressMapper
 from pants.engine.rules import GraphMaker, Rule, RuleIndex, RulesetValidator
 from pants.engine.selectors import Select, SelectDependencies, SelectLiteral, SelectProjection
@@ -88,6 +88,10 @@ class BoringRule(Rule):
   def output_product_type(self):
     return self._output_product_type
 
+  @property
+  def constraint(self):
+    return Exactly(self._output_product_type)
+
   def __repr__(self):
     return '{}({})'.format(type(self).__name__, self.output_product_type.__name__)
 
@@ -101,17 +105,17 @@ class RuleIndexTest(unittest.TestCase):
       str(cm.exception))
 
   def test_creation_fails_with_intrinsic_that_overwrites_another_intrinsic(self):
-    a_provider = (A, A, noop)
+    a_intrinsic = (A, A, noop)
     with self.assertRaises(ValueError):
-      RuleIndex.create([BoringRule(A)], (a_provider, a_provider))
+      RuleIndex.create([BoringRule(A)], (a_intrinsic, a_intrinsic))
 
 
 class RulesetValidatorTest(unittest.TestCase):
   def test_ruleset_with_missing_product_type(self):
     rules = [(A, (Select(B),), noop)]
     validator = RulesetValidator(RuleIndex.create(rules, tuple()),
-      goal_to_product={},
-      root_subject_fns={k: lambda p: Select(p) for k in (SubA,)})
+                                 goal_to_product={},
+                                 root_subject_fns={k: lambda p: Select(p) for k in (SubA,)})
     with self.assertRaises(ValueError) as cm:
       validator.validate()
 
@@ -145,18 +149,6 @@ class RulesetValidatorTest(unittest.TestCase):
       root_subject_fns={k: lambda p: Select(p) for k in (B,)})
 
     validator.validate()
-
-  def test_fails_if_root_subject_types_empty(self):
-    rules = [
-      (A, (Select(B),), noop),
-    ]
-    with self.assertRaises(ValueError) as cm:
-      RulesetValidator(RuleIndex.create(rules, tuple()),
-      goal_to_product={},
-      root_subject_fns={})
-    self.assertEquals(dedent("""
-                                root_subject_fns must not be empty
-                             """).strip(), str(cm.exception))
 
   def test_ruleset_with_superclass_of_selected_type_produced_fails(self):
     rules = [
@@ -219,6 +211,7 @@ class RulesetValidatorTest(unittest.TestCase):
     with self.assertRaises(ValueError) as cm:
       validator.validate()
 
+    # This error message could note near matches like the intrinsic.
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 1
                                         (D, (Select(C),), noop):
@@ -242,7 +235,7 @@ class RulesetValidatorTest(unittest.TestCase):
 
     self.assert_equal_with_printing(dedent("""
                              Rules with errors: 1
-                               (A, (SelectDependencies(B, SubA, u'dependencies', field_types=(D,)),), noop):
+                               (A, (SelectDependencies(B, SubA, field_types=(D,)),), noop):
                                  Unreachable with subject types: Any
                              """).strip(),
                                     str(cm.exception))
@@ -265,8 +258,8 @@ class RulesetValidatorTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                       Rules with errors: 2
                         (B, (Select(D),), noop):
-                          depends on unfulfillable (D, (Select(A), SelectDependencies(A, SubA, u'dependencies', field_types=(C,))), noop) of SubA with subject types: SubA
-                        (D, (Select(A), SelectDependencies(A, SubA, u'dependencies', field_types=(C,))), noop):
+                          depends on unfulfillable (D, (Select(A), SelectDependencies(A, SubA, field_types=(C,))), noop) of SubA with subject types: SubA
+                        (D, (Select(A), SelectDependencies(A, SubA, field_types=(C,))), noop):
                           depends on unfulfillable (A, (Select(SubA),), noop) of C with subject types: SubA""").strip(),
         str(cm.exception))
 
@@ -317,19 +310,30 @@ class RuleGraphMakerTest(unittest.TestCase):
   # TODO something with variants
   # TODO HasProducts?
 
+  def test_fails_if_root_subject_types_empty(self):
+    rules = [
+      (A, (Select(B),), noop),
+    ]
+    with self.assertRaises(ValueError) as cm:
+      GraphMaker(RuleIndex.create(rules), tuple())
+    self.assertEquals(dedent("""
+                                  root_subject_fns must not be empty
+                               """).strip(), str(cm.exception))
+
   def test_smallest_full_test(self):
     rules = [
       (Exactly(A), (Select(SubA),), noop)
     ]
 
-    graphmaker = GraphMaker(RuleIndex.create(rules, tuple()),
-      root_subject_fns={k: lambda p: Select(p) for k in (SubA,)})
-    fullgraph = graphmaker.full_graph()
+    fullgraph = GraphMaker(RuleIndex.create(rules, tuple()),
+      root_subject_fns={k: lambda p: Select(p) for k in (SubA,)}).full_graph()
 
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (Exactly(A), (Select(SubA),), noop) of SubA
+                                 root_rules:
+                                 Select(A) for SubA => ((Exactly(A), (Select(SubA),), noop) of SubA,)
+                                 all_rules:
                                  (Exactly(A), (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
                                }""").strip(), fullgraph)
 
@@ -364,10 +368,13 @@ class RuleGraphMakerTest(unittest.TestCase):
       rules_remaining_in_graph_strs
     )
 
+    # statically assert that the number of dependency keys is fixed
+    self.assertEquals(41, len(fullgraph.rule_dependencies))
+
   def test_smallest_full_test_multiple_root_subject_types(self):
     rules = [
-      (Exactly(A), (Select(SubA),), noop),
-      (Exactly(B), (Select(A),), noop)
+      (A, (Select(SubA),), noop),
+      (B, (Select(A),), noop)
     ]
     select_p = lambda p: Select(p)
     graphmaker = GraphMaker(RuleIndex.create(rules, tuple()),
@@ -377,10 +384,15 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA, A,)
-                                        root_rules: (Exactly(A), (Select(SubA),), noop) of SubA, (Exactly(B), (Select(A),), noop) of A, (Exactly(B), (Select(A),), noop) of SubA, SubjectIsProduct(A)
-                                        (Exactly(A), (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
-                                        (Exactly(B), (Select(A),), noop) of A => (SubjectIsProduct(A),)
-                                        (Exactly(B), (Select(A),), noop) of SubA => ((Exactly(A), (Select(SubA),), noop) of SubA,)
+                                        root_rules:
+                                        Select(A) for A => (SubjectIsProduct(A),)
+                                        Select(A) for SubA => ((A, (Select(SubA),), noop) of SubA,)
+                                        Select(B) for A => ((B, (Select(A),), noop) of A,)
+                                        Select(B) for SubA => ((B, (Select(A),), noop) of SubA,)
+                                        all_rules:
+                                        (A, (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
+                                        (B, (Select(A),), noop) of A => (SubjectIsProduct(A),)
+                                        (B, (Select(A),), noop) of SubA => ((A, (Select(SubA),), noop) of SubA,)
                                       }""").strip(),
                                     fullgraph)
 
@@ -396,7 +408,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (Exactly(A), (Select(SubA),), noop) of SubA
+                                 root_rules:
+                                 Select(A) for SubA => ((Exactly(A), (Select(SubA),), noop) of SubA,)
+                                 all_rules:
                                  (Exactly(A), (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
                                }""").strip(), subgraph)
 
@@ -413,7 +427,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (Select(SubA), Select(B)), noop) of SubA
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (Select(SubA), Select(B)), noop) of SubA,)
+                                        all_rules:
                                         (B, (), noop) of SubA => (,)
                                         (Exactly(A), (Select(SubA), Select(B)), noop) of SubA => (SubjectIsProduct(SubA), (B, (), noop) of SubA,)
                                       }""").strip(),
@@ -432,7 +448,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (Exactly(A), (Select(B),), noop) of SubA
+                                 root_rules:
+                                 Select(A) for SubA => ((Exactly(A), (Select(B),), noop) of SubA,)
+                                 all_rules:
                                  (B, (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
                                  (Exactly(A), (Select(B),), noop) of SubA => ((B, (Select(SubA),), noop) of SubA,)
                                }""").strip(), subgraph)
@@ -448,14 +466,16 @@ class RuleGraphMakerTest(unittest.TestCase):
     ]
 
     graphmaker = GraphMaker(RuleIndex.create(rules,
-                                               intrinsics),
+                                             intrinsics),
       root_subject_fns=_suba_root_subject_fns)
     subgraph = graphmaker.generate_subgraph(SubA(), requested_product=A)
 
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (Exactly(A), (), noop) of SubA
+                                 root_rules:
+                                 Select(A) for SubA => ((Exactly(A), (), noop) of SubA,)
+                                 all_rules:
                                  (Exactly(A), (), noop) of SubA => (,)
                                }""").strip(), subgraph)
 
@@ -466,7 +486,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       (Exactly(A), tuple(), noop),
     ]
     intrinsics = [
-      (B, C, BoringRule(C)),
+      (B, C, noop),
     ]
 
     graphmaker = GraphMaker(RuleIndex.create(rules, intrinsics),
@@ -476,7 +496,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (Exactly(A), (), noop) of SubA
+                                 root_rules:
+                                 Select(A) for SubA => ((Exactly(A), (), noop) of SubA,)
+                                 all_rules:
                                  (Exactly(A), (), noop) of SubA => (,)
                                }""").strip(), fullgraph)
 
@@ -500,7 +522,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (Exactly(A), (), noop) of SubA
+                                 root_rules:
+                                 Select(A) for SubA => ((Exactly(A), (), noop) of SubA,)
+                                 all_rules:
                                  (Exactly(A), (), noop) of SubA => (,)
                                }""").strip(), subgraph)
 
@@ -518,10 +542,12 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (SelectDependencies(B, C, u'dependencies', field_types=(D,)),), noop) of SubA
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (SelectDependencies(B, C, field_types=(D,)),), noop) of SubA,)
+                                        all_rules:
                                         (B, (Select(D),), noop) of D => (SubjectIsProduct(D),)
                                         (C, (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
-                                        (Exactly(A), (SelectDependencies(B, C, u'dependencies', field_types=(D,)),), noop) of SubA => ((C, (Select(SubA),), noop) of SubA, (B, (Select(D),), noop) of D,)
+                                        (Exactly(A), (SelectDependencies(B, C, field_types=(D,)),), noop) of SubA => ((C, (Select(SubA),), noop) of SubA, (B, (Select(D),), noop) of D,)
                                       }""").strip(),
                                     subgraph)
 
@@ -538,9 +564,11 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(D,)),), noop) of SubA
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (SelectDependencies(B, SubA, field_types=(D,)),), noop) of SubA,)
+                                        all_rules:
                                         (B, (Select(D),), noop) of D => (SubjectIsProduct(D),)
-                                        (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(D),), noop) of D,)
+                                        (Exactly(A), (SelectDependencies(B, SubA, field_types=(D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(D),), noop) of D,)
                                       }""").strip(),
                                     subgraph)
 
@@ -557,10 +585,12 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of SubA
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of SubA,)
+                                        all_rules:
                                         (B, (Select(Exactly(C, D)),), noop) of C => (SubjectIsProduct(C),)
                                         (B, (Select(Exactly(C, D)),), noop) of D => (SubjectIsProduct(D),)
-                                        (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(Exactly(C, D)),), noop) of C, (B, (Select(Exactly(C, D)),), noop) of D,)
+                                        (Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(Exactly(C, D)),), noop) of C, (B, (Select(Exactly(C, D)),), noop) of D,)
                                       }""").strip(),
                                     subgraph)
 
@@ -579,11 +609,13 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of SubA
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of SubA,)
+                                        all_rules:
                                         (B, (Select(C),), noop) of C => (SubjectIsProduct(C),)
                                         (B, (Select(C),), noop) of D => ((C, (Select(D),), noop) of D,)
                                         (C, (Select(D),), noop) of D => (SubjectIsProduct(D),)
-                                        (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(C),), noop) of C, (B, (Select(C),), noop) of D,)
+                                        (Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(C),), noop) of C, (B, (Select(C),), noop) of D,)
                                       }""").strip(),
                                     subgraph)
 
@@ -602,12 +634,14 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of SubA
-                                        (B, (Select(A),), noop) of C => ((Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of C,)
-                                        (B, (Select(A),), noop) of D => ((Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of D,)
-                                        (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of C => ((SubA, (), noop) of C, (B, (Select(A),), noop) of C, (B, (Select(A),), noop) of D,)
-                                        (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of D => ((SubA, (), noop) of D, (B, (Select(A),), noop) of C, (B, (Select(A),), noop) of D,)
-                                        (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C, D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(A),), noop) of C, (B, (Select(A),), noop) of D,)
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of SubA,)
+                                        all_rules:
+                                        (B, (Select(A),), noop) of C => ((Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of C,)
+                                        (B, (Select(A),), noop) of D => ((Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of D,)
+                                        (Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of C => ((SubA, (), noop) of C, (B, (Select(A),), noop) of C, (B, (Select(A),), noop) of D,)
+                                        (Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of D => ((SubA, (), noop) of D, (B, (Select(A),), noop) of C, (B, (Select(A),), noop) of D,)
+                                        (Exactly(A), (SelectDependencies(B, SubA, field_types=(C, D,)),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(A),), noop) of C, (B, (Select(A),), noop) of D,)
                                         (SubA, (), noop) of C => (,)
                                         (SubA, (), noop) of D => (,)
                                       }""").strip(),
@@ -627,8 +661,8 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing('{empty graph}', subgraph)
     self.assert_equal_with_printing(dedent("""
                          Rules with errors: 1
-                           (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(D,)),), noop):
-                             no matches for Select(B) when resolving SelectDependencies(B, SubA, u'dependencies', field_types=(D,)) with subject types: D""").strip(),
+                           (Exactly(A), (SelectDependencies(B, SubA, field_types=(D,)),), noop):
+                             no matches for Select(B) when resolving SelectDependencies(B, SubA, field_types=(D,)) with subject types: D""").strip(),
                                     subgraph.error_message())
 
   def test_select_dependencies_with_matching_intrinsic(self):
@@ -646,9 +680,11 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C,)),), noop) of SubA
-                                        (Exactly(A), (SelectDependencies(B, SubA, u'dependencies', field_types=(C,)),), noop) of SubA => (SubjectIsProduct(SubA), IntrinsicRule(noop) of C,)
-                                        IntrinsicRule(noop) of C => (,)
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (SelectDependencies(B, SubA, field_types=(C,)),), noop) of SubA,)
+                                        all_rules:
+                                        (Exactly(A), (SelectDependencies(B, SubA, field_types=(C,)),), noop) of SubA => (SubjectIsProduct(SubA), IntrinsicRule((C, B), noop) of C,)
+                                        IntrinsicRule((C, B), noop) of C => (,)
                                       }""").strip(),
                                     subgraph)
 
@@ -666,7 +702,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (B, (Select(A),), noop) of SubA
+                                 root_rules:
+                                 Select(B) for SubA => ((B, (Select(A),), noop) of SubA,)
+                                 all_rules:
                                  (A, (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
                                  (B, (Select(A),), noop) of SubA => ((A, (Select(SubA),), noop) of SubA,)
                                }""").strip(), subgraph)
@@ -685,7 +723,11 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (A, (Select(SubA),), noop) of SubA, (B, (Select(A),), noop) of SubA, (C, (Select(A),), noop) of SubA
+                                        root_rules:
+                                        Select(A) for SubA => ((A, (Select(SubA),), noop) of SubA,)
+                                        Select(B) for SubA => ((B, (Select(A),), noop) of SubA,)
+                                        Select(C) for SubA => ((C, (Select(A),), noop) of SubA,)
+                                        all_rules:
                                         (A, (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
                                         (B, (Select(A),), noop) of SubA => ((A, (Select(SubA),), noop) of SubA,)
                                         (C, (Select(A),), noop) of SubA => ((A, (Select(SubA),), noop) of SubA,)
@@ -704,7 +746,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                {
                                  root_subject_types: (SubA,)
-                                 root_rules: (B, (SelectLiteral(A(), A),), noop) of SubA
+                                 root_rules:
+                                 Select(B) for SubA => ((B, (SelectLiteral(A(), A),), noop) of SubA,)
+                                 all_rules:
                                  (B, (SelectLiteral(A(), A),), noop) of SubA => (Literal(A(), A),)
                                }""").strip(), subgraph)
 
@@ -721,7 +765,9 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (Exactly(A), (SelectProjection(B, D, (u'some',), SubA),), noop) of SubA
+                                        root_rules:
+                                        Select(A) for SubA => ((Exactly(A), (SelectProjection(B, D, (u'some',), SubA),), noop) of SubA,)
+                                        all_rules:
                                         (B, (Select(D),), noop) of D => (SubjectIsProduct(D),)
                                         (Exactly(A), (SelectProjection(B, D, (u'some',), SubA),), noop) of SubA => (SubjectIsProduct(SubA), (B, (Select(D),), noop) of D,)
                                       }""").strip(),
@@ -741,9 +787,11 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assert_equal_with_printing(dedent("""
                                       {
                                         root_subject_types: (SubA,)
-                                        root_rules: (D, (Select(Exactly(B)), SelectDependencies(B, SubA, u'dependencies', field_types=(SubA, C,))), noop) of SubA
+                                        root_rules:
+                                        Select(D) for SubA => ((D, (Select(Exactly(B)), SelectDependencies(B, SubA, field_types=(SubA, C,))), noop) of SubA,)
+                                        all_rules:
                                         (B, (Select(SubA),), noop) of SubA => (SubjectIsProduct(SubA),)
-                                        (D, (Select(Exactly(B)), SelectDependencies(B, SubA, u'dependencies', field_types=(SubA, C,))), noop) of SubA => ((B, (Select(SubA),), noop) of SubA, SubjectIsProduct(SubA), (B, (Select(SubA),), noop) of SubA,)
+                                        (D, (Select(Exactly(B)), SelectDependencies(B, SubA, field_types=(SubA, C,))), noop) of SubA => ((B, (Select(SubA),), noop) of SubA, SubjectIsProduct(SubA), (B, (Select(SubA),), noop) of SubA,)
                                       }""").strip(),
       subgraph)
 

--- a/tests/python/pants_test/engine/test_selectors.py
+++ b/tests/python/pants_test/engine/test_selectors.py
@@ -24,7 +24,7 @@ class SelectorsTest(unittest.TestCase):
     self.assert_repr("SelectVariant(AClass, u'field')", SelectVariant(AClass, 'field'))
 
   def test_dependencies_repr(self):
-    self.assert_repr("SelectDependencies(AClass, AClass, u'dependencies')", SelectDependencies(AClass, AClass))
+    self.assert_repr("SelectDependencies(AClass, AClass)", SelectDependencies(AClass, AClass))
     self.assert_repr("SelectDependencies(AClass, AClass, u'some_field')",
                      SelectDependencies(AClass, AClass, field='some_field'))
     self.assert_repr("SelectDependencies(AClass, AClass, u'some_field', field_types=(AClass,))",

--- a/tests/python/pants_test/engine/test_selectors.py
+++ b/tests/python/pants_test/engine/test_selectors.py
@@ -29,6 +29,8 @@ class SelectorsTest(unittest.TestCase):
                      SelectDependencies(AClass, AClass, field='some_field'))
     self.assert_repr("SelectDependencies(AClass, AClass, u'some_field', field_types=(AClass,))",
                      SelectDependencies(AClass, AClass, field='some_field', field_types=(AClass,)))
+    self.assert_repr("SelectDependencies(AClass, AClass, transitive=True)",
+                     SelectDependencies(AClass, AClass, transitive=True))
 
   def test_projection_repr(self):
     self.assert_repr("SelectProjection(AClass, AClass, (u'field',), AClass)",


### PR DESCRIPTION
### Problem
I'm working on porting my patch for #3580 to the native engine, (#3960). First, I'm updating the graph construction code with the changes there. It hadn't covered Snapshot processes, and it modeled root rules as a set rather than a graph, which caused problems.

### Solution

Include snapshot process' behavior in the rule graph construction used by the validator. Update tests to expect the new visualization format.

### List of changes
* rename NodeBuilder to RuleIndex
* rename RootRule to RootRuleGraphEntry
* support SnapshotProcess in validator
* Name snapshot process funcs so they are printable
* Include subject and product types in intrinsic rule repr
* Include graph generation methods that can construct new graphs from an existing one--these are currently unused
* Raise an error if a declared rule is not reachable from the declared root types.
* Unify naming for input selector for projection selectors
* If field of a SelectDependencies is the default value, don't include it in the repr
* Include a map of root rule to the rules that would fulfill it.