### PR TITLE
Ensure that the protoc root import path is examined first.

### DIFF
--- a/src/python/pants/backend/codegen/tasks/protobuf_gen.py
+++ b/src/python/pants/backend/codegen/tasks/protobuf_gen.py
@@ -117,10 +117,13 @@ class ProtobufGen(SimpleCodegenTask):
     sources_by_base = self._calculate_sources(target)
     sources = target.sources_relative_to_buildroot()
 
-    bases = OrderedSet(sources_by_base.keys())
-    bases.update(self._proto_path_imports([target]))
+    bases = OrderedSet()
+    # Note that the root import must come first, otherwise protoc can get confused
+    # when trying to resolve imports from the root against the import's source root.
     if self.get_options().import_from_root:
       bases.add('.')
+    bases.update(sources_by_base.keys())
+    bases.update(self._proto_path_imports([target]))
 
     gen_flag = '--java_out'
 

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/README.md
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/README.md
@@ -1,0 +1,4 @@
+Note that the structure of this package exposes a particular issue with the proto compiler
+that is then exercised in `ProtobufIntegrationTest.test_import_from_buildroot`. 
+
+ Please do not modify this unless you know what you're doing.

--- a/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/baz.proto
+++ b/testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/baz.proto
@@ -1,0 +1,10 @@
+// Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.testproject.import_from_buildroot;
+
+import "testprojects/src/protobuf/org/pantsbuild/testproject/import_from_buildroot/bar/bar.proto";
+
+message SomethingElseAgain {
+  optional SomethingElse somethingElse = 1;
+}


### PR DESCRIPTION
### Problem

While using this feature I noticed that protoc can sometimes get confused by the other proto_path entries when doing imports from the repo root of `.proto` files in the same package (I'm not 100% sure why).

The easy fix is to make sure the root is the first thing to be searched for the imports. The other option was to assume that if you're importing from the root anywhere then you have to everywhere, and not even use the source roots as proto_paths. But that seemed more extreme than was called for.

### Solution

Simply move the root to the front of the list of proto paths to add to the cmd line.

### Result

Protoc doesn't get confused any more. I modified the test case to exercise the issue.