### PR TITLE
Keep failed target mapping free from `None` key.

### DIFF
--- a/src/python/pants/java/junit/junit_xml_parser.py
+++ b/src/python/pants/java/junit/junit_xml_parser.py
@@ -156,7 +156,11 @@ def parse_failed_targets(test_registry, junit_xml_path, error_handler):
             test = Test(classname=testcase.getAttribute('classname'),
                         methodname=testcase.getAttribute('name'))
             target = test_registry.get_owning_target(test)
-            failed_targets[target].add(test)
+            # There are some cases where we'll fail to find an owning target; in which case its
+            # better to have partial failure results, than none at all due to an internal error.
+            # See: https://github.com/pantsbuild/pants/pull/4055
+            if target:
+              failed_targets[target].add(test)
     except (XmlParser.XmlError, ValueError) as e:
       error_handler(ParseError(path, e))
 

--- a/tests/python/pants_test/java/junit/test_junit_xml_parser.py
+++ b/tests/python/pants_test/java/junit/test_junit_xml_parser.py
@@ -183,4 +183,4 @@ class TestParseFailedTargets(unittest.TestCase):
       self.assertEqual(2, len(collect_handler.errors))
       self.assertEqual({bad_file1, bad_file2}, {e.junit_xml_path for e in collect_handler.errors})
 
-      self.assertEqual({None: {JUnitTest('org.pantsbuild.Error', 'testError')}}, failed_targets)
+      self.assertEqual({}, failed_targets)


### PR DESCRIPTION
Consumers don't know how to handle `None`. The longer term fix will be
to enhance consumers to be able to handle failed tests without
identifiable owning targets.