### PR TITLE
Fix resource loading issue in the python eval task.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/BUILD
@@ -3,8 +3,8 @@
 
 python_library(
   dependencies=[
+    ':resources',
     '3rdparty/python:pex',
-    'contrib/python/src/python/pants/contrib/python/checks/tasks:resources',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks2',
     'src/python/pants/base:exceptions',
@@ -12,4 +12,9 @@ python_library(
     'src/python/pants/base:workunit',
     'src/python/pants/util:dirutil',
   ]
+)
+
+resources(
+  name='resources',
+  sources=globs('templates/python_eval/*.mustache'),
 )

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
@@ -41,7 +41,7 @@ class PythonEval(ResolveRequirementsTaskBase):
       self.failed = failed
 
   _EXEC_NAME = '__pants_executable__'
-  _EVAL_TEMPLATE_PATH = os.path.join('..', 'tasks', 'templates', 'python_eval', 'eval.py.mustache')
+  _EVAL_TEMPLATE_PATH = os.path.join('templates', 'python_eval', 'eval.py.mustache')
 
   @classmethod
   def prepare(cls, options, round_manager):

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/templates/python_eval/eval.py.mustache
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/templates/python_eval/eval.py.mustache
@@ -1,0 +1,45 @@
+from __future__ import print_function
+
+import inspect
+import os
+import sys
+import traceback
+
+
+def backtrace_to_here():
+  trace = inspect.trace(context=1)
+  trace.pop(0)  # discard this helper function frame
+
+  pre_processed = []
+  for info in trace:
+    frame = info[0]
+    tb = inspect.getframeinfo(frame)
+    filename = tb.filename
+    if filename.startswith('{{chroot_parent}}'):
+      relpath_parent = os.path.relpath(filename, '{{chroot_parent}}')
+      relpath = relpath_parent.split(os.sep, 1)[1]
+      filename = os.path.join('[srcroot]', relpath)
+    line_text = tb.code_context[tb.index]
+    pre_processed.append((filename, tb.lineno, tb.function, line_text))
+
+  return ''.join(traceback.format_list(pre_processed)).rstrip()
+
+
+def log(message=''):
+  print(message, file=sys.stderr)
+
+
+if __name__ == '__main__':
+  # TODO(John Sirois): Consider collecting all import errors before exiting non-zero.
+  {{#modules}}
+  try:
+    {{import_statement}}
+  except ImportError as e:
+    log()
+    log("Failed to eval '{{source}}':")
+    log(backtrace_to_here())
+    log(str(e))
+    sys.exit(1)
+
+  {{/modules}}
+  sys.exit(0)


### PR DESCRIPTION
Turns out that `..` is not allowed in the path (which makes sense),
but this worked in practice when running from loose sources.

This change copies the relevant resource to the 'tasks2' dir, so that
the new task can load it from there.  It's a shame about the duplication,
but it's only temporary (and I didn't want to start messing around with 
symlinks in git, which can get confusing quickly).