### PR TITLE
Removes the slf4j implementation from the classpath when running Cobertura

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
@@ -55,8 +55,7 @@ class Cobertura(Coverage):
     register_jvm_tool(register,
                       'cobertura-run',
                       classpath=[
-                        cobertura_jar(intransitive=True),
-                        slf4j_jar
+                        cobertura_jar(intransitive=True)
                       ])
 
     register_jvm_tool(register, 'cobertura-report', classpath=[cobertura_jar()])

--- a/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
@@ -28,6 +28,7 @@ class Cobertura(Coverage):
   @classmethod
   def register_options(cls, register, register_jvm_tool):
     slf4j_jar = JarDependency(org='org.slf4j', name='slf4j-simple', rev='1.7.5')
+    slf4j_api_jar = JarDependency(org='org.slf4j', name='slf4j-api', rev='1.7.5')
 
     register('--coverage-cobertura-include-classes', advanced=True, type=list,
              help='Regex patterns passed to cobertura specifying which classes should be '
@@ -51,11 +52,12 @@ class Cobertura(Coverage):
                       ])
 
     # Instrumented code needs cobertura.jar in the classpath to run, but not most of the
-    # dependencies.
+    # dependencies; inject the SLF4J API so that Cobertura doesn't crash when it attempts to log
     register_jvm_tool(register,
                       'cobertura-run',
                       classpath=[
-                        cobertura_jar(intransitive=True)
+                        cobertura_jar(intransitive=True),
+                        slf4j_api_jar
                       ])
 
     register_jvm_tool(register, 'cobertura-report', classpath=[cobertura_jar()])


### PR DESCRIPTION
### Problem

The Cobertura plugin adds SLF4J to the classpath when generating code coverage; as a result it's not possible to run tests that depend on using their own slf4j implementation.

See #4197 

### Solution

Removed slf4j-simple from the Cobertura runtime classpath.

### Result

There is no slf4j implementation on the classpath when coverage is generate unless an implementation is added by the user.

If Cobertura fails then it's logging output will be directed to the SLF4J NOOP logging implementation (so it will fail silently).