### PR TITLE
Make usage of pantsd imply usage of watchman

### DIFF
--- a/pants.daemon.ini
+++ b/pants.daemon.ini
@@ -26,6 +26,3 @@
 
 [GLOBAL]
 enable_pantsd: True
-
-[pantsd]
-fs_event_detection: True

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -81,10 +81,9 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         print(line)
 
   def test_pantsd_run_with_watchman(self):
-    config = {'pantsd': {'fs_event_detection': True},
-              # The absolute paths in CI can exceed the UNIX socket path limitation
-              # (>104-108 characters), so we override that here with a shorter path.
-              'watchman': {'socket_path': '/tmp/watchman.{}.sock'.format(os.getpid())}}
+    # The absolute paths in CI can exceed the UNIX socket path limitation
+    # (>104-108 characters), so we override that here with a shorter path.
+    config = {'watchman': {'socket_path': '/tmp/watchman.{}.sock'.format(os.getpid())}}
 
     with self.pantsd_test_context(config) as (workdir, pantsd_config, checker):
       print('log: {}/pantsd/pantsd.log'.format(workdir))


### PR DESCRIPTION
### Problem

The pants daemon is only useful in the context of the `--fs-event-detection` flag, but usage of that flag is currently optional.

### Solution

Deprecate that flag, such that usage of `--enable-pantsd` implies `--fs-event-detection`.