### PR TITLE
Options should only default to --color=True if sys.stdout.isatty()

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import os
+import sys
 
 from pants.base.build_environment import (get_buildroot, get_default_pants_config_file,
                                           get_pants_cachedir, get_pants_configdir, pants_version)
@@ -45,7 +46,7 @@ class GlobalOptionsRegistrar(Optionable):
              help='Squelches most console output.')
     # Not really needed in bootstrap options, but putting it here means it displays right
     # after -l and -q in help output, which is conveniently contextual.
-    register('--colors', type=bool, default=True, recursive=True,
+    register('--colors', type=bool, default=sys.stdout.isatty(), recursive=True,
              help='Set whether log messages are displayed in color.')
 
     # Pants code uses this only to verify that we are of the requested version. However


### PR DESCRIPTION
### Problem

When running `./pants options|grep blah` to find the relevant option for a given feature, the output is colorized unless the flag `--no-colors` is given explicitly.  

### Solution

Set the default for `--colors` based on `sys.stdout.isatty()`. It only makes sense to colorize output if it will be shown on a terminal, so one may use this as the basis for the default and get the correct result.

### Result

Output of `options` is only colorized by default when outputting directly to a terminal.