### PR TITLE
Make post_stat async

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -304,7 +304,8 @@ class RunTracker(Subsystem):
     # Upload to remote stats db.
     stats_url = self.get_options().stats_upload_url
     if stats_url:
-      self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
+      t = threading.Thread(target=self.post_stats, args=(stats_url, stats, self.get_options().stats_upload_timeout))
+      t.start()
 
     # Write stats to local json file.
     stats_json_file_name = self.get_options().stats_local_json_file


### PR DESCRIPTION
### Problem

Currently posting stat is synchronous so if user cannot reach the stat server, the whole operation will have to wait for timeout.

### Solution

This PR changes the post action to be asynchronous. The return value is discarded (also status quo)

Existing test can be found [here](https://github.com/pantsbuild/pants/blob/f7f75cd523eb809cc78d24b98a88a0b20fedd3ed/tests/python/pants_test/goal/test_run_tracker.py#L45)

### Result

It is async and does not block user actions.