### PR TITLE
Fix shallow CI builds

### DIFF
--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -13,5 +13,13 @@ fi
 echo -n "* Checking native_engine_version: " && ./build-support/bin/check_native_engine_version.sh || exit 1
 echo "* Checking packages" && ./build-support/bin/check_packages.sh || exit 1
 echo "* Checking headers" && ./build-support/bin/check_header.sh || exit 1
-echo "* Checking imports" && ./build-support/bin/isort.sh || \
-  die "To fix import sort order, run \`./build-support/bin/isort.sh -f\`"
+
+$(git rev-parse --verify master > /dev/null 2>&1)
+if [[ $? -eq 0 ]]; then
+  echo "* Checking imports" && ./build-support/bin/isort.sh || \
+    die "To fix import sort order, run \`./build-support/bin/isort.sh -f\`"
+else
+  # When travis builds a tag, it does so in a shallow clone without master fetched, which
+  # fails in pants changed.
+  echo "* Skipping import check in partial working copy."
+fi


### PR DESCRIPTION
### Problem

94775d9 switched `build-support/bin/isort.sh` to a more useful range for `--changed`: from `master` to `HEAD`. Unfortunately, when travis builds git tags, it does so in a shallow clone that does not contain master.

### Solution

Detect whether we're in a partial clone, and skip isort checks. It's possible that there is a way to get travis to always include master while cloning for tags, but I couldn't find it.

### Result

https://travis-ci.org/pantsbuild/pants/builds/227030779 should be fixable.