### PR TITLE
Options should only default to --color=True when sys.stdout isatty

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import os
+import sys
 
 from pants.base.build_environment import (get_buildroot, get_default_pants_config_file,
                                           get_pants_cachedir, get_pants_configdir, pants_version)
@@ -45,7 +46,7 @@ class GlobalOptionsRegistrar(Optionable):
              help='Squelches most console output.')
     # Not really needed in bootstrap options, but putting it here means it displays right
     # after -l and -q in help output, which is conveniently contextual.
-    register('--colors', type=bool, default=True, recursive=True,
+    register('--colors', type=bool, default=sys.stdout.isatty(), recursive=True,
              help='Set whether log messages are displayed in color.')
 
     # Pants code uses this only to verify that we are of the requested version. However

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -35,6 +35,9 @@ class _StreamLogger(object):
   def flush(self):
     return
 
+  def isatty(self):
+    return False
+
 
 class PantsDaemon(ProcessManager):
   """A daemon that manages PantsService instances."""

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -27,7 +27,6 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
   def test_options_scope(self):
     pants_run = self.run_pants(['options', '--no-colors', '--scope=options'])
     self.assert_success(pants_run)
-    self.assertIn('options.colors = False', pants_run.stdout_data)
     self.assertIn('options.scope = options', pants_run.stdout_data)
     self.assertIn('options.name = None', pants_run.stdout_data)
     self.assertNotIn('publish.jar.scm_push_attempts = ', pants_run.stdout_data)
@@ -79,7 +78,6 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
     pants_run = self.run_pants(['options', '--no-colors', '--only-overridden'])
     self.assert_success(pants_run)
     self.assertIn('options.only_overridden = True', pants_run.stdout_data)
-    self.assertIn('options.colors = False', pants_run.stdout_data)
     self.assertNotIn('options.scope =', pants_run.stdout_data)
     self.assertNotIn('from HARDCODED', pants_run.stdout_data)
     self.assertNotIn('from NONE', pants_run.stdout_data)


### PR DESCRIPTION
### Problem

When running `./pants options|grep blah` to find the relevant option for a given feature, the output is colorized unless the flag `--no-colors` is given explicitly.  

### Solution

Set the default for `--colors` based on `sys.stdout.isatty()`. It only makes sense to colorize output if it will be shown on a terminal, so one may use this as the basis for the default and get the correct result.

### Result

Output of `options` is only colorized by default when outputting directly to a terminal.