### PR TITLE
Get rid of resources=[] stanzas in our JVMTargets.

### DIFF
--- a/examples/src/java/org/pantsbuild/example/hello/main/BUILD
+++ b/examples/src/java/org/pantsbuild/example/hello/main/BUILD
@@ -20,8 +20,6 @@ jvm_app(
 jvm_binary(name = 'main-bin',
   dependencies = [
     'examples/src/java/org/pantsbuild/example/hello/greet',
-  ],
-  resources=[
     'examples/src/resources/org/pantsbuild/example/hello',
   ],
   source = 'HelloMain.java',

--- a/examples/src/scala/org/pantsbuild/example/hello/welcome/BUILD
+++ b/examples/src/scala/org/pantsbuild/example/hello/welcome/BUILD
@@ -6,8 +6,6 @@
 scala_library(
   dependencies=[
     'examples/src/java/org/pantsbuild/example/hello/greet:greet',
-  ],
-  resources = [
     'examples/src/resources/org/pantsbuild/example/hello',
   ],
   provides = scala_artifact(org='org.pantsbuild.example.hello',

--- a/examples/tests/java/org/pantsbuild/example/hello/greet/BUILD
+++ b/examples/tests/java/org/pantsbuild/example/hello/greet/BUILD
@@ -6,8 +6,6 @@
 junit_tests(
   dependencies=[
     'examples/src/java/org/pantsbuild/example/hello/greet',
-  ],
-  resources=[
     'examples/src/resources/org/pantsbuild/example/hello',
   ],
 )

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -154,7 +154,7 @@ class Jar(object):
 
     If called multiple times, new entry will be appended to the existing classpath.
 
-    :param list classpath: a list of paths
+    :param iterable classpath: a list of paths
     """
     self._classpath = self._classpath + maybe_list(classpath)
 

--- a/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_binary_task.py
@@ -79,7 +79,7 @@ class JvmBinaryTask(JarBuilderTask):
 
     :param binary: The jvm_binary target to operate on.
     :param path: Write the output jar here, overwriting an existing file, if any.
-    :param string manifest_classpath: If set output jar will set as its manifest's
+    :param iterable manifest_classpath: If set output jar will set as its manifest's
       classpath, otherwise output jar will simply include class files.
     """
     # TODO(benjy): There's actually nothing here that requires 'binary' to be a jvm_binary.

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
@@ -7,9 +7,7 @@ junit_tests(
   ],
   dependencies=[
     '3rdparty:junit',
-  ],
-  resources=[
-    'testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources'
+    'testprojects/maven_layout/junit_resource_collision/onedir/src/test/resources',
   ],
   cwd='testprojects/maven_layout/junit_resource_collision/onedir',
 )

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
@@ -7,9 +7,7 @@ junit_tests(
   ],
   dependencies=[
     '3rdparty:junit',
-  ],
-  resources=[
-    'testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources'
+    'testprojects/maven_layout/junit_resource_collision/twodir/src/test/resources',
   ],
   cwd='testprojects/maven_layout/junit_resource_collision/twodir',
 )

--- a/testprojects/maven_layout/resource_collision/example_a/src/main/java/org/pantsbuild/duplicateres/examplea/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_a/src/main/java/org/pantsbuild/duplicateres/examplea/BUILD
@@ -10,9 +10,9 @@ jvm_binary(
 
 java_library(name='lib',
   sources=['Main.java'],
-  resources=['testprojects/maven_layout/resource_collision/example_a/src/main/resources'],
   dependencies=[
     'testprojects/maven_layout/resource_collision/example_b/src/main/java/org/pantsbuild/duplicateres/exampleb:lib',
     'testprojects/maven_layout/resource_collision/lib/src/main/java/org/pantsbuild/duplicateres/lib',
+    'testprojects/maven_layout/resource_collision/example_a/src/main/resources',
   ],
 )

--- a/testprojects/maven_layout/resource_collision/example_b/src/main/java/org/pantsbuild/duplicateres/exampleb/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_b/src/main/java/org/pantsbuild/duplicateres/exampleb/BUILD
@@ -8,9 +8,9 @@ jvm_binary(
 
 java_library(name='lib',
   sources=['Main.java'],
-  resources=['testprojects/maven_layout/resource_collision/example_b/src/main/resources'],
   dependencies=[
     'testprojects/maven_layout/resource_collision/example_c/src/main/java/org/pantsbuild/duplicateres/examplec:lib',
     'testprojects/maven_layout/resource_collision/lib/src/main/java/org/pantsbuild/duplicateres/lib',
+    'testprojects/maven_layout/resource_collision/example_b/src/main/resources',
   ],
 )

--- a/testprojects/maven_layout/resource_collision/example_c/src/main/java/org/pantsbuild/duplicateres/examplec/BUILD
+++ b/testprojects/maven_layout/resource_collision/example_c/src/main/java/org/pantsbuild/duplicateres/examplec/BUILD
@@ -10,8 +10,8 @@ jvm_binary(
 
 java_library(name='lib',
   sources=['Main.java'],
-  resources=['testprojects/maven_layout/resource_collision/example_c/src/main/resources'],
   dependencies=[
     'testprojects/maven_layout/resource_collision/lib/src/main/java/org/pantsbuild/duplicateres/lib',
+    'testprojects/maven_layout/resource_collision/example_c/src/main/resources',
   ],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/bundle/BUILD
@@ -43,11 +43,9 @@ jvm_binary(name = 'bundle-bin',
   source = 'BundleMain.java',
   main = 'org.pantsbuild.testproject.bundle.BundleMain',
   basename = 'bundle-example-bin',
-  resources = [
-    'testprojects/src/resources/org/pantsbuild/testproject/bundleresources:resources',
-  ],
   dependencies = [
     '3rdparty:guava',
+    'testprojects/src/resources/org/pantsbuild/testproject/bundleresources:resources',
   ]
 )
 
@@ -60,14 +58,14 @@ jvm_app(name='missing-files',
   ]
 )
 
-# Tests `resources=` ordering via integration test.
+# Tests resources ordering via integration test.
 jvm_binary(
   name='bundle-resource-ordering',
   source='BundleMain.java',
   main='org.pantsbuild.testproject.bundle.BundleMain',
-  resources=[
+  dependencies=[
+    '3rdparty:guava',
     'testprojects/src/resources/org/pantsbuild/testproject/bundleresources:resources',
     'testprojects/tests/resources/org/pantsbuild/testproject/bundleresources:resources',
-  ],
-  dependencies=['3rdparty:guava']
+  ]
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/ideacodeandresources/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/ideacodeandresources/BUILD
@@ -5,7 +5,7 @@
 java_library(
   name='code',
   sources = ['ResourcesAndCode.java'],
-  resources=[
+  dependencies=[
       ':readme',
       'testprojects/src/resources/org/pantsbuild/testproject/ideacodeandresources:resource',
    ],

--- a/testprojects/src/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
@@ -4,7 +4,7 @@
 # see test_idea_integration.py
 java_library(
   sources = ['Code.java'],
-  resources=[
+  dependencies=[
       'testprojects/src/resources/org/pantsbuild/testproject/idearesourcesonly:resource',
    ],
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/ideacodeandresources/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/ideacodeandresources/BUILD
@@ -5,15 +5,13 @@
 junit_tests(
   name='code',
   sources = ['TestResourcesAndCode.java'],
-  resources=[
-      ':readme',
-      # Add a direct dependency on a non-test resources folder
-      # to make sure it stays non-test resources
-      'testprojects/src/resources/org/pantsbuild/testproject/ideacodeandresources:resource',
-      'testprojects/tests/resources/org/pantsbuild/testproject/ideacodeandresources:resource',
-   ],
   dependencies=[
     '3rdparty:junit',
+    ':readme',
+    # Add a direct dependency on a non-test resources folder
+    # to make sure it stays non-test resources
+    'testprojects/src/resources/org/pantsbuild/testproject/ideacodeandresources:resource',
+    'testprojects/tests/resources/org/pantsbuild/testproject/ideacodeandresources:resource',
   ]
 )
 

--- a/testprojects/tests/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/idearesourcesonly/code/BUILD
@@ -4,10 +4,8 @@
 # see test_idea_integration.py
 junit_tests(
   sources=['TestCode.java'],
-  resources=[
-      'testprojects/tests/resources/org/pantsbuild/testproject/idearesourcesonly:resource',
-   ],
   dependencies=[
     '3rdparty:junit',
+    'testprojects/tests/resources/org/pantsbuild/testproject/idearesourcesonly:resource',
   ],
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/ivyclassifier/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/ivyclassifier/BUILD
@@ -3,12 +3,10 @@
 
 junit_tests(
   sources=['IvyClassifierTest.java'],
-  resources=[
-    'testprojects/tests/resources/org/pantsbuild/testproject/ivyclassifier',
-  ],
   dependencies=[
    '3rdparty:junit',
    ':jars_with_classifier',
+    'testprojects/tests/resources/org/pantsbuild/testproject/ivyclassifier',
   ],
 )
 

--- a/tests/java/org/pantsbuild/tools/jar/BUILD
+++ b/tests/java/org/pantsbuild/tools/jar/BUILD
@@ -11,8 +11,6 @@ junit_tests(
     'src/java/org/pantsbuild/args4j',
     'src/java/org/pantsbuild/testing',
     'src/java/org/pantsbuild/tools/jar',
-  ],
-  resources=[
     'tests/resources/org/pantsbuild/tools/jar',
   ],
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_bundle_create.py
@@ -83,8 +83,7 @@ class TestBundleCreate(JvmBinaryTaskTestBase):
 
     self.binary_target = self.make_target(spec='//foo:foo-binary',
                                           target_type=JvmBinary,
-                                          dependencies=[self.java_lib_target, self.jar_lib],
-                                          resources=[self.resources_target.address.spec])
+                                          dependencies=[self.java_lib_target, self.jar_lib, self.resources_target])
 
     self.dist_root = os.path.join(self.build_root, 'dist')
 


### PR DESCRIPTION
Resources targets can, and should, just be regular dependencies.
We should probably deprecate resources=[], there's no good reason for it to exist.

Note that nothing changes for PythonTargets, where resources= are filesets.
