### PR TITLE
First attempt at #3630: User specified hashbang

### DIFF
--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -39,6 +39,7 @@ class PythonBinary(PythonTarget):
                repositories=None,         # pex option
                indices=None,              # pex option
                ignore_errors=False,       # pex option
+               shebang=None,              # pex option
                platforms=(),
                **kwargs):
     """
@@ -79,6 +80,7 @@ class PythonBinary(PythonTarget):
       'indices': PrimitiveField(maybe_list(indices or [])),
       'ignore_errors': PrimitiveField(bool(ignore_errors)),
       'platforms': PrimitiveField(tuple(maybe_list(platforms or []))),
+      'shebang': PrimitiveField(shebang or None),
     })
 
     sources = [] if source is None else [source]
@@ -126,6 +128,13 @@ class PythonBinary(PythonTarget):
       assert len(self.payload.sources.source_paths) == 1
       entry_source = list(self.sources_relative_to_source_root())[0]
       return self._translate_to_entry_point(entry_source)
+    else:
+      return None
+
+  @property
+  def shebang(self):
+    if self.payload.shebang:
+      return self.payload.shebang
     else:
       return None
 

--- a/src/python/pants/backend/python/targets/python_binary.py
+++ b/src/python/pants/backend/python/targets/python_binary.py
@@ -80,7 +80,7 @@ class PythonBinary(PythonTarget):
       'indices': PrimitiveField(maybe_list(indices or [])),
       'ignore_errors': PrimitiveField(bool(ignore_errors)),
       'platforms': PrimitiveField(tuple(maybe_list(platforms or []))),
-      'shebang': PrimitiveField(shebang or None),
+      'shebang': PrimitiveField(shebang),
     })
 
     sources = [] if source is None else [source]
@@ -133,11 +133,8 @@ class PythonBinary(PythonTarget):
 
   @property
   def shebang(self):
-    if self.payload.shebang:
-      return self.payload.shebang
-    else:
-      return None
-
+    return self.payload.shebang
+    
   @property
   def pexinfo(self):
     info = PexInfo.default()

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -118,6 +118,8 @@ class PythonTask(Task):
     pex_info = PexInfo.from_pex(path)
     # Now create a PythonChroot wrapper without dumping it.
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info, copy=True)
+    if targets[0].shebang:
+      builder.set_shebang(targets[0].shebang)
     return self.create_chroot(interpreter=interpreter,
                               builder=builder,
                               targets=targets,
@@ -138,6 +140,8 @@ class PythonTask(Task):
                      extra_requirements=None, executable_file_content=None):
     """Create a PythonChroot with the specified args."""
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info, copy=True)
+    if targets[0].shebang:
+      builder.set_shebang(targets[0].shebang)
     with self.context.new_workunit('chroot'):
       chroot = self.create_chroot(
         interpreter=interpreter,

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -17,6 +17,7 @@ from pex.pex_info import PexInfo
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.python_chroot import PythonChroot
 from pants.backend.python.python_setup import PythonRepos, PythonSetup
+from pants.backend.python.targets.python_binary import PythonBinary
 from pants.base import hash_utils
 from pants.binaries.thrift_binary import ThriftBinary
 from pants.ivy.bootstrapper import Bootstrapper
@@ -118,8 +119,11 @@ class PythonTask(Task):
     pex_info = PexInfo.from_pex(path)
     # Now create a PythonChroot wrapper without dumping it.
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info, copy=True)
-    if targets[0].shebang:
-      builder.set_shebang(targets[0].shebang)
+
+    binary_target = filter(lambda x: isinstance(x, PythonBinary), targets)
+    if len(binary_target)==1 and binary_target[0].shebang:
+      builder.set_shebang(binary_target[0].shebang)
+
     return self.create_chroot(interpreter=interpreter,
                               builder=builder,
                               targets=targets,
@@ -140,8 +144,11 @@ class PythonTask(Task):
                      extra_requirements=None, executable_file_content=None):
     """Create a PythonChroot with the specified args."""
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info, copy=True)
-    if targets[0].shebang:
-      builder.set_shebang(targets[0].shebang)
+
+    binary_target = filter(lambda x: isinstance(x, PythonBinary), targets)
+    if len(binary_target)==1 and binary_target[0].shebang:
+      builder.set_shebang(binary_target[0].shebang)
+
     with self.context.new_workunit('chroot'):
       chroot = self.create_chroot(
         interpreter=interpreter,

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -120,9 +120,7 @@ class PythonTask(Task):
     # Now create a PythonChroot wrapper without dumping it.
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info, copy=True)
 
-    binary_target = filter(lambda x: isinstance(x, PythonBinary), targets)
-    if len(binary_target)==1 and binary_target[0].shebang:
-      builder.set_shebang(binary_target[0].shebang)
+    self._configure_shebang(targets, builder)
 
     return self.create_chroot(interpreter=interpreter,
                               builder=builder,
@@ -145,9 +143,7 @@ class PythonTask(Task):
     """Create a PythonChroot with the specified args."""
     builder = PEXBuilder(path=path, interpreter=interpreter, pex_info=pex_info, copy=True)
 
-    binary_target = filter(lambda x: isinstance(x, PythonBinary), targets)
-    if len(binary_target)==1 and binary_target[0].shebang:
-      builder.set_shebang(binary_target[0].shebang)
+    self._configure_shebang(targets, builder)
 
     with self.context.new_workunit('chroot'):
       chroot = self.create_chroot(
@@ -200,3 +196,9 @@ class PythonTask(Task):
 
     fingerprint = hash_utils.hash_all(fingerprint_components)
     return os.path.join(self.chroot_cache_dir, fingerprint)
+
+  def _configure_shebang(self, targets, builder):
+    # binary_target = filter(lambda x: isinstance(x, PythonBinary), targets)
+    binary_targets = [target for target in targets if isinstance(target, PythonBinary)]
+    if len(binary_targets) == 1 and binary_targets[0].shebang:
+      builder.set_shebang(binary_targets[0].shebang)

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -82,6 +82,39 @@ class PythonChrootTest(BaseTest):
       finally:
         python_chroot.delete()
 
+  def test_shebang_modified(self):
+      self.create_file(relpath='src/python/test/main.py', contents=dedent("""
+      def main():
+        print('Hello World!')
+      """))
+
+      binary = self.make_target(spec='src/python/test',
+                                target_type=PythonBinary,
+                                source='main.py',
+                                shebang='/usr/bin/env python2'
+                                )
+
+      with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
+          pex_builder.freeze()
+
+          self.assertEqual(python_chroot._targets[0].shebang, '/usr/bin/env python2')
+
+  def test_shebang(self):
+      self.create_file(relpath='src/python/test/main.py', contents=dedent("""
+      def main():
+        print('Hello World!')
+      """))
+
+      binary = self.make_target(spec='src/python/test',
+                                target_type=PythonBinary,
+                                source='main.py',
+                                )
+
+      with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
+          pex_builder.freeze()
+
+          self.assertEqual(python_chroot._targets[0].shebang, None)
+
   def test_antlr(self):
     self.create_file(relpath='src/antlr/word/word.g', contents=dedent("""
       grammar word;

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -83,21 +83,20 @@ class PythonChrootTest(BaseTest):
         python_chroot.delete()
 
   def test_shebang_modified(self):
-      self.create_file(relpath='src/python/test/main.py', contents=dedent("""
-      def main():
-        print('Hello World!')
-      """))
+    self.create_file(relpath='src/python/test/main.py', contents=dedent("""
+    def main():
+      print('Hello World!')
+    """))
 
-      binary = self.make_target(spec='src/python/test',
-                                target_type=PythonBinary,
-                                source='main.py',
-                                shebang='/usr/bin/env python2'
-                                )
+    binary = self.make_target(spec='src/python/test',
+                              target_type=PythonBinary,
+                              source='main.py',
+                              shebang='/usr/bin/env python2'
+                             )
 
-      with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
-          pex_builder.freeze()
-
-          self.assertEqual(python_chroot._targets[0].shebang, '/usr/bin/env python2')
+    with self.dumped_chroot([binary]) as (pex_builder, python_chroot):
+        pex_builder.freeze()
+        self.assertEqual(python_chroot._targets[0].shebang, '/usr/bin/env python2')
 
   def test_shebang(self):
       self.create_file(relpath='src/python/test/main.py', contents=dedent("""


### PR DESCRIPTION
### Problem

Approaches the problem of overly specific shebang lines making cross platform usability harder than necessary. 
See #3630 for discussion

### Solution

- Plumbed the PEXBuilder's set_shebang to a new PythonBinary argument.
- Plumbing only happens for PythonBinary targets

### Result
- Once the new shebang argument is set, the PEX ends up with the set shebang line.
- As long as it is not set, nothing changes.

### Questions / Assumptions / ...
- Also, advice on how to get proper documentation included would be welcome.