### PR TITLE
Avoid creating deprecated resources in JavaAgent's constructor

### DIFF
--- a/src/python/pants/backend/jvm/targets/java_agent.py
+++ b/src/python/pants/backend/jvm/targets/java_agent.py
@@ -18,7 +18,6 @@ class JavaAgent(JavaLibrary):
                name,
                sources=None,
                excludes=None,
-               resources=None,
                premain=None,
                agent_class=None,
                can_redefine=False,
@@ -44,7 +43,6 @@ class JavaAgent(JavaLibrary):
         sources=sources,
         provides=None,
         excludes=self.assert_list(excludes, key_arg='excludes'),
-        resources=self.assert_list(resources, key_arg='resources'),
         **kwargs)
 
     if not (premain or agent_class):


### PR DESCRIPTION
### Problem

We are deprecating `resources` in JVM targets (d32b23acfcd92bae8596020f3de3b9fb490fbe5c). By using `assert_list` in `JavaAgent`'s constructor, an empty list of `resources` is always created and will trigger deprecation warning.

### Solution

Remove `assert_list`

### Result

`./pants test tests/python/pants_test/targets:java_agent`