### PR TITLE
Repair handling of resources kwargs for changed.

### DIFF
--- a/src/python/pants/engine/legacy/source_mapper.py
+++ b/src/python/pants/engine/legacy/source_mapper.py
@@ -81,11 +81,17 @@ class EngineSourceMapper(SourceMapper):
       #      java_library(..., resources=['testprojects/src/resources/...:resource'])
       #
       #    which is closer in premise to the `resource_targets` param.
+      elif isinstance(target_resources, list):
+        resource_dep_subjects = resolve_and_parse_specs(legacy_target.adaptor.address.spec_path,
+                                                        target_resources)
+        for hydrated_targets in self._engine.product_request(HydratedTargets, resource_dep_subjects):
+          for hydrated_target in hydrated_targets.dependencies:
+            resource_sources = hydrated_target.adaptor.kwargs().get('sources')
+            if resource_sources:
+              for f in resource_sources.paths_from_buildroot_iter():
+                yield f
       else:
-        # TODO: this case should be impossible... resource targets are located in the `resource_targets`
-        # kwarg.
-        #   see https://github.com/pantsbuild/pants/issues/4010
-        raise ValueError('TODO: Not supported: see #4010.')
+        raise AssertionError('Could not process target_resources with type {}'.format(type(target_resources)))
 
   def iter_target_addresses_for_sources(self, sources):
     """Bulk, iterable form of `target_addresses_for_source`."""


### PR DESCRIPTION
This repairs the following traceback on a `./pants --enable-v2-engine changed --changed-parent=X --changed-include-dependees=transitive` in our monorepo:

```
Exception caught: (<type 'exceptions.ValueError'>)
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_exe.py", line 50, in <module>
    main()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_exe.py", line 44, in main
    PantsRunner(exiter).run()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_runner.py", line 57, in run
    options_bootstrapper=options_bootstrapper)
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_runner.py", line 46, in _run
    return LocalPantsRunner(exiter, args, env, options_bootstrapper=options_bootstrapper).run()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/local_pants_runner.py", line 37, in run
    self._run()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/local_pants_runner.py", line 77, in _run
    self._exiter).setup()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 193, in setup
    goals, context = self._setup_context(pantsd_launcher)
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 165, in _setup_context
    self._global_options.subproject_roots,
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 106, in _init_graph
    change_calculator=graph_helper.change_calculator)
  File "/Users/kwilson/dev/pants/src/python/pants/init/target_roots.py", line 73, in create
    changed_addresses = change_calculator.changed_target_addresses(changed_request)
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/change_calculator.py", line 128, in changed_target_addresses
    return list(self.iter_changed_target_addresses(changed_request))
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/change_calculator.py", line 107, in iter_changed_target_addresses
    in self._mapper.iter_target_addresses_for_sources(changed_files))
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/change_calculator.py", line 105, in <genexpr>
    changed_addresses = set(address
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/source_mapper.py", line 107, in iter_target_addresses_for_sources
    if any(source_file in sources_set for source_file in target_files_iter):
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/source_mapper.py", line 107, in <genexpr>
    if any(source_file in sources_set for source_file in target_files_iter):
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/source_mapper.py", line 89, in _iter_owned_files_from_hydrated_target
    raise ValueError('TODO: Not supported: see #4010.')

Exception message: TODO: Not supported: see #4010.
```
