### PR TITLE
[engine] Skip cycle detection test

### DIFF
--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -6,12 +6,14 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import unittest
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
 class BuildGraphIntegrationTest(PantsRunIntegrationTest):
 
+  @unittest.skip('https://github.com/pantsbuild/pants/issues/4358')
   def test_cycle(self):
     prefix = 'testprojects/src/java/org/pantsbuild/testproject'
     with self.file_renamed(os.path.join(prefix, 'cycle1'), 'TEST_BUILD', 'BUILD'):


### PR DESCRIPTION
### Problem

We know #4349 is going to miss cycle detection, we already created #4358 to follow up. The issue is we didn't realize we have an integration test for it, so #4349 was checked in around the same time #4340, the former was only tested in v1, and the latter turned v2 on. Now master is broken.

### Solution

Skip the failing test

### Result

Will follow up with #4358 next for the proper fix.