### PR TITLE
Upgrade to mock 2.0.0.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -7,7 +7,7 @@ fasteners==0.14.1
 futures==3.0.5
 isort==4.2.5
 Markdown==2.1.1
-mock==1.3.0
+mock==2.0.0
 packaging==16.8
 pathspec==0.5.0
 pep8==1.6.2


### PR DESCRIPTION
The version we were using is missing several of the newer
`assert_*` methods, such as `assert_called_once()`.