### PR TITLE
Bump default nodejs version to LTS 6.9.1 from 6.2.0

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -32,7 +32,7 @@ class NodeDistribution(object):
       register('--supportdir', advanced=True, default='bin/node',
                help='Find the Node distributions under this dir.  Used as part of the path to '
                     'lookup the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', advanced=True, default='6.2.0',
+      register('--version', advanced=True, default='6.9.1',
                help='Node distribution version.  Used as part of the path to lookup the '
                     'distribution with --binary-util-baseurls and --pants-bootstrapdir')
 


### PR DESCRIPTION
LTS Node v6.9.1 (which bundles NPM 3.10.8) is out. This should be our default for a while.

See issue #4160

Bugs closed: 4160