### PR TITLE
A new Python run task.

### DIFF
--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -11,6 +11,7 @@ python_library(
     ':python_requirements',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
+    'src/python/pants/backend/python/tasks2',
     'src/python/pants/build_graph',
     'src/python/pants/goal:task_registrar',
   ]

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -77,7 +77,7 @@ class PythonInterpreterCache(object):
       # Create a helpful error message.
       unique_compatibilities = set(tuple(t.compatibility) for t in tgts_with_compatibilities)
       unique_compatibilities_strs = [','.join(x) for x in unique_compatibilities if x]
-      tgts_with_compatibilities_strs = [str(t) for t in tgts_with_compatibilities]
+      tgts_with_compatibilities_strs = [t.address.spec for t in tgts_with_compatibilities]
       raise TaskError('Unable to detect a suitable interpreter for compatibilities: {} '
                       '(Conflicting targets: {})'.format(' && '.join(unique_compatibilities_strs),
                                                          ', '.join(tgts_with_compatibilities_strs)))

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -19,6 +19,10 @@ from pants.backend.python.tasks.python_isort import IsortPythonTask
 from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
 from pants.backend.python.tasks.setup_py import SetupPy
+from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.backend.python.tasks2.python_run import PythonRun as PythonRun2
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -52,3 +56,8 @@ def register_goals():
   task(name='py', action=PythonRepl).install('repl')
   task(name='setup-py', action=SetupPy).install()
   task(name='isort', action=IsortPythonTask).install('fmt')
+
+  task(name='interpreter', action=SelectInterpreter).install('pyprep')
+  task(name='requirements', action=ResolveRequirements).install('pyprep')
+  task(name='sources', action=GatherSources).install('pyprep')
+  task(name='py', action=PythonRun2).install('run2')

--- a/src/python/pants/backend/python/tasks/python_run.py
+++ b/src/python/pants/backend/python/tasks/python_run.py
@@ -15,9 +15,6 @@ from pants.util.strutil import safe_shlex_split
 
 
 class PythonRun(PythonTask):
-  def __init__(self, *args, **kwargs):
-    super(PythonRun, self).__init__(*args, **kwargs)
-
   @classmethod
   def register_options(cls, register):
     super(PythonRun, cls).register_options(register)

--- a/src/python/pants/backend/python/tasks2/BUILD
+++ b/src/python/pants/backend/python/tasks2/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/invalidation',
     'src/python/pants/task',
+    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import signal
+
+from pex.interpreter import PythonInterpreter
+from pex.pex import PEX
+from pex.pex_builder import PEXBuilder
+
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
+from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnitLabel
+from pants.task.task import Task
+from pants.util.contextutil import temporary_dir
+from pants.util.strutil import safe_shlex_split
+
+
+class PythonRun(Task):
+
+  @classmethod
+  def register_options(cls, register):
+    super(PythonRun, cls).register_options(register)
+    register('--args', type=list, help='Run with these extra args to main().')
+
+  @classmethod
+  def supports_passthru_args(cls):
+    return True
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    round_manager.require_data(PythonInterpreter)
+    round_manager.require_data(ResolveRequirements.REQUIREMENTS_PEX)
+    round_manager.require_data(GatherSources.PYTHON_SOURCES)
+
+  def execute(self):
+    binary = self.require_single_root_target()
+    if isinstance(binary, PythonBinary):
+      # We can't throw if binary isn't a PythonBinary, because perhaps we were called on a
+      # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
+      # TODO(benjy): Some more elegant way to coordinate how tasks claim targets.
+      interpreter = self.context.products.get_data(PythonInterpreter)
+
+      with temporary_dir() as tmpdir:
+        # Create a wrapper pex to "merge" the other pexes into via PEX_PATH.
+        builder = PEXBuilder(tmpdir, interpreter, pex_info=binary.pexinfo)
+        builder.freeze()
+
+        pexes = [self.context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX),
+                 self.context.products.get_data(GatherSources.PYTHON_SOURCES)]
+
+        pex_path = os.pathsep.join([pex.cmdline()[1] for pex in pexes])
+
+        pex = PEX(tmpdir, interpreter)
+
+        self.context.release_lock()
+        with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
+          args = []
+          for arg in self.get_options().args:
+            args.extend(safe_shlex_split(arg))
+          args += self.get_passthru_args()
+          po = pex.run(blocking=False, args=args, env={ 'PEX_PATH': pex_path })
+          try:
+            result = po.wait()
+            if result != 0:
+              msg = '{interpreter} {entry_point} {args} ... exited non-zero ({code})'.format(
+                  interpreter=interpreter.binary,
+                  entry_point=binary.entry_point,
+                  args=' '.join(args),
+                  code=result)
+              raise TaskError(msg, exit_code=result)
+          except KeyboardInterrupt:
+            po.send_signal(signal.SIGINT)
+            raise

--- a/src/python/pants/backend/python/tasks2/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks2/select_interpreter.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pex.interpreter import PythonInterpreter
+from pex.interpreter import PythonInterpreter, PythonIdentity
 
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.python_setup import PythonRepos, PythonSetup
@@ -50,7 +50,7 @@ class SelectInterpreter(Task):
   @classmethod
   def register_options(cls, register):
     super(SelectInterpreter, cls).register_options(register)
-    # TODO: This will eventually supercede the global --interpreter flag.  That flag is only
+    # TODO: This supercedes the global --interpreter flag.  That flag is only
     # relevant in the python backend, and should never have been global to begin with.
     register('--constraints', advanced=True, default=[], type=list,
              metavar='<requirement>',
@@ -80,7 +80,7 @@ class SelectInterpreter(Task):
         # We filter the interpreter cache itself (and not just the interpreters we pull from it)
         # because setting up some python versions (e.g., 3<=python<3.3) crashes, and this gives us
         # an escape hatch.
-        filters = self.get_options().interpreter or [b'']
+        filters = self.get_options().constraints or [b'']
 
         # Cache setup's requirement fetching can hang if run concurrently by another pants proc.
         self.context.acquire_lock()
@@ -92,11 +92,20 @@ class SelectInterpreter(Task):
         interpreter = interpreter_cache.select_interpreter_for_targets(python_tgts)
         safe_mkdir_for(interpreter_path_file)
         with open(interpreter_path_file, 'w') as outfile:
-          outfile.write('{}\t{}'.format(interpreter.binary, interpreter.identity))
+          outfile.write('{}\t{}\n'.format(interpreter.binary, str(interpreter.identity)))
+          for dist, location in interpreter.extras.items():
+            dist_name, dist_version = dist
+            outfile.write('{}\t{}\t{}\n'.format(dist_name, dist_version, location))
 
     if not interpreter:
       with open(interpreter_path_file, 'r') as infile:
-        binary, identity = infile.read().split('\t')
-      interpreter = PythonInterpreter(binary, identity)
+        lines = infile.readlines()
+        binary, identity = lines[0].strip().split('\t')
+        extras = {}
+        for line in lines[1:]:
+          dist_name, dist_version, location = line.strip().split('\t')
+          extras[(dist_name, dist_version)] = location
+
+      interpreter = PythonInterpreter(binary, PythonIdentity.from_path(identity), extras)
 
     self.context.products.get_data(PythonInterpreter, lambda: interpreter)

--- a/src/python/pants/backend/python/tasks2/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks2/select_interpreter.py
@@ -50,8 +50,9 @@ class SelectInterpreter(Task):
   @classmethod
   def register_options(cls, register):
     super(SelectInterpreter, cls).register_options(register)
-    # TODO: This supercedes the global --interpreter flag.  That flag is only
-    # relevant in the python backend, and should never have been global to begin with.
+    # Note: This replaces the global --interpreter flag in the old python tasks.
+    # That flag is only relevant in the python backend, and should never have been
+    # global to begin with.
     register('--constraints', advanced=True, default=[], type=list,
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
@@ -92,10 +93,10 @@ class SelectInterpreter(Task):
         interpreter = interpreter_cache.select_interpreter_for_targets(python_tgts)
         safe_mkdir_for(interpreter_path_file)
         with open(interpreter_path_file, 'w') as outfile:
-          outfile.write('{}\t{}\n'.format(interpreter.binary, str(interpreter.identity)))
+          outfile.write(b'{}\t{}\n'.format(interpreter.binary, str(interpreter.identity)))
           for dist, location in interpreter.extras.items():
             dist_name, dist_version = dist
-            outfile.write('{}\t{}\t{}\n'.format(dist_name, dist_version, location))
+            outfile.write(b'{}\t{}\t{}\n'.format(dist_name, dist_version, location))
 
     if not interpreter:
       with open(interpreter_path_file, 'r') as infile:

--- a/tests/python/pants_test/backend/python/tasks2/BUILD
+++ b/tests/python/pants_test/backend/python/tasks2/BUILD
@@ -3,17 +3,29 @@
 
 
 python_tests(
-    dependencies=[
-      '3rdparty/python:mock',
-      '3rdparty/python:pex',
-      'src/python/pants/backend/python:interpreter_cache',
-      'src/python/pants/backend/python:python_requirement',
-      'src/python/pants/backend/python:python_setup',
-      'src/python/pants/backend/python/targets',
-      'src/python/pants/backend/python/tasks2',
-      'src/python/pants/base:build_root',
-      'src/python/pants/base:exceptions',
-      'src/python/pants/util:contextutil',
-      'tests/python/pants_test/tasks:task_test_base',
-    ]
+  sources=globs('test_*.py', exclude=[globs('test_*_integration.py')]),
+  dependencies=[
+    '3rdparty/python:mock',
+    '3rdparty/python:pex',
+    'src/python/pants/backend/python:interpreter_cache',
+    'src/python/pants/backend/python:python_requirement',
+    'src/python/pants/backend/python:python_setup',
+    'src/python/pants/backend/python/targets',
+    'src/python/pants/backend/python/tasks2',
+    'src/python/pants/base:build_root',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/tasks:task_test_base',
+  ]
+)
+
+
+python_tests(
+  name='python_run_integration',
+  sources=['test_python_run_integration.py'],
+  dependencies=[
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
 )

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -64,6 +64,5 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
                '--pyprep-interpreter-constraints=CPython>=2.6,<3',
                '--pyprep-interpreter-constraints=CPython>=3.3',
                '--quiet']
-    print('XXXXX ' + ' '.join(command))
     pants_run = self.run_pants(command=command)
     return pants_run.stdout_data.rstrip().split('\n')[-1]

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class PythonRunIntegrationTest(PantsRunIntegrationTest):
+  testproject = 'testprojects/src/python/interpreter_selection'
+
+  def test_run_26(self):
+    self._maybe_run_version('2.6')
+
+  def test_run_27(self):
+    self._maybe_run_version('2.7')
+
+  def test_run_27_and_then_26(self):
+    with temporary_dir() as interpreters_cache:
+      pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
+      pants_run_27 = self.run_pants(
+        command=['run2', '{}:echo_interpreter_version_2.7'.format(self.testproject)],
+        config=pants_ini_config
+      )
+      self.assert_success(pants_run_27)
+      pants_run_26 = self.run_pants(
+        command=['run2', '{}:echo_interpreter_version_2.6'.format(self.testproject),
+                 '--pyprep-interpreter-constraints=CPython>=2.6,<3',
+                 '--pyprep-interpreter-constraints=CPython>=3.3'],
+        config=pants_ini_config
+      )
+      self.assert_success(pants_run_26)
+
+  def test_die(self):
+    command = ['run2',
+               '{}:die'.format(self.testproject),
+               '--pyprep-interpreter-constraints=CPython>=2.6,<3',
+               '--pyprep-interpreter-constraints=CPython>=3.3',
+               '--quiet']
+    pants_run = self.run_pants(command=command)
+    assert pants_run.returncode == 57
+
+  def _maybe_run_version(self, version):
+    if self.has_python_version(version):
+      print('Found python {}. Testing running on it.'.format(version))
+      echo = self._run_echo_version(version)
+      v = echo.split('.')  # E.g., 2.6.8.
+      self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
+      self.assertEquals(version, '{}.{}'.format(v[0], v[1]))
+    else:
+      print('No python {} found. Skipping.'.format(version))
+      self.skipTest('No python {} on system'.format(version))
+
+  def _run_echo_version(self, version):
+    binary_name = 'echo_interpreter_version_{}'.format(version)
+    binary_target = '{}:{}'.format(self.testproject, binary_name)
+    # Build a pex.
+    # Avoid some known-to-choke-on interpreters.
+    command = ['run2',
+               binary_target,
+               '--pyprep-interpreter-constraints=CPython>=2.6,<3',
+               '--pyprep-interpreter-constraints=CPython>=3.3',
+               '--quiet']
+    print('XXXXX ' + ' '.join(command))
+    pants_run = self.run_pants(command=command)
+    return pants_run.stdout_data.rstrip().split('\n')[-1]


### PR DESCRIPTION
- This is the first useful task in the new Python pipeline (the others
  are just preparation tasks).

- Required small fixes to the interpreter selection task, namely
  consulting the correct constraints option, and remembering the
  interpreter's "extras" (as subsequent code needs to consult them).

- Its integration test is identical to that of the old Python run task,
  with just option name changes, so that's some reasonable reassurance...

- The new task is registered under the "run2" goal, so the old and new
  can co-exist.  This will allow repo owners to try out the new pipeline
  in their repos without disrupting other users (especially since the
  old global "interpreters" flag is not consulted in the new pipeline,
  so some option setting on the new tasks may be necessary).

- Note that the new pipeline does not yet support test/repl/bundling
  or codegen.  Subsequent changes will provide this functionality,
  presumably pending some refactoring of the codegen backend.