### PR TITLE
Handle unicode in classpath entries

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -100,6 +100,7 @@ python_library(
   sources = ['shader.py'],
   dependencies = [
     'src/python/pants/backend/jvm/targets:jvm',
+    'src/python/pants/backend/jvm/tasks:classpath_util',
     'src/python/pants/backend/jvm/tasks:jvm_tool_task_mixin',
     'src/python/pants/java/distribution',
     'src/python/pants/java:executor',

--- a/src/python/pants/backend/jvm/subsystems/shader.py
+++ b/src/python/pants/backend/jvm/subsystems/shader.py
@@ -12,10 +12,11 @@ from contextlib import contextmanager
 
 from pants.backend.jvm.subsystems.jvm_tool_mixin import JvmToolMixin
 from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.subsystem.subsystem import Subsystem, SubsystemError
-from pants.util.contextutil import open_zip, temporary_file
+from pants.util.contextutil import temporary_file
 
 
 class UnaryRule(namedtuple('UnaryRule', ['name', 'pattern'])):
@@ -320,12 +321,11 @@ class Shader(object):
 
   @classmethod
   def _iter_jar_packages(cls, path):
-    with open_zip(path) as jar:
-      paths = set()
-      for pathname in jar.namelist():
-        if cls._potential_package_path(pathname):
-          paths.add(os.path.dirname(pathname))
-      return cls._iter_packages(paths)
+    paths = set()
+    for pathname in ClasspathUtil.classpath_entries_contents([path]):
+      if cls._potential_package_path(pathname):
+        paths.add(os.path.dirname(pathname))
+    return cls._iter_packages(paths)
 
   def __init__(self, jarjar_classpath, executor):
     """Creates a `Shader` the will use the given `jarjar` jar to create shaded jars.

--- a/src/python/pants/backend/jvm/targets/BUILD
+++ b/src/python/pants/backend/jvm/targets/BUILD
@@ -33,6 +33,8 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
     '3rdparty/python:six',
     'src/python/pants/backend/jvm/subsystems:java',
+    # TODO Fix the circular dependency https://github.com/pantsbuild/pants/issues/4138
+    # 'src/python/pants/backend/jvm/subsystems:junit',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm:jar_dependency_utils',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -145,7 +145,6 @@ python_library(
   sources = ['classpath_util.py'],
   dependencies = [
     ':classpath_products',
-    '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
@@ -173,7 +172,6 @@ python_library(
     'src/python/pants/base:exceptions',
     'src/python/pants/java/jar:manifest',
     'src/python/pants/option',
-    'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',
   ],
 )
@@ -404,7 +402,6 @@ python_library(
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/build_graph',
     'src/python/pants/java/distribution',
-    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
   ]

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -145,12 +145,11 @@ python_library(
   sources = ['classpath_util.py'],
   dependencies = [
     ':classpath_products',
-    # TODO(pl): Use twitter.common.lang instead, but for the to_bytes helper, twitter.commons
-    # needs to be updated so the standard compatibility helpers act like the ones in pex
     '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:strutil',
   ],
 )
 

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -145,6 +145,9 @@ python_library(
   sources = ['classpath_util.py'],
   dependencies = [
     ':classpath_products',
+    # TODO(pl): Use twitter.common.lang instead, but for the to_bytes helper, twitter.commons
+    # needs to be updated so the standard compatibility helpers act like the ones in pex
+    '3rdparty/python:pex',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
@@ -168,9 +171,6 @@ python_library(
   sources = ['detect_duplicates.py'],
   dependencies = [
     ':jvm_binary_task',
-    # TODO(pl): Use twitter.common.lang instead, but for the to_bytes helper, twitter.commons
-    # needs to be updated so the standard compatibility helpers act like the ones in pex
-    '3rdparty/python:pex',
     'src/python/pants/base:exceptions',
     'src/python/pants/java/jar:manifest',
     'src/python/pants/option',

--- a/src/python/pants/backend/jvm/tasks/classpath_util.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_util.py
@@ -10,12 +10,12 @@ import os
 import re
 from collections import OrderedDict
 
-from pex.compatibility import to_bytes
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.tasks.classpath_products import ClasspathEntry
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import fast_relpath, safe_delete, safe_open, safe_walk
+from pants.util.strutil import ensure_text
 
 
 class MissingClasspathEntryError(Exception):
@@ -155,11 +155,7 @@ class ClasspathUtil(object):
         # Walk the jar namelist.
         with open_zip(entry, mode='r') as jar:
           for name in jar.namelist():
-            # Zip entry names can come in any encoding and in practice we find some jars that have
-            # utf-8 encoded entry names, some not.  As a result we cannot simply decode in all cases
-            # and need to do this to_bytes(...).decode('utf-8') dance to stay safe across all entry
-            # name flavors and under all supported pythons.
-            yield to_bytes(name).decode('utf-8')
+            yield ensure_text(name)
       elif os.path.isdir(entry):
         # Walk the directory, including subdirs.
         def rel_walk_name(abs_sub_dir, name):

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
@@ -20,7 +20,6 @@ from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
 from pants.java.distribution.distribution import DistributionLocator
-from pants.util.contextutil import open_zip
 from pants.util.memo import memoized_method, memoized_property
 
 
@@ -82,10 +81,9 @@ class JvmDependencyAnalyzer(object):
 
   def _jar_classfiles(self, jar_file):
     """Returns an iterator over the classfiles inside jar_file."""
-    with open_zip(jar_file, 'r') as jar:
-      for cls in jar.namelist():
-        if cls.endswith(b'.class'):
-          yield cls
+    for cls in ClasspathUtil.classpath_entries_contents([jar_file]):
+      if cls.endswith(b'.class'):
+        yield cls
 
   def count_products(self, target):
     contents = ClasspathUtil.classpath_contents((target,), self.runtime_classpath)

--- a/src/python/pants/task/console_task.py
+++ b/src/python/pants/task/console_task.py
@@ -55,7 +55,7 @@ class ConsoleTask(QuietTaskMixin, Task):
       try:
         targets = self.context.targets()
         for value in self.console_output(targets):
-          self._outstream.write(str(value))
+          self._outstream.write(value.encode('utf-8'))
           self._outstream.write(self._console_separator)
       finally:
         self._outstream.flush()

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
@@ -26,7 +26,7 @@ class ShaderTest(unittest.TestCase):
     self.output_jar = '/not/really/shaded.jar'
 
   def populate_input_jar(self, *entries):
-    fd, input_jar_path = tempfile.mkstemp()
+    fd, input_jar_path = tempfile.mkstemp(suffix='.jar')
     os.close(fd)
     self.addCleanup(safe_delete, input_jar_path)
     with open_zip(input_jar_path, 'w') as jar:

--- a/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_classmap_integration.py
@@ -17,6 +17,9 @@ class ClassmapTaskIntegrationTest(PantsRunIntegrationTest):
                                  'testprojects/tests/java/org/pantsbuild/testproject/testjvms:base')
   EXTERNAL_MAPPING = ('org.junit.ClassRule 3rdparty:junit')
 
+  UNICODE_TEST_TARGET = 'testprojects/src/java/org/pantsbuild/testproject/unicode/cucumber'
+  UNICODE_MAPPING = 'cucumber.api.java.zh_cn.假如 3rdparty:cucumber-java'
+
   def test_classmap_none(self):
     pants_run = self.do_command('classmap', success=True)
     self.assertEqual(len(pants_run.stdout_data.strip().split()), 0)
@@ -38,3 +41,7 @@ class ClassmapTaskIntegrationTest(PantsRunIntegrationTest):
     self.assertIn(self.INTERNAL_MAPPING, pants_run.stdout_data)
     self.assertNotIn(self.INTERNAL_TRANSITIVE_MAPPING, pants_run.stdout_data)
     self.assertNotIn(self.EXTERNAL_MAPPING, pants_run.stdout_data)
+
+  def test_classmap_unicode(self):
+    pants_run = self.do_command('classmap', self.UNICODE_TEST_TARGET, success=True)
+    self.assertIn(self.UNICODE_MAPPING, pants_run.stdout_data)


### PR DESCRIPTION
### Problem

`classmap` console task fails with the following error
```
./pants classmap testprojects/src/java/org/pantsbuild/testproject/unicode/cucumber
...
  File "/Users/peiyu/github/pants/src/python/pants/backend/jvm/tasks/classmap.py", line 41, in console_output
    for file in self.classname_for_classfile(target, classpath_product):
  File "/Users/peiyu/github/pants/src/python/pants/backend/jvm/tasks/classmap.py", line 28, in classname_for_classfile
    classname = ClasspathUtil.classname_for_rel_classfile(f)
  File "/Users/peiyu/github/pants/src/python/pants/backend/jvm/tasks/classpath_util.py", line 174, in classname_for_rel_classfile
    if not class_file_name.endswith('.class'):

Exception message: 'ascii' codec can't decode byte 0xd8 in position 21: ordinal not in range(128)
```

### Solution

There is already logic handing mixed encodings in `DuplicateDetector`, refactor that into `ClasspathUtil` so it can be shared by other classes that need to extra entries from jars.

### Result

```
./pants classmap testprojects/src/java/org/pantsbuild/testproject/unicode/cucumber
...
cucumber.api.java.hi.और 3rdparty:cucumber-java
cucumber.api.java.hi.कदा 3rdparty:cucumber-java
cucumber.api.java.hi.किन्तु 3rdparty:cucumber-java
cucumber.api.java.hi.चूंकि 3rdparty:cucumber-java
cucumber.api.java.hi.जब 3rdparty:cucumber-java
```