### PR TITLE
Bring back --no-fast mode in pytest run.

### DIFF
--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -75,7 +75,7 @@ class PytestRun(TestRunnerTaskMixin, PythonExecutionTaskBase):
     register('--fast', type=bool, default=True,
              help='Run all tests in a single pytest invocation. If turned off, each test target '
                   'will run in its own pytest invocation, which will be slower, but isolates '
-                  'tests from process-wide state created by test in other targets.')
+                  'tests from process-wide state created by tests in other targets.')
     register('--junit-xml-dir', metavar='<DIR>',
              help='Specifying a directory causes junit xml results files to be emitted under '
                   'that dir for each test run.')


### PR DESCRIPTION
Note however that this is a little different from the previous
implementation in the old backend.  The old implementation allowed
you to run tests with conflicting requirements in a single pants
invocation. This implementation allows you to run each test in its
own pytest invocation, so that tests in other targets can't pollute
a test's environmnent, but all targets in a single invocation must
still be able to resolve their requirements together.

In the future we hope to add back the ability to run multiple
conflicting tests in a single invocation of Pants, but that is
out of scope for this change.
