### PR TITLE
Cleanup and give better debug output for exclude patterns in findbugs  and errorprone

### DIFF
--- a/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/errorprone.py
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/errorprone.py
@@ -58,7 +58,7 @@ class ErrorProne(NailgunTask):
 
   @memoized_property
   def _exclude_patterns(self):
-    return "(" + ")|(".join(self.get_options().exclude_patterns) + ")"
+    return [re.compile(x) for x in set(self.get_options().exclude_patterns or [])]
 
   def _is_errorprone_target(self, target):
     if not target.has_sources(self._JAVA_SOURCE_EXTENSION):
@@ -67,9 +67,11 @@ class ErrorProne(NailgunTask):
     if target.is_synthetic:
       self.context.log.debug('Skipping [{}] because it is a synthetic target'.format(target.address.spec))
       return False
-    if self.get_options().exclude_patterns and re.match(self._exclude_patterns, target.address.spec):
-      self.context.log.debug('Skipping [{}] because it matches exclude pattern'.format(target.address.spec))
-      return False
+    for pattern in self._exclude_patterns:
+      if pattern.search(target.address.spec):
+        self.context.log.debug(
+          "Skipping [{}] because it matches exclude pattern '{}'".format(target.address.spec, pattern.pattern))
+        return False
     return True
 
   @property


### PR DESCRIPTION
### Problem

For exclude patterns in errorprone and findbugs you don't get debug output telling you which exclude pattern was matched.  Based on feedback received from @baroquebobcat 

### Solution

Loop through the exclude patterns and print debug output if one is matched
