### PR TITLE
Enable v2 engine by default.

### DIFF
--- a/contrib/node/examples/src/node/hello-test/BUILD
+++ b/contrib/node/examples/src/node/hello-test/BUILD
@@ -4,10 +4,9 @@ node_module(
   package_manager='yarn',
 )
 
-# FIXME: https://github.com/pantsbuild/pants/issues/4355
-# node_test(
-#   name='mocha',
-#   dependencies=[
-#     ':pantsbuild-hello-mocha'
-#   ]
-# )
+node_test(
+  name='mocha',
+  dependencies=[
+    ':pantsbuild-hello-mocha'
+  ]
+)

--- a/contrib/node/examples/src/node/hello-test/BUILD
+++ b/contrib/node/examples/src/node/hello-test/BUILD
@@ -4,9 +4,10 @@ node_module(
   package_manager='yarn',
 )
 
-node_test(
-  name='mocha',
-  dependencies=[
-    ':pantsbuild-hello-mocha'
-  ]
-)
+# FIXME: https://github.com/pantsbuild/pants/issues/4355
+# node_test(
+#   name='mocha',
+#   dependencies=[
+#     ':pantsbuild-hello-mocha'
+#   ]
+# )

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -130,7 +130,7 @@ def deprecated_conditional(predicate,
     warn_or_error(removal_version, entity_description, hint_message, stacklevel=stacklevel)
 
 
-def deprecated(removal_version, hint_message=None):
+def deprecated(removal_version, hint_message=None, subject=None):
   """Marks a function or method as deprecated.
 
   A removal version must be supplied and it must be greater than the current 'pantsbuild.pants'
@@ -146,6 +146,8 @@ def deprecated(removal_version, hint_message=None):
   :param str removal_version: The pantsbuild.pants version which will remove the deprecated
                               function.
   :param str hint_message: An optional hint pointing to alternatives to the deprecation.
+  :param str subject: The name of the subject that has been deprecated for logging clarity. Defaults
+                      to the name of the decorated function/method.
   :raises DeprecationApplicationError if the @deprecation is applied improperly.
   """
   validate_removal_semver(removal_version)
@@ -158,7 +160,7 @@ def deprecated(removal_version, hint_message=None):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-      warn_or_error(removal_version, func_full_name, hint_message)
+      warn_or_error(removal_version, subject or func_full_name, hint_message)
       return func(*args, **kwargs)
     return wrapper
   return decorator

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -91,7 +91,7 @@ class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'engine', 
     :returns: A tuple of (BuildGraph, AddressMapper).
     """
     logger.debug('target_roots are: %r', target_roots)
-    graph = LegacyBuildGraph(self.scheduler, self.engine, self.symbol_table_cls)
+    graph = LegacyBuildGraph.create(self.scheduler, self.engine, self.symbol_table_cls)
     logger.debug('build_graph is: %s', graph)
     with self.scheduler.locked():
       # Ensure the entire generator is unrolled.

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -102,6 +102,10 @@ class BuildGraph(AbstractClass):
   def __init__(self):
     self.reset()
 
+  @abstractmethod
+  def clone_new(self):
+    """Returns a new BuildGraph instance of the same type and with the same __init__ params."""
+
   def reset(self):
     """Clear out the state of the BuildGraph, in particular Target mappings and dependencies.
 

--- a/src/python/pants/build_graph/mutable_build_graph.py
+++ b/src/python/pants/build_graph/mutable_build_graph.py
@@ -23,6 +23,10 @@ class MutableBuildGraph(BuildGraph):
     self._address_mapper = address_mapper
     super(MutableBuildGraph, self).__init__()
 
+  def clone_new(self):
+    """Returns a new BuildGraph instance of the same type and with the same __init__ params."""
+    return MutableBuildGraph(self._address_mapper)
+
   def reset(self):
     super(MutableBuildGraph, self).reset()
     self._addresses_already_closed = set()

--- a/src/python/pants/core_tasks/changed_target_tasks.py
+++ b/src/python/pants/core_tasks/changed_target_tasks.py
@@ -5,14 +5,18 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.base.deprecated import deprecated
 from pants.core_tasks.noop import NoopCompile, NoopTest
 from pants.task.changed_target_task import ChangedTargetTask
 
+# TODO: Remove this entire file in 1.5.0dev0.
 
 class CompileChanged(ChangedTargetTask):
   """Find and compile changed targets."""
 
   @classmethod
+  @deprecated('1.5.0dev0', 'Use e.g. `./pants --changed-parent=HEAD compile` instead.',
+              '`./pants compile-changed`')
   def prepare(cls, options, round_manager):
     super(CompileChanged, cls).prepare(options, round_manager)
     round_manager.require_data(NoopCompile.product_types()[0])
@@ -22,6 +26,8 @@ class TestChanged(ChangedTargetTask):
   """Find and test changed targets."""
 
   @classmethod
+  @deprecated('1.5.0dev0', 'Use e.g. `./pants --changed-parent=HEAD test` instead.',
+              '`./pants test-changed`')
   def prepare(cls, options, round_manager):
     super(TestChanged, cls).prepare(options, round_manager)
     round_manager.require_data(NoopTest.product_types()[0])

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -82,6 +82,7 @@ def register_goals():
   task(name='test', action=NoopTest).install('test')
 
   # Operations on files that the SCM detects as changed.
+  # TODO: Remove these in `1.5.0dev0` as part of the changed goal deprecations.
   task(name='changed', action=WhatChanged).install()
   task(name='compile-changed', action=CompileChanged).install()
   task(name='test-changed', action=TestChanged).install()

--- a/src/python/pants/core_tasks/what_changed.py
+++ b/src/python/pants/core_tasks/what_changed.py
@@ -5,9 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.base.deprecated import deprecated
 from pants.scm.subsystems.changed import Changed
 from pants.task.console_task import ConsoleTask
 
+# TODO: Remove this entire file in 1.5.0dev0.
 
 class WhatChanged(ConsoleTask):
   """Emits the targets that have been modified since a given commit."""
@@ -16,13 +18,16 @@ class WhatChanged(ConsoleTask):
   def register_options(cls, register):
     super(WhatChanged, cls).register_options(register)
     # N.B. The bulk of options relevant to this task now come from the `Changed` subsystem.
-    register('--files', type=bool,
-             help='Show changed files instead of the targets that own them.')
+    register('--files', type=bool, removal_version='1.5.0dev0',
+             help='Show changed files instead of the targets that own them.',
+             removal_hint='Use your scm implementation (e.g. `git diff --stat`) instead.')
 
   @classmethod
   def subsystem_dependencies(cls):
     return super(WhatChanged, cls).subsystem_dependencies() + (Changed.Factory,)
 
+  @deprecated('1.5.0dev0', 'Use e.g. `./pants --changed-parent=HEAD list` instead.',
+              '`./pants changed`')
   def console_output(self, _):
     # N.B. This task shares an options scope ('changed') with the `Changed` subsystem.
     options = self.get_options()

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -39,7 +39,9 @@ class TargetAdaptor(StructWithDeps):
       see: https://github.com/pantsbuild/pants/issues/2997
     """
     sources = getattr(self, 'sources', None)
-    if not sources:
+    # N.B. Here we check specifically for `sources is None`, as it's possible for sources
+    # to be e.g. an explicit empty list (sources=[]).
+    if sources is None:
       if self.default_sources_globs:
         return Globs(*self.default_sources_globs,
                      spec_path=self.address.spec_path,

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -15,7 +15,6 @@ from twitter.common.collections import OrderedSet
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.worker_pool import SubprocPool
 from pants.base.workunit import WorkUnitLabel
-from pants.build_graph.mutable_build_graph import MutableBuildGraph
 from pants.build_graph.target import Target
 from pants.goal.products import Products
 from pants.goal.workspace import ScmWorkspace
@@ -351,7 +350,7 @@ class Context(object):
     :param string root: The path to scan; by default, the build root.
     :returns: A new build graph encapsulating the targets found.
     """
-    build_graph = MutableBuildGraph(self.address_mapper)
+    build_graph = self.build_graph.clone_new()
     for address in self.address_mapper.scan_addresses(root):
       build_graph.inject_address_closure(address)
     return build_graph

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -127,8 +127,9 @@ class GlobalOptionsRegistrar(Optionable):
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
 
     # This facilitates use of the v2 engine, sans daemon.
+    # TODO: Add removal_version='1.5.0dev0' before 1.4 lands.
     register('--enable-v2-engine', advanced=True, type=bool, default=True,
-             help='Enables use of the v2 engine.', removal_version='1.5.0dev0')
+             help='Enables use of the v2 engine.')
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -126,9 +126,9 @@ class GlobalOptionsRegistrar(Optionable):
     register('--enable-pantsd', advanced=True, type=bool, default=False,
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
 
-    # This facilitates use of the v2 engine for BuildGraph construction, sans daemon.
-    register('--enable-v2-engine', advanced=True, type=bool, default=False,
-             help='Enables use of the v2 engine. (Beta)')
+    # This facilitates use of the v2 engine, sans daemon.
+    register('--enable-v2-engine', advanced=True, type=bool, default=True,
+             help='Enables use of the v2 engine.', removal_version='1.5.0dev0')
 
   @classmethod
   def register_options(cls, register):

--- a/src/python/pants/scm/change_calculator.py
+++ b/src/python/pants/scm/change_calculator.py
@@ -40,6 +40,7 @@ class ChangeCalculator(AbstractClass):
     """Find changed targets, according to SCM."""
 
 
+# TODO: Remove this in 1.5.0dev0 in favor of `EngineChangeCalculator`.
 class BuildGraphChangeCalculator(ChangeCalculator):
   """A `BuildGraph`-based helper for calculating changed target addresses."""
 

--- a/src/python/pants/scm/subsystems/changed.py
+++ b/src/python/pants/scm/subsystems/changed.py
@@ -13,6 +13,7 @@ from pants.subsystem.subsystem import Subsystem
 from pants.util.objects import datatype
 
 
+# TODO: Remove this in 1.5.0dev0.
 class _ChainedOptions(object):
   def __init__(self, options_seq):
     self._options_seq = options_seq
@@ -63,6 +64,7 @@ class Changed(object):
       register('--fast', type=bool,
                help='Stop searching for owners once a source is mapped to at least one owning target.')
 
+    # TODO: Remove or reduce this in 1.5.0dev0 - we only need the subsystem's options scope going fwd.
     @classmethod
     def create(cls, alternate_options=None):
       """
@@ -80,6 +82,7 @@ class Changed(object):
   def __init__(self, changed_request):
     self._changed_request = changed_request
 
+  # TODO: Remove this in 1.5.0dev0 in favor of `TargetRoots` use of `EngineChangeCalculator`.
   def change_calculator(self, build_graph, address_mapper, scm=None, workspace=None,
                         exclude_target_regexp=None):
     """Constructs and returns a BuildGraphChangeCalculator.

--- a/src/python/pants/task/changed_target_task.py
+++ b/src/python/pants/task/changed_target_task.py
@@ -11,6 +11,9 @@ from pants.scm.subsystems.changed import Changed
 from pants.task.noop_exec_task import NoopExecTask
 
 
+# TODO: Remove this entire file in 1.5.0dev0.
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/python/pants_test/backend/graph_info/tasks/test_filemap.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_filemap.py
@@ -52,6 +52,7 @@ class FilemapTest(ConsoleTaskTestBase):
       'common/src/py/b/two.py common/src/py/b:b',
       'common/src/py/b/three.py common/src/py/b:b',
       'common/src/py/c/four.py common/src/py/c:c',
+      targets=self.targets('::')
     )
 
   def test_one(self):

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_zinc_compile_integration.py
@@ -17,9 +17,7 @@ from pants_test.backend.jvm.tasks.missing_jvm_check import is_missing_jvm
 class ZincCompileIntegrationTest(BaseCompileIT):
 
   def test_java_src_zinc_compile(self):
-    # TODO: Remove the --exclude-target-regexp once we're on Java 8 everywhere.
-    with self.do_test_compile('examples/src/java/::',
-        extra_args=['--exclude-target-regexp=examples/src/java/org/pantsbuild/example/javac/plugin']):
+    with self.do_test_compile('examples/src/java/::'):
       # run succeeded as expected
       pass
     with self.do_test_compile('examples/tests/java/::'):

--- a/tests/python/pants_test/base/test_deprecated.py
+++ b/tests/python/pants_test/base/test_deprecated.py
@@ -102,6 +102,18 @@ class DeprecatedTest(unittest.TestCase):
       self.assertEqual(expected_return, deprecated_function())
       self.assertIn(hint_message, str(extract_deprecation_warning()))
 
+  def test_deprecation_subject(self):
+    subject = '`./pants blah`'
+    expected_return = 'deprecated_function'
+
+    @deprecated(self.FUTURE_VERSION, subject=subject)
+    def deprecated_function():
+      return expected_return
+
+    with self._test_deprecation() as extract_deprecation_warning:
+      self.assertEqual(expected_return, deprecated_function())
+      self.assertIn(subject, str(extract_deprecation_warning()))
+
   def test_removal_version_required(self):
     with self.assertRaises(MissingRemovalVersionError):
       @deprecated(None)

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -7,14 +7,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pants.base.build_environment import get_buildroot
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class BuildGraphIntegrationTest(PantsRunIntegrationTest):
 
   def test_cycle(self):
-    prefix = os.path.join(get_buildroot(), 'testprojects/src/java/org/pantsbuild/testproject')
+    prefix = os.path.join('testprojects/src/java/org/pantsbuild/testproject')
     with self.file_renamed(os.path.join(prefix, 'cycle1'), 'TEST_BUILD', 'BUILD'):
       with self.file_renamed(os.path.join(prefix, 'cycle2'), 'TEST_BUILD', 'BUILD'):
         pants_run = self.run_pants(['compile', os.path.join(prefix, 'cycle1')])

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -19,7 +19,4 @@ class BuildGraphIntegrationTest(PantsRunIntegrationTest):
       with self.file_renamed(os.path.join(prefix, 'cycle2'), 'TEST_BUILD', 'BUILD'):
         pants_run = self.run_pants(['compile', os.path.join(prefix, 'cycle1')])
         self.assert_failure(pants_run)
-        # FIXME: The output in this test should probably indicate a cycle. Currently, it
-        # receives: "Throw(No source of required dependencies)" - so we'll bind to that
-        # for now to be intentionally ~brittle.
-        self.assertIn('No source of required dependencies', pants_run.stderr_data)
+        self.assertIn('contained a cycle', pants_run.stderr_data)

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -7,17 +7,19 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
+from pants.base.build_environment import get_buildroot
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class BuildGraphIntegrationTest(PantsRunIntegrationTest):
 
-  # TODO: Disabled to expedite landing #3821: see #4007.
-  # @ensure_engine
   def test_cycle(self):
-    prefix = 'testprojects/src/java/org/pantsbuild/testproject'
+    prefix = os.path.join(get_buildroot(), 'testprojects/src/java/org/pantsbuild/testproject')
     with self.file_renamed(os.path.join(prefix, 'cycle1'), 'TEST_BUILD', 'BUILD'):
       with self.file_renamed(os.path.join(prefix, 'cycle2'), 'TEST_BUILD', 'BUILD'):
         pants_run = self.run_pants(['compile', os.path.join(prefix, 'cycle1')])
         self.assert_failure(pants_run)
-        self.assertIn('Cycle detected', pants_run.stderr_data)
+        # FIXME: The output in this test should probably indicate a cycle. Currently, it
+        # receives: "Throw(No source of required dependencies)" - so we'll bind to that
+        # for now to be intentionally ~brittle.
+        self.assertIn('No source of required dependencies', pants_run.stderr_data)

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -13,7 +13,7 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class BuildGraphIntegrationTest(PantsRunIntegrationTest):
 
   def test_cycle(self):
-    prefix = os.path.join('testprojects/src/java/org/pantsbuild/testproject')
+    prefix = 'testprojects/src/java/org/pantsbuild/testproject'
     with self.file_renamed(os.path.join(prefix, 'cycle1'), 'TEST_BUILD', 'BUILD'):
       with self.file_renamed(os.path.join(prefix, 'cycle2'), 'TEST_BUILD', 'BUILD'):
         pants_run = self.run_pants(['compile', os.path.join(prefix, 'cycle1')])

--- a/tests/python/pants_test/core_tasks/test_deferred_sources_mapper_integration.py
+++ b/tests/python/pants_test/core_tasks/test_deferred_sources_mapper_integration.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
 from pants.util.dirutil import safe_open
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_engine
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class DeferredSourcesMapperIntegration(PantsRunIntegrationTest):
@@ -79,13 +79,11 @@ class DeferredSourcesMapperIntegration(PantsRunIntegrationTest):
     )
     return pants_run
 
-  @ensure_engine
   def test_deferred_sources_gen_successfully(self):
     with self.temporary_workdir() as workdir:
       pants_run = self._configured_pants_run(['gen', self._emit_targets(workdir)[0]], workdir)
       self.assert_success(pants_run)
 
-  @ensure_engine
   def test_deferred_sources_export_successfully(self):
     with self.temporary_workdir() as workdir:
       proto7, proto8 = self._emit_targets(workdir)

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -58,7 +58,7 @@ def ensure_cached(expected_num_artifacts=None):
     return wrapper
   return decorator
 
-
+# TODO: Remove this in 1.5.0dev0, when `--enable-v2-engine` is removed.
 def ensure_engine(f):
   """A decorator for running an integration test with and without the v2 engine enabled via
   temporary environment variables."""

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -58,6 +58,7 @@ def ensure_cached(expected_num_artifacts=None):
     return wrapper
   return decorator
 
+
 # TODO: Remove this in 1.5.0dev0, when `--enable-v2-engine` is removed.
 def ensure_engine(f):
   """A decorator for running an integration test with and without the v2 engine enabled via

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -120,12 +120,14 @@ class SubsystemTest(unittest.TestCase):
         Subsystem.closure((root,))
 
   def test_uninitialized_global(self):
-
+    Subsystem.reset()
     with self.assertRaisesRegexp(Subsystem.UninitializedSubsystemError,
                                  r'UninitializedSubsystem.*uninitialized-scope'):
       UninitializedSubsystem.global_instance()
 
   def test_uninitialized_scoped_instance(self):
+    Subsystem.reset()
+
     class UninitializedOptional(Optionable):
       options_scope = 'optional'
 


### PR DESCRIPTION
This enables the v2 engine by default and deprecates the `changed`-class goals.