### PR TITLE
Fork to post_stat

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -307,7 +307,7 @@ class RunTracker(Subsystem):
       pid = os.fork()
       if pid == 0:
         self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
-        exit(0)
+        os._exit(0)
 
     # Write stats to local json file.
     stats_json_file_name = self.get_options().stats_local_json_file

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -307,6 +307,7 @@ class RunTracker(Subsystem):
       pid = os.fork()
       if pid == 0:
         self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
+        exit(0)
 
     # Write stats to local json file.
     stats_json_file_name = self.get_options().stats_local_json_file

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -304,9 +304,9 @@ class RunTracker(Subsystem):
     # Upload to remote stats db.
     stats_url = self.get_options().stats_upload_url
     if stats_url:
-      t = threading.Thread(target=self.post_stats, args=(stats_url, stats, self.get_options().stats_upload_timeout))
-      t.setDaemon(True)
-      t.start()
+      pid = os.fork()
+      if pid == 0:
+        self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
 
     # Write stats to local json file.
     stats_json_file_name = self.get_options().stats_local_json_file

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -305,6 +305,7 @@ class RunTracker(Subsystem):
     stats_url = self.get_options().stats_upload_url
     if stats_url:
       t = threading.Thread(target=self.post_stats, args=(stats_url, stats, self.get_options().stats_upload_timeout))
+      t.daemon = True
       t.start()
 
     # Write stats to local json file.

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -305,7 +305,7 @@ class RunTracker(Subsystem):
     stats_url = self.get_options().stats_upload_url
     if stats_url:
       t = threading.Thread(target=self.post_stats, args=(stats_url, stats, self.get_options().stats_upload_timeout))
-      t.daemon = True
+      t.setDaemon(True)
       t.start()
 
     # Write stats to local json file.

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -306,8 +306,10 @@ class RunTracker(Subsystem):
     if stats_url:
       pid = os.fork()
       if pid == 0:
-        self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
-        os._exit(0)
+        try:
+          self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
+        finally:
+          os._exit(0)
 
     # Write stats to local json file.
     stats_json_file_name = self.get_options().stats_local_json_file


### PR DESCRIPTION
### Problem

Earlier thread to `post_stat` may leave the pants process hanging from exiting until timeout. Although demonizing then joining the thread may help, `post_stat` procedure is already at the very end of the pants run, so there is not much time to save if we eventually want to wait for it to finish.

### Solution

Fork a process to do the post.