### PR TITLE
Memoize validation of deprecated versions

### DIFF
--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -11,6 +11,7 @@ from functools import wraps
 
 import six
 from packaging.version import InvalidVersion, Version
+from pants.util.memo import memoized_method
 
 from pants.version import PANTS_SEMVER
 
@@ -50,6 +51,7 @@ def get_deprecated_tense(removal_version, future_tense='will be', past_tense='wa
   return future_tense if (Version(removal_version) >= PANTS_SEMVER) else past_tense
 
 
+@memoized_method
 def validate_removal_semver(removal_version):
   """Validates that removal_version is a valid semver.
 


### PR DESCRIPTION
### Problem

7% of the runtime for `./pants list` in our repo was being taken up in version validation (all for a relatively small set of deprecation versions used in pantsbuild/pants).

### Solution

Memoize validation of versions.