### PR TITLE
A PythonEval task that uses the new pipeline.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/BUILD
@@ -6,6 +6,7 @@ contrib_plugin(
   dependencies=[
     'contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle:all',
     'contrib/python/src/python/pants/contrib/python/checks/tasks:python',
+    'contrib/python/src/python/pants/contrib/python/checks/tasks2',
     'src/python/pants/goal:task_registrar',
   ],
   distribution_name='pantsbuild.pants.contrib.python.checks',

--- a/contrib/python/src/python/pants/contrib/python/checks/register.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/register.py
@@ -9,8 +9,10 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.python.checks.tasks.checkstyle.checker import PythonCheckStyleTask
 from pants.contrib.python.checks.tasks.python_eval import PythonEval
+from pants.contrib.python.checks.tasks2.python_eval import PythonEval as PythonEval2
 
 
 def register_goals():
   task(name='python-eval', action=PythonEval).install('compile')
+  task(name='python-eval', action=PythonEval2).install('compile2')
   task(name='pythonstyle', action=PythonCheckStyleTask).install('compile')

--- a/contrib/python/src/python/pants/contrib/python/checks/register.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/register.py
@@ -7,9 +7,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.goal.task_registrar import TaskRegistrar as task
 
+from pants.contrib.python.checks.tasks2.python_eval import PythonEval as PythonEval2
 from pants.contrib.python.checks.tasks.checkstyle.checker import PythonCheckStyleTask
 from pants.contrib.python.checks.tasks.python_eval import PythonEval
-from pants.contrib.python.checks.tasks2.python_eval import PythonEval as PythonEval2
 
 
 def register_goals():

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  dependencies=[
+    '3rdparty/python:pex',
+    'contrib/python/src/python/pants/contrib/python/checks/tasks:resources',
+    'src/python/pants/backend/python/targets:python',
+    'src/python/pants/backend/python/tasks2',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:generator',
+    'src/python/pants/base:workunit',
+    'src/python/pants/util:dirutil',
+  ]
+)

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
@@ -1,0 +1,247 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import hashlib
+import os
+import pkgutil
+import shutil
+
+from pex.pex import PEX
+from pex.pex_builder import PEXBuilder
+from pex.pex_info import PexInfo
+
+from pants.backend.python.interpreter_cache import PythonInterpreterCache
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.tasks.python_task import PythonTask
+from pants.backend.python.tasks2.pex_build_util import has_python_requirements, dump_sources, \
+  has_python_sources, dump_requirements
+from pants.backend.python.tasks2.python_execution_task_base import WrappedPEX
+from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
+from pants.base.exceptions import TaskError
+from pants.base.generator import Generator, TemplateData
+from pants.base.workunit import WorkUnit, WorkUnitLabel
+from pants.python.python_repos import PythonRepos
+from pants.util.dirutil import safe_rmtree, safe_mkdir, safe_concurrent_creation
+from pants.util.memo import memoized_method
+
+
+class PythonEval(ResolveRequirementsTaskBase):
+  class Error(TaskError):
+    """A richer failure exception type useful for tests."""
+
+    def __init__(self, *args, **kwargs):
+      compiled = kwargs.pop('compiled')
+      failed = kwargs.pop('failed')
+      super(PythonEval.Error, self).__init__(*args, **kwargs)
+      self.compiled = compiled
+      self.failed = failed
+
+  _EXEC_NAME = '__pants_executable__'
+  _EVAL_TEMPLATE_PATH = os.path.join('..', 'tasks', 'templates', 'python_eval', 'eval.py.mustache')
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    # We don't need an interpreter selected for all targets in play, so prevent one being selected.
+    pass
+
+  @staticmethod
+  def _is_evalable(target):
+    return isinstance(target, (PythonLibrary, PythonBinary))
+
+  @classmethod
+  def register_options(cls, register):
+    super(PythonEval, cls).register_options(register)
+    register('--skip', type=bool,
+             help='If enabled, skip eval of python targets.')
+    register('--fail-slow', type=bool,
+             help='Compile all targets and present the full list of errors.')
+    register('--closure', type=bool,
+             help='Eval all targets in the closure individually instead of just the targets '
+                  'specified on the command line.')
+
+  def execute(self):
+    if self.get_options().skip:
+      return
+
+    targets = self.context.targets() if self.get_options().closure else self.context.target_roots
+    with self.invalidated(filter(self._is_evalable, targets),
+                          invalidate_dependents=True,
+                          topological_order=True) as invalidation_check:
+      compiled = self._compile_targets(invalidation_check.invalid_vts)
+      return compiled  # Collected and returned for tests
+
+  @memoized_method
+  def _interpreter_cache(self):
+    interpreter_cache = PythonInterpreterCache(PythonSetup.global_instance(),
+                                               PythonRepos.global_instance(),
+                                               logger=self.context.log.debug)
+    # Cache setup's requirement fetching can hang if run concurrently by another pants proc.
+    self.context.acquire_lock()
+    try:
+      interpreter_cache.setup()
+    finally:
+      self.context.release_lock()
+    return interpreter_cache
+
+  def _compile_targets(self, invalid_vts):
+    with self.context.new_workunit(name='eval-targets', labels=[WorkUnitLabel.MULTITOOL]):
+      compiled = []
+      failed = []
+      for vt in invalid_vts:
+        target = vt.target
+        return_code = self._compile_target(vt)
+        if return_code == 0:
+          vt.update()  # Ensure partial progress is marked valid.
+          compiled.append(target)
+        else:
+          if self.get_options().fail_slow:
+            failed.append(target)
+          else:
+            raise self.Error('Failed to eval {}'.format(target.address.spec),
+                             compiled=compiled,
+                             failed=[target])
+
+      if failed:
+        msg = 'Failed to evaluate {} targets:\n  {}'.format(
+            len(failed),
+            '\n  '.join(t.address.spec for t in failed))
+        raise self.Error(msg, compiled=compiled, failed=failed)
+
+      return compiled
+
+  def _compile_target(self, vt):
+    # "Compiles" a target by forming an isolated chroot of its sources and transitive deps and then
+    # attempting to import each of the target's sources in the case of a python library or else the
+    # entry point in the case of a python binary.
+    #
+    # For a library with sources lib/core.py and lib/util.py a "compiler" main file would look like:
+    #
+    #   if __name__ == '__main__':
+    #     import lib.core
+    #     import lib.util
+    #
+    # For a binary with entry point lib.bin:main the "compiler" main file would look like:
+    #
+    #   if __name__ == '__main__':
+    #     from lib.bin import main
+    #
+    # In either case the main file is executed within the target chroot to reveal missing BUILD
+    # dependencies.
+    target = vt.target
+    with self.context.new_workunit(name=target.address.spec):
+      modules = self._get_modules(target)
+      if not modules:
+        # Nothing to eval, so a trivial compile success.
+        return 0
+
+      interpreter = self._get_interpreter_for_target_closure(target)
+      reqs_pex = self._resolve_requirements_for_versioned_target_closure(interpreter, vt)
+      srcs_pex = self._source_pex_for_versioned_target_closure(interpreter, vt)
+
+      # Create the executable pex.
+      exec_pex_parent = os.path.join(self.workdir, 'executable_pex')
+      executable_file_content = self._get_executable_file_content(exec_pex_parent, modules)
+      hasher = hashlib.sha1()
+      hasher.update(executable_file_content)
+      exec_file_hash = hasher.hexdigest()
+      exec_pex_path = os.path.realpath(os.path.join(exec_pex_parent, exec_file_hash))
+      if not os.path.isdir(exec_pex_path):
+        # Write the entry point.
+        exec_pex_path_tmp = '{}.tmp'.format(exec_pex_path)
+        safe_rmtree(exec_pex_path_tmp)
+        safe_mkdir(exec_pex_path_tmp)
+        with open(os.path.join(exec_pex_path_tmp, '{}.py'.format(self._EXEC_NAME)), 'w') as outfile:
+          outfile.write(executable_file_content)
+        pex_info = (target.pexinfo if isinstance(target, PythonBinary) else None) or PexInfo()
+        # Override any user-specified entry point, under the assumption that the
+        # executable_file_content does what the user intends (including, probably, calling that
+        # underlying entry point).
+        pex_info.entry_point = self._EXEC_NAME
+        builder = PEXBuilder(exec_pex_path_tmp, interpreter, pex_info=pex_info)
+        builder.freeze()
+        shutil.move(exec_pex_path_tmp, exec_pex_path)
+
+      exec_pex = PEX(exec_pex_path, interpreter)
+      extra_pex_paths = [pex.path() for pex in filter(None, [reqs_pex, srcs_pex])]
+      pex = WrappedPEX(exec_pex, extra_pex_paths, interpreter)
+
+      with self.context.new_workunit(name='eval',
+                                     labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.RUN,
+                                             WorkUnitLabel.TOOL],
+                                     cmd=' '.join(exec_pex.cmdline())) as workunit:
+        returncode = pex.run(stdout=workunit.output('stdout'), stderr=workunit.output('stderr'))
+        workunit.set_outcome(WorkUnit.SUCCESS if returncode == 0 else WorkUnit.FAILURE)
+        if returncode != 0:
+          self.context.log.error('Failed to eval {}'.format(target.address.spec))
+        return returncode
+
+  @staticmethod
+  def _get_modules(target):
+    modules = []
+    if isinstance(target, PythonBinary):
+      source = 'entry_point {}'.format(target.entry_point)
+      components = target.entry_point.rsplit(':', 1)
+      if not all([x.strip() for x in components]):
+        raise TaskError('Invalid entry point {} for target {}'.format(
+          target.entry_point, target.address.spec))
+      module = components[0]
+      if len(components) == 2:
+        function = components[1]
+        data = TemplateData(source=source,
+                            import_statement='from {} import {}'.format(module, function))
+      else:
+        data = TemplateData(source=source, import_statement='import {}'.format(module))
+      modules.append(data)
+    else:
+      for path in target.sources_relative_to_source_root():
+        if path.endswith('.py'):
+          if os.path.basename(path) == '__init__.py':
+            module_path = os.path.dirname(path)
+          else:
+            module_path, _ = os.path.splitext(path)
+          source = 'file {}'.format(os.path.join(target.target_base, path))
+          module = module_path.replace(os.path.sep, '.')
+          if module:
+            data = TemplateData(source=source, import_statement='import {}'.format(module))
+            modules.append(data)
+    return modules
+
+  def _get_executable_file_content(self, exec_pex_parent, modules):
+    generator = Generator(pkgutil.get_data(__name__, self._EVAL_TEMPLATE_PATH),
+                          chroot_parent=exec_pex_parent, modules=modules)
+    return generator.render()
+
+  def _get_interpreter_for_target_closure(self, target):
+    targets = [t for t in target.closure() if isinstance(t, PythonTask)]
+    return self._interpreter_cache().select_interpreter_for_targets(targets)
+
+  def _resolve_requirements_for_versioned_target_closure(self, interpreter, vt):
+    reqs_pex_path = os.path.realpath(os.path.join(self.workdir, str(interpreter.identity),
+                                                  vt.cache_key.hash))
+    if not os.path.isdir(reqs_pex_path):
+      req_libs = filter(has_python_requirements, vt.target.closure())
+      with safe_concurrent_creation(reqs_pex_path) as safe_path:
+        builder = PEXBuilder(safe_path, interpreter=interpreter, copy=True)
+        dump_requirements(builder, interpreter, req_libs, self.context.log)
+        builder.freeze()
+    return PEX(reqs_pex_path, interpreter=interpreter)
+
+  def _source_pex_for_versioned_target_closure(self, interpreter, vt):
+    source_pex_path = os.path.realpath(os.path.join(self.workdir, vt.cache_key.hash))
+    if not os.path.isdir(source_pex_path):
+      with safe_concurrent_creation(source_pex_path) as safe_path:
+        self._build_source_pex(interpreter, safe_path, vt.target.closure())
+    return PEX(source_pex_path, interpreter=interpreter)
+
+  def _build_source_pex(self, interpreter, path, targets):
+    builder = PEXBuilder(path=path, interpreter=interpreter, copy=True)
+    for target in targets:
+      if has_python_sources(target):
+        dump_sources(builder, target, self.context.log)
+    builder.freeze()

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks2/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks2/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_tests(
+  name='python_eval',
+  sources=['test_python_eval.py'],
+  dependencies=[
+    'src/python/pants/backend/python/subsystems',
+    'contrib/python/src/python/pants/contrib/python/checks/tasks2',
+    'src/python/pants/python',
+    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
+  ]
+)

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks2/test_python_eval.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks2/test_python_eval.py
@@ -1,0 +1,187 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from textwrap import dedent
+
+from pants.backend.python.subsystems.python_setup import PythonSetup
+from pants.python.python_repos import PythonRepos
+from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
+
+from pants.contrib.python.checks.tasks2.python_eval import PythonEval
+
+
+class PythonEvalTest(PythonTaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return PythonEval
+
+  def setUp(self):
+    super(PythonEvalTest, self).setUp()
+    self._create_graph(broken_b_library=True)
+
+  def _create_graph(self, broken_b_library):
+    self.reset_build_graph()
+
+    self.a_library = self.create_python_library('src/python/a', 'a', {'a.py': dedent("""
+    import inspect
+
+
+    def compile_time_check_decorator(cls):
+      if not inspect.isclass(cls):
+        raise TypeError('This decorator can only be applied to classes, given {}'.format(cls))
+      return cls
+    """)})
+
+    self.b_library = self.create_python_library('src/python/b', 'b', {'b.py': dedent("""
+    from a.a import compile_time_check_decorator
+
+
+    @compile_time_check_decorator
+    class BarB(object):
+      pass
+    """)})
+
+    # TODO: Presumably this was supposed to be c_library, not override b_library. Unravel and fix.
+    self.b_library = self.create_python_library('src/python/c', 'c', {'c.py': dedent("""
+    from a.a import compile_time_check_decorator
+
+
+    @compile_time_check_decorator
+    {}:
+      pass
+    """.format('def baz_c()' if broken_b_library else 'class BazC(object)')
+    )}, dependencies=['//src/python/a'])
+
+    self.d_library = self.create_python_library('src/python/d', 'd', { 'd.py': dedent("""
+    from a.a import compile_time_check_decorator
+
+
+    @compile_time_check_decorator
+    class BazD(object):
+      pass
+    """)}, dependencies=['//src/python/a'])
+
+    self.e_binary = self.create_python_binary('src/python/e', 'e', 'a.a',
+                                              dependencies=['//src/python/a'])
+    self.f_binary = self.create_python_binary('src/python/f', 'f',
+                                              'a.a:compile_time_check_decorator',
+                                              dependencies=['//src/python/a'])
+    self.g_binary = self.create_python_binary('src/python/g', 'g', 'a.a:does_not_exist',
+                                              dependencies=['//src/python/a'])
+    self.h_binary = self.create_python_binary('src/python/h', 'h', 'a.a')
+
+  def _create_task(self, target_roots, options=None):
+    if options:
+      self.set_options(**options)
+    return self.create_task(self.context(target_roots=target_roots,
+                                         for_subsystems=[PythonSetup, PythonRepos]))
+
+  def test_noop(self):
+    python_eval = self._create_task(target_roots=[])
+    compiled = python_eval.execute()
+    self.assertEqual([], compiled)
+
+  def test_compile(self):
+    python_eval = self._create_task(target_roots=[self.a_library])
+    compiled = python_eval.execute()
+    self.assertEqual([self.a_library], compiled)
+
+  def test_skip(self):
+    self.set_options(skip=True)
+    python_eval = self._create_task(target_roots=[self.a_library])
+    compiled = python_eval.execute()
+    self.assertIsNone(compiled)
+
+  def test_compile_incremental(self):
+    python_eval = self._create_task(target_roots=[self.a_library])
+    compiled = python_eval.execute()
+    self.assertEqual([self.a_library], compiled)
+
+    python_eval = self._create_task(target_roots=[self.a_library])
+    compiled = python_eval.execute()
+    self.assertEqual([], compiled)
+
+  def test_compile_closure(self):
+    python_eval = self._create_task(target_roots=[self.d_library], options={'closure': True})
+    compiled = python_eval.execute()
+    self.assertEqual({self.d_library, self.a_library}, set(compiled))
+
+  def test_compile_fail_closure(self):
+    python_eval = self._create_task(target_roots=[self.b_library], options={'closure': True})
+
+    with self.assertRaises(PythonEval.Error) as e:
+      python_eval.execute()
+    self.assertEqual([self.a_library], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_compile_incremental_progress(self):
+    python_eval = self._create_task(target_roots=[self.b_library], options={'closure': True})
+
+    with self.assertRaises(PythonEval.Error) as e:
+      python_eval.execute()
+    self.assertEqual([self.a_library], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+    self._create_graph(broken_b_library=False)
+    python_eval = self._create_task(target_roots=[self.b_library], options={'closure': True})
+
+    compiled = python_eval.execute()
+    self.assertEqual([self.b_library], compiled)
+
+  def test_compile_fail_missing_build_dep(self):
+    python_eval = self._create_task(target_roots=[self.b_library])
+
+    with self.assertRaises(python_eval.Error) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_compile_fail_compile_time_check_decorator(self):
+    python_eval = self._create_task(target_roots=[self.b_library])
+
+    with self.assertRaises(PythonEval.Error) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_compile_failslow(self):
+    python_eval = self._create_task(target_roots=[self.a_library, self.b_library, self.d_library],
+                                    options={'fail_slow': True})
+
+    with self.assertRaises(PythonEval.Error) as e:
+      python_eval.execute()
+    self.assertEqual({self.a_library, self.d_library}, set(e.exception.compiled))
+    self.assertEqual([self.b_library], e.exception.failed)
+
+  def test_entry_point_module(self):
+    python_eval = self._create_task(target_roots=[self.e_binary])
+
+    compiled = python_eval.execute()
+    self.assertEqual([self.e_binary], compiled)
+
+  def test_entry_point_function(self):
+    python_eval = self._create_task(target_roots=[self.f_binary])
+
+    compiled = python_eval.execute()
+    self.assertEqual([self.f_binary], compiled)
+
+  def test_entry_point_does_not_exist(self):
+    python_eval = self._create_task(target_roots=[self.g_binary])
+
+    with self.assertRaises(PythonEval.Error) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.g_binary], e.exception.failed)
+
+  def test_entry_point_missing_build_dep(self):
+    python_eval = self._create_task(target_roots=[self.h_binary])
+
+    with self.assertRaises(PythonEval.Error) as e:
+      python_eval.execute()
+    self.assertEqual([], e.exception.compiled)
+    self.assertEqual([self.h_binary], e.exception.failed)

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -10,6 +10,10 @@ target(
 
 python_library(
   name='pants-packaged',
+  sources=[],
+  dependencies=[
+    ':version',
+  ],
   provides=pants_setup_py(
     name='pantsbuild.pants',
     description='A scalable build tool for large, complex, heterogeneous repos.',

--- a/src/python/pants/backend/python/tasks2/gather_sources.py
+++ b/src/python/pants/backend/python/tasks2/gather_sources.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import shutil
 
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
@@ -15,6 +14,7 @@ from pex.pex_builder import PEXBuilder
 from pants.backend.python.tasks2.pex_build_util import dump_sources, has_python_sources
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task
+from pants.util.dirutil import safe_concurrent_creation
 
 
 class GatherSources(Task):
@@ -24,7 +24,6 @@ class GatherSources(Task):
   This PEX can be merged with a requirements PEX to create a unified Python environment
   for running the relevant python code.
   """
-
   PYTHON_SOURCES = 'python_sources'
 
   @classmethod
@@ -45,10 +44,10 @@ class GatherSources(Task):
     interpreter = self.context.products.get_data(PythonInterpreter)
 
     with self.invalidated(targets) as invalidation_check:
-      pex = self._build_pex_for_versioned_targets(interpreter, invalidation_check.all_vts)
+      pex = self._get_pex_for_versioned_targets(interpreter, invalidation_check.all_vts)
       self.context.products.get_data(self.PYTHON_SOURCES, lambda: pex)
 
-  def _build_pex_for_versioned_targets(self, interpreter, versioned_targets):
+  def _get_pex_for_versioned_targets(self, interpreter, versioned_targets):
     if versioned_targets:
       target_set_id = VersionedTargetSet.from_versioned_targets(versioned_targets).cache_key.hash
     else:
@@ -56,26 +55,18 @@ class GatherSources(Task):
       # an empty set of sources, to prevent downstream tasks from having to check
       # for this special case.
       target_set_id = 'no_targets'
-    source_pex_path = self._source_pex_path(target_set_id)
+    source_pex_path = os.path.realpath(os.path.join(self.workdir, target_set_id))
     # Note that we check for the existence of the directory, instead of for invalid_vts,
     # to cover the empty case.
     if not os.path.isdir(source_pex_path):
       # Note that we use the same interpreter for all targets: We know the interpreter
       # is compatible (since it's compatible with all targets in play).
-      self._safe_build_pex(interpreter, source_pex_path, [vt.target for vt in versioned_targets])
+      with safe_concurrent_creation(source_pex_path) as safe_path:
+        self._build_pex(interpreter, safe_path, [vt.target for vt in versioned_targets])
     return PEX(source_pex_path, interpreter=interpreter)
-
-  def _safe_build_pex(self, interpreter, path, targets):
-    path_tmp = path + '.tmp'
-    shutil.rmtree(path_tmp, ignore_errors=True)
-    self._build_pex(interpreter, path_tmp, targets)
-    shutil.move(path_tmp, path)
 
   def _build_pex(self, interpreter, path, targets):
     builder = PEXBuilder(path=path, interpreter=interpreter, copy=True)
     for target in targets:
       dump_sources(builder, target, self.context.log)
     builder.freeze()
-
-  def _source_pex_path(self, target_set_id):
-    return os.path.realpath(os.path.join(self.workdir, target_set_id))

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -17,6 +17,7 @@ python_library(
   sources = ['file_system_project_tree.py', 'project_tree.py', 'project_tree_factory.py',
              'scm_project_tree.py'],
   dependencies = [
+    ':deprecated',
     '3rdparty/python:pathspec',
     '3rdparty/python:scandir',
     '3rdparty/python:six',
@@ -63,6 +64,7 @@ python_library(
     '3rdparty/python:six',
     ':revision',
     'src/python/pants:version',
+    'src/python/pants/util:memo',
   ]
 )
 

--- a/src/python/pants/invalidation/BUILD
+++ b/src/python/pants/invalidation/BUILD
@@ -8,5 +8,6 @@ python_library(
     'src/python/pants/build_graph',
     'src/python/pants/fs',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ],
 )

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -146,20 +146,6 @@ class VersionedTargetSet(object):
       if self.has_previous_results_dir:
         yield self.previous_results_dir
 
-  def for_closure(self, target):
-    """Returns a VersionedTargetSet for the intersection of this one with the target's closure.
-
-    Useful primarily when the target and all (relevant) targets in its closure are already in
-    this VersionedTargetSet.
-    """
-    target_to_vt = self._target_to_vt()
-    vts = []
-    for t in target.closure():
-      vt = target_to_vt.get(t)
-      if vt:
-        vts.append(vt)
-    return self.from_versioned_targets(vts)
-
   @memoized_method
   def _target_to_vt(self):
     return {vt.target: vt for vt in self.versioned_targets}

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -14,6 +14,7 @@ from pants.build_graph.build_graph import sort_targets
 from pants.build_graph.target import Target
 from pants.invalidation.build_invalidator import BuildInvalidator, CacheKeyGenerator
 from pants.util.dirutil import relative_symlink, safe_delete, safe_mkdir, safe_rmtree
+from pants.util.memo import memoized_method
 
 
 class VersionedTargetSet(object):
@@ -144,6 +145,24 @@ class VersionedTargetSet(object):
       yield self.current_results_dir
       if self.has_previous_results_dir:
         yield self.previous_results_dir
+
+  def for_closure(self, target):
+    """Returns a VersionedTargetSet for the intersection of this one with the target's closure.
+
+    Useful primarily when the target and all (relevant) targets in its closure are already in
+    this VersionedTargetSet.
+    """
+    target_to_vt = self._target_to_vt()
+    vts = []
+    for t in target.closure():
+      vt = target_to_vt.get(t)
+      if vt:
+        vts.append(vt)
+    return self.from_versioned_targets(vts)
+
+  @memoized_method
+  def _target_to_vt(self):
+    return {vt.target: vt for vt in self.versioned_targets}
 
   def __repr__(self):
     return 'VTS({}, {})'.format(','.join(target.address.spec for target in self.targets),


### PR DESCRIPTION
New task, and its test, were copied from the old ones and modified appropriately.

This task is more robust than the old one:

- It properly selects an interpreter for the closure of each eval'd target.
  The old task, presumably due to a bug, only applied the eval'd target's 
  constraints when selecting an interpreter, but not those of its deps.

- It uses the WrappedPEX mechanism, which uses PEX_PATH to combine
  the source and requirements pexes for the target closure into the pex 
  containing our eval execution code, so there's far more opportunity for
  pex reuse, even when sources change.

Note that the old task wasn't hermetic when run from sources: missing deps
would be picked up from the source tree, because all our python source roots
are on the PYTHONPATH when running from sources.  As a result, we have
many undetected missing deps in pantsbuild/pants. 

This new task technically also has that problem, but it's far less prominent, 
because the source pex precedes the source roots on the PYTHONPATH, 
so in most cases the package search stops there and the eval fails, as it should.  
This problem still occurs when all deps to the package are missing, as then the 
package doesn't exist in the source pex at all, and the search falls through to 
the source roots.  But this is a less common occurrence.

(The true fix is to run the evals in CI from a built pants.pex, and not form sources.)

Note that this commit doesn't pass CI yet, because it exposes many missing deps
in our code that we didn't detect previously due to the issue explained above.
Will send out a separate change with all those BUILD file fixes, once I've
tracked them all down.