### PR TITLE
[engine] fix address node creation in v2 build graph; fix filedeps

### DIFF
--- a/contrib/buildgen/src/python/pants/contrib/buildgen/build_file_manipulator.py
+++ b/contrib/buildgen/src/python/pants/contrib/buildgen/build_file_manipulator.py
@@ -331,7 +331,7 @@ class BuildFileManipulator(object):
     """See BuildFileManipulator.load() for how to construct one as a user."""
     self.name = name
     self.build_file = build_file
-    self.target_address = BuildFileAddress(build_file, name)
+    self.target_address = BuildFileAddress(build_file=build_file, target_name=name)
     self._build_file_source_lines = build_file_source_lines
     self._target_source_lines = target_source_lines
     self._target_interval = target_interval

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -23,6 +23,7 @@ from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.build_environment import get_buildroot
 from pants.base.build_file import BuildFile
 from pants.base.exceptions import TaskError
+from pants.base.project_tree_factory import get_project_tree
 from pants.build_graph.address import BuildFileAddress
 from pants.build_graph.resources import Resources
 from pants.util import desktop
@@ -605,13 +606,14 @@ class Project(object):
         if not isinstance(target.address, BuildFileAddress):
           return []  # Siblings only make sense for BUILD files.
         candidates = OrderedSet()
-        build_file = target.address.build_file
-        dir_relpath = os.path.dirname(build_file.relpath)
-        for descendant in BuildFile.scan_build_files(build_file.project_tree, dir_relpath,
+
+        dir_relpath = target.address.spec_path
+        project_tree = get_project_tree(self.context.options.for_global_scope())
+        for descendant in BuildFile.scan_build_files(project_tree, dir_relpath,
                                                      build_ignore_patterns=self.build_ignore_patterns):
           candidates.update(self.target_util.get_all_addresses(descendant))
         if not self._is_root_relpath(dir_relpath):
-          ancestors = self._collect_ancestor_build_files(build_file.project_tree, os.path.dirname(dir_relpath),
+          ancestors = self._collect_ancestor_build_files(project_tree, os.path.dirname(dir_relpath),
                                                          self.build_ignore_patterns)
           for ancestor in ancestors:
             candidates.update(self.target_util.get_all_addresses(ancestor))

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -259,8 +259,6 @@ class BuildFileAddress(Address):
     super(BuildFileAddress, self).__init__(spec_path=spec_path,
                                            target_name=target_name or os.path.basename(spec_path))
     self.rel_path = rel_path
-    with open("a", "w") as a:
-      a.write(self.rel_path)
     self._build_file = build_file
 
   @property

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -244,18 +244,21 @@ class BuildFileAddress(Address):
   :API: public
   """
 
-  def __init__(self, build_file, target_name=None):
+  def __init__(self, build_file=None, target_name=None, rel_path=None):
     """
     :param build_file: The build file that contains the object this address points to.
     :type build_file: :class:`pants.base.build_file.BuildFile`
+    :param string rel_path: The path relative to root_dir where the BUILD file is located.
     :param string target_name: The name of the target within the BUILD file; defaults to the default
                                target, aka the name of the BUILD file parent dir.
 
     :API: public
     """
-    spec_path = os.path.dirname(build_file.relpath)
+    rel_path = rel_path or build_file.relpath
+    spec_path = os.path.dirname(rel_path)
     super(BuildFileAddress, self).__init__(spec_path=spec_path,
                                            target_name=target_name or os.path.basename(spec_path))
+    self.rel_path = rel_path
     self._build_file = build_file
 
   @property
@@ -269,5 +272,5 @@ class BuildFileAddress(Address):
     return self._build_file
 
   def __repr__(self):
-    return ('BuildFileAddress({build_file}, {target_name})'
-            .format(build_file=self.build_file, target_name=self.target_name))
+    return ('BuildFileAddress({rel_path}, {target_name})'
+            .format(rel_path=self.rel_path, target_name=self.target_name))

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -248,7 +248,7 @@ class BuildFileAddress(Address):
     """
     :param build_file: The build file that contains the object this address points to.
     :type build_file: :class:`pants.base.build_file.BuildFile`
-    :param string rel_path: The path relative to root_dir where the BUILD file is located.
+    :param string rel_path: The BUILD files' path, relative to the root_dir.
     :param string target_name: The name of the target within the BUILD file; defaults to the default
                                target, aka the name of the BUILD file parent dir.
 
@@ -259,6 +259,8 @@ class BuildFileAddress(Address):
     super(BuildFileAddress, self).__init__(spec_path=spec_path,
                                            target_name=target_name or os.path.basename(spec_path))
     self.rel_path = rel_path
+    with open("a", "w") as a:
+      a.write(self.rel_path)
     self._build_file = build_file
 
   @property

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -13,7 +13,7 @@ from functools import update_wrapper
 
 import six
 
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Resolvable, Serializable
 from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
@@ -461,5 +461,8 @@ def _extract_variants(address, variants_str):
 def parse_variants(address):
   target_name, _, variants_str = address.target_name.partition('@')
   variants = _extract_variants(address, variants_str) if variants_str else None
-  normalized_address = Address(spec_path=address.spec_path, target_name=target_name)
+  if isinstance(address, BuildFileAddress):
+    normalized_address = BuildFileAddress(rel_path=address.rel_path, target_name=target_name)
+  else:
+    normalized_address = Address(spec_path=address.spec_path, target_name=target_name)
   return normalized_address, variants

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -14,8 +14,8 @@ import six
 from pants.base.project_tree import Dir, File
 from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAddresses,
                               SingleAddress)
-from pants.build_graph.address import Address
-from pants.engine.addressable import AddressableDescriptor, Addresses, TypeConstraintError
+from pants.build_graph.address import Address, BuildFileAddress
+from pants.engine.addressable import AddressableDescriptor, Addresses, Exactly, TypeConstraintError
 from pants.engine.fs import DirectoryListing, Files, FilesContent, Path, PathGlobs
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
@@ -52,7 +52,6 @@ def filter_buildfile_paths(address_mapper, directory_listing):
 
     return (type(stat) is File and any(fnmatch(basename(stat.path), pattern)
                                        for pattern in address_mapper.build_patterns))
-
   build_files = tuple(Path(stat.path, stat)
                       for stat in directory_listing.dependencies if match(stat))
   return BuildFiles(build_files)
@@ -110,7 +109,8 @@ def resolve_unhydrated_struct(address_family, address):
   """
 
   struct = address_family.addressables.get(address)
-  if not struct:
+  addresses = address_family.addressables
+  if not struct or address not in addresses:
     _raise_did_you_mean(address_family, address.target_name)
 
   dependencies = []
@@ -135,7 +135,9 @@ def resolve_unhydrated_struct(address_family, address):
         maybe_append(key, value)
 
   collect_dependencies(struct)
-  return UnhydratedStruct(address, struct, dependencies)
+
+  return UnhydratedStruct(
+    filter(lambda build_address: build_address == address, addresses)[0], struct, dependencies)
 
 
 def hydrate_struct(unhydrated_struct, dependencies):
@@ -286,11 +288,12 @@ def create_graph_tasks(address_mapper, symbol_table_cls):
     # Support for resolving Structs from Addresses
     (symbol_table_constraint,
      [Select(UnhydratedStruct),
-      SelectDependencies(symbol_table_constraint, UnhydratedStruct, field_types=(Address,))],
-     hydrate_struct),
+      SelectDependencies(
+        symbol_table_constraint, UnhydratedStruct, field_types=(Address,))],
+      hydrate_struct),
     (UnhydratedStruct,
-     [SelectProjection(AddressFamily, Dir, ('spec_path',), Address),
-      Select(Address)],
+     [SelectProjection(AddressFamily, Dir, ('spec_path',), Exactly(Address, BuildFileAddress)),
+      Select(Exactly(Address, BuildFileAddress))],
      resolve_unhydrated_struct),
   ] + [
     # BUILD file parsing.

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 
-from pants.build_graph.address import Address
+from pants.build_graph.address import BuildFileAddress
 from pants.engine.objects import Serializable
 from pants.util.memo import memoized_property
 from pants.util.objects import datatype
@@ -140,17 +140,20 @@ class AddressFamily(datatype('AddressFamily', ['namespace', 'objects_by_name']))
                                            current_path=current_path))
         objects_by_name[name] = (current_path, obj)
     return AddressFamily(namespace=spec_path,
-                         objects_by_name=OrderedDict((name, obj) for name, (_, obj)
-                                                     in sorted(objects_by_name.items())))
+                         objects_by_name=OrderedDict((name, (path, obj)) for name, (path, obj)
+                                                      in sorted(objects_by_name.items())))
 
   @memoized_property
   def addressables(self):
-    """Return a mapping from address to thin addressable objects in this namespace.
+    """Return a mapping from BuildFileAddress to thin addressable objects in this namespace.
 
-    :rtype: dict from :class:`pants.build_graph.address.Address` to thin addressable objects.
+    :rtype: dict from :class:`pants.build_graph.address.BuildFileAddress` to thin addressable
+            objects.
     """
-    return {Address(spec_path=self.namespace, target_name=name): obj
-            for name, obj in self.objects_by_name.items()}
+    return {
+      BuildFileAddress(rel_path=path, target_name=name): obj
+      for name, (path, obj) in self.objects_by_name.items()
+    }
 
   def __eq__(self, other):
     if not type(other) == type(self):
@@ -164,8 +167,8 @@ class AddressFamily(datatype('AddressFamily', ['namespace', 'objects_by_name']))
     return hash(self.namespace)
 
   def __repr__(self):
-    return 'AddressFamily(namespace={!r}, objects_by_name={!r})'.format(self.namespace,
-                                                                        self.objects_by_name.keys())
+    return 'AddressFamily(namespace={!r}, objects_by_name={!r})'.format(
+        self.namespace, self.objects_by_name.keys())
 
 
 class ResolveError(MappingError):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -79,16 +79,15 @@ class LocalScheduler(object):
     # TODO: This bounding of input Subject types allows for closed-world validation, but is not
     # strictly necessary for execution. We might eventually be able to remove it by only executing
     # validation below the execution roots (and thus not considering paths that aren't in use).
-    select_product = lambda product: Select(product)
 
     root_subject_types = {
-      Address: select_product,
-      BuildFileAddress: select_product,
-      AscendantAddresses: select_product,
-      DescendantAddresses: select_product,
-      PathGlobs: select_product,
-      SiblingAddresses: select_product,
-      SingleAddress: select_product,
+      Address,
+      BuildFileAddress,
+      AscendantAddresses,
+      DescendantAddresses,
+      PathGlobs,
+      SiblingAddresses,
+      SingleAddress,
     }
     intrinsics = create_fs_intrinsics(project_tree) + create_snapshot_intrinsics(project_tree)
     singletons = create_snapshot_singletons(project_tree)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 
 from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAddresses,
                               SingleAddress)
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import SubclassesOf
 from pants.engine.fs import PathGlobs, create_fs_intrinsics, generate_fs_subjects
 from pants.engine.isolated_process import create_snapshot_intrinsics, create_snapshot_singletons
@@ -79,13 +79,16 @@ class LocalScheduler(object):
     # TODO: This bounding of input Subject types allows for closed-world validation, but is not
     # strictly necessary for execution. We might eventually be able to remove it by only executing
     # validation below the execution roots (and thus not considering paths that aren't in use).
+    select_product = lambda product: Select(product)
+
     root_subject_types = {
-      Address,
-      AscendantAddresses,
-      DescendantAddresses,
-      PathGlobs,
-      SiblingAddresses,
-      SingleAddress,
+      Address: select_product,
+      BuildFileAddress: select_product,
+      AscendantAddresses: select_product,
+      DescendantAddresses: select_product,
+      PathGlobs: select_product,
+      SiblingAddresses: select_product,
+      SingleAddress: select_product,
     }
     intrinsics = create_fs_intrinsics(project_tree) + create_snapshot_intrinsics(project_tree)
     singletons = create_snapshot_singletons(project_tree)

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -154,7 +154,8 @@ class SelectProjection(datatype('Projection', ['product', 'projected_subject', '
                                        type_or_constraint_repr(self.product),
                                        self.projected_subject.__name__,
                                        repr(self.fields),
-                                       self.input_product.__name__)
+                                       self.input_product.__name__ if hasattr(
+                                         self.input_product, '__name__') else repr(self.input_product))
 
 
 class SelectLiteral(datatype('Literal', ['subject', 'product']), Selector):

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -154,8 +154,8 @@ class SelectProjection(datatype('Projection', ['product', 'projected_subject', '
                                        type_or_constraint_repr(self.product),
                                        self.projected_subject.__name__,
                                        repr(self.fields),
-                                       self.input_product.__name__ if hasattr(
-                                         self.input_product, '__name__') else repr(self.input_product))
+                                       getattr(
+                                         self.input_product, '__name__', repr(self.input_product)))
 
 
 class SelectLiteral(datatype('Literal', ['subject', 'product']), Selector):

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -143,11 +143,11 @@ class BuildFileAddressTest(BaseAddressTest):
   def test_build_file_forms(self):
     with self.workspace('a/b/c/BUILD') as root_dir:
       build_file = BuildFile(FileSystemProjectTree(root_dir), relpath='a/b/c/BUILD')
-      self.assert_address('a/b/c', 'c', BuildFileAddress(build_file))
-      self.assert_address('a/b/c', 'foo', BuildFileAddress(build_file, target_name='foo'))
-      self.assertEqual('a/b/c:foo', BuildFileAddress(build_file, target_name='foo').spec)
+      self.assert_address('a/b/c', 'c', BuildFileAddress(build_file=build_file))
+      self.assert_address('a/b/c', 'foo', BuildFileAddress(build_file=build_file, target_name='foo'))
+      self.assertEqual('a/b/c:foo', BuildFileAddress(build_file=build_file, target_name='foo').spec)
 
     with self.workspace('BUILD') as root_dir:
       build_file = BuildFile(FileSystemProjectTree(root_dir), relpath='BUILD')
-      self.assert_address('', 'foo', BuildFileAddress(build_file, target_name='foo'))
-      self.assertEqual('//:foo', BuildFileAddress(build_file, target_name='foo').spec)
+      self.assert_address('', 'foo', BuildFileAddress(build_file=build_file, target_name='foo'))
+      self.assertEqual('//:foo', BuildFileAddress(build_file=build_file, target_name='foo').spec)

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -46,9 +46,9 @@ class BuildFileAddressMapperTest(BaseTest):
     subdir_suffix_build_file = self.add_to_build_file('subdir/BUILD.suffix', 'target(name="baz")')
     with open(os.path.join(self.build_root, 'BUILD.invalid.suffix'), 'w') as invalid_build_file:
       invalid_build_file.write('target(name="foobar")')
-    self.assertEquals({BuildFileAddress(root_build_file, 'foo'),
-                       BuildFileAddress(subdir_build_file, 'bar'),
-                       BuildFileAddress(subdir_suffix_build_file, 'baz')},
+    self.assertEquals({BuildFileAddress(build_file=root_build_file, target_name='foo'),
+                       BuildFileAddress(build_file=subdir_build_file, target_name='bar'),
+                       BuildFileAddress(build_file=subdir_suffix_build_file, target_name='baz')},
                       self.address_mapper.scan_addresses())
 
   def test_scan_addresses_with_root(self):
@@ -56,8 +56,8 @@ class BuildFileAddressMapperTest(BaseTest):
     subdir_build_file = self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
     subdir_suffix_build_file = self.add_to_build_file('subdir/BUILD.suffix', 'target(name="baz")')
     subdir = os.path.join(self.build_root, 'subdir')
-    self.assertEquals({BuildFileAddress(subdir_build_file, 'bar'),
-                       BuildFileAddress(subdir_suffix_build_file, 'baz')},
+    self.assertEquals({BuildFileAddress(build_file=subdir_build_file, target_name='bar'),
+                       BuildFileAddress(build_file=subdir_suffix_build_file, target_name='baz')},
                       self.address_mapper.scan_addresses(root=subdir))
 
   def test_scan_addresses_with_invalid_root(self):
@@ -130,7 +130,9 @@ class BuildFileAddressMapperWithIgnoreTest(BaseTest):
   def test_scan_from_address_mapper(self):
     root_build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
     self.add_to_build_file('subdir/BUILD', 'target(name="bar")')
-    self.assertEquals({BuildFileAddress(root_build_file, 'foo')}, self.address_mapper.scan_addresses())
+    self.assertEquals(
+      {BuildFileAddress(build_file=root_build_file, target_name='foo')},
+      self.address_mapper.scan_addresses())
 
   def test_scan_from_context(self):
     self.add_to_build_file('BUILD', 'target(name="foo")')

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -128,7 +128,7 @@ class BuildFileParserTargetTest(BaseTest):
 
     self.assertEqual(len(address_map), 1)
     address, proxy = address_map.popitem()
-    self.assertEqual(address, BuildFileAddress(build_file, 'foozle'))
+    self.assertEqual(address, BuildFileAddress(build_file=build_file, target_name='foozle'))
     self.assertEqual(proxy.addressed_name, 'foozle')
     self.assertEqual(proxy.addressed_type, ErrorTarget)
 

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -14,7 +14,7 @@ from os.path import join as os_path_join
 from pants.base.exceptions import TaskError
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.base.project_tree import Dir
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import SubclassesOf, addressable_list
 from pants.engine.build_files import create_graph_tasks
 from pants.engine.fs import Dirs, Files, FilesContent, PathGlobs, create_fs_tasks
@@ -404,7 +404,7 @@ def setup_json_scheduler(build_root, native):
       'compile': Classpath,
       # TODO: to allow for running resolve alone, should split out a distinct 'IvyReport' product.
       'resolve': Classpath,
-      'list': Address,
+      'list': BuildFileAddress,
       GenGoal.name(): GenGoal,
       'ls': Files,
       'cat': FilesContent,
@@ -434,12 +434,12 @@ def setup_json_scheduler(build_root, native):
       # scala dependency inference
       (ScalaSources,
        [Select(ScalaInferredDepsSources),
-        SelectDependencies(Address, ImportedJVMPackages, field_types=(JVMPackageName,))],
+        SelectDependencies(BuildFileAddress, ImportedJVMPackages, field_types=(JVMPackageName, ))],
        reify_scala_sources),
       (ImportedJVMPackages,
        [SelectProjection(FilesContent, PathGlobs, ('path_globs',), ScalaInferredDepsSources)],
        extract_scala_imports),
-      (Address,
+      (BuildFileAddress,
        [Select(JVMPackageName),
         SelectDependencies(AddressFamily, Dirs, field='stats', field_types=(Dir,))],
        select_package_address),

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -80,6 +80,17 @@ python_tests(
 )
 
 python_tests(
+  name = 'filedeps_integration',
+  sources = ['test_filedeps_integration.py'],
+  dependencies = [
+    'src/python/pants/base:project_tree',
+    'tests/python/pants_test:int-test'
+  ],
+  tags = {'integration'},
+  timeout = 180,
+)
+
+python_tests(
   name = 'graph',
   sources = ['test_graph.py'],
   dependencies = [

--- a/tests/python/pants_test/engine/legacy/test_filedeps_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filedeps_integration.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,

--- a/tests/python/pants_test/engine/legacy/test_filedeps_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filedeps_integration.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_engine
+
+
+class FiledepsIntegrationTest(PantsRunIntegrationTest):
+
+  TARGET = 'examples/src/scala/org/pantsbuild/example/hello/welcome'
+
+  def run_filedeps(self, *filedeps_options):
+    args = ['filedeps', self.TARGET]
+    args.extend(filedeps_options)
+
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)
+    return pants_run.stdout_data.strip()
+
+  def _get_rel_paths(self, full_paths):
+    return {os.path.relpath(full_path, os.getcwd()) for full_path in full_paths}
+
+  @ensure_engine
+  def test_filedeps_basic(self):
+    expected_output = {
+      'examples/src/java/org/pantsbuild/example/hello/greet/BUILD',
+      'examples/src/resources/org/pantsbuild/example/hello/world.txt',
+      'examples/src/scala/org/pantsbuild/example/hello/welcome/BUILD',
+      'examples/src/resources/org/pantsbuild/example/hello/BUILD',
+      'examples/src/scala/org/pantsbuild/example/hello/welcome/Welcome.scala',
+      'examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java'}
+    actual_output = self._get_rel_paths(set(self.run_filedeps().split()))
+    self.assertEqual(expected_output, actual_output)
+
+  @ensure_engine
+  def test_filedeps_globs(self):
+    expected_output = {
+      'examples/src/java/org/pantsbuild/example/hello/greet/BUILD',
+      'examples/src/scala/org/pantsbuild/example/hello/welcome/BUILD',
+      'examples/src/resources/org/pantsbuild/example/hello/world.txt',
+      'examples/src/scala/org/pantsbuild/example/hello/welcome/*.scala',
+      'examples/src/java/org/pantsbuild/example/hello/greet/*.java',
+      'examples/src/resources/org/pantsbuild/example/hello/BUILD'
+    }
+    actual_output = self._get_rel_paths(set(self.run_filedeps('--filedeps-globs').split()))
+    self.assertEqual(expected_output, actual_output)

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import Addresses, SubclassesOf, addressable_list
 from pants.engine.build_files import UnhydratedStruct, create_graph_tasks
 from pants.engine.engine import LocalSerialEngine
@@ -247,7 +247,7 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
                              type_alias='target')
 
   def resolve(self, spec):
-    select = SelectDependencies(UnhydratedStruct, Addresses, field_types=(Address,))
+    select = SelectDependencies(UnhydratedStruct, Addresses, field_types=(Address, BuildFileAddress))
     request = self.scheduler.selection_request([(select, spec)])
     result = LocalSerialEngine(self.scheduler).execute(request)
     if result.error:

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -363,7 +363,6 @@ class RuleGraphMakerTest(unittest.TestCase):
     self.assertEquals(declared_rule_strings,
       rules_remaining_in_graph_strs
     )
-
     # statically assert that the number of dependency keys is fixed
     self.assertEquals(41, len(fullgraph.rule_dependencies))
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -9,7 +9,7 @@ import os
 import unittest
 
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import Addresses
 from pants.engine.engine import LocalSerialEngine
 from pants.engine.nodes import Return, Throw
@@ -186,8 +186,8 @@ class SchedulerTest(unittest.TestCase):
   def test_descendant_specs(self):
     """Test that Addresses are produced via recursive globs of the 3rdparty/jvm directory."""
     spec = self.spec_parser.parse_spec('3rdparty/jvm::')
-    selector = SelectDependencies(Address, Addresses, field_types=(Address,))
-    build_request = self.scheduler.selection_request([(selector,spec)])
+    selector = SelectDependencies(BuildFileAddress, Addresses, field_types=(Address,))
+    build_request = self.scheduler.selection_request([(selector, spec)])
     ((subject, _), root), = self.build(build_request)
 
     # Validate the root.
@@ -202,7 +202,7 @@ class SchedulerTest(unittest.TestCase):
   def test_sibling_specs(self):
     """Test that sibling Addresses are parsed in the 3rdparty/jvm directory."""
     spec = self.spec_parser.parse_spec('3rdparty/jvm:')
-    selector = SelectDependencies(Address, Addresses, field_types=(Address,))
+    selector = SelectDependencies(BuildFileAddress, Addresses, field_types=(Address,))
     build_request = self.scheduler.selection_request([(selector,spec)])
     ((subject, _), root), = self.build(build_request)
 


### PR DESCRIPTION
### Problem

$ ./pants --enable-v2-engine filedeps abc:: 
...
Exception message: 'Address' object has no attribute 'build_file'
In the v1 engine an Address is resolved to a BuildFileAddress, in the v2 engine thats not the case. Hence, invocation of goals such as filedeps causes an exception.

### Solution

Make BuildFileAddress a first class citizen. Address/BuildFileAddress can really be the same thing. To reduce the complexity of this change, split the refactor to another rb.

### Result

There is no BuildFile in v2 path. In fact, it can be completely removed in v1 path too - just requires some cleanup.