### PR TITLE
[engine] minor clean up `engine.close` usage in `visualizer`

### DIFF
--- a/tests/python/pants_test/engine/examples/visualizer.py
+++ b/tests/python/pants_test/engine/examples/visualizer.py
@@ -39,11 +39,8 @@ def visualize_build_request(build_root, goals, subjects):
     execution_request = scheduler.build_request(goals, subjects)
     # NB: Calls `reduce` independently of `execute`, in order to render a graph before validating it.
     engine = LocalSerialEngine(scheduler, Storage.create())
-    try:
-      engine.reduce(execution_request)
-      visualize_execution_graph(scheduler)
-    finally:
-      engine.close()
+    engine.reduce(execution_request)
+    visualize_execution_graph(scheduler)
 
 
 def pop_build_root_and_goals(description, args):


### PR DESCRIPTION
### Problem

daf5dc4f2eb3558f96c458d2b4714d60dc23f2ed removed `engine.close` as part of the storage clean up but there is still one usage by `visualizer`.

### Solution

Remove the dead `engine.close` in `visualizer`

### Result

Before
```
  File "/Users/peiyu/github/pants/.pants.d/python-setup/chroots/214a9a01b046594b9d6402b68728f0578dae2861/pants_test/engine/examples/visualizer.py", line 80, in main_addresses
    visualize_build_request(build_root, goals, spec_roots)
  File "/Users/peiyu/github/pants/.pants.d/python-setup/chroots/214a9a01b046594b9d6402b68728f0578dae2861/pants_test/engine/examples/visualizer.py", line 46, in visualize_build_request
    engine.close()
AttributeError: 'LocalSerialEngine' object has no attribute 'close'
```

After
```
dot file saved to: /var/folders/z8/hfw3c_sj25b2t3wmnlfq3kjm0000gn/T/tmp0xb6at.dot
svg file saved to: /var/folders/z8/hfw3c_sj25b2t3wmnlfq3kjm0000gn/T/tmpke3EvL.svg

10:30:40 00:12     [jvm]
10:30:40 00:12     [cpp]
10:30:40 00:12     [go]
10:30:40 00:12     [node]
10:30:40 00:12   [complete]
               SUCCESS
```