### PR TITLE
[pantsd] Add an option to configure the watchman startup timeout.

### DIFF
--- a/src/python/pants/pantsd/subsystem/watchman_launcher.py
+++ b/src/python/pants/pantsd/subsystem/watchman_launcher.py
@@ -31,6 +31,9 @@ class WatchmanLauncher(object):
       register('--supportdir', advanced=True, default='bin/watchman',
                help='Find watchman binaries under this dir. Used as part of the path to lookup '
                     'the binary with --binary-util-baseurls and --pants-bootstrapdir.')
+      register('--startup-timeout', type=float, advanced=True, default=Watchman.SOCKET_TIMEOUT_SECONDS,
+               help='The watchman socket timeout (in seconds) for the initial `watch-project` command. '
+                    'This may need to be set higher for larger repos due to watchman startup cost.')
       register('--socket-timeout', type=float, advanced=True, default=Watchman.SOCKET_TIMEOUT_SECONDS,
                help='The watchman client socket timeout (in seconds).')
       register('--socket-path', type=str, advanced=True, default=None,
@@ -45,11 +48,12 @@ class WatchmanLauncher(object):
                               options.level,
                               options.version,
                               options.supportdir,
+                              options.startup_timeout,
                               options.socket_timeout,
                               options.socket_path)
 
   def __init__(self, binary_util, workdir, log_level, watchman_version, watchman_supportdir,
-               socket_timeout, socket_path_override=None):
+               startup_timeout, socket_timeout, socket_path_override=None):
     """
     :param binary_util: The BinaryUtil subsystem instance for binary retrieval.
     :param workdir: The current pants workdir.
@@ -63,6 +67,7 @@ class WatchmanLauncher(object):
     self._workdir = workdir
     self._watchman_version = watchman_version
     self._watchman_supportdir = watchman_supportdir
+    self._startup_timeout = startup_timeout
     self._socket_timeout = socket_timeout
     self._socket_path_override = socket_path_override
     self._log_level = log_level
@@ -86,6 +91,7 @@ class WatchmanLauncher(object):
     return Watchman(watchman_binary,
                     self._workdir,
                     self._convert_log_level(self._log_level),
+                    self._startup_timeout,
                     self._socket_timeout,
                     self._socket_path_override)
 

--- a/src/python/pants/pantsd/subsystem/watchman_launcher.py
+++ b/src/python/pants/pantsd/subsystem/watchman_launcher.py
@@ -31,7 +31,7 @@ class WatchmanLauncher(object):
       register('--supportdir', advanced=True, default='bin/watchman',
                help='Find watchman binaries under this dir. Used as part of the path to lookup '
                     'the binary with --binary-util-baseurls and --pants-bootstrapdir.')
-      register('--startup-timeout', type=float, advanced=True, default=Watchman.SOCKET_TIMEOUT_SECONDS,
+      register('--startup-timeout', type=float, advanced=True, default=Watchman.STARTUP_TIMEOUT_SECONDS,
                help='The watchman socket timeout (in seconds) for the initial `watch-project` command. '
                     'This may need to be set higher for larger repos due to watchman startup cost.')
       register('--socket-timeout', type=float, advanced=True, default=Watchman.SOCKET_TIMEOUT_SECONDS,

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -24,12 +24,13 @@ class Watchman(ProcessManager):
 
   EventHandler = namedtuple('EventHandler', ['name', 'metadata', 'callback'])
 
-  def __init__(self, watchman_path, work_dir, log_level='1', timeout=SOCKET_TIMEOUT_SECONDS,
-               socket_path_override=None, metadata_base_dir=None):
+  def __init__(self, watchman_path, work_dir, log_level='1', startup_timeout=SOCKET_TIMEOUT_SECONDS,
+               timeout=SOCKET_TIMEOUT_SECONDS, socket_path_override=None, metadata_base_dir=None):
     """
     :param str watchman_path: The path to the watchman binary.
     :param str work_dir: The path to the pants work dir.
-    :param float timeout: The watchman socket timeout (in seconds).
+    :param float startup_timeout: The timeout for the initial `watch-project` query (in seconds).
+    :param float timeout: The watchman socket timeout for all subsequent queries (in seconds).
     :param str log_level: The watchman log level. Watchman has 3 log levels: '0' for no logging,
                           '1' for standard logging and '2' for verbose logging.
     :param str socket_path_override: The overridden target path of the watchman socket, if any.
@@ -42,6 +43,7 @@ class Watchman(ProcessManager):
     self._watchman_path = self._normalize_watchman_path(watchman_path)
     self._watchman_work_dir = os.path.join(work_dir, self.name)
     self._log_level = log_level
+    self._startup_timeout = startup_timeout
     self._timeout = timeout
 
     self._state_file = os.path.join(self._watchman_work_dir, '{}.state'.format(self.name))
@@ -60,7 +62,10 @@ class Watchman(ProcessManager):
 
   def _make_client(self):
     """Create a new watchman client using the BSER protocol over a UNIX socket."""
-    return StreamableWatchmanClient(sockpath=self.socket, transport='local', timeout=self._timeout)
+    self._logger.debug('setting initial watchman timeout to %s', self._startup_timeout)
+    return StreamableWatchmanClient(sockpath=self.socket,
+                                    transport='local',
+                                    timeout=self._startup_timeout)
 
   def _is_valid_executable(self, binary_path):
     return os.path.isfile(binary_path) and os.access(binary_path, os.X_OK)
@@ -137,7 +142,12 @@ class Watchman(ProcessManager):
 
     :param string path: the path to the watchman project root/pants build root.
     """
-    return self.client.query('watch-project', os.path.realpath(path))
+    # TODO(kwlzn): Add a client.query(timeout=X) param to the upstream pywatchman project.
+    try:
+      return self.client.query('watch-project', os.path.realpath(path))
+    finally:
+      self.client.setTimeout(self._timeout)
+      self._logger.debug('setting post-startup watchman timeout to %s', self._timeout)
 
   def subscribed(self, build_root, handlers):
     """Bulk subscribe generator for StreamableWatchmanClient.

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -20,11 +20,12 @@ from pants.util.retry import retry_on_exception
 class Watchman(ProcessManager):
   """Watchman process manager and helper class."""
 
+  STARTUP_TIMEOUT_SECONDS = 30.0
   SOCKET_TIMEOUT_SECONDS = 5.0
 
   EventHandler = namedtuple('EventHandler', ['name', 'metadata', 'callback'])
 
-  def __init__(self, watchman_path, work_dir, log_level='1', startup_timeout=SOCKET_TIMEOUT_SECONDS,
+  def __init__(self, watchman_path, work_dir, log_level='1', startup_timeout=STARTUP_TIMEOUT_SECONDS,
                timeout=SOCKET_TIMEOUT_SECONDS, socket_path_override=None, metadata_base_dir=None):
     """
     :param str watchman_path: The path to the watchman binary.


### PR DESCRIPTION
Fixes #4224

### Problem

In large repos, the initial `watch-project` command can take longer than the default timeout of 5 seconds due to watchman startup. This can cause a `SocketTimeout` exception, which leads to a `FSEventService` crash and subsequently tears down the daemon.

### Solution

Add an option to set the initial watchman client timeout, which is then set to the default timeout after the initial `watch-project` command is issued.

### Result

After testing in our monorepo, I'm unable to reproduce the startup crash seen in #4224 with this option set to 30 seconds.