### PR TITLE
Add ParseContext singleton helper

### DIFF
--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -9,11 +9,12 @@ import functools
 import threading
 
 
-class ObjectNamespace(threading.local):
-  def __init__(self):
-    self.clear()
+class Storage(threading.local):
+  def __init__(self, rel_path):
+    self.clear(rel_path)
 
-  def clear(self):
+  def clear(self, rel_path):
+    self.rel_path = rel_path
     self.objects_by_name = dict()
     self.objects = []
 
@@ -48,9 +49,8 @@ class ParseContext(object):
       constructor for the alias.
     """
 
-    self._rel_path = rel_path
     self._type_aliases = type_aliases
-    self._object_namespace = ObjectNamespace()
+    self._storage = Storage(rel_path)
 
   def create_object(self, alias, *args, **kwargs):
     """Constructs the type with the given alias using the given args and kwargs.
@@ -90,7 +90,7 @@ class ParseContext(object):
                                     name=name,
                                     *args,
                                     **kwargs)
-    return self._object_namespace.add_if_not_exists(name, obj_creator)
+    return self._storage.add_if_not_exists(name, obj_creator)
 
   @property
   def rel_path(self):
@@ -100,4 +100,4 @@ class ParseContext(object):
 
     :rtype string
     """
-    return self._rel_path
+    return self._storage.rel_path

--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -4,6 +4,8 @@
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
+
+import functools
 import threading
 
 
@@ -24,15 +26,15 @@ class ObjectNamespace(threading.local):
   def add_if_not_exists(self, name, obj_creator):
     if name is None:
       raise ValueError('Method requires a `name`d object.')
-    obj = self._objects_by_name.get(name)
+    obj = self.objects_by_name.get(name)
     if obj is None:
-      obj = self._objects[name] = obj_creator()
+      obj = self.objects_by_name[name] = obj_creator()
     return obj
 
 
 class ParseContext(object):
   """The build file context that context aware objects - aka BUILD macros - operate against.
-  
+
   All fields of the ParseContext must be assumed to be mutable by macros, and should
   thus only be consumed in the context of a macro's `__call__` method (rather than
   in its `__init__`).

--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -4,19 +4,58 @@
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
+import threading
+
+
+class ObjectNamespace(threading.local):
+  def __init__(self):
+    self.clear()
+
+  def clear(self):
+    self.objects_by_name = dict()
+    self.objects = []
+
+  def add(self, obj, name=None):
+    if name is not None:
+      # NB: `src/python/pants/engine/mapper.py` will detect an overwritten object later.
+      self.objects_by_name[name] = obj
+    self.objects.append(obj)
+
+  def add_if_not_exists(self, name, obj_creator):
+    if name is None:
+      raise ValueError('Method requires a `name`d object.')
+    obj = self._objects_by_name.get(name)
+    if obj is None:
+      obj = self._objects[name] = obj_creator()
+    return obj
 
 
 class ParseContext(object):
-  """The build file context that context aware objects - aka BUILD macros - operate against."""
+  """The build file context that context aware objects - aka BUILD macros - operate against.
+  
+  All fields of the ParseContext must be assumed to be mutable by macros, and should
+  thus only be consumed in the context of a macro's `__call__` method (rather than
+  in its `__init__`).
+  """
 
   def __init__(self, rel_path, type_aliases):
+    """Create a ParseContext.
+
+    :param rel_path: The (build file) path that the parse is currently operating on: initially None.
+    :param type_aliases: A dictionary of alias name strings or alias classes to a callable
+      constructor for the alias.
+    """
+
     self._rel_path = rel_path
     self._type_aliases = type_aliases
+    self._object_namespace = ObjectNamespace()
 
   def create_object(self, alias, *args, **kwargs):
     """Constructs the type with the given alias using the given args and kwargs.
 
     NB: aliases may be the alias' object type itself if that type is known.
+
+    :API: public
 
     :param alias: Either the type alias or the type itself.
     :type alias: string|type
@@ -29,9 +68,33 @@ class ParseContext(object):
       raise KeyError('There is no type registered for alias {0}'.format(alias))
     return object_type(*args, **kwargs)
 
+  def create_object_if_not_exists(self, alias, name=None, *args, **kwargs):
+    """Constructs the type with the given alias using the given args and kwargs.
+
+    NB: aliases may be the alias' object type itself if that type is known.
+
+    :API: public
+
+    :param alias: Either the type alias or the type itself.
+    :type alias: string|type
+    :param *args: These pass through to the underlying callable object.
+    :param **kwargs: These pass through to the underlying callable object.
+    :returns: The created object, or an existing object with the same `name`.
+    """
+    if name is None:
+      raise ValueError("Method requires an object `name`.")
+    obj_creator = functools.partial(self.create_object,
+                                    alias,
+                                    name=name,
+                                    *args,
+                                    **kwargs)
+    return self._object_namespace.add_if_not_exists(name, obj_creator)
+
   @property
   def rel_path(self):
     """Relative path from the build root to the BUILD file the context aware object is called in.
+
+    :API: public
 
     :rtype string
     """

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -22,7 +22,10 @@ logger = logging.getLogger(__name__)
 class BuildConfiguration(object):
   """Stores the types and helper functions exposed to BUILD files."""
 
-  ParseState = namedtuple('ParseState', ['parse_context', 'parse_globals'])
+  class ParseState(namedtuple('ParseState', ['parse_context', 'parse_globals'])):
+    @property
+    def objects(self):
+      return self.parse_context._object_namespace.objects
 
   def __init__(self):
     self._target_by_alias = {}

--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -25,7 +25,7 @@ class BuildConfiguration(object):
   class ParseState(namedtuple('ParseState', ['parse_context', 'parse_globals'])):
     @property
     def objects(self):
-      return self.parse_context._object_namespace.objects
+      return self.parse_context._storage.objects
 
   def __init__(self):
     self._target_by_alias = {}
@@ -151,7 +151,7 @@ class BuildConfiguration(object):
 
     def create_call_proxy(tgt_type, tgt_alias=None):
       def registration_callback(address, addressable):
-        parse_context._object_namespace.add(addressable, name=address.target_name)
+        parse_context._storage.add(addressable, name=address.target_name)
       addressable_factory = self._get_addressable_factory(tgt_type, tgt_alias)
       return AddressableCallProxy(addressable_factory=addressable_factory,
                                   build_file=build_file,

--- a/src/python/pants/build_graph/build_file_parser.py
+++ b/src/python/pants/build_graph/build_file_parser.py
@@ -143,22 +143,25 @@ class BuildFileParser(object):
       raise self.ExecuteError("{message}\n while executing BUILD file {build_file}"
                               .format(message=e, build_file=build_file))
 
-    address_map = {}
-    for address, addressable in parse_state.registered_addressable_instances:
-      logger.debug('Adding {addressable} to the BuildFileParser address map with {address}'
+    name_map = {}
+    for addressable in parse_state.parse_context._object_namespace.objects:
+      name = addressable.addressed_name
+      logger.debug('Adding {addressable} to the BuildFileParser address map for {build_file} with {name}'
                    .format(addressable=addressable,
-                           address=address))
-      if address in address_map:
-        raise self.AddressableConflictException(
+                           build_file=build_file,
+                           name=name))
+      if name in name_map:
+        raise self.AddressableConflictException( 
           "File {conflicting_file} defines address '{target_name}' more than once."
-          .format(conflicting_file=address.build_file,
-                  target_name=address.target_name))
-      address_map[address] = addressable
+          .format(conflicting_file=build_file,
+                  target_name=name))
+      name_map[name] = addressable
 
     logger.debug("{build_file} produced the following Addressables:"
                  .format(build_file=build_file))
-    for address, addressable in address_map.items():
-      logger.debug("  * {address}: {addressable}"
-                   .format(address=address,
+    for name, addressable in name_map.items():
+      logger.debug("  * {name}: {addressable}"
+                   .format(name=name,
                            addressable=addressable))
+    
     return address_map

--- a/src/python/pants/build_graph/build_file_parser.py
+++ b/src/python/pants/build_graph/build_file_parser.py
@@ -10,6 +10,8 @@ import warnings
 
 import six
 
+from pants.build_graph.address import BuildFileAddress
+
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +153,7 @@ class BuildFileParser(object):
                            build_file=build_file,
                            name=name))
       if name in name_map:
-        raise self.AddressableConflictException( 
+        raise self.AddressableConflictException(
           "File {conflicting_file} defines address '{target_name}' more than once."
           .format(conflicting_file=build_file,
                   target_name=name))
@@ -159,9 +161,11 @@ class BuildFileParser(object):
 
     logger.debug("{build_file} produced the following Addressables:"
                  .format(build_file=build_file))
+    address_map = {}
     for name, addressable in name_map.items():
+      address_map[BuildFileAddress(build_file=build_file, target_name=name)] = addressable
       logger.debug("  * {name}: {addressable}"
                    .format(name=name,
                            addressable=addressable))
-    
+
     return address_map

--- a/src/python/pants/build_graph/build_file_parser.py
+++ b/src/python/pants/build_graph/build_file_parser.py
@@ -146,7 +146,7 @@ class BuildFileParser(object):
                               .format(message=e, build_file=build_file))
 
     name_map = {}
-    for addressable in parse_state.parse_context.objects:
+    for addressable in parse_state.objects:
       name = addressable.addressed_name
       logger.debug('Adding {addressable} to the BuildFileParser address map for {build_file} with {name}'
                    .format(addressable=addressable,

--- a/src/python/pants/build_graph/build_file_parser.py
+++ b/src/python/pants/build_graph/build_file_parser.py
@@ -146,7 +146,7 @@ class BuildFileParser(object):
                               .format(message=e, build_file=build_file))
 
     name_map = {}
-    for addressable in parse_state.parse_context._object_namespace.objects:
+    for addressable in parse_state.parse_context.objects:
       name = addressable.addressed_name
       logger.debug('Adding {addressable} to the BuildFileParser address map for {build_file} with {name}'
                    .format(addressable=addressable,

--- a/src/python/pants/build_graph/intermediate_target_factory.py
+++ b/src/python/pants/build_graph/intermediate_target_factory.py
@@ -24,14 +24,8 @@ def hash_target(address, suffix):
 class IntermediateTargetFactoryBase(AbstractClass):
   """Convenience factory which constructs an intermediate target with the appropriate attributes."""
 
-  _targets = set()
-
   class ExpectedAddressError(TargetDefinitionException):
     """Thrown if an object that is not an address is used as the dependency spec."""
-
-  @classmethod
-  def reset(cls):
-    cls._targets.clear()
 
   def __init__(self, parse_context):
     self._parse_context = parse_context
@@ -63,13 +57,11 @@ class IntermediateTargetFactoryBase(AbstractClass):
       index=hash_str,
     )
 
-    #if (name, self._parse_context.rel_path) not in self._targets:
-    self._parse_context.create_object(
+    self._parse_context.create_object_if_not_exists(
       'target',
       name=name,
       dependencies=[address.spec],
       **self.extra_target_arguments
     )
-    self._targets.add((name, self._parse_context.rel_path))
 
     return ':{}'.format(name)

--- a/src/python/pants/build_graph/intermediate_target_factory.py
+++ b/src/python/pants/build_graph/intermediate_target_factory.py
@@ -63,13 +63,13 @@ class IntermediateTargetFactoryBase(AbstractClass):
       index=hash_str,
     )
 
-    if (name, self._parse_context.rel_path) not in self._targets:
-      self._parse_context.create_object(
-        'target',
-        name=name,
-        dependencies=[address.spec],
-        **self.extra_target_arguments
-      )
-      self._targets.add((name, self._parse_context.rel_path))
+    #if (name, self._parse_context.rel_path) not in self._targets:
+    self._parse_context.create_object(
+      'target',
+      name=name,
+      dependencies=[address.spec],
+      **self.extra_target_arguments
+    )
+    self._targets.add((name, self._parse_context.rel_path))
 
     return ':{}'.format(name)

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import threading
 
 import six
 

--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -70,7 +70,7 @@ class LegacyPythonCallbacksParser(Parser):
         if name and self._serializable:
           kwargs.setdefault('type_alias', self._type_alias)
           obj = self._object_type(**kwargs)
-          parse_context._object_namespace.add(obj)
+          parse_context._storage.add(obj)
           return obj
         else:
           return self._object_type(*args, **kwargs)
@@ -112,13 +112,7 @@ class LegacyPythonCallbacksParser(Parser):
     symbols, parse_context = cls._get_symbols(symbol_table_cls)
     python = filecontent
 
-    # Mutate the parse context for the new path, and clear its (thread local) object_namespace
-    parse_context._rel_path = os.path.dirname(filepath)
-
-    # Then exec, copy the resulting objects, and clear the namespace.
+    # Mutate the parse context for the new path, then exec, and copy the resulting objects.
+    parse_context._storage.clear(os.path.dirname(filepath))
     six.exec_(python, symbols)
-    resulting_objects = list(parse_context._object_namespace.objects)
-    parse_context._object_namespace.clear()
-
-    # Return resulting objects.
-    return resulting_objects
+    return list(parse_context._storage.objects)

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.build_graph.intermediate_target_factory import IntermediateTargetFactoryBase
 from pants.goal.goal import Goal
 from pants.goal.run_tracker import RunTracker
 from pants.init.options_initializer import OptionsInitializer
@@ -25,9 +24,6 @@ def clean_global_runtime_state(reset_runtracker=True, reset_subsystem=False):
   if reset_subsystem:
     # Reset subsystem state.
     Subsystem.reset()
-
-  #TODO: Think of an alternative for IntermediateTargetFactoryBase._targets to avoid this call
-  IntermediateTargetFactoryBase.reset()
 
   # Reset Goals and Tasks.
   Goal.clear()

--- a/tests/python/pants_test/build_graph/test_build_configuration.py
+++ b/tests/python/pants_test/build_graph/test_build_configuration.py
@@ -43,14 +43,14 @@ class BuildConfigurationTest(unittest.TestCase):
     with self._create_mock_build_file('fred') as build_file:
       parse_state = self.build_configuration.initialize_parse_state(build_file)
 
-      self.assertEqual(0, len(parse_state.registered_addressable_instances))
+      self.assertEqual(0, len(parse_state.objects))
       self.assertEqual(1, len(parse_state.parse_globals))
 
       target_call_proxy = parse_state.parse_globals['fred']
       target_call_proxy(name='jake')
 
-      self.assertEqual(1, len(parse_state.registered_addressable_instances))
-      name, target_proxy = parse_state.registered_addressable_instances.pop()
+      self.assertEqual(1, len(parse_state.objects))
+      target_proxy = parse_state.objects[0]
       self.assertEqual('jake', target_proxy.addressed_name)
       self.assertEqual(Fred, target_proxy.addressed_type)
 
@@ -85,14 +85,14 @@ class BuildConfigurationTest(unittest.TestCase):
     with self._create_mock_build_file('fred') as build_file:
       parse_state = self.build_configuration.initialize_parse_state(build_file)
 
-      self.assertEqual(0, len(parse_state.registered_addressable_instances))
+      self.assertEqual(0, len(parse_state.objects))
       self.assertEqual(1, len(parse_state.parse_globals))
 
       target_call_proxy = parse_state.parse_globals['fred']
       target_call_proxy(name='jake')
 
-      self.assertEqual(1, len(parse_state.registered_addressable_instances))
-      name, target_proxy = parse_state.registered_addressable_instances.pop()
+      self.assertEqual(1, len(parse_state.objects))
+      target_proxy = parse_state.objects[0]
       self.assertEqual('frog', target_proxy.addressed_name)
       self.assertEqual(Fred, target_proxy.addressed_type)
       self.assertEqual(['jake'], target_proxy.dependency_specs)
@@ -109,7 +109,7 @@ class BuildConfigurationTest(unittest.TestCase):
     with self._create_mock_build_file('jane') as build_file:
       parse_state = self.build_configuration.initialize_parse_state(build_file)
 
-      self.assertEqual(0, len(parse_state.registered_addressable_instances))
+      self.assertEqual(0, len(parse_state.objects))
       self.assertEqual(1, len(parse_state.parse_globals))
       self.assertEqual(42, parse_state.parse_globals['jane'])
 
@@ -169,7 +169,7 @@ class BuildConfigurationTest(unittest.TestCase):
       build_file = BuildFile(FileSystemProjectTree(root), 'george/BUILD')
       parse_state = self.build_configuration.initialize_parse_state(build_file)
 
-      self.assertEqual(0, len(parse_state.registered_addressable_instances))
+      self.assertEqual(0, len(parse_state.objects))
       self.assertEqual(1, len(parse_state.parse_globals))
       yield parse_state.parse_globals['george']
 


### PR DESCRIPTION
### Problem

Because no capability for parse-local state existed, `IntermediateTargetFactory` used class-local state to determine whether a singleton intermediate target had been created, rather than parse-local state.

The result was fragile... a subtle symptom (#4416) was that after a buildfile was invalidated in the daemon, the singleton targets it contained would not be recreated, causing them to go missing completely. A more obvious symptom was that `init.py` needed to reset the class-level state to ensure that intermediate targets could be recreated.

### Solution

Add support for parse-level state via a new method `create_object_if_not_exists` on `ParseContext`, and mark the already effectively-public methods of `ParseContext` as such.

As an orthogonal change, move from using a lock to guard the collection of created objects to using a thread-local collection.

### Result

Daemon runs that involve intermediate/'scoped'/'provided' targets that have been invalidated will succeed. Fixes #4416