### PR TITLE
fix instructions for ivy debug logging

### DIFF
--- a/src/docs/tshoot.md
+++ b/src/docs/tshoot.md
@@ -45,7 +45,7 @@ Ivy Failures
 
 You can see an Ivy invocation's detailed outputs in the [[HTML report|pants('src/docs:reporting_server')]].
 
-You can get more verbose information from Ivy with the `--resolve-ivy-debug` option.
+You can get more verbose information from Ivy with the `--resolve-ivy-args=-debug` option.
 
 This setting does not affect the output of the Ivy tasks used for bootstrapping tools.
 


### PR DESCRIPTION
### Problem

http://www.pantsbuild.org/tshoot.html#ivy-failures suggests `--resolve-ivy-debug`, which is not a valid argument.

### Solution

Update the docs to use `--resolve-ivy-args=-debug`, which now seems to be the best way to get ivy debug logs.

### Result

Readers of http://www.pantsbuild.org/tshoot.html#ivy-failures looking to debug ivy failures might succeed at their task.