### PR TITLE
Update errorprone to version 2.0.17

### DIFF
--- a/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/errorprone.py
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/errorprone.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
-from pants.backend.jvm.subsystems.shader import Shader
+from pants.backend.jvm.subsystems.shader import Shader, Shading
 from pants.backend.jvm.targets.jar_dependency import JarDependency
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
@@ -42,11 +42,12 @@ class ErrorProne(NailgunTask):
                           classpath=[
                             JarDependency(org='com.google.errorprone',
                                           name='error_prone_core',
-                                          rev='2.0.15'),
+                                          rev='2.0.17'),
                           ],
                           main=cls._ERRORPRONE_MAIN,
                           custom_rules=[
                             Shader.exclude_package('com.google.errorprone', recursive=True),
+                            Shading.create_exclude('*'), # https://github.com/pantsbuild/pants/issues/4288
                           ]
                          )
 

--- a/src/java/org/pantsbuild/tools/jar/JarBuilder.java
+++ b/src/java/org/pantsbuild/tools/jar/JarBuilder.java
@@ -1081,6 +1081,7 @@ public class JarBuilder implements Closeable {
     return FluentIterable.from(getAdditions().asMap().entrySet()).transformAndConcat(mergeEntries);
   }
 
+  @SuppressWarnings("UnnecessaryDefaultInEnumSwitch")
   private Optional<ReadableEntry> processEntries(
       Predicate<CharSequence> skipPath,
       DuplicateHandler duplicateHandler,

--- a/src/java/org/pantsbuild/tools/junit/impl/ConcurrentRunnerScheduler.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConcurrentRunnerScheduler.java
@@ -50,7 +50,7 @@ public class ConcurrentRunnerScheduler implements RunnerScheduler {
   @Override
   public void schedule(Runnable childStatement) {
     if (shouldMethodsRunParallel()) {
-      executor.submit(childStatement);
+      executor.execute(childStatement);
     } else {
       serialTasks.offer(childStatement);
     }
@@ -62,7 +62,7 @@ public class ConcurrentRunnerScheduler implements RunnerScheduler {
    */
   public void schedule(Runnable childStatement, Class<?> clazz) {
     if (shouldClassRunParallel(clazz)) {
-      executor.submit(childStatement);
+      executor.execute(childStatement);
     } else {
       serialTasks.offer(childStatement);
     }


### PR DESCRIPTION
### Problem

Updating Error Prone to the latest release

### Solution

Update Error Prone to version 2.0.17

### Result

Needed to fix some new warnings in the code.

```
src/java/org/pantsbuild/tools/jar/JarBuilder.java:1143: warning: [UnnecessaryDefaultInEnumSwitch] Switch handles all enum values; an explicit default case is unnecessary and defeats error checking for non-exhaustive switches.
                           default:
                           ^
(see http://errorprone.info/bugpattern/UnnecessaryDefaultInEnumSwitch)
```

and

```
src/java/org/pantsbuild/tools/junit/impl/ConcurrentRunnerScheduler.java:53: warning: [FutureReturnValueIgnored] Return value of methods returning Future must be checked.
                           executor.submit(childStatement);
                                          ^
(see http://errorprone.info/bugpattern/FutureReturnValueIgnored)
```