### PR TITLE
[engine] pass on ResolveErrors during address injection

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -246,6 +246,8 @@ class LegacyBuildGraph(BuildGraph):
           yield address
 
   def _assert_type_is_return(self, node, state):
+    # TODO Verifying the type is return should be handled in a more central way.
+    #      It's related to the clean up tracked via https://github.com/pantsbuild/pants/issues/4229
     if type(state) is Return:
       return
 
@@ -260,6 +262,8 @@ class LegacyBuildGraph(BuildGraph):
         'Build graph construction failed for {}:\n{}'.format(node, trace))
 
   def _assert_correct_value_type(self, state, expected_type):
+    # TODO This is a pretty general assertion, and it should live closer to where the result is generated.
+    #      It's related to the clean up tracked via https://github.com/pantsbuild/pants/issues/4229
     if type(state.value) is not expected_type:
       raise TypeError('Expected roots to hold {}; got: {}'.format(
         expected_type, type(state.value)))

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -96,7 +96,6 @@ class GraphTargetScanFailureTests(GraphTestBase):
     with self.assertRaises(AddressLookupError) as cm:
       with self.graph_helper() as graph_helper:
         self.create_graph_from_specs(graph_helper, ['no-such-path:'])
-        self.fail('Expected an exception.')
 
     self.assertIn('Path "no-such-path" contains no BUILD files',
                   str(cm.exception))
@@ -105,11 +104,19 @@ class GraphTargetScanFailureTests(GraphTestBase):
     with self.assertRaises(AddressLookupError) as cm:
       with self.graph_helper() as graph_helper:
         self.create_graph_from_specs(graph_helper, ['build-support/bin::'])
-        self.fail('Expected an exception.')
 
     self.assertIn('Path "build-support/bin" contains no BUILD files',
                   str(cm.exception))
 
+  def test_inject_bad_dir(self):
+    with self.assertRaises(AddressLookupError) as cm:
+      with self.graph_helper() as graph_helper:
+        graph, target_roots = self.create_graph_from_specs(graph_helper, ['3rdparty/python:'])
+
+        graph.inject_address_closure(Address('build-support/bin','wat'))
+
+    self.assertIn('Path "build-support/bin" contains no BUILD files',
+                  str(cm.exception))
 
 
 class GraphInvalidationTest(GraphTestBase):


### PR DESCRIPTION
### Problem.

Injected addresses that were bad were not being caught by the error handling introduced in the other patches for #3912

### Solution.

Add the checks that raise the right exceptions to the `_inject` method.

### Result.

Now injections will also get the more helpful error.

I also removed the additional unnecessary root_entries call in `_inject`.