### PR TITLE
Bump pex requirement to 1.2.3

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,7 +11,7 @@ mock==1.3.0
 packaging==16.8
 pathspec==0.5.0
 pep8==1.6.2
-pex==1.2.1
+pex==1.2.3
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4


### PR DESCRIPTION
A quick version bump for pex to pickup a couple of recent bugfixes.