### PR TITLE
Qualify the build invalidator root.

### DIFF
--- a/src/python/pants/base/fingerprint_strategy.py
+++ b/src/python/pants/base/fingerprint_strategy.py
@@ -39,6 +39,8 @@ class FingerprintStrategy(AbstractClass):
   def fingerprint_target(self, target):
     """Consumers of subclass instances call this to get a fingerprint labeled with the name"""
     fingerprint = self.compute_fingerprint(target)
+    # TODO: We probably don't need to qualify the fingerprint with the strategy name any more,
+    # since the BuildInvalidator root is now qualified by it.
     if fingerprint:
       return '{fingerprint}-{name}'.format(fingerprint=fingerprint, name=type(self).__name__)
     else:

--- a/src/python/pants/invalidation/build_invalidator.py
+++ b/src/python/pants/invalidation/build_invalidator.py
@@ -58,7 +58,9 @@ class CacheKeyGenerator(object):
     cache_key_gen_version - If provided, added to all cache keys. Allows you to invalidate
       all cache keys in a single pants repo, by changing this value in config.
     """
-
+    # TODO: Qualify the BuildInvalidator root with the cache_key_gen_version, instead of mixing
+    # it into the key, for uniformity with other qualifiers like the fprint strategy and the
+    # transitivity setting.
     self._cache_key_gen_version = '_'.join([cache_key_gen_version or '',
                                             GLOBAL_CACHE_KEY_GEN_VERSION])
 
@@ -123,10 +125,6 @@ class BuildInvalidator(object):
     :param cache_key: A CacheKey object (typically returned by CacheKeyGenerator.key_for()).
     """
     self._write_sha(cache_key)
-
-  def force_invalidate_all(self):
-    """Force-invalidates all cached items."""
-    safe_mkdir(self._root, clean=True)
 
   def force_invalidate(self, cache_key):
     """Force-invalidate the cached item."""

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -269,7 +269,10 @@ class InvalidationCacheManager(object):
     self._task_name = task_name or 'UNKNOWN'
     self._task_version = task_version or 'Unknown_0'
     self._invalidate_dependents = invalidate_dependents
-    self._invalidator = BuildInvalidator(build_invalidator_dir)
+    build_invalidator_root = os.path.join(build_invalidator_dir,
+                                          type(fingerprint_strategy).__name__,
+                                          '{}invalidate_dependents'.format('' if invalidate_dependents else 'no'))
+    self._invalidator = BuildInvalidator(build_invalidator_root)
     self._fingerprint_strategy = fingerprint_strategy
     self._artifact_write_callback = artifact_write_callback
     self.invalidation_report = invalidation_report

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -110,7 +110,6 @@ class JvmToolTaskTestBase(JvmTaskTestBase):
     :returns: The prepared Task instance.
     """
     task = self.create_task(context)
-    task.invalidate()
 
     # Bootstrap the tools needed by the task under test.
     # We need the bootstrap task's workdir to be under the test's .pants.d, so that it can


### PR DESCRIPTION
Adds the name of the fprint strategy, and the value of the invalidate_dependents
setting, to the build invalidator root path.

Previously a task had a single root for all fprint strategies and transitivity
settings it might use.  Mostly this isn't a problem, since a task typically uses
only one such combination.

However the BootstrapJvmTool uses two: the ShadedToolFingerprintStrategy for
shaded tools and the IvyResolveFingerprintStrategy for unshaded ones.
If you happen to use the same jar spec as both a shaded and unshaded tool
then the two different fingerprints will thrash on the same key file, causing
unnecessary and confusing invalidation.

This isn't hypothetical: In my repo I have a jar that acts both as a custom javac compiler jar
and also contains other tooling. Pants doesn't shade the compiler so plugins can access
its internals, but we do shade the jar when used for other tooling, for the usual reasons.

This change also removes a wrinkle where we were creating a BuildInvalidator directly
just to call force_invalidate_all() on it. That is no longer a good abstraction, since
we can't at that point know what the qualifying subdirs are. Fortunately, however,
we don't actually need that functionality any more.  It was only used in one place,
in a test base class, added before we guaranteed that each test runs in a clean workdir
(see eae725b307e13349970ccbdf9bfbdc94c901a24e).

This change also gets rid of the helper function to create a cache manager, since
nothing outside the class was actually using it.  So this change has the nice
side-effect of further encapsulating both CacheManager and BuildInvalidator.
