### PR TITLE
Invalidate all go compiles when the go version changes.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -32,7 +32,7 @@ class GoDistribution(object):
       register('--supportdir', advanced=True, default='bin/go',
                help='Find the go distributions under this dir.  Used as part of the path to lookup '
                     'the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', advanced=True, default='1.8',
+      register('--version', advanced=True, default='1.8', fingerprint=True,
                help='Go distribution version.  Used as part of the path to lookup the distribution '
                     'with --binary-util-baseurls and --pants-bootstrapdir')
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -25,7 +25,7 @@ class GoCompile(GoWorkspaceTask):
   @classmethod
   def register_options(cls, register):
     super(GoCompile, cls).register_options(register)
-    register('--build-flags', default='',
+    register('--build-flags', default='', fingerprint=True,
              help='Build flags to pass to Go compiler.')
 
   @classmethod


### PR DESCRIPTION
Also make sure build flags are mixed into the fprint.
