### PR TITLE
Simplify ci script test running stanzas.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -167,7 +167,8 @@ fi
 if [[ "${skip_internal_backends:-false}" == "false" ]]; then
   banner "Running internal backend python tests"
   (
-    ./pants.pex ${PANTS_ARGS[@]} test.pytest pants-plugins/tests/python::
+    ./pants.pex ${PANTS_ARGS[@]} test.pytest --compile-python-eval-skip \
+    pants-plugins/tests/python::
   ) || die "Internal backend python test failure"
 fi
 
@@ -180,6 +181,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     ./pants.pex --tag='-integration' ${PANTS_ARGS[@]} test.pytest \
       --coverage=paths:pants/ \
       --test-pytest-test-shard=${python_unit_shard} \
+      --compile-python-eval-skip \
       tests/python::
   ) || die "Core python test failure"
 fi
@@ -192,7 +194,9 @@ if [[ "${skip_contrib:-false}" == "false" ]]; then
     # TODO(John Sirois): Get to the bottom of the issue and kill --no-fast, see:
     #  https://github.com/pantsbuild/pants/issues/1149
     ./pants.pex ${PANTS_ARGS[@]} --exclude-target-regexp='.*/testprojects/.*' \
-    --build-ignore=$SKIP_ANDROID_PATTERN test.pytest --no-fast contrib::
+    --build-ignore=$SKIP_ANDROID_PATTERN test.pytest --no-fast \
+    --compile-python-eval-skip \
+    contrib:: \
   ) || die "Contrib python test failure"
 fi
 
@@ -203,6 +207,7 @@ if [[ "${skip_integration:-false}" == "false" ]]; then
   banner "Running Pants Integration tests${shard_desc}"
   (
     ./pants.pex ${PANTS_ARGS[@]} --tag='+integration' test.pytest \
+      --compile-python-eval-skip \
       --test-pytest-test-shard=${python_intg_shard} \
       tests/python::
   ) || die "Pants Integration test failure"

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -167,11 +167,7 @@ fi
 if [[ "${skip_internal_backends:-false}" == "false" ]]; then
   banner "Running internal backend python tests"
   (
-    targets=$(
-      ./pants.pex list pants-plugins/tests/python:: | \
-      xargs ./pants.pex filter --filter-type=python_tests
-    ) && \
-    ./pants.pex ${PANTS_ARGS[@]} test.pytest ${targets}
+    ./pants.pex ${PANTS_ARGS[@]} test.pytest pants-plugins/tests/python::
   ) || die "Internal backend python test failure"
 fi
 
@@ -181,14 +177,10 @@ if [[ "${skip_python:-false}" == "false" ]]; then
   fi
   banner "Running core python tests${shard_desc}"
   (
-    targets=$(
-      ./pants.pex list tests/python:: | \
-      xargs ./pants.pex --tag='-integration' filter --filter-type=python_tests
-    ) && \
-    ./pants.pex ${PANTS_ARGS[@]} test.pytest \
+    ./pants.pex --tag='-integration' ${PANTS_ARGS[@]} test.pytest \
       --coverage=paths:pants/ \
       --test-pytest-test-shard=${python_unit_shard} \
-      ${targets}
+      tests/python::
   ) || die "Core python test failure"
 fi
 
@@ -199,7 +191,8 @@ if [[ "${skip_contrib:-false}" == "false" ]]; then
     # test (ie: pants_test.contrib) namespace packages.
     # TODO(John Sirois): Get to the bottom of the issue and kill --no-fast, see:
     #  https://github.com/pantsbuild/pants/issues/1149
-    ./pants.pex ${PANTS_ARGS[@]}  --exclude-target-regexp='.*/testprojects/.*' --build-ignore=$SKIP_ANDROID_PATTERN test.pytest --no-fast contrib::
+    ./pants.pex ${PANTS_ARGS[@]} --exclude-target-regexp='.*/testprojects/.*' \
+    --build-ignore=$SKIP_ANDROID_PATTERN test.pytest --no-fast contrib::
   ) || die "Contrib python test failure"
 fi
 
@@ -209,11 +202,9 @@ if [[ "${skip_integration:-false}" == "false" ]]; then
   fi
   banner "Running Pants Integration tests${shard_desc}"
   (
-    targets=$(
-      ./pants.pex list tests/python:: | \
-      xargs ./pants.pex --tag='+integration' filter --filter-type=python_tests
-    ) && \
-    ./pants.pex ${PANTS_ARGS[@]} test.pytest --test-pytest-test-shard=${python_intg_shard} ${targets}
+    ./pants.pex ${PANTS_ARGS[@]} --tag='+integration' test.pytest \
+      --test-pytest-test-shard=${python_intg_shard} \
+      tests/python::
   ) || die "Pants Integration test failure"
 fi
 

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -56,6 +56,7 @@ python_library(
   sources=['fs.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    ':selectors',
     'src/python/pants/base:project_tree',
     'src/python/pants/source',
     'src/python/pants/util:meta',
@@ -131,6 +132,7 @@ python_library(
   sources=['parser.py'],
   dependencies=[
     '3rdparty/python:six',
+    ':addressable',
     ':objects',
     'src/python/pants/build_graph',
     'src/python/pants/util:memo',

--- a/tests/python/pants_test/engine/examples/BUILD
+++ b/tests/python/pants_test/engine/examples/BUILD
@@ -62,6 +62,7 @@ python_library(
     'src/python/pants/engine:engine',
     'src/python/pants/engine:scheduler',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:desktop',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
@@ -81,3 +82,4 @@ python_binary(
     ':visualizer'
   ]
 )
+


### PR DESCRIPTION
The xargs thing should be unnecessary: the --tags= filter can
be applied in the test run itself, and there should be no need
to filter by target type - we don't expect to find much other
than python_tests in those dirs, and in any case the test running
task will ignore targets it doesn't know how to handle.

WEIRD: This change actually slows the CI down by 10% or so.
I can't see why this would be true, any ideas? I would have thought
it would speed things up (running pants in an xargs loops is hideously
slow on my laptop at least). Obviously I don't want to merge this until 
that's addressed.  Was something like this already tried and
abandoned?

