### PR TITLE
Ignore dot-directories by default

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -60,7 +60,6 @@ backend_packages: +[
 pants_ignore: +[
     # venv directories under build-support.
     '/build-support/*.venv/',
-    '!.babelrc',
   ]
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -169,15 +169,15 @@ class GlobalOptionsRegistrar(Optionable):
     # e.g. '/dist/'
     rel_distdir = '/{}/'.format(os.path.relpath(register.bootstrap.pants_distdir, get_buildroot()))
     register('--ignore-patterns', advanced=True, type=list, fromfile=True,
-             default=['.*', rel_distdir, 'bower_components', 'node_modules', '*.egg-info'],
+             default=['.*/', rel_distdir, 'bower_components/', 'node_modules/', '*.egg-info/'],
              removal_version='1.3.0.dev0', removal_hint='Use --build-ignore instead.',
              mutually_exclusive_group='build_ignore', help='See help for --build-ignore.')
     register('--build-ignore', advanced=True, type=list, fromfile=True,
-             default=['.*', rel_distdir, 'bower_components', 'node_modules', '*.egg-info'],
+             default=['.*/', rel_distdir, 'bower_components/', 'node_modules/', '*.egg-info/'],
              help='Paths to ignore when identifying BUILD files. '
                   'This does not affect any other filesystem operations. '
                   'Patterns use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')
-    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=['.*', rel_distdir],
+    register('--pants-ignore', advanced=True, type=list, fromfile=True, default=['.*/', rel_distdir],
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore). '

--- a/tests/python/pants_test/option/test_options_integration.py
+++ b/tests/python/pants_test/option/test_options_integration.py
@@ -288,7 +288,7 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
                                   '--no-colors',
                                   'options'])
       self.assert_success(pants_run)
-      self.assertIn("pants_ignore = ['.*', '/dist/', 'some/random/dir'] (from CONFIG)",
+      self.assertIn("pants_ignore = ['.*/', '/dist/', 'some/random/dir'] (from CONFIG)",
                     pants_run.stdout_data)
 
   @ensure_engine
@@ -305,5 +305,5 @@ class TestOptionsIntegration(PantsRunIntegrationTest):
                                   '--no-colors',
                                   'options'])
       self.assert_success(pants_run)
-      self.assertIn("pants_ignore = ['.*', '/some/other/dist/dir/', 'some/random/dir'] (from CONFIG)",
+      self.assertIn("pants_ignore = ['.*/', '/some/other/dist/dir/', 'some/random/dir'] (from CONFIG)",
                     pants_run.stdout_data)


### PR DESCRIPTION
### Problem

#4547 showed that ignoring all dot-files by default is not a good choice... and the majority of the filesystem access that is avoided by ignoring dot-files is actually due to ignoring dot-directories.

### Solution

Ignore only dot-directories by default. Additionally, restrict a few default patterns that should definitely only match directories to directories.

### Result

Fixes #4547.

In the medium term, we should absolutely support using the `.gitignore` file for this (especially since it's trivial in the rust code), but currently it would involve lots of edits in deprecated code paths, and I'd like to avoid significant changes immediately before `1.3.0`.