### PR TITLE
Improve our use of gofmt.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/register.py
+++ b/contrib/go/src/python/pants/contrib/go/register.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.build_graph.build_file_aliases import BuildFileAliases, TargetMacro
+from pants.contrib.go.tasks.go_fmt import GoFmt
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.go.targets.go_binary import GoBinary
@@ -14,7 +15,7 @@ from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary
 from pants.contrib.go.targets.go_thrift_library import GoThriftLibrary
 from pants.contrib.go.tasks.go_binary_create import GoBinaryCreate
 from pants.contrib.go.tasks.go_buildgen import GoBuildgen
-from pants.contrib.go.tasks.go_checkstyle import GoFmt
+from pants.contrib.go.tasks.go_checkstyle import GoCheckstyle
 from pants.contrib.go.tasks.go_compile import GoCompile
 from pants.contrib.go.tasks.go_fetch import GoFetch
 from pants.contrib.go.tasks.go_go import GoEnv, GoGo
@@ -45,5 +46,6 @@ def register_goals():
   task(name='go', action=GoCompile).install('compile')
   task(name='go', action=GoBinaryCreate).install('binary')
   task(name='go', action=GoRun).install('run')
-  task(name='gofmt', action=GoFmt).install('compile')
+  task(name='go-checkstyle', action=GoCheckstyle).install('compile')
   task(name='go', action=GoTest).install('test')
+  task(name='go', action=GoFmt).install('fmt')

--- a/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
@@ -5,7 +5,7 @@ python_library(
   dependencies=[
     '3rdparty/python:requests',
     '3rdparty/python:six',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
+    'contrib/go/src/python/pants/contrib/go/targets',
     'src/python/pants/base:workunit',
     'src/python/pants/binaries:binary_util',
     'src/python/pants/fs',

--- a/contrib/go/src/python/pants/contrib/go/targets/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/targets/BUILD
@@ -1,67 +1,11 @@
-target(
-  dependencies=[
-    ':go_binary',
-    ':go_library',
-    ':go_local_source',
-    ':go_remote_library',
-    ':go_thrift_library',
-  ]
-)
-
 python_library(
-  name='go_binary',
-  sources=['go_binary.py'],
   dependencies=[
-    ':go_local_source',
-  ],
-)
-
-python_library(
-  name='go_library',
-  sources=['go_library.py'],
-  dependencies=[
-    ':go_local_source',
-  ],
-)
-
-python_library(
-  name='go_local_source',
-  sources=['go_local_source.py'],
-  dependencies=[
-    ':go_target',
     'src/python/pants/base:build_environment',
-    'src/python/pants/base:parse_context',
-    'src/python/pants/base:payload',
-    'src/python/pants/source',
-  ],
-)
-
-python_library(
-  name='go_remote_library',
-  sources=['go_remote_library.py'],
-  dependencies=[
-    ':go_target',
     'src/python/pants/base:exceptions',
+    'src/python/pants/base:parse_context',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
-  ],
-)
-
-python_library(
-  name='go_target',
-  sources=['go_target.py'],
-  dependencies=[
-    'src/python/pants/build_graph'
-  ]
-)
-
-python_library(
-  name='go_thrift_library',
-  sources=['go_thrift_library.py'],
-  dependencies=[
-    ':go_local_source',
-    'src/python/pants/base:parse_context',
-    'src/python/pants/base:payload',
     'src/python/pants/build_graph',
-  ]
+    'src/python/pants/source',
+  ],
 )

--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -21,8 +21,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
     'src/python/pants/option',
-    'src/python/pants/task',
-    'src/python/pants/util:dirutil',
-    'src/python/pants/util:memo',
   ]
 )

--- a/contrib/go/src/python/pants/contrib/go/tasks/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/tasks/BUILD
@@ -1,157 +1,28 @@
-target(
-  dependencies=[
-    ':go_binary_create',
-    ':go_buildgen',
-    ':go_checkstyle',
-    ':go_compile',
-    ':go_fetch',
-    ':go_go',
-    ':go_run',
-    ':go_test',
-    ':go_thrift_gen',
-  ]
-)
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='go_binary_create',
-  sources=['go_binary_create.py'],
+  sources=globs('*.py'),  # Need explicit sources, because `go_test.py` won't match the default.
   dependencies=[
-    'contrib/go/src/python/pants/contrib/go/tasks:go_task',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/util:dirutil',
-    'src/python/pants/util:memo',
-  ]
-)
-
-python_library(
-  name='go_buildgen',
-  sources=['go_buildgen.py'],
-  dependencies=[
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:ansicolors',
     'contrib/go/src/python/pants/contrib/go/subsystems',
-    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
-    'contrib/go/src/python/pants/contrib/go/targets:go_library',
-    'contrib/go/src/python/pants/contrib/go/targets:go_local_source',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_task',
+    'contrib/go/src/python/pants/contrib/go/targets',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:generator',
     'src/python/pants/base:workunit',
+    'src/python/pants/binaries:thrift_util',
     'src/python/pants/build_graph',
+    'src/python/pants/process',
     'src/python/pants/source',
+    'src/python/pants/task',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
-)
-
-python_library(
-  name='go_checkstyle',
-  sources=['go_checkstyle.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/tasks:go_workspace_task',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:workunit',
-    'src/python/pants/util:dirutil',
-  ]
-)
-
-python_library(
-  name='go_compile',
-  sources=['go_compile.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/tasks:go_workspace_task',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:workunit',
-    'src/python/pants/util:dirutil',
-  ]
-)
-
-python_library(
-  name='go_fetch',
-  sources=['go_fetch.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/subsystems',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_task',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/build_graph',
-    'src/python/pants/util:dirutil',
-    'src/python/pants/util:memo',
-  ]
-)
-
-python_library(
-  name='go_go',
-  sources=['go_go.py'],
-  dependencies=[
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    '3rdparty/python:ansicolors',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_workspace_task',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/task',
-  ]
-)
-
-python_library(
-  name='go_run',
-  sources=['go_run.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/tasks:go_task',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/process',
-  ]
-)
-
-python_library(
-  name='go_task',
-  sources=['go_task.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/subsystems',
-    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
-    'contrib/go/src/python/pants/contrib/go/targets:go_library',
-    'contrib/go/src/python/pants/contrib/go/targets:go_local_source',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
-    'contrib/go/src/python/pants/contrib/go/targets:go_target',
-    'src/python/pants/task',
-    'src/python/pants/util:memo',
-  ]
-)
-
-python_library(
-  name='go_test',
-  sources=['go_test.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/tasks:go_workspace_task',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:workunit',
-  ]
-)
-
-python_library(
-  name='go_thrift_gen',
-  sources=['go_thrift_gen.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_library',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
-    'contrib/go/src/python/pants/contrib/go/targets:go_thrift_library',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/base:exceptions',
-    'src/python/pants/base:workunit',
-    'src/python/pants/binaries:thrift_util',
     'src/python/pants/option',
     'src/python/pants/task',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
-  ]
-)
-
-python_library(
-  name='go_workspace_task',
-  sources=['go_workspace_task.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/tasks:go_task',
-    'src/python/pants/base:build_environment',
-    'src/python/pants/util:dirutil',
   ]
 )

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
@@ -5,15 +5,11 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-import subprocess
-
 from pants.base.exceptions import TaskError
+from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
-from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
 
-
-class GoCheckstyle(GoWorkspaceTask):
+class GoCheckstyle(GoFmtTaskBase):
   """Checks Go code matches gofmt style."""
 
   deprecated_options_scope = 'compile.gofmt'
@@ -24,32 +20,10 @@ class GoCheckstyle(GoWorkspaceTask):
     super(GoCheckstyle, cls).register_options(register)
     register('--skip', type=bool, fingerprint=True, help='Skip checkstyle.')
 
-  _GO_SOURCE_EXTENSION = '.go'
-
-  def _is_checked(self, target):
-    return target.has_sources(self._GO_SOURCE_EXTENSION) and not target.is_synthetic
-
   def execute(self):
     if self.get_options().skip:
       return
-    targets = self.context.targets(self._is_checked)
-    with self.invalidated(targets) as invalidation_check:
-      invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
-      sources = self.calculate_sources(invalid_targets)
-      if sources:
-        args = [os.path.join(self.go_dist.goroot, 'bin', 'gofmt'), '-d'] + list(sources)
-        try:
-          output = subprocess.check_output(args)
-        except subprocess.CalledProcessError as e:
-          raise TaskError('{} failed with exit code {}'.format(' '.join(args), e.returncode),
-                          exit_code=e.returncode)
-        if output:
-          self.context.log.error(output)
-          raise TaskError('Found style errors. Use `./pants fmt` to fix.')
-
-  def calculate_sources(self, targets):
-    sources = set()
-    for target in targets:
-      sources.update(source for source in target.sources_relative_to_buildroot()
-                     if source.endswith(self._GO_SOURCE_EXTENSION))
-    return sources
+    with self.go_fmt_invalid_targets(['-d']) as output:
+      if output:
+        self.context.log.error(output)
+        raise TaskError('Found style errors. Use `./pants fmt` to fix.')

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
@@ -16,6 +16,9 @@ from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
 class GoCheckstyle(GoWorkspaceTask):
   """Checks Go code matches gofmt style."""
 
+  deprecated_options_scope = 'compile.gofmt'
+  deprecated_options_scope_removal_version = '1.5.0.dev0'
+
   @classmethod
   def register_options(cls, register):
     super(GoCheckstyle, cls).register_options(register)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt.py
@@ -5,40 +5,13 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-import subprocess
-
-from pants.base.exceptions import TaskError
-
-from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
+from pants.contrib.go.tasks.go_fmt_task_base import GoFmtTaskBase
 
 
-class GoFmt(GoWorkspaceTask):
+class GoFmt(GoFmtTaskBase):
   """Format Go code using gofmt."""
 
-  _GO_SOURCE_EXTENSION = '.go'
-
-  def _is_checked(self, target):
-    return target.has_sources(self._GO_SOURCE_EXTENSION) and not target.is_synthetic
-
   def execute(self):
-    targets = self.context.targets(self._is_checked)
-    with self.invalidated(targets) as invalidation_check:
-      invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
-      sources = self.calculate_sources(invalid_targets)
-      if sources:
-        args = [os.path.join(self.go_dist.goroot, 'bin', 'gofmt'), '-w'] + list(sources)
-        try:
-          output = subprocess.check_output(args)
-        except subprocess.CalledProcessError as e:
-          raise TaskError('{} failed with exit code {}'.format(' '.join(args), e.returncode),
-                          exit_code=e.returncode)
-        if output:
-          self.context.logger.info(output)
-
-  def calculate_sources(self, targets):
-    sources = set()
-    for target in targets:
-      sources.update(source for source in target.sources_relative_to_buildroot()
-                     if source.endswith(self._GO_SOURCE_EXTENSION))
-    return sources
+    with self.go_fmt_invalid_targets(['-w']) as output:
+      if output:
+        self.context.logger.info(output)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_fmt_task_base.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import subprocess
+from contextlib import contextmanager
+
+from pants.base.exceptions import TaskError
+from pants.contrib.go.targets.go_local_source import GoLocalSource
+from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
+
+
+class GoFmtTaskBase(GoWorkspaceTask):
+  """Base class for tasks that run gofmt."""
+
+  @classmethod
+  def is_checked(cls, target):
+    return isinstance(target, GoLocalSource) and not target.is_synthetic
+
+  @classmethod
+  def calculate_sources(cls, targets):
+    sources = set()
+    for target in targets:
+      sources.update(source for source in target.sources_relative_to_buildroot())
+    return sources
+
+  @contextmanager
+  def go_fmt_invalid_targets(self, flags):
+    targets = self.context.targets(self.is_checked)
+    with self.invalidated(targets) as invalidation_check:
+      invalid_targets = [vt.target for vt in invalidation_check.invalid_vts]
+      sources = self.calculate_sources(invalid_targets)
+      if sources:
+        args = [os.path.join(self.go_dist.goroot, 'bin', 'gofmt')] + flags + list(sources)
+        try:
+          output = subprocess.check_output(args)
+        except subprocess.CalledProcessError as e:
+          raise TaskError('{} failed with exit code {}'.format(' '.join(args), e.returncode),
+                          exit_code=e.returncode)
+        yield output
+      else:
+        yield None

--- a/contrib/go/tests/python/pants_test/contrib/go/targets/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/targets/BUILD
@@ -1,28 +1,9 @@
-python_tests(
-  name='go_binary',
-  sources=['test_go_binary.py'],
-  dependencies=[
-    ':go_local_source_test_base',
-    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
-    'tests/python/pants_test:base_test',
-  ]
-)
-
-python_tests(
-  name='go_library',
-  sources=['test_go_library.py'],
-  dependencies=[
-    ':go_local_source_test_base',
-    'contrib/go/src/python/pants/contrib/go/targets:go_library',
-    'tests/python/pants_test:base_test',
-  ]
-)
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  name='go_local_source_test_base',
-  sources=['go_local_source_test_base.py'],
+  name='lib',
   dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
     'contrib/go/src/python/pants/contrib/go:plugin',
     'src/python/pants/build_graph',
     'src/python/pants/util:meta',
@@ -31,11 +12,10 @@ python_library(
 )
 
 python_tests(
-  name='go_remote_library',
-  sources=['test_go_remote_library.py'],
   dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
+    ':lib',
     'contrib/go/src/python/pants/contrib/go:plugin',
+    'contrib/go/src/python/pants/contrib/go/targets',
     'src/python/pants/build_graph',
     'tests/python/pants_test:base_test',
   ]

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -1,106 +1,25 @@
-python_tests(
-  name='go_binary_create',
-  sources=['test_go_binary_create.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_binary_create',
-    'src/python/pants/build_graph',
-    'src/python/pants/util:contextutil',
-    'src/python/pants/util:dirutil',
-    'tests/python/pants_test/tasks:task_test_base',
-  ]
-)
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name='go_buildgen',
-  sources=['test_go_buildgen.py'],
+  sources = globs('*.py', exclude=[globs('*_integration.py')]),
   dependencies=[
-    'contrib/go/src/python/pants/contrib/go/subsystems',
-    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
-    'contrib/go/src/python/pants/contrib/go/targets:go_library',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_buildgen',
     'contrib/go/src/python/pants/contrib/go:plugin',
+    'contrib/go/src/python/pants/contrib/go/subsystems',
+    'contrib/go/src/python/pants/contrib/go/targets',
+    'contrib/go/src/python/pants/contrib/go/tasks',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
-    'tests/python/pants_test/tasks:task_test_base',
-  ]
-)
-
-python_tests(
-  name='go_workspace_task',
-  sources=['test_go_workspace_task.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_library',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_workspace_task',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )
 
-python_tests(
-  name='go_compile',
-  sources=['test_go_compile.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_library',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_compile',
-    'src/python/pants/util:dirutil',
-    'tests/python/pants_test/tasks:task_test_base',
-  ]
-)
 
 python_tests(
-  name='go_fetch',
-  sources=['test_go_fetch.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/subsystems',
-    'contrib/go/src/python/pants/contrib/go/targets:go_remote_library',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_fetch',
-    'src/python/pants/build_graph',
-    'src/python/pants/util:contextutil',
-    'tests/python/pants_test/tasks:task_test_base',
-  ]
-)
-
-python_tests(
-  name='go_go',
-  sources=['test_go_go.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/targets:go_binary',
-    'contrib/go/src/python/pants/contrib/go/tasks:go_go',
-    'src/python/pants/util:contextutil',
-    'tests/python/pants_test/tasks:task_test_base',
-  ]
-)
-
-python_tests(
-  name='go_compile_integration',
-  sources=['test_go_compile_integration.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/subsystems',
-    'src/python/pants/util:contextutil',
-    'tests/python/pants_test/subsystem:subsystem_utils',
-    'tests/python/pants_test/testutils:file_test_util',
-    'tests/python/pants_test:int-test',
-  ],
-  tags={'integration'},
-)
-
-python_tests(
-  name='go_test_integration',
-  sources=['test_go_test_integration.py'],
-  dependencies=[
-    'src/python/pants/util:dirutil',
-    'tests/python/pants_test:int-test',
-  ],
-  tags={'integration'},
-)
-
-python_tests(
-  name='go_thrift_gen_integration',
-  sources=['test_go_thrift_gen_integration.py'],
+  name = 'integration',
+  sources = globs('*_integration.py'),
   dependencies=[
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'src/python/pants/base:build_environment',
@@ -111,32 +30,5 @@ python_tests(
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},
-  timeout=120,
-)
-
-python_tests(
-  name='go_run_integration',
-  sources=['test_go_run_integration.py'],
-  dependencies=[
-    'tests/python/pants_test:int-test',
-  ],
-  tags={'integration'},
-)
-
-python_tests(
-  name='go_fetch_integration',
-  sources=['test_go_fetch_integration.py'],
-  dependencies=[
-    'tests/python/pants_test:int-test',
-  ],
-  tags={'integration'},
-)
-
-python_tests(
-  name='go_task',
-  sources=['test_go_task.py'],
-  dependencies=[
-    'contrib/go/src/python/pants/contrib/go/tasks:go_task',
-    'tests/python/pants_test/tasks:task_test_base',
-  ],
+  timeout=180,
 )


### PR DESCRIPTION
Previously we integrated as a checkstyle-type check, that only logged
errors but didn't correct them.  In fact, it didn't even do that, it
just logged the names of files that had style errors (and even that
in a convoluted way).

Now the checkstyle task actually reports the errors it found.

Also adds a fmt task that actually fixes the errors.
