### PR TITLE
Default --resolver-allow-prereleases to None.

### DIFF
--- a/src/python/pants/backend/python/subsystems/BUILD
+++ b/src/python/pants/backend/python/subsystems/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies = [
     '3rdparty/python:setuptools',
+    'src/python/pants/option',
     'src/python/pants/subsystem',
   ],
 )

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -9,6 +9,7 @@ import os
 
 from pkg_resources import Requirement
 
+from pants.option.custom_types import UnsetBool
 from pants.subsystem.subsystem import Subsystem
 
 
@@ -56,7 +57,7 @@ class PythonSetup(Subsystem):
              default=10 * 365 * 86400,  # 10 years.
              help='The time in seconds before we consider re-resolving an open-ended requirement, '
                   'e.g. "flask>=0.2" if a matching distribution is available on disk.')
-    register('--resolver-allow-prereleases', advanced=True, type=bool, default=False,
+    register('--resolver-allow-prereleases', advanced=True, type=bool, default=UnsetBool,
              fingerprint=True, help='Whether to include pre-releases when resolving requirements.')
     register('--artifact-cache-dir', advanced=True, default=None, metavar='<dir>',
              help='The parent directory for the python artifact cache. '

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -15,11 +15,18 @@ from pants.util.memo import memoized_method
 from pants.util.strutil import ensure_text
 
 
-# A default value for a bool typed option that indicates it can act as a tri-state that defaults to
-# `None`; ie: the option is un-set.
-#
-# :API: public
-UnsetBool = object()
+class UnsetBool(object):
+  """A type that can be used as the default value for a bool typed option to indicate un-set.
+
+  In other words, `bool`-typed options with a `default=UnsetBool` that are not explicitly set will
+  have the value `None`, enabling a tri-state.
+
+  :API: public
+  """
+
+  def __init__(self):
+    raise NotImplementedError('UnsetBool cannot be instantiated. It should only be used as a '
+                              'sentinel type.')
 
 
 def dict_option(s):

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -15,6 +15,13 @@ from pants.util.memo import memoized_method
 from pants.util.strutil import ensure_text
 
 
+# A default value for a bool typed option that indicates it can act as a tri-state that defaults to
+# `None`; ie: the option is un-set.
+#
+# :API: public
+UnsetBool = object()
+
+
 def dict_option(s):
   """An option of type 'dict'.
 

--- a/tests/python/pants_test/option/test_custom_types.py
+++ b/tests/python/pants_test/option/test_custom_types.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import unittest
 from textwrap import dedent
 
-from pants.option.custom_types import ListValueComponent, dict_option, list_option
+from pants.option.custom_types import ListValueComponent, UnsetBool, dict_option, list_option
 from pants.option.errors import ParseError
 from pants.util.strutil import ensure_binary
 
@@ -31,6 +31,11 @@ class CustomTypesTest(unittest.TestCase):
 
   def _do_split(self, expr, expected):
     self.assertEqual(expected, ListValueComponent._split_modifier_expr(expr))
+
+  def test_unset_bool(self):
+    # UnsetBool should only be use-able as a singleton value via its type.
+    with self.assertRaises(NotImplementedError):
+      UnsetBool()
 
   def test_dict(self):
     self._do_test({}, '{}')

--- a/tests/python/pants_test/option/test_options.py
+++ b/tests/python/pants_test/option/test_options.py
@@ -16,7 +16,7 @@ from textwrap import dedent
 from pants.base.deprecated import CodeRemovedError
 from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.config import Config
-from pants.option.custom_types import file_option, target_option
+from pants.option.custom_types import UnsetBool, file_option, target_option
 from pants.option.errors import (BooleanOptionNameWithNo, FrozenRegistration, ImplicitValIsNone,
                                  InvalidKwarg, InvalidMemberType, MemberTypeNotAllowed,
                                  NoOptionNames, OptionAlreadyRegistered, OptionNameDash,
@@ -76,6 +76,7 @@ class OptionsTest(unittest.TestCase):
     register_global('--store-true-def-false-flag', type=bool, default=False)
     register_global('--store-false-def-false-flag', type=bool, implicit_value=False, default=False)
     register_global('--store-false-def-true-flag', type=bool, implicit_value=False, default=True)
+    register_global('--def-unset-bool-flag', type=bool, default=UnsetBool)
 
     # Choices.
     register_global('--str-choices', choices=['foo', 'bar'])
@@ -281,11 +282,13 @@ class OptionsTest(unittest.TestCase):
     self.assertTrue(options.for_global_scope().store_true_def_true_flag)
     self.assertFalse(options.for_global_scope().store_false_def_false_flag)
     self.assertTrue(options.for_global_scope().store_false_def_true_flag)
+    self.assertIsNone(options.for_global_scope().def_unset_bool_flag)
 
   def test_boolean_set_option(self):
     options = self._parse('./pants --store-true-flag --store-false-flag '
                           ' --store-true-def-true-flag --store-true-def-false-flag '
-                          ' --store-false-def-true-flag --store-false-def-false-flag')
+                          ' --store-false-def-true-flag --store-false-def-false-flag '
+                          ' --def-unset-bool-flag')
 
     self.assertTrue(options.for_global_scope().store_true_flag)
     self.assertFalse(options.for_global_scope().store_false_flag)
@@ -293,17 +296,20 @@ class OptionsTest(unittest.TestCase):
     self.assertTrue(options.for_global_scope().store_true_def_true_flag)
     self.assertFalse(options.for_global_scope().store_false_def_false_flag)
     self.assertFalse(options.for_global_scope().store_false_def_true_flag)
+    self.assertTrue(options.for_global_scope().def_unset_bool_flag)
 
   def test_boolean_negate_option(self):
     options = self._parse('./pants --no-store-true-flag --no-store-false-flag '
                           ' --no-store-true-def-true-flag --no-store-true-def-false-flag '
-                          ' --no-store-false-def-true-flag --no-store-false-def-false-flag')
+                          ' --no-store-false-def-true-flag --no-store-false-def-false-flag '
+                          ' --no-def-unset-bool-flag')
     self.assertFalse(options.for_global_scope().store_true_flag)
     self.assertTrue(options.for_global_scope().store_false_flag)
     self.assertFalse(options.for_global_scope().store_true_def_false_flag)
     self.assertFalse(options.for_global_scope().store_true_def_true_flag)
     self.assertTrue(options.for_global_scope().store_false_def_false_flag)
     self.assertTrue(options.for_global_scope().store_false_def_true_flag)
+    self.assertFalse(options.for_global_scope().def_unset_bool_flag)
 
   def test_boolean_config_override_true(self):
     options = self._parse('./pants', config={'DEFAULT': {'store_true_flag': True,
@@ -312,6 +318,7 @@ class OptionsTest(unittest.TestCase):
                                                          'store_true_def_false_flag': True,
                                                          'store_false_def_true_flag': True,
                                                          'store_false_def_false_flag': True,
+                                                         'def_unset_bool_flag': True,
                                                          }})
     self.assertTrue(options.for_global_scope().store_true_flag)
     self.assertTrue(options.for_global_scope().store_false_flag)
@@ -319,6 +326,7 @@ class OptionsTest(unittest.TestCase):
     self.assertTrue(options.for_global_scope().store_true_def_true_flag)
     self.assertTrue(options.for_global_scope().store_false_def_false_flag)
     self.assertTrue(options.for_global_scope().store_false_def_true_flag)
+    self.assertTrue(options.for_global_scope().def_unset_bool_flag)
 
   def test_boolean_config_override_false(self):
     options = self._parse('./pants', config={'DEFAULT': {'store_true_flag': False,
@@ -327,6 +335,7 @@ class OptionsTest(unittest.TestCase):
                                                          'store_true_def_false_flag': False,
                                                          'store_false_def_true_flag': False,
                                                          'store_false_def_false_flag': False,
+                                                         'def_unset_bool_flag': False,
                                                          }})
     self.assertFalse(options.for_global_scope().store_true_flag)
     self.assertFalse(options.for_global_scope().store_false_flag)
@@ -334,6 +343,7 @@ class OptionsTest(unittest.TestCase):
     self.assertFalse(options.for_global_scope().store_true_def_true_flag)
     self.assertFalse(options.for_global_scope().store_false_def_false_flag)
     self.assertFalse(options.for_global_scope().store_false_def_true_flag)
+    self.assertFalse(options.for_global_scope().def_unset_bool_flag)
 
   def test_boolean_invalid_value(self):
     with self.assertRaises(Parser.BooleanConversionError):


### PR DESCRIPTION
Add a sentinel value that can be used to indicate a bool option
can in fact take on a tri-state to support this.