### PR TITLE
Make open_zip print realpath when raising BadZipfile.

### DIFF
--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -169,7 +169,9 @@ def pushd(directory):
 
 @contextmanager
 def open_zip(path_or_file, *args, **kwargs):
-  """A with-context for zip files.  Passes through positional and kwargs to zipfile.ZipFile.
+  """A with-context for zip files.
+
+  Passes through *args and **kwargs to zipfile.ZipFile.
 
   :API: public
 

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -169,8 +169,7 @@ def pushd(directory):
 
 @contextmanager
 def open_zip(path_or_file, *args, **kwargs):
-  """
-  A with-context for zip files.  Passes through positional and kwargs to zipfile.ZipFile.
+  """A with-context for zip files.  Passes through positional and kwargs to zipfile.ZipFile.
 
   :API: public
 


### PR DESCRIPTION
### Problem
`contextutil.open_zip(fp)` is generally called on files under .pants.d, which
increasingly are symlinks.

In the motivating example, a jar was corrupted and could
not be opened by detect_duplicates task. The Exception was:

```
Exception message: Bad Zipfile
/buildroot/.pants.d/pom-resolve/pom-resolve/syms/org/some/corrupted.jar: File is not a zip file
```

The corrupted file is really at the realpath, and
neither cleaning nor deleting the symlink will help.

Also, it turns out that zipfile does not filter for falsey values
but instead bubbles up an AttributeError that is tough to traceback:
```
        # Determine file size
>       fpin.seek(0, 2)
E       AttributeError: 'NoneType' object has no attribute 'seek'
```
### Solution
* Check if open_zip is passed a falsey value, and return a custom subclass of
zipfile.BadZipfile created for that circumstance
* Provide the realpath of files that cause zipfile.BadZipfile to bubble up.

### Result
* If passed a falsey file path:
```
        if not path_or_file:
>       raise InvalidZipPath('{} is not a valid zip location'.format(path_or_file))
E       InvalidZipPath: Invalid zip location: None
```

* If passed a symlink to a corrupted archive:

It used to be:
```
    Exception message: Bad Zipfile
    /buildroot/.pants.d/pom-resolve/pom-resolve/syms/org/some/corrupted.jar: File is not a zip file
```
And now it says
```
    Exception message: Bad Zipfile
    ~/.m2/repository/org/some/corrupted.jar: File is not a zip file
```
