### PR TITLE
Add a 'current' symlink to the task-versioned prefix of the workdir.

### DIFF
--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen_integration.py
@@ -82,7 +82,8 @@ class GoThriftGenIntegrationTest(PantsRunIntegrationTest):
         self.assert_success(pants_run)
 
         # Fetch the hash for task impl version.
-        go_thrift_contents = os.listdir(os.path.join(workdir, 'gen', 'go-thrift'))
+        go_thrift_contents = [p for p in os.listdir(os.path.join(workdir, 'gen', 'go-thrift'))
+                              if p != 'current']  # Ignore the 'current' symlink.
         self.assertEqual(len(go_thrift_contents), 1)
         hash_dir = go_thrift_contents[0]
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -144,13 +144,14 @@ class CacheCompileIntegrationTest(BaseCompileIT):
 
       root = os.path.join(workdir, 'compile', 'zinc')
 
-      versioned_root = os.path.join(root, os.listdir(root)[0])
-      self.assertEqual(len(os.listdir(root)), 1, 'Expected 1 task version.')
+      task_versions = [p for p in os.listdir(root) if p != 'current']
+      self.assertEqual(len(task_versions), 1, 'Expected 1 task version.')
+      versioned_root = os.path.join(root, task_versions[0])
 
-      target_root = os.path.join(root, os.listdir(root)[0])
-      self.assertEqual(len(os.listdir(target_root)), 1, 'Expected 1 target.')
+      per_target_dirs = os.listdir(versioned_root)
+      self.assertEqual(len(per_target_dirs), 1, 'Expected 1 target.')
+      target_workdir_root = os.path.join(versioned_root, per_target_dirs[0])
 
-      target_workdir_root = os.path.join(versioned_root, os.listdir(versioned_root)[0])
       target_workdirs = os.listdir(target_workdir_root)
       self.assertEqual(len(target_workdirs), 3, 'Expected 3 workdirs (current, and two versioned).')
       self.assertIn('current', target_workdirs)

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -36,8 +36,9 @@ class InvalidationCacheManagerTest(BaseTest):
     super(InvalidationCacheManagerTest, self).setUp()
     self._dir = tempfile.mkdtemp()
     self.cache_manager = InvalidationCacheManager(
+      results_dir_root=os.path.join(self._dir, 'results'),
       cache_key_generator=CacheKeyGenerator(),
-      build_invalidator_dir=self ._dir,
+      build_invalidator_dir=os.path.join(self._dir, 'build_invalidator'),
       invalidate_dependents=True,
     )
 
@@ -56,7 +57,7 @@ class InvalidationCacheManagerTest(BaseTest):
     return vt
 
   def task_execute(self, vt):
-    vt.create_results_dir(self._dir)
+    vt.create_results_dir()
     task_output = os.path.join(vt.results_dir, 'a_file')
     self.create_file(task_output, 'foo')
 
@@ -94,7 +95,7 @@ class InvalidationCacheManagerTest(BaseTest):
     vt.force_invalidate()
     self.assertFalse(self.is_empty(vt.results_dir))
 
-    vt.create_results_dir(self._dir)
+    vt.create_results_dir()
     self.assertTrue(self.has_symlinked_result_dir(vt))
     self.assertTrue(self.is_empty(vt.results_dir))
 
@@ -104,7 +105,7 @@ class InvalidationCacheManagerTest(BaseTest):
     self.assertFalse(self.is_empty(vt.results_dir))
     file_names = os.listdir(vt.results_dir)
 
-    vt.create_results_dir(self._dir)
+    vt.create_results_dir()
     self.assertFalse(self.is_empty(vt.results_dir))
     self.assertTrue(self.has_symlinked_result_dir(vt))
 
@@ -145,7 +146,7 @@ class InvalidationCacheManagerTest(BaseTest):
     # This only is caught here if the VT is still invalid for some reason, otherwise it's caught by the update() method.
     vt.force_invalidate()
     with self.assertRaisesRegexp(ValueError, r'Path for link.*overwrite an existing directory*'):
-      vt.create_results_dir(self._dir)
+      vt.create_results_dir()
 
   def test_raises_for_clobbered_symlink(self):
     vt = self.make_vt()

--- a/tests/python/pants_test/invalidation/test_cache_manager.py
+++ b/tests/python/pants_test/invalidation/test_cache_manager.py
@@ -61,6 +61,23 @@ class InvalidationCacheManagerTest(BaseTest):
     task_output = os.path.join(vt.results_dir, 'a_file')
     self.create_file(task_output, 'foo')
 
+  def test_creates_stable_result_dir_symlink(self):
+    vt = self.make_vt()
+    vt.create_results_dir()
+    parent, unstable_dir_name = os.path.split(vt._current_results_dir)
+    self.assertSetEqual({'current', unstable_dir_name}, set(os.listdir(parent)))
+    symlink = os.path.join(parent, 'current')
+    self.assertTrue(os.path.islink(symlink))
+    self.assertTrue(unstable_dir_name, os.readlink(symlink))
+    self.assertEquals(symlink, vt.results_dir)
+
+  def test_creates_stable_results_dir_prefix_symlink(self):
+    parent, unstable_dir_name = os.path.split(self.cache_manager._results_dir_prefix)
+    self.assertSetEqual({'current', unstable_dir_name}, set(os.listdir(parent)))
+    symlink = os.path.join(parent, 'current')
+    self.assertTrue(os.path.islink(symlink))
+    self.assertTrue(unstable_dir_name, os.readlink(symlink))
+
   def test_check_marks_all_as_invalid_by_default(self):
     a = self.make_target(':a', dependencies=[])
     b = self.make_target(':b', dependencies=[a])


### PR DESCRIPTION
When working on custom tasks it's common to have to bump their versions,
and it quickly gets confusing to figure out which workdir is the current
one to poke around in.
