### PR TITLE
Make the release script more idempotent.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -312,7 +312,7 @@ function tag_release() {
     --local-user=$(get_pgp_keyid) \
     -m "pantsbuild.pants release ${release_version}" \
     ${tag_name} && \
-  git push git@github.com:pantsbuild/pants.git ${tag_name}
+  git push -f git@github.com:pantsbuild/pants.git ${tag_name}
 }
 
 function publish_docs_if_master() {

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -308,7 +308,7 @@ EOF
 function tag_release() {
   release_version="$(local_version)" && \
   tag_name="release_${release_version}" && \
-  git tag \
+  git tag -f \
     --local-user=$(get_pgp_keyid) \
     -m "pantsbuild.pants release ${release_version}" \
     ${tag_name} && \

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -70,7 +70,7 @@ script fail:
         EOF
         
   - Note that the release script expects your pantsbuild/pants git remote to be named `origin`.
-    If you have another name for it, you should `git rename othername origin` before running
+    If you have another name for it, you should `git remote rename othername origin` before running
     the release script, and rename it back afterwards.
 
 Prepare Release


### PR DESCRIPTION
If the tag already exists, from a previous attempt
to run this release, don't choke.

Also fixes a doc.

