### PR TITLE
[engine] short circuit native engine build failures

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -116,7 +116,7 @@ function bootstrap_native_code() {
 
     # If bootstrapping the native engine fails, don't attempt to run pants
     # afterwards.
-    if [ -z $native_binary ]
+    if [ -f $native_binary ]
     then
       die "Failed to build native engine."
     fi

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -116,7 +116,7 @@ function bootstrap_native_code() {
 
     # If bootstrapping the native engine fails, don't attempt to run pants
     # afterwards.
-    if [ -f $native_binary ]
+    if ! [ -f "${native_binary}" ]
     then
       die "Failed to build native engine."
     fi

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -114,6 +114,13 @@ function bootstrap_native_code() {
     source "${cffi_env_script}"
     local readonly native_binary="$(build_native_code)"
 
+    # If bootstrapping the native engine fails, don't attempt to run pants
+    # afterwards.
+    if [ -z $native_binary ]
+    then
+      die "Failed to build native engine."
+    fi
+
     # Pick up Cargo.lock changes if any caused by the `cargo build`.
     native_engine_version="$(calculate_current_hash)"
     target_binary="${CACHE_TARGET_DIR}/${native_engine_version}/${NATIVE_ENGINE_BINARY}"


### PR DESCRIPTION
### Problem:
 When the native engine fails to compile, pants will still try to run. If pants is running with the engine enabled, this blows up and pushes the compiler errors out of the first screen in the terminal.

### Solution: 
If the binary was not built, stop bootstrapping. This adds a check to see if there is a binary created by building the native code. If not, bootstrap stops.

### Discussion
I tried using `set -e`, but that didn't work as well as I would like. First, `build_native_code` already dies on failure. We just silently ignore it. `set -e` revealed that because instead of continuing execution, the copy of the binary would fail. Relying on the copy failing felt a bit haphazard, so I put in an explicit check.