### PR TITLE
Fix ivy resolve when libraries are not jar files (for example, zip files)

### DIFF
--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -673,7 +673,7 @@ class IvyInfo(object):
       return OrderedSet([dep])
     for jar in coordinates:
       classifier = jar.classifier if self._conf == 'default' else self._conf
-      jar_module_ref = IvyModuleRef(jar.org, jar.name, jar.rev, classifier)
+      jar_module_ref = IvyModuleRef(jar.org, jar.name, jar.rev, classifier, jar.ext)
       for module_ref in self.traverse_dependency_graph(jar_module_ref, create_collection, memo):
         for artifact_path in self._artifacts_by_ref[module_ref.unversioned]:
           resolved_jars.add(to_resolved_jar(module_ref, artifact_path))


### PR DESCRIPTION
ivy resolution does not add non-jar (zip) artifacts to the JarImportProducts.  It defaults the file extension to `.jar` in one spot.  Carrying through the correct extension fixes this.

### Problem

I noticed this when I was trying to use `unpack-jars` with a zip file.  When I do this, nothing is unzipped in .pants.d, but a similar BUILD with a jar file works as expected.

```
jar_library(name='groovy', jars=[ jar('org.codehaus.groovy', 'groovy-binary', '2.2.2', intransitive=True, ext='zip') ])
unpacked_jars(name="unpack_groovy", libraries=[':groovy'])
```

`./pants -ldebug unpack-jars :unpack_groovy` shows no output that indicates the zip is unpacked.  With the fix, this works.

### Solution

The code was carrying through most properties of the jar (name, org, rev), but not extension.  This caused the extension to default to `.jar`.  The fix carries through the extension.

