### PR TITLE
Triggering Travis with new node distribution.

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -36,14 +36,14 @@ class NodeDistribution(object):
       register('--supportdir', advanced=True, default='bin/node',
                help='Find the Node distributions under this dir.  Used as part of the path to '
                     'lookup the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', advanced=True, default='6.9.1',
+      register('--version', advanced=True, default='6.10.2',
                help='Node distribution version.  Used as part of the path to lookup the '
                     'distribution with --binary-util-baseurls and --pants-bootstrapdir')
       register('--package-manager', advanced=True, default='npm', fingerprint=True,
                choices=NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys(),
                help='Default package manager config for repo. Should be one of {}'.format(
                  NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys()))
-      register('--yarnpkg-version', advanced=True, default='v0.19.1', fingerprint=True,
+      register('--yarnpkg-version', advanced=True, default='v0.23.3', fingerprint=True,
                help='Yarnpkg version. Used for binary utils')
 
     def create(self):


### PR DESCRIPTION
Note: This PR is not intended to be submitted and is only used to trigger Travis based tests.

### Problem
Use this PR to trigger a Travis run for validation of node 6.10.2 + yarnpkg 0.23.3 to be used with Pants.

### Solution
N/A

### Result
N/A