### PR TITLE
Repair `Broken pipe` on pantsd thin client execution when piped to a non-draining reader.

### DIFF
--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -72,7 +72,11 @@ class RemotePantsRunner(object):
     modified_env = self._combine_dicts(self._env, ng_env)
 
     # Instantiate a NailgunClient.
-    client = NailgunClient(port=self._port, ins=self._stdin, out=self._stdout, err=self._stderr)
+    client = NailgunClient(port=self._port,
+                           ins=self._stdin,
+                           out=self._stdout,
+                           err=self._stderr,
+                           exit_on_broken_pipe=True)
 
     with self._trapped_control_c(client):
       # Execute the command on the pailgun.

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -173,7 +173,13 @@ class PantsRunIntegrationTest(unittest.TestCase):
       args.append('--config-override=' + ini_file_name)
 
     pants_script = os.path.join(build_root or get_buildroot(), self.PANTS_SCRIPT_NAME)
-    pants_command = [pants_script] + args + command
+
+    # Permit usage of shell=True and string-based commands to allow e.g. `./pants | head`.
+    if kwargs.get('shell') is True:
+      assert not isinstance(command, list), 'must pass command as a string when using shell=True'
+      pants_command = ' '.join([pants_script, ' '.join(args), command])
+    else:
+      pants_command = [pants_script] + args + command
 
     # Only whitelisted entries will be included in the environment if hermetic=True.
     if self.hermetic():

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from contextlib import contextmanager
 import os
 
 from pants.pantsd.process_manager import ProcessManager
@@ -34,15 +35,20 @@ def read_pantsd_log(workdir):
 
 
 class TestPantsDaemonIntegration(PantsRunIntegrationTest):
-  def test_pantsd_run(self):
+  @contextmanager
+  def pantsd_test_context(self, config=None):
     with self.temporary_workdir() as workdir_base:
       pid_dir = os.path.join(workdir_base, '.pids')
       workdir = os.path.join(workdir_base, '.workdir.pants.d')
-      pantsd_config = {'GLOBAL': {'enable_pantsd': True,
-                                  'level': 'debug',
-                                  'pants_subprocessdir': pid_dir}}
+      pantsd_config = config or {}
+      pantsd_config.setdefault('GLOBAL', {'enable_pantsd': True,
+                                          'level': 'debug',
+                                          'pants_subprocessdir': pid_dir})
       checker = PantsDaemonMonitor(pid_dir)
+      yield workdir, pantsd_config, checker
 
+  def test_pantsd_run(self):
+    with self.pantsd_test_context() as (workdir, pantsd_config, checker):
       # Explicitly kill any running pantsd instances for the current buildroot.
       self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
       try:
@@ -72,18 +78,12 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         print(line)
 
   def test_pantsd_run_with_watchman(self):
-    with self.temporary_workdir() as workdir_base:
-      pid_dir = os.path.join(workdir_base, '.pids')
-      workdir = os.path.join(workdir_base, '.workdir.pants.d')
-      pantsd_config = {'GLOBAL': {'enable_pantsd': True,
-                                  'level': 'debug',
-                                  'pants_subprocessdir': pid_dir},
-                       'pantsd': {'fs_event_detection': True},
-                       # The absolute paths in CI can exceed the UNIX socket path limitation
-                       # (>104-108 characters), so we override that here with a shorter path.
-                       'watchman': {'socket_path': '/tmp/watchman.{}.sock'.format(os.getpid())}}
-      checker = PantsDaemonMonitor(pid_dir)
+    config = {'pantsd': {'fs_event_detection': True},
+              # The absolute paths in CI can exceed the UNIX socket path limitation
+              # (>104-108 characters), so we override that here with a shorter path.
+              'watchman': {'socket_path': '/tmp/watchman.{}.sock'.format(os.getpid())}}
 
+    with self.pantsd_test_context(config) as (workdir, pantsd_config, checker):
       print('log: {}/pantsd/pantsd.log'.format(workdir))
       # Explicitly kill any running pantsd instances for the current buildroot.
       print('\nkill-pantsd')
@@ -127,3 +127,21 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
           continue
 
         self.assertNotRegexpMatches(line, r'^[WE].*')
+
+  def test_pantsd_broken_pipe(self):
+    with self.pantsd_test_context() as (workdir, pantsd_config, checker):
+      # Explicitly kill any running pantsd instances for the current buildroot.
+      self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
+      try:
+        # Start pantsd implicitly via a throwaway invocation.
+        self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
+        checker.await_pantsd()
+
+        run = self.run_pants_with_workdir('help | head -1', workdir, pantsd_config, shell=True)
+        self.assertNotIn('broken pipe', run.stderr_data.lower())
+        checker.assert_running()
+      finally:
+        # Explicitly kill pantsd (from a pantsd-launched runner).
+        self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
+
+      checker.assert_stopped()


### PR DESCRIPTION
### Problem

When piping output of the pantsd thin client to e.g. `head`, the client will throw an unhandled `Broken pipe` IOError attempting to flush the now-defunct fd after `head` short-circuits after consuming only its needed output.

### Solution

Catch `Broken pipe` errors and exit when encountered.

### Result

Broken pipe is no longer seen.

Fixes #4166