### PR TITLE
Switch to using the new PythonEval task instead of the old one.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/register.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/register.py
@@ -7,12 +7,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.goal.task_registrar import TaskRegistrar as task
 
-from pants.contrib.python.checks.tasks2.python_eval import PythonEval as PythonEval2
+from pants.contrib.python.checks.tasks2.python_eval import PythonEval
 from pants.contrib.python.checks.tasks.checkstyle.checker import PythonCheckStyleTask
-from pants.contrib.python.checks.tasks.python_eval import PythonEval
 
 
 def register_goals():
   task(name='python-eval', action=PythonEval).install('compile')
-  task(name='python-eval', action=PythonEval2).install('compile2')
   task(name='pythonstyle', action=PythonCheckStyleTask).install('compile')

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/BUILD
@@ -8,10 +8,10 @@ python_library(
     '3rdparty/python:pep8',
     '3rdparty/python:pyflakes',
     'src/python/pants/backend/python/targets:python',
-    'src/python/pants/backend/python/tasks:python',
     'src/python/pants/base:exceptions',
     'src/python/pants/option',
     'src/python/pants/subsystem',
+    'src/python/pants/task',
     'src/python/pants/util:meta',
   ]
 )

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -9,15 +9,13 @@ import re
 from collections import namedtuple
 
 from pants.backend.python.targets.python_target import PythonTarget
-from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
-from pants.option.custom_types import file_option
-
 from pants.contrib.python.checks.tasks.checkstyle.common import CheckSyntaxError, Nit, PythonFile
 from pants.contrib.python.checks.tasks.checkstyle.file_excluder import FileExcluder
 from pants.contrib.python.checks.tasks.checkstyle.register_plugins import register_plugins
-
+from pants.option.custom_types import file_option
+from pants.task.task import Task
 
 _NOQA_LINE_SEARCH = re.compile(r'# noqa\b').search
 _NOQA_FILE_SEARCH = re.compile(r'# (flake8|checkstyle): noqa$').search
@@ -39,7 +37,7 @@ def noqa_file_filter(python_file):
   return any(_NOQA_FILE_SEARCH(line) is not None for line in python_file.lines)
 
 
-class PythonCheckStyleTask(PythonTask):
+class PythonCheckStyleTask(Task):
   _PYTHON_SOURCE_EXTENSION = '.py'
   _plugins = []
   _subsystems = tuple()
@@ -52,7 +50,7 @@ class PythonCheckStyleTask(PythonTask):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(PythonTask, cls).subsystem_dependencies() + cls._subsystems
+    return super(Task, cls).subsystem_dependencies() + cls._subsystems
 
   @classmethod
   def register_options(cls, register):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
@@ -13,11 +13,11 @@ from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.pex_build_util import (dump_requirements, dump_sources,
                                                         has_python_requirements, has_python_sources)
 from pants.backend.python.tasks2.python_execution_task_base import WrappedPEX
 from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
-from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.exceptions import TaskError
 from pants.base.generator import Generator, TemplateData
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -217,7 +217,7 @@ class PythonEval(ResolveRequirementsTaskBase):
     return generator.render()
 
   def _get_interpreter_for_target_closure(self, target):
-    targets = [t for t in target.closure() if isinstance(t, PythonTask)]
+    targets = [t for t in target.closure() if isinstance(t, PythonTarget)]
     return self._interpreter_cache().select_interpreter_for_targets(targets)
 
   def _resolve_requirements_for_versioned_target_closure(self, interpreter, vt):

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
@@ -1,13 +1,9 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_library(
-  name='lib'
-)
 
 python_tests(
   dependencies=[
-    ':lib',
     'contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle:all',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',


### PR DESCRIPTION
The old one was broken anyway, so there's not much
to lose here...

This doesn't affect the Python backend tasks, so it's a good way to
dip a toe in the new pipeline waters.

