### PR TITLE
Optimize TravisCI configuration and logging.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,15 @@ before_cache:
   # Kill all python bytecode in our cached venvs.  Some files appear to
   # get bytecode compiled in non-yet-understood circumstances leading to
   # a full cache re-pack due to new bytecode files.
-  - find build-support -name "*.py[co]" -print -delete
+  - find build-support -name "*.py[co]" -delete
   # The `ivydata-*.properties` & root level `*.{properties,xml}` files'
   # effect on resolution time is in the noise, but they are
   # re-timestamped in internal comments and fields on each run and this
   # leads to travis-ci cache thrash.  Kill these files before the cache
   # check to avoid un-needed cache re-packing and re-upload (a ~100s
   # operation).
-  - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -print -delete
-  - rm -fv ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
+  - find ${HOME}/.ivy2/pants -type f -name "ivydata-*.properties" -delete
+  - rm -f ${HOME}/.ivy2/pants/*.{css,properties,xml,xsl}
   # We have several tests that do local file:// url resolves for
   # com.example artifacts, these disrupt the cache but are fast since
   # they're resolved from local files when omitted from the cache.
@@ -55,7 +55,10 @@ matrix:
   include:
     - os: osx
       language: generic
-      env: TRAVIS_SCRIPT="./pants --version"
+      env:
+        - SHARD="OSX"
+      script:
+        - ./pants --version
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -70,18 +73,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -cjlpn 'Various pants self checks'" # (fkmsr)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Various pants self checks"
+      script:
+        - ./build-support/bin/ci.sh -x -cjlpn 'Various pants self checks'
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -96,18 +103,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrcn -u 0/2 'Unit tests for pants and pants-plugins - shard 1'" # (jlp)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Unit tests for pants and pants-plugins - shard 1"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrcn -u 0/2 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -122,18 +133,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrcn -u 1/2 'Unit tests for pants and pants-plugins - shard 2'" # (jlp)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Unit tests for pants and pants-plugins - shard 2"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrcn -u 1/2 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -148,18 +163,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrcjlp 'Python contrib tests'" # (n)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python contrib tests"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrcjlp "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -174,18 +193,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 0/7 'Python integration tests for pants - shard 1'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python integration tests for pants - shard 1"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 0/7 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -200,18 +223,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 1/7 'Python integration tests for pants - shard 2'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python integration tests for pants - shard 2"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 1/7 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -226,18 +253,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 2/7 'Python integration tests for pants - shard 3'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python integration tests for pants - shard 3"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 2/7 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -252,18 +283,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 3/7 'Python integration tests for pants - shard 4'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python integration tests for pants - shard 4"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 3/7 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -278,18 +313,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 4/7 'Python integration tests for pants - shard 5'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python integration tests for pants - shard 5"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 4/7 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -304,18 +343,22 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 5/7 'Python integration tests for pants - shard 6'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python integration tests for pants - shard 6"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 5/7 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
 
@@ -330,35 +373,24 @@ matrix:
             - lib32z1-dev
             - oracle-java6-installer
             - gcc-multilib
+            - python-dev
       language: python
-      python: "2.7.12"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      env: TRAVIS_SCRIPT="./build-support/bin/ci.sh -x -fkmsrjlpn -i 6/7 'Python integration tests for pants - shard 7'" # (c)
       before_script:
         - ./build-support/bin/ci-sync.sh
         - ./build-support/bin/install-android-sdk.sh
+      env:
+        - SHARD="Python integration tests for pants - shard 7"
+      script:
+        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 6/7 "${SHARD}"
       after_success:
         - ./build-support/bin/native/generate-bintray-manifest.sh
-
-script: |-
-  uname -a
-
-  if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-    export CXX=clang++
-    /usr/libexec/java_home
-  else # linux
-    export CXX=g++
-    echo ${JAVA_HOME}
-  fi
-
-  java -version
-
-  ${TRAVIS_SCRIPT}
 
 deploy:
   # See: https://docs.travis-ci.com/user/deployment/bintray/

--- a/build-support/bin/check_native_engine_version.sh
+++ b/build-support/bin/check_native_engine_version.sh
@@ -11,7 +11,7 @@ readonly current_native_engine_version="$(cat ${NATIVE_ENGINE_VERSION_RESOURCE} 
 
 
 if [ "${actual_native_engine_version}" != "${current_native_engine_version}" ]; then
-  die "native_engine_version failed verification: ${current_native_engine_version} != ${actual_native_engine_version}";
+  die "failed verification: ${current_native_engine_version} != ${actual_native_engine_version}";
 else
-  echo "native_engine_version verified: ${current_native_engine_version}"
+  echo "verified: ${current_native_engine_version}"
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -83,16 +83,24 @@ if [[ -z "${ANDROID_HOME}"  || "${skip_android:-false}" == "true" ]] ; then
   export SKIP_ANDROID_PATTERN='contrib/android'
 fi
 
+echo
 if [[ $# > 0 ]]; then
   banner "CI BEGINS: $@"
 else
   banner "CI BEGINS"
 fi
 
-if [[ "${skip_pre_commit_checks:-false}" == "false" ]]; then
-  banner "Running pre-commit checks"
+case "${OSTYPE}" in
+  darwin*) export CXX="clang++";
+           ;;
+  *)       export CXX="g++";
+           ;;
+esac
 
+if [[ "${skip_pre_commit_checks:-false}" == "false" ]]; then
+  start_travis_section "PreCommit" "Running pre-commit checks"
   FULL_CHECK=1 ./build-support/bin/pre-commit.sh || exit 1
+  end_travis_section
 fi
 
 # TODO(John sirois): Re-plumb build such that it grabs constraints from the built python_binary
@@ -112,9 +120,8 @@ PANTS_ARGS=(
   "${INTERPRETER_ARGS[@]}"
 )
 
-
 if [[ "${skip_bootstrap:-false}" == "false" ]]; then
-  banner "Bootstrapping pants"
+  start_travis_section "Bootstrap" "Bootstrapping pants"
   (
     if [[ "${skip_bootstrap_clean:-false}" == "false" ]]; then
       ./build-support/python/clean.sh || die "Failed to clean before bootstrapping pants."
@@ -122,13 +129,13 @@ if [[ "${skip_bootstrap:-false}" == "false" ]]; then
     ./pants ${PANTS_ARGS[@]} ${bootstrap_compile_args[@]} binary \
       src/python/pants/bin:pants_local_binary && \
     mv dist/pants_local_binary.pex pants.pex && \
-    ./pants.pex -V && \
-    ./pants.pex --version
+    ./pants.pex -V
   ) || die "Failed to bootstrap pants."
+  end_travis_section
 fi
 
 if [[ "${skip_sanity_checks:-false}" == "false" ]]; then
-  banner "Sanity checking bootstrapped pants and repo BUILD files"
+  start_travis_section "SanityCheck" "Sanity checking bootstrapped pants and repo BUILD files"
   sanity_tests=(
     "bash-completion"
     "reference"
@@ -140,13 +147,14 @@ if [[ "${skip_sanity_checks:-false}" == "false" ]]; then
   )
   for cur_test in "${sanity_tests[@]}"; do
     cmd="./pants.pex ${PANTS_ARGS[@]} ${cur_test}"
-    echo "Executing command '${cmd}' as a sanity test:"
-    ${cmd} >/dev/null || die "Failed to execute '${cmd}'."
-    echo ""
+    echo "* Executing command '${cmd}' as a sanity test"
+    ${cmd} >/dev/null 2>&1 || die "Failed to execute '${cmd}'."
   done
+  end_travis_section
 fi
 
 if [[ "${skip_distribution:-false}" == "false" ]]; then
+  # N.B. Defer start_travis_section to those within release.sh, since we can't nest.
   banner "Running pants distribution tests"
   (
     ./build-support/bin/release.sh -n
@@ -154,30 +162,33 @@ if [[ "${skip_distribution:-false}" == "false" ]]; then
 fi
 
 if [[ "${skip_docs:-false}" == "false" ]]; then
-  banner "Running site doc generation test"
+  start_travis_section "DocGen" "Running site doc generation test"
   ./build-support/bin/publish_docs.sh || die "Failed to generate site docs."
+  end_travis_section
 fi
 
 if [[ "${skip_jvm:-false}" == "false" ]]; then
-  banner "Running core jvm tests"
+  start_travis_section "CoreJVM" "Running core jvm tests"
   (
     ./pants.pex ${PANTS_ARGS[@]} doc test {src,tests}/{java,scala}:: zinc::
   ) || die "Core jvm test failure"
+  end_travis_section
 fi
 
 if [[ "${skip_internal_backends:-false}" == "false" ]]; then
-  banner "Running internal backend python tests"
+  start_travis_section "BackendTests" "Running internal backend python tests"
   (
     ./pants.pex ${PANTS_ARGS[@]} test.pytest --compile-python-eval-skip \
     pants-plugins/tests/python::
   ) || die "Internal backend python test failure"
+  end_travis_section
 fi
 
 if [[ "${skip_python:-false}" == "false" ]]; then
   if [[ "0/1" != "${python_unit_shard}" ]]; then
     shard_desc=" [shard ${python_unit_shard}]"
   fi
-  banner "Running core python tests${shard_desc}"
+  start_travis_section "CoreTests" "Running core python tests${shard_desc}"
   (
     ./pants.pex --tag='-integration' ${PANTS_ARGS[@]} test.pytest \
       --coverage=paths:pants/ \
@@ -185,33 +196,38 @@ if [[ "${skip_python:-false}" == "false" ]]; then
       --compile-python-eval-skip \
       tests/python::
   ) || die "Core python test failure"
+  end_travis_section
 fi
 
 if [[ "${skip_contrib:-false}" == "false" ]]; then
-  banner "Running contrib python tests"
+  start_travis_section "ContribTests" "Running contrib python tests"
   (
     # We run python tests using --no-fast - aka test chroot per target - to work around issues with
     # test (ie: pants_test.contrib) namespace packages.
     # TODO(John Sirois): Get to the bottom of the issue and kill --no-fast, see:
     #  https://github.com/pantsbuild/pants/issues/1149
     ./pants.pex ${PANTS_ARGS[@]} --exclude-target-regexp='.*/testprojects/.*' \
-    --build-ignore=$SKIP_ANDROID_PATTERN test.pytest --no-fast \
+    --build-ignore=$SKIP_ANDROID_PATTERN test.pytest \
     --compile-python-eval-skip \
     contrib:: \
   ) || die "Contrib python test failure"
+  end_travis_section
 fi
 
 if [[ "${skip_integration:-false}" == "false" ]]; then
   if [[ "0/1" != "${python_intg_shard}" ]]; then
     shard_desc=" [shard ${python_intg_shard}]"
   fi
-  banner "Running Pants Integration tests${shard_desc}"
+  start_travis_section "IntegrationTests" "Running Pants Integration tests${shard_desc}"
   (
     ./pants.pex ${PANTS_ARGS[@]} --tag='+integration' test.pytest \
       --compile-python-eval-skip \
       --test-pytest-test-shard=${python_intg_shard} \
       tests/python::
   ) || die "Pants Integration test failure"
+  end_travis_section
 fi
 
-banner "CI SUCCESS"
+banner "CI ENDS"
+echo
+green "SUCCESS"

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,9 +33,4 @@ do
   esac
 done
 
-to_sort=$(mktemp -t changed.isort.XXXXX)
-trap "rm -f ${to_sort}" EXIT
-if [[ "$(./pants changed | tee ${to_sort})" != "" ]]
-then
-  ./pants -q --target-spec-file=${to_sort} fmt.isort -- ${isort_args[@]}
-fi
+./pants -q --changed-parent=HEAD fmt.isort -- ${isort_args[@]}

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -10,10 +10,8 @@ then
 fi
 
 # N.B. This check needs to happen first, before any inadvertent bootstrapping can take place.
-echo "Checking native_engine_version" && ./build-support/bin/check_native_engine_version.sh || exit 1
-echo "Checking packages" && ./build-support/bin/check_packages.sh || exit 1
-echo "Checking imports" && ./build-support/bin/isort.sh || \
-  die "To fix import sort order, run \`build-support/bin/isort.sh -f\`"
-echo "Checking headers" && ./build-support/bin/check_header.sh || exit 1
-echo "Success"
-
+echo -n "* Checking native_engine_version: " && ./build-support/bin/check_native_engine_version.sh || exit 1
+echo "* Checking packages" && ./build-support/bin/check_packages.sh || exit 1
+echo "* Checking headers" && ./build-support/bin/check_header.sh || exit 1
+echo "* Checking imports" && ./build-support/bin/isort.sh || \
+  die "To fix import sort order, run \`./build-support/bin/isort.sh -f\`"

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -120,10 +120,10 @@ function build_packages() {
     NAME=$(pkg_name $PACKAGE)
     BUILD_TARGET=$(pkg_build_target $PACKAGE)
 
-    banner "Building package ${NAME}-$(local_version) with target '${BUILD_TARGET}' ..."
-
+    start_travis_section "${NAME}" "Building package ${NAME}-$(local_version) with target '${BUILD_TARGET}'"
     run_local_pants setup-py --recursive ${BUILD_TARGET} || \
-    die "Failed to build package ${NAME}-$(local_version) with target '${BUILD_TARGET}'!"
+      die "Failed to build package ${NAME}-$(local_version) with target '${BUILD_TARGET}'!"
+    end_travis_section
   done
 }
 
@@ -133,16 +133,18 @@ function publish_packages() {
   do
     targets+=($(pkg_build_target $PACKAGE))
   done
-  banner "Publishing packages ..."
+  start_travis_section "Publishing" "Publishing packages"
   run_local_pants setup-py --run="register sdist upload --sign --identity=$(get_pgp_keyid)" \
-    --recursive ${targets[@]} || \
-  die "Failed to publish packages!"
+    --recursive ${targets[@]} || die "Failed to publish packages!"
+  end_travis_section
 }
 
 function pre_install() {
+  start_travis_section "SetupVenv" "Setting up virtualenv"
   VENV_DIR=$(mktemp -d -t pants.XXXXX) && \
   ${ROOT}/build-support/virtualenv $VENV_DIR && \
   source $VENV_DIR/bin/activate
+  end_travis_section
 }
 
 function post_install() {
@@ -185,10 +187,10 @@ function install_and_test_packages() {
     NAME=$(pkg_name $PACKAGE)
     INSTALL_TEST_FUNC=$(pkg_install_test_func $PACKAGE)
 
-    banner "Installing and testing package ${NAME}-$(local_version) ..."
-
+    start_travis_section "${NAME}" "Installing and testing package ${NAME}-$(local_version)"
     eval $INSTALL_TEST_FUNC ${PIP_ARGS[@]} || \
-    die "Failed to install and test package ${NAME}-$(local_version)!"
+      die "Failed to install and test package ${NAME}-$(local_version)!"
+    end_travis_section
   done
 
   post_install || die "Failed to deactivate virtual env while testing ${NAME}-$(local_version)!"
@@ -387,14 +389,14 @@ function check_owners() {
   username="$(check_pypi)"
 
   total=${#RELEASE_PACKAGES[@]}
-  banner "Checking package ownership for pypi user ${username} of ${total} packages ..."
+  banner "Checking package ownership for pypi user ${username} of ${total} packages"
   dont_own=()
   index=0
   for PACKAGE in "${RELEASE_PACKAGES[@]}"
   do
     index=$((index+1))
     package_name="$(pkg_name $PACKAGE)"
-    banner "[${index}/${total}] checking that ${username} owns ${package_name}..."
+    banner "[${index}/${total}] checking that ${username} owns ${package_name}"
     if package_exists ${package_name}
     then
       if ! check_owner "${username}" "${package_name}"
@@ -504,25 +506,25 @@ fi
 if [[ "${dry_run}" == "true" && "${test_release}" == "true" ]]; then
   usage "The dry run and test options are mutually exclusive, pick one."
 elif [[ "${dry_run}" == "true" ]]; then
-  banner "Performing a dry run release - no artifacts will be uploaded." && \
+  banner "Performing a dry run release" && \
   (
     dry_run_install && \
-    banner "Dry run release succeeded."
+    banner "Dry run release succeeded"
   ) || die "Dry run release failed."
 elif [[ "${test_release}" == "true" ]]; then
-  banner "Installing and testing the latest released packages." && \
+  banner "Installing and testing the latest released packages" && \
   (
     install_and_test_packages && \
-    banner "Successfully installed and tested the latest released packages."
+    banner "Successfully installed and tested the latest released packages"
   ) || die "Failed to install and test the latest released packages."
 else
-  banner "Releasing packages to PyPi." && \
+  banner "Releasing packages to PyPi" && \
   (
     # NB: Ideally we'd `check_native_engine`, but it won't get built until the tag created
     # in `tag_release` is pushed to origin, triggering a TravisCI run.
     # See: https://github.com/pantsbuild/pants/issues/4269
     check_origin && check_clean_branch && check_pgp && check_owners && \
       dry_run_install && publish_packages && tag_release && publish_docs_if_master && \
-      banner "Successfully released packages to PyPi."
+      banner "Successfully released packages to PyPi"
   ) || die "Failed to release packages to PyPi."
 fi

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
 
+TRAVIS_FOLD_STATE="/tmp/.travis_fold_current"
+CLEAR_LINE="\x1b[K"
+COLOR_BLUE="\x1b[34m"
+COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
+COLOR_RESET="\x1b[0m"
+
+
 function log() {
   echo -e "$@" 1>&2
 }
 
 function die() {
-  (($# > 0)) && log "\n$@"
+  (($# > 0)) && log "\n${COLOR_RED}$@${COLOR_RESET}"
   exit 1
+}
+
+function green() {
+  (($# > 0)) && log "\n${COLOR_GREEN}$@${COLOR_RESET}"
 }
 
 # Initialization for elapsed()
@@ -21,9 +33,29 @@ function elapsed() {
 }
 
 function banner() {
-  echo
-  echo "[== $(elapsed) $@ ==]"
-  echo
+  echo -e "${COLOR_BLUE}[=== $(elapsed) $@ ===]${COLOR_RESET}"
+}
+
+function travis_fold() {
+  local action=$1
+  local slug=$2
+  # Use the line clear terminal escape code to prevent the travis_fold lines from
+  # showing up if e.g. a user is running the calling script.
+  echo -en "travis_fold:${action}:${slug}\r${CLEAR_LINE}"
+}
+
+function start_travis_section() {
+  local slug=$1
+  travis_fold start "${slug}"
+  /bin/echo -n "${slug}" > "${TRAVIS_FOLD_STATE}"
+  shift
+  local section="$@"
+  banner "${section}"
+}
+
+function end_travis_section() {
+  travis_fold end "$(cat ${TRAVIS_FOLD_STATE})"
+  rm -f "${TRAVIS_FOLD_STATE}"
 }
 
 function fingerprint_data() {

--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Wrapper for self-bootstrapping virtualenv
+
 set -e
-VIRTUALENV_VERSION=15.0.2
+
+VIRTUALENV_VERSION=15.1.0
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.io/packages/source/v/virtualenv}
 
 if [[ $GIT_HOOK == 1 ]] ; then
@@ -11,7 +13,6 @@ else
 fi
 source ${REPO_ROOT}/build-support/common.sh
 
-
 if [[ -z "${PY}" ]]; then
   if which python2.7 >/dev/null; then
     PY=`which python2.7`
@@ -20,23 +21,23 @@ if [[ -z "${PY}" ]]; then
   fi
 fi
 
-log "Using ${PY}"
+log "Using python at ${PY}"
 
 HERE=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
 if ! [ -f "${HERE}/virtualenv.dist/BOOTSTRAPPED-${VIRTUALENV_VERSION}" ]; then
-  pushd "${HERE}"
-  VIRTUALENV_PACKAGE_FULL_URL=${VIRTUALENV_PACKAGE_LOCATION}/virtualenv-${VIRTUALENV_VERSION}.tar.gz
-  log "Downloading ${VIRTUALENV_PACKAGE_FULL_URL}..."
-  curl -L -O ${VIRTUALENV_PACKAGE_FULL_URL} || \
-    die "Failed to download ${VIRTUALENV_PACKAGE_FULL_URL}."
-  rm -rf virtualenv-${VIRTUALENV_VERSION} && \
-  tar zxvf virtualenv-${VIRTUALENV_VERSION}.tar.gz || \
-    die "Failed to extract ${VIRTUALENV_PACKAGE_FULL_URL}."
-  # TODO(ksweeney): Checksum
-  touch virtualenv-${VIRTUALENV_VERSION}/BOOTSTRAPPED-${VIRTUALENV_VERSION} && \
-    rm -rf virtualenv.dist && \
-    mv -v virtualenv-${VIRTUALENV_VERSION} virtualenv.dist
-  popd
+  pushd "${HERE}" >/dev/null
+    VIRTUALENV_PACKAGE_FULL_URL="${VIRTUALENV_PACKAGE_LOCATION}/virtualenv-${VIRTUALENV_VERSION}.tar.gz"
+    log "Downloading ${VIRTUALENV_PACKAGE_FULL_URL}..."
+    curl -#L -O ${VIRTUALENV_PACKAGE_FULL_URL} || \
+      die "Failed to download ${VIRTUALENV_PACKAGE_FULL_URL}."
+    rm -rf virtualenv-${VIRTUALENV_VERSION} && \
+    tar zxf virtualenv-${VIRTUALENV_VERSION}.tar.gz || \
+      die "Failed to extract ${VIRTUALENV_PACKAGE_FULL_URL}."
+    # TODO(ksweeney): Checksum
+    touch virtualenv-${VIRTUALENV_VERSION}/BOOTSTRAPPED-${VIRTUALENV_VERSION} && \
+      rm -rf virtualenv.dist && \
+      mv -f virtualenv-${VIRTUALENV_VERSION} virtualenv.dist
+  popd >/dev/null
 fi
 
 exec "${PY}" "${HERE}/virtualenv.dist/virtualenv.py" "$@"


### PR DESCRIPTION
- Disable removed file printing in some noisy places.
- Eliminate the use of $TRAVIS_SCRIPT, which leads to clearer log output from travis on failures and eliminates printing of the entire `script: section`.
- Bump to python 2.7.13 and virtualenv 15.1.0.
- Leverage `travis_fold` to fold top level sections for improved CI scrutability.
- Ansi colors to highlight text vs surrounding whitespace.
- Inline setting of CXX var in ci.sh.
- Use curl `-#` arg to streamline display of virtualenv fetch.
- Add `python-dev` package for Python header files needed for native engine build.

