### PR TITLE
Support local jar with relative path in JarDependency

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -296,8 +296,8 @@ class FrozenResolution(object):
 
     # Assuming target is a jar library.
     for j in target.jar_dependencies:
-      if j.url:
-        self.coordinate_to_attributes[j.coordinate] = {'url': j.url}
+      if j.get_url():
+        self.coordinate_to_attributes[j.coordinate] = {'url': j.get_url()}
       else:
         self.coordinate_to_attributes[j.coordinate] = {}
 
@@ -1156,7 +1156,7 @@ class IvyUtils(object):
     artifacts = OrderedDict()
     for jar in jars:
       ext = jar.ext
-      url = jar.url
+      url = jar.get_url()
       if url:
         any_have_url = True
       classifier = jar.classifier
@@ -1202,7 +1202,7 @@ class IvyUtils(object):
     artifacts = OrderedDict()
     for jar in jars:
       ext = jar.ext
-      url = jar.url
+      url = jar.get_url()
       if url:
         any_have_url = True
       classifier = jar.classifier

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -17,7 +17,7 @@ from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.benchmark import Benchmark
 from pants.backend.jvm.targets.credentials import LiteralCredentials, NetrcCredentials
 from pants.backend.jvm.targets.exclude import Exclude
-from pants.backend.jvm.targets.jar_dependency import JarDependency, JarDependencyWrapper
+from pants.backend.jvm.targets.jar_dependency import JarDependency, JarDependencyParseContextWrapper
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -125,7 +125,7 @@ def build_file_aliases():
     },
     context_aware_object_factories={
       'bundle': Bundle,
-      'jar': JarDependencyWrapper,
+      'jar': JarDependencyParseContextWrapper,
       'managed_jar_libraries': ManagedJarLibraries,
     }
   )

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -17,7 +17,7 @@ from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.benchmark import Benchmark
 from pants.backend.jvm.targets.credentials import LiteralCredentials, NetrcCredentials
 from pants.backend.jvm.targets.exclude import Exclude
-from pants.backend.jvm.targets.jar_dependency import JarDependency
+from pants.backend.jvm.targets.jar_dependency import JarDependency, JarDependencyWrapper
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.java_library import JavaLibrary
@@ -125,6 +125,7 @@ def build_file_aliases():
     },
     context_aware_object_factories={
       'bundle': Bundle,
+      'jar': JarDependencyWrapper,
       'managed_jar_libraries': ManagedJarLibraries,
     }
   )

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -109,7 +109,6 @@ def build_file_aliases():
       'DirectoryReMapper': DirectoryReMapper,
       'Duplicate': Duplicate,
       'exclude': Exclude,
-      'jar': JarDependency,
       'scala_jar': ScalaJarDependency,
       'jar_rules': JarRules,
       'repository': repo,

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -17,7 +17,7 @@ from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
 from pants.backend.jvm.targets.benchmark import Benchmark
 from pants.backend.jvm.targets.credentials import LiteralCredentials, NetrcCredentials
 from pants.backend.jvm.targets.exclude import Exclude
-from pants.backend.jvm.targets.jar_dependency import JarDependency, JarDependencyParseContextWrapper
+from pants.backend.jvm.targets.jar_dependency import JarDependencyParseContextWrapper
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_agent import JavaAgent
 from pants.backend.jvm.targets.java_library import JavaLibrary

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -40,7 +40,7 @@ class JarDependencyParseContextWrapper(object):
     """
     :param parse_context: The BUILD file parse context.
     """
-    self._rel_path = parse_context.rel_path
+    self._rel_path = parse_context.rel_path or ''
 
   def __call__(self, org, name, rev=None, force=False, ext=None, url=None, apidocs=None,
               classifier=None, mutable=None, intransitive=False, excludes=None):

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -18,7 +18,23 @@ from pants.util.objects import datatype
 
 
 class JarDependencyParseContextWrapper(object):
-  """A pre-built Maven repository dependency."""
+  """A pre-built Maven repository dependency.
+
+  Examples: ::
+
+    # The typical use case.
+    jar('com.puppycrawl.tools', 'checkstyle', '1.2')
+
+    # Test external dependency locally.
+    jar('org.foobar', 'foobar', '1.2-SNAPSHOT',
+        url='file:///Users/pantsdev/workspace/project/jars/checkstyle/checkstyle.jar')
+
+    # Test external dependency locally using relative path (with respect to the path
+    # of the belonging BUILD file)
+    jar('org.foobar', 'foobar', '1.2-SNAPSHOT',
+        url='file:../checkstyle/checkstyle.jar')
+
+  """
 
   def __init__(self, parse_context):
     """

--- a/src/python/pants/backend/jvm/targets/jar_dependency.py
+++ b/src/python/pants/backend/jvm/targets/jar_dependency.py
@@ -13,6 +13,21 @@ from pants.util.memo import memoized_property
 from pants.util.objects import datatype
 
 
+class JarDependencyWrapper(object):
+  def __init__(self, parse_context):
+    """
+    :param parse_context: The BUILD file parse context.
+    """
+    self._rel_path = parse_context.rel_path
+
+  def __call__(self, org, name, rev=None, **kwargs):
+    return self.create_jar_dependency(self._rel_path, org, name, rev, **kwargs)
+
+  @classmethod
+  def create_jar_dependency(cls, rel_path, org, name, rev=None, **kwargs):
+    return JarDependency(org, name, rev, **kwargs)
+
+
 class JarDependency(datatype('JarDependency', [
   'org', 'base_name', 'rev', 'force', 'ext', 'url', 'apidocs',
   'classifier', 'mutable', 'intransitive', 'excludes'])):

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_dependency.py
@@ -25,6 +25,20 @@ class JarDependencyTest(unittest.TestCase):
   def test_scala_jar_dependency_copy(self):
     self._test_copy(self._mkjardep(tpe=ScalaJarDependency))
 
+  def test_get_url(self):
+    """Test using relative url and absolute url are equivalent."""
+    abs_url = 'file:///a/b/c'
+    rel_url = 'file:c'
+    base_path = '/a/b'
+
+    jar_with_rel_url = self._mkjardep(url=rel_url, base_path=base_path)
+    self.assertEquals(abs_url, jar_with_rel_url.get_url())
+    self.assertEquals(rel_url, jar_with_rel_url.get_url(relative=True))
+
+    jar_with_abs_url = self._mkjardep(url=abs_url, base_path=base_path)
+    self.assertEquals(abs_url, jar_with_abs_url.get_url())
+    self.assertEquals(rel_url, jar_with_abs_url.get_url(relative=True))
+
   def _test_copy(self, original):
     # A no-op clone results in an equal object.
     self.assertEqual(original, original.copy())
@@ -35,5 +49,6 @@ class JarDependencyTest(unittest.TestCase):
     self.assertEqual(original.copy(rev='1.2.3'), original.copy(rev='1.2.3'))
 
   def _mkjardep(self, org='foo', name='foo',
-                excludes=(Exclude(org='example.com', name='foo-lib'),), tpe=JarDependency):
-    return tpe(org=org, name=name, excludes=excludes)
+                excludes=(Exclude(org='example.com', name='foo-lib'),), tpe=JarDependency,
+                **kwargs):
+    return tpe(org=org, name=name, excludes=excludes, **kwargs)


### PR DESCRIPTION
### Problem

Using relative path in `jar`'s `url` field makes `BUILD` file more portable, see #3966. Another use case is some prepare task might build and inject a local `jar` into the graph, having absolute path in the fingerprint is going to invalidate every time even this local jar has been cached later.

Since `ivy` still requires path to be absolute, we need to support retrieving relative and absolute path.

### Solution

This rb allows user express relative path in `jar`.`url`, also add `get_url` method to support accessing in either format.
