### PR TITLE
Resolve only stable releases by default.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,12 @@ mock==1.3.0
 packaging==16.7
 pathspec==0.3.4
 pep8==1.6.2
+
 pex==1.2.0
+
+# TODO(John Sirois): Kill this dep - which satisfies pex needs - when pex internalises.
+packaging==16.8
+
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ mock==1.3.0
 packaging==16.7
 pathspec==0.3.4
 pep8==1.6.2
-pex==1.1.20
+pex==1.2.0
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -257,6 +257,7 @@ class PythonChroot(object):
         platform=platform,
         context=context,
         cache=requirements_cache_dir,
-        cache_ttl=self._python_setup.resolver_cache_ttl)
+        cache_ttl=self._python_setup.resolver_cache_ttl,
+        allow_prereleases=self._python_setup.resolver_allow_prereleases)
 
     return distributions

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -43,6 +43,8 @@ class PythonSetup(Subsystem):
              default=10 * 365 * 86400,  # 10 years.
              help='The time in seconds before we consider re-resolving an open-ended requirement, '
                   'e.g. "flask>=0.2" if a matching distribution is available on disk.')
+    register('--resolver-allow-prereleases', advanced=True, type=bool, default=False,
+             fingerprint=True, help='Whether to include pre-releases when resolving requirements.')
     register('--artifact-cache-dir', advanced=True, default=None, metavar='<dir>',
              help='The parent directory for the python artifact cache. '
                   'If unspecified, a standard path under the workdir is used.')
@@ -81,6 +83,10 @@ class PythonSetup(Subsystem):
   @property
   def resolver_cache_ttl(self):
     return self.get_options().resolver_cache_ttl
+
+  @property
+  def resolver_allow_prereleases(self):
+    return self.get_options().resolver_allow_prereleases
 
   @property
   def artifact_cache_dir(self):

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -151,6 +151,7 @@ class ResolveRequirements(Task):
           platform=None if platform == 'current' else platform,
           context=python_repos.get_network_context(),
           cache=requirements_cache_dir,
-          cache_ttl=python_setup.resolver_cache_ttl)
+          cache_ttl=python_setup.resolver_cache_ttl,
+          allow_prereleases=python_setup.resolver_allow_prereleases)
 
     return distributions


### PR DESCRIPTION
Upgrade to pex `1.2.0` to pickup control over pre-release resolution and
setup resolves to use only stable releases by default.

This closes #4196