### PR TITLE
A temporary `python2` backend for the new python pipeline tasks.

### DIFF
--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/BUILD
@@ -1,9 +1,13 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+python_library(
+  name='lib'
+)
 
 python_tests(
   dependencies=[
+    ':lib',
     'contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle:all',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/backend/python/tasks:python_task_test_base',

--- a/src/python/pants/backend/python2/BUILD
+++ b/src/python/pants/backend/python2/BUILD
@@ -1,0 +1,13 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  name = 'plugin',
+  sources = ['__init__.py', 'register.py'],
+  dependencies = [
+    'src/python/pants/backend/python:plugin',
+    'src/python/pants/backend/python/tasks:python',  # For isort.
+    'src/python/pants/backend/python/tasks2',
+    'src/python/pants/goal:task_registrar',
+  ]
+)

--- a/src/python/pants/backend/python2/register.py
+++ b/src/python/pants/backend/python2/register.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.register import build_file_aliases as orig_build_file_aliases
+from pants.backend.python.tasks.python_isort import IsortPythonTask
+from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.pytest_run import PytestRun
+from pants.backend.python.tasks2.python_binary_create import PythonBinaryCreate
+from pants.backend.python.tasks2.python_repl import PythonRepl
+from pants.backend.python.tasks2.python_run import PythonRun
+from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.backend.python.tasks2.setup_py import SetupPy
+from pants.goal.task_registrar import TaskRegistrar as task
+
+
+def build_file_aliases():
+  return orig_build_file_aliases()
+
+
+def register_goals():
+  task(name='interpreter', action=SelectInterpreter).install('pyprep')
+  task(name='requirements', action=ResolveRequirements).install('pyprep')
+  task(name='sources', action=GatherSources).install('pyprep')
+  task(name='py', action=PythonRun).install('run')
+  task(name='pytest', action=PytestRun).install('test')
+  task(name='py', action=PythonRepl).install('repl')
+  task(name='setup-py', action=SetupPy).install()
+  task(name='py', action=PythonBinaryCreate).install('binary')
+  task(name='isort', action=IsortPythonTask).install('fmt')
+
+  # Integration tests of the new pipeline still use the `*2` aliases.
+  task(name='py', action=PythonRun).install('run2')
+  task(name='pytest', action=PytestRun).install('test2')
+  task(name='py', action=PythonRepl).install('repl2')
+  task(name='py', action=PythonBinaryCreate).install('binary2')
+  task(name='setup-py2', action=SetupPy).install()

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -41,5 +41,6 @@ target(
     'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/project_info:plugin',
     'src/python/pants/backend/python:plugin',
+    'src/python/pants/backend/python2:plugin',
   ],
 )

--- a/tests/python/pants_test/backend/python/tasks2/BUILD
+++ b/tests/python/pants_test/backend/python/tasks2/BUILD
@@ -24,6 +24,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/tasks:task_test_base',
+    'tests/python/pants_test/backend/python/tasks:python_task_test_base',
     'tests/python/pants_test/subsystem:subsystem_utils'
   ]
 )


### PR DESCRIPTION
Allows sites to experiment with the new pipeline with just a change to pants.ini.

Sites can switch out the backends with this config in `pants.ini`:
```
[GLOBAL]
backend_packages: +["pants.backend.python2"],-["pants.backend.python"]
```

A followup change will apply this in the pants repo itself, so we can eat our own dogfood.
I've verified that CI passes under this dogfooding.
