### PR TITLE
Profile the pants invocations in integration tests.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -78,3 +78,16 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
                                   'testprojects/tests/python/pants/constants_only:constants_only'])
       self.assert_success(pants_run)
       self.assertTrue(os.path.exists(os.path.join(coverage_dir, 'coverage.xml')))
+
+  def test_pytest_with_profile(self):
+    with temporary_dir() as profile_dir:
+      prof = os.path.join(profile_dir, 'pants.prof')
+      pants_run = self.run_pants(['clean-all',
+                                  'test.pytest',
+                                  'testprojects/tests/python/pants/constants_only:constants_only'],
+                                 extra_env={'PANTS_PROFILE': prof})
+      self.assert_success(pants_run)
+      # Note that the subprocess profile mechanism will add a ".0" to the profile path.
+      # We won't see a profile at prof itself because PANTS_PROFILE wasn't set when the
+      # current process started.
+      self.assertTrue(os.path.exists('{}.0'.format(prof)))

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -200,7 +200,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
     if self.hermetic():
       env = dict()
       for h in self.hermetic_env_whitelist():
-        env[h] = os.getenv(h)
+        env[h] = os.getenv(h) or ''
       hermetic_env = os.getenv('HERMETIC_ENV')
       if hermetic_env:
         for h in hermetic_env.strip(',').split(','):


### PR DESCRIPTION
If the user asks for a perf profile (by setting PANTS_PROFILE) when
running an integration test, then they likely mean that they want
a profile of the invocation of pants in a subprocess, not of
the calling process.

This change passes the PANTS_PROFILE setting through to those
subprocesses, appropriately modified so that the child profile doesn't
stomp on that of the parent.
