### PR TITLE
Bump scala platform versions to 2.11.11 and 2.12.2

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -24,7 +24,7 @@ major_version_info = namedtuple('major_version_info', ['full_version'])
 scala_build_info = {
   '2.10': major_version_info(full_version='2.10.6'),
   '2.11': major_version_info(full_version='2.11.9'),
-  '2.12': major_version_info(full_version='2.12.1'),
+  '2.12': major_version_info(full_version='2.12.2'),
 }
 
 

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -23,7 +23,7 @@ major_version_info = namedtuple('major_version_info', ['full_version'])
 # runtime library (when compiling plugins, which require the compiler library as a dependency).
 scala_build_info = {
   '2.10': major_version_info(full_version='2.10.6'),
-  '2.11': major_version_info(full_version='2.11.9'),
+  '2.11': major_version_info(full_version='2.11.11'),
   '2.12': major_version_info(full_version='2.12.2'),
 }
 

--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -23,7 +23,7 @@ major_version_info = namedtuple('major_version_info', ['full_version'])
 # runtime library (when compiling plugins, which require the compiler library as a dependency).
 scala_build_info = {
   '2.10': major_version_info(full_version='2.10.6'),
-  '2.11': major_version_info(full_version='2.11.8'),
+  '2.11': major_version_info(full_version='2.11.9'),
   '2.12': major_version_info(full_version='2.12.1'),
 }
 

--- a/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export_integration.py
@@ -147,13 +147,13 @@ class ExportIntegrationTest(ResolveJarsTestMixin, PantsRunIntegrationTest):
 
   def test_sources_and_javadocs(self):
     with self.temporary_workdir() as workdir:
-      test_target = 'examples/src/scala/org/pantsbuild/example/scala_with_java_sources'
+      test_target = 'testprojects/src/scala/org/pantsbuild/testproject/unicode/shapeless'
       json_data = self.run_export(test_target, workdir, load_libs=True)
-      scala_lang_lib = json_data.get('libraries').get('org.scala-lang:scala-library:2.11.8')
-      self.assertIsNotNone(scala_lang_lib)
-      self.assertIsNotNone(scala_lang_lib['default'])
-      self.assertIsNotNone(scala_lang_lib['sources'])
-      self.assertIsNotNone(scala_lang_lib['javadoc'])
+      shapeless_lib = json_data.get('libraries').get('com.chuusai:shapeless_2.11:2.2.5')
+      self.assertIsNotNone(shapeless_lib)
+      self.assertIsNotNone(shapeless_lib['default'])
+      self.assertIsNotNone(shapeless_lib['sources'])
+      self.assertIsNotNone(shapeless_lib['javadoc'])
 
   # This test fails when the `PANTS_IVY_CACHE_DIR` is set to something that isn't
   # the default location.  The set cache_dir likely needs to be plumbed down

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish.hello/welcome_2.11/welcome_2.11-0.0.1-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish.hello/welcome_2.11/welcome_2.11-0.0.1-SNAPSHOT.pom
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.8</version>
+      <version>2.11.9</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish.hello/welcome_2.11/welcome_2.11-0.0.1-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish.hello/welcome_2.11/welcome_2.11-0.0.1-SNAPSHOT.pom
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.9</version>
+      <version>2.11.11</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-0.0.1-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-0.0.1-SNAPSHOT.pom
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.8</version>
+      <version>2.11.9</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-0.0.1-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-0.0.1-SNAPSHOT.pom
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.9</version>
+      <version>2.11.11</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-1.2.3-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-1.2.3-SNAPSHOT.pom
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.8</version>
+      <version>2.11.9</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-1.2.3-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/classifiers_2.11-1.2.3-SNAPSHOT.pom
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.9</version>
+      <version>2.11.11</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/jvm-example-lib_2.11/jvm-example-lib_2.11-0.0.1-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/jvm-example-lib_2.11/jvm-example-lib_2.11-0.0.1-SNAPSHOT.pom
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.8</version>
+      <version>2.11.9</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/jvm-example-lib_2.11/jvm-example-lib_2.11-0.0.1-SNAPSHOT.pom
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/jvm-example-lib_2.11/jvm-example-lib_2.11-0.0.1-SNAPSHOT.pom
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.9</version>
+      <version>2.11.11</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Problem

New stable releases of Scala arrived, but are not yet the default in pants.

### Solution

Add the `2.11.11` and `2.12.2` versions as the defaults for their platforms.