### PR TITLE
[engine] include rule graph in dot files generated with --visualize-to

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -471,7 +471,8 @@ class LocalScheduler(object):
 
       if self._scheduler.visualize_to_dir() is not None:
         name = 'run.{}.dot'.format(self._run_count)
-        rule_graph_name = 'rule_graph.{}.dot'.format(self._run_count)
+        rule_graph_name = 'rule_graph.dot'
+
         self._run_count += 1
         self.visualize_graph_to_file(os.path.join(self._scheduler.visualize_to_dir(), name))
         self.visualize_rule_graph_to_file(os.path.join(self._scheduler.visualize_to_dir(), rule_graph_name))

--- a/src/python/pants/engine/subsystem/native.py
+++ b/src/python/pants/engine/subsystem/native.py
@@ -572,7 +572,7 @@ class Native(object):
                help='Find native engine binaries under this dir. Used as part of the path to '
                     'lookup the binary with --binary-util-baseurls and --pants-bootstrapdir.')
       register('--visualize-to', default=None, type=dir_option,
-               help='A directory to write execution graphs to as `dot` files. The contents '
+               help='A directory to write execution and rule graphs to as `dot` files. The contents '
                     'of the directory will be overwritten if any filenames collide.')
 
     def create(self):

--- a/src/python/pants/engine/subsystem/native_engine_version
+++ b/src/python/pants/engine/subsystem/native_engine_version
@@ -1,1 +1,1 @@
-1c6344ab2dcdbddd692cc4afa7885e4e286f12ba
+eb74d6db1ec92ee0fcc817c7f40e5d677c9187be


### PR DESCRIPTION
### Problem
Currently there's no way to visualize the rule graph from the command line.
### Solution

Add rule graph dot files to the visualize-to directory

### Result

When I run with --native-engine-visualize-to=somedir, I get `rule_graph.<n>.dot` files. It would be cleaner if I only generated one, but there could be reasons to generate multiple anyway.