### PR TITLE
Upgrade default jarjar to 1.6.4.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/shader.py
+++ b/src/python/pants/backend/jvm/subsystems/shader.py
@@ -237,7 +237,7 @@ class Shader(object):
       cls.register_jvm_tool(register,
                             'jarjar',
                             classpath=[
-                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.6.2')
+                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.6.4')
                             ])
 
     @classmethod


### PR DESCRIPTION
This picks up asm fixes from and closes
https://github.com/pantsbuild/jarjar/issues/26.