### PR TITLE
Deprecate `BuildFileAddress.build_file`

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/BUILD
+++ b/src/python/pants/backend/graph_info/tasks/BUILD
@@ -5,6 +5,7 @@ python_library(
   dependencies = [
     'src/python/pants/base:build_environment',
     'src/python/pants/base:cmd_line_spec_parser',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:specs',
     'src/python/pants/base:workunit',

--- a/src/python/pants/backend/graph_info/tasks/pathdeps.py
+++ b/src/python/pants/backend/graph_info/tasks/pathdeps.py
@@ -7,6 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
+from pants.base.build_environment import get_buildroot
+from pants.base.deprecated import deprecated_conditional
 from pants.task.console_task import ConsoleTask
 
 
@@ -14,6 +16,10 @@ class PathDeps(ConsoleTask):
   """List all paths containing BUILD files the target depends on."""
 
   def console_output(self, targets):
+    deprecated_conditional(lambda: True, '1.5.0.dev0',
+                           'The `pathdeps` goal is deprecated. Please use `filedeps` instead.')
     def is_safe(t):
       return hasattr(t, 'address') and hasattr(t.address, 'rel_path')
-    return set(os.path.dirname(t.address.rel_path) for t in targets if is_safe(t))
+    buildroot = get_buildroot()
+    return set(os.path.normpath(os.path.join(buildroot, os.path.dirname(t.address.rel_path)))
+               for t in targets if is_safe(t))

--- a/src/python/pants/backend/graph_info/tasks/pathdeps.py
+++ b/src/python/pants/backend/graph_info/tasks/pathdeps.py
@@ -1,9 +1,11 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
+
+import os
 
 from pants.task.console_task import ConsoleTask
 
@@ -13,5 +15,5 @@ class PathDeps(ConsoleTask):
 
   def console_output(self, targets):
     def is_safe(t):
-      return hasattr(t, 'address') and hasattr(t.address, 'build_file')
-    return set(t.address.build_file.parent_path for t in targets if is_safe(t))
+      return hasattr(t, 'address') and hasattr(t.address, 'rel_path')
+    return set(os.path.dirname(t.address.rel_path) for t in targets if is_safe(t))

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from collections import namedtuple
 
-from pants.base.deprecated import deprecated_conditional
+from pants.base.deprecated import deprecated, deprecated_conditional
 from pants.util.dirutil import longest_dir_prefix
 from pants.util.strutil import strip_prefix
 
@@ -283,10 +283,11 @@ class BuildFileAddress(Address):
     return Address(spec_path=self.spec_path, target_name=self.target_name)
 
   @property
+  @deprecated('1.5.0.dev0',
+              hint_message='Use `BuildFileAddress.rel_path` to access the relative path to the '
+                           'BUILD file for a target.')
   def build_file(self):
     """The build file that contains the object this address points to.
-
-    :API: public
 
     :rtype: :class:`pants.base.build_file.BuildFile`
     """

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -289,6 +289,8 @@ class BuildFileAddress(Address):
   def build_file(self):
     """The build file that contains the object this address points to.
 
+    :API: public
+
     :rtype: :class:`pants.base.build_file.BuildFile`
     """
     return self._build_file

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -256,8 +256,8 @@ class BuildFileAddressMapper(AddressMapper):
         '{was_not_found_message}, because that directory contains no BUILD files defining addressable entities.'
           .format(was_not_found_message=was_not_found_message))
     # Print BUILD file extensions if there's more than one BUILD file with targets only.
-    if (any(not hasattr(address, 'build_file') for address in addresses) or
-        len(set(address.build_file for address in addresses)) == 1):
+    if (any(not hasattr(address, 'rel_path') for address in addresses) or
+        len(set(address.rel_path for address in addresses)) == 1):
       specs = [':{}'.format(address.target_name) for address in addresses]
     else:
       specs = [':{} (from {})'.format(address.target_name, os.path.basename(address.build_file.relpath))

--- a/src/python/pants/build_graph/build_file_parser.py
+++ b/src/python/pants/build_graph/build_file_parser.py
@@ -82,7 +82,7 @@ class BuildFileParser(object):
               "Both {conflicting_file} and {addressable_file} define the same address: "
               "'{target_name}'"
               .format(conflicting_file=sibling_build_file,
-                      addressable_file=address.build_file,
+                      addressable_file=address.rel_path,
                       target_name=address.target_name))
       family_address_map_by_build_file[bf] = bf_address_map
     return family_address_map_by_build_file

--- a/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
+++ b/tests/python/pants_test/build_graph/test_build_file_address_mapper.py
@@ -23,10 +23,10 @@ from pants_test.base_test import BaseTest
 class BuildFileAddressMapperTest(BaseTest):
 
   def test_resolve(self):
-    build_file = self.add_to_build_file('BUILD', 'target(name="foo")')
+    self.add_to_build_file('BUILD', 'target(name="foo")')
     address, addressable = self.address_mapper.resolve(Address.parse('//:foo'))
     self.assertIsInstance(address, BuildFileAddress)
-    self.assertEqual(build_file, address.build_file)
+    self.assertEqual('BUILD', address.rel_path)
     self.assertEqual('foo', address.target_name)
     self.assertEqual(address.target_name, addressable.addressed_name)
     self.assertEqual(addressable.addressed_type, Target)

--- a/tests/python/pants_test/build_graph/test_build_file_parser.py
+++ b/tests/python/pants_test/build_graph/test_build_file_parser.py
@@ -161,8 +161,8 @@ class BuildFileParserTargetTest(BaseTest):
     address_map = self.build_file_parser.address_map_from_build_files(
       BuildFile.get_build_files_family(FileSystemProjectTree(self.build_root), "."))
     addresses = address_map.keys()
-    self.assertEqual({bar_build_file, base_build_file, foo_build_file},
-                     set([address.build_file for address in addresses]))
+    self.assertEqual({bar_build_file.relpath, base_build_file.relpath, foo_build_file.relpath},
+                     set([address.rel_path for address in addresses]))
     self.assertEqual({'//:base', '//:foo', '//:bat'},
                      set([address.spec for address in addresses]))
 


### PR DESCRIPTION
### Problem

`BuildFileAddress.build_file` (which is marked `API: public`) needs to go away, as `BuildFile` and `BuildFileAddressMapper` (which are not marked public) will be going away along with the v1 engine.

### Solution

As part of #4365, switch all internal usages of `BuildFileAddress.build_file` to `BuildFileAddress.rel_path`, which is stringly typed, and sufficient for all known usages.