### PR TITLE
Replace `indices` with `indexes` in docs

### DIFF
--- a/src/docs/setup_repo.md
+++ b/src/docs/setup_repo.md
@@ -246,7 +246,7 @@ For python repos, you need to override the following settings in pants.ini:
         "https://pantsbuild.github.io/cheeseshop/third_party/python/index.html"
       ]
 
-    indices: [
+    indexes: [
         "https://pypi.python.org/simple/"
       ]
 


### PR DESCRIPTION
### Problem

The docs refer to a non existent configuration option `python-repos.indices`. Apparently, the one that is currently (1.2.1) works is `python-repos.indexes`. 