### PR TITLE
Suppress thrift linter output to error only

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -96,7 +96,7 @@ class ThriftLinter(NailgunTask):
                               main='com.twitter.scrooge.linter.Main',
                               args=args,
                               jvm_options=self.get_options().jvm_options,
-                              workunit_labels=[WorkUnitLabel.COMPILER])  # to let stdout/err through.
+                              workunit_labels=[WorkUnitLabel.MULTITOOL])
 
     if returncode != 0:
       raise ThriftLintError(

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -50,4 +50,4 @@ class ThriftLinterTest(TaskTestBase):
       args=['--ignore-errors', '--include-path', 'src/thrift/users', '--include-path',
             'src/thrift/tweet', 'src/thrift/tweet/b.thrift', 'src/thrift/tweet/a.thrift'],
       jvm_options=get_default_jvm_options(),
-      workunit_labels=['COMPILER'])
+      workunit_labels=['MULTITOOL'])


### PR DESCRIPTION
### Problem

Thrift linter is too verbose.
```
12:19:06 01:21       [com.twitter.scrooge.linter.Main]

12:19:06 01:21       [com.twitter.scrooge.linter.Main]

12:19:06 01:21       [com.twitter.scrooge.linter.Main]

12:19:07 01:22       [com.twitter.scrooge.linter.Main]
...
```

### Solution

Change the tool output mode to MULTITOOL, so only error will show up.

### Result
* Bad thrift target

```
/Users/yic/workspace/pants/build-support/pants_dev_deps.venv/bin/python2.7 /Users/yic/workspace/pants/src/python/pants/bin/pants_exe.py --no-cache-read --thrift-linter-strict invalidate thrift-linter examples/tests/java/org/pantsbuild/example/usethrift/::

15:22:21 00:00 [main]
               (To run a reporting server: ./pants server)
15:22:21 00:00   [setup]
15:22:21 00:00     [parse]
               Executing tasks in goals: invalidate -> bootstrap -> thrift-linter
15:22:21 00:00   [invalidate]
15:22:21 00:00     [ng-killall]INFO] killing nailgun server pid=66097

15:22:21 00:00     [invalidate]
15:22:21 00:00   [bootstrap]
15:22:21 00:00     [substitute-aliased-targets]
15:22:21 00:00     [jar-dependency-management]
15:22:21 00:00     [bootstrap-jvm-tools]
15:22:21 00:00     [provide-tools-jar]
15:22:21 00:00   [thrift-linter]
15:22:21 00:00     [thrift-linter]
                   Invalidated 2 targets.
15:22:21 00:00       [parallel-thrift-linter]
15:22:21 00:00         [bootstrap-scrooge-linter]
15:22:22 00:01       [bootstrap-nailgun-server]
15:22:23 00:02       [com.twitter.scrooge.linter.Main]
                     ==== stderr ====
                     LINT-ERROR: examples/src/thrift/org/pantsbuild/example/distance/distance.thrift
                     Missing namespace: scala.
                     LINT-ERROR: examples/src/thrift/org/pantsbuild/example/distance/distance.thrift
                     Missing namespace: scala.
                     
                     ==== stdout ====
                     
15:22:23 00:02       [com.twitter.scrooge.linter.Main]
                     ==== stderr ====
                     LINT-ERROR: examples/src/thrift/org/pantsbuild/example/distance/distance.thrift
                     Missing namespace: scala.
                     LINT-ERROR: examples/src/thrift/org/pantsbuild/example/distance/distance.thrift
                     Missing namespace: scala.
                     LINT-ERROR: examples/src/thrift/org/pantsbuild/example/precipitation/precipitation.thrift
                     Missing namespace: scala.
                     LINT-ERROR: examples/src/thrift/org/pantsbuild/example/precipitation/precipitation.thrift
                     Missing namespace: scala.
                     
                     ==== stdout ====
                     
FAILURE: Lint errors in target examples/src/thrift/org/pantsbuild/example/distance:distance-java for set([u'examples/src/thrift/org/pantsbuild/example/distance/distance.thrift']).
Lint errors in target examples/src/thrift/org/pantsbuild/example/precipitation:precipitation-java for set([u'examples/src/thrift/org/pantsbuild/example/distance/distance.thrift', u'examples/src/thrift/org/pantsbuild/example/precipitation/precipitation.thrift']).


               Waiting for background workers to finish.
15:22:24 00:03   [complete]
               FAILURE

Process finished with exit code 1
```
* Good thrift target
```
/Users/yic/workspace/pants/build-support/pants_dev_deps.venv/bin/python2.7 /Users/yic/workspace/pants/src/python/pants/bin/pants_exe.py --no-cache-read --thrift-linter-strict invalidate thrift-linter contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter:good-thrift

15:22:47 00:00 [main]
               (To run a reporting server: ./pants server)
15:22:47 00:00   [setup]
15:22:47 00:00     [parse]
               Executing tasks in goals: invalidate -> bootstrap -> thrift-linter
15:22:47 00:00   [invalidate]
15:22:47 00:00     [ng-killall]INFO] killing nailgun server pid=66425

15:22:47 00:00     [invalidate]
15:22:47 00:00   [bootstrap]
15:22:47 00:00     [substitute-aliased-targets]
15:22:47 00:00     [jar-dependency-management]
15:22:47 00:00     [bootstrap-jvm-tools]
15:22:47 00:00     [provide-tools-jar]
15:22:47 00:00   [thrift-linter]
15:22:47 00:00     [thrift-linter]
                   Invalidated 1 target.
15:22:47 00:00       [parallel-thrift-linter]
15:22:47 00:00         [bootstrap-scrooge-linter]
15:22:49 00:02       [bootstrap-nailgun-server]
               Waiting for background workers to finish.
15:22:50 00:03   [complete]
               SUCCESS

Process finished with exit code 0
```