### PR TITLE
Update target scope docs

### DIFF
--- a/examples/src/java/org/pantsbuild/example/BUILD
+++ b/examples/src/java/org/pantsbuild/example/BUILD
@@ -19,6 +19,7 @@ page(
   source='from_maven.md',
   links=[
     ':3rdparty_jvm',
+    ':readme',
   ],
 )
 

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -513,7 +513,7 @@ Target Scopes
 
 ### Overview
 
-Pants supports marking targets with a `scope` value which the JVM backend will use to filter
+Pants supports marking targets with one or more `scope` values which the JVM backend will use to filter
 dependency subgraphs at compiletime and runtime. Scopes are also used for unused dependency
 detection: only `default` scoped targets are eligible to be considered as "unused" deps.
 
@@ -538,6 +538,9 @@ Pants' built in scopes are:
 * `runtime`: Indicates that a target is only used at runtime, and should not be presented to the
   compiler. Targets which are only used via JVM reflection are good examples of runtime-only
   dependencies.
+* `test`: Indicates that a target is used when running tests. This scope is typically used in
+  addition to another scope (e.g.: `scope='compile test'`). Targets which are are provided by an
+  external execution environment are good examples of compile+test dependencies.
 * `forced` _(available from pants 1.1.0)_: The `forced` scope is equivalent to the `default` scope, but additionally indicates
   that a target is not eligible to be considered an "unused" dependency. It is sometimes necessary
   to mark a target `forced` due to false positives in the static analysis used for unused
@@ -553,6 +556,15 @@ that target:
     java_library(name='lib',
       ..,
       scope='runtime',
+    )
+
+Multiple scopes can be specified. The equivalent of Maven's `provided` scope can be expressed by
+specifying both compile and test scopes.
+
+    :::python
+    java_library(name='lib',
+      ..,
+      scope='compile test',
     )
 
 If the scope of a target is not matched for a particular context, the entire subgraph represented

--- a/examples/src/java/org/pantsbuild/example/from_maven.md
+++ b/examples/src/java/org/pantsbuild/example/from_maven.md
@@ -108,3 +108,29 @@ jvm_binary(name='your-bin',
               Duplicate('^META-INF/services/', Duplicate.CONCAT_TEXT)
           ]))
 ```
+
+**Dependency Scopes**<br>
+
+Pants supports dependency scopes. To emulate Maven's `provided` scope you
+can specify both the `compile` and `test` scopes for a target. For details,
+see [[JVM Projects with Pants|pants('examples/src/java/org/pantsbuild/example:readme')]].
+
+Maven
+```xml
+<dependency>
+  <groupId>org.apache.spark</groupId>
+  <artifactId>spark-core_2.11</artifactId>
+  <scope>provided</scope>
+</dependency>
+```
+
+Pants
+```python
+jar_library(
+  name='spark-core',
+  jars=[
+    scala_jar(org='org.apache.spark', name='spark-core', rev='2.1.0'),
+  ],
+  scope='compile test',
+)
+```


### PR DESCRIPTION
### Problem

In #4544 we describe an issue where the `test` scope is not documented, and the docs do not let users know that multiple scopes can be specified for a target. In particular, it's not clear in the existing docs how to emulate the maven `provided` scope.

### Solution

Add user documentation about the `test` scope, and how to emulate the Maven
`provided` scope in Pants.

### Result

Users should be able to emulate the maven provided scope in pants.