### PR TITLE
[New Python Pipeline] Add resources to PEXes correctly.

### DIFF
--- a/src/python/pants/backend/python/tasks2/gather_sources.py
+++ b/src/python/pants/backend/python/tasks2/gather_sources.py
@@ -76,7 +76,10 @@ class GatherSources(Task):
     for relpath in tgt.sources_relative_to_source_root():
       try:
         src = os.path.join(buildroot, tgt.target_base, relpath)
-        builder.add_source(src, relpath)
+        if isinstance(tgt, Resources):
+          builder.add_resource(src, relpath)
+        else:
+          builder.add_source(src, relpath)
       except OSError:
         self.context.log.error('Failed to copy {} for target {}'.format(
             os.path.join(tgt.target_base, relpath), tgt.address.spec))

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -32,8 +32,8 @@ python_tests(
 )
 
 python_tests(
-  name = 'test_round_engine',
-  sources = ['test_round_engine.py'],
+  name='test_round_engine',
+  sources=['test_round_engine.py'],
   dependencies = [
     ':engine_test_base',
     'src/python/pants/engine:legacy_engine',
@@ -58,6 +58,7 @@ python_tests(
     'src/python/pants/engine:fs',
     'src/python/pants/engine:nodes',
     'tests/python/pants_test/testutils:git_util',
+    'tests/python/pants_test/engine/examples:fs_test',
   ]
 )
 
@@ -84,6 +85,8 @@ python_tests(
     'src/python/pants/engine:nodes',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/testutils:git_util',
+    'tests/python/pants_test/engine/examples:fs_test',
+    'tests/python/pants_test/engine/examples:scheduler_inputs',
   ]
 )
 
@@ -121,7 +124,9 @@ python_tests(
   dependencies=[
     'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
+    'tests/python/pants_test/engine:util',
     'tests/python/pants_test/engine/examples:planners',
+    'tests/python/pants_test/engine/examples:scheduler_inputs',
     'src/python/pants/engine:engine',
     'src/python/pants/engine:scheduler',
     'src/python/pants/engine:nodes',
@@ -141,6 +146,7 @@ python_tests(
     'src/python/pants/engine:parser',
     'src/python/pants/engine:storage',
     'src/python/pants/engine:struct',
+    'tests/python/pants_test/engine/examples:graph_test',
     'tests/python/pants_test/engine/examples:parsers',
   ]
 )
@@ -151,11 +157,12 @@ python_tests(
   dependencies=[
     ':scheduler_test_base',
     'src/python/pants/build_graph',
-    'tests/python/pants_test/engine/examples:parsers',
     'src/python/pants/engine:mapper',
     'src/python/pants/engine:storage',
     'src/python/pants/engine:struct',
     'src/python/pants/util:dirutil',
+    'tests/python/pants_test/engine/examples:mapper_test',
+    'tests/python/pants_test/engine/examples:parsers',
   ]
 )
 
@@ -200,6 +207,7 @@ python_tests(
     'src/python/pants/engine:engine',
     'src/python/pants/engine:scheduler',
     'tests/python/pants_test/engine/examples:planners',
+    'tests/python/pants_test/engine/examples:scheduler_inputs',
   ]
 )
 

--- a/tests/python/pants_test/engine/examples/BUILD
+++ b/tests/python/pants_test/engine/examples/BUILD
@@ -83,3 +83,22 @@ python_binary(
   ]
 )
 
+resources(
+  name='fs_test',
+  sources=rglobs('fs_test/*')
+)
+
+resources(
+  name='graph_test',
+  sources=rglobs('graph_test/*')
+)
+
+resources(
+  name='mapper_test',
+  sources=rglobs('mapper_test/*')
+)
+
+resources(
+  name='scheduler_inputs',
+  sources=rglobs('scheduler_inputs/*')
+)


### PR DESCRIPTION
Previously the builder would add `__init__.py` files to resource dirs,
which is not what we want.

Also fixes the engine tests, that were relying on being run out of
the source tree, and so weren't correctly depending on the resources
they use.
