### PR TITLE
Speed up typical go builds.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
@@ -38,9 +38,10 @@ class GoFmt(GoWorkspaceTask):
         try:
           output = subprocess.check_output(args)
         except subprocess.CalledProcessError as e:
-          raise TaskError('{} failed with exit code {}'.format(args, e.returncode), exit_code=e.returncode)
+          raise TaskError('{} failed with exit code {}'.format(' '.join(args), e.returncode),
+                          exit_code=e.returncode)
         if output:
-          raise TaskError('gofmt command {} failed with output {}'.format(args, output))
+          raise TaskError('gofmt command {} failed with output {}'.format(' '.join(args), output))
 
   def calculate_sources(self, targets):
     sources = set()

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -56,10 +56,11 @@ class GoCompile(GoWorkspaceTask):
 
   def _go_install(self, target, gopath):
     args = self.get_options().build_flags.split() + [target.import_path]
-    self.context.log.info('Installing {}'.format(target.address.spec))
-    result, go_cmd = self.go_dist.execute_go_cmd('install', gopath=gopath, args=args,
-                                                 workunit_factory=self.context.new_workunit,
-                                                 workunit_labels=[WorkUnitLabel.COMPILER])
+    result, go_cmd = self.go_dist.execute_go_cmd(
+      'install', gopath=gopath, args=args,
+      workunit_factory=self.context.new_workunit,
+      workunit_name='install {}'.format(target.address.spec),
+      workunit_labels=[WorkUnitLabel.COMPILER])
     if result != 0:
       raise TaskError('{} failed with exit code {}'.format(go_cmd, result))
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -56,6 +56,7 @@ class GoCompile(GoWorkspaceTask):
 
   def _go_install(self, target, gopath):
     args = self.get_options().build_flags.split() + [target.import_path]
+    self.context.log.info('Installing {}'.format(target.address.spec))
     result, go_cmd = self.go_dist.execute_go_cmd('install', gopath=gopath, args=args,
                                                  workunit_factory=self.context.new_workunit,
                                                  workunit_labels=[WorkUnitLabel.COMPILER])

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_task.py
@@ -143,7 +143,8 @@ class ImportOracle(object):
              of `pkg`.
     """
     go_cmd = self._go_dist.create_go_cmd('list', args=['-json', pkg], gopath=gopath)
-    with self._workunit_factory(pkg, cmd=str(go_cmd), labels=[WorkUnitLabel.TOOL]) as workunit:
+    with self._workunit_factory('list {}'.format(pkg), cmd=str(go_cmd),
+                                labels=[WorkUnitLabel.TOOL]) as workunit:
       # TODO(John Sirois): It would be nice to be able to tee the stdout to the workunit to we have
       # a capture of the json available for inspection in the server console.
       process = go_cmd.spawn(stdout=subprocess.PIPE, stderr=workunit.output('stderr'))

--- a/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
+++ b/src/python/pants/backend/jvm/tasks/bootstrap_jvm_tools.py
@@ -109,7 +109,7 @@ class BootstrapJvmTools(IvyTaskMixin, JarTask):
     return cls.ToolResolveError(msg)
 
   @classmethod
-  def _alternate_target_roots(cls, options, address_mapper, build_graph):
+  def get_alternate_target_roots(cls, options, address_mapper, build_graph):
     processed = set()
     for jvm_tool in JvmToolMixin.get_registered_tools():
       dep_spec = jvm_tool.dep_spec(options)

--- a/src/python/pants/engine/round_engine.py
+++ b/src/python/pants/engine/round_engine.py
@@ -143,13 +143,13 @@ class RoundEngine(Engine):
       tasktypes_by_name[task_name] = task_type
       visited_task_types.add(task_type)
 
-      alternate_target_roots = task_type._alternate_target_roots(context.options,
-                                                                 context.address_mapper,
-                                                                 context.build_graph)
+      alternate_target_roots = task_type.get_alternate_target_roots(context.options,
+                                                                    context.address_mapper,
+                                                                    context.build_graph)
       target_roots_replacement.propose_alternates(task_type, alternate_target_roots)
 
       round_manager = RoundManager(context)
-      task_type._prepare(context.options, round_manager)
+      task_type.invoke_prepare(context.options, round_manager)
       try:
         dependencies = round_manager.get_dependencies()
         for producer_info in dependencies:

--- a/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
+++ b/tests/python/pants_test/jvm/jvm_tool_task_test_base.py
@@ -115,9 +115,9 @@ class JvmToolTaskTestBase(JvmTaskTestBase):
     # Bootstrap the tools needed by the task under test.
     # We need the bootstrap task's workdir to be under the test's .pants.d, so that it can
     # use artifact caching.  Making it a sibling of the main task's workdir achieves this.
-    self.bootstrap_task_type._alternate_target_roots(context.options,
-                                                     self.address_mapper,
-                                                     self.build_graph)
+    self.bootstrap_task_type.get_alternate_target_roots(context.options,
+                                                        self.address_mapper,
+                                                        self.build_graph)
     bootstrap_workdir = os.path.join(os.path.dirname(task.workdir), 'bootstrap_jvm_tools')
     self.bootstrap_task_type(context, bootstrap_workdir).execute()
     return task


### PR DESCRIPTION
Resolving remote Go libraries involves injecting targets representing
the remote sources into the build graph, so they can be compiled locally.
This must happen for every target, valid or not, in every build.

Previously, however, this involved two time-consuming operations
per item in the transitive closure of all remote deps:

- A network call to fetch the go meta tag, to figure out the
  remote library root from the import path (at least for remote libraries
  fetched by cloning).

- Shelling out to `go list` to get a library's imports.

This change caches both results in workdir files, for reuse in
subsequent pants runs.  This restores some of the snappiness of
Go when run in Pants.

Note that the first of these two items is unversioned (we're essentially
caching the resullts of network calls that are not qualified by version).
The second, however, is versioned, as expected.
