### PR TITLE
Allow tasks to independently call create_results_dir

### DIFF
--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -195,8 +195,12 @@ class VersionedTarget(VersionedTargetSet):
 
     if not self.valid:
       # Clean the workspace for invalid vts.
-      safe_mkdir(self._current_results_dir, clean=True)
-      relative_symlink(self._current_results_dir, self._results_dir)
+      safe_rmtree(self._current_results_dir)
+
+    # Tasks may not enable cache_target_dirs but still call this outside of invalidated(). If so, the dirs
+    # should still be made and pass ensure_legal().
+    safe_mkdir(self._current_results_dir)
+    relative_symlink(self._current_results_dir, self._results_dir)
     self.ensure_legal()
 
   def copy_previous_results(self, root_dir):


### PR DESCRIPTION
### Problem

Task.py only creates the results dir during the invalidated
block, and even then only when the task has cache_target_dirs
enabled. But tasks could be managing their own caching yet
still want to upload artifacts. In those cases, standardizing
on using the vt.results_dir makes perfect sense.

But the recent change to wipe invalid results_dirs only ensured
state for invalid vts. So if a task called create_results_dir
inside its own invalidation block, it would noop for
valid dirs.

### Solution

This change maintains that the create_results_dir wipes only invalid
results_dirs, but now that call is sufficient to ensure that
the results_dirs exist and they pass ensure_legal.

This catches a pretty specialized corner case - but we have a task
that called create_results_dir and expected that to create the
dirs, for valid and invalid vts alike.

The change is maybe a line or two - the rest is additional test coverage.

closes: #4148 
