### PR TITLE
Suggest missing dependencies from target's transitive dependencies

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -61,6 +61,7 @@ python_library(
   dependencies = [
     ':compile_context',
     ':execution_graph',
+    ':missing_dependency_finder',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:jvm_platform',
     'src/python/pants/backend/jvm/subsystems:scala_platform',
@@ -132,9 +133,10 @@ python_binary(
   ],
 )
 
-python_binary(
+python_library(
   name = 'missing_dependency_finder',
-  source = 'missing_dependency_finder.py',
-  dependencies = [
+  sources = [
+    'class_not_found_error_patterns.py',
+    'missing_dependency_finder.py'
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -139,4 +139,8 @@ python_library(
     'class_not_found_error_patterns.py',
     'missing_dependency_finder.py'
   ],
+  dependencies = [
+    '3rdparty/python:ansicolors',
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+  ],
 )

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -131,3 +131,10 @@ python_binary(
     'src/python/pants/util:dirutil',
   ],
 )
+
+python_binary(
+  name = 'missing_dependency_finder',
+  source = 'missing_dependency_finder.py',
+  dependencies = [
+  ],
+)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -9,7 +9,7 @@ import re
 
 
 _CLASS_NOT_FOUND_ERROR_PATTERNS = [
-  # javac errors
+  # javac errors.
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
    '\s*\[error\]   symbol:   class (\S+)\n'
    '\s*\[error\]   location: package (\S+)\n'
@@ -24,8 +24,9 @@ _CLASS_NOT_FOUND_ERROR_PATTERNS = [
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): '
    'package (?P<packagename>\S+) does not exist\n'
    '\s*\[error\] .*\W(?P<classname>(?P=packagename)\.\w+)\W.*'),
+  (r'.*java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
 
-  # scalac errors
+  # scalac errors. More work undergoing to improve scalac error messages.
   (r'\s*\[error\] missing or invalid dependency detected while loading class file '
    '\'(?P<dependee_classname>\S+)\.class\'\.\n'
    '\s*\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
@@ -37,15 +38,11 @@ _CLASS_NOT_FOUND_ERROR_PATTERNS = [
    '\s*\[error\] import (?P<classname>\S+)'),
   (r'\s*\[error\] Class (?P<classname>\S+) not found \- continuing with a stub\.'),
 
-
-  # zinc errors
+  # zinc errors.
   (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
    '\s*\[error\] Type (?P<classname>\S+) not present'),
   (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
    '\s*\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
-
-  # javac error but needs to be after the more specific pattern
-  (r'.*java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
 ]
 
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -5,10 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import re
 
-
-_CLASS_NOT_FOUND_ERROR_PATTERNS = [
+CLASS_NOT_FOUND_ERROR_PATTERNS = [
   # javac errors.
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
    '\s*\[error\]   symbol:   class (\S+)\n'
@@ -44,6 +42,3 @@ _CLASS_NOT_FOUND_ERROR_PATTERNS = [
   (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
    '\s*\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
 ]
-
-
-CLASS_NOT_FOUND_ERROR_PATTERNS = [re.compile(p) for p in _CLASS_NOT_FOUND_ERROR_PATTERNS]

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import re
 
+
 _CLASS_NOT_FOUND_ERROR_JAVAC_PATTERNS = [
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
    '\s*\[error\]   symbol:   class (\S+)\n'

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import re
+
+_CLASS_NOT_FOUND_ERROR_JAVAC_PATTERNS = [
+  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
+   '\s+\[error\]   symbol:   class (\S+)\n'
+   '\s+\[error\]   location: package (\S+)\n'
+   '\s+\[error\] import (?P<classname>\S+);'),
+  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot access (\S+)\n'
+   '\s+\[error\]   class file for (?P<classname>\S+) not found'),
+  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): package (\S+) does not exist\n'
+   '\s+\[error\] import (?P<classname>\S+);'),
+  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
+   '\s+\[error\]   symbol:   class (?P<classnameonly>\S+)\n'
+   '\s+\[error\]   location: package (?P<packagename>\S+)'),
+  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): '
+   'package (?P<packagename>\S+) does not exist\n'
+   '\s+\[error\] .*\W(?P<classname>(?P=packagename)\.\w+)\W.*'),
+]
+
+
+_CLASS_NOT_FOUND_ERROR_SCALAC_PATTERNS = [
+  (r'\s+\[error\] missing or invalid dependency detected while loading class file '
+   '\'(?P<dependee_classname>\S+)\.class\'\.\n'
+   '\s+\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
+   '(?P<packagename>\S+),'),
+  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): exception during macro expansion:\s*\n'
+   '\s+\[error\] java.lang.ClassNotFoundException: (?P<classname>\S+)'),
+  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): object (\S+) '
+   'is not a member of package (\S+)\n'
+   '\s+\[error\] import (?P<classname>\S+)'),
+  (r'\s+\[error\] Class (?P<classname>\S+) not found \- continuing with a stub\.'),
+]
+
+
+_CLASS_NOT_FOUND_ERROR_ZINC_PATTERNS = [
+  (r'\s+\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
+   '\s+\[error\] Type (?P<classname>\S+) not present'),
+  (r'\s+\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
+   '\s+\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
+  (r'.*java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
+]
+
+
+CLASS_NOT_FOUND_ERROR_PATTERNS = [re.compile(p) for p in _CLASS_NOT_FOUND_ERROR_JAVAC_PATTERNS +
+                                  _CLASS_NOT_FOUND_ERROR_SCALAC_PATTERNS +
+                                  _CLASS_NOT_FOUND_ERROR_ZINC_PATTERNS]

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -8,42 +8,42 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import re
 
 _CLASS_NOT_FOUND_ERROR_JAVAC_PATTERNS = [
-  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
-   '\s+\[error\]   symbol:   class (\S+)\n'
-   '\s+\[error\]   location: package (\S+)\n'
-   '\s+\[error\] import (?P<classname>\S+);'),
-  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot access (\S+)\n'
-   '\s+\[error\]   class file for (?P<classname>\S+) not found'),
-  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): package (\S+) does not exist\n'
-   '\s+\[error\] import (?P<classname>\S+);'),
-  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
-   '\s+\[error\]   symbol:   class (?P<classnameonly>\S+)\n'
-   '\s+\[error\]   location: package (?P<packagename>\S+)'),
-  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): '
+  (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
+   '\s*\[error\]   symbol:   class (\S+)\n'
+   '\s*\[error\]   location: package (\S+)\n'
+   '\s*\[error\] import (?P<classname>\S+);'),
+  (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot access (\S+)\n'
+   '\s*\[error\]   class file for (?P<classname>\S+) not found'),
+  (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): package (\S+) does not exist\n'
+   '\s*\[error\] import (?P<classname>\S+);'),
+  (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
+   '\s*\[error\]   symbol:   class (?P<classnameonly>\S+)\n'
+   '\s*\[error\]   location: package (?P<packagename>\S+)'),
+  (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): '
    'package (?P<packagename>\S+) does not exist\n'
-   '\s+\[error\] .*\W(?P<classname>(?P=packagename)\.\w+)\W.*'),
+   '\s*\[error\] .*\W(?P<classname>(?P=packagename)\.\w+)\W.*'),
 ]
 
 
 _CLASS_NOT_FOUND_ERROR_SCALAC_PATTERNS = [
-  (r'\s+\[error\] missing or invalid dependency detected while loading class file '
+  (r'\s*\[error\] missing or invalid dependency detected while loading class file '
    '\'(?P<dependee_classname>\S+)\.class\'\.\n'
-   '\s+\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
+   '\s*\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
    '(?P<packagename>\S+),'),
-  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): exception during macro expansion:\s*\n'
-   '\s+\[error\] java.lang.ClassNotFoundException: (?P<classname>\S+)'),
-  (r'\s+\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): object (\S+) '
+  (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): exception during macro expansion:\s*\n'
+   '\s*\[error\] java.lang.ClassNotFoundException: (?P<classname>\S+)'),
+  (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): object (\S+) '
    'is not a member of package (\S+)\n'
-   '\s+\[error\] import (?P<classname>\S+)'),
-  (r'\s+\[error\] Class (?P<classname>\S+) not found \- continuing with a stub\.'),
+   '\s*\[error\] import (?P<classname>\S+)'),
+  (r'\s*\[error\] Class (?P<classname>\S+) not found \- continuing with a stub\.'),
 ]
 
 
 _CLASS_NOT_FOUND_ERROR_ZINC_PATTERNS = [
-  (r'\s+\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
-   '\s+\[error\] Type (?P<classname>\S+) not present'),
-  (r'\s+\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
-   '\s+\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
+  (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
+   '\s*\[error\] Type (?P<classname>\S+) not present'),
+  (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
+   '\s*\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
   # This is a javac pattern but places here below the more specific pattern above since
   # we want to match the more specific pattern first
   (r'.*java.lang.NoClassDefFoundError: (?P<classname>\S+)'),

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -8,7 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import re
 
 
-_CLASS_NOT_FOUND_ERROR_JAVAC_PATTERNS = [
+_CLASS_NOT_FOUND_ERROR_PATTERNS = [
+  # javac errors
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): cannot find symbol\n'
    '\s*\[error\]   symbol:   class (\S+)\n'
    '\s*\[error\]   location: package (\S+)\n'
@@ -23,10 +24,8 @@ _CLASS_NOT_FOUND_ERROR_JAVAC_PATTERNS = [
   (r'\s*\[error\] (?P<filename>\S+):(?P<lineno>\d+):(\d+): '
    'package (?P<packagename>\S+) does not exist\n'
    '\s*\[error\] .*\W(?P<classname>(?P=packagename)\.\w+)\W.*'),
-]
 
-
-_CLASS_NOT_FOUND_ERROR_SCALAC_PATTERNS = [
+  # scalac errors
   (r'\s*\[error\] missing or invalid dependency detected while loading class file '
    '\'(?P<dependee_classname>\S+)\.class\'\.\n'
    '\s*\[error\] Could not access type (?P<classnameonly>\S+) in (value|package) '
@@ -37,20 +36,17 @@ _CLASS_NOT_FOUND_ERROR_SCALAC_PATTERNS = [
    'is not a member of package (\S+)\n'
    '\s*\[error\] import (?P<classname>\S+)'),
   (r'\s*\[error\] Class (?P<classname>\S+) not found \- continuing with a stub\.'),
-]
 
 
-_CLASS_NOT_FOUND_ERROR_ZINC_PATTERNS = [
+  # zinc errors
   (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
    '\s*\[error\] Type (?P<classname>\S+) not present'),
   (r'\s*\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
    '\s*\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
-  # This is a javac pattern but places here below the more specific pattern above since
-  # we want to match the more specific pattern first
+
+  # javac error but needs to be after the more specific pattern
   (r'.*java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
 ]
 
 
-CLASS_NOT_FOUND_ERROR_PATTERNS = [re.compile(p) for p in _CLASS_NOT_FOUND_ERROR_JAVAC_PATTERNS +
-                                  _CLASS_NOT_FOUND_ERROR_SCALAC_PATTERNS +
-                                  _CLASS_NOT_FOUND_ERROR_ZINC_PATTERNS]
+CLASS_NOT_FOUND_ERROR_PATTERNS = [re.compile(p) for p in _CLASS_NOT_FOUND_ERROR_PATTERNS]

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/class_not_found_error_patterns.py
@@ -44,6 +44,8 @@ _CLASS_NOT_FOUND_ERROR_ZINC_PATTERNS = [
    '\s+\[error\] Type (?P<classname>\S+) not present'),
   (r'\s+\[error\] ## Exception when compiling (?P<filename>\S+) and others\.\.\.\n'
    '\s+\[error\] java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
+  # This is a javac pattern but places here below the more specific pattern above since
+  # we want to match the more specific pattern first
   (r'.*java.lang.NoClassDefFoundError: (?P<classname>\S+)'),
 ]
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -534,6 +534,7 @@ class JvmCompile(NailgunTaskBase):
           def find_failed_compile_log(workunits):
             for workunit in workunits:
               for output_name, outpath in workunit.output_paths().items():
+                # Locate failure log from child compilation workunit's stdout
                 if (workunit.name == self.name() and output_name == 'stdout'
                     and workunit.outcome() == WorkUnit.FAILURE):
                   return outpath

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -434,7 +434,7 @@ class JvmCompile(NailgunTaskBase):
     assert invalid_targets, "compile_chunk should only be invoked if there are invalid targets."
 
     # This ensures the workunit for the worker pool is set before attempting to compile.
-    with self.context.new_workunit('isolation-{}-pool-bootstrap'.format(self._name)) \
+    with self.context.new_workunit('isolation-{}-pool-bootstrap'.format(self.name())) \
             as workunit:
       # This uses workunit.parent as the WorkerPool's parent so that child workunits
       # of different pools will show up in order in the html output. This way the current running
@@ -509,7 +509,7 @@ class JvmCompile(NailgunTaskBase):
         ' (',
         progress_message,
         ').')
-      with self.context.new_workunit('compile', labels=[WorkUnitLabel.COMPILER]):
+      with self.context.new_workunit('compile', labels=[WorkUnitLabel.COMPILER]) as compile_workunit:
         # The compiler may delete classfiles, then later exit on a compilation error. Then if the
         # change triggering the error is reverted, we won't rebuild to restore the missing
         # classfiles. So we force-invalidate here, to be on the safe side.
@@ -522,6 +522,7 @@ class JvmCompile(NailgunTaskBase):
         self.compile(self._args, classpath, sources, outdir, upstream_analysis, analysis_file,
                      log_file, settings, fatal_warnings, zinc_file_manager,
                      javac_plugins_to_exclude)
+        print(compile_workunit.name)
 
   def check_artifact_cache(self, vts):
     """Localizes the fetched analysis for targets we found in the cache."""

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -327,7 +327,6 @@ class JvmCompile(NailgunTaskBase):
     self._capture_log = self.get_options().capture_log
     self._delete_scratch = self.get_options().delete_scratch
     self._clear_invalid_analysis = self.get_options().clear_invalid_analysis
-    self._missing_dependency_finder = MissingDependencyFinder(self._dep_analyzer)
 
     try:
       worker_count = self.get_options().worker_count
@@ -353,6 +352,10 @@ class JvmCompile(NailgunTaskBase):
     return JvmDependencyAnalyzer(get_buildroot(),
                                  self.context.products.get_data('runtime_classpath'),
                                  self.context.products.get_data('product_deps_by_src'))
+
+  @memoized_property
+  def _missing_deps_finder(self):
+    return MissingDependencyFinder(self._dep_analyzer)
 
   @property
   def _analysis_parser(self):
@@ -650,7 +653,7 @@ class JvmCompile(NailgunTaskBase):
 
   def _find_missing_deps(self, compile_failure_log, target):
     with self.context.new_workunit('missing-deps-suggest', labels=[WorkUnitLabel.COMPILER]):
-      missing_dep_suggestions, no_suggestions = self._missing_dependency_finder.find(
+      missing_dep_suggestions, no_suggestions = self._missing_deps_finder.find(
         compile_failure_log, target)
 
       if missing_dep_suggestions:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -717,14 +717,14 @@ class JvmCompile(NailgunTaskBase):
         suggestion_msg = (
           '\nIf the above information is correct, '
           'please add the following to the dependencies of ({}):\n  {}\n'
-            .format(target.address.spec, '\n    '.join(sorted(list(suggested_deps))))
+            .format(target.address.spec, '\n  '.join(sorted(list(suggested_deps))))
         )
         self.context.log.info(suggestion_msg)
 
       if no_suggestions:
         self.context.log.debug('Unable to find any deps from target\'s transitive '
                                'dependencies that provide the following missing classes:')
-        no_suggestion_msg = '\n     '.join(sorted(list(no_suggestions)))
+        no_suggestion_msg = '\n   '.join(sorted(list(no_suggestions)))
         self.context.log.debug('  {}'.format(no_suggestion_msg))
 
   def _upstream_analysis(self, compile_contexts, classpath_entries):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -670,7 +670,7 @@ class JvmCompile(NailgunTaskBase):
         self.context.log.info('Unable to find any deps from target\'s transitive '
                               'dependencies that contain the following not found classes:')
         no_suggestion_msg = '\n    '.join(sorted(list(no_suggestions)))
-        self.context.log.info(no_suggestion_msg)
+        self.context.log.info('  {}'.format(no_suggestion_msg))
 
   def _upstream_analysis(self, compile_contexts, classpath_entries):
     """Returns tuples of classes_dir->analysis_file for the closure of the target."""

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -722,7 +722,7 @@ class JvmCompile(NailgunTaskBase):
 
       if no_suggestions:
         self.context.log.debug('Unable to find any deps from target\'s transitive '
-                               'dependencies that contain the following not found classes:')
+                               'dependencies that provide the following missing classes:')
         no_suggestion_msg = '\n     '.join(sorted(list(no_suggestions)))
         self.context.log.debug('  {}'.format(no_suggestion_msg))
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -166,7 +166,8 @@ class JvmCompile(NailgunTaskBase):
                   'errors.')
 
     register('--suggest-missing-deps', advanced=False, type=bool,
-             help='Suggest missing dependencies on compilation failures.')
+             help='Suggest missing dependencies best-effort from target\'s transitive deps '
+                  'for compilation failures that are due to class not found.')
 
     register('--use-classpath-jars', advanced=True, type=bool, fingerprint=True,
              help='Use jar files on the compile_classpath. Note: Using this option degrades '
@@ -531,10 +532,10 @@ class JvmCompile(NailgunTaskBase):
                        javac_plugins_to_exclude)
         except TaskError:
           def find_failed_compile_log(workunits):
-            for wu in workunits:
-              for output_name, outpath in wu.output_paths().items():
-                if (wu.name == self.name() and output_name == 'stdout'
-                    and wu.outcome() == WorkUnit.FAILURE):
+            for workunit in workunits:
+              for output_name, outpath in workunit.output_paths().items():
+                if (workunit.name == self.name() and output_name == 'stdout'
+                    and workunit.outcome() == WorkUnit.FAILURE):
                   return outpath
             return None
           if self.get_options().suggest_missing_deps:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -138,7 +138,7 @@ class JvmCompile(NailgunTaskBase):
              help='Extra compiler args to use when warnings are disabled.')
 
     register('--fatal-warnings-enabled-args', advanced=True, type=list, fingerprint=True,
-             default=CLASS_NOT_FOUND_ERROR_PATTERNS,
+             default=list(cls.get_fatal_warnings_enabled_args_default()),
              help='Extra compiler args to use when fatal warnings are enabled.')
 
     register('--fatal-warnings-disabled-args', advanced=True, type=list, fingerprint=True,
@@ -589,7 +589,7 @@ class JvmCompile(NailgunTaskBase):
           raise
 
   def _find_failed_compile_log(self, compile_workunit):
-    '''One of the compile child workunits actually calls compiler, locate its stdout.'''
+    """One of the compile child workunits actually calls compiler, this is to locate its stdout."""
     for workunit in compile_workunit.children:
       for output_name, outpath in workunit.output_paths().items():
         # Workunit that runs compiler is id-ed by the task name.

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -583,7 +583,7 @@ class JvmCompile(NailgunTaskBase):
                        javac_plugins_to_exclude)
         except TaskError:
           if self.get_options().suggest_missing_deps:
-            log_path = self.find_failed_compile_log(compile_workunit)
+            log_path = self._find_failed_compile_log(compile_workunit)
             if log_path:
               self._find_missing_deps(read_file(log_path), target)
           raise

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -534,7 +534,7 @@ class JvmCompile(NailgunTaskBase):
             return None
           log_path = find_failed_compile_log(compile_workunit.children)
           if log_path:
-            self._suggest_missing_deps(read_file(log_path))
+            self._find_missing_deps(read_file(log_path))
           raise
 
   def check_artifact_cache(self, vts):
@@ -640,7 +640,7 @@ class JvmCompile(NailgunTaskBase):
         self.context.log.warn('Target {} had {}\n'.format(
           compile_context.target.address.spec, unused_msg))
 
-  def _suggest_missing_deps(self, compile_output):
+  def _find_missing_deps(self, compile_output):
     with self.context.new_workunit('missing-deps-suggest', labels=[WorkUnitLabel.COMPILER]):
       print('Invoking missing deps check: \n{}'.format(compile_output))
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
@@ -12,6 +12,13 @@ from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import \
   CLASS_NOT_FOUND_ERROR_PATTERNS
 
 
+def normalize_classname(classname):
+  """
+  Ensure the dot separated class name.
+  """
+  return classname.replace('$', '.').replace('/', '.')
+
+
 class ClassNotFoundError(namedtuple('CompileError', ['source', 'lineno', 'classname'])):
   """Compilation error specifically about class not found."""
   pass
@@ -25,7 +32,7 @@ class CompileErrorExtractor(object):
   def __init__(self, error_patterns=CLASS_NOT_FOUND_ERROR_PATTERNS):
     self._error_patterns = error_patterns
 
-  def extract(self, compile_output, first_only=True):
+  def extract(self, compile_output):
     def safe_get_named_group(match, name, default=None):
       try:
         return match.group(name)
@@ -42,7 +49,7 @@ class CompileErrorExtractor(object):
         if classnameonly and packagename:
           classname = '.'.join([packagename, classnameonly])
       if classname:
-        classname = self._normalize_classname(classname)
+        classname = normalize_classname(classname)
       return ClassNotFoundError(source, lineno, classname)
 
     errors = []
@@ -61,16 +68,7 @@ class CompileErrorExtractor(object):
       errors.append(get_matched_error(first_match))
       start = first_match.end() + 1
 
-      if first_only:
-        break
-
     return errors
-
-  def _normalize_classname(self, classname):
-    """
-    Ensure the dot separated class name.
-    """
-    return classname.replace('$', '.').replace('/', '.')
 
 
 class StringSimilarityRanker(object):

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import namedtuple
+from difflib import SequenceMatcher
+
+from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import \
+  CLASS_NOT_FOUND_ERROR_PATTERNS
+
+
+class ClassNotFoundError(namedtuple('CompileError', ['source', 'lineno', 'classname'])):
+  """Compilation error specifically about class not found."""
+  pass
+
+
+class CompileErrorExtractor(object):
+  """
+  Extract `ClassNotFoundError`s from pants compile log.
+  """
+
+  def __init__(self, error_patterns=CLASS_NOT_FOUND_ERROR_PATTERNS):
+    self._error_patterns = error_patterns
+
+  def extract(self, compile_output, first_only=True):
+    def safe_get_named_group(match, name, default=None):
+      try:
+        return match.group(name)
+      except IndexError:
+        return default
+
+    def get_matched_error(match):
+      source = safe_get_named_group(match, 'filename')
+      lineno = safe_get_named_group(match, 'lineno')
+      classname = safe_get_named_group(match, 'classname')
+      if not classname:
+        classnameonly = safe_get_named_group(match, 'classnameonly')
+        packagename = safe_get_named_group(match, 'packagename')
+        if classnameonly and packagename:
+          classname = '.'.join([packagename, classnameonly])
+      if classname:
+        classname = self._normalize_classname(classname)
+      return ClassNotFoundError(source, lineno, classname)
+
+    errors = []
+    start = 0
+    while start < len(compile_output):
+      first_match = None
+      for p in self._error_patterns:
+        m = p.search(compile_output, start)
+        if m:
+          if not first_match or m.start() < first_match.start():
+            first_match = m
+
+      if not first_match:
+        break
+
+      errors.append(get_matched_error(first_match))
+      start = first_match.end() + 1
+
+      if first_only:
+        break
+
+    return errors
+
+  def _normalize_classname(self, classname):
+    """
+    Ensure the dot separated class name.
+    """
+    return classname.replace('$', '.').replace('/', '.')
+
+
+class StringSimilarityRanker(object):
+  """
+  Sort strings according to their similarities to a given string.
+  """
+
+  def __init__(self, base_str):
+    """
+    :param base_str: the given string to compute similarity against.
+    """
+    self._base_str = base_str
+
+  def sort(self, strings):
+    return sorted(strings, key=lambda str: SequenceMatcher(a=self._base_str, b=str).ratio(),
+      reverse=True)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
@@ -120,8 +120,11 @@ class MissingDependencyFinder(object):
     class2deps, no_dep_found = {}, set()
     for classname in classnames:
       if classname not in class2deps:
-        candidates_for_class = [tgt.address.spec for tgt in
-                                self.dep_analyzer.targets_for_class(target, classname)]
+        candidates_for_class = []
+        for tgt in self.dep_analyzer.targets_for_class(target, classname):
+          if tgt.is_synthetic and tgt.derived_from:
+            tgt = tgt.derived_from
+          candidates_for_class.append(tgt.address.spec)
         if candidates_for_class:
           candidates_for_class = StringSimilarityRanker(classname).sort(candidates_for_class)
           class2deps[classname] = OrderedSet(candidates_for_class)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
@@ -101,18 +101,19 @@ class MissingDependencyFinder(object):
     self.compile_error_extractor = CompileErrorExtractor()
 
   def find(self, compile_failure_log, target):
-    not_found_classes = [err.classname for err in
+    not_found_classnames = [err.classname for err in
                          self.compile_error_extractor.extract(compile_failure_log)]
-    return self.select_target_candidates_for_class(not_found_classes, target)
+    return self.select_target_candidates_for_class(not_found_classnames, target)
 
   def select_target_candidates_for_class(self, classnames, target):
     """Select top candidate for a given classname.
 
-    When multiple candidates are available, sometimes common in 3rdparty dependencies,
-    they are ranked according to their similiarities with the classname because the way
-    3rdparty targets are conventionally named.
+    When multiple candidates are available, not uncommon in 3rdparty dependencies,
+    they are ranked according to their string similiarities with the classname because
+    the way 3rdparty targets are conventionally named often shares similar naming
+    structure.
     """
-    candiates = {}
+    candiates, no_target_candidates = {}, set()
     for classname in classnames:
       if classname not in candiates:
         candidates_for_class = [tgt.address.spec for tgt in
@@ -121,5 +122,5 @@ class MissingDependencyFinder(object):
           candidates_for_class = StringSimilarityRanker(classname).sort(candidates_for_class)
           candiates[classname] = OrderedSet(candidates_for_class)
         else:
-          candiates[classname] = set()
-    return candiates
+          no_target_candidates.add(classname)
+    return candiates, no_target_candidates

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
@@ -99,7 +99,7 @@ class MissingDependencyFinder(object):
     self.compile_error_extractor = error_extractor
 
   def find(self, compile_failure_log, target):
-    """Find missing deps best-effort from target's transitive dependencies.
+    """Find missing deps on a best-effort basis from target's transitive dependencies.
 
     Returns (class2deps, no_dep_found) tuple. `class2deps` contains classname
     to deps that contain the class mapping. `no_dep_found` are the classnames that are

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
@@ -17,7 +17,7 @@ from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import \
 
 def normalize_classname(classname):
   """
-  Ensure the dot separated class name (zinc reported class not found may contain '/')
+  Ensure the dot separated class name (zinc reported class not found may use '/' separator)
   """
   return classname.replace('/', '.')
 
@@ -109,9 +109,9 @@ class MissingDependencyFinder(object):
     """
     not_found_classnames = [err.classname for err in
                             self.compile_error_extractor.extract(compile_failure_log)]
-    return self.select_target_candidates_for_class(not_found_classnames, target)
+    return self._select_target_candidates_for_class(not_found_classnames, target)
 
-  def select_target_candidates_for_class(self, classnames, target):
+  def _select_target_candidates_for_class(self, classnames, target):
     """Select a target that contains the given classname.
 
     When multiple candidates are available, not uncommon in 3rdparty dependencies,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/missing_dependency_finder.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from collections import namedtuple
 from difflib import SequenceMatcher
 
+from colors import strip_color
 from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import \
@@ -56,6 +57,7 @@ class CompileErrorExtractor(object):
 
     errors = []
     start = 0
+    compile_output = strip_color(compile_output)
     while start < len(compile_output):
       first_match = None
       for p in self._error_patterns:

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -56,6 +56,8 @@ class BaseZincCompile(JvmCompile):
 
   _supports_concurrent_execution = True
 
+  _name = 'zinc'
+
   @staticmethod
   def _write_scalac_plugin_info(resources_dir, scalac_plugin_target):
     scalac_plugin_info_file = os.path.join(resources_dir, _SCALAC_PLUGIN_INFO_FILE)
@@ -381,7 +383,7 @@ class BaseZincCompile(JvmCompile):
                     main=self._ZINC_MAIN,
                     jvm_options=jvm_options,
                     args=zinc_args,
-                    workunit_name='zinc',
+                    workunit_name=self.name(),
                     workunit_labels=[WorkUnitLabel.COMPILER]):
       raise TaskError('Zinc compile failed.')
 
@@ -410,8 +412,6 @@ class BaseZincCompile(JvmCompile):
 
 class ZincCompile(BaseZincCompile):
   """Compile Scala and Java code using Zinc."""
-
-  _name = 'zinc'
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
@@ -79,6 +79,20 @@ class JvmDependencyAnalyzer(object):
 
     return targets_by_file
 
+  def targets_for_class(self, target, classname):
+    """Search which targets from `target`'s transitie dependencies contain `classname`."""
+    return self._targets_by_class(target.closure()).get(classname)
+
+  def _targets_by_class(self, targets):
+    targets_by_class = defaultdict(set)
+    for target in targets:
+      contents = ClasspathUtil.classpath_contents((target,), self.runtime_classpath)
+      for f in contents:
+        classname = ClasspathUtil.classname_for_rel_classfile(f)
+        if classname:
+          targets_by_class[classname].add(target)
+    return targets_by_class
+
   def _jar_classfiles(self, jar_file):
     """Returns an iterator over the classfiles inside jar_file."""
     for cls in ClasspathUtil.classpath_entries_contents([jar_file]):

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
@@ -81,7 +81,7 @@ class JvmDependencyAnalyzer(object):
 
   def targets_for_class(self, target, classname):
     """Search which targets from `target`'s transitie dependencies contain `classname`."""
-    return self._targets_by_class(target.closure()).get(classname)
+    return self._targets_by_class(target.closure()).get(classname, set())
 
   def _targets_by_class(self, targets):
     targets_by_class = defaultdict(set)

--- a/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_dependency_analyzer.py
@@ -80,9 +80,10 @@ class JvmDependencyAnalyzer(object):
     return targets_by_file
 
   def targets_for_class(self, target, classname):
-    """Search which targets from `target`'s transitie dependencies contain `classname`."""
-    return self._targets_by_class(target.closure()).get(classname, set())
+    """Search which targets from `target`'s transitive dependencies contain `classname`."""
+    return self._targets_by_class(tuple(target.closure())).get(classname, set())
 
+  @memoized_method
   def _targets_by_class(self, targets):
     targets_by_class = defaultdict(set)
     for target in targets:

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -30,3 +30,11 @@ python_tests(
   ],
   tags={'integration'},
 )
+
+python_tests(
+  name='missing_dependency_finder',
+  sources=['test_missing_dependency_finder.py'],
+  dependencies=[
+    'src/python/pants/backend/jvm/tasks/jvm_compile:missing_dependency_finder',
+  ],
+)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/BUILD
@@ -38,3 +38,13 @@ python_tests(
     'src/python/pants/backend/jvm/tasks/jvm_compile:missing_dependency_finder',
   ],
 )
+
+python_tests(
+  name='missing_dependency_finder_integration',
+  sources=['test_missing_dependency_finder_integration.py'],
+  dependencies=[
+    'tests/python/pants_test:int-test',
+    'src/python/pants/backend/jvm/tasks/jvm_compile:missing_dependency_finder',
+  ],
+  tags={'integration'},
+)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
@@ -20,8 +20,6 @@ class CompileErrorExtractorTest(unittest.TestCase):
       [error]   location: package javax.annotation
       [error] import javax.annotation.Nullable;""",
     r"""
-      java.lang.NoClassDefFoundError: org/apache/thrift/TEnum""",
-    r"""
       [error] /path/to/file/Hello.java:63:1: cannot access org.apache.thrift.TBase
       [error]   class file for org.apache.thrift.TBase not found""",
     r"""
@@ -41,34 +39,32 @@ class CompileErrorExtractorTest(unittest.TestCase):
       [error] ## Exception when compiling /path/to/file/Hello.java and others...
       [error] java.lang.NoClassDefFoundError: a.b.c.XYZ""",
     r"""
-      [error] missing or invalid dependency detected while loading class file 'Logging.class'.
-      [error] Could not access type Future in value com.twitter.util,""",
-    r"""
-      [error] missing or invalid dependency detected while loading class file 'ThriftEnum.class'.
-      [error] Could not access type TEnum in value org.apache.thrift,""",
-    r"""
       [error] /path/to/file/Hello.scala:211:26: exception during macro expansion:
       [error] java.lang.ClassNotFoundException: com.twitter.x.thrift.thriftscala.Y""",
     r"""
       [error] /path/to/file/Hello.scala:7:33: object x is not a member of package a.b.c
       [error] import a.b.c.x.Y""",
     r"""
+      java.lang.NoClassDefFoundError: org/apache/thrift/TEnum""",
+    r"""
+      [error] missing or invalid dependency detected while loading class file 'Logging.class'.
+      [error] Could not access type Future in value com.twitter.util,""",
+    r"""
       [error] Class a.b.c.X not found - continuing with a stub."""
   ]
 
   EXPECTED_ERRORS = [
     ClassNotFoundError('/path/to/file/Hello.java', '3', 'javax.annotation.Nullable'),
-    ClassNotFoundError(None, None, 'org.apache.thrift.TEnum'),
     ClassNotFoundError('/path/to/file/Hello.java', '63', 'org.apache.thrift.TBase'),
     ClassNotFoundError('/path/to/file/Hello.java', '6', 'a.b.c.ImmutableMap'),
     ClassNotFoundError('/path/to/file/Hello.java', '36', 'a.b.c.XYZ'),
     ClassNotFoundError('/path/to/file/Hello.java', '102', 'a.b.c.XYZ'),
     ClassNotFoundError('/path/to/file/Hello.java', None, 'com.twitter.util.lint.Rule'),
     ClassNotFoundError('/path/to/file/Hello.java', None, 'a.b.c.XYZ'),
-    ClassNotFoundError(None, None, 'com.twitter.util.Future'),
-    ClassNotFoundError(None, None, 'org.apache.thrift.TEnum'),
     ClassNotFoundError('/path/to/file/Hello.scala', '211', 'com.twitter.x.thrift.thriftscala.Y'),
     ClassNotFoundError('/path/to/file/Hello.scala', '7', 'a.b.c.x.Y'),
+    ClassNotFoundError(None, None, 'org.apache.thrift.TEnum'),
+    ClassNotFoundError(None, None, 'com.twitter.util.Future'),
     ClassNotFoundError(None, None, 'a.b.c.X'),
   ]
 
@@ -82,7 +78,7 @@ class CompileErrorExtractorTest(unittest.TestCase):
   def test_extract_all_errors(self):
     compile_log = '\n'.join(self.ERROR_MESSAGES)
     self.assertEqual(self.EXPECTED_ERRORS,
-      self.compile_error_finder.extract(compile_log, first_only=False))
+      self.compile_error_finder.extract(compile_log))
 
 
 class StringSimilarityRankerTest(unittest.TestCase):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
@@ -8,6 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import random
 import unittest
 
+from pants.backend.jvm.tasks.jvm_compile.class_not_found_error_patterns import \
+  CLASS_NOT_FOUND_ERROR_PATTERNS
 from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (ClassNotFoundError,
                                                                            CompileErrorExtractor,
                                                                            StringSimilarityRanker)
@@ -70,7 +72,7 @@ class CompileErrorExtractorTest(unittest.TestCase):
   ]
 
   def setUp(self):
-    self.compile_error_finder = CompileErrorExtractor()
+    self.compile_error_finder = CompileErrorExtractor(CLASS_NOT_FOUND_ERROR_PATTERNS)
 
   def test_extract_single_error(self):
     for error_message, expected_error in zip(self.ERROR_MESSAGES, self.EXPECTED_ERRORS):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (ClassNotFoundError,
+                                                                           CompileErrorExtractor,
+                                                                           StringSimilarityRanker)
+
+
+class CompileErrorExtractorTest(unittest.TestCase):
+  ERROR_MESSAGES = [
+    r"""
+      [error] /path/to/file/Hello.java:3:1: cannot find symbol
+      [error]   symbol:   class Nullable
+      [error]   location: package javax.annotation
+      [error] import javax.annotation.Nullable;""",
+    r"""
+      java.lang.NoClassDefFoundError: org/apache/thrift/TEnum""",
+    r"""
+      [error] /path/to/file/Hello.java:63:1: cannot access org.apache.thrift.TBase
+      [error]   class file for org.apache.thrift.TBase not found""",
+    r"""
+      [error] /path/to/file/Hello.java:6:1: package a.b.c does not exist
+      [error] import a.b.c.ImmutableMap;""",
+    r"""
+      [error] /path/to/file/Hello.java:36:1: cannot find symbol
+      [error]   symbol:   class XYZ
+      [error]   location: package a.b.c""",
+    r"""
+      [error] /path/to/file/Hello.java:102:1: package a.b.c does not exist
+      [error]     public static final A<a.b.c.XYZ> xyz = new ...;    """,
+    r"""
+      [error] ## Exception when compiling /path/to/file/Hello.java and others...
+      [error] Type com.twitter.util.lint.Rule not present""",
+    r"""
+      [error] ## Exception when compiling /path/to/file/Hello.java and others...
+      [error] java.lang.NoClassDefFoundError: a.b.c.XYZ""",
+    r"""
+      [error] missing or invalid dependency detected while loading class file 'Logging.class'.
+      [error] Could not access type Future in value com.twitter.util,""",
+    r"""
+      [error] missing or invalid dependency detected while loading class file 'ThriftEnum.class'.
+      [error] Could not access type TEnum in value org.apache.thrift,""",
+    r"""
+      [error] /path/to/file/Hello.scala:211:26: exception during macro expansion:
+      [error] java.lang.ClassNotFoundException: com.twitter.x.thrift.thriftscala.Y""",
+    r"""
+      [error] /path/to/file/Hello.scala:7:33: object x is not a member of package a.b.c
+      [error] import a.b.c.x.Y""",
+    r"""
+      [error] Class a.b.c.X not found - continuing with a stub."""
+  ]
+
+  EXPECTED_ERRORS = [
+    ClassNotFoundError('/path/to/file/Hello.java', '3', 'javax.annotation.Nullable'),
+    ClassNotFoundError(None, None, 'org.apache.thrift.TEnum'),
+    ClassNotFoundError('/path/to/file/Hello.java', '63', 'org.apache.thrift.TBase'),
+    ClassNotFoundError('/path/to/file/Hello.java', '6', 'a.b.c.ImmutableMap'),
+    ClassNotFoundError('/path/to/file/Hello.java', '36', 'a.b.c.XYZ'),
+    ClassNotFoundError('/path/to/file/Hello.java', '102', 'a.b.c.XYZ'),
+    ClassNotFoundError('/path/to/file/Hello.java', None, 'com.twitter.util.lint.Rule'),
+    ClassNotFoundError('/path/to/file/Hello.java', None, 'a.b.c.XYZ'),
+    ClassNotFoundError(None, None, 'com.twitter.util.Future'),
+    ClassNotFoundError(None, None, 'org.apache.thrift.TEnum'),
+    ClassNotFoundError('/path/to/file/Hello.scala', '211', 'com.twitter.x.thrift.thriftscala.Y'),
+    ClassNotFoundError('/path/to/file/Hello.scala', '7', 'a.b.c.x.Y'),
+    ClassNotFoundError(None, None, 'a.b.c.X'),
+  ]
+
+  def setUp(self):
+    self.compile_error_finder = CompileErrorExtractor()
+
+  def test_extract_single_error(self):
+    for error_message, expected_error in zip(self.ERROR_MESSAGES, self.EXPECTED_ERRORS):
+      self.assertEqual([expected_error], self.compile_error_finder.extract(error_message))
+
+  def test_extract_all_errors(self):
+    compile_log = '\n'.join(self.ERROR_MESSAGES)
+    self.assertEqual(self.EXPECTED_ERRORS,
+      self.compile_error_finder.extract(compile_log, first_only=False))
+
+
+class StringSimilarityRankerTest(unittest.TestCase):
+  def test_rank_dependency_candidates(self):
+    expected = [
+      '3rdparty/jvm/com/google/inject:guice',
+      '3rdparty/jvm/com/google/guava:guava',
+      '3rdparty/jvm/cascading:cascading-local',
+    ]
+    self.assertEqual(expected,
+      StringSimilarityRanker('com.google.inject.Inject').sort([
+        '3rdparty/jvm/cascading:cascading-local',
+        '3rdparty/jvm/com/google/guava:guava',
+        '3rdparty/jvm/com/google/inject:guice',
+      ]))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
@@ -50,7 +50,7 @@ class CompileErrorExtractorTest(unittest.TestCase):
       [error] missing or invalid dependency detected while loading class file 'Logging.class'.
       [error] Could not access type Future in value com.twitter.util,""",
     r"""
-      [error] Class a.b.c.X not found - continuing with a stub."""
+      [error] Class a.b.c.X not found - continuing with a stub.""",
   ]
 
   EXPECTED_ERRORS = [

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import random
 import unittest
 
 from pants.backend.jvm.tasks.jvm_compile.missing_dependency_finder import (ClassNotFoundError,
@@ -83,14 +84,15 @@ class CompileErrorExtractorTest(unittest.TestCase):
 
 class StringSimilarityRankerTest(unittest.TestCase):
   def test_rank_dependency_candidates(self):
+    not_found_classname = 'com.google.inject.Inject'
+
+    # Expect 3rdparty/jvm/com/google/inject:guice is more similar to the missing class name.
     expected = [
       '3rdparty/jvm/com/google/inject:guice',
       '3rdparty/jvm/com/google/guava:guava',
       '3rdparty/jvm/cascading:cascading-local',
     ]
-    self.assertEqual(expected,
-      StringSimilarityRanker('com.google.inject.Inject').sort([
-        '3rdparty/jvm/cascading:cascading-local',
-        '3rdparty/jvm/com/google/guava:guava',
-        '3rdparty/jvm/com/google/inject:guice',
-      ]))
+
+    shuffled = list(expected)
+    random.shuffle(shuffled)
+    self.assertEqual(expected, StringSimilarityRanker(not_found_classname).sort(shuffled))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import re
+
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -14,14 +16,16 @@ class MissingDependencyFinderIntegrationTest(PantsRunIntegrationTest):
     target = 'testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist'
     run = self.run_pants(['compile', target, '--compile-zinc-suggest-missing-deps'])
     self.assert_failure(run)
-    self.assertTrue('Found the following deps from target\'s transitive dependencies '
-                    'that contain the not found classes:\n  '
-                    '  com.google.common.io.Closer: 3rdparty:guava', run.stdout_data)
+    self.assertTrue(re.search('Found the following deps from target\'s transitive dependencies '
+                              'that provide the missing classes:.*'
+                              'com.google.common.io.Closer: 3rdparty:guava', run.stdout_data,
+                              re.DOTALL))
 
   def test_missing_deps_not_found(self):
     target = 'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target'
-    run = self.run_pants(['compile', target, '--compile-zinc-suggest-missing-deps'])
+    run = self.run_pants(['compile', target, '--compile-zinc-suggest-missing-deps', '-ldebug'])
     self.assert_failure(run)
-    self.assertTrue('Unable to find any deps from target\'s transitive dependencies '
-                    'that contain the following not found classes:\n'
-                    '  System2.out', run.stdout_data)
+    self.assertTrue(re.search('Unable to find any deps from target\'s transitive dependencies '
+                              'that provide the following missing classes:.*'
+                              'System2.out', run.stdout_data,
+                              re.DOTALL))

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class MissingDependencyFinderIntegrationTest(PantsRunIntegrationTest):
+
+  def test_missing_deps_found(self):
+    target = 'testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist'
+    run = self.run_pants(['compile', target, '--compile-zinc-suggest-missing-deps'])
+    self.assert_failure(run)
+    self.assertTrue('Found the following deps from target\'s transitive dependencies '
+                    'that contain the not found classes:\n  '
+                    '  com.google.common.io.Closer: 3rdparty:guava', run.stdout_data)
+
+  def test_missing_deps_not_found(self):
+    target = 'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target'
+    run = self.run_pants(['compile', target, '--compile-zinc-suggest-missing-deps'])
+    self.assertTrue('Unable to find any deps from target\'s transitive dependencies '
+                    'that contain the following not found classes:\n'
+                    '  System2.out', run.stdout_data)

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
@@ -21,6 +21,7 @@ class MissingDependencyFinderIntegrationTest(PantsRunIntegrationTest):
   def test_missing_deps_not_found(self):
     target = 'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target'
     run = self.run_pants(['compile', target, '--compile-zinc-suggest-missing-deps'])
+    self.assert_failure(run)
     self.assertTrue('Unable to find any deps from target\'s transitive dependencies '
                     'that contain the following not found classes:\n'
                     '  System2.out', run.stdout_data)


### PR DESCRIPTION
### Problem

Switching from `non-strict_deps` to `strict-deps` may result missing deps compile errors if deps used are from target's transitive deps but not declared as direct deps.

### Solution

This PR extracts the class names that are reported as `not found` from failure compile log and locate them in target's transitive classpath.

This approach is on a best-effort bsis:

* Compiler may not always report the not found class name, even though the error is due to missing deps. Work to improve scalac coverage is undergoing
* Newly introduced deps that are not in the transitive deps are not covered.

### Result
```
./pants compile testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist --compile-zinc-suggest-missing-deps
...
                       [info] Compiling 1 Java source to /Users/peiyu/github/pants/.pants.d/compile/zinc/66ac1c9326be/testprojects.src.java.org.pantsbuild.testproject.missingjardepswhitelist.missingjardepswhitelist/current/classes...
                       [error] /Users/peiyu/github/pants/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/MissingJarDepsWhitelist.java:4:1: package com.google.common.io does not exist
                       [error] import com.google.common.io.Closer;
                       [error] /Users/peiyu/github/pants/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/MissingJarDepsWhitelist.java:8:1: cannot find symbol
                       [error]   symbol:   class Closer
                       [error]   location: class org.pantsbuild.testproject.missingjardepswhitelist.MissingJarDepsWhitelist
                       [error]     Closer c = Closer.create();
                       [error] /Users/peiyu/github/pants/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/MissingJarDepsWhitelist.java:8:1: cannot find symbol
                       [error]   symbol:   variable Closer
                       [error]   location: class org.pantsbuild.testproject.missingjardepswhitelist.MissingJarDepsWhitelist
                       [error]     Closer c = Closer.create();
                       [error] Compile failed at Jan 10, 2017 11:23:09 AM [0.058s]
                       
11:23:09 00:03         [missing-deps-suggest]
                       
                       Found the following deps from target's transitive dependencies that provide the missing classes:
                         com.google.common.io.Closer: 3rdparty:guava
                       
                       If the above information is correct, please add the following to the dependencies of (testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist):
                         3rdparty:guava
                       
                   compile(testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist) failed: Zinc compile failed.
```