### PR TITLE
Require dev-suffixed deprecation versions

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
@@ -68,11 +68,6 @@ class FetcherFactory(Subsystem):
                   "'master' for git.\n"
                   "2. An integer indicating the number of leading path components to strip from "
                   "files upacked from the archive.")
-    register('--prefixes', metavar='<paths>', type=list, advanced=True,
-             fromfile=True, default=[],
-             removal_version='1.2.0',
-             removal_hint='Remove this option from pants.ini.  It does nothing now.',
-             help="Does nothing.")
 
   def get_fetcher(self, import_path):
     for matcher, unexpanded_url_info in self._matchers:

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fetch.py
@@ -33,10 +33,7 @@ class GoFetch(GoTask):
 
   @classmethod
   def register_options(cls, register):
-    register('--skip-meta-tag-resolution', advanced=True, type=bool, default=False,
-             removal_version='1.2.0',
-             removal_hint='Use --disallow-cloning-fetcher on scope go-fetchers instead.',
-             help='Whether to ignore meta tag resolution when resolving remote libraries.')
+    pass
 
   @property
   def cache_target_dirs(self):

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -72,7 +72,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 class DeprecatedJavaTests(JUnitTests):
   def __init__(self, *args, **kwargs):
     super(DeprecatedJavaTests, self).__init__(*args, **kwargs)
-    warn_or_error('1.4.0',
+    warn_or_error('1.4.0.dev0',
                   'java_tests(...) target type',
                   'Use junit_tests(...) instead for target {}.'.format(self.address.spec))
 

--- a/src/python/pants/backend/jvm/targets/java_tests.py
+++ b/src/python/pants/backend/jvm/targets/java_tests.py
@@ -11,7 +11,7 @@ from pants.base.deprecated import warn_or_error
 
 # Warn if any code imports this module.
 # There's a separate deprecation warning in register.py for targets that use the old alias.
-warn_or_error('1.4.0',
+warn_or_error('1.4.0.dev0',
               'pants.backend.jvm.targets.java_tests.JavaTests',
               'Use pants.backend.jvm.targets.junit_tests.JUnitTests instead.')
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -160,7 +160,7 @@ class BaseZincCompile(JvmCompile):
     register('--name-hashing', advanced=True, type=bool, fingerprint=True,
              removal_hint='Name hashing is required for operation in zinc 1.0.0-X: this '
                           'option no longer has any effect.',
-             removal_version='1.4.0',
+             removal_version='1.4.0.dev0',
              help='Use zinc name hashing.')
     register('--whitelisted-args', advanced=True, type=dict,
              default={

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -27,6 +27,10 @@ class BadRemovalVersionError(DeprecationApplicationError):
   """Indicates the supplied removal_version was not a valid semver string."""
 
 
+class NonDevRemovalVersionError(DeprecationApplicationError):
+  """Indicates the supplied removal_version was not a pre-release version."""
+
+
 class CodeRemovedError(Exception):
   """Indicates that the removal_version is not in the future.
 
@@ -64,8 +68,12 @@ def validate_removal_semver(removal_version):
     # We explicitly want our versions to be of the form x.y.z.
     v = Version(removal_version)
     if len(v.base_version.split('.')) != 3:
-      raise BadRemovalVersionError('The given removal version {} is not a valid version: '
-                                   '{}'.format(removal_version, removal_version))
+      raise BadRemovalVersionError('The given removal version is not a valid version: '
+                                   '{}'.format(removal_version))
+    if not v.is_prerelease:
+      raise NonDevRemovalVersionError('The given removal version is not a dev version: {}\n'
+                                      'Features should generally be removed in the first `dev` release '
+                                      'of a release cycle.'.format(removal_version))
     return v
   except InvalidVersion as e:
     raise BadRemovalVersionError('The given removal version {} is not a valid version: '

--- a/src/python/pants/build_graph/prep_command.py
+++ b/src/python/pants/build_graph/prep_command.py
@@ -70,7 +70,7 @@ class PrepCommand(Target):
     if goals:
       goals = sorted(goals)
     elif goal:
-      warn_or_error('1.5.0', 'goal', hint='Use `goals=[{!r}]` instead.'.format(goal))
+      warn_or_error('1.5.0.dev0', 'goal', hint='Use `goals=[{!r}]` instead.'.format(goal))
       goals = [goal]
     else:
       goals = ['test']

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -151,7 +151,7 @@ class Target(AbstractTarget):
 
     options_scope = 'target-arguments'
     deprecated_options_scope = 'unknown-arguments'
-    deprecated_options_scope_removal_version = '1.4.0'
+    deprecated_options_scope_removal_version = '1.4.0.dev0'
 
     @classmethod
     def register_options(cls, register):

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -255,7 +255,7 @@ class CacheFactory(object):
 
     deprecated_conditional(
         lambda: compression == 0,
-        '1.4.0',
+        '1.4.0.dev0',
         'compression==0',
         'The artifact cache depends on gzip compression for checksumming: a compression level '
         '==0 disables compression, and can prevent detection of corrupted artifacts.'

--- a/src/python/pants/core_tasks/deferred_sources_mapper.py
+++ b/src/python/pants/core_tasks/deferred_sources_mapper.py
@@ -52,7 +52,7 @@ class DeferredSourcesMapper(Task):
   @classmethod
   def register_options(cls, register):
     register('--allow-from-target', default=True, type=bool,
-             removal_hint='from_target was removed in 1.3.0', removal_version='1.5.0',
+             removal_hint='from_target was removed in 1.3.0', removal_version='1.5.0.dev0',
              help='This option has no effect, because from_target has been removed.')
 
   def process_remote_sources(self):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -166,7 +166,7 @@ class GlobalOptionsRegistrar(Optionable):
     rel_distdir = '/{}/'.format(os.path.relpath(register.bootstrap.pants_distdir, get_buildroot()))
     register('--ignore-patterns', advanced=True, type=list, fromfile=True,
              default=['.*', rel_distdir, 'bower_components', 'node_modules', '*.egg-info'],
-             removal_version='1.3.0', removal_hint='Use --build-ignore instead.',
+             removal_version='1.4.0.dev0', removal_hint='Use --build-ignore instead.',
              mutually_exclusive_group='build_ignore', help='See help for --build-ignore.')
     register('--build-ignore', advanced=True, type=list, fromfile=True,
              default=['.*', rel_distdir, 'bower_components', 'node_modules', '*.egg-info'],

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -166,7 +166,7 @@ class GlobalOptionsRegistrar(Optionable):
     rel_distdir = '/{}/'.format(os.path.relpath(register.bootstrap.pants_distdir, get_buildroot()))
     register('--ignore-patterns', advanced=True, type=list, fromfile=True,
              default=['.*', rel_distdir, 'bower_components', 'node_modules', '*.egg-info'],
-             removal_version='1.4.0.dev0', removal_hint='Use --build-ignore instead.',
+             removal_version='1.3.0.dev0', removal_hint='Use --build-ignore instead.',
              mutually_exclusive_group='build_ignore', help='See help for --build-ignore.')
     register('--build-ignore', advanced=True, type=list, fromfile=True,
              default=['.*', rel_distdir, 'bower_components', 'node_modules', '*.egg-info'],

--- a/testprojects/src/python/plugins/dummy_options/tasks/dummy_options.py
+++ b/testprojects/src/python/plugins/dummy_options/tasks/dummy_options.py
@@ -17,8 +17,8 @@ class DummyOptionsTask(Task):
   @classmethod
   def register_options(cls, register):
     super(DummyOptionsTask, cls).register_options(register)
-    register('--dummy-crufty-expired', removal_version='0.0.1',
+    register('--dummy-crufty-expired', removal_version='0.0.1.dev0',
                 removal_hint='blah')
-    register('--dummy-crufty-deprecated-but-still-functioning', removal_version='999.99.9',
+    register('--dummy-crufty-deprecated-but-still-functioning', removal_version='999.99.9.dev0',
                 removal_hint='blah')
     register('--normal-option')

--- a/tests/python/pants_test/base/test_deprecated.py
+++ b/tests/python/pants_test/base/test_deprecated.py
@@ -10,13 +10,14 @@ import warnings
 from contextlib import contextmanager
 
 from pants.base.deprecated import (BadDecoratorNestingError, BadRemovalVersionError,
-                                   CodeRemovedError, MissingRemovalVersionError, deprecated,
-                                   deprecated_conditional, deprecated_module, warn_or_error)
+                                   CodeRemovedError, MissingRemovalVersionError,
+                                   NonDevRemovalVersionError, deprecated, deprecated_conditional,
+                                   deprecated_module, warn_or_error)
 from pants.version import VERSION
 
 
 class DeprecatedTest(unittest.TestCase):
-  FUTURE_VERSION = '9999.9.9'
+  FUTURE_VERSION = '9999.9.9.dev0'
 
   @contextmanager
   def _test_deprecation(self, deprecation_expected=True):
@@ -132,6 +133,12 @@ class DeprecatedTest(unittest.TestCase):
       def test_func1a():
         pass
 
+  def test_removal_version_non_dev(self):
+    with self.assertRaises(NonDevRemovalVersionError):
+      @deprecated('1.0.0')
+      def test_func1a():
+        pass
+
   def test_removal_version_same(self):
     with self.assertRaises(CodeRemovedError):
       warn_or_error(VERSION, 'dummy description')
@@ -144,9 +151,9 @@ class DeprecatedTest(unittest.TestCase):
 
   def test_removal_version_lower(self):
     with self.assertRaises(CodeRemovedError):
-      warn_or_error('0.0.27', 'dummy description')
+      warn_or_error('0.0.27.dev0', 'dummy description')
 
-    @deprecated('0.0.27')
+    @deprecated('0.0.27.dev0')
     def test_func():
       pass
     with self.assertRaises(CodeRemovedError):

--- a/tests/python/pants_test/option/BUILD
+++ b/tests/python/pants_test/option/BUILD
@@ -11,6 +11,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:base_test',
   ],
+  timeout=30,
 )
 
 python_tests(
@@ -23,4 +24,5 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
+  timeout=90,
 )

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -100,11 +100,11 @@ class OptionsTest(unittest.TestCase):
     register_global('--b', type=int, recursive=True)
 
     # Deprecated global options
-    register_global('--global-crufty', removal_version='999.99.9',
+    register_global('--global-crufty', removal_version='999.99.9.dev0',
                     removal_hint='use a less crufty global option')
-    register_global('--global-crufty-boolean', type=bool, removal_version='999.99.9',
+    register_global('--global-crufty-boolean', type=bool, removal_version='999.99.9.dev0',
                       removal_hint='say no to crufty global options')
-    register_global('--global-crufty-expired', removal_version='0.0.1',
+    register_global('--global-crufty-expired', removal_version='0.0.1.dev0',
                     removal_hint='use a less crufty global option')
 
     # Mutual Exclusive options
@@ -121,10 +121,10 @@ class OptionsTest(unittest.TestCase):
     # Test deprecated options with a scope
     options.register('stale', '--still-good')
     options.register('stale', '--crufty',
-                     removal_version='999.99.9',
+                     removal_version='999.99.9.dev0',
                      removal_hint='use a less crufty stale scoped option')
     options.register('stale', '--crufty-boolean', type=bool,
-                     removal_version='999.99.9',
+                     removal_version='999.99.9.dev0',
                      removal_hint='say no to crufty, stale scoped options')
 
     # Test mutual exclusive options with a scope
@@ -1185,13 +1185,13 @@ class OptionsTest(unittest.TestCase):
       options_scope = 'new-scope1'
       options_scope_category = ScopeInfo.SUBSYSTEM
       deprecated_options_scope = 'deprecated-scope'
-      deprecated_options_scope_removal_version = '9999.9.9'
+      deprecated_options_scope_removal_version = '9999.9.9.dev0'
 
     class DummyOptionable2(Optionable):
       options_scope = 'new-scope2'
       options_scope_category = ScopeInfo.SUBSYSTEM
       deprecated_options_scope = 'deprecated-scope'
-      deprecated_options_scope_removal_version = '9999.9.9'
+      deprecated_options_scope_removal_version = '9999.9.9.dev0'
 
     options = Options.create(env={},
                              config=self._create_config({

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -19,7 +19,7 @@ _deprecation_msg = ("Use the for_subsystems and options arguments to BaseTest.co
                     "the methods init_subsystem(), global_subsystem_instance() in this module.")
 
 
-@deprecated('1.4.0', _deprecation_msg)
+@deprecated('1.4.0.dev0', _deprecation_msg)
 def create_subsystem(subsystem_type, scope='test-scope', **options):
   """Creates a Subsystem for test.
 
@@ -39,7 +39,7 @@ def create_subsystem(subsystem_type, scope='test-scope', **options):
 
 
 @contextmanager
-@deprecated('1.4.0', _deprecation_msg)
+@deprecated('1.4.0.dev0', _deprecation_msg)
 def subsystem_instance(subsystem_type, scope=None, **options):
   """Creates a Subsystem instance for test.
 


### PR DESCRIPTION
### Problem

Removing code in a stable release is risky, and generally defers code removal longer than is necessary. See #4162

### Solution

Require that deprecation versions be pre-release (generally, `dev`) releases, and fix existing instances by bumping them forward.