### PR TITLE
Ensure that invalid vts have results_dir cleaned before passing to ta…

### DIFF
--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -67,6 +67,10 @@ class BaseLocalArtifactCache(ArtifactCache):
       tarball = self._store_tarball(cache_key, tmp.name)
       artifact = self._artifact(tarball)
 
+      # NOTE(mateo): The two clean=True args passed in this method are likely safe, since the cache will by
+      # definition be dealing with unique results_dir, as opposed to the stable vt.results_dir (aka 'current').
+      # But if by chance it's passed the stable results_dir, safe_makedir(clean=True) will silently convert it
+      # from a symlink to a real dir and cause mysterious 'Operation not permitted' errors until the workdir is cleaned.
       if results_dir is not None:
         safe_mkdir(results_dir, clean=True)
 

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -86,7 +86,7 @@ class VersionedTargetSet(object):
 
   @property
   def has_previous_results_dir(self):
-    return self._previous_results_dir is not None
+    return self._previous_results_dir is not None and os.path.isdir(self._previous_results_dir)
 
   @property
   def results_dir(self):
@@ -116,7 +116,7 @@ class VersionedTargetSet(object):
     TODO: Exposing old results is a bit of an abstraction leak, because ill-behaved Tasks could
     mutate them.
     """
-    if self._previous_results_dir is None:
+    if not self.has_previous_results_dir:
       raise ValueError('There is no previous_results_dir for: {}'.format(self))
     return self._previous_results_dir
 

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -208,12 +208,13 @@ class VersionedTarget(VersionedTargetSet):
       return None
     previous_path = self._results_dir_path(root_dir, self.previous_cache_key, stable=False)
     if os.path.isdir(previous_path):
-      self._previous_results_dir = previous_path
       self.is_incremental = True
       safe_rmtree(self._current_results_dir)
-      shutil.copytree(self._previous_results_dir, self._current_results_dir)
+      shutil.copytree(previous_path, self._current_results_dir)
     safe_mkdir(self._current_results_dir)
     relative_symlink(self._current_results_dir, self.results_dir)
+    # Set the self._previous last, so that it is only True after the copy completed.
+    self._previous_results_dir = previous_path
 
   def _use_previous_dir(self, allow_incremental, root_dir):
     if not allow_incremental or not self.previous_cache_key:

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -187,20 +187,15 @@ class VersionedTarget(VersionedTargetSet):
     )
 
   def create_results_dir(self, root_dir):
-    """Ensures that a cleaned results_dir exists for invalid versioned targets.
-
-    Only guarantees results_dirs for invalid VTs.
-    """
+    """Ensure that the empty results directory and a stable symlink exist for these versioned targets."""
     self._current_results_dir = self._results_dir_path(root_dir, self.cache_key, stable=False)
     self._results_dir = self._results_dir_path(root_dir, self.cache_key, stable=True)
 
-    # If the target is valid, both directories are assumed to exist.
-    if self.valid:
-      self.ensure_legal()
-    else:
-      # If the vt is invalid, clean the unique file path and create a symlink to be the stable path.
+    if not self.valid:
+      # Clean the workspace for invalid vts.
       safe_mkdir(self._current_results_dir, clean=True)
       relative_symlink(self._current_results_dir, self._results_dir)
+    self.ensure_legal()
 
   def copy_previous_results(self, root_dir):
     """Use the latest valid results_dir as the starting contents of the current results_dir.

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -137,6 +137,8 @@ class VersionedTargetSet(object):
 
   def live_dirs(self):
     """Yields directories that must exist for this VersionedTarget to function."""
+    # The only caller of this function is the workdir cleaning pipeline. It is not clear that the previous_results_dir
+    # should be returned for that purpose. And, by the time this is called, the contents have already been copied.
     if self.has_results_dir:
       yield self.results_dir
       yield self.current_results_dir
@@ -203,6 +205,7 @@ class VersionedTarget(VersionedTargetSet):
     Should be called after the cache is checked, since previous_results are not useful if there is a cached artifact.
     """
     # TODO(mateo): An immediate followup removes the root_dir param, it is identical to the task.workdir.
+    # TODO(mateo): This should probably be managed by the task, which manages the rest of the incremental support.
     if not self.previous_cache_key:
       return None
     previous_path = self._results_dir_path(root_dir, self.previous_cache_key, stable=False)

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -402,13 +402,17 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
         invalidation_report.add_vts(cache_manager, vts.targets, vts.cache_key, vts.valid,
                                     phase='pre-check')
 
+    # Cache has been checked to create the full list of invalid VTs. Only copy previous_results for this subset of VTs.
+    for vts in invalidation_check.invalid_vts:
+      if self.incremental:
+        vts.copy_previous_results(self.workdir)
+
     # Yield the result, and then mark the targets as up to date.
     yield invalidation_check
 
     if invalidation_report:
       for vts in invalidation_check.all_vts:
-        invalidation_report.add_vts(cache_manager, vts.targets, vts.cache_key, vts.valid,
-                                    phase='post-check')
+        invalidation_report.add_vts(cache_manager, vts.targets, vts.cache_key, vts.valid, phase='post-check')
 
     for vt in invalidation_check.invalid_vts:
       vt.update()
@@ -448,7 +452,7 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     """If `cache_target_dirs`, create results_dirs for the given versioned targets."""
     if self.create_target_dirs:
       for vt in vts:
-        vt.create_results_dir(self.workdir, allow_incremental=self.incremental)
+        vt.create_results_dir(self.workdir)
 
   def check_artifact_cache_for(self, invalidation_check):
     """Decides which VTS to check the artifact cache for.
@@ -480,10 +484,7 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     read_cache = self._cache_factory.get_read_cache()
     items = [(read_cache, vt.cache_key, vt.current_results_dir if self.cache_target_dirs else None)
              for vt in vts]
-
     res = self.context.subproc_map(call_use_cached_files, items)
-
-    self._maybe_create_results_dirs(vts)
 
     cached_vts = []
     uncached_vts = []

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -24,7 +24,7 @@ class TestRunnerTaskMixin(object):
     super(TestRunnerTaskMixin, cls).register_options(register)
     register('--skip', type=bool, help='Skip running tests.')
     register('--timeouts', type=bool, default=True,
-             help='Enable test target timeouts. If timeouts are enabled then tests with a'
+             help='Enable test target timeouts. If timeouts are enabled then tests with a '
                   'timeout= parameter set on their target will time out after the given number of '
                   'seconds if not completed. If no timeout is set, then either the default timeout '
                   'is used or no timeout is configured. In the current implementation, all the '

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -290,6 +290,10 @@ def relative_symlink(source_path, link_path):
     raise ValueError("Path for link:{} must be absolute".format(link_path))
   if source_path == link_path:
     raise ValueError("Path for link is identical to source:{}".format(source_path))
+  # The failure state below had a long life as an uncaught error. No behavior was changed here, it just adds a catch.
+  # Raising an exception does differ from absolute_symlink, which takes the liberty of deleting existing directories.
+  if os.path.isdir(link_path) and not os.path.islink(link_path):
+    raise ValueError("Path for link would overwrite an existing directory: {}".format(link_path))
   try:
     if os.path.lexists(link_path):
       os.unlink(link_path)

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -46,7 +46,6 @@ python_tests(
     'src/python/pants/base:payload',
     'src/python/pants/build_graph:build_graph',
     'src/python/pants/cache:cache',
-    'src/python/pants/util:dirutil',
     'tests/python/pants_test/tasks:task_test_base',
   ],
 )

--- a/tests/python/pants_test/cache/BUILD
+++ b/tests/python/pants_test/cache/BUILD
@@ -67,6 +67,8 @@ python_library(
   sources = ['cache_server.py'],
   dependencies = [
     '3rdparty/python:six',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
     'tests/python/pants_test/testutils:file_test_util',
   ]
 )

--- a/tests/python/pants_test/cache/test_caching.py
+++ b/tests/python/pants_test/cache/test_caching.py
@@ -11,7 +11,6 @@ from pants.base.payload import Payload
 from pants.build_graph.target import Target
 from pants.cache.cache_setup import CacheSetup
 from pants.task.task import Task
-from pants.util.dirutil import safe_rmtree
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
@@ -74,8 +73,8 @@ class LocalCachingTest(TaskTestBase):
     # Executing the task for the first time the vt is expected to be in the invalid_vts list
     self.assertGreater(len(invalid_vts), 0)
     first_vt = invalid_vts[0]
-    # Delete .pants.d
-    safe_rmtree(self.task._workdir)
+    # Mark the target invalid.
+    self.target.mark_invalidation_hash_dirty()
     all_vts2, invalid_vts2 = self.task.execute()
     # Check that running the task a second time results in a valid vt,
     # implying the artifact cache was hit.

--- a/tests/python/pants_test/cache/test_caching.py
+++ b/tests/python/pants_test/cache/test_caching.py
@@ -25,7 +25,6 @@ class DummyLibrary(Target):
 
 
 class DummyTask(Task):
-  """A task that appends the content of a DummyLibrary's source into its results_dir."""
   options_scope = 'dummy'
 
   @property

--- a/tests/python/pants_test/invalidation/BUILD
+++ b/tests/python/pants_test/invalidation/BUILD
@@ -7,6 +7,7 @@ python_tests(
   sources = ['test_cache_manager.py'],
   dependencies = [
     'src/python/pants/invalidation',
+    'src/python/pants/util:dirutil',
     'tests/python/pants_test/testutils:mock_logger',
     'tests/python/pants_test/tasks:task_test_base',
   ]

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -9,50 +9,37 @@ import os
 import shutil
 import tempfile
 
-from pants.util.dirutil import safe_mkdir, safe_rmtree
-from pants.invalidation.build_invalidator import CacheKey, CacheKeyGenerator
+from pants.invalidation.build_invalidator import CacheKeyGenerator
 from pants.invalidation.cache_manager import InvalidationCacheManager, VersionedTargetSet
+from pants.util.dirutil import safe_mkdir, safe_rmtree
 from pants_test.base_test import BaseTest
-
-
-class AppendingCacheKeyGenerator(CacheKeyGenerator):
-  """Generates cache keys for versions of target sets."""
-
-  @staticmethod
-  def combine_cache_keys(cache_keys):
-    if len(cache_keys) == 1:
-      return cache_keys[0]
-    else:
-      sorted_cache_keys = sorted(cache_keys)  # For commutativity.
-      combined_id = ','.join([cache_key.id for cache_key in sorted_cache_keys])
-      combined_hash = ','.join([cache_key.hash for cache_key in sorted_cache_keys])
-      combined_num_sources = reduce(lambda x, y: x + y,
-                                    [cache_key.num_sources for cache_key in sorted_cache_keys], 0)
-      return CacheKey(combined_id, combined_hash, combined_num_sources)
-
-  def key_for_target(self, target, sources=None, transitive=False, fingerprint_strategy=None):
-    return CacheKey(target.id, target.id)
-
-  def key_for(self, tid, sources):
-    return CacheKey(tid, tid, len(sources))
-
-
-def print_vt(vt):
-  print('%d (%s) %s: [ %s ]' % (len(vt.targets), vt.cache_key, vt.valid, ', '.join(['%s(%s)' % (v.id, v.cache_key) for v in vt.versioned_targets])))
 
 
 class InvalidationCacheManagerTest(BaseTest):
 
-  class TestInvalidationCacheManager(InvalidationCacheManager):
+  @staticmethod
+  def is_empty(dir_name):
+    return not os.listdir(dir_name)
 
-    def __init__(self, tmpdir):
-      super(InvalidationCacheManagerTest.TestInvalidationCacheManager, self).__init__(
-        AppendingCacheKeyGenerator(), tmpdir, True)
+  @staticmethod
+  def has_symlinked_result_dir(vt):
+    return os.path.realpath(vt.results_dir) == os.path.realpath(vt.current_results_dir)
+
+  @staticmethod
+  def clobber_symlink(vt):
+    # Munge the state to mimic a common error found before we added the clean- it accidentally clobbers the symlink!
+    # Commonly caused by safe_mkdir(vt.results_dir, clean=True), broken up here to keep the tests from being brittle.
+    safe_rmtree(vt.results_dir)
+    safe_mkdir(vt.results_dir)
 
   def setUp(self):
     super(InvalidationCacheManagerTest, self).setUp()
     self._dir = tempfile.mkdtemp()
-    self.cache_manager = InvalidationCacheManagerTest.TestInvalidationCacheManager(self._dir)
+    self.cache_manager = InvalidationCacheManager(
+      cache_key_generator=CacheKeyGenerator(),
+      build_invalidator_dir=self ._dir,
+      invalidate_dependents=True,
+    )
 
   def tearDown(self):
     shutil.rmtree(self._dir, ignore_errors=True)
@@ -72,19 +59,6 @@ class InvalidationCacheManagerTest(BaseTest):
     vt.create_results_dir(self._dir)
     task_output = os.path.join(vt.results_dir, 'a_file')
     self.create_file(task_output, 'foo')
-
-  def is_empty(self, dirname):
-    return not os.listdir(dirname)
-
-  def matching_result_dirs(self, vt):
-    # Ensure that the result_dirs contain the same files.
-    return self.is_empty(vt.results_dir) == self.is_empty(vt.current_results_dir)
-
-  def clobber_symlink(self, vt):
-    # Munge the state to mimic a common error found before we added the clean- it accidentally clobbers the symlink!
-    # Commonly caused by safe_mkdir(vt.results_dir, clean=True), broken up here to keep the test from being brittle.
-    safe_rmtree(vt.results_dir)
-    safe_mkdir(vt.results_dir)
 
   def test_check_marks_all_as_invalid_by_default(self):
     a = self.make_target(':a', dependencies=[])
@@ -115,21 +89,27 @@ class InvalidationCacheManagerTest(BaseTest):
     # Ensure that calling create_results_dir on an invalid target will wipe any pre-existing output.
     vt = self.make_vt()
     self.assertFalse(self.is_empty(vt.results_dir))
-    self.assertTrue(self.matching_result_dirs(vt))
 
+    # Force invalidate should change no state under the results_dir.
     vt.force_invalidate()
+    self.assertFalse(self.is_empty(vt.results_dir))
+
     vt.create_results_dir(self._dir)
+    self.assertTrue(self.has_symlinked_result_dir(vt))
     self.assertTrue(self.is_empty(vt.results_dir))
-    self.assertTrue(self.matching_result_dirs(vt))
-    vt.ensure_legal()
 
   def test_valid_vts_are_not_cleaned(self):
     # No cleaning of results_dir occurs, since create_results_dir short-circuits if the VT is valid.
     vt = self.make_vt()
     self.assertFalse(self.is_empty(vt.results_dir))
+    file_names = os.listdir(vt.results_dir)
+
     vt.create_results_dir(self._dir)
     self.assertFalse(self.is_empty(vt.results_dir))
-    self.assertTrue(self.matching_result_dirs(vt))
+    self.assertTrue(self.has_symlinked_result_dir(vt))
+
+    # Show that the files inside the directory have not changed during the create_results_dir noop.
+    self.assertEqual(file_names, os.listdir(vt.results_dir))
 
   def test_illegal_results_dir_cannot_be_updated_to_valid(self):
     # A regression test for a former bug. Calling safe_mkdir(vt.results_dir, clean=True) would silently
@@ -137,29 +117,30 @@ class InvalidationCacheManagerTest(BaseTest):
     # https://github.com/pantsbuild/pants/issues/4137
     # https://github.com/pantsbuild/pants/issues/4051
 
+    vt = self.make_vt()
+    # Show all is right with the world, there is content from the task run and it's visible from both legal result_dirs.
+    self.assertFalse(self.is_empty(vt.results_dir))
+    self.assertTrue(self.has_symlinked_result_dir(vt))
+    vt.force_invalidate()
+    self.clobber_symlink(vt)
+
+    # Arg, and the resultingly unlinked current_results_dir is uncleaned. The two directories have diverging contents!
+    self.assertFalse(os.path.islink(vt.results_dir))
+    self.assertFalse(self.has_symlinked_result_dir(vt))
+
+    # Big consequences- the files used for Products(vt.results_dir) and the cache(vt.current_results_dir) have diverged!
+    self.assertNotEqual(os.listdir(vt.results_dir), os.listdir(vt.current_results_dir))
+
+    # The main protection for this is the exception raised when the cache_manager attempts to mark the VT valid.
+    self.assertFalse(vt.valid)
     with self.assertRaises(VersionedTargetSet.IllegalResultsDir):
-      # All is right with the world, mock task is generally well-behaved and output is placed in both result_dirs.
-      vt = self.make_vt()
-      self.assertFalse(self.is_empty(vt.results_dir))
-      self.assertTrue(self.matching_result_dirs(vt))
-      self.assertTrue(os.path.islink(vt.results_dir))
-      vt.force_invalidate()
-      self.clobber_symlink(vt)
-
-      # Arg, and the resultingly unlinked current_results_dir is uncleaned. The two directories have diverging contents!
-      # The product pipeline and the artifact cache will get different task output!
-      self.assertFalse(os.path.islink(vt.results_dir))
-      self.assertFalse(self.matching_result_dirs(vt))
-
-      # The main protection for this is the exception raised when the cache_manager attempts to mark the VT valid.
-      self.assertFalse(vt.valid)
       vt.update()
 
   def test_exception_for_invalid_vt_result_dirs(self):
     # Show that the create_results_dir will error if a previous operation changed the results_dir from a symlink.
     vt = self.make_vt()
     self.clobber_symlink(vt)
-    self.assertFalse(os.path.islink(vt.results_dir))
+    self.assertFalse(self.has_symlinked_result_dir(vt))
 
     # This only is caught here if the VT is still invalid for some reason, otherwise it's caught by the update() method.
     vt.force_invalidate()
@@ -172,13 +153,13 @@ class InvalidationCacheManagerTest(BaseTest):
     with self.assertRaisesRegexp(VersionedTargetSet.IllegalResultsDir, r'The.*symlink*'):
       vt.ensure_legal()
 
-  def test_raises_missing_unique_results_dir(self):
+  def test_raises_missing_current_results_dir(self):
     vt = self.make_vt()
     safe_rmtree(vt.current_results_dir)
     with self.assertRaisesRegexp(VersionedTargetSet.IllegalResultsDir, r'The.*current_results_dir*'):
       vt.ensure_legal()
 
-  def test_raises_both_clobbered_symlink_and_missing_unique_results_dir(self):
+  def test_raises_both_clobbered_symlink_and_missing_current_results_dir(self):
     vt = self.make_vt()
     self.clobber_symlink(vt)
     safe_rmtree(vt.current_results_dir)
@@ -189,8 +170,8 @@ class InvalidationCacheManagerTest(BaseTest):
 
   def test_for_illegal_vts(self):
     # The update() checks this through vts.ensure_legal, checked here since those checks are on different branches.
+    vt = self.make_vt()
+    self.clobber_symlink(vt)
+    vts = VersionedTargetSet.from_versioned_targets([vt])
     with self.assertRaises(VersionedTargetSet.IllegalResultsDir):
-      vt = self.make_vt()
-      self.clobber_symlink(vt)
-      vts = VersionedTargetSet.from_versioned_targets([vt])
       vts.update()

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -125,7 +125,7 @@ class InvalidationCacheManagerTest(BaseTest):
     self.clobber_symlink(vt)
 
     # Arg, and the resultingly unlinked current_results_dir is uncleaned. The two directories have diverging contents!
-    self.assertFalse(os.path.islink(vt.results_dir))
+    self.assertFalse(self.has_symlinked_result_dir(vt))
     self.assertFalse(self.has_symlinked_result_dir(vt))
 
     # Big consequences- the files used for Products(vt.results_dir) and the cache(vt.current_results_dir) have diverged!

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -47,7 +47,10 @@ python_tests(
 python_tests(
   sources=['test_task.py'],
   dependencies=[
+    'src/python/pants/base:payload',
+    'src/python/pants/base:build_environment',
     'src/python/pants/build_graph',
+    'src/python/pants/cache:cache',
     'src/python/pants/task',
     'tests/python/pants_test/tasks:task_test_base',
   ]

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -52,6 +52,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/cache:cache',
     'src/python/pants/task',
+    'src/python/pants/util:dirutil',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -47,8 +47,8 @@ python_tests(
 python_tests(
   sources=['test_task.py'],
   dependencies=[
-    'src/python/pants/base:payload',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:payload',
     'src/python/pants/build_graph',
     'src/python/pants/cache:cache',
     'src/python/pants/task',

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -244,3 +244,22 @@ class TaskTest(TaskTestBase):
     # Verify the content. The task was invalid twice - the initial run and the run with the changed source file.
     # Only vtC (previous sucessful runs + cache miss) resulted in copying the previous_results.
     self.assertContent(vtC, first_contents + second_contents)
+
+  # live_dirs() is in cache_manager, but like all of these tests, only makes sense to test as a sequence of task runs.
+  def test_live_dirs(self):
+    task, vtA, _ = self._run_fixture(incremental=True)
+
+    vtA_live = list(vtA.live_dirs())
+    self.assertIn(vtA.results_dir, vtA_live)
+    self.assertIn(vtA.current_results_dir, vtA_live)
+    self.assertEqual(len(vtA_live), 2)
+
+    self._create_clean_file(vtA.target, 'foo')
+    vtB, _ = task.execute()
+    vtB_live = list(vtB.live_dirs())
+
+    # This time it contains the previous_results_dir.
+    self.assertIn(vtB.results_dir, vtB_live)
+    self.assertIn(vtB.current_results_dir, vtB_live)
+    self.assertIn(vtA.current_results_dir, vtB_live)
+    self.assertEqual(len(vtB_live), 3)

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -109,7 +109,6 @@ class TaskTest(TaskTestBase):
     one = '1\n'
     two = '2\n'
     three = '3\n'
-    four = '4\n'
     task, target = self._fixture(incremental=True)
 
     # Clean - this is the first run so the VT is invalid.

--- a/tests/python/pants_test/task/test_task.py
+++ b/tests/python/pants_test/task/test_task.py
@@ -10,9 +10,9 @@ import os
 from pants.base.build_environment import get_buildroot
 from pants.base.payload import Payload
 from pants.build_graph.target import Target
+from pants.cache.cache_setup import CacheSetup
 from pants.task.task import Task
 from pants_test.tasks.task_test_base import TaskTestBase
-from pants.cache.cache_setup import CacheSetup
 
 
 class DummyLibrary(Target):

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -157,6 +157,24 @@ class DirutilTest(unittest.TestCase):
       with self.assertRaisesRegexp(ValueError, r'Path for link.*absolute'):
         relative_symlink(source, link)
 
+  def test_relative_symlink_overwrite_existing_file(self):
+    # Succeeds, since os.unlink can be safely called on files that aren't symlinks.
+    with temporary_dir() as tmpdir_1:  # source and link in same dir
+      source = os.path.join(tmpdir_1, 'source')
+      link_path = os.path.join(tmpdir_1, 'link')
+      touch(link_path)
+      relative_symlink(source, link_path)
+
+  def test_relative_symlink_exception_on_existing_dir(self):
+    # This historically was an uncaught exception, the tested behavior is to begin catching the error.
+    with temporary_dir() as tmpdir_1:
+      source = os.path.join(tmpdir_1, 'source')
+      link_path = os.path.join(tmpdir_1, 'link')
+
+      safe_mkdir(link_path)
+      with self.assertRaisesRegexp(ValueError, r'Path for link.*overwrite an existing directory*'):
+        relative_symlink(source, link_path)
+
   def test_get_basedir(self):
     self.assertEquals(get_basedir('foo/bar/baz'), 'foo')
     self.assertEquals(get_basedir('/foo/bar/baz'), '')


### PR DESCRIPTION
Tasks that sometimes fail due to outside factors (download failures,
resolve issues, etc) often would call safe_mkdir(vt.results_dir, clean=True)
in order to wipe possibly truncated or crufty state.

But since vt.results_dir is a symlink, that replaced it with a real dir.
That ended up breaking caching, since the task output was therefore
never making it into the artifact cache, and other weird
bugs.

This is a small change that deletes the existing directories if
a target is invalid, removing the need for tasks to wipe the
results_dir, and also now checks to make sure that the results_dir
is legal before marking valid and passing to the artifact_caches.

The majority of the change is added test coverage around the breaks.
I have a couple immediate followups that cover an additional failure
state, and reworks the cache_manager to remove some of the harder
to reason about bits.

Closes: #4137