### PR TITLE
Avoid re-walking for every target root in minimize

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/minimal_cover.py
+++ b/src/python/pants/backend/graph_info/tasks/minimal_cover.py
@@ -5,8 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.task.console_task import ConsoleTask
 from pants.build_graph.target import Target
+from pants.task.console_task import ConsoleTask
 
 
 class MinimalCover(ConsoleTask):

--- a/src/python/pants/backend/graph_info/tasks/minimal_cover.py
+++ b/src/python/pants/backend/graph_info/tasks/minimal_cover.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.task.console_task import ConsoleTask
+from pants.build_graph.target import Target
 
 
 class MinimalCover(ConsoleTask):
@@ -16,9 +17,7 @@ class MinimalCover(ConsoleTask):
   """
 
   def console_output(self, _):
-    internal_deps = set()
-    for target in self.context.target_roots:
-      internal_deps.update(self._collect_internal_deps(target))
+    internal_deps = self._collect_internal_deps(self.context.target_roots)
 
     minimal_cover = set()
     for target in self.context.target_roots:
@@ -26,8 +25,13 @@ class MinimalCover(ConsoleTask):
         minimal_cover.add(target)
         yield target.address.spec
 
-  def _collect_internal_deps(self, target):
-    internal_deps = set()
-    target.walk(internal_deps.add)
-    internal_deps.discard(target)
-    return internal_deps
+  def _collect_internal_deps(self, targets):
+    """Collect one level of dependencies from the given targets, and then transitively walk.
+
+    This is different from directly executing `Target.closure_for_targets`, because the
+    resulting set will not include the roots unless the roots depend on one another.
+    """
+    roots = set()
+    for target in targets:
+      roots.update(target.dependencies)
+    return Target.closure_for_targets(roots)


### PR DESCRIPTION
### Problem

`./pants minimize` executes `Target.walk` once per target... each call to `Target.walk` memoizes visited dependencies, but for a command like `./pants minimize ::`, this still adds up to doing n^2 node visits.

### Solution

Use an equivalent call to `Target.closure_for_targets` to reduce the runtime.

### Result

The runtime of `./pants --no-enable-v2-engine minimize ::` in `pantsbuild/pants` (~1.5k targets) is reduced by 10-15%, and in Twitter's repo (~55k targets) is reduced by ~50%.

And with a warm copy of the v2 engine+daemon in Twitter's repo, the runtime for `minimize` drops by ~90%.