### PR TITLE
fix a small bug in ApacheThriftGenBase class

### DIFF
--- a/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
+++ b/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
@@ -130,7 +130,7 @@ class ApacheThriftGenBase(SimpleCodegenTask):
       return item[0] if not item[1] else '{}={}'.format(*item)
 
     gen_opts_map = self.get_options().gen_options_map or {}
-    gen_opts = [opt_str(item) for item in gen_opts_map]
+    gen_opts = [opt_str(item) for item in gen_opts_map.iteritems()]
     if self.get_options().gen_options:  # Add the deprecated, old options.
       gen_opts.append(self.get_options().gen_options)
 

--- a/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
+++ b/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
@@ -130,7 +130,7 @@ class ApacheThriftGenBase(SimpleCodegenTask):
       return item[0] if not item[1] else '{}={}'.format(*item)
 
     gen_opts_map = self.get_options().gen_options_map or {}
-    gen_opts = [opt_str(item) for item in gen_opts_map.iteritems()]
+    gen_opts = [opt_str(item) for item in gen_opts_map.items()]
     if self.get_options().gen_options:  # Add the deprecated, old options.
       gen_opts.append(self.get_options().gen_options)
 


### PR DESCRIPTION
### Problem

The way to consume gen_opts_map in ApacheThriftGenBase._thrift_cmd method is not correct.

### Solution

Change "for item in gen_opts_map" to "for item in gen_opts_map.iteritems()"

### Note

One consequence of this bug is that "new_style" option in python_thrift_library is not passed correct, causing thrift to generate old style python classes.
