### PR TITLE
add various codegen packages to default backend packages

### DIFF
--- a/src/python/pants/backend/codegen/antlr/java/BUILD
+++ b/src/python/pants/backend/codegen/antlr/java/BUILD
@@ -7,6 +7,7 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
     'src/python/pants/base:exceptions',
+    'src/python/pants/build_graph',
     'src/python/pants/java:util',
     'src/python/pants/option',
     'src/python/pants/task',

--- a/src/python/pants/backend/codegen/antlr/python/BUILD
+++ b/src/python/pants/backend/codegen/antlr/python/BUILD
@@ -4,5 +4,6 @@
 python_library(
   dependencies = [
     'src/python/pants/backend/python/targets:python',
+    'src/python/pants/build_graph',
   ],
 )

--- a/src/python/pants/backend/codegen/antlr/python/register.py
+++ b/src/python/pants/backend/codegen/antlr/python/register.py
@@ -1,0 +1,17 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.codegen.antlr.python.python_antlr_library import PythonAntlrLibrary
+from pants.build_graph.build_file_aliases import BuildFileAliases
+
+
+def build_file_aliases():
+  return BuildFileAliases(
+    targets={
+      'python_antlr_library': PythonAntlrLibrary,
+    }
+  )

--- a/src/python/pants/backend/codegen/protobuf/java/register.py
+++ b/src/python/pants/backend/codegen/protobuf/java/register.py
@@ -20,4 +20,4 @@ def build_file_aliases():
 
 
 def register_goals():
-  task(name='proto', action=ProtobufGen).install('gen')
+  task(name='protoc', action=ProtobufGen).install('gen')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -64,7 +64,6 @@ class GlobalOptionsRegistrar(Optionable):
              default=['pants.backend.graph_info',
                       'pants.backend.python',
                       'pants.backend.jvm',
-                      'pants.backend.codegen',
                       'pants.backend.codegen.antlr.java',
                       'pants.backend.codegen.jaxb',
                       'pants.backend.codegen.protobuf.java',

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -65,6 +65,13 @@ class GlobalOptionsRegistrar(Optionable):
                       'pants.backend.python',
                       'pants.backend.jvm',
                       'pants.backend.codegen',
+                      'pants.backend.codegen.antlr.java',
+                      'pants.backend.codegen.jaxb',
+                      'pants.backend.codegen.protobuf.java',
+                      'pants.backend.codegen.ragel.java',
+                      'pants.backend.codegen.thrift.java',
+                      'pants.backend.codegen.thrift.python',
+                      'pants.backend.codegen.wire.java',
                       'pants.backend.project_info'],
              help='Load backends from these packages that are already on the path. '
                   'Add contrib and custom backends to this list.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -65,6 +65,7 @@ class GlobalOptionsRegistrar(Optionable):
                       'pants.backend.python',
                       'pants.backend.jvm',
                       'pants.backend.codegen.antlr.java',
+                      'pants.backend.codegen.antlr.python',
                       'pants.backend.codegen.jaxb',
                       'pants.backend.codegen.protobuf.java',
                       'pants.backend.codegen.ragel.java',


### PR DESCRIPTION
### Problem

#4147 #4155 #4151 refactored codegen backend, and split it into multiple smaller packages.

We used to have codegen as one of the default backend packages, now we want to add these new packages to the default list as well.

### Solution

When registering "--backend-packages" option, add these new packages to the default list.
