### PR TITLE
Bump pex version to 1.1.20

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ mock==1.3.0
 packaging==16.7
 pathspec==0.3.4
 pep8==1.6.2
-pex==1.1.17
+pex==1.1.20
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4


### PR DESCRIPTION
### Problem

Current pex version used by pants needs to pickup a handful of bugfixes.

### Solution

Bump to the latest pex release.

### Result

Features and bugfixes in 1.1.20 are realized.