### PR TITLE
New python repl task.

### DIFF
--- a/examples/src/python/example/hello/greet/greet.py
+++ b/examples/src/python/example/hello/greet/greet.py
@@ -10,4 +10,4 @@ from colors import green
 
 def greet(greetee):
   """Given the name, return a greeting for a person of that name."""
-  return green('Hello, %s!' % greetee)
+  return green('Hello, {}!'.format(greetee))

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -14,6 +14,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.python_repl import PythonRepl as PythonRepl2
 from pants.backend.python.tasks2.python_run import PythonRun as PythonRun2
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
@@ -61,3 +62,4 @@ def register_goals():
   task(name='requirements', action=ResolveRequirements).install('pyprep')
   task(name='sources', action=GatherSources).install('pyprep')
   task(name='py', action=PythonRun2).install('run2')
+  task(name='py', action=PythonRepl2).install('repl2')

--- a/src/python/pants/backend/python/tasks2/BUILD
+++ b/src/python/pants/backend/python/tasks2/BUILD
@@ -8,11 +8,9 @@ python_library(
     'src/python/pants/backend/python:interpreter_cache',
     'src/python/pants/backend/python:python_setup',
     'src/python/pants/backend/python/targets',
-    'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/build_graph',
     'src/python/pants/invalidation',
     'src/python/pants/task',
-    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
   ]
 )

--- a/src/python/pants/backend/python/tasks2/BUILD
+++ b/src/python/pants/backend/python/tasks2/BUILD
@@ -9,6 +9,7 @@ python_library(
     'src/python/pants/backend/python:python_setup',
     'src/python/pants/backend/python/targets',
     'src/python/pants/base:fingerprint_strategy',
+    'src/python/pants/build_graph',
     'src/python/pants/invalidation',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',

--- a/src/python/pants/backend/python/tasks2/gather_sources.py
+++ b/src/python/pants/backend/python/tasks2/gather_sources.py
@@ -51,13 +51,11 @@ class GatherSources(Task):
       else:
         target_set_id = 'no_targets'
 
-      path = os.path.join(self.workdir, target_set_id)
-      path_tmp = path + '.tmp'
-
-      shutil.rmtree(path_tmp, ignore_errors=True)
-
       interpreter = self.context.products.get_data(PythonInterpreter)
+      path = os.path.join(self.workdir, target_set_id)
       if not os.path.isdir(path):
+        path_tmp = path + '.tmp'
+        shutil.rmtree(path_tmp, ignore_errors=True)
         self._build_pex(interpreter, path_tmp, invalidation_check.all_vts)
         shutil.move(path_tmp, path)
 

--- a/src/python/pants/backend/python/tasks2/gather_sources.py
+++ b/src/python/pants/backend/python/tasks2/gather_sources.py
@@ -53,6 +53,8 @@ class GatherSources(Task):
 
       interpreter = self.context.products.get_data(PythonInterpreter)
       path = os.path.join(self.workdir, target_set_id)
+
+      # Note that we check for the existence of the directory, instead of for invalid_vts, to cover the empty case.
       if not os.path.isdir(path):
         path_tmp = path + '.tmp'
         shutil.rmtree(path_tmp, ignore_errors=True)

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+from copy import copy
+
+from pex.interpreter import PythonInterpreter
+from pex.pex import PEX
+from pex.pex_builder import PEXBuilder
+
+from pants.backend.python.python_requirement import PythonRequirement
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
+from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
+from pants.build_graph.address import Address
+
+
+class WrappedPEX(object):
+  """Wrapper around a PEX that exposes only its run() method.
+
+  Allows us to set the PEX_PATH in the environment when running.
+  """
+
+  def __init__(self, pex, extra_pex_paths, interpreter):
+    self._pex = pex
+    self._extra_pex_paths = extra_pex_paths
+    self._interpreter = interpreter
+
+  @property
+  def interpreter(self):
+    return self._interpreter
+
+  def run(self, *args, **kwargs):
+    kwargs_copy = copy(kwargs)
+    env = copy(kwargs_copy.get('env')) if 'env' in kwargs_copy else {}
+    env['PEX_PATH'] = self._extra_pex_paths
+    kwargs_copy['env'] = env
+    return self._pex.run(*args, **kwargs_copy)
+
+  def path(self):
+    return self._pex.path()
+
+
+class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
+  """Base class for tasks that execute user Python code in a PEX environment.
+
+  Note: Extends ResolveRequirementsTaskBase because it may need to resolve
+  extra requirements in order to execute the code.
+  """
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    round_manager.require_data(PythonInterpreter)
+    round_manager.require_data(ResolveRequirements.REQUIREMENTS_PEX)
+    round_manager.require_data(GatherSources.PYTHON_SOURCES)
+
+  def extra_requirements(self):
+    """Override to provide extra requirements needed for execution.
+
+    Must return a list of pip-style requirement strings.
+    """
+    return []
+
+  def create_pex(self, path, pex_info):
+    """Returns a wrapped pex that "merges" the other pexes via PEX_PATH."""
+    interpreter = self.context.products.get_data(PythonInterpreter)
+    builder = PEXBuilder(path, interpreter, pex_info=pex_info)
+    builder.freeze()
+
+    pexes = [
+      self.context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX),
+      self.context.products.get_data(GatherSources.PYTHON_SOURCES)
+    ]
+
+    if self.extra_requirements():
+      extra_reqs = [PythonRequirement(req_str) for req_str in self.extra_requirements()]
+      addr = Address.parse('{}_extra_reqs'.format(self.__class__.__name__))
+      self.context.build_graph.inject_synthetic_target(
+        addr, PythonRequirementLibrary, requirements=extra_reqs)
+      # Add the extra requirements first, so they take precedence over any colliding version
+      # in the target set's dependency closure.
+      pexes = [self.resolve_requirements([self.context.build_graph.get_target(addr)])] + pexes
+
+    extra_pex_paths = os.pathsep.join([pex.path() for pex in pexes])
+    return WrappedPEX(PEX(path, interpreter), extra_pex_paths, interpreter)

--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -1,11 +1,9 @@
 # coding=utf-8
-# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
-
-import tempfile
 
 from pex.pex_info import PexInfo
 
@@ -13,10 +11,10 @@ from pants.backend.python.targets.python_requirement_library import PythonRequir
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
 from pants.task.repl_task_mixin import ReplTaskMixin
-from pants.util.dirutil import safe_rmtree
 
 
 class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
+  """Launch an interactive Python interpreter session."""
 
   @classmethod
   def register_options(cls, register):
@@ -41,17 +39,15 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
       return []
 
   def setup_repl_session(self, targets):
-    tmpdir = tempfile.mkdtemp()
     if self.get_options().ipython:
       entry_point = self.get_options().ipython_entry_point
     else:
       entry_point = 'code:interact'
     pex_info = PexInfo.default()
     pex_info.entry_point = entry_point
-    return self.create_pex(tmpdir, pex_info)
+    return self.create_pex(pex_info)
 
   # NB: **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):
     po = pex.run(blocking=False, **pex_run_kwargs)
     po.wait()
-    safe_rmtree(pex.path())

--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import tempfile
+
+from pex.pex_info import PexInfo
+
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.targets.python_target import PythonTarget
+from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
+from pants.task.repl_task_mixin import ReplTaskMixin
+from pants.util.dirutil import safe_rmtree
+
+
+class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
+
+  @classmethod
+  def register_options(cls, register):
+    super(PythonRepl, cls).register_options(register)
+    # TODO: Create a python equivalent of register_jvm_tool, and use that instead of these
+    # ad-hoc options.
+    register('--ipython', type=bool,
+             help='Run an IPython REPL instead of the standard python one.')
+    register('--ipython-entry-point', advanced=True, default='IPython:start_ipython',
+             help='The IPython REPL entry point.')
+    register('--ipython-requirements', advanced=True, type=list, default=['ipython==1.0.0'],
+             help='The IPython interpreter version to use.')
+
+  @classmethod
+  def select_targets(cls, target):
+    return isinstance(target, (PythonTarget, PythonRequirementLibrary))
+
+  def extra_requirements(self):
+    if self.get_options().ipython:
+      return [self.get_options().ipython_requirements]
+    else:
+      return []
+
+  def setup_repl_session(self, targets):
+    tmpdir = tempfile.mkdtemp()
+    if self.get_options().ipython:
+      entry_point = self.get_options().ipython_entry_point
+    else:
+      entry_point = 'code:interact'
+    pex_info = PexInfo.default()
+    pex_info.entry_point = entry_point
+    return self.create_pex(tmpdir, pex_info)
+
+  # NB: **pex_run_kwargs is used by tests only.
+  def launch_repl(self, pex, **pex_run_kwargs):
+    po = pex.run(blocking=False, **pex_run_kwargs)
+    po.wait()
+    safe_rmtree(pex.path())

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -11,7 +11,6 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.util.contextutil import temporary_dir
 from pants.util.strutil import safe_shlex_split
 
 
@@ -33,24 +32,23 @@ class PythonRun(PythonExecutionTaskBase):
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
       # TODO(benjy): Use MutexTask to coordinate this.
 
-      with temporary_dir() as tmpdir:
-        pex = self.create_pex(tmpdir, binary.pexinfo)
-        self.context.release_lock()
-        with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
-          args = []
-          for arg in self.get_options().args:
-            args.extend(safe_shlex_split(arg))
-          args += self.get_passthru_args()
-          po = pex.run(blocking=False, args=args)
-          try:
-            result = po.wait()
-            if result != 0:
-              msg = '{interpreter} {entry_point} {args} ... exited non-zero ({code})'.format(
-                  interpreter=pex.interpreter.binary,
-                  entry_point=binary.entry_point,
-                  args=' '.join(args),
-                  code=result)
-              raise TaskError(msg, exit_code=result)
-          except KeyboardInterrupt:
-            po.send_signal(signal.SIGINT)
-            raise
+      pex = self.create_pex(binary.pexinfo)
+      self.context.release_lock()
+      with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
+        args = []
+        for arg in self.get_options().args:
+          args.extend(safe_shlex_split(arg))
+        args += self.get_passthru_args()
+        po = pex.run(blocking=False, args=args)
+        try:
+          result = po.wait()
+          if result != 0:
+            msg = '{interpreter} {entry_point} {args} ... exited non-zero ({code})'.format(
+                interpreter=pex.interpreter.binary,
+                entry_point=binary.entry_point,
+                args=' '.join(args),
+                code=result)
+            raise TaskError(msg, exit_code=result)
+        except KeyboardInterrupt:
+          po.send_signal(signal.SIGINT)
+          raise

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -5,24 +5,17 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
 import signal
 
-from pex.interpreter import PythonInterpreter
-from pex.pex import PEX
-from pex.pex_builder import PEXBuilder
-
 from pants.backend.python.targets.python_binary import PythonBinary
-from pants.backend.python.tasks2.gather_sources import GatherSources
-from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
+from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.task.task import Task
 from pants.util.contextutil import temporary_dir
 from pants.util.strutil import safe_shlex_split
 
 
-class PythonRun(Task):
+class PythonRun(PythonExecutionTaskBase):
 
   @classmethod
   def register_options(cls, register):
@@ -33,46 +26,27 @@ class PythonRun(Task):
   def supports_passthru_args(cls):
     return True
 
-  @classmethod
-  def prepare(cls, options, round_manager):
-    round_manager.require_data(PythonInterpreter)
-    round_manager.require_data(ResolveRequirements.REQUIREMENTS_PEX)
-    round_manager.require_data(GatherSources.PYTHON_SOURCES)
-
   def execute(self):
     binary = self.require_single_root_target()
     if isinstance(binary, PythonBinary):
       # We can't throw if binary isn't a PythonBinary, because perhaps we were called on a
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
       # TODO(benjy): Use MutexTask to coordinate this.
-      interpreter = self.context.products.get_data(PythonInterpreter)
 
       with temporary_dir() as tmpdir:
-        # Create a wrapper pex to "merge" the other pexes into via PEX_PATH.
-        builder = PEXBuilder(tmpdir, interpreter, pex_info=binary.pexinfo)
-        builder.freeze()
-
-        pexes = [self.context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX),
-                 self.context.products.get_data(GatherSources.PYTHON_SOURCES)]
-
-        # TODO: Expose the path as a property in pex, instead of relying on
-        # fishing it out of the cmdline.
-        pex_path = os.pathsep.join([pex.cmdline()[1] for pex in pexes])
-
-        pex = PEX(tmpdir, interpreter)
-
+        pex = self.create_pex(tmpdir, binary.pexinfo)
         self.context.release_lock()
         with self.context.new_workunit(name='run', labels=[WorkUnitLabel.RUN]):
           args = []
           for arg in self.get_options().args:
             args.extend(safe_shlex_split(arg))
           args += self.get_passthru_args()
-          po = pex.run(blocking=False, args=args, env={'PEX_PATH': pex_path})
+          po = pex.run(blocking=False, args=args)
           try:
             result = po.wait()
             if result != 0:
               msg = '{interpreter} {entry_point} {args} ... exited non-zero ({code})'.format(
-                  interpreter=interpreter.binary,
+                  interpreter=pex.interpreter.binary,
                   entry_point=binary.entry_point,
                   args=' '.join(args),
                   code=result)

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -15,6 +15,7 @@ from pants.util.strutil import safe_shlex_split
 
 
 class PythonRun(PythonExecutionTaskBase):
+  """Run a Python executable."""
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -10,6 +10,7 @@ from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRe
 
 
 class ResolveRequirements(ResolveRequirementsTaskBase):
+  """Resolve external Python requirements."""
   REQUIREMENTS_PEX = 'python_requirements_pex'
 
   @classmethod

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -5,153 +5,18 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-import shutil
-
-from pex.fetcher import Fetcher
-from pex.interpreter import PythonInterpreter
-from pex.pex import PEX
-from pex.pex_builder import PEXBuilder
-from pex.platforms import Platform
-from pex.resolver import resolve
-from twitter.common.collections import OrderedSet
-
-from pants.backend.python.python_setup import PythonRepos, PythonSetup
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-from pants.base.fingerprint_strategy import (DefaultFingerprintHashingMixin,
-                                             TaskIdentityFingerprintStrategy)
-from pants.invalidation.cache_manager import VersionedTargetSet
-from pants.task.task import Task
+from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
 
 
-class PythonRequirementFingerprintStrategy(DefaultFingerprintHashingMixin,
-                                           TaskIdentityFingerprintStrategy):
-
-  def compute_fingerprint(self, req_lib):
-    hash_elements_for_target = []
-    hash_elements_for_target.extend([req.cache_key() for req in req_lib.requirements])
-    if not hash_elements_for_target:
-      return None
-    hasher = self._build_hasher(req_lib)
-    for element in hash_elements_for_target:
-      hasher.update(element)
-    return hasher.hexdigest()
-
-
-class ResolveRequirements(Task):
-  """Resolve 3rd-party Python requirements.
-
-  Creates an (unzipped) PEX on disk containing all the resolved requirements.
-  This PEX can be merged with source PEXes to create a unified Python environment
-  for running the relevant python code.
-  """
-
+class ResolveRequirements(ResolveRequirementsTaskBase):
   REQUIREMENTS_PEX = 'python_requirements_pex'
 
   @classmethod
   def product_types(cls):
     return [cls.REQUIREMENTS_PEX]
 
-  @classmethod
-  def subsystem_dependencies(cls):
-    return super(ResolveRequirements, cls).subsystem_dependencies() + (PythonSetup, PythonRepos)
-
-  @classmethod
-  def prepare(cls, options, round_manager):
-    round_manager.require_data(PythonInterpreter)
-
   def execute(self):
     req_libs = self.context.targets(lambda tgt: isinstance(tgt, PythonRequirementLibrary))
-    fs = PythonRequirementFingerprintStrategy(task=self)
-    with self.invalidated(req_libs, fingerprint_strategy=fs) as invalidation_check:
-      # If there are no relevant targets, we still go through the motions of resolving
-      # an empty set of requirements, to prevent downstream tasks from having to check
-      # for this special case.
-      if invalidation_check.all_vts:
-        target_set_id = VersionedTargetSet.from_versioned_targets(
-            invalidation_check.all_vts).cache_key.hash
-      else:
-        target_set_id = 'no_targets'
-
-      interpreter = self.context.products.get_data(PythonInterpreter)
-      path = os.path.join(self.workdir, str(interpreter.identity), target_set_id)
-      path_tmp = path + '.tmp'
-
-      shutil.rmtree(path_tmp, ignore_errors=True)
-
-      if not os.path.isdir(path):
-        self._build_pex(interpreter, path_tmp, req_libs)
-        shutil.move(path_tmp, path)
-
-    pex = PEX(os.path.realpath(path), interpreter=interpreter)
+    pex = self.resolve_requirements(req_libs)
     self.context.products.get_data(self.REQUIREMENTS_PEX, lambda: pex)
-
-  def _build_pex(self, interpreter, path, req_libs):
-    builder = PEXBuilder(path=path, interpreter=interpreter, copy=True)
-
-    # Gather and de-dup all requirements.
-    reqs = OrderedSet()
-    for req_lib in req_libs:
-      for req in req_lib.requirements:
-        reqs.add(req)
-
-    # See which ones we need to build.
-    reqs_to_build = OrderedSet()
-    find_links = OrderedSet()
-    for req in reqs:
-      # TODO: should_build appears to be hardwired to always be True. Get rid of it?
-      if req.should_build(interpreter.python, Platform.current()):
-        reqs_to_build.add(req)
-        self.context.log.debug('  Dumping requirement: {}'.format(req))
-        builder.add_requirement(req.requirement)
-        if req.repository:
-          find_links.add(req.repository)
-      else:
-        self.context.log.debug('Skipping {} based on version filter'.format(req))
-
-    # Resolve the requirements into distributions.
-    distributions = self._resolve_multi(interpreter, reqs_to_build, find_links)
-
-    locations = set()
-    for platform, dists in distributions.items():
-      for dist in dists:
-        if dist.location not in locations:
-          self.context.log.debug('  Dumping distribution: .../{}'.format(
-              os.path.basename(dist.location)))
-          builder.add_distribution(dist)
-        locations.add(dist.location)
-
-    builder.freeze()
-
-  def _resolve_multi(self, interpreter, requirements, find_links):
-    """Multi-platform dependency resolution for PEX files.
-
-    Returns a list of distributions that must be included in order to satisfy a set of requirements.
-    That may involve distributions for multiple platforms.
-
-    :param interpreter: The :class:`PythonInterpreter` to resolve for.
-    :param requirements: A list of :class:`PythonRequirement` objects to resolve.
-    :param find_links: Additional paths to search for source packages during resolution.
-    :return: Map of platform name -> list of :class:`pkg_resources.Distribution` instances needed
-             to satisfy the requirements on that platform.
-    """
-    python_setup = PythonSetup.global_instance()
-    python_repos = PythonRepos.global_instance()
-    distributions = {}
-    fetchers = python_repos.get_fetchers()
-    fetchers.extend(Fetcher([path]) for path in find_links)
-
-    for platform in python_setup.platforms:
-      requirements_cache_dir = os.path.join(python_setup.resolver_cache_dir,
-                                            str(interpreter.identity))
-      distributions[platform] = resolve(
-          requirements=[req.requirement for req in requirements],
-          interpreter=interpreter,
-          fetchers=fetchers,
-          platform=None if platform == 'current' else platform,
-          context=python_repos.get_network_context(),
-          cache=requirements_cache_dir,
-          cache_ttl=python_setup.resolver_cache_ttl,
-          allow_prereleases=python_setup.resolver_allow_prereleases)
-
-    return distributions

--- a/src/python/pants/backend/python/tasks2/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements_task_base.py
@@ -1,0 +1,148 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import shutil
+
+from pex.fetcher import Fetcher
+from pex.interpreter import PythonInterpreter
+from pex.pex import PEX
+from pex.pex_builder import PEXBuilder
+from pex.platforms import Platform
+from pex.resolver import resolve
+from twitter.common.collections import OrderedSet
+
+from pants.backend.python.python_setup import PythonRepos, PythonSetup
+from pants.base.fingerprint_strategy import (DefaultFingerprintHashingMixin,
+                                             TaskIdentityFingerprintStrategy)
+from pants.invalidation.cache_manager import VersionedTargetSet
+from pants.task.task import Task
+from pants.util.dirutil import safe_rmtree
+
+
+class PythonRequirementFingerprintStrategy(DefaultFingerprintHashingMixin,
+                                           TaskIdentityFingerprintStrategy):
+
+  def compute_fingerprint(self, req_lib):
+    hash_elements_for_target = []
+    hash_elements_for_target.extend([req.cache_key() for req in req_lib.requirements])
+    if not hash_elements_for_target:
+      return None
+    hasher = self._build_hasher(req_lib)
+    for element in hash_elements_for_target:
+      hasher.update(element)
+    return hasher.hexdigest()
+
+
+class ResolveRequirementsTaskBase(Task):
+  """Base class for tasks that resolve 3rd-party Python requirements.
+
+  Creates an (unzipped) PEX on disk containing all the resolved requirements.
+  This PEX can be merged with other PEXes to create a unified Python environment
+  for running the relevant python code.
+  """
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(ResolveRequirementsTaskBase, cls).subsystem_dependencies() + (PythonSetup, PythonRepos)
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    round_manager.require_data(PythonInterpreter)
+
+  def resolve_requirements(self, req_libs):
+    fs = PythonRequirementFingerprintStrategy(task=self)
+    with self.invalidated(req_libs, fingerprint_strategy=fs) as invalidation_check:
+      # If there are no relevant targets, we still go through the motions of resolving
+      # an empty set of requirements, to prevent downstream tasks from having to check
+      # for this special case.
+      if invalidation_check.all_vts:
+        target_set_id = VersionedTargetSet.from_versioned_targets(
+            invalidation_check.all_vts).cache_key.hash
+      else:
+        target_set_id = 'no_targets'
+
+      interpreter = self.context.products.get_data(PythonInterpreter)
+      path = os.path.join(self.workdir, str(interpreter.identity), target_set_id)
+      if not os.path.isdir(path):
+        path_tmp = path + '.tmp'
+        safe_rmtree(path_tmp)
+        self._build_pex(interpreter, path_tmp, req_libs)
+        safe_rmtree(path)
+        shutil.move(path_tmp, path)
+
+    return PEX(os.path.realpath(path), interpreter=interpreter)
+
+  def _build_pex(self, interpreter, path, req_libs):
+    builder = PEXBuilder(path=path, interpreter=interpreter, copy=True)
+
+    # Gather and de-dup all requirements.
+    reqs = OrderedSet()
+    for req_lib in req_libs:
+      for req in req_lib.requirements:
+        reqs.add(req)
+
+    # See which ones we need to build.
+    reqs_to_build = OrderedSet()
+    find_links = OrderedSet()
+    for req in reqs:
+      # TODO: should_build appears to be hardwired to always be True. Get rid of it?
+      if req.should_build(interpreter.python, Platform.current()):
+        reqs_to_build.add(req)
+        self.context.log.debug('  Dumping requirement: {}'.format(req))
+        builder.add_requirement(req.requirement)
+        if req.repository:
+          find_links.add(req.repository)
+      else:
+        self.context.log.debug('Skipping {} based on version filter'.format(req))
+
+    # Resolve the requirements into distributions.
+    distributions = self._resolve_multi(interpreter, reqs_to_build, find_links)
+
+    locations = set()
+    for platform, dists in distributions.items():
+      for dist in dists:
+        if dist.location not in locations:
+          self.context.log.debug('  Dumping distribution: .../{}'.format(
+              os.path.basename(dist.location)))
+          builder.add_distribution(dist)
+        locations.add(dist.location)
+
+    builder.freeze()
+
+  def _resolve_multi(self, interpreter, requirements, find_links):
+    """Multi-platform dependency resolution for PEX files.
+
+    Returns a list of distributions that must be included in order to satisfy a set of requirements.
+    That may involve distributions for multiple platforms.
+
+    :param interpreter: The :class:`PythonInterpreter` to resolve for.
+    :param requirements: A list of :class:`PythonRequirement` objects to resolve.
+    :param find_links: Additional paths to search for source packages during resolution.
+    :return: Map of platform name -> list of :class:`pkg_resources.Distribution` instances needed
+             to satisfy the requirements on that platform.
+    """
+    python_setup = PythonSetup.global_instance()
+    python_repos = PythonRepos.global_instance()
+    distributions = {}
+    fetchers = python_repos.get_fetchers()
+    fetchers.extend(Fetcher([path]) for path in find_links)
+
+    for platform in python_setup.platforms:
+      requirements_cache_dir = os.path.join(python_setup.resolver_cache_dir,
+                                            str(interpreter.identity))
+      distributions[platform] = resolve(
+          requirements=[req.requirement for req in requirements],
+          interpreter=interpreter,
+          fetchers=fetchers,
+          platform=None if platform == 'current' else platform,
+          context=python_repos.get_network_context(),
+          cache=requirements_cache_dir,
+          cache_ttl=python_setup.resolver_cache_ttl,
+          allow_prereleases=python_setup.resolver_allow_prereleases)
+
+    return distributions

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -421,7 +421,8 @@ class Products(object):
     :API: public
 
     If the product isn't found, returns None, unless init_func is set, in which case the product's
-    value is set to the return value of init_func(), and returned."""
+    value is set to the return value of init_func(), and returned.
+    """
     if typename not in self.data_products:
       if not init_func:
         return None

--- a/src/python/pants/task/mutex_task_mixin.py
+++ b/src/python/pants/task/mutex_task_mixin.py
@@ -66,7 +66,6 @@ class MutexTaskMixin(Task):
   @classmethod
   def prepare(cls, options, round_manager):
     super(MutexTaskMixin, cls).prepare(options, round_manager)
-
     cls._implementations[cls.mutex_base()].add(cls)
 
   @classmethod

--- a/tests/python/pants_test/backend/python/tasks2/BUILD
+++ b/tests/python/pants_test/backend/python/tasks2/BUILD
@@ -3,7 +3,7 @@
 
 
 python_tests(
-  sources=globs('test_*.py', exclude=[globs('test_*_integration.py')]),
+  sources=globs('test_*.py', exclude=[globs('*_integration.py')]),
   dependencies=[
     '3rdparty/python:mock',
     '3rdparty/python:pex',
@@ -21,8 +21,8 @@ python_tests(
 
 
 python_tests(
-  name='python_run_integration',
-  sources=['test_python_run_integration.py'],
+  name='integration',
+  sources=globs('*_integration.py'),
   dependencies=[
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',

--- a/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import sys
+from contextlib import contextmanager
+from textwrap import dedent
+
+from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.python_repl import PythonRepl
+from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.base.exceptions import TaskError
+from pants.build_graph.address import Address
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.target import Target
+from pants.task.repl_task_mixin import ReplTaskMixin
+from pants.util.contextutil import temporary_dir
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
+
+
+class PythonReplTest(PythonTaskTestBase):
+  @classmethod
+  def task_type(cls):
+    return PythonRepl
+
+  class JvmTarget(Target):
+    pass
+
+  @property
+  def alias_groups(self):
+    return super(PythonReplTest, self).alias_groups.merge(
+        BuildFileAliases(targets={'jvm_target': self.JvmTarget}))
+
+  def create_non_python_target(self, relpath, name):
+    self.create_file(relpath=self.build_path(relpath), contents=dedent("""
+    jvm_target(
+      name='{name}',
+    )
+    """).format(name=name))
+
+    return self.target(Address(relpath, name).spec)
+
+  def setUp(self):
+    super(PythonReplTest, self).setUp()
+    self.six = self.create_python_requirement_library('3rdparty/python/six', 'six',
+                                                      requirements=['six==1.9.0'])
+    self.requests = self.create_python_requirement_library('3rdparty/python/requests', 'requests',
+                                                           requirements=['requests==2.6.0'])
+
+    self.library = self.create_python_library('src/python/lib', 'lib', {'lib.py': dedent("""
+    import six
+
+
+    def go():
+      six.print_('go', 'go', 'go!', sep='')
+    """)}, dependencies=['//3rdparty/python/six'])
+
+    self.binary = self.create_python_binary('src/python/bin', 'bin', 'lib.go',
+                                            dependencies=['//src/python/lib'])
+
+    self.non_python_target = self.create_non_python_target('src/python/java', 'java')
+
+  def tearDown(self):
+    super(PythonReplTest, self).tearDown()
+    ReplTaskMixin.reset_implementations()
+
+  @contextmanager
+  def new_io(self, input):
+    orig_stdin, orig_stdout, orig_stderr = sys.stdin, sys.stdout, sys.stderr
+    with temporary_dir() as iodir:
+      stdin = os.path.join(iodir, 'stdin')
+      stdout = os.path.join(iodir, 'stdout')
+      stderr = os.path.join(iodir, 'stderr')
+      with open(stdin, 'w') as fp:
+        fp.write(input)
+      with open(stdin, 'rb') as inp, open(stdout, 'wb') as out, open(stderr, 'wb') as err:
+        sys.stdin, sys.stdout, sys.stderr = inp, out, err
+        try:
+          yield inp, out, err
+        finally:
+          sys.stdin, sys.stdout, sys.stderr = orig_stdin, orig_stdout, orig_stderr
+
+  def do_test_repl(self, code, expected, targets, options=None):
+    if options:
+      self.set_options(**options)
+
+    class JvmRepl(ReplTaskMixin):
+      options_scope = 'test_scope_jvm_repl'
+
+      @classmethod
+      def select_targets(cls, target):
+        return isinstance(target, self.JvmTarget)
+
+      def setup_repl_session(_, targets):
+        raise AssertionError()
+
+      def launch_repl(_, session_setup):
+        raise AssertionError()
+
+    # Add a competing REPL impl.
+    JvmRepl.prepare(self.options, round_manager=None)
+
+    # repltest_tgt = self.create_python_library(
+    #   'src/python/repltest', 'repltest', {'repltest.py': '\n'.join(code)},
+    #   dependencies=[t.address.spec for t in targets])
+
+    # The easiest way to create products required by the PythonRepl task is to
+    # execute the relevant tasks.
+    si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
+    rr_task_type = self.synthesize_task_subtype(ResolveRequirements, 'rr_scope')
+    gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
+    context = self.context(for_task_types=[si_task_type, rr_task_type, gs_task_type],
+                           target_roots=targets)
+    with temporary_dir() as tmpdir:
+      si_task_type(context, os.path.join(tmpdir, 'si')).execute()
+      rr_task_type(context, os.path.join(tmpdir, 'rr')).execute()
+      gs_task_type(context, os.path.join(tmpdir, 'gs')).execute()
+      python_repl = self.create_task(context)
+
+      original_launcher = python_repl.launch_repl
+      with self.new_io('\n'.join(code)) as (inp, out, err):
+        def custom_io_patched_launcher(pex):
+          return original_launcher(pex, stdin=inp, stdout=out, stderr=err)
+        python_repl.launch_repl = custom_io_patched_launcher
+
+        python_repl.execute()
+        with open(out.name) as fp:
+          lines = fp.read()
+          if not expected:
+            self.assertEqual('', lines)
+          else:
+            for expectation in expected:
+              self.assertIn(expectation, lines)
+
+  def do_test_library(self, *targets):
+    self.do_test_repl(code=['from lib.lib import go',
+                            'go()'],
+                      expected=['gogogo!'],
+                      targets=targets)
+
+  def test_library(self):
+    self.do_test_library(self.library)
+
+  def test_binary(self):
+    self.do_test_library(self.binary)
+
+  def test_requirement(self):
+    self.do_test_repl(code=['import six',
+                            'print("python 2?:{}".format(six.PY2))'],
+                      expected=['python 2?:True'],
+                      targets=[self.six])
+
+  def test_mixed_python(self):
+    self.do_test_repl(code=['import requests',
+                            'import six',
+                            'from lib.lib import go',
+                            'print("teapot response code is: {}".format(requests.codes.teapot))',
+                            'go()',
+                            'print("python 2?:{}".format(six.PY2))'],
+                      expected=['teapot response code is: 418',
+                                'gogogo!',
+                                'python 2?:True'],
+                      targets=[self.requests, self.binary])
+
+  def test_disallowed_mix(self):
+    with self.assertRaises(TaskError):
+      self.do_test_repl(code=['print("unreachable")'],
+                        expected=[],
+                        targets=[self.library, self.non_python_target])
+
+  def test_non_python_targets(self):
+    self.do_test_repl(code=['import java.lang.unreachable'],
+                      expected=[''],
+                      targets=[self.non_python_target])
+
+  def test_ipython(self):
+    # IPython supports shelling out with a leading !, so indirectly test its presence by reading
+    # the head of this very file.
+    with open(__file__) as fp:
+      me = fp.readline()
+      self.do_test_repl(code=['!head -1 {}'.format(__file__)],
+                        expected=[me],
+                        targets=[self.six],  # Just to get the repl to pop up.
+                        options={'ipython': True})

--- a/tests/python/pants_test/backend/python/tasks2/test_python_repl_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_repl_integration.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class PythonReplIntegrationTest(PantsRunIntegrationTest):
+
+  def test_run_repl(self):
+    # Run a repl on a library target. Avoid some known-to-choke-on interpreters.
+    command = ['repl2',
+               'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
+               '--pyprep-interpreter-constraints=CPython>=2.6,<3',
+               '--pyprep-interpreter-constraints=CPython>=3.3',
+               '--quiet']
+    program = 'from interpreter_selection.echo_interpreter_version import say_hello; say_hello()'
+    pants_run = self.run_pants(command=command, stdin_data=program)
+    output_lines = pants_run.stdout_data.rstrip().split('\n')
+    self.assertEquals(len(output_lines), 4,
+                      msg='Expected 4 lines, got:\n{}'.format('\n'.join(output_lines)))
+    self.assertEquals('echo_interpreter_version loaded successfully.', output_lines[-2])


### PR DESCRIPTION
Uses the new python pipeline.

This involved a little refactoring, namely the creation of
two helper base classes:

1. The PythonExecutionTaskBase base class provides the 
  logic (ripped from the new PythonRun task) to "merge" pexes 
  together using PEX_PATH, so you have a single pex to execute.

1. The ResolveRequirementsTaskBase  provides the logic for 
  resolving requirements (ripped from the new
  ResolveRequirements task).

PythonExecutionTaskBase extends ResolveRequirementsTaskBase, 
so it can resolve any extra requirements it needs in order to run
(e.g., ipython).  This is a lightweight alternative to a full Python equivalent 
of register_jvm_tool, as that would be significant work, and it's not yet 
clear if that's a path we want to go down (esp. since the new engine should 
provide an entirely different way of doing this sort of thing).

The old ResolveRequirements task also extends ResolveRequirementsTaskBase
of course, and the PythonRepl task introduced in this change extends 
PythonExecutionTaskBase, as does the PythonRun task.
 
