### PR TITLE
Fix `str`-typed options with `int` defaults.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/archive_retriever.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/archive_retriever.py
@@ -34,7 +34,7 @@ class ArchiveRetriever(Subsystem):
              default=10 * 1024,  # 10KB in case jumbo frames are in play.
              help='The number of bytes of archive content to buffer in memory before flushing to '
                   'disk when downloading an archive.')
-    register('--retries', default=1, advanced=True,
+    register('--retries', type=int, default=1, advanced=True,
              help='How many times to retry when fetching a remote archive.')
 
   def fetch_archive(self, archive_url, strip_level, dest):

--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
@@ -24,7 +24,7 @@ class GoImportMetaTagReader(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(GoImportMetaTagReader, cls).register_options(register)
-    register('--retries', default=1, advanced=True,
+    register('--retries', type=int, default=1, advanced=True,
              help='How many times to retry when fetching meta tags.')
 
   _META_IMPORT_REGEX = re.compile(r"""


### PR DESCRIPTION
Prompted by a [CI failure](https://travis-ci.org/pantsbuild/pants/jobs/191847635) in #4183:
```
...
E   	  File "/home/travis/build/pantsbuild/pants/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py", line 61, in get_imported_repo
E   	    page_data = session.get('http://{import_path}?go-get=1'.format(import_path=import_path))
E   	  File "/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/requests/sessions.py", line 473, in get
E   	    return self.request('GET', url, **kwargs)
E   	  File "/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/requests/sessions.py", line 461, in request
E   	    resp = self.send(prep, **send_kwargs)
E   	  File "/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/requests/sessions.py", line 573, in send
E   	    r = adapter.send(request, **kwargs)
E   	  File "/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/requests/adapters.py", line 370, in send
E   	    timeout=timeout
E   	  File "/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py", line 597, in urlopen
E   	    _stacktrace=sys.exc_info()[2])
E   	  File "/home/travis/build/pantsbuild/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/requests/packages/urllib3/util/retry.py", line 226, in increment
E   	    total -= 1
E   	
E   	Exception message: unsupported operand type(s) for -=: 'str' and 'int'
...
```

Instances of the issue swept via:
```
$ git grep register | grep -E "default=[0-9]" | grep -v -E "type=(int|float)"
contrib/go/src/python/pants/contrib/go/subsystems/archive_retriever.py:    register('--retries', default=1, advanced=True,
contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py:    register('--retries', default=1, advanced=True,
```