### PR TITLE
Invoke setup-py using an interpreter that matches the target. (#4482)

### DIFF
--- a/src/python/pants/backend/python/tasks2/setup_py.py
+++ b/src/python/pants/backend/python/tasks2/setup_py.py
@@ -15,6 +15,7 @@ from collections import OrderedDict, defaultdict
 
 from pex.compatibility import string, to_bytes
 from pex.installer import InstallerBase, Packager
+from pex.interpreter import PythonInterpreter
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.chroot import Chroot
 
@@ -31,6 +32,7 @@ from pants.build_graph.resources import Resources
 from pants.task.task import Task
 from pants.util.dirutil import safe_rmtree, safe_walk
 from pants.util.meta import AbstractClass
+
 
 
 SETUP_BOILERPLATE = """
@@ -314,6 +316,7 @@ class SetupPy(Task):
   @classmethod
   def prepare(cls, options, round_manager):
     round_manager.require_data(GatherSources.PYTHON_SOURCES)
+    round_manager.require_data(PythonInterpreter)
 
   @classmethod
   def register_options(cls, register):
@@ -593,12 +596,13 @@ class SetupPy(Task):
       create(target)
 
     executed = {}  # Collected and returned for tests, processed target -> sdist|setup_dir.
+    interpreter = self.context.products.get_data(PythonInterpreter)
     for target in reversed(sort_targets(created.keys())):
       setup_dir = created.get(target)
       if setup_dir:
         if not self._run:
           self.context.log.info('Running packager against {}'.format(setup_dir))
-          setup_runner = Packager(setup_dir)
+          setup_runner = Packager(setup_dir, interpreter=interpreter)
           tgz_name = os.path.basename(setup_runner.sdist())
           sdist_path = os.path.join(dist_dir, tgz_name)
           self.context.log.info('Writing {}'.format(sdist_path))
@@ -607,7 +611,7 @@ class SetupPy(Task):
           executed[target] = sdist_path
         else:
           self.context.log.info('Running {} against {}'.format(self._run, setup_dir))
-          setup_runner = SetupPyRunner(setup_dir, self._run)
+          setup_runner = SetupPyRunner(setup_dir, self._run, interpreter=interpreter)
           setup_runner.run()
           executed[target] = setup_dir
     return executed


### PR DESCRIPTION
### Problem

Prior to this change setup-py used the default interpreter to invoke
pex.installer.SetupPyRunner and pex.installer.Packager. However, if the package is
meant for Python 3 this could result in a failure.

### Solution

This change makes setup-py require a PythonInterpreter which is passed along
to SetupPyRunner and Packager.
