### PR TITLE
Treat PythonTarget dependencies on Resources targets appropriately.

### DIFF
--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -124,21 +124,12 @@ class PythonTarget(Target):
 
   @property
   def resources(self):
-    resource_targets = []
-
-    if self._resource_target_specs:
-      def get_target(spec):
-        address = Address.parse(spec, relative_to=self.address.spec_path)
-        tgt = self._build_graph.get_target(address)
-        if tgt is None:
-          raise TargetDefinitionException(self, 'No such resource target: {}'.format(address))
-        return tgt
-      resource_targets.extend(get_target(spec) for spec in self._resource_target_specs)
-
-    if self._synthetic_resources_target:
-      resource_targets.append(self._synthetic_resources_target)
-
-    return resource_targets
+    # Note: Will correctly find:
+    #   - Regular dependencies on Resources targets.
+    #   - Resources targets specified via resource_targets=.
+    #   - The synthetic Resources target created from the resources= fileset.
+    # Because these are all in the traversable_dependency_specs.
+    return [dep for dep in self.dependencies if isinstance(dep, Resources)]
 
   def walk(self, work, predicate=None):
     super(PythonTarget, self).walk(work, predicate)

--- a/tests/python/pants_test/targets/test_python_target.py
+++ b/tests/python/pants_test/targets/test_python_target.py
@@ -79,3 +79,15 @@ class PythonTargetTest(BaseTest):
                                                    expected_resource_path='res/data.txt',
                                                    expected_resource_contents='1/137')
     self.assertIs(res, resource_dep)
+
+  def test_resource_dependencies(self):
+    self.create_file('res/data.txt', contents='1/137')
+    res = self.make_target(spec='res:resources', target_type=Resources, sources=['data.txt'])
+    lib = self.make_target(spec='test:lib',
+                           target_type=PythonLibrary,
+                           sources=[],
+                           dependencies=[res])
+    resource_dep = self.assert_single_resource_dep(lib,
+                                                   expected_resource_path='res/data.txt',
+                                                   expected_resource_contents='1/137')
+    self.assertIs(res, resource_dep)


### PR DESCRIPTION
`target.resources` will now iterate over those, as well as the other
two ways of specifying resources.

Also simplifies that iteration: all ways of specifying python target
resources end up in the traversable_dependency_specs, so there's
no need for `target.resources` to laboriously handle each way separately,
as it did before.
