### PR TITLE
[docs] Update the cache section on the Task developer page.

### DIFF
--- a/src/docs/dev_tasks.md
+++ b/src/docs/dev_tasks.md
@@ -225,22 +225,13 @@ shows some useful idioms for JVM tasks.
 Enabling Artifact Caching For Tasks
 --------------------------
 
-An artifact is the output file produced by a task processing some target.
-For example, the artifacts of a `JavaCompile` task on a target
+Artifacts are the output created when a task processes a target. For example, the artifacts of a `JavaCompile` task on a target
 `java_library` would be the `.class` files produced by compiling the library.
-In this scenario, the `java_library` (i.e. the target) would have its sources
-used to compute a cache key, and the `.class` files would be used as the cached value.
 
-If your task follows an isolated strategy where each target produces artifacts into
-its own directory, then the task will be able to take advantage of automatic
-target workdir caching. If your task has more complicated behavior
-(for example, all targets produce artifacts into the same directory), then check
-out the manual caching section below.
+**Automatic results_dir caching**
 
-**Automatic target workdir caching**
+Pants offers automatic caching of a target's output directory. Automatic caching works by assigning a results directory to each VersionedTarget (VT) of the InvalidationCheck yielded by `Task->invalidated`.
 
-Automatic target workdir caching works by assigning a results directory to
-each VersionedTarget (VT) of the InvalidationCheck yielded by `Task->invalidated`.
 A task operating on a given VT should place the resulting artifacts in the VT's
 `results_dir`. After exiting the `invalidated` context block, these artifacts
 will be automatically uploaded to the artifact cache.
@@ -248,42 +239,26 @@ will be automatically uploaded to the artifact cache.
 This interface for caching is disabled by default. To enable, override
 `Task->cache_target_dirs` to return True.
 
+**VersionedTargetSets**
+
+By default, Pants caching operates on (VT, artifacts) pairs. But certain tasks may need to write multiple targets and their artifacts together under a single cache key. For example, Ivy resolution, where the set of resolved 3rd party dependencies is a property of all targets taken together, not of each target individually.
+
+To implement caching for groupings of targets, you can override the `check_artifact_cache_for` method in your task to check for the collected `VersionedTarget`s as a `VersionedTargetSet`:
+
+    def check_artifact_cache_for(self, invalidation_check):
+      return [VersionedTargetSet.from_versioned_targets(invalidation_check.all_vts)]
+
 **Manual caching**
 
-Manual caching is much more complicated than automatic target workdir caching,
-and as such should only be used for non-standard usecases. Instead of placing
-artifacts in known target directories, artifacts may be placed anywhere -- although
-it is now the responsibility of the task developer to manually upload
-VT / artifact pairs to the cache. Here is a template for how manual caching
-would be implemented in the `execute` method:
+Pants allows more fine grained cache management, although it then becomes the responsibility of the task developer to manually upload VT / artifact pairs to the cache. Here is a template for how manual caching might be implemented:
 
     def execute(self):
       targets = self.context.targets()
       with self.invalidated(targets) as invalidation_check:
 
-        # for each VersionedTarget in invalidation_check.invalid_vts,
-        # run your task on the target and remember where the output files are
-        output_files = do_some_work()
+        # Run your task over the invalid vts and cache the output.
+        for vt in invalidation_check.invalids_vts:
+          output_location = do_some_work()
+          if self.artifact_cache_writes_enabled():
+            self.update_artifact_cache((vt, [output_location]))
 
-        if self.artifact_cache_writes_enabled():
-          # build a list of (VersionedTarget, output_files) pairs
-          pairs = match_up(invalidation_check.invalid_vts, output_files)
-
-          self.update_artifact_cache(pairs)
-
-The above implementation writes each target/artifact (key/val) pair to the cache
-independently of all other targets. However you might want to write multiple
-targets and their artifacts together under a single cache key. A good example of
-this is Ivy resolution, where the set of resolved 3rd party dependencies is a property
-of all targets taken together, not of each target individually.
-
-To implement caching for groupings of targets, you can use a `VersionedTargetSet`
-in place of a `VersionedTarget`, and group the `invalid_vts` within
-`VersionedTargetSet`s. If you choose to do this, however, you must override the
-`check_artifact_cache_for` method in your task to return the groupings
-of targets you want to read (`VersionedTargetSet`s). If you don't, you will miss
-the cache, because by default Pants reads each target from the cache
-independently.
-
-    def check_artifact_cache_for(self, invalidation_check):
-      return [VersionedTargetSet.from_versioned_targets(invalidation_check.invalid_vts)]

--- a/src/docs/dev_tasks.md
+++ b/src/docs/dev_tasks.md
@@ -253,7 +253,7 @@ To implement caching for groupings of targets, you can override the `check_artif
 Pants allows more fine grained cache management, although it then becomes the responsibility of the task developer to manually upload VT / artifact pairs to the cache. Here is a template for how manual caching might be implemented:
 
     def execute(self):
-      targets = self.context.targets()
+      targets = self.context.targets(lambda t: isinstance(t, YourTarget)):
       with self.invalidated(targets) as invalidation_check:
 
         # Run your task over the invalid vts and cache the output.

--- a/src/docs/dev_tasks.md
+++ b/src/docs/dev_tasks.md
@@ -225,12 +225,15 @@ shows some useful idioms for JVM tasks.
 Enabling Artifact Caching For Tasks
 --------------------------
 
-Artifacts are the output created when a task processes a target. For example, the artifacts of a `JavaCompile` task on a target
-`java_library` would be the `.class` files produced by compiling the library.
+* **Artifacts** are the output created when a task processes a target.
+    - For example, the artifacts of a `JavaCompile` task on a target `java_library` would be the `.class` files produced by compiling the library.
 
-**Automatic results_dir caching**
+* **VersionedTarget** (VT) is a wrapper around a Pants target that is used to determine whether a task should do work for that target.
+    - If a task determines the VT has already been processed, that VT is considered "valid".
 
-Pants offers automatic caching of a target's output directory. Automatic caching works by assigning a results directory to each VersionedTarget (VT) of the InvalidationCheck yielded by `Task->invalidated`.
+**Automatic caching**
+
+Pants offers automatic caching of a target's output directory. Automatic caching works by assigning a results directory to each VT of the InvalidationCheck yielded by `Task->invalidated`.
 
 A task operating on a given VT should place the resulting artifacts in the VT's
 `results_dir`. After exiting the `invalidated` context block, these artifacts


### PR DESCRIPTION

### Problem
The existing example had a bug, in that it was only checking the cache
for a VTS of the invalid_vts. It also was a little long and hand waved over
the code snippets in places.

### Solution
I fixed the examples and simplified them some.

The manual caching section may be marginally non-optimal, in that it
doesn't update the cache with all pairs at once, but once per vt.
But we do this within jvm_compile, so it isn't like it doesn't happen.
And that allowed to remove the unimplemented match_up method call.

This also separates the VersionedTargetSets out of the manual caching
section since using VTS does not necessarily mean that the task dev must 
upload the VTS manually.

### Result
I believe the examples have improved correctness/clarity the section
is about 25 lines shorter as a bonus.
