### PR TITLE
Add a scala specs2 example

### DIFF
--- a/3rdparty/jvm/org/specs2/BUILD
+++ b/3rdparty/jvm/org/specs2/BUILD
@@ -5,5 +5,6 @@ jar_library(
   name='specs2-core',
   jars=[
     jar(org='org.specs2', name='specs2-core_2.11', rev='3.8.9'),
+    jar(org='org.specs2', name='specs2-junit_2.11', rev='3.8.9'),
   ],
 )

--- a/3rdparty/jvm/org/specs2/BUILD
+++ b/3rdparty/jvm/org/specs2/BUILD
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jar_library(
+  name='specs2-junit_2.11',
   jars=[
-    jar(org='org.specs2', name='specs2-core_2.11', rev='3.8.9'),
     jar(org='org.specs2', name='specs2-junit_2.11', rev='3.8.9'),
   ],
 )

--- a/3rdparty/jvm/org/specs2/BUILD
+++ b/3rdparty/jvm/org/specs2/BUILD
@@ -1,0 +1,9 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+jar_library(
+  name='specs2-core',
+  jars=[
+    jar(org='org.specs2', name='specs2-core_2.11', rev='3.8.9'),
+  ],
+)

--- a/3rdparty/jvm/org/specs2/BUILD
+++ b/3rdparty/jvm/org/specs2/BUILD
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jar_library(
-  name='specs2-core',
   jars=[
     jar(org='org.specs2', name='specs2-core_2.11', rev='3.8.9'),
     jar(org='org.specs2', name='specs2-junit_2.11', rev='3.8.9'),

--- a/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
@@ -3,7 +3,7 @@
 
 junit_tests(
   dependencies=[
-    '3rdparty/jvm/org/specs2:specs2-core',
+    '3rdparty/jvm/org/specs2',
     '3rdparty:junit',
     '3rdparty:scalatest',
   ],

--- a/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
@@ -3,9 +3,6 @@
 
 junit_tests(
   dependencies=[
-    'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome',
-    '3rdparty:junit',
-    '3rdparty:scalatest',
     '3rdparty/jvm/org/specs2:specs2-core',
   ],
 )

--- a/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+junit_tests(
+  dependencies=[
+    'examples/src/scala/org/pantsbuild/example/hello/welcome:welcome',
+    '3rdparty:junit',
+    '3rdparty:scalatest',
+    '3rdparty/jvm/org/specs2:specs2-core',
+  ],
+)

--- a/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
@@ -1,10 +1,9 @@
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
   dependencies=[
-    '3rdparty/jvm/org/specs2',
+    '3rdparty/jvm/org/specs2:specs2-junit_2.11',
     '3rdparty:junit',
-    '3rdparty:scalatest',
   ],
 )

--- a/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
@@ -4,6 +4,5 @@
 junit_tests(
   dependencies=[
     '3rdparty/jvm/org/specs2:specs2-junit_2.11',
-    '3rdparty:junit',
   ],
 )

--- a/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
@@ -4,5 +4,7 @@
 junit_tests(
   dependencies=[
     '3rdparty/jvm/org/specs2:specs2-core',
+    '3rdparty:junit',
+    '3rdparty:scalatest',
   ],
 )

--- a/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
@@ -1,10 +1,7 @@
 package org.pantsbuild.example.specs2
 
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.specs2.mutable._
 
-//@RunWith(classOf[JUnitRunner])
 class HelloWorldSpec extends Specification {
   "This is a specification for the 'Hello world' string".txt
 

--- a/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
@@ -1,12 +1,8 @@
 package org.pantsbuild.example.specs2
 
-import org.junit.runner.RunWith
-import org.specs2.mutable.Specification
-//import org.specs2.runner.JUnitRunner
-import org.scalatest.junit.JUnitRunner
+import org.specs2.mutable.SpecificationWithJUnit
 
-@RunWith(classOf[JUnitRunner])
-object HelloWorldSpec extends Specification {
+class HelloWorldSpec extends SpecificationWithJUnit {
 
   "add three numbers" in {
     1 + 1 + 1 mustEqual 3

--- a/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
@@ -1,19 +1,17 @@
 package org.pantsbuild.example.specs2
 
-import org.specs2.mutable._
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
 
-class HelloWorldSpec extends Specification {
-  "This is a specification for the 'Hello world' string".txt
+@RunWith(classOf[JUnitRunner])
+object HelloWorldSpec extends Specification {
 
-  "The 'Hello world' string should" >> {
-    "contain 11 characters" >> {
-      "Hello world" must haveSize(11)
-    }
-    "start with 'Hello'" >> {
-      "Hello world" must startWith("Hello")
-    }
-    "end with 'world'" >> {
-      "Hello world" must endWith("world")
-    }
+  "add three numbers" in {
+    1 + 1 + 1 mustEqual 3
+  }
+
+  "add 2 numbers" in {
+    1 + 1 mustEqual 2
   }
 }

--- a/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
@@ -1,0 +1,22 @@
+package org.pantsbuild.example.specs2
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.specs2.mutable._
+
+//@RunWith(classOf[JUnitRunner])
+class HelloWorldSpec extends Specification {
+  "This is a specification for the 'Hello world' string".txt
+
+  "The 'Hello world' string should" >> {
+    "contain 11 characters" >> {
+      "Hello world" must haveSize(11)
+    }
+    "start with 'Hello'" >> {
+      "Hello world" must startWith("Hello")
+    }
+    "end with 'world'" >> {
+      "Hello world" must endWith("world")
+    }
+  }
+}

--- a/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
@@ -2,7 +2,8 @@ package org.pantsbuild.example.specs2
 
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
-import org.specs2.runner.JUnitRunner
+//import org.specs2.runner.JUnitRunner
+import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 object HelloWorldSpec extends Specification {

--- a/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/HelloWorldSpec.scala
@@ -1,3 +1,6 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 package org.pantsbuild.example.specs2
 
 import org.specs2.mutable.SpecificationWithJUnit

--- a/examples/tests/scala/org/pantsbuild/example/specs2/README.md
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/README.md
@@ -1,0 +1,9 @@
+# Scala Specs2 Example
+
+Pants supports Scala Specs2. In order for it to work you have to extend the `SpecificationWithJUnit` class, because Pants uses JUnit's runner to run tests.
+
+You can run these tests with the command:
+
+`./pants test examples/tests/scala/org/pantsbuild/example/specs2`
+
+This target can also be imported in IntelliJ. If you choose to run it with IntelliJ Scala Runner, you can see a Specs2 run configuration generated under Run -> Edit Configurations.


### PR DESCRIPTION
Adding a specs2 example, so it is more clear how it can be used. Also tested in an IntelliJ project, the tests run as expected as well in both IntelliJ JUnit runner and specs2 runner.

Example:
```
$ ./pants test examples/tests/scala/org/pantsbuild/example/specs2/
...
00:12:49 00:02     [junit]
00:12:49 00:02       [run]
                     Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=256m; support was removed in 8.0
                     Java HotSpot(TM) 64-Bit Server VM warning: ignoring option UseSplitVerifier; support was removed in 8.0
                     Auto-detected 8 processors, using -parallel-threads=8
                     ....
                     Time: 0
                     
                     OK (0 tests)
                     
                     
                     Time: 0.164
                     
                     OK (2 tests)
                     
                     
00:12:50 00:03     [go]
00:12:50 00:03     [node]
00:12:50 00:03   [complete]
               SUCCESS
```