### PR TITLE
Remove our use of resources= and resource_targets= in python targets.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/BUILD
@@ -3,10 +3,8 @@
 
 python_library(
   name='python',
-  resource_targets=[
-    ':resources'
-  ],
   dependencies=[
+    ':resources',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks:python',
     'src/python/pants/base:exceptions',

--- a/src/docs/common_tasks/jvm_library.md
+++ b/src/docs/common_tasks/jvm_library.md
@@ -21,7 +21,6 @@ A `scala_library` or `java_library` target should specify the following:
 * A `name` for the library. This may be something like just `scala` if you have only one `scala_library` target in a project or something more specific like `client-lib`.
 * Either a single `source` file or a list of `sources`. If you're including just a few files, you should consider specifying a sources list, e.g. `sources=['File1.scala', 'File2.scala']`; if you're including, you may want to specify a `globs` or `rglobs`, e.g. `sources=globs('*.scala')`. More info can be found in [[Use globs and rglobs to Group Files|pants('src/docs/common_tasks:globs')]]. The example further down use an `rglobs` definition.
 * A list of `dependencies` (optional). More info on dependencies can be found in [[Add a Dependency on Another Target|pants('src/docs/common_tasks:dependencies')]].
-* A list of `resources` (optional). More info on resources can be found in [[Create a Resource Bundle|pants('src/docs/common_tasks:resources')]].
 
 Here's an example target definition:
 
@@ -31,9 +30,9 @@ Here's an example target definition:
       sources=globs('*.scala'),
       dependencies=[
         'client-lib',
-        'analytics-lib'
+        'analytics-lib',
+        'static/resources/json:config',
       ],
-      resources=['myproject/src/main/resources']
     )
 
 That library can then be compiled (perhaps for debugging purposes):

--- a/src/docs/common_tasks/python_library.md
+++ b/src/docs/common_tasks/python_library.md
@@ -17,7 +17,6 @@ A `python_library` target definition should specify the following:
 * A `name` for the target
 * Either a single `source` Python file or a list of `sources`
 * A list of `dependencies` (optional)
-* A list of `resources` (optional). More info can be found in [[Create a Resource Bundle|pants('src/docs/common_tasks:resources')]].
 
 Here is an example target definition:
 
@@ -27,10 +26,8 @@ Here is an example target definition:
       dependencies=[
         'server/src/python:server-lib',
         'client/src/python:client-lib',
+        'static/json:config'
       ],
-      resources=[
-        globs('static/*.json')
-      ]
     )
 
 Now, another library or binary can depend on the target you created:

--- a/src/docs/common_tasks/resources.md
+++ b/src/docs/common_tasks/resources.md
@@ -38,7 +38,7 @@ You can also exclude files, globs, or rglobs using the `-` operator:
       sources=rglobs('*') - rglobs('*.pyc')
     )
 
-Once your resource bundle has been specified, you can depend on it, for example, a library target definition. Here's an example:
+Once your resource bundle has been specified, you can depend on it from the target that consumes the resources:
 
     ::python
     java_library(name='server',
@@ -49,7 +49,8 @@ Once your resource bundle has been specified, you can depend on it, for example,
       ]
     )
 
-This dependency ensures that the files in the resource bundle will be present at runtime (e.g., they will be bundled up with the code).
+This dependency ensures that the files in the resource bundle will be present at runtime (e.g.,
+for JVM binaries, they will be included on the runtime classpath).
 
 ## See Also
 

--- a/src/docs/common_tasks/resources.md
+++ b/src/docs/common_tasks/resources.md
@@ -38,13 +38,18 @@ You can also exclude files, globs, or rglobs using the `-` operator:
       sources=rglobs('*') - rglobs('*.pyc')
     )
 
-Once your resource bundle has been specified, you can include it in, for example, a library target definition. Here's an example:
+Once your resource bundle has been specified, you can depend on it, for example, a library target definition. Here's an example:
 
     ::python
     java_library(name='server',
-      # Other parameters
-      resources=['myproject/src/main/resources:config']
+      sources=globs('*.java'),
+      dependencies=[
+        ...
+        'myproject/src/main/resources:config'
+      ]
     )
+
+This dependency ensures that the files in the resource bundle will be present at runtime (e.g., they will be bundled up with the code).
 
 ## See Also
 

--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -79,7 +79,6 @@ class Page(Target):
                source=None,
                format=None,
                links=None,
-               resources=None,
                provides=None,
                **kwargs):
     """
@@ -91,7 +90,6 @@ class Page(Target):
     :param provides: Optional "Addresses" at which this page is published.
        E.g., a wiki location.
     :type provides: List of ``wiki_artifact``s
-    :param resources: An optional list of Resources objects.
     """
     payload = payload or Payload()
     if not format:
@@ -107,7 +105,6 @@ class Page(Target):
       'links': PrimitiveField(links or []),
       'provides': self.ProvidesTupleField(provides or []),
     })
-    self._resource_specs = resources or []
     super(Page, self).__init__(address=address, payload=payload, **kwargs)
 
     if provides and not isinstance(provides[0], WikiArtifact):
@@ -117,13 +114,6 @@ class Page(Target):
   def source(self):
     """The first (and only) source listed by this Page."""
     return list(self.payload.sources.source_paths)[0]
-
-  @property
-  def traversable_dependency_specs(self):
-    for spec in super(Page, self).traversable_dependency_specs:
-      yield spec
-    for resource_spec in self._resource_specs:
-      yield resource_spec
 
   @property
   def traversable_specs(self):

--- a/src/python/pants/backend/docgen/tasks/BUILD
+++ b/src/python/pants/backend/docgen/tasks/BUILD
@@ -2,10 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  resource_targets = [
-    ':resources',
-  ],
   dependencies = [
+    ':resources',
     '3rdparty/python:docutils',
     '3rdparty/python:Markdown',
     '3rdparty/python:Pygments',

--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -50,12 +50,10 @@ python_library(
 python_library(
   name='ivy_utils',
   sources=['ivy_utils.py'],
-  resource_targets=[
-    ':ivy_utils_resources',
-  ],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:six',
+    ':ivy_utils_resources',
     ':jar_dependency_utils',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:jvm',

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -246,14 +246,12 @@ python_library(
 python_library(
   name = 'jar_publish',
   sources = ['jar_publish.py'],
-  resource_targets = [
-    ':jar_publish_resources',
-    ':reports_resources'
-  ],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    ':jar_publish_resources',
     ':jar_task',
     ':properties',
+    ':reports_resources',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm/targets:scala',
     'src/python/pants/backend/jvm:ivy_utils',

--- a/src/python/pants/backend/project_info/tasks/BUILD
+++ b/src/python/pants/backend/project_info/tasks/BUILD
@@ -41,10 +41,8 @@ python_library(
 python_library(
   name = 'eclipse_gen',
   sources = ['eclipse_gen.py'],
-  resource_targets = [
-    ':eclipse_gen_resources',
-  ],
   dependencies = [
+    ':eclipse_gen_resources',
     ':ide_gen',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
@@ -61,10 +59,8 @@ resources(
 python_library(
   name = 'ensime_gen',
   sources = ['ensime_gen.py'],
-  resource_targets = [
-    ':ensime_gen_resources',
-  ],
   dependencies = [
+    ':ensime_gen_resources',
     ':ide_gen',
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
@@ -140,11 +136,9 @@ python_library(
 python_library(
   name = 'idea_gen',
   sources = ['idea_gen.py'],
-  resource_targets = [
-    ':idea_resources',
-  ],
   dependencies = [
     ':ide_gen',
+    ':idea_resources',
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:generator',
@@ -156,10 +150,8 @@ python_library(
 python_library(
   name = 'idea_plugin_gen',
   sources = ['idea_plugin_gen.py'],
-  resource_targets = [
-    ':idea_resources',
-  ],
   dependencies = [
+    ':idea_resources',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -45,6 +45,7 @@ class AbstractTarget(object):
     """
     return tuple()
 
+  # TODO: Kill this in 1.5.0.dev0, once this old-style resource specification is gone.
   @property
   def has_resources(self):
     """Returns True if the target has an associated set of Resources.

--- a/src/python/pants/core_tasks/BUILD
+++ b/src/python/pants/core_tasks/BUILD
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  resource_targets=[':templates',],
   dependencies=[
+    ':templates',
     '3rdparty/python:ansicolors',
     '3rdparty/python:setuptools',
     '3rdparty/python:packaging',

--- a/src/python/pants/engine/legacy/source_mapper.py
+++ b/src/python/pants/engine/legacy/source_mapper.py
@@ -64,6 +64,7 @@ class EngineSourceMapper(SourceMapper):
         yield f
 
     # Handle `resources`-declaring targets.
+    # TODO: Remember to get rid of this in 1.5.0.dev0, when the deprecation of `resources` is complete.
     target_resources = target_kwargs.get('resources')
     if target_resources:
       # N.B. `resources` params come in two flavors:

--- a/src/python/pants/engine/subsystem/BUILD
+++ b/src/python/pants/engine/subsystem/BUILD
@@ -5,15 +5,13 @@ python_library(
   name='native',
   sources=['native.py'],
   dependencies=[
+    ':native_engine_version',
     '3rdparty/python:cffi',
     '3rdparty/python:setuptools',
     'src/python/pants/binaries:binary_util',
     'src/python/pants/subsystem:subsystem',
     'src/python/pants/engine:storage',
   ],
-  resource_targets=[
-    ':native_engine_version'
-  ]
 )
 
 resources(

--- a/src/python/pants/java/distribution/BUILD
+++ b/src/python/pants/java/distribution/BUILD
@@ -3,10 +3,8 @@
 
 python_library(
   sources=[ 'distribution.py' ],
-  resource_targets=[
-    ':resources',
-  ],
   dependencies=[
+    ':resources',
     '3rdparty/python:six',
     'src/python/pants/base:revision',
     'src/python/pants/java:util',

--- a/src/python/pants/reporting/BUILD
+++ b/src/python/pants/reporting/BUILD
@@ -3,14 +3,12 @@
 
 python_library(
   sources=globs('*.py', exclude=[['report.py']]),
-  resource_targets=[
-    ':reporting_resources',
-  ],
   dependencies=[
     '3rdparty/python:ansicolors',
     '3rdparty/python:pystache',
     '3rdparty/python:six',
     ':report',
+    ':reporting_resources',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:mustache',

--- a/testprojects/src/python/sources/BUILD
+++ b/testprojects/src/python/sources/BUILD
@@ -1,3 +1,3 @@
 python_library(
-  resources=globs('*.txt'),
+  sources=globs('*.py'),
 )

--- a/testprojects/src/python/sources/BUILD
+++ b/testprojects/src/python/sources/BUILD
@@ -1,3 +1,6 @@
 python_library(
+  # TODO: Some tests in tests/python/pants_test/engine/legacy:changed_integration
+  # (e.g., test_changed_coverage_direct_src_python_sources_sources_py) fail if this
+  # target doesn't have an explicit sources= stanza.  Figure out why, and fix.
   sources=globs('*.py'),
 )

--- a/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_dependees.py
@@ -94,7 +94,7 @@ class BaseReverseDepmapTest(ConsoleTaskTestBase):
       java_library(
         name='a_java',
         sources=[],
-        resources=['resources/a:a_resources']
+        dependencies=['resources/a:a_resources']
       )
     """))
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_depmap.py
@@ -101,7 +101,7 @@ class DepmapTest(BaseDepmapTest):
       java_library(
         name='a_java',
         sources=[],
-        resources=['resources/a:a_resources']
+        dependencies=['resources/a:a_resources']
       )
     """))
     self.add_to_build_file('src/java/a', dedent("""

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -404,6 +404,7 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
       result['targets']['src/python/z:z']['globs']
     )
 
+  # TODO: Delete this test in 1.5.0.dev0, once we remove support for resources=.
   def test_synthetic_target(self):
     # Create a BUILD file then add itself as resources
     self.add_to_build_file('src/python/alpha/BUILD', """

--- a/tests/python/pants_test/build_graph/test_source_mapper.py
+++ b/tests/python/pants_test/build_graph/test_source_mapper.py
@@ -46,7 +46,7 @@ class SourceMapperTest(object):
     self.add_to_build_file('path', dedent('''
     java_library(name='target',
                  sources=['BUILD'],
-                 resources=[':buildholder']
+                 dependencies=[':buildholder']
     )
     java_library(name='buildholder',
                  sources=['BUILD']

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -202,8 +202,8 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
       transitive=['src/java/org/pantsbuild/helloworld:helloworld',
                   'src/resources/org/pantsbuild/resourceonly:resource'],
     ),
-    # A `python_library` with `resources=['file.name']`.
-    'src/python/sources/sources.txt': dict(
+    # A `python_library` with `sources=['file.name'] .
+    'src/python/sources/sources.py': dict(
       none=['src/python/sources:sources'],
       direct=['src/python/sources:sources'],
       transitive=['src/python/sources:sources']

--- a/tests/python/pants_test/engine/legacy/test_filemap_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_filemap_integration.py
@@ -48,9 +48,6 @@ class FilemapIntegrationTest(PantsRunIntegrationTest):
                           success=True,
                           enable_v2_engine=True)
     self.assertIn('testprojects/src/python/sources/sources.py', run.stdout_data)
-    # FIXME: The synthetic target that is created to expose the `resources=globs` arg does not show
-    # up in filemap, because it is synthetic. see https://github.com/pantsbuild/pants/issues/3563
-    #self.assertIn('testprojects/src/python/sources/sources.txt', run.stdout_data)
 
   def test_exclude_invalid_string(self):
     build_path = os.path.join(self.PATH_PREFIX, 'BUILD.invalid')


### PR DESCRIPTION
So we can deprecate them.

Also fixes up documentation around resources, and a few stray jvm target
resources= uses.
