### PR TITLE
Speed up changed task when backed by v2 engine.

### DIFF
--- a/src/python/pants/scm/BUILD
+++ b/src/python/pants/scm/BUILD
@@ -24,6 +24,7 @@ python_library(
   name = 'change_calculator',
   sources = ['change_calculator.py'],
   dependencies = [
+    'src/python/pants/base:specs',
     'src/python/pants/build_graph',
     'src/python/pants/goal:workspace',
   ],

--- a/src/python/pants/scm/change_calculator.py
+++ b/src/python/pants/scm/change_calculator.py
@@ -9,6 +9,7 @@ import logging
 import re
 from abc import abstractmethod
 
+from pants.base.specs import DescendantAddresses
 from pants.build_graph.source_mapper import SpecSourceMapper
 from pants.goal.workspace import ScmWorkspace
 from pants.util.meta import AbstractClass
@@ -55,7 +56,6 @@ class BuildGraphChangeCalculator(ChangeCalculator):
                diffspec=None,
                exclude_target_regexp=None):
     super(BuildGraphChangeCalculator, self).__init__(scm, workspace, changes_since, diffspec)
-    self._address_mapper = address_mapper
     self._build_graph = build_graph
     self._include_dependees = include_dependees
     self._fast = fast
@@ -82,8 +82,8 @@ class BuildGraphChangeCalculator(ChangeCalculator):
       return changed
 
     # Load the whole build graph since we need it for dependee finding in either remaining case.
-    for address in self._address_mapper.scan_addresses():
-      self._build_graph.inject_address_closure(address)
+    for _ in self._build_graph.inject_specs_closure([DescendantAddresses('')]):
+      pass
 
     if self._include_dependees == 'direct':
       return changed.union(*[self._build_graph.dependents_of(addr) for addr in changed])


### PR DESCRIPTION
### Problem

Currently, when backed by the v2 engine the existing `./pants changed` tasks runs incredibly slow (on the order of 1-2 hours in our monorepo) due to `LegacyBuildGraph`-based single-target injection.

### Solution

Use `LegacyBuildGraph.inject_specs_closure([DescendantAddresses('')])` for a full graph walk vs the combination of `LegacyAddressMapper.scan_addresses()` + individual spec injection via `LegacyBuildGraph.inject_address_closure()`.

### Result

`./pants changed ... --include-dependees=transitive` in our monorepo goes from ~1-2 hours to ~2m with the daemon enabled.