### PR TITLE
Check for stale native_engine_version.

### DIFF
--- a/build-support/bin/check_native_engine_version.sh
+++ b/build-support/bin/check_native_engine_version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+REPO_ROOT="$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../.. && pwd -P)"
+
+source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
+
+readonly actual_native_engine_version="$(calculate_current_hash)"
+readonly current_native_engine_version="$(cat ${NATIVE_ENGINE_VERSION_RESOURCE} | tr -d ' \n\r')"
+
+
+if [ "${actual_native_engine_version}" != "${current_native_engine_version}" ]; then
+  die "native_engine_version failed verification: ${current_native_engine_version} != ${actual_native_engine_version}";
+else
+  echo "native_engine_version verified: ${current_native_engine_version}"
+fi

--- a/build-support/bin/check_native_engine_version.sh
+++ b/build-support/bin/check_native_engine_version.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 REPO_ROOT="$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../.. && pwd -P)"
 
 source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -9,6 +9,8 @@ then
     export GIT_HOOK=1
 fi
 
+# N.B. This check needs to happen first, before any inadvertent bootstrapping can take place.
+echo "Checking native_engine_version" && ./build-support/bin/check_native_engine_version.sh || exit 1
 echo "Checking packages" && ./build-support/bin/check_packages.sh || exit 1
 echo "Checking imports" && ./build-support/bin/isort.sh || \
   die "To fix import sort order, run \`build-support/bin/isort.sh -f\`"


### PR DESCRIPTION
Fixes #4359

### Problem

Currently, the `native_engine_version` file can make it through a PR while stale causing issues in subsequent PRs when the original green PR is landed.

### Solution

Add a pre-commit.sh hook to check for staleness and bomb the build if stale.

### Result

Staleness is now surfaced in the causing PR.