### PR TITLE
Use released ivy-dependency-update-checker jar tool for outdated.ivy command

### DIFF
--- a/src/python/pants/backend/jvm/tasks/ivy_outdated.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_outdated.py
@@ -37,16 +37,9 @@ class IvyOutdated(NailgunTask):
     cls.register_jvm_tool(register,
                           'dependency-update-checker',
                           classpath=[
-                            # TODO: Add jar dependency after the jar has been released
-                            # JarDependency(org='org.pantsbuild',
-                            #               name='ivy-dependency-update-checker',
-                            #               rev='0.0.1'),
-                            # First run ./pants binary src/java/org/pantsbuild/tools/ivy:ivy-dependency-update-checker
-                            JarDependency(org = 'org.pantsbuild',
-                                          name = 'ivy-dependency-update-checker',
-                                          rev = 'none',
-                                          mutable = True,
-                                url = 'file://<fullpath-to>/pants/dist/ivy-dependency-update-checker.jar'),
+                            JarDependency(org='org.pantsbuild',
+                                          name='ivy-dependency-update-checker',
+                                          rev='0.0.1'),
                           ],
                           main=cls._IVY_DEPENDENCY_UPDATE_MAIN,
                           custom_rules=[

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_outdated_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_outdated_integration.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import unittest
 from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
@@ -16,7 +15,6 @@ from pants.util.contextutil import temporary_dir
 
 class IvyOutdatedIntegrationTest(PantsRunIntegrationTest):
 
-  @unittest.skip("Pending release of ivy-dependency-update-checker jar")
   def test_with_no_dependencies(self):
     with temporary_dir(root_dir=get_buildroot()) as tmpdir:
       with open(os.path.join(tmpdir, 'BUILD'), 'w+') as f:
@@ -29,7 +27,6 @@ class IvyOutdatedIntegrationTest(PantsRunIntegrationTest):
       self.assertIn('Dependency updates available:', pants_run.stdout_data)
       self.assertIn('All dependencies are up to date', pants_run.stdout_data)
 
-  @unittest.skip("Pending release of ivy-dependency-update-checker jar")
   def test_with_available_updates(self):
     with temporary_dir(root_dir=get_buildroot()) as tmpdir:
       with open(os.path.join(tmpdir, 'BUILD'), 'w+') as f:
@@ -49,7 +46,6 @@ class IvyOutdatedIntegrationTest(PantsRunIntegrationTest):
       self.assertIn('commons-io#commons-io  2.4 -> ', pants_run.stdout_data)
       self.assertIn('org.scala-lang#scala-library  2.11.8 -> ', pants_run.stdout_data)
 
-  @unittest.skip("Pending release of ivy-dependency-update-checker jar")
   def test_with_exclude_coordinates(self):
     with temporary_dir(root_dir=get_buildroot()) as tmpdir:
       with open(os.path.join(tmpdir, 'BUILD'), 'w+') as f:


### PR DESCRIPTION
### Problem

Use released version of ivy-dependency-update-checker.jar committed in https://github.com/pantsbuild/pants/pull/4386

### Solution

Reference the new jar that has been released to maven central

### Result

The `outdated.ivy` command should work normally for all users now