### PR TITLE
Redirect bootstrapping calls in pants binary to stderr

### DIFF
--- a/pants
+++ b/pants
@@ -61,8 +61,9 @@ fi
 PANTS_SRCPATH="$(echo ${PANTS_SRCPATH[@]} | tr ' ' :)"
 
 function exec_pants_bare() {
-  activate_pants_venv
-  bootstrap_native_code
+  # Redirect activation and native bootstrap to ensure that they don't interfere with stdout.
+  activate_pants_venv 1>&2
+  bootstrap_native_code 1>&2
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" \
     exec python ${PANTS_EXE} "$@"
 }


### PR DESCRIPTION
I'm testing my hypothesis that these are what cause the intermittent CI failures