### PR TITLE
Strip the root-level __init__.py that apache thrift generates.

### DIFF
--- a/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
+++ b/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
@@ -10,6 +10,7 @@ import os
 from pants.backend.codegen.thrift.lib.apache_thrift_gen_base import ApacheThriftGenBase
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.backend.python.targets.python_library import PythonLibrary
+from pants.util.dirutil import safe_delete
 
 
 class ApacheThriftPyGen(ApacheThriftGenBase):
@@ -22,6 +23,12 @@ class ApacheThriftPyGen(ApacheThriftGenBase):
 
   def synthetic_target_type(self, target):
     return PythonLibrary
+
+  def execute_codegen(self, target, target_workdir):
+    super(ApacheThriftPyGen, self).execute_codegen(target, target_workdir)
+    # Thrift puts an __init__.py file at the root, and we don't want one there
+    # (it's not needed, and it confuses some import mechanisms).
+    safe_delete(os.path.join(target_workdir, '__init__.py'))
 
   def ignore_dup(self, tgt1, tgt2, rel_src):
     # Thrift generates all the intermediate __init__.py files, and they shouldn't

--- a/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
+++ b/tests/python/pants_test/backend/codegen/thrift/python/test_apache_thrift_py_gen.py
@@ -45,7 +45,7 @@ class ApacheThriftPyGenTest(TaskTestBase):
                            target_type=PythonThriftLibrary,
                            sources=['one.thrift'])
     synthetic_target = self.generate_single_thrift_target(one)
-    self.assertEqual({'__init__.py', 'foo/__init__.py', 'foo/ThingService-remote',
+    self.assertEqual({'foo/__init__.py', 'foo/ThingService-remote',
                       'foo/ThingService.py', 'foo/ttypes.py', 'foo/constants.py'},
                      set(synthetic_target.sources_relative_to_source_root()))
 
@@ -64,6 +64,6 @@ class ApacheThriftPyGenTest(TaskTestBase):
                            target_type=PythonThriftLibrary,
                            sources=['one.thrift', 'bar/two.thrift'])
     synthetic_target = self.generate_single_thrift_target(one)
-    self.assertEqual({'__init__.py', 'foo/__init__.py', 'foo/ttypes.py', 'foo/constants.py',
+    self.assertEqual({'foo/__init__.py', 'foo/ttypes.py', 'foo/constants.py',
                       'foo/bar/__init__.py', 'foo/bar/ttypes.py', 'foo/bar/constants.py'},
                      set(synthetic_target.sources_relative_to_source_root()))


### PR DESCRIPTION
It's superfluous, and actually causes problems in pex chroots.
