### PR TITLE
Improve BUILD file matching in the v2 path.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ lmdb==0.89
 Markdown==2.1.1
 mock==1.3.0
 packaging==16.8
-pathspec==0.3.4
+pathspec==0.5.0
 pep8==1.6.2
 pex==1.2.1
 psutil==4.3.0

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -11,7 +11,7 @@ import shutil
 from collections import defaultdict
 
 from pathspec import PathSpec
-from pathspec.gitignore import GitIgnorePattern
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 from twitter.common.collections.orderedset import OrderedSet
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -207,7 +207,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
                       jvm_targets,
                       not self.intransitive,
                       self.TargetUtil(self.context),
-                      PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns))
+                      PathSpec.from_lines(GitWildMatchPattern, build_ignore_patterns))
 
     if self.python:
       python_source_paths = self.get_options().python_source_paths

--- a/src/python/pants/base/project_tree.py
+++ b/src/python/pants/base/project_tree.py
@@ -10,8 +10,8 @@ import os
 from abc import abstractmethod, abstractproperty
 
 import six
-from pathspec.gitignore import GitIgnorePattern
 from pathspec.pathspec import PathSpec
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 from pants.util.dirutil import fast_relpath
 from pants.util.meta import AbstractClass
@@ -38,7 +38,7 @@ class ProjectTree(AbstractClass):
           'ProjectTree build_root {} must be an absolute path.'.format(build_root))
     self.build_root = os.path.realpath(build_root)
     logger.debug('ProjectTree ignore_patterns: %s', ignore_patterns)
-    self.ignore = PathSpec.from_lines(GitIgnorePattern, ignore_patterns if ignore_patterns else [])
+    self.ignore = PathSpec.from_lines(GitWildMatchPattern, ignore_patterns if ignore_patterns else [])
 
   @abstractmethod
   def _glob1_raw(self, dir_relpath, glob):
@@ -164,8 +164,7 @@ class ProjectTree(AbstractClass):
     relpath = self._relpath_no_dot(relpath)
     if directory:
       relpath = self._append_trailing_slash(relpath)
-    # TODO: Use match_file instead when pathspec 0.4.1 (TBD) is released.
-    return any(True for _ in self.ignore.match_files([relpath]))
+    return self.ignore.match_file(relpath)
 
   def _filter_ignored(self, entries, selector=None):
     """Given an opaque entry list, filter any ignored entries.

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 
 import six
 from pathspec import PathSpec
-from pathspec.gitignore import GitIgnorePattern
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
@@ -56,7 +56,7 @@ class BuildFileAddressMapper(AddressMapper):
     self._build_file_parser = build_file_parser
     self._spec_path_to_address_map_map = {}  # {spec_path: {address: addressable}} mapping
     self._project_tree = project_tree
-    self._build_ignore_patterns = PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns or [])
+    self._build_ignore_patterns = PathSpec.from_lines(GitWildMatchPattern, build_ignore_patterns or [])
 
     self._exclude_target_regexps = exclude_target_regexps or []
     self._exclude_patterns = [re.compile(pattern) for pattern in self._exclude_target_regexps]

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -241,21 +241,12 @@ def filter_build_dirs(address_mapper, build_files):
   return BuildDirs(tuple(Dir(d) for d in dirnames if d not in ignored_dirnames))
 
 
-def _pattern_yielder(pattern):
-  yield pattern
-  yield join('**', pattern)
-
-
 def descendant_addresses_to_globs(address_mapper, descendant_addresses):
   """Given a DescendantAddresses object, return a PathGlobs object for matching build files.
 
   This allows us to limit our AddressFamily requests to directories that contain build files.
   """
-  patterns = [
-    pattern
-    for build_pattern in address_mapper.build_patterns
-    for pattern in _pattern_yielder(build_pattern)
-  ]
+  patterns = [join('**', pattern) for pattern in address_mapper.build_patterns]
   return PathGlobs.create_from_specs(descendant_addresses.directory, patterns)
 
 

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -190,7 +190,7 @@ class AddressMapper(object):
     :type symbol_table_cls: A :class:`pants.engine.parser.SymbolTable`.
     :param parser_cls: The BUILD file parser cls to use.
     :type parser_cls: A :class:`pants.engine.parser.Parser`.
-    :param tuple build_patterns: A tuple of fnmatch-compatible pattern for identifying BUILD files
+    :param tuple build_patterns: A tuple of fnmatch-compatible patterns for identifying BUILD files
                                  used to resolve addresses.
     :param list build_ignore_patterns: A list of path ignore patterns used when searching for BUILD files.
     :param list exclude_target_regexps: A list of regular expressions for excluding targets.

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -10,7 +10,7 @@ import re
 from collections import OrderedDict
 
 from pathspec import PathSpec
-from pathspec.gitignore import GitIgnorePattern
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 from pants.build_graph.address import Address
 from pants.engine.objects import Serializable
@@ -178,7 +178,7 @@ class AddressMapper(object):
   def __init__(self,
                symbol_table_cls,
                parser_cls,
-               build_pattern=None,
+               build_patterns=None,
                build_ignore_patterns=None,
                exclude_target_regexps=None):
     """Create an AddressMapper.
@@ -190,16 +190,15 @@ class AddressMapper(object):
     :type symbol_table_cls: A :class:`pants.engine.parser.SymbolTable`.
     :param parser_cls: The BUILD file parser cls to use.
     :type parser_cls: A :class:`pants.engine.parser.Parser`.
-    :param string build_pattern: A fnmatch-compatible pattern for identifying BUILD files used
-                                 to resolve addresses; by default looks for `BUILD*` files.
+    :param tuple build_patterns: A tuple of fnmatch-compatible pattern for identifying BUILD files
+                                 used to resolve addresses.
     :param list build_ignore_patterns: A list of path ignore patterns used when searching for BUILD files.
     :param list exclude_target_regexps: A list of regular expressions for excluding targets.
     """
     self.symbol_table_cls = symbol_table_cls
     self.parser_cls = parser_cls
-    self.build_pattern = build_pattern or 'BUILD*'
-
-    self.build_ignore_patterns = PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns or [])
+    self.build_patterns = build_patterns or ('BUILD', 'BUILD.*')
+    self.build_ignore_patterns = PathSpec.from_lines(GitWildMatchPattern, build_ignore_patterns or [])
     self._exclude_target_regexps = exclude_target_regexps or []
     self.exclude_patterns = [re.compile(pattern) for pattern in self._exclude_target_regexps]
 
@@ -209,7 +208,7 @@ class AddressMapper(object):
     if type(other) != type(self):
       return NotImplemented
     return (other.symbol_table_cls == self.symbol_table_cls and
-            other.build_pattern == self.build_pattern and
+            other.build_patterns == self.build_patterns and
             other.parser_cls == self.parser_cls)
 
   def __ne__(self, other):
@@ -220,8 +219,8 @@ class AddressMapper(object):
     return hash((self.symbol_table_cls, self.parser_cls))
 
   def __repr__(self):
-    return 'AddressMapper(parser={}, symbol_table={}, build_pattern={})'.format(
-      self.parser_cls, self.symbol_table_cls, self.build_pattern)
+    return 'AddressMapper(parser={}, symbol_table={}, build_patterns={})'.format(
+      self.parser_cls, self.symbol_table_cls, self.build_patterns)
 
   def __str__(self):
     return repr(self)

--- a/tests/python/pants_test/base/build_file_test_base.py
+++ b/tests/python/pants_test/base/build_file_test_base.py
@@ -11,7 +11,7 @@ import tempfile
 import unittest
 
 from pathspec import PathSpec
-from pathspec.gitignore import GitIgnorePattern
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
 from pants.base.build_file import BuildFile
 from pants.util.dirutil import safe_mkdir, touch
@@ -28,7 +28,7 @@ class BuildFileTestBase(unittest.TestCase):
     touch(self.fullpath(path))
 
   def _create_ignore_spec(self, build_ignore_patterns):
-    return PathSpec.from_lines(GitIgnorePattern, build_ignore_patterns or [])
+    return PathSpec.from_lines(GitWildMatchPattern, build_ignore_patterns or [])
 
   def scan_buildfiles(self, base_relpath, build_ignore_patterns=None):
     return BuildFile.scan_build_files(self._project_tree, base_relpath,

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -395,8 +395,8 @@ def setup_json_scheduler(build_root, native):
   # Register "literal" subjects required for these tasks.
   # TODO: Replace with `Subsystems`.
   address_mapper = AddressMapper(symbol_table_cls=symbol_table_cls,
-                                                  build_pattern='BLD.json',
-                                                  parser_cls=JsonParser)
+                                 build_pattern=('BLD.json',),
+                                 parser_cls=JsonParser)
   source_roots = SourceRoots(('src/java','src/scala'))
   scrooge_tool_address = Address.parse('src/scala/scrooge')
 

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -395,7 +395,7 @@ def setup_json_scheduler(build_root, native):
   # Register "literal" subjects required for these tasks.
   # TODO: Replace with `Subsystems`.
   address_mapper = AddressMapper(symbol_table_cls=symbol_table_cls,
-                                 build_pattern=('BLD.json',),
+                                 build_patterns=('BLD.json',),
                                  parser_cls=JsonParser)
   source_roots = SourceRoots(('src/java','src/scala'))
   scrooge_tool_address = Address.parse('src/scala/scrooge')

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -92,11 +92,11 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
   def setUp(self):
     super(GraphTestBase, self).setUp()
 
-  def create(self, build_pattern=None, parser_cls=None):
+  def create(self, build_patterns=None, parser_cls=None):
     symbol_table_cls = TestTable
 
     address_mapper = AddressMapper(symbol_table_cls=symbol_table_cls,
-                                   build_pattern=build_pattern,
+                                   build_patterns=build_patterns,
                                    parser_cls=parser_cls)
 
     tasks = create_graph_tasks(address_mapper, symbol_table_cls)
@@ -105,7 +105,7 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
     return scheduler
 
   def create_json(self):
-    return self.create(build_pattern='*.BUILD.json', parser_cls=JsonParser)
+    return self.create(build_patterns=('*.BUILD.json',), parser_cls=JsonParser)
 
   def _populate(self, scheduler, address):
     """Perform an ExecutionRequest to parse the given Address into a Struct."""
@@ -169,12 +169,12 @@ class InlinedGraphTest(GraphTestBase):
     self.do_test_codegen_simple(scheduler)
 
   def test_python(self):
-    scheduler = self.create(build_pattern='*.BUILD.python',
+    scheduler = self.create(build_patterns=('*.BUILD.python',),
                             parser_cls=PythonAssignmentsParser)
     self.do_test_codegen_simple(scheduler)
 
   def test_python_classic(self):
-    scheduler = self.create(build_pattern='*.BUILD',
+    scheduler = self.create(build_patterns=('*.BUILD',),
                             parser_cls=PythonCallbacksParser)
     self.do_test_codegen_simple(scheduler)
 
@@ -330,11 +330,11 @@ class LazyResolvingGraphTest(GraphTestBase):
     self.do_test_codegen_simple(scheduler)
 
   def test_python_lazy(self):
-    scheduler = self.create(build_pattern='*.BUILD.python',
+    scheduler = self.create(build_patterns=('*.BUILD.python',),
                             parser_cls=PythonAssignmentsParser)
     self.do_test_codegen_simple(scheduler)
 
   def test_python_classic_lazy(self):
-    scheduler = self.create(build_pattern='*.BUILD',
+    scheduler = self.create(build_patterns=('*.BUILD',),
                             parser_cls=PythonCallbacksParser)
     self.do_test_codegen_simple(scheduler)

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -233,7 +233,7 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
     symbol_table_cls = TargetTable
     address_mapper = AddressMapper(symbol_table_cls=symbol_table_cls,
                                    parser_cls=JsonParser,
-                                   build_pattern='*.BUILD.json')
+                                   build_patterns=('*.BUILD.json',))
     tasks = create_graph_tasks(address_mapper, symbol_table_cls)
 
     project_tree = self.mk_fs_tree(os.path.join(os.path.dirname(__file__), 'examples/mapper_test'))


### PR DESCRIPTION
### Problem

Presently, the v2 engine path matches BUILD files using the pattern `BUILD*`. This can erroneously match files like `BUILDtemplate.xml` et al requiring extraneous ignores in a real world environment.

### Solution

Move to a matching pattern of `('BUILD', 'BUILD.*')` to align better with the v1 path. Also, bump the pathspec version and clean out a couple of TODOs.

### Result

Improved BUILD file matching ergonomics.

Fixes #4217 