### PR TITLE
Upgrade pants to current versions of pytest et al.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,7 +1,7 @@
 ansicolors==1.0.2
 beautifulsoup4>=4.3.2,<4.4
 cffi==1.7.0
-coverage>=3.7,<3.8
+coverage>=4.3.4,<4.4
 docutils>=0.12,<0.13
 fasteners==0.14.1
 futures==3.0.5
@@ -16,8 +16,8 @@ psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4
 pystache==0.5.3
-pytest-cov>=1.8,<1.9
-pytest>=2.6,<2.7
+pytest-cov>=2.4,<2.5
+pytest>=3.0.7,<4.0
 pywatchman==1.3.0
 requests>=2.5.0,<2.6
 scandir==1.2

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -191,7 +191,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
   start_travis_section "CoreTests" "Running core python tests${shard_desc}"
   (
     ./pants.pex --tag='-integration' ${PANTS_ARGS[@]} test.pytest \
-      --coverage=paths:pants/ \
+      --coverage=pants/ \
       --test-pytest-test-shard=${python_unit_shard} \
       --compile-python-eval-skip \
       tests/python::

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -191,7 +191,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
   start_travis_section "CoreTests" "Running core python tests${shard_desc}"
   (
     ./pants.pex --tag='-integration' ${PANTS_ARGS[@]} test.pytest \
-      --coverage=pants/ \
+      --coverage=pants \
       --test-pytest-test-shard=${python_unit_shard} \
       --compile-python-eval-skip \
       tests/python::

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_test.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_test.py
@@ -9,7 +9,7 @@ import os
 from textwrap import dedent
 
 from mock import patch
-from pants.base.exceptions import TestFailedTaskError
+from pants.base.exceptions import ErrorWhileTesting
 from pants.util.timeout import TimeoutReached
 from pants_test.tasks.task_test_base import TaskTestBase
 
@@ -73,7 +73,7 @@ class NodeTestTest(TaskTestBase):
     with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       mock_timeout().__exit__.side_effect = TimeoutReached(5)
 
-      with self.assertRaises(TestFailedTaskError):
+      with self.assertRaises(ErrorWhileTesting):
         task.execute()
 
       # Ensures that Timeout is instantiated with a 5 second timeout.
@@ -97,7 +97,7 @@ class NodeTestTest(TaskTestBase):
     with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       mock_timeout().__exit__.side_effect = TimeoutReached(5)
 
-      with self.assertRaises(TestFailedTaskError) as cm:
+      with self.assertRaises(ErrorWhileTesting) as cm:
         task.execute()
 
       # Verify that only the first target is in the failed_targets list, not all test targets.

--- a/examples/src/python/example/README.md
+++ b/examples/src/python/example/README.md
@@ -332,36 +332,23 @@ parameters:
 ### Code Coverage
 
 To get code coverage data, set the `--coverage` flag in `test.pytest` scope.
-If you haven't configured coverage data, it doesn't do much:
+
+The value of the flag is a comma-separated list of names of python packages or directories 
+containing code to measure coverage against.  It can also take the special value `auto`, which
+will cause Pants to attempt to deduce what to measure coverage against.
+
+This auto-deduction examines the `coverage` attribute on each `python_tests` 
+target, which should be a list of packages.  If a target has no `coverage` attribute, 
+Pants uses the package containing the test code.  This is of course only useful if the
+code under test lives in the same package as the code that tests it.
+
+If you do specify package or directory names with `--coverage`, this overrides any `coverage`
+attributes on `python_tests` targets.
+
+For example:
 
     :::bash
-    $ ./pants test.pytest --coverage=1 examples/tests/python/example_test/hello/greet:greet
-        ...lots of build output...
-                         ============ 2 passed in 0.23 seconds ============
-                         Name    Stmts   Miss  Cover
-                         ---------------------------
-                         No data to report.
-
-    14:30:36 00:04     [junit]
-    14:30:36 00:04     [specs]
-
-This uses the `python_tests.coverage` target attribute to determine what
-modules to measure coverage against for each `python_tests` target run.
-If the attribute is not present it's assumed the coverage should be
-measured over the same packages that house the test target's sources.
-This heuristic only works with parallel source and test package
-structures and reliance upon it is discouraged.
-
-There are 2 alternatives to specifying coverage attributes on all
-`python_tests` targets, but both override any existing coverage
-attributes in-play to form a global coverage specification for the test
-run.
-
-`--coverage=modules:[module1](,...,[moduleN])` allows specification of
-package or module names to track coverage against. For example:
-
-    :::bash
-    $ ./pants test.pytest --coverage=modules:example.hello.greet,example.hello.main examples/tests/python/example_test/hello/greet:greet
+    $ ./pants test.pytest --coverage=example.hello.greet,example.hello.main examples/tests/python/example_test/hello/greet
         ...lots of build output...
                      ============ 2 passed in 0.22 seconds ============
                      Name                                               Stmts   Miss Branch BrMiss  Cover
@@ -372,13 +359,11 @@ package or module names to track coverage against. For example:
                      TOTAL                                                  4      0      0      0   100%
 
 This measures coverage against all python code in `example.hello.greet` and `example.hello.main`.
-It ignores `python_library` `coverage=...` attributes.
 
-Similarly, a set of base paths can be specified containing the code for
-coverage to be measured over:
+Similarly, a list of directories can be specified (either absolute or relative to the build root):
 
     :::bash
-    $ ./pants test.pytest --coverage=paths:example/hello examples/tests/python/example_test/hello/greet:greet
+    $ ./pants test.pytest --coverage=example/hello examples/tests/python/example_test/hello/greet
         ...lots of build output...
                      ============ 2 passed in 0.23 seconds ============
                      Name                                               Stmts   Miss Branch BrMiss  Cover
@@ -388,9 +373,6 @@ coverage to be measured over:
                      examples/src/python/example/hello/greet/greet          4      0      0      0   100%
                      ------------------------------------------------------------------------------------
                      TOTAL                                                  4      0      0      0   100%
-
-Paths are relative to the source root housing the python code; for this example,
-`examples/src/python`.
 
 ### Interactive Debugging on Test Failure
 

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -25,7 +25,7 @@ from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.reports.junit_html_report import JUnitHtmlReport
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TargetDefinitionException, TaskError, TestFailedTaskError
+from pants.base.exceptions import TargetDefinitionException, TaskError, ErrorWhileTesting
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
@@ -450,7 +450,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
           .format(main=JUnit.RUNNER_MAIN, code=result, failed=len(failed_targets),
                   targets=pluralize(len(failed_targets), 'target'))
       )
-      raise TestFailedTaskError('\n'.join(error_message_lines), failed_targets=list(failed_targets))
+      raise ErrorWhileTesting('\n'.join(error_message_lines), failed_targets=list(failed_targets))
 
   def _partition(self, tests):
     stride = min(self._batch_size, len(tests))

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -31,7 +31,7 @@ from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes
 from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
-from pants.java.junit.junit_xml_parser import Test, TestRegistry, parse_failed_targets
+from pants.java.junit.junit_xml_parser import Test, RegistryOfTests, parse_failed_targets
 from pants.process.lock import OwnerPrintingInterProcessFileLock
 from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
 from pants.util import desktop
@@ -324,10 +324,10 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     If `self._tests_to_run` is set, return a registry of explicitly specified tests instead.
 
     :returns: A registry of tests to run.
-    :rtype: :class:`pants.java.junit.junit_xml_parser.Test.TestRegistry`
+    :rtype: :class:`pants.java.junit.junit_xml_parser.Test.RegistryOfTests`
     """
 
-    test_registry = TestRegistry(tuple(self._calculate_tests_from_targets(targets)))
+    test_registry = RegistryOfTests(tuple(self._calculate_tests_from_targets(targets)))
 
     if targets and self._tests_to_run:
       # If there are some junit_test targets in the graph, find ones that match the requested
@@ -346,7 +346,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
                         "specifier or bring in the proper target(s)."
                         .format("'\n  '".join(t.render_test_spec() for t in unknown_tests)))
 
-      return TestRegistry(possible_test_to_target)
+      return RegistryOfTests(possible_test_to_target)
     else:
       return test_registry
 

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -25,7 +25,7 @@ from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.reports.junit_html_report import JUnitHtmlReport
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TargetDefinitionException, TaskError, ErrorWhileTesting
+from pants.base.exceptions import ErrorWhileTesting, TargetDefinitionException, TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
 from pants.build_graph.target_scopes import Scopes

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -13,7 +13,6 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
-from pants.backend.python.tasks.python_isort import IsortPythonTask
 from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.pytest_run import PytestRun
 from pants.backend.python.tasks2.python_binary_create import PythonBinaryCreate
@@ -22,6 +21,7 @@ from pants.backend.python.tasks2.python_run import PythonRun
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.backend.python.tasks2.setup_py import SetupPy
+from pants.backend.python.tasks.python_isort import IsortPythonTask
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.resources import Resources
 from pants.goal.task_registrar import TaskRegistrar as task

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -14,13 +14,11 @@ class PyTest(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(PyTest, cls).register_options(register)
-    register('--requirements', advanced=True, default='pytest>=2.6,<2.7',
+    register('--requirements', advanced=True, default='pytest>=3.0.7,<4.0',
              help='Requirements string for the pytest library.')
-    # NB, pytest-timeout 1.0.0 introduces a conflicting pytest>=2.8.0 requirement, see:
-    #   https://github.com/pantsbuild/pants/issues/2566
-    register('--timeout-requirements', advanced=True, default='pytest-timeout<1.0.0',
+    register('--timeout-requirements', advanced=True, default='pytest-timeout>=1.2,<1.3',
              help='Requirements string for the pytest-timeout library.')
-    register('--cov-requirements', advanced=True, default='pytest-cov>=1.8,<1.9',
+    register('--cov-requirements', advanced=True, default='pytest-cov>=2.4,<2.5',
              help='Requirements string for the pytest-cov library.')
     register('--unittest2-requirements', advanced=True, default='unittest2>=0.6.0,<=1.9.0',
              help='Requirements string for the unittest2 library, which some python versions '

--- a/src/python/pants/backend/python/tasks/BUILD
+++ b/src/python/pants/backend/python/tasks/BUILD
@@ -6,7 +6,6 @@ python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
-    '3rdparty/python:coverage',
     '3rdparty/python:pex',
     '3rdparty/python:setuptools',
     '3rdparty/python:six',

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -20,7 +20,6 @@ from six import StringIO
 from six.moves import configparser
 
 from pants.backend.python.python_requirement import PythonRequirement
-from pants.backend.python.subsystems.pytest import PyTest
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.build_environment import get_buildroot
@@ -69,10 +68,6 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
   """
   :API: public
   """
-
-  @classmethod
-  def subsystem_dependencies(cls):
-    return super(PytestRun, cls).subsystem_dependencies() + (PyTest,)
 
   @classmethod
   def register_options(cls, register):
@@ -402,8 +397,15 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
 
-    testing_reqs = [PythonRequirement(s)
-                    for s in PyTest.global_instance().get_requirement_strings()]
+    # We hard-code the requirements here because they can't be upgraded without
+    # major changes to this code, and the PyTest subsystem now contains the versions
+    # for the new PytestRun task.  This one is about to be deprecated anyway.
+    testing_reqs = [PythonRequirement(s) for s in [
+      'pytest>=2.6,<2.7',
+      'pytest-timeout<1.0.0',
+      'pytest-cov>=1.8,<1.9',
+      'unittest2>=0.6.0,<=1.9.0',
+    ]]
 
     chroot = self.cached_chroot(interpreter=interpreter,
                                 pex_info=pex_info,

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -23,7 +23,7 @@ from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.python_task import PythonTask
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError, ErrorWhileTesting
+from pants.base.exceptions import ErrorWhileTesting, TaskError
 from pants.base.hash_utils import Sharder
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target

--- a/src/python/pants/backend/python/tasks2/BUILD
+++ b/src/python/pants/backend/python/tasks2/BUILD
@@ -14,7 +14,6 @@ python_library(
     'src/python/pants/base:specs',
     'src/python/pants/build_graph',
     'src/python/pants/invalidation',
-    'src/python/pants/java/junit',
     'src/python/pants/python',
     'src/python/pants/task',
     'src/python/pants/util:contextutil',

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -22,7 +22,7 @@ from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError, ErrorWhileTesting
+from pants.base.exceptions import ErrorWhileTesting, TaskError
 from pants.base.hash_utils import Sharder
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -22,7 +22,7 @@ from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError, TestFailedTaskError
+from pants.base.exceptions import TaskError, ErrorWhileTesting
 from pants.base.hash_utils import Sharder
 from pants.base.workunit import WorkUnitLabel
 from pants.build_graph.target import Target
@@ -133,7 +133,7 @@ class PytestRun(TestRunnerTaskMixin, PythonExecutionTaskBase):
   def run_tests(self, targets, workunit):
     result = self._do_run_tests(targets, workunit)
     if not result.success:
-      raise TestFailedTaskError(failed_targets=result.failed_targets)
+      raise ErrorWhileTesting(failed_targets=result.failed_targets)
 
   class InvalidShardSpecification(TaskError):
     """Indicates an invalid `--test-shard` option."""
@@ -389,9 +389,9 @@ class PytestRun(TestRunnerTaskMixin, PythonExecutionTaskBase):
         env['PEX_PROFILE_FILENAME'] = '{0}.subprocess.{1:.6f}'.format(profile, time.time())
       rc = self._spawn_and_wait(pex, workunit, args=args, setsid=True, env=env)
       return PythonTestResult.rc(rc)
-    except TestFailedTaskError:
+    except ErrorWhileTesting:
       # _spawn_and_wait wraps the test runner in a timeout, so it could
-      # fail with a TestFailedTaskError. We can't just set PythonTestResult
+      # fail with a ErrorWhileTesting. We can't just set PythonTestResult
       # to a failure because the resultslog doesn't have all the failures
       # when tests are killed with a timeout. Therefore we need to re-raise
       # here.

--- a/src/python/pants/backend/python_old/register.py
+++ b/src/python/pants/backend/python_old/register.py
@@ -6,12 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.python.register import build_file_aliases as orig_build_file_aliases
-from pants.backend.python.tasks.pytest_run import PytestRun
-from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
-from pants.backend.python.tasks.python_isort import IsortPythonTask
-from pants.backend.python.tasks.python_repl import PythonRepl
-from pants.backend.python.tasks.python_run import PythonRun
-from pants.backend.python.tasks.setup_py import SetupPy
 from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.pytest_run import PytestRun as PytestRun2
 from pants.backend.python.tasks2.python_binary_create import \
@@ -21,6 +15,12 @@ from pants.backend.python.tasks2.python_run import PythonRun as PythonRun2
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.backend.python.tasks2.setup_py import SetupPy as SetupPy2
+from pants.backend.python.tasks.pytest_run import PytestRun
+from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
+from pants.backend.python.tasks.python_isort import IsortPythonTask
+from pants.backend.python.tasks.python_repl import PythonRepl
+from pants.backend.python.tasks.python_run import PythonRun
+from pants.backend.python.tasks.setup_py import SetupPy
 from pants.base.deprecated import deprecated
 from pants.goal.task_registrar import TaskRegistrar as task
 

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import warnings
+
 
 class TaskError(Exception):
   """Indicates a task has failed.
@@ -30,13 +32,30 @@ class TaskError(Exception):
     return self._failed_targets
 
 
-class TestFailedTaskError(TaskError):
+class ErrorWhileTesting(TaskError):
   """Raised when an actual test run failed.
 
   This is used to distinguish test run failures from infrastructure failures.
 
   :API: public
   """
+
+
+# Renamed this to ErrorWhileTesting, because pytest will see the `Test` prefix and attempt
+# to do test discovery on this class, but then issue this warning:
+# "cannot collect test class 'TestFailedTaskError' because it has a __init__ constructor".
+class TestFailedTaskError(ErrorWhileTesting):
+  def __init__(self, *args, **kwargs):
+    # Note that we can't use our regular deprecation mechanism because we want this module
+    # to remain dependency-free.
+    # Note also that this warning will only trigger if some code actually instantiates
+    # an instance of this exception.  This is the best we can do, since there's no
+    # way of detecting "this class was imported in some other module".
+    # Fortunately, it's pretty unlikely that anyone is actually using this exception...
+    msg = ('DEPRECATED: TestFailedTaskError will be removed in version 1.5.0.dev0.\n'
+           'Use ErrorWhileTesting instead.')
+    warnings.warn(msg)
+    super(TestFailedTaskError, self).__init__(*args, **kwargs)
 
 
 class TargetDefinitionException(Exception):

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -129,8 +129,7 @@ class Target(AbstractTarget):
     """Raised when there are too many recursive calls to calculate the fingerprint."""
     pass
 
-
-  _MAX_RECURSION_DEPTH=300
+  _MAX_RECURSION_DEPTH=250
 
   class WrongNumberOfAddresses(Exception):
     """Internal error, too many elements in Addresses

--- a/src/python/pants/core_tasks/changed_target_tasks.py
+++ b/src/python/pants/core_tasks/changed_target_tasks.py
@@ -9,6 +9,7 @@ from pants.base.deprecated import deprecated
 from pants.core_tasks.noop import NoopCompile, NoopTest
 from pants.task.changed_target_task import ChangedTargetTask
 
+
 # TODO: Remove this entire file in 1.5.0dev0.
 
 class CompileChanged(ChangedTargetTask):

--- a/src/python/pants/core_tasks/changed_target_tasks.py
+++ b/src/python/pants/core_tasks/changed_target_tasks.py
@@ -11,7 +11,6 @@ from pants.task.changed_target_task import ChangedTargetTask
 
 
 # TODO: Remove this entire file in 1.5.0dev0.
-
 class CompileChanged(ChangedTargetTask):
   """Find and compile changed targets."""
 

--- a/src/python/pants/core_tasks/what_changed.py
+++ b/src/python/pants/core_tasks/what_changed.py
@@ -9,6 +9,7 @@ from pants.base.deprecated import deprecated
 from pants.scm.subsystems.changed import Changed
 from pants.task.console_task import ConsoleTask
 
+
 # TODO: Remove this entire file in 1.5.0dev0.
 
 class WhatChanged(ConsoleTask):

--- a/src/python/pants/core_tasks/what_changed.py
+++ b/src/python/pants/core_tasks/what_changed.py
@@ -11,7 +11,6 @@ from pants.task.console_task import ConsoleTask
 
 
 # TODO: Remove this entire file in 1.5.0dev0.
-
 class WhatChanged(ConsoleTask):
   """Emits the targets that have been modified since a given commit."""
 

--- a/src/python/pants/java/junit/junit_xml_parser.py
+++ b/src/python/pants/java/junit/junit_xml_parser.py
@@ -43,7 +43,7 @@ class Test(datatype('Test', ['classname', 'methodname'])):
       return '{}#{}'.format(self.classname, self.methodname)
 
 
-class TestRegistry(object):
+class RegistryOfTests(object):
   """A registry of tests and the targets that own them."""
 
   def __init__(self, mapping_or_seq):
@@ -133,7 +133,7 @@ def parse_failed_targets(test_registry, junit_xml_path, error_handler):
   Targets with no failed tests are omitted from the returned mapping.
 
   :param test_registry: A registry of tests that were run.
-  :type test_registry: :class:`TestRegistry`
+  :type test_registry: :class:`RegistryOfTests`
   :param string junit_xml_path: A path to a file or directory containing test junit xml reports
                                 to analyze.
   :param error_handler: An error handler that will be called with any junit xml parsing errors.

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from abc import abstractmethod
 from threading import Timer
 
-from pants.base.exceptions import TestFailedTaskError
+from pants.base.exceptions import ErrorWhileTesting
 from pants.util.timeout import Timeout, TimeoutReached
 
 
@@ -53,7 +53,7 @@ class TestRunnerTaskMixin(object):
         self.get_options().timeout_default
       )
       self.context.log.error(message)
-      raise TestFailedTaskError(message)
+      raise ErrorWhileTesting(message)
 
     if not self.get_options().skip:
       test_targets = self._get_test_targets()
@@ -111,7 +111,7 @@ class TestRunnerTaskMixin(object):
                                                      self.get_options().timeout_terminate_wait)):
         return process_handler.wait()
     except TimeoutReached as e:
-      raise TestFailedTaskError(str(e), failed_targets=test_targets)
+      raise ErrorWhileTesting(str(e), failed_targets=test_targets)
 
   @abstractmethod
   def _spawn(self, *args, **kwargs):

--- a/tests/python/pants_test/backend/jvm/tasks/coverage/test_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/coverage/test_base.py
@@ -42,7 +42,7 @@ class fake_log(object):
     return
 
 
-class TestCoverageEngine(Coverage):
+class CoverageEngineForTesting(Coverage):
   """
   :API: public
   """
@@ -52,7 +52,7 @@ class TestCoverageEngine(Coverage):
     self.copytree_calls = defaultdict(list)
     self.safe_makedir_calls = []
 
-    super(TestCoverageEngine, self).__init__(
+    super(CoverageEngineForTesting, self).__init__(
         settings,
         copy2=lambda frm, to: self.copy2_calls[frm].append(to),
         copytree=lambda frm, to: self.copytree_calls[frm].append(to),
@@ -141,7 +141,7 @@ class TestBase(BaseTest):
     options = attrdict(coverage=True, coverage_jvm_options=[])
 
     settings = CoverageTaskSettings(options, None, self.pants_workdir, None, None, fake_log())
-    coverage = TestCoverageEngine(settings)
+    coverage = CoverageEngineForTesting(settings)
 
     classpath_products = ClasspathProducts(self.pants_workdir)
     self._add_for_target(classpath_products, self.jar_lib, '/jar/lib/classpath')
@@ -167,7 +167,7 @@ class TestBase(BaseTest):
     options = attrdict(coverage=True, coverage_jvm_options=[])
 
     settings = CoverageTaskSettings(options, None, self.pants_workdir, None, None, fake_log())
-    coverage = TestCoverageEngine(settings)
+    coverage = CoverageEngineForTesting(settings)
 
     classpath_products = ClasspathProducts(self.pants_workdir)
     self._add_for_target(classpath_products, self.java_target, '/java/target/first.jar')
@@ -194,7 +194,7 @@ class TestBase(BaseTest):
     options = attrdict(coverage=True, coverage_jvm_options=[])
 
     settings = CoverageTaskSettings(options, None, self.pants_workdir, None, None, fake_log())
-    coverage = TestCoverageEngine(settings)
+    coverage = CoverageEngineForTesting(settings)
 
     classpath_products = ClasspathProducts(self.pants_workdir)
     self._add_for_target(classpath_products, self.annotation_target, '/anno/target/dir')

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -41,7 +41,6 @@ python_tests(
   name='pytest_run',
   sources=['test_pytest_run.py'],
   dependencies=[
-    '3rdparty/python:coverage',
     '3rdparty/python:pex',
     '3rdparty/python:mock',
     ':python_task_test_base',

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -14,7 +14,7 @@ import coverage
 from mock import patch
 
 from pants.backend.python.tasks.pytest_run import PytestRun
-from pants.base.exceptions import TestFailedTaskError
+from pants.base.exceptions import ErrorWhileTesting
 from pants.util.contextutil import pushd
 from pants.util.timeout import TimeoutReached
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
@@ -38,7 +38,7 @@ class PythonTestBuilderTestBase(PythonTaskTestBase):
       pytest_run_task.execute()
 
   def run_failing_tests(self, targets, failed_targets, **options):
-    with self.assertRaises(TestFailedTaskError) as cm:
+    with self.assertRaises(ErrorWhileTesting) as cm:
       self.run_tests(targets=targets, **options)
     self.assertEqual(set(failed_targets), set(cm.exception.failed_targets))
 
@@ -249,7 +249,7 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
     self.all_with_coverage = self.target('tests:all-with-coverage')
 
   def test_error(self):
-    """Test that a test that errors rather than fails shows up in TestFailedTaskError."""
+    """Test that a test that errors rather than fails shows up in ErrorWhileTesting."""
 
     self.run_failing_tests(targets=[self.red, self.green, self.error],
                            failed_targets=[self.red, self.error])

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -10,7 +10,6 @@ import os
 import xml.dom.minidom as DOM
 from textwrap import dedent
 
-import coverage
 from mock import patch
 
 from pants.backend.python.tasks.pytest_run import PytestRun
@@ -334,95 +333,6 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
     self.assertEqual(0, len(children_by_test_name['test_one'].childNodes))
     self.assertEqual(1, len(children_by_test_name['test_two'].childNodes))
     self.assertEqual('failure', children_by_test_name['test_two'].firstChild.nodeName)
-
-  def coverage_data_file(self):
-    return os.path.join(self.build_root, '.coverage')
-
-  def load_coverage_data(self, path):
-    data_file = self.coverage_data_file()
-    self.assertTrue(os.path.isfile(data_file))
-    coverage_data = coverage.coverage(data_file=data_file)
-    coverage_data.load()
-    _, all_statements, not_run_statements, _ = coverage_data.analysis(path)
-    return all_statements, not_run_statements
-
-  def test_coverage_simple_option(self):
-    # TODO(John Sirois): Consider eliminating support for "simple" coverage or at least formalizing
-    # the coverage option value that turns this on to "1" or "all" or "simple" = anything formal.
-    simple_coverage_kwargs = {'coverage': '1'}
-
-    self.assertFalse(os.path.isfile(self.coverage_data_file()))
-    covered_file = os.path.join(self.build_root, 'lib', 'core.py')
-
-    self.run_tests(targets=[self.green], **simple_coverage_kwargs)
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([6], not_run_statements)
-
-    self.run_failing_tests(targets=[self.red], failed_targets=[self.red], **simple_coverage_kwargs)
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([2], not_run_statements)
-
-    self.run_failing_tests(targets=[self.green, self.red], failed_targets=[self.red],
-                           **simple_coverage_kwargs)
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([], not_run_statements)
-
-    # The all target has no coverage attribute and the code under test does not follow the
-    # auto-discover pattern so we should get no coverage.
-    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], **simple_coverage_kwargs)
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([1, 2, 5, 6], not_run_statements)
-
-    self.run_failing_tests(targets=[self.all_with_coverage],
-                           failed_targets=[self.all_with_coverage],
-                           **simple_coverage_kwargs)
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([], not_run_statements)
-
-  def test_coverage_modules_dne_option(self):
-    self.assertFalse(os.path.isfile(self.coverage_data_file()))
-    covered_file = os.path.join(self.build_root, 'lib', 'core.py')
-
-    # modules: should trump .coverage
-    self.run_failing_tests(targets=[self.green, self.red], failed_targets=[self.red],
-                           coverage='modules:does_not_exist,nor_does_this')
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([1, 2, 5, 6], not_run_statements)
-
-  def test_coverage_modules_option(self):
-    self.assertFalse(os.path.isfile(self.coverage_data_file()))
-    covered_file = os.path.join(self.build_root, 'lib', 'core.py')
-
-    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='modules:core')
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([], not_run_statements)
-
-  def test_coverage_paths_dne_option(self):
-    self.assertFalse(os.path.isfile(self.coverage_data_file()))
-    covered_file = os.path.join(self.build_root, 'lib', 'core.py')
-
-    # paths: should trump .coverage
-    self.run_failing_tests(targets=[self.green, self.red], failed_targets=[self.red],
-                           coverage='paths:does_not_exist/,nor_does_this/')
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([1, 2, 5, 6], not_run_statements)
-
-  def test_coverage_paths_option(self):
-    self.assertFalse(os.path.isfile(self.coverage_data_file()))
-    covered_file = os.path.join(self.build_root, 'lib', 'core.py')
-
-    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='paths:core.py')
-    all_statements, not_run_statements = self.load_coverage_data(covered_file)
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([], not_run_statements)
 
   def test_sharding(self):
     self.run_failing_tests(targets=[self.red, self.green], failed_targets=[self.red],

--- a/tests/python/pants_test/backend/python/tasks2/BUILD
+++ b/tests/python/pants_test/backend/python/tasks2/BUILD
@@ -7,6 +7,7 @@ python_tests(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python/twitter/commons:twitter.common.dirutil',
+    '3rdparty/python:coverage',
     '3rdparty/python:mock',
     '3rdparty/python:pex',
     'src/python/pants/backend/python:interpreter_cache',

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
@@ -339,14 +339,11 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
     self.assertTrue(os.path.isfile(data_file))
     coverage_data = coverage.coverage(data_file=data_file)
     coverage_data.load()
-    coverage_data.report()
     _, all_statements, not_run_statements, _ = coverage_data.analysis(path)
     return all_statements, not_run_statements
 
-  def test_coverage_simple_option(self):
-    # TODO(John Sirois): Consider eliminating support for "simple" coverage or at least formalizing
-    # the coverage option value that turns this on to "1" or "all" or "simple" = anything formal.
-    simple_coverage_kwargs = {'coverage': '1'}
+  def test_coverage_auto_option(self):
+    simple_coverage_kwargs = {'coverage': 'auto'}
 
     self.assertFalse(os.path.isfile(self.coverage_data_file()))
 
@@ -382,9 +379,9 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
   def test_coverage_modules_dne_option(self):
     self.assertFalse(os.path.isfile(self.coverage_data_file()))
 
-    # modules: should trump .coverage
+    # Explicit modules should trump .coverage.
     self.run_failing_tests(targets=[self.green, self.red], failed_targets=[self.red],
-                           coverage='modules:does_not_exist,nor_does_this')
+                           coverage='does_not_exist,nor_does_this')
     all_statements, not_run_statements = self.load_coverage_data()
     self.assertEqual([1, 2, 5, 6], all_statements)
     self.assertEqual([1, 2, 5, 6], not_run_statements)
@@ -392,25 +389,15 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
   def test_coverage_modules_option(self):
     self.assertFalse(os.path.isfile(self.coverage_data_file()))
 
-    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='modules:core')
+    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='core')
     all_statements, not_run_statements = self.load_coverage_data()
     self.assertEqual([1, 2, 5, 6], all_statements)
     self.assertEqual([], not_run_statements)
 
-  def test_coverage_paths_dne_option(self):
-    self.assertFalse(os.path.isfile(self.coverage_data_file()))
-
-    # paths: should trump .coverage
-    self.run_failing_tests(targets=[self.green, self.red], failed_targets=[self.red],
-                           coverage='paths:does_not_exist/,nor_does_this/')
-    all_statements, not_run_statements = self.load_coverage_data()
-    self.assertEqual([1, 2, 5, 6], all_statements)
-    self.assertEqual([1, 2, 5, 6], not_run_statements)
-
   def test_coverage_paths_option(self):
     self.assertFalse(os.path.isfile(self.coverage_data_file()))
 
-    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='paths:lib/')
+    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='lib/')
     all_statements, not_run_statements = self.load_coverage_data()
     self.assertEqual([1, 2, 5, 6], all_statements)
     self.assertEqual([], not_run_statements)

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
@@ -339,6 +339,7 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
     self.assertTrue(os.path.isfile(data_file))
     coverage_data = coverage.coverage(data_file=data_file)
     coverage_data.load()
+    coverage_data.report()
     _, all_statements, not_run_statements, _ = coverage_data.analysis(path)
     return all_statements, not_run_statements
 
@@ -409,7 +410,7 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
   def test_coverage_paths_option(self):
     self.assertFalse(os.path.isfile(self.coverage_data_file()))
 
-    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='paths:core.py')
+    self.run_failing_tests(targets=[self.all], failed_targets=[self.all], coverage='paths:lib/')
     all_statements, not_run_statements = self.load_coverage_data()
     self.assertEqual([1, 2, 5, 6], all_statements)
     self.assertEqual([], not_run_statements)

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
@@ -15,7 +15,7 @@ from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.pytest_run import PytestRun
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
-from pants.base.exceptions import TestFailedTaskError
+from pants.base.exceptions import ErrorWhileTesting
 from pants.util.contextutil import pushd
 from pants.util.timeout import TimeoutReached
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
@@ -37,7 +37,7 @@ class PythonTestBuilderTestBase(PythonTaskTestBase):
 
   def run_failing_tests(self, targets, failed_targets, **options):
     context = self._prepare_test_run(targets, **options)
-    with self.assertRaises(TestFailedTaskError) as cm:
+    with self.assertRaises(ErrorWhileTesting) as cm:
       self._do_run_tests(context)
     self.assertEqual(set(failed_targets), set(cm.exception.failed_targets))
 
@@ -274,7 +274,7 @@ class PythonTestBuilderTest(PythonTestBuilderTestBase):
     self.all_with_coverage = self.target('tests:all-with-coverage')
 
   def test_error(self):
-    """Test that a test that errors rather than fails shows up in TestFailedTaskError."""
+    """Test that a test that errors rather than fails shows up in ErrorWhileTesting."""
 
     self.run_failing_tests(targets=[self.red, self.green, self.error],
                            failed_targets=[self.red, self.error])

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run_integration.py
@@ -73,7 +73,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     with temporary_dir() as coverage_dir:
       pants_run = self.run_pants(['clean-all',
                                   'test.pytest',
-                                  '--test-pytest-coverage=path:testprojects',
+                                  '--test-pytest-coverage=testprojects',
                                   '--test-pytest-coverage-output-dir={}'.format(coverage_dir),
                                   'testprojects/tests/python/pants/constants_only:constants_only'])
       self.assert_success(pants_run)

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run_integration.py
@@ -27,7 +27,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     start = time.time()
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
-                                '--test-pytest-coverage=1',
+                                '--test-pytest-coverage=auto',
                                 '--test-pytest-options=-k exceeds_timeout',
                                 '--timeout-default=1',
                                 'testprojects/tests/python/pants/timeout:exceeds_timeout'])
@@ -49,7 +49,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     terminate_wait = 2
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
-                                '--test-pytest-coverage=1',
+                                '--test-pytest-coverage=auto',
                                 '--test-pytest-timeout-terminate-wait=%d' % terminate_wait,
                                 '--timeout-default=1',
                                 'testprojects/tests/python/pants/timeout:ignores_terminate'])
@@ -70,12 +70,12 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
                   "killing...".format(terminate_wait), pants_run.stderr_data)
 
   def test_pytest_explicit_coverage(self):
-    with temporary_dir() as coverage_dir:
+    with temporary_dir(cleanup=False) as coverage_dir:
       pants_run = self.run_pants(['clean-all',
                                   'test.pytest',
-                                  '--test-pytest-coverage=testprojects',
+                                  '--test-pytest-coverage=pants',
                                   '--test-pytest-coverage-output-dir={}'.format(coverage_dir),
-                                  'testprojects/tests/python/pants/constants_only:constants_only'])
+                                  'testprojects/tests/python/pants/constants_only'])
       self.assert_success(pants_run)
       self.assertTrue(os.path.exists(os.path.join(coverage_dir, 'coverage.xml')))
 

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -27,7 +27,7 @@ from pants.build_graph.target import Target
 from pants.init.util import clean_global_runtime_state
 from pants.source.source_root import SourceRootConfig
 from pants.subsystem.subsystem import Subsystem
-from pants.util.dirutil import safe_mkdir, safe_open
+from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree
 from pants_test.base.context_utils import create_context
 from pants_test.option.util.fakes import create_options_for_optionables
 
@@ -216,7 +216,7 @@ class BaseTest(unittest.TestCase):
 
     self.build_root = os.path.realpath(mkdtemp(suffix='_BUILD_ROOT'))
     self.subprocess_dir = os.path.join(self.build_root, '.pids')
-    #self.addCleanup(safe_rmtree, self.build_root)
+    self.addCleanup(safe_rmtree, self.build_root)
 
     self.pants_workdir = os.path.join(self.build_root, '.pants.d')
     safe_mkdir(self.pants_workdir)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -27,7 +27,7 @@ from pants.build_graph.target import Target
 from pants.init.util import clean_global_runtime_state
 from pants.source.source_root import SourceRootConfig
 from pants.subsystem.subsystem import Subsystem
-from pants.util.dirutil import safe_mkdir, safe_open, safe_rmtree
+from pants.util.dirutil import safe_mkdir, safe_open
 from pants_test.base.context_utils import create_context
 from pants_test.option.util.fakes import create_options_for_optionables
 
@@ -216,7 +216,7 @@ class BaseTest(unittest.TestCase):
 
     self.build_root = os.path.realpath(mkdtemp(suffix='_BUILD_ROOT'))
     self.subprocess_dir = os.path.join(self.build_root, '.pids')
-    self.addCleanup(safe_rmtree, self.build_root)
+    #self.addCleanup(safe_rmtree, self.build_root)
 
     self.pants_workdir = os.path.join(self.build_root, '.pants.d')
     safe_mkdir(self.pants_workdir)

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -16,11 +16,11 @@ from pants_test.base_test import BaseTest
 from pants_test.subsystem.subsystem_util import init_subsystem
 
 
-class TestImplicitSourcesTarget(Target):
+class ImplicitSourcesTestingTarget(Target):
   default_sources_globs = '*.foo'
 
 
-class TestImplicitSourcesTargetMulti(Target):
+class ImplicitSourcesTestingTargetMulti(Target):
   default_sources_globs = ('*.foo', '*.bar')
   default_sources_exclude_globs = ('*.baz', '*.qux')
 
@@ -96,13 +96,13 @@ class TargetTest(BaseTest):
   def test_implicit_sources(self):
     options = {Target.Arguments.options_scope: {'implicit_sources': True}}
     init_subsystem(Target.Arguments, options)
-    target = self.make_target(':a', TestImplicitSourcesTarget)
+    target = self.make_target(':a', ImplicitSourcesTestingTarget)
     # Note explicit key_arg.
     sources = target.create_sources_field(sources=None, sources_rel_path='src/foo/bar',
                                           key_arg='sources')
     self.assertEqual(sources.filespec, {'globs': ['src/foo/bar/*.foo']})
 
-    target = self.make_target(':b', TestImplicitSourcesTargetMulti)
+    target = self.make_target(':b', ImplicitSourcesTestingTargetMulti)
     # Note no explicit key_arg, which should behave just like key_arg='sources'.
     sources = target.create_sources_field(sources=None, sources_rel_path='src/foo/bar')
     self.assertEqual(sources.filespec, {
@@ -118,7 +118,7 @@ class TargetTest(BaseTest):
   def test_implicit_sources_disabled(self):
     options = {Target.Arguments.options_scope: {'implicit_sources': False}}
     init_subsystem(Target.Arguments, options)
-    target = self.make_target(':a', TestImplicitSourcesTarget)
+    target = self.make_target(':a', ImplicitSourcesTestingTarget)
     sources = target.create_sources_field(sources=None, sources_rel_path='src/foo/bar')
     self.assertEqual(sources.filespec, {'globs': []})
 

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -15,13 +15,13 @@ from pkg_resources import (Distribution, EmptyProvider, VersionConflict, Working
                            yield_lines)
 
 from pants.base.exceptions import BuildConfigurationError
-from pants.init.extension_loader import (PluginLoadOrderError, PluginNotFound, load_backend,
-                                         load_backends_and_plugins, load_plugins)
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar
+from pants.init.extension_loader import (PluginLoadOrderError, PluginNotFound, load_backend,
+                                         load_backends_and_plugins, load_plugins)
 from pants.subsystem.subsystem import Subsystem
 from pants.task.task import Task
 

--- a/tests/python/pants_test/java/junit/test_junit_xml_parser.py
+++ b/tests/python/pants_test/java/junit/test_junit_xml_parser.py
@@ -11,7 +11,7 @@ import unittest
 from pants.java.junit.junit_xml_parser import Test as JUnitTest
 # NB: The Test -> JUnitTest import re-name above is needed to work around conflicts with pytest test
 # collection and a conflicting Test type in scope during that process.
-from pants.java.junit.junit_xml_parser import ParseError, TestRegistry, parse_failed_targets
+from pants.java.junit.junit_xml_parser import ParseError, RegistryOfTests, parse_failed_targets
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open
 from pants.util.xml_parser import XmlParser
@@ -42,14 +42,14 @@ class TestTest(unittest.TestCase):
 
 class TestTestRegistry(unittest.TestCase):
   def test_empty(self):
-    self.assertTrue(TestRegistry({}).empty)
-    self.assertTrue(TestRegistry(()).empty)
-    self.assertTrue(TestRegistry([]).empty)
+    self.assertTrue(RegistryOfTests({}).empty)
+    self.assertTrue(RegistryOfTests(()).empty)
+    self.assertTrue(RegistryOfTests([]).empty)
 
   def test_get_owning_target(self):
-    registry = TestRegistry(((JUnitTest('class1'), 'Bob'),
-                             (JUnitTest('class2'), 'Jane'),
-                             (JUnitTest('class3', 'method1'), 'Heidi')))
+    registry = RegistryOfTests(((JUnitTest('class1'), 'Bob'),
+                                (JUnitTest('class2'), 'Jane'),
+                                (JUnitTest('class3', 'method1'), 'Heidi')))
 
     self.assertEqual('Bob', registry.get_owning_target(JUnitTest('class1')))
     self.assertEqual('Bob', registry.get_owning_target(JUnitTest('class1', 'method1')))
@@ -68,10 +68,10 @@ class TestTestRegistry(unittest.TestCase):
     self.assertEqual(sorted_values(expected), sorted_values(actual))
 
   def test_index_nominal(self):
-    registry = TestRegistry({JUnitTest('class1'): (1, 'a'),
-                             JUnitTest('class2'): (2, 'b'),
-                             JUnitTest('class3', 'method1'): (1, 'a'),
-                             JUnitTest('class3', 'method2'): (4, 'b')})
+    registry = RegistryOfTests({JUnitTest('class1'): (1, 'a'),
+                                JUnitTest('class2'): (2, 'b'),
+                                JUnitTest('class3', 'method1'): (1, 'a'),
+                                JUnitTest('class3', 'method2'): (4, 'b')})
 
     actual_index = registry.index(lambda t: t[0], lambda t: t[1])
     expected_index = {(1, 'a'): (JUnitTest('class1'), JUnitTest('class3', 'method1')),
@@ -80,11 +80,11 @@ class TestTestRegistry(unittest.TestCase):
     self._assert_index(expected_index, actual_index)
 
   def test_index_empty(self):
-    self._assert_index({}, TestRegistry({}).index())
+    self._assert_index({}, RegistryOfTests({}).index())
 
   def test_index_no_indexers(self):
-    registry = TestRegistry({JUnitTest('class1'): (1, 'a'),
-                             JUnitTest('class2'): (2, 'b')})
+    registry = RegistryOfTests({JUnitTest('class1'): (1, 'a'),
+                                JUnitTest('class2'): (2, 'b')})
 
     self._assert_index({(): (JUnitTest('class1'), JUnitTest('class2'))}, registry.index())
 
@@ -106,16 +106,16 @@ class TestParseFailedTargets(unittest.TestCase):
       return self._errors
 
   def test_parse_failed_targets_no_files(self):
-    registry = TestRegistry({})
+    registry = RegistryOfTests({})
     with temporary_dir() as junit_xml_dir:
       failed_targets = parse_failed_targets(registry, junit_xml_dir, self._raise_handler)
 
       self.assertEqual({}, failed_targets)
 
   def test_parse_failed_targets_nominal(self):
-    registry = TestRegistry({JUnitTest('org.pantsbuild.Failure'): 'Bob',
-                             JUnitTest('org.pantsbuild.Error'): 'Jane',
-                             JUnitTest('org.pantsbuild.AnotherError'): 'Bob'})
+    registry = RegistryOfTests({JUnitTest('org.pantsbuild.Failure'): 'Bob',
+                                JUnitTest('org.pantsbuild.Error'): 'Jane',
+                                JUnitTest('org.pantsbuild.AnotherError'): 'Bob'})
 
     with temporary_dir() as junit_xml_dir:
       with open(os.path.join(junit_xml_dir, 'TEST-a.xml'), 'w') as fp:
@@ -150,7 +150,7 @@ class TestParseFailedTargets(unittest.TestCase):
                        failed_targets)
 
   def test_parse_failed_targets_error_raise(self):
-    registry = TestRegistry({})
+    registry = RegistryOfTests({})
     with temporary_dir() as junit_xml_dir:
       junit_xml_file = os.path.join(junit_xml_dir, 'TEST-bad.xml')
       with open(junit_xml_file, 'w') as fp:
@@ -161,7 +161,7 @@ class TestParseFailedTargets(unittest.TestCase):
       self.assertIsInstance(exc.exception.cause, XmlParser.XmlError)
 
   def test_parse_failed_targets_error_continue(self):
-    registry = TestRegistry({})
+    registry = RegistryOfTests({})
     with temporary_dir() as junit_xml_dir:
       bad_file1 = os.path.join(junit_xml_dir, 'TEST-bad1.xml')
       with open(bad_file1, 'w') as fp:

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -9,7 +9,7 @@ import collections
 
 from mock import patch
 
-from pants.base.exceptions import TestFailedTaskError
+from pants.base.exceptions import ErrorWhileTesting
 from pants.task.task import TaskBase
 from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
 from pants.util.process_handler import ProcessHandler
@@ -131,7 +131,7 @@ class TestRunnerTaskMixinTest(TaskTestBase):
 
     self.set_options(timeouts=True, timeout_maximum=1, timeout_default=10)
     task = self.create_task(self.context())
-    with self.assertRaises(TestFailedTaskError):
+    with self.assertRaises(ErrorWhileTesting):
       task.execute()
 
 
@@ -186,7 +186,7 @@ class TestRunnerTaskMixinSimpleTimeoutTest(TaskTestBase):
     with patch('pants.task.testrunner_task_mixin.Timeout') as mock_timeout:
       mock_timeout().__exit__.side_effect = TimeoutReached(1)
 
-      with self.assertRaises(TestFailedTaskError):
+      with self.assertRaises(ErrorWhileTesting):
         task.execute()
 
       # Ensures that Timeout is instantiated with a 1 second timeout.
@@ -279,7 +279,7 @@ class TestRunnerTaskMixinGracefulTimeoutTest(TaskTestBase):
       mock_timer.side_effect = set_handler
 
 
-      with self.assertRaises(TestFailedTaskError):
+      with self.assertRaises(ErrorWhileTesting):
         task.execute()
 
       # Ensure that all the calls we want to kill the process gracefully are made.
@@ -301,7 +301,7 @@ class TestRunnerTaskMixinGracefulTimeoutTest(TaskTestBase):
       mock_timer.side_effect = set_handler
 
 
-      with self.assertRaises(TestFailedTaskError):
+      with self.assertRaises(ErrorWhileTesting):
         task.execute()
 
       # Ensure that we only call terminate, and not kill.
@@ -355,13 +355,13 @@ class TestRunnerTaskMixinMultipleTargets(TaskTestBase):
       task = self.create_task(self.context())
 
       task.current_targets = [targetA]
-      with self.assertRaises(TestFailedTaskError) as cm:
+      with self.assertRaises(ErrorWhileTesting) as cm:
         task.execute()
       self.assertEqual(len(cm.exception.failed_targets), 1)
       self.assertEqual(cm.exception.failed_targets[0].address.spec, 'TargetA')
 
       task.current_targets = [targetB]
-      with self.assertRaises(TestFailedTaskError) as cm:
+      with self.assertRaises(ErrorWhileTesting) as cm:
         task.execute()
       self.assertEqual(len(cm.exception.failed_targets), 1)
       self.assertEqual(cm.exception.failed_targets[0].address.spec, 'TargetB')


### PR DESCRIPTION
- Recent versions of pytest have a "file" attribute in the
junit xml they emit, which allowed us to simplify the logic
for mapping failed tests to targets.  But the new logic
no longer re-uses the junit xml parser helper we use on the
JVM side, as it doesn't support this 'file' attribute (it's
unclear if JUnit populates it) and modifying it to do so would
have made that helper more cumbersome than it's worth. Since
the new logic is so trivial, this isn't an issue.
    
- New pytest also has a much simpler way of turning off
console reporting than the previous hack, now removed.
    
- Ensures that the paths in coverage reports are displayed 
relative to the buildroot.  This was the case in the old pipeline, 
but not in the new, until now.
    
- Simplifies the coverage tests - we don't need to know the 
source pex's chroot in order to read the coverage file. 
It understands sources relative to the buildroot as equivalent.

- Rename TestFailedTaskError to ErrorWhileTesting.  
This prevents new pytest from attempting test discovery on
TestFailedTaskError (because of the 'Test' prefix) and then
issuing a warning.
