### PR TITLE
Bump the default scala minor version to 2.12.1

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -24,7 +24,7 @@ major_version_info = namedtuple('major_version_info', ['full_version'])
 scala_build_info = {
   '2.10': major_version_info(full_version='2.10.6'),
   '2.11': major_version_info(full_version='2.11.8'),
-  '2.12': major_version_info(full_version='2.12.0'),
+  '2.12': major_version_info(full_version='2.12.1'),
 }
 
 


### PR DESCRIPTION
### Problem

We're defaulting to a 3+ month outdated version of the scala `2.12.x` series.

### Solution

Default to the latest version in the series.