### PR TITLE
Fix #4389: python-binary-create task maps all product directories to the same target

### DIFF
--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -61,8 +61,8 @@ class PythonBinaryCreate(PythonTask):
         else:
           self.context.log.debug('using cache for {}'.format(vt.target))
 
-        python_pex_product.add(binary, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
-        python_deployable_archive.add(binary, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
+        python_pex_product.add(vt.target, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
+        python_deployable_archive.add(vt.target, os.path.dirname(pex_path)).append(os.path.basename(pex_path))
         self.context.log.debug('created {}'.format(os.path.relpath(pex_path, get_buildroot())))
 
         # Create a copy for pex.

--- a/src/python/pants/backend/python/tasks2/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks2/python_binary_create.py
@@ -76,8 +76,8 @@ class PythonBinaryCreate(Task):
           self.context.log.debug('using cache for {}'.format(vt.target))
 
         basename = os.path.basename(pex_path)
-        python_pex_product.add(binary, os.path.dirname(pex_path)).append(basename)
-        python_deployable_archive.add(binary, os.path.dirname(pex_path)).append(basename)
+        python_pex_product.add(vt.target, os.path.dirname(pex_path)).append(basename)
+        python_deployable_archive.add(vt.target, os.path.dirname(pex_path)).append(basename)
         self.context.log.debug('created {}'.format(os.path.relpath(pex_path, get_buildroot())))
 
         # Create a copy for pex.


### PR DESCRIPTION
### Problem

This fixes https://github.com/pantsbuild/pants/issues/4389

### Solution

I've simply noticed that the `binary` variable was  erroneously used outside the scope of its for loop, and replaced that use with `vt.targets`, which was likely what the original author intended. Using the wrong variable, in this case, caused all pex mappings to be mapped from the same target (whatever wound up being the terminal for loop case).

### Result

When this patch is applied, product mappings are assembled correctly. From the example in #4389 , here's what the product mapping looks like now:

```
ProductMapping(pex_archives) {
  PythonBinary(BuildFileAddress(BuildFile(docker/monitoring_sidecar/BUILD, FileSystemProjectTree(/Users/kyle.derr/Repositories/allclearid/odin/mono)), monitoring_sidecar)) => /Users/kyle.derr/Repositories/allclearid/odin/mono/.pants.d/binary/python-binary-create/0550b754d96b/docker.monitoring_sidecar.monitoring_sidecar/current
    [u'monitoring_sidecar.pex']
  PythonBinary(BuildFileAddress(BuildFile(tools/templating/BUILD, FileSystemProjectTree(/Users/kyle.derr/Repositories/allclearid/odin/mono)), configure)) => /Users/kyle.derr/Repositories/allclearid/odin/mono/.pants.d/binary/python-binary-create/0550b754d96b/tools.templating.configure/current
    [u'configure.pex']
}
```