### PR TITLE
decode compile logs with utf-8

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -595,7 +595,7 @@ class JvmCompile(NailgunTaskBase):
           if self.get_options().suggest_missing_deps:
             logs = self._find_failed_compile_logs(compile_workunit)
             if logs:
-              self._find_missing_deps('\n'.join([read_file(log) for log in logs]), target)
+              self._find_missing_deps('\n'.join([read_file(log).decode('utf-8') for log in logs]), target)
           raise
 
   def _get_plugin_map(self, compiler, target):


### PR DESCRIPTION
### Problem

Find missing deps workunit may not work with non-ascii compile fail logs.

### Solution

decode compile logs with utf-8 codec
