### PR TITLE
Introduce SUPPRESS_LABEL on workunit's console output and have thrift-linter and jar-tool adopt it

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -96,7 +96,8 @@ class ThriftLinter(NailgunTask):
                               main='com.twitter.scrooge.linter.Main',
                               args=args,
                               jvm_options=self.get_options().jvm_options,
-                              workunit_labels=[WorkUnitLabel.COMPILER])  # to let stdout/err through.
+                              # to let stdout/err through, but don't print tool's label.
+                              workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.IGNORE_LABEL])
 
     if returncode != 0:
       raise ThriftLintError(

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -97,7 +97,7 @@ class ThriftLinter(NailgunTask):
                               args=args,
                               jvm_options=self.get_options().jvm_options,
                               # to let stdout/err through, but don't print tool's label.
-                              workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.IGNORE_LABEL])
+                              workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.SUPPRESS_LABEL])
 
     if returncode != 0:
       raise ThriftLintError(

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -47,8 +47,8 @@ class ThriftLinterTest(TaskTestBase):
     task._lint(thrift_target, task.tool_classpath('scrooge-linter'))
 
     self._run_java_mock.assert_called_once_with(classpath='foo_classpath',
-      main='com.twitter.scrooge.linter.Main',
-      args=['--ignore-errors', '--include-path', 'src/thrift/users', '--include-path',
+                                                main='com.twitter.scrooge.linter.Main',
+                                                args=['--ignore-errors', '--include-path', 'src/thrift/users', '--include-path',
             'src/thrift/tweet', 'src/thrift/tweet/b.thrift', 'src/thrift/tweet/a.thrift'],
-      jvm_options=get_default_jvm_options(),
-      workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.IGNORE_LABEL])
+                                                jvm_options=get_default_jvm_options(),
+                                                workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.SUPPRESS_LABEL])

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -46,9 +46,10 @@ class ThriftLinterTest(TaskTestBase):
     mock_calculate_compile_sources.return_value = (expected_include_paths, expected_paths)
     task._lint(thrift_target, task.tool_classpath('scrooge-linter'))
 
-    self._run_java_mock.assert_called_once_with(classpath='foo_classpath',
-                                                main='com.twitter.scrooge.linter.Main',
-                                                args=['--ignore-errors', '--include-path', 'src/thrift/users', '--include-path',
+    self._run_java_mock.assert_called_once_with(
+      classpath='foo_classpath',
+      main='com.twitter.scrooge.linter.Main',
+      args=['--ignore-errors', '--include-path', 'src/thrift/users', '--include-path',
             'src/thrift/tweet', 'src/thrift/tweet/b.thrift', 'src/thrift/tweet/a.thrift'],
-                                                jvm_options=get_default_jvm_options(),
-                                                workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.SUPPRESS_LABEL])
+      jvm_options=get_default_jvm_options(),
+      workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.SUPPRESS_LABEL])

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from mock import Mock, patch
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
+from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants_test.tasks.task_test_base import TaskTestBase
 
@@ -50,4 +51,4 @@ class ThriftLinterTest(TaskTestBase):
       args=['--ignore-errors', '--include-path', 'src/thrift/users', '--include-path',
             'src/thrift/tweet', 'src/thrift/tweet/b.thrift', 'src/thrift/tweet/a.thrift'],
       jvm_options=get_default_jvm_options(),
-      workunit_labels=['COMPILER'])
+      workunit_labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.IGNORE_LABEL])

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -31,4 +31,4 @@ class JarTool(JvmToolMixin, Subsystem):
                    args=args,
                    workunit_name='jar-tool',
                    workunit_labels=[WorkUnitLabel.TOOL, WorkUnitLabel.JVM,
-                                    WorkUnitLabel.NAILGUN, WorkUnitLabel.IGNORE_LABEL])
+                                    WorkUnitLabel.NAILGUN, WorkUnitLabel.SUPPRESS_LABEL])

--- a/src/python/pants/backend/jvm/subsystems/jar_tool.py
+++ b/src/python/pants/backend/jvm/subsystems/jar_tool.py
@@ -30,4 +30,5 @@ class JarTool(JvmToolMixin, Subsystem):
                    jvm_options=self.get_options().jvm_options,
                    args=args,
                    workunit_name='jar-tool',
-                   workunit_labels=[WorkUnitLabel.TOOL, WorkUnitLabel.JVM, WorkUnitLabel.NAILGUN])
+                   workunit_labels=[WorkUnitLabel.TOOL, WorkUnitLabel.JVM,
+                                    WorkUnitLabel.NAILGUN, WorkUnitLabel.IGNORE_LABEL])

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -47,7 +47,7 @@ class WorkUnitLabel(object):
 
   # Do not attempt to print workunit's label upon invocation
   # This has nothing to do with a process's own stderr/stdout.
-  IGNORE_LABEL = 'IGNORE_LABEL'
+  SUPPRESS_LABEL = 'SUPPRESS_LABEL'
 
   @classmethod
   @memoized_method

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -45,8 +45,9 @@ class WorkUnitLabel(object):
   PREP = 'PREP'           # Running a prep command
   LINT = 'LINT'           # Running a lint or static analysis tool.
 
-  IGNORE_LABEL = 'IGNORE_LABEL'  # Do not attempt to print workunit's label upon invocation
-
+  # Do not attempt to print workunit's label upon invocation
+  # This has nothing to do with a process's own stderr/stdout.
+  IGNORE_LABEL = 'IGNORE_LABEL'
 
   @classmethod
   @memoized_method

--- a/src/python/pants/base/workunit.py
+++ b/src/python/pants/base/workunit.py
@@ -45,6 +45,9 @@ class WorkUnitLabel(object):
   PREP = 'PREP'           # Running a prep command
   LINT = 'LINT'           # Running a lint or static analysis tool.
 
+  IGNORE_LABEL = 'IGNORE_LABEL'  # Do not attempt to print workunit's label upon invocation
+
+
   @classmethod
   @memoized_method
   def keys(cls):

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -127,7 +127,8 @@ class PlainTextReporter(PlainTextReporterBase):
     label_format = self._get_label_format(workunit)
 
     if label_format == LabelFormat.FULL:
-      self._emit_indented_workunit_label(workunit)
+      if not WorkUnitLabel.IGNORE_LABEL in workunit.labels:
+        self._emit_indented_workunit_label(workunit)
       # Start output on a new line.
       tool_output_format = self._get_tool_output_format(workunit)
       if tool_output_format == ToolOutputFormat.INDENT:

--- a/src/python/pants/reporting/plaintext_reporter.py
+++ b/src/python/pants/reporting/plaintext_reporter.py
@@ -127,7 +127,7 @@ class PlainTextReporter(PlainTextReporterBase):
     label_format = self._get_label_format(workunit)
 
     if label_format == LabelFormat.FULL:
-      if not WorkUnitLabel.IGNORE_LABEL in workunit.labels:
+      if not WorkUnitLabel.SUPPRESS_LABEL in workunit.labels:
         self._emit_indented_workunit_label(workunit)
       # Start output on a new line.
       tool_output_format = self._get_tool_output_format(workunit)

--- a/tests/python/pants_test/logging/BUILD
+++ b/tests/python/pants_test/logging/BUILD
@@ -8,3 +8,15 @@ python_tests(
     'src/python/pants/util:contextutil',
   ],
 )
+
+python_tests(
+  name='test_workunit_label',
+  sources=[
+    'test_workunit_label.py'
+  ],
+  dependencies=[
+    'src/python/pants/goal:run_tracker',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)

--- a/tests/python/pants_test/logging/data/register.py
+++ b/tests/python/pants_test/logging/data/register.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,

--- a/tests/python/pants_test/logging/data/register.py
+++ b/tests/python/pants_test/logging/data/register.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.workunit import WorkUnit, WorkUnitLabel
+from pants.goal.task_registrar import TaskRegistrar as task
+from pants.task.task import Task
+
+
+def register_goals():
+  task(name='run-workunit-label-test', action=TestWorkUnitLabelTask).install()
+
+
+class TestWorkUnitLabelTask(NailgunTask):
+
+  @classmethod
+  def register_options(cls, register):
+    super(TestWorkUnitLabelTask, cls).register_options(register)
+    register('--ignore-label', default=False, type=bool)
+
+  def execute(self):
+    labels = [WorkUnitLabel.COMPILER]
+    if self.get_options().ignore_label:
+      labels.append(WorkUnitLabel.IGNORE_LABEL)
+
+    with self.context.new_workunit('dummy_workunit') as workunit:
+      self.runjava(classpath=[], main='non-existent-main-class', args=['-version'], workunit_labels=labels)

--- a/tests/python/pants_test/logging/data/register.py
+++ b/tests/python/pants_test/logging/data/register.py
@@ -25,7 +25,7 @@ class TestWorkUnitLabelTask(NailgunTask):
   def execute(self):
     labels = [WorkUnitLabel.COMPILER]
     if self.get_options().ignore_label:
-      labels.append(WorkUnitLabel.IGNORE_LABEL)
+      labels.append(WorkUnitLabel.SUPPRESS_LABEL)
 
     with self.context.new_workunit('dummy_workunit') as workunit:
       self.runjava(classpath=[], main='non-existent-main-class', args=['-version'], workunit_labels=labels)

--- a/tests/python/pants_test/logging/test_workunit_label.py
+++ b/tests/python/pants_test/logging/test_workunit_label.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,

--- a/tests/python/pants_test/logging/test_workunit_label.py
+++ b/tests/python/pants_test/logging/test_workunit_label.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class WorkUnitLabelTest(PantsRunIntegrationTest):
+  """
+  This tests whether workunit label will appear in the log.
+  The pants run itself is going to fail due to non existent main class when invoking java,
+  but the point is to check whether certain label gets printed out.
+  """
+
+  def test_workunit_no_label_ignore(self):
+    pants_run = self.run_pants([
+      '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
+      '--backend-packages={}'.format('pants_test.goal.data'),
+      'run-workunit-label-test',
+    ])
+
+    self.assert_failure(pants_run)
+    self.assertIn("[non-existent-main-class]", pants_run.stdout_data)
+
+  def test_workunit_label_ignore(self):
+    pants_run = self.run_pants([
+      '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
+      '--backend-packages={}'.format('pants_test.goal.data'),
+      'run-workunit-label-test',
+      '--ignore-label'
+    ])
+    self.assert_failure(pants_run)
+    self.assertNotIn("[non-existent-main-class]", pants_run.stdout_data)

--- a/tests/python/pants_test/logging/test_workunit_label.py
+++ b/tests/python/pants_test/logging/test_workunit_label.py
@@ -20,7 +20,7 @@ class WorkUnitLabelTest(PantsRunIntegrationTest):
   def test_workunit_no_label_ignore(self):
     pants_run = self.run_pants([
       '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
-      '--backend-packages={}'.format('pants_test.goal.data'),
+      '--backend-packages={}'.format('pants_test.logging.data'),
       'run-workunit-label-test',
     ])
 
@@ -30,7 +30,7 @@ class WorkUnitLabelTest(PantsRunIntegrationTest):
   def test_workunit_label_ignore(self):
     pants_run = self.run_pants([
       '--pythonpath={}'.format(os.path.join(os.getcwd(), 'tests', 'python')),
-      '--backend-packages={}'.format('pants_test.goal.data'),
+      '--backend-packages={}'.format('pants_test.logging.data'),
       'run-workunit-label-test',
       '--ignore-label'
     ])


### PR DESCRIPTION
### Problem

Certain tools' workunit is too verbose, such as thrift linter and jar-tool.
```
12:19:06 01:21       [com.twitter.scrooge.linter.Main]

12:19:06 01:21       [com.twitter.scrooge.linter.Main]

12:19:06 01:21       [com.twitter.scrooge.linter.Main]

12:19:07 01:22       [com.twitter.scrooge.linter.Main]
```

```
15:48:28 16:20 [jar-tool]
15:48:28 16:20 [jar-tool]
... ...
15:48:35 16:27 [jar-tool]
15:48:35 16:27 [jar-tool]
```


### Solution

Introduce WorkUnitLabel.SUPPRESS_LABEL. When used, the label of the workunit itself will not be printed. This has nothing to do with stdout/stderr of the subprocess.

### Result
Bundle before:
```
18:40:37 00:05   [binary]
18:40:37 00:05     [binary-jvm-prep-command]
18:40:37 00:05       [jvm_prep_command]
18:40:37 00:05     [binary-prep-command]
18:40:37 00:05     [python-binary-create]
18:40:37 00:05     [jvm]
                   creating dist/hello-example.jar
18:40:37 00:05       [create-monolithic-jar]
18:40:37 00:05         [add-internal-classes]
18:40:37 00:05         [add-dependency-jars]
18:40:37 00:05         [cache].
18:40:37 00:05         [jar-tool]
18:40:37 00:05     [dup]
18:40:37 00:05     [dex]
18:40:37 00:05     [cpplib]
18:40:37 00:05       [cpp-library]
18:40:37 00:05     [cpp]
18:40:37 00:05       [cpp-binary]
18:40:37 00:05     [go]
18:40:37 00:05   [apk]
18:40:37 00:05     [apk]
18:40:37 00:05   [sign]
18:40:37 00:05     [sign]
18:40:37 00:05   [bundle]
18:40:37 00:05     [consolidate-classpath]
                   Invalidated 4 targets.
18:40:37 00:05       [jar-tool]
18:40:38 00:06     [jvm]
                   Invalidated 2 targets.
18:40:38 00:06       [create-monolithic-jar]
18:40:38 00:06         [jar-tool]
                   created bundle copy dist/examples.src.java.org.pantsbuild.example.hello.main.main-bundle
18:40:38 00:06       [create-monolithic-jar]
18:40:38 00:06         [jar-tool]
18:40:38 00:06     [dup]
18:40:38 00:06     [zipalign]
18:40:38 00:06     [node]
18:40:38 00:06   [invalidate]
```

Bundle after:
```
18:39:50 00:01   [binary]
18:39:50 00:01     [binary-jvm-prep-command]
18:39:50 00:01       [jvm_prep_command]
18:39:50 00:01     [binary-prep-command]
18:39:50 00:01     [python-binary-create]
18:39:50 00:01     [jvm]
                   creating dist/hello-example.jar
18:39:50 00:01       [create-monolithic-jar]
18:39:50 00:01         [add-internal-classes]
18:39:50 00:01         [add-dependency-jars]
18:39:50 00:01     [dup]
18:39:50 00:01     [dex]
18:39:50 00:01     [cpplib]
18:39:50 00:01       [cpp-library]
18:39:50 00:01     [cpp]
18:39:50 00:01       [cpp-binary]
18:39:50 00:01     [go]
18:39:50 00:01   [apk]
18:39:50 00:01     [apk]
18:39:50 00:01   [sign]
18:39:50 00:01     [sign]
18:39:50 00:01   [bundle]
18:39:50 00:01     [consolidate-classpath]
18:39:50 00:01     [jvm]
                   created bundle copy dist/examples.src.java.org.pantsbuild.example.hello.main.main-bundle
18:39:50 00:01     [dup]
18:39:50 00:01     [zipalign]
18:39:50 00:01     [node]
18:39:51 00:02   [invalidate]
```

thrift-linter before:
```
                   Invalidated 1 target.
18:43:20 00:00       [parallel-thrift-linter]
18:43:20 00:00         [cache]..
18:43:20 00:00       [cache]
18:43:20 00:00       [com.twitter.scrooge.linter.Main]
                     LINT-ERROR: contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/bad-non-strict.thrift
                     Missing namespace: scala.
                     LINT-ERROR: contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/bad-non-strict.thrift
                     Missing namespace: java.
```

thrift-linter after:
```
18:44:19 00:01     [thrift-linter]
                   Invalidated 1 target.
18:44:19 00:01       [parallel-thrift-linter].
18:44:19 00:01         [cache]
18:44:19 00:01       [cache].
                     LINT-ERROR: contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/bad-non-strict.thrift
                     Missing namespace: scala.
                     LINT-ERROR: contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/bad-non-strict.thrift
                     Missing namespace: java.
                     
18:44:20 00:02   [complete]
```