### PR TITLE
Revert the zinc `1.0.0-X7` upgrade

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -31,7 +31,6 @@ from pants.base.exceptions import TaskError
 from pants.base.hash_utils import hash_file
 from pants.base.workunit import WorkUnitLabel
 from pants.java.distribution.distribution import DistributionLocator
-from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency import JarDependency
 from pants.util.contextutil import open_zip
 from pants.util.dirutil import safe_open
@@ -188,7 +187,7 @@ class BaseZincCompile(JvmCompile):
                   'only clean/cold builds.')
 
     def sbt_jar(name, **kwargs):
-      return JarDependency(org='org.scala-sbt', name=name, rev='1.0.0-X7', **kwargs)
+      return JarDependency(org='org.scala-sbt', name=name, rev='1.0.0-X5', **kwargs)
 
     shader_rules = [
         # The compiler-interface and compiler-bridge tool jars carry xsbt and
@@ -203,12 +202,7 @@ class BaseZincCompile(JvmCompile):
     cls.register_jvm_tool(register,
                           'zinc',
                           classpath=[
-                            # Use older util-interface to be jdk7 compatible.
-                            # TODO decide whether to keep the compatibility or stop supporting jdk7
-                            # https://github.com/sbt/util/issues/75
-                            JarDependency('org.pantsbuild', 'zinc_2.11', '0.0.1',
-                                          excludes=(Exclude(org='org.scala-sbt', name='util-interface'),)),
-                            JarDependency('org.scala-sbt', 'util-interface', '0.1.0-M15')
+                            JarDependency('org.pantsbuild', 'zinc_2.10', '0.0.5'),
                           ],
                           main=cls._ZINC_MAIN,
                           custom_rules=shader_rules)

--- a/src/python/pants/backend/jvm/zinc/zinc_analysis_element.py
+++ b/src/python/pants/backend/jvm/zinc/zinc_analysis_element.py
@@ -45,10 +45,6 @@ class ZincAnalysisElement(object):
   # To rebase pants home we must string-replace anywhere in the line.
   pants_home_anywhere = ()
 
-  # Sections that can reference paths under the pants home anywhere on a line, paths are encoded in base64.
-  # To rebase pants home we must first decode, string-replace anywhere in the line and then encode again.
-  pants_home_anywhere_base64 = ()
-
   # Sections that can reference paths under the pants home, but only at the beginning of a line.
   # To rebase pants home we can just check the prefix.
   pants_home_prefix_only = ()

--- a/src/python/pants/backend/jvm/zinc/zinc_analysis_element_types.py
+++ b/src/python/pants/backend/jvm/zinc/zinc_analysis_element_types.py
@@ -9,14 +9,12 @@ from pants.backend.jvm.zinc.zinc_analysis_element import ZincAnalysisElement
 
 
 class CompileSetup(ZincAnalysisElement):
-  headers = ('output mode', 'output directories', 'classpath hash', 'compile options', 'javac options',
+  headers = ('output mode', 'output directories', 'classpath options', 'compile options', 'javac options',
              'compiler version', 'compile order', 'name hashing', 'skip Api storing', 'extra')
 
   # Output directories can obviously contain directories under pants_home. Compile/javac options may
   # refer to directories under pants_home.
-  pants_home_anywhere = ('output directories')
-
-  pants_home_anywhere_base64 = ('classpath hash')
+  pants_home_anywhere = ('output directories', 'classpath options')
 
   def __init__(self, args):
     # Most sections in CompileSetup are arrays represented as maps from index to item:
@@ -27,9 +25,8 @@ class CompileSetup(ZincAnalysisElement):
     # We ensure these are sorted, in case any reading code makes assumptions about the order.
     # These are very small sections, so there's no performance impact to sorting them.
     super(CompileSetup, self).__init__(args, always_sort=True)
-    (self.output_mode, self.output_dirs, self.classpath_hash, self.compile_options,
-     self.javac_options, self.compiler_version, self.compile_order, self.name_hashing,
-     self.skip_api_storing, self.extra) = self.args
+    (self.output_mode, self.output_dirs, self.compile_options, self.javac_options,
+     self.compiler_version, self.compile_order, self.name_hashing, self.extra) = self.args
 
   def translate(self, token_translator):
     self.translate_values(token_translator, self.output_dirs)

--- a/src/python/pants/backend/jvm/zinc/zinc_analysis_parser.py
+++ b/src/python/pants/backend/jvm/zinc/zinc_analysis_parser.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import base64
 import os
 import re
 from collections import defaultdict
@@ -94,11 +93,6 @@ class ZincAnalysisParser(object):
         self.rebase(infile, outfile, rebase_mappings, java_home)
 
   def rebase(self, infile, outfile, rebase_mappings, java_home=None):
-    """Rebase from/to absolute paths with placeholders so analysis files can be cached and reused.
-
-    TODO with https://github.com/sbt/zinc/issues/218 for zinc to generate machine independent analysis
-    first rebase from absolute paths to placeholders will move into zinc.
-    """
     self._verify_version(infile)
     outfile.write(ZincAnalysis.FORMAT_VERSION_LINE)
 
@@ -119,7 +113,6 @@ class ZincAnalysisParser(object):
   def _rebase_section(self, cls, header, lines_iter, outfile, rebase_mappings, java_home=None):
     # Booleans describing the rebasing logic to apply, if any.
     rebase_pants_home_anywhere = header in cls.pants_home_anywhere
-    rebase_pants_home_anywhere_base64 = header in cls.pants_home_anywhere_base64
     rebase_pants_home_prefix = header in cls.pants_home_prefix_only
     filter_java_home_anywhere = java_home and header in cls.java_home_anywhere
     filter_java_home_prefix = java_home and header in cls.java_home_prefix_only
@@ -142,16 +135,6 @@ class ZincAnalysisParser(object):
         if rebase_pants_home_anywhere:
           for rebased_from, rebased_to in rebase_mappings:
             rebased_line = rebased_line.replace(rebased_from, rebased_to)
-        elif rebase_pants_home_anywhere_base64:
-          val_pos = rebased_line.find(' -> ')
-          if val_pos >= 0:
-            prefix, val = rebased_line[:val_pos+4], rebased_line[val_pos+4:-1]
-          else:
-            prefix, val = '', rebased_line.rstrip()
-          val = base64.b64decode(val)
-          for rebased_from, rebased_to in rebase_mappings:
-            val = val.replace(rebased_from, rebased_to)
-          rebased_line = '{}{}\n'.format(prefix, base64.b64encode(val))
         elif rebase_pants_home_prefix:
           for rebased_from, rebased_to in rebase_mappings:
             if line.startswith(rebased_from):

--- a/tests/python/pants_test/backend/jvm/zinc/testdata/simple/simple.analysis
+++ b/tests/python/pants_test/backend/jvm/zinc/testdata/simple/simple.analysis
@@ -5,15 +5,15 @@ output mode:
 output directories:
 1 items
 file:/src/pants/.pants.d/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/ -> file:/src/pants/.pants.d/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
-classpath hash:
+classpath options:
 7 items
-0 -> AIQvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uZXhlLmV4ZS9jdXJyZW50L2NsYXNzZXMAAAAB
-1 -> AGYvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2l2eS9qYXJzL29yZy5zY2FsYS1sYW5nL3NjYWxhLWxpYnJhcnkvamFycy9zY2FsYS1saWJyYXJ5LTIuMTEuOC5qYXKQfS/G
-2 -> AIQvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uZXhlLmV4ZS9jdXJyZW50L2NsYXNzZXMAAAAB
-3 -> AIwvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8ud2VsY29tZS53ZWxjb21lL2N1cnJlbnQvY2xhc3NlcwAAAAE=
-4 -> AIcvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLmphdmEub3JnLnBhbnRzYnVpbGQuZXhhbXBsZS5oZWxsby5ncmVldC5ncmVldC9jdXJyZW50L2NsYXNzZXMAAAAB
-5 -> AIMvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL3Jlc291cmNlcy9wcmVwYXJlLzI1MmQ2NDUyMWNmOS9leGFtcGxlcy5zcmMucmVzb3VyY2VzLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uaGVsbG8vY3VycmVudAAAAAE=
-6 -> AGYvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2l2eS9qYXJzL29yZy5zY2FsYS1sYW5nL3NjYWxhLWxpYnJhcnkvamFycy9zY2FsYS1saWJyYXJ5LTIuMTEuOC5qYXKQfS/G
+0 -> file:/src/pants/.pants.d/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
+1 -> file:/src/pants/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar
+2 -> file:/src/pants/.pants.d/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
+3 -> file:/src/pants/.pants.d/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes/
+4 -> file:/src/pants/.pants.d/compile/zinc/66ac1c9326be/examples.src.java.org.pantsbuild.example.hello.greet.greet/current/classes/
+5 -> file:/src/pants/.pants.d/resources/prepare/252d64521cf9/examples.src.resources.org.pantsbuild.example.hello.hello/current/
+6 -> file:/src/pants/.pants.d/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar
 compile options:
 6 items
 0 -> -encoding

--- a/tests/python/pants_test/backend/jvm/zinc/testdata/simple/simple.rebased.analysis
+++ b/tests/python/pants_test/backend/jvm/zinc/testdata/simple/simple.rebased.analysis
@@ -5,15 +5,15 @@ output mode:
 output directories:
 1 items
 file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/ -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
-classpath hash:
+classpath options:
 7 items
-0 -> AIQvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uZXhlLmV4ZS9jdXJyZW50L2NsYXNzZXMAAAAB
-1 -> AGYvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2l2eS9qYXJzL29yZy5zY2FsYS1sYW5nL3NjYWxhLWxpYnJhcnkvamFycy9zY2FsYS1saWJyYXJ5LTIuMTEuOC5qYXKQfS/G
-2 -> AIQvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uZXhlLmV4ZS9jdXJyZW50L2NsYXNzZXMAAAAB
-3 -> AIwvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8ud2VsY29tZS53ZWxjb21lL2N1cnJlbnQvY2xhc3NlcwAAAAE=
-4 -> AIcvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLmphdmEub3JnLnBhbnRzYnVpbGQuZXhhbXBsZS5oZWxsby5ncmVldC5ncmVldC9jdXJyZW50L2NsYXNzZXMAAAAB
-5 -> AIMvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL3Jlc291cmNlcy9wcmVwYXJlLzI1MmQ2NDUyMWNmOS9leGFtcGxlcy5zcmMucmVzb3VyY2VzLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uaGVsbG8vY3VycmVudAAAAAE=
-6 -> AGYvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2l2eS9qYXJzL29yZy5zY2FsYS1sYW5nL3NjYWxhLWxpYnJhcnkvamFycy9zY2FsYS1saWJyYXJ5LTIuMTEuOC5qYXKQfS/G
+0 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
+1 -> file:/_PANTS_WORKDIR_PLACEHOLDER/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar
+2 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
+3 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes/
+4 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.java.org.pantsbuild.example.hello.greet.greet/current/classes/
+5 -> file:/_PANTS_WORKDIR_PLACEHOLDER/resources/prepare/252d64521cf9/examples.src.resources.org.pantsbuild.example.hello.hello/current/
+6 -> file:/_PANTS_WORKDIR_PLACEHOLDER/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar
 compile options:
 6 items
 0 -> -encoding

--- a/tests/python/pants_test/backend/jvm/zinc/testdata/simple/simple.rebased.filtered.analysis
+++ b/tests/python/pants_test/backend/jvm/zinc/testdata/simple/simple.rebased.filtered.analysis
@@ -5,15 +5,15 @@ output mode:
 output directories:
 1 items
 file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/ -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
-classpath hash:
+classpath options:
 7 items
-0 -> AIQvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uZXhlLmV4ZS9jdXJyZW50L2NsYXNzZXMAAAAB
-1 -> AGYvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2l2eS9qYXJzL29yZy5zY2FsYS1sYW5nL3NjYWxhLWxpYnJhcnkvamFycy9zY2FsYS1saWJyYXJ5LTIuMTEuOC5qYXKQfS/G
-2 -> AIQvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uZXhlLmV4ZS9jdXJyZW50L2NsYXNzZXMAAAAB
-3 -> AIwvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLnNjYWxhLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8ud2VsY29tZS53ZWxjb21lL2N1cnJlbnQvY2xhc3NlcwAAAAE=
-4 -> AIcvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2NvbXBpbGUvemluYy82NmFjMWM5MzI2YmUvZXhhbXBsZXMuc3JjLmphdmEub3JnLnBhbnRzYnVpbGQuZXhhbXBsZS5oZWxsby5ncmVldC5ncmVldC9jdXJyZW50L2NsYXNzZXMAAAAB
-5 -> AIMvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL3Jlc291cmNlcy9wcmVwYXJlLzI1MmQ2NDUyMWNmOS9leGFtcGxlcy5zcmMucmVzb3VyY2VzLm9yZy5wYW50c2J1aWxkLmV4YW1wbGUuaGVsbG8uaGVsbG8vY3VycmVudAAAAAE=
-6 -> AGYvVXNlcnMvcGVpeXUvZ2l0aHViL3BhbnRzLy5wYW50cy5kL2l2eS9qYXJzL29yZy5zY2FsYS1sYW5nL3NjYWxhLWxpYnJhcnkvamFycy9zY2FsYS1saWJyYXJ5LTIuMTEuOC5qYXKQfS/G
+0 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
+1 -> file:/_PANTS_WORKDIR_PLACEHOLDER/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar
+2 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.exe.exe/current/classes/
+3 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.scala.org.pantsbuild.example.hello.welcome.welcome/current/classes/
+4 -> file:/_PANTS_WORKDIR_PLACEHOLDER/compile/zinc/66ac1c9326be/examples.src.java.org.pantsbuild.example.hello.greet.greet/current/classes/
+5 -> file:/_PANTS_WORKDIR_PLACEHOLDER/resources/prepare/252d64521cf9/examples.src.resources.org.pantsbuild.example.hello.hello/current/
+6 -> file:/_PANTS_WORKDIR_PLACEHOLDER/ivy/jars/org.scala-lang/scala-library/jars/scala-library-2.10.6.jar
 compile options:
 6 items
 0 -> -encoding


### PR DESCRIPTION
### Problem

The zinc 1.0.0-X7 upgrade resulted in a few issues, including complete target invalidation (#4477), and some unconfirmed assertion failures from within zinc.

### Solution

This reverts #4419 until after the `1.3.0` stable branch has been cut. It should be re-landed immediately afterward.