### PR TITLE
minor: Fix bad import from race commits

### DIFF
--- a/tests/python/pants_test/backend/python/tasks2/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_select_interpreter.py
@@ -13,7 +13,6 @@ from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.base.exceptions import TaskError
-from pants.python.python_setup import PythonSetup
 from pants_test.tasks.task_test_base import TaskTestBase
 
 


### PR DESCRIPTION
### Problem

A race condition that I didn't experience before from two consecutive commits:

1. 50544b9318aa945b0cf5323f971b14e28790947d 
2. 2d7a6908cccd0eef6675dca951bd4628be1de44a 

The latter ci was green before merging to master w/o the former.

### Solution

Removed the extra import from 2nd commit.