### PR TITLE
[engine] Improve error messages for missing/empty dirs

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -234,7 +234,12 @@ def _hydrate(item_type, spec_path, **kwargs):
       [SelectDependencies(AddressFamily, BuildDirs, field_types=(Dir,)),
        Select(_SPECS_CONSTRAINT)])
 def addresses_from_address_families(address_families, spec):
-  """Given a list of AddressFamilies and a Spec, return matching Addresses."""
+  """Given a list of AddressFamilies and a Spec, return matching Addresses.
+
+  Raises a ResolveError if:
+     - there were no matching AddressFamilies, or
+     - the Spec matches no addresses for SingleAddresses.
+  """
   if not address_families:
     raise ResolveError('Path "{}" contains no BUILD files.'.format(spec.directory))
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -235,6 +235,9 @@ def _hydrate(item_type, spec_path, **kwargs):
        Select(_SPECS_CONSTRAINT)])
 def addresses_from_address_families(address_families, spec):
   """Given a list of AddressFamilies and a Spec, return matching Addresses."""
+  if not address_families:
+    raise ResolveError('Path "{}" contains no BUILD files.'.format(spec.directory))
+
   if type(spec) in (DescendantAddresses, SiblingAddresses, AscendantAddresses):
     addresses = tuple(a for af in address_families for a in af.addressables.keys())
   elif type(spec) is SingleAddress:

--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -73,17 +73,24 @@ class LegacyAddressMapper(AddressMapper):
     result = self._engine.execute(request)
     if result.error:
       raise self.BuildFileScanError(str(result.error))
-    root_entries = self._scheduler.root_entries(request)
+    root_entries = result.root_products
 
     addresses = set()
     for (spec, _), state in root_entries.items():
-      if missing_is_fatal:
-        if isinstance(state, Throw) and isinstance(state.exc, ResolveError):
-          raise self.BuildFileScanError(
-            'Spec `{}` does not match any targets.\n{}'.format(spec.to_spec_string(), str(state.exc)))
-        elif not state.value.dependencies:
-          raise self.BuildFileScanError(
-            'Spec `{}` does not match any targets.'.format(spec.to_spec_string()))
+      if isinstance(state, Throw):
+        if isinstance(state.exc, ResolveError):
+          if missing_is_fatal:
+            raise self.BuildFileScanError(
+              'Spec `{}` does not match any targets.\n{}'.format(spec.to_spec_string(), str(state.exc)))
+          else:
+            # NB: ignore Throws containing ResolveErrors because they are due to missing targets / files
+            continue
+        else:
+          raise self.BuildFileScanError(str(state.exc))
+      elif missing_is_fatal and not state.value.dependencies:
+        raise self.BuildFileScanError(
+          'Spec `{}` does not match any targets.'.format(spec.to_spec_string()))
+
       addresses.update(state.value.dependencies)
     return addresses
 


### PR DESCRIPTION
### Problem
When the engine has an issue finding BUILD files to fulfill a request for targets, it should have a good message even if the requested spec has no associated BUILD files.

### Solution
This patch adds another error raising path to addresses_from_address_families so that missing directories and empty directories have improved error messages.

### Result
The cases in #3912 for missing directories or directories without BUILD files have ok errors.
