### PR TITLE
Fix some compiler plugin documentation nits.

### DIFF
--- a/examples/src/java/org/pantsbuild/example/javac/plugin/README.md
+++ b/examples/src/java/org/pantsbuild/example/javac/plugin/README.md
@@ -88,6 +88,7 @@ java_library(
 
 In order to load a plugin, it has to be on javac's classpath. 
 This can be achieved in one of two ways:
+
 - Have targets that must be compiled with a plugin depend (directly or indirectly) 
 either on the `javac_plugin` target, or on a `jar_library` pointing to a published version
 of the plugin.

--- a/examples/src/java/org/pantsbuild/example/javac/plugin/README.md
+++ b/examples/src/java/org/pantsbuild/example/javac/plugin/README.md
@@ -77,8 +77,8 @@ These are specified like this:
 ```
 java_library(
   ...
-  javac_plugins: ['simple_javac_plugin'],
-  javac_plugin_args: {
+  javac_plugins=['simple_javac_plugin'],
+  javac_plugin_args={
       'simple_javac_plugin': ['arg1', 'arg2']
     }
 )

--- a/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
+++ b/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
@@ -76,8 +76,8 @@ These are specified like this:
 ```
 scala_library(
   ...
-  scalac_plugins: ['simple_scalac_plugin'],
-  scalac_plugin_args: {
+  scalac_plugins=['simple_scalac_plugin'],
+  scalac_plugin_args={
       'simple_scalac_plugin': ['arg1', 'arg2']
     }
 )

--- a/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
+++ b/examples/src/scala/org/pantsbuild/example/scalac/plugin/README.md
@@ -87,6 +87,7 @@ scala_library(
 
 In order to load a plugin, it has to be on scalac's classpath. 
 This can be achieved in one of two ways:
+
 - Have targets that must be compiled with a plugin depend (directly or indirectly) 
 either on the `scalac_plugin` target, or on a `jar_library` pointing to a published version
 of the plugin.

--- a/src/python/pants/backend/jvm/subsystems/java.py
+++ b/src/python/pants/backend/jvm/subsystems/java.py
@@ -36,7 +36,7 @@ class Java(JvmToolMixin, ZincLanguageMixin, Subsystem):
 
     register('--compiler-plugin-deps', advanced=True, type=list, member_type=target_option,
              removal_version='1.5.0.dev0',
-             removal_hint='Use --compile-zinc-javac-plugin-deps instead.',
+             removal_hint='See http://www.pantsbuild.org/javac_plugins.html#depending-on-plugins.',
              fingerprint=True)
 
   @classmethod


### PR DESCRIPTION
The deprecation help message was incorrect.

The markdown bullet points weren't rendering correctly 
(see http://www.pantsbuild.org/javac_plugins.html#depending-on-plugins)