### PR TITLE
scrooge_gen task copy strict_deps field

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -282,4 +282,4 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
   @property
   def _copy_target_attributes(self):
-    return ['provides']
+    return ['provides', 'strict_deps']

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -110,7 +110,8 @@ class ScroogeGenTest(TaskTestBase):
         dependencies=[],
         compiler='scrooge',
         language='{language}',
-        rpc_style='{rpc_style}'
+        rpc_style='{rpc_style}',
+        strict_deps=True,
       )
     '''.format(language=language, rpc_style=rpc_style))
 
@@ -141,6 +142,7 @@ class ScroogeGenTest(TaskTestBase):
       self.assertEquals(call_kwargs['provides'], None)
       self.assertEquals(call_kwargs['sources'], [])
       self.assertEquals(call_kwargs['derived_from'], target)
+      self.assertEquals(call_kwargs['strict_deps'], True)
 
     finally:
       Context.add_new_target = saved_add_new_target


### PR DESCRIPTION
### Problem

Currently, strict_deps field in java_thrift_target will not be copied to the generated synthetic target.

### Solution

add 'strict_deps' into target attributes list to be copied.

