### PR TITLE
Binary builder task for the new python pipeline.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -15,17 +15,19 @@ from pants.backend.python.targets.python_requirement_library import PythonRequir
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.pytest_run import PytestRun as PytestRun2
+from pants.backend.python.tasks2.python_binary_create import \
+  PythonBinaryCreate as PythonBinaryCreate2
 from pants.backend.python.tasks2.python_repl import PythonRepl as PythonRepl2
 from pants.backend.python.tasks2.python_run import PythonRun as PythonRun2
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.backend.python.tasks2.setup_py import SetupPy as SetupPy2
 from pants.backend.python.tasks.pytest_run import PytestRun
 from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
 from pants.backend.python.tasks.python_isort import IsortPythonTask
 from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
 from pants.backend.python.tasks.setup_py import SetupPy
-from pants.backend.python.tasks2.setup_py import SetupPy as SetupPy2
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
 from pants.goal.task_registrar import TaskRegistrar as task
@@ -66,4 +68,5 @@ def register_goals():
   task(name='py', action=PythonRun2).install('run2')
   task(name='pytest', action=PytestRun2).install('test2')
   task(name='py', action=PythonRepl2).install('repl2')
+  task(name='py', action=PythonBinaryCreate2).install('binary2')
   task(name='setup-py2', action=SetupPy2).install()

--- a/src/python/pants/backend/python/tasks2/BUILD
+++ b/src/python/pants/backend/python/tasks2/BUILD
@@ -15,6 +15,7 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/invalidation',
     'src/python/pants/task',
+    'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',
   ]

--- a/src/python/pants/backend/python/tasks2/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks2/pex_build_util.py
@@ -1,0 +1,144 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pex.fetcher import Fetcher
+from pex.platforms import Platform
+from pex.resolver import resolve
+from twitter.common.collections import OrderedSet
+
+from pants.backend.python.python_setup import PythonRepos, PythonSetup
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.targets.python_tests import PythonTests
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
+from pants.build_graph.resources import Resources
+
+
+def has_python_sources(tgt):
+  # We'd like to take all PythonTarget subclasses, but currently PythonThriftLibrary and
+  # PythonAntlrLibrary extend PythonTarget, and until we fix that (which we can't do until
+  # we remove the old python pipeline entirely) we want to ignore those target types here.
+  return isinstance(tgt, (PythonLibrary, PythonTests, PythonBinary, Resources))
+
+
+def has_resources(tgt):
+  return isinstance(tgt, Resources)
+
+
+def has_python_requirements(tgt):
+  return isinstance(tgt, PythonRequirementLibrary)
+
+
+def dump_sources(builder, tgt, log):
+  buildroot = get_buildroot()
+  log.debug('  Dumping sources: {}'.format(tgt))
+  for relpath in tgt.sources_relative_to_source_root():
+    try:
+      src = os.path.join(buildroot, tgt.target_base, relpath)
+      if isinstance(tgt, Resources):
+        builder.add_resource(src, relpath)
+      else:
+        builder.add_source(src, relpath)
+    except OSError:
+      log.error('Failed to copy {} for target {}'.format(
+        os.path.join(tgt.target_base, relpath), tgt.address.spec))
+      raise
+
+  if (getattr(tgt, '_resource_target_specs', None) or
+      getattr(tgt, '_synthetic_resources_target', None)):
+    # No one should be on old-style resources any more.  And if they are,
+    # switching to the new python pipeline will be a great opportunity to fix that.
+    raise TaskError('Old-style resources not supported for target {}.  '
+                    'Depend on resources() targets instead.'.format(tgt.address.spec))
+
+
+def dump_requirements(builder, interpreter, req_libs, log, platforms=None):
+  """Multi-platform dependency resolution for PEX files.
+
+  Returns a list of distributions that must be included in order to satisfy a set of requirements.
+  That may involve distributions for multiple platforms.
+
+  :param builder: Dump the requirements into this builder.
+  :param interpreter: The :class:`PythonInterpreter` to resolve requirements for.
+  :param req_libs: A list of :class:`PythonRequirementLibrary` targets to resolve.
+  :param log: Use this logger.
+  :param platforms: A list of :class:`Platform`s to resolve requirements for.
+                    Defaults to the platforms specified by PythonSetup.
+  """
+
+  # Gather and de-dup all requirements.
+  reqs = OrderedSet()
+  for req_lib in req_libs:
+    for req in req_lib.requirements:
+      reqs.add(req)
+
+  # See which ones we need to build.
+  reqs_to_build = OrderedSet()
+  find_links = OrderedSet()
+  for req in reqs:
+    # TODO: should_build appears to be hardwired to always be True. Get rid of it?
+    if req.should_build(interpreter.python, Platform.current()):
+      reqs_to_build.add(req)
+      log.debug('  Dumping requirement: {}'.format(req))
+      builder.add_requirement(req.requirement)
+      if req.repository:
+        find_links.add(req.repository)
+    else:
+      log.debug('  Skipping {} based on version filter'.format(req))
+
+  # Resolve the requirements into distributions.
+  distributions = _resolve_multi(interpreter, reqs_to_build, platforms, find_links)
+
+  locations = set()
+  for platform, dists in distributions.items():
+    for dist in dists:
+      if dist.location not in locations:
+        log.debug('  Dumping distribution: .../{}'.format(os.path.basename(dist.location)))
+        builder.add_distribution(dist)
+      locations.add(dist.location)
+
+
+def _resolve_multi(interpreter, requirements, platforms, find_links):
+  """Multi-platform dependency resolution for PEX files.
+
+  Returns a list of distributions that must be included in order to satisfy a set of requirements.
+  That may involve distributions for multiple platforms.
+
+  :param interpreter: The :class:`PythonInterpreter` to resolve for.
+  :param requirements: A list of :class:`PythonRequirement` objects to resolve.
+  :param platforms: A list of :class:`Platform`s to resolve for.
+  :param find_links: Additional paths to search for source packages during resolution.
+  :return: Map of platform name -> list of :class:`pkg_resources.Distribution` instances needed
+           to satisfy the requirements on that platform.
+  """
+  python_setup = PythonSetup.global_instance()
+  python_repos = PythonRepos.global_instance()
+  platforms = [Platform.current() if p == 'current' else p
+               for p in (platforms or python_setup.platforms)]
+  find_links = find_links or []
+  distributions = {}
+  fetchers = python_repos.get_fetchers()
+  fetchers.extend(Fetcher([path]) for path in find_links)
+
+  for platform in platforms:
+    requirements_cache_dir = os.path.join(python_setup.resolver_cache_dir,
+                                          str(interpreter.identity))
+    distributions[platform] = resolve(
+      requirements=[req.requirement for req in requirements],
+      interpreter=interpreter,
+      fetchers=fetchers,
+      platform=None if platform == 'current' else platform,
+      context=python_repos.get_network_context(),
+      cache=requirements_cache_dir,
+      cache_ttl=python_setup.resolver_cache_ttl,
+      allow_prereleases=python_setup.resolver_allow_prereleases)
+
+  return distributions

--- a/src/python/pants/backend/python/tasks2/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks2/pex_build_util.py
@@ -121,8 +121,7 @@ def _resolve_multi(interpreter, requirements, platforms, find_links):
   """
   python_setup = PythonSetup.global_instance()
   python_repos = PythonRepos.global_instance()
-  platforms = [Platform.current() if p == 'current' else p
-               for p in (platforms or python_setup.platforms)]
+  platforms = platforms or python_setup.platforms
   find_links = find_links or []
   distributions = {}
   fetchers = python_repos.get_fetchers()

--- a/src/python/pants/backend/python/tasks2/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks2/python_binary_create.py
@@ -1,0 +1,123 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pex.interpreter import PythonInterpreter
+from pex.pex_builder import PEXBuilder
+from pex.pex_info import PexInfo
+
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.tasks2.pex_build_util import (dump_requirements, dump_sources,
+                                                        has_python_requirements, has_python_sources,
+                                                        has_resources)
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
+from pants.build_graph.target_scopes import Scopes
+from pants.task.task import Task
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_mkdir_for
+from pants.util.fileutil import atomic_copy
+
+
+class PythonBinaryCreate(Task):
+  """Create an executable .pex file."""
+
+  @classmethod
+  def product_types(cls):
+    return ['pex_archives', 'deployable_archives']
+
+  @classmethod
+  def implementation_version(cls):
+    return super(PythonBinaryCreate, cls).implementation_version() + [('PythonBinaryCreate', 2)]
+
+  @property
+  def cache_target_dirs(self):
+    return True
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    round_manager.require_data(PythonInterpreter)
+    round_manager.require_data('python')  # For codegen.
+
+  @staticmethod
+  def is_binary(target):
+    return isinstance(target, PythonBinary)
+
+  def __init__(self, *args, **kwargs):
+    super(PythonBinaryCreate, self).__init__(*args, **kwargs)
+    self._distdir = self.get_options().pants_distdir
+
+  def execute(self):
+    binaries = self.context.targets(self.is_binary)
+
+    # Check for duplicate binary names, since we write the pexes to <dist>/<name>.pex.
+    names = {}
+    for binary in binaries:
+      name = binary.name
+      if name in names:
+        raise TaskError('Cannot build two binaries with the same name in a single invocation. '
+                        '{} and {} both have the name {}.'.format(binary, names[name], name))
+      names[name] = binary
+
+    with self.invalidated(binaries, invalidate_dependents=True) as invalidation_check:
+      python_deployable_archive = self.context.products.get('deployable_archives')
+      python_pex_product = self.context.products.get('pex_archives')
+      for vt in invalidation_check.all_vts:
+        pex_path = os.path.join(vt.results_dir, '{}.pex'.format(vt.target.name))
+        if not vt.valid:
+          self.context.log.debug('cache for {} is invalid, rebuilding'.format(vt.target))
+          self._create_binary(vt.target, vt.results_dir)
+        else:
+          self.context.log.debug('using cache for {}'.format(vt.target))
+
+        basename = os.path.basename(pex_path)
+        python_pex_product.add(binary, os.path.dirname(pex_path)).append(basename)
+        python_deployable_archive.add(binary, os.path.dirname(pex_path)).append(basename)
+        self.context.log.debug('created {}'.format(os.path.relpath(pex_path, get_buildroot())))
+
+        # Create a copy for pex.
+        pex_copy = os.path.join(self._distdir, os.path.basename(pex_path))
+        safe_mkdir_for(pex_copy)
+        atomic_copy(pex_path, pex_copy)
+        self.context.log.info('created pex {}'.format(os.path.relpath(pex_copy, get_buildroot())))
+
+  def _create_binary(self, binary_tgt, results_dir):
+    """Create a .pex file for the specified binary target."""
+    # Note that we rebuild a chroot from scratch, instead of using the REQUIREMENTS_PEX
+    # and PYTHON_SOURCES products, because those products are already-built pexes, and there's
+    # no easy way to merge them into a single pex file (for example, they each have a __main__.py,
+    # metadata, and so on, which the merging code would have to handle specially).
+    interpreter = self.context.products.get_data(PythonInterpreter)
+    with temporary_dir() as tmpdir:
+      # Create the pex_info for the binary.
+      run_info_dict = self.context.run_tracker.run_info.get_as_dict()
+      build_properties = PexInfo.make_build_properties()
+      build_properties.update(run_info_dict)
+      pex_info = binary_tgt.pexinfo.copy()
+      pex_info.build_properties = build_properties
+
+      builder = PEXBuilder(path=tmpdir, interpreter=interpreter, pex_info=pex_info, copy=True)
+
+      # Find which targets provide sources and which specify requirements.
+      source_tgts = []
+      req_tgts = []
+      for tgt in binary_tgt.closure(exclude_scopes=Scopes.COMPILE):
+        if has_python_sources(tgt) or has_resources(tgt):
+          source_tgts.append(tgt)
+        elif has_python_requirements(tgt):
+          req_tgts.append(tgt)
+
+      # Dump everything into the builder's chroot.
+      for tgt in source_tgts:
+        dump_sources(builder, tgt, self.context.log)
+      dump_requirements(builder, interpreter, req_tgts, self.context.log, binary_tgt.platforms)
+
+      # Build the .pex file.
+      pex_path = os.path.join(results_dir, '{}.pex'.format(binary_tgt.name))
+      builder.build(pex_path)
+      return pex_path

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -65,6 +65,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
 
   @classmethod
   def prepare(cls, options, round_manager):
+    super(PythonExecutionTaskBase, cls).prepare(options, round_manager)
     round_manager.require_data(PythonInterpreter)
     round_manager.require_data(ResolveRequirements.REQUIREMENTS_PEX)
     round_manager.require_data(GatherSources.PYTHON_SOURCES)
@@ -76,7 +77,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
     """
     return []
 
-  def create_pex(self, pex_info):
+  def create_pex(self, pex_info=None):
     """Returns a wrapped pex that "merges" the other pexes via PEX_PATH."""
     with self.invalidated(self.context.targets(
         lambda tgt: isinstance(tgt, (PythonRequirementLibrary, PythonTarget, Resources)))) as invalidation_check:
@@ -95,7 +96,8 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
       extra_pex_paths_file_path = path + '.extra_pex_paths'
       extra_pex_paths = None
 
-      # Note that we check for the existence of the directory, instead of for invalid_vts, to cover the empty case.
+      # Note that we check for the existence of the directory, instead of for invalid_vts,
+      # to cover the empty case.
       if not os.path.isdir(path):
         pexes = [
           self.context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX),
@@ -111,7 +113,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           # in the target set's dependency closure.
           pexes = [self.resolve_requirements([self.context.build_graph.get_target(addr)])] + pexes
 
-        extra_pex_paths = [pex.path() for pex in pexes]
+        extra_pex_paths = [pex.path() for pex in pexes if pex]
 
         path_tmp = path + '.tmp'
         safe_rmtree(path_tmp)

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
+from pants.backend.python.tasks2.pex_build_util import has_python_requirements
 from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
 
 
@@ -18,6 +18,6 @@ class ResolveRequirements(ResolveRequirementsTaskBase):
     return [cls.REQUIREMENTS_PEX]
 
   def execute(self):
-    req_libs = self.context.targets(lambda tgt: isinstance(tgt, PythonRequirementLibrary))
+    req_libs = self.context.targets(has_python_requirements)
     pex = self.resolve_requirements(req_libs)
     self.context.products.get_data(self.REQUIREMENTS_PEX, lambda: pex)

--- a/src/python/pants/backend/python/tasks2/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements_task_base.py
@@ -8,15 +8,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import shutil
 
-from pex.fetcher import Fetcher
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
-from pex.platforms import Platform
-from pex.resolver import resolve
-from twitter.common.collections import OrderedSet
 
 from pants.backend.python.python_setup import PythonRepos, PythonSetup
+from pants.backend.python.tasks2.pex_build_util import dump_requirements
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task
 from pants.util.dirutil import safe_rmtree
@@ -32,7 +29,8 @@ class ResolveRequirementsTaskBase(Task):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(ResolveRequirementsTaskBase, cls).subsystem_dependencies() + (PythonSetup, PythonRepos)
+    return (super(ResolveRequirementsTaskBase, cls).subsystem_dependencies() +
+            (PythonSetup, PythonRepos))
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -52,7 +50,8 @@ class ResolveRequirementsTaskBase(Task):
       interpreter = self.context.products.get_data(PythonInterpreter)
       path = os.path.join(self.workdir, str(interpreter.identity), target_set_id)
 
-      # Note that we check for the existence of the directory, instead of for invalid_vts, to cover the empty case.
+      # Note that we check for the existence of the directory, instead of for invalid_vts,
+      # to cover the empty case.
       if not os.path.isdir(path):
         path_tmp = path + '.tmp'
         safe_rmtree(path_tmp)
@@ -64,70 +63,5 @@ class ResolveRequirementsTaskBase(Task):
 
   def _build_pex(self, interpreter, path, req_libs):
     builder = PEXBuilder(path=path, interpreter=interpreter, copy=True)
-
-    # Gather and de-dup all requirements.
-    reqs = OrderedSet()
-    for req_lib in req_libs:
-      for req in req_lib.requirements:
-        reqs.add(req)
-
-    # See which ones we need to build.
-    reqs_to_build = OrderedSet()
-    find_links = OrderedSet()
-    for req in reqs:
-      # TODO: should_build appears to be hardwired to always be True. Get rid of it?
-      if req.should_build(interpreter.python, Platform.current()):
-        reqs_to_build.add(req)
-        self.context.log.debug('  Dumping requirement: {}'.format(req))
-        builder.add_requirement(req.requirement)
-        if req.repository:
-          find_links.add(req.repository)
-      else:
-        self.context.log.debug('  Skipping {} based on version filter'.format(req))
-
-    # Resolve the requirements into distributions.
-    distributions = self._resolve_multi(interpreter, reqs_to_build, find_links)
-
-    locations = set()
-    for platform, dists in distributions.items():
-      for dist in dists:
-        if dist.location not in locations:
-          self.context.log.debug('  Dumping distribution: .../{}'.format(
-              os.path.basename(dist.location)))
-          builder.add_distribution(dist)
-        locations.add(dist.location)
-
+    dump_requirements(builder, interpreter, req_libs, self.context.log)
     builder.freeze()
-
-  def _resolve_multi(self, interpreter, requirements, find_links):
-    """Multi-platform dependency resolution for PEX files.
-
-    Returns a list of distributions that must be included in order to satisfy a set of requirements.
-    That may involve distributions for multiple platforms.
-
-    :param interpreter: The :class:`PythonInterpreter` to resolve for.
-    :param requirements: A list of :class:`PythonRequirement` objects to resolve.
-    :param find_links: Additional paths to search for source packages during resolution.
-    :return: Map of platform name -> list of :class:`pkg_resources.Distribution` instances needed
-             to satisfy the requirements on that platform.
-    """
-    python_setup = PythonSetup.global_instance()
-    python_repos = PythonRepos.global_instance()
-    distributions = {}
-    fetchers = python_repos.get_fetchers()
-    fetchers.extend(Fetcher([path]) for path in find_links)
-
-    for platform in python_setup.platforms:
-      requirements_cache_dir = os.path.join(python_setup.resolver_cache_dir,
-                                            str(interpreter.identity))
-      distributions[platform] = resolve(
-          requirements=[req.requirement for req in requirements],
-          interpreter=interpreter,
-          fetchers=fetchers,
-          platform=None if platform == 'current' else platform,
-          context=python_repos.get_network_context(),
-          cache=requirements_cache_dir,
-          cache_ttl=python_setup.resolver_cache_ttl,
-          allow_prereleases=python_setup.resolver_allow_prereleases)
-
-    return distributions

--- a/src/python/pants/bin/extension_loader.py
+++ b/src/python/pants/bin/extension_loader.py
@@ -50,7 +50,7 @@ def load_plugins(build_configuration, plugins, working_set):
 
   * Plugins are loaded in the order they are provided. *
 
-  This is important as loading can add, remove or replace exiting tasks installed by other plugins.
+  This is important as loading can add, remove or replace existing tasks installed by other plugins.
 
   If a plugin needs to assert that another plugin is registered before it, it can define an
   entrypoint "load_after" which can return a list of plugins which must have been loaded before it

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -23,7 +23,7 @@ from pants.build_graph.address import Address, parse_spec
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.address_mapper import AddressMapper
 from pants.build_graph.build_file_parser import BuildFileParser
-from pants.util.dirutil import fast_relpath, longest_dir_prefix, join_specs
+from pants.util.dirutil import fast_relpath, join_specs, longest_dir_prefix
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/build_graph/target_scopes.py
+++ b/src/python/pants/build_graph/target_scopes.py
@@ -47,9 +47,9 @@ class Scope(frozenset):
     :rtype: bool
     """
     if include_scopes is not None and not isinstance(include_scopes, Scope):
-      raise ValueError('include_scopes must by a Scope instance.')
+      raise ValueError('include_scopes must be a Scope instance.')
     if exclude_scopes is not None and not isinstance(exclude_scopes, Scope):
-      raise ValueError('exclude_scopes must by a Scope instance.')
+      raise ValueError('exclude_scopes must be a Scope instance.')
     if exclude_scopes and any(s in exclude_scopes for s in self):
       return False
     if include_scopes and not any(s in include_scopes for s in self):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -17,7 +17,7 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.addressable import SubclassesOf
 from pants.engine.fs import FileContent, FilesContent, Path, PathGlobs, Snapshot
-from pants.engine.isolated_process import create_snapshot_singletons, _Snapshots
+from pants.engine.isolated_process import _Snapshots, create_snapshot_singletons
 from pants.engine.nodes import Return, Throw
 from pants.engine.rules import RuleIndex
 from pants.engine.selectors import (Select, SelectDependencies, SelectLiteral, SelectProjection,

--- a/tests/python/pants_test/backend/python/tasks2/BUILD
+++ b/tests/python/pants_test/backend/python/tasks2/BUILD
@@ -17,6 +17,7 @@ python_tests(
     'src/python/pants/backend/python/tasks2',
     'src/python/pants/base:build_root',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:run_info',
     'src/python/pants/build_graph',
     'src/python/pants/fs',
     'src/python/pants/util:contextutil',

--- a/tests/python/pants_test/backend/python/tasks2/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_binary_create.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+from textwrap import dedent
+
+from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.python_binary_create import PythonBinaryCreate
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.base.run_info import RunInfo
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
+
+
+class PythonBinaryCreateTest(PythonTaskTestBase):
+  @classmethod
+  def task_type(cls):
+    return PythonBinaryCreate
+
+  def setUp(self):
+    super(PythonBinaryCreateTest, self).setUp()
+
+    self.library = self.create_python_library('src/python/lib', 'lib', {'lib.py': dedent("""
+    import os
+
+
+    def main():
+      os.getcwd()
+    """)})
+
+    self.binary = self.create_python_binary('src/python/bin', 'bin', 'lib.lib:main',
+                                            dependencies=['//src/python/lib'])
+
+    # The easiest way to create products required by the PythonBinaryCreate task is to
+    # execute the relevant tasks.
+    si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
+    gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
+
+    self.task_context = self.context(for_task_types=[si_task_type, gs_task_type],
+                                     target_roots=[self.binary])
+    self.run_info_dir = os.path.join(self.pants_workdir, self.options_scope, 'test/info')
+    self.task_context.run_tracker.run_info = RunInfo(self.run_info_dir)
+
+    si_task_type(self.task_context, os.path.join(self.pants_workdir, 'si')).execute()
+    gs_task_type(self.task_context, os.path.join(self.pants_workdir, 'gs')).execute()
+
+    self.test_task = self.create_task(self.task_context)
+    self.dist_root = os.path.join(self.build_root, 'dist')
+
+  def _check_products(self, bin_name):
+    pex_name = '{}.pex'.format(bin_name)
+    products = self.task_context.products.get('deployable_archives')
+    self.assertIsNotNone(products)
+    product_data = products.get(self.binary)
+    product_basedir = product_data.keys()[0]
+    self.assertEquals(product_data[product_basedir], [pex_name])
+
+    # Check pex copy.
+    pex_copy = os.path.join(self.dist_root, pex_name)
+    self.assertTrue(os.path.isfile(pex_copy))
+
+  def test_deployable_archive_products(self):
+    self.test_task.execute()
+    self._check_products('bin')


### PR DESCRIPTION
The PEX_PATH merging mechanism only works when executing a pex. It doesn't allow you to literally merge multiple pexes into a single `.pex` file. Therefore the most straightforward way of building that `.pex` is to dump the sources and requirements into it from scratch, ignoring the partial pexes that are the products of `GatherSources` and `ResolveRequirements`.

To make this easy, this change breaks out the relevant pex-building code from those tasks, so it can be re-used in this new task.

The remainder of the logic was copied from the old task, as was the test.