### PR TITLE
Resolve only stable releases by default.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -9,10 +9,10 @@ isort==4.2.5
 lmdb==0.89
 Markdown==2.1.1
 mock==1.3.0
-packaging==16.7
+packaging==16.8
 pathspec==0.3.4
 pep8==1.6.2
-pex==1.1.20
+pex==1.2.1
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4

--- a/src/python/pants/backend/python/python_chroot.py
+++ b/src/python/pants/backend/python/python_chroot.py
@@ -257,6 +257,7 @@ class PythonChroot(object):
         platform=platform,
         context=context,
         cache=requirements_cache_dir,
-        cache_ttl=self._python_setup.resolver_cache_ttl)
+        cache_ttl=self._python_setup.resolver_cache_ttl,
+        allow_prereleases=self._python_setup.resolver_allow_prereleases)
 
     return distributions

--- a/src/python/pants/backend/python/python_setup.py
+++ b/src/python/pants/backend/python/python_setup.py
@@ -43,6 +43,8 @@ class PythonSetup(Subsystem):
              default=10 * 365 * 86400,  # 10 years.
              help='The time in seconds before we consider re-resolving an open-ended requirement, '
                   'e.g. "flask>=0.2" if a matching distribution is available on disk.')
+    register('--resolver-allow-prereleases', advanced=True, type=bool, default=False,
+             fingerprint=True, help='Whether to include pre-releases when resolving requirements.')
     register('--artifact-cache-dir', advanced=True, default=None, metavar='<dir>',
              help='The parent directory for the python artifact cache. '
                   'If unspecified, a standard path under the workdir is used.')
@@ -81,6 +83,10 @@ class PythonSetup(Subsystem):
   @property
   def resolver_cache_ttl(self):
     return self.get_options().resolver_cache_ttl
+
+  @property
+  def resolver_allow_prereleases(self):
+    return self.get_options().resolver_allow_prereleases
 
   @property
   def artifact_cache_dir(self):

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -151,6 +151,7 @@ class ResolveRequirements(Task):
           platform=None if platform == 'current' else platform,
           context=python_repos.get_network_context(),
           cache=requirements_cache_dir,
-          cache_ttl=python_setup.resolver_cache_ttl)
+          cache_ttl=python_setup.resolver_cache_ttl,
+          allow_prereleases=python_setup.resolver_allow_prereleases)
 
     return distributions

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -71,6 +71,7 @@ python_library(
     'src/python/pants/subsystem:subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
+    'src/python/pants:version',
   ]
 )
 

--- a/src/python/pants/bin/plugin_resolver.py
+++ b/src/python/pants/bin/plugin_resolver.py
@@ -24,7 +24,7 @@ from pants.option.global_options import GlobalOptionsRegistrar
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import safe_open
 from pants.util.memo import memoized_property
-
+from pants.version import PANTS_SEMVER
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,8 @@ class PluginResolver(object):
                             context=self._python_repos.get_network_context(),
                             precedence=precedence,
                             cache=self.plugin_cache_dir,
-                            cache_ttl=self._python_setup.resolver_cache_ttl)
+                            cache_ttl=self._python_setup.resolver_cache_ttl,
+                            allow_prereleases=PANTS_SEMVER.is_prerelease)
 
   @memoized_property
   def plugin_cache_dir(self):


### PR DESCRIPTION
Upgrade to pex `1.2.1` to pickup control over pre-release resolution and
setup resolves to use only stable releases by default.

Closes #4196