### PR TITLE
Adding pragma back in the default coverage config

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -218,6 +218,9 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
     exclude_lines =
         def __repr__
         raise NotImplementedError
+        pragma: no cover
+        pragma: no branch
+        pragma: recursive coverage
     """)
 
   @staticmethod


### PR DESCRIPTION
The [report] section contains an exclude_lines array. This breaks default
pragmas and has to be fixed by excluding the pragma lines again.

See doc:
http://coverage.readthedocs.io/en/coverage-3.7.1/config.html

### Problem
While running test coverage, I realized that `# pragma: no cover` was not working. Thus reflecting a lower than expected coverage percentage.

### Solution
Based on the docs, we need to exclude the pragma lines again, so that coverage can process these pragmas again.