### PR TITLE
Make go targets work with v2 changed.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
@@ -58,17 +58,18 @@ class GoLocalSource(GoTarget):
     """
     raise NotImplementedError()
 
-  def __init__(self, address=None, payload=None, **kwargs):
-    # We grab all files in the current directory except BUILD files for 2 reasons:
-    # 1. cgo: If a file imports "C" then it may rely on sibling .c, .cc, etc files that `go build`
-    #    will compile.
-    # 2. resources: Even though go does not support them; ie by providing a protocol to embed them
-    #    in binaries, it does allow them to be placed in a directory where a test might use them
-    #    for example via plain old filesystem access.
-    globs = Globs(ParseContext(rel_path=address.spec_path, type_aliases={}))
-    sources = globs('*', exclude=[globs('BUILD*'),
-                                  # This skips subdir content.
-                                  globs('*/**')])
+  def __init__(self, address=None, payload=None, sources=None, **kwargs):
+    if not sources:
+      # We grab all files in the current directory except BUILD files for 2 reasons:
+      # 1. cgo: If a file imports "C" then it may rely on sibling .c, .cc, etc files that `go build`
+      #    will compile.
+      # 2. resources: Even though go does not support them; ie by providing a protocol to embed them
+      #    in binaries, it does allow them to be placed in a directory where a test might use them
+      #    for example via plain old filesystem access.
+      globs = Globs(ParseContext(rel_path=address.spec_path, type_aliases={}))
+      sources = globs('*', exclude=[globs('BUILD*'),
+                                    # This skips subdir content.
+                                    globs('*/**')])
 
     payload = payload or Payload()
     payload.add_fields({

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -17,10 +17,10 @@ from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.change_calculator import EngineChangeCalculator
 from pants.engine.legacy.graph import HydratedTargets, LegacyBuildGraph, create_legacy_graph_tasks
 from pants.engine.legacy.parser import LegacyPythonCallbacksParser
-from pants.engine.legacy.structs import (JavaLibraryAdaptor, JunitTestsAdaptor, JvmAppAdaptor,
-                                         PythonLibraryAdaptor, PythonTargetAdaptor,
-                                         PythonTestsAdaptor, RemoteSourcesAdaptor,
-                                         ScalaLibraryAdaptor, TargetAdaptor)
+from pants.engine.legacy.structs import (GoTargetAdaptor, JavaLibraryAdaptor, JunitTestsAdaptor,
+                                         JvmAppAdaptor, PythonLibraryAdaptor, PythonTargetAdaptor,
+                                         PythonTestsAdaptor, RemoteSourcesAdaptor, ScalaLibraryAdaptor,
+                                         TargetAdaptor)
 from pants.engine.mapper import AddressMapper
 from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import LocalScheduler
@@ -58,6 +58,8 @@ class LegacySymbolTable(SymbolTable):
       aliases[alias] = ScalaLibraryAdaptor
     for alias in ['python_library', 'pants_plugin']:
       aliases[alias] = PythonLibraryAdaptor
+    for alias in ['go_library', 'go_binary']:
+      aliases[alias] = GoTargetAdaptor
 
     aliases['junit_tests'] = JunitTestsAdaptor
     aliases['jvm_app'] = JvmAppAdaptor

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -104,7 +104,6 @@ class SourcesField(datatype('SourcesField', ['address', 'arg', 'filespecs', 'pat
 
 
 class JavaLibraryAdaptor(TargetAdaptor):
-
   @property
   def default_sources_globs(self):
     return ('*.java',)
@@ -115,7 +114,6 @@ class JavaLibraryAdaptor(TargetAdaptor):
 
 
 class ScalaLibraryAdaptor(TargetAdaptor):
-
   @property
   def default_sources_globs(self):
     return ('*.scala',)
@@ -126,7 +124,6 @@ class ScalaLibraryAdaptor(TargetAdaptor):
 
 
 class JunitTestsAdaptor(TargetAdaptor):
-
   java_test_globs = ('*Test.java',)
   scala_test_globs = ('*Test.scala', '*Spec.scala')
 
@@ -227,7 +224,6 @@ class PythonTargetAdaptor(TargetAdaptor):
 
 
 class PythonLibraryAdaptor(PythonTargetAdaptor):
-
   @property
   def default_sources_globs(self):
     return ('*.py',)
@@ -238,12 +234,18 @@ class PythonLibraryAdaptor(PythonTargetAdaptor):
 
 
 class PythonTestsAdaptor(PythonTargetAdaptor):
-
   python_test_globs = ('test_*.py', '*_test.py')
 
   @property
   def default_sources_globs(self):
     return self.python_test_globs
+
+
+class GoTargetAdaptor(TargetAdaptor):
+  @property
+  def default_sources_globs(self):
+    # N.B. Go targets glob on `*` due to the way resources and .c companion files are handled.
+    return ('*',)
 
 
 class BaseGlobs(Locatable, AbstractClass):

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -116,6 +116,19 @@ def create_isolated_git_repo():
         git.add(*files)
         git.commit(commit_msg)
 
+      add_to_git('a go target with default sources',
+        create_file('src/go/tester/BUILD', 'go_binary()'),
+        create_file('src/go/tester/main.go',
+          """
+          package main
+          import "fmt"
+          func main() {
+            fmt.Println("hello, world")
+          }
+          """
+        )
+      )
+
       add_to_git('resource file',
         create_file('src/resources/org/pantsbuild/resourceonly/BUILD',
         """
@@ -166,19 +179,6 @@ def create_isolated_git_repo():
 
       add_to_git('a python_library with resources=["filename"]',
         copy_into('testprojects/src/python/sources', 'src/python/sources')
-      )
-
-      add_to_git('a go target with default sources',
-        create_file('src/go/tester/BUILD', 'go_binary()'),
-        create_file('src/go/tester/main.go',
-          """
-          package main
-          import "fmt"
-          func main() {
-            fmt.Println("hello, world")
-          }
-          """
-        )
       )
 
       add_to_git('3rdparty/BUILD', copy_into('3rdparty/BUILD'))

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -131,12 +131,12 @@ def create_isolated_git_repo():
 
       add_to_git('resource file',
         create_file('src/resources/org/pantsbuild/resourceonly/BUILD',
-        """
-        resources(
-          name='resource',
-          sources=['README.md']
-        )
-        """
+          """
+          resources(
+            name='resource',
+            sources=['README.md']
+          )
+          """
         ),
         create_file('src/resources/org/pantsbuild/resourceonly/README.md', 'Just a resource.')
       )


### PR DESCRIPTION
Fixes #4393.

### Problem

Currently, go targets (e.g. `go_binary`) fail to be detected by the v2 engine changed implementation due to no `TargetAdaptor` coverage. 

### Solution

Add `TargetAdaptor` coverage and an integration test. This required plumbing an explicit `sources=` kwarg for `GoLocalSource` and subclasses, which is hopefully ok now that default sources are the norm.

### Result

Integration test now passes.