### PR TITLE
Warn when implicit_sources would be used, but is disabled

### DIFF
--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -35,6 +35,7 @@ python_library(
   name='structs',
   sources=['structs.py'],
   dependencies=[
+    'src/python/pants/base:deprecated',
     'src/python/pants/build_graph',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:nodes',

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -10,11 +10,11 @@ from abc import abstractproperty
 
 from six import string_types
 
+from pants.base.deprecated import deprecated_conditional
+from pants.build_graph.target import Target
 from pants.engine.addressable import Exactly, addressable_list
 from pants.engine.fs import PathGlobs
 from pants.engine.objects import Locatable
-from pants.base.deprecated import deprecated_conditional
-from pants.build_graph.target import Target
 from pants.engine.struct import Struct, StructWithDeps
 from pants.source import wrapped_globs
 from pants.util.contextutil import exception_logging

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -43,7 +43,7 @@ class TargetAdaptor(StructWithDeps):
     # N.B. Here we check specifically for `sources is None`, as it's possible for sources
     # to be e.g. an explicit empty list (sources=[]).
     if sources is None and self.default_sources_globs is not None:
-      if Target.Arguments.global_instance().get_options().implicit_sources:
+      if self.default_sources:
         return Globs(*self.default_sources_globs,
                      spec_path=self.address.spec_path,
                      exclude=self.default_sources_exclude_globs or [])
@@ -66,6 +66,11 @@ class TargetAdaptor(StructWithDeps):
       base_globs = BaseGlobs.from_sources_field(sources, self.address.spec_path)
       path_globs = base_globs.to_path_globs(self.address.spec_path)
       return (SourcesField(self.address, 'sources', base_globs.filespecs, path_globs),)
+
+  @property
+  def default_sources(self):
+    """True if this adaptor should use default sources if they are defined."""
+    return Target.Arguments.global_instance().get_options().implicit_sources
 
   @property
   def default_sources_globs(self):
@@ -250,6 +255,12 @@ class PythonTestsAdaptor(PythonTargetAdaptor):
 
 
 class GoTargetAdaptor(TargetAdaptor):
+
+  @property
+  def default_sources(self):
+    # Go has always used implicit_sources: override to ignore the option.
+    return True
+
   @property
   def default_sources_globs(self):
     # N.B. Go targets glob on `*` due to the way resources and .c companion files are handled.

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -156,20 +156,6 @@ class GraphInvalidationTest(GraphTestBase):
       self.assertEquals(['p', 'a', 'n', 't', 's', 'b', 'u', 'i', 'l', 'd'],
                         sources)
 
-  def test_implicit_sources(self):
-    expected_sources = {
-      'testprojects/tests/python/pants/file_sets:implicit_sources':
-        ['a.py', 'aa.py', 'aaa.py', 'aabb.py', 'ab.py'],
-      'testprojects/tests/python/pants/file_sets:test_with_implicit_sources':
-        ['test_a.py']
-    }
-
-    for spec, exp_sources in expected_sources.items():
-      with self.open_scheduler([spec]) as (graph, _, _):
-        target = graph.get_target(Address.parse(spec))
-        sources = sorted([os.path.basename(s) for s in target.sources_relative_to_buildroot()])
-        self.assertEquals(exp_sources, sources)
-
   def test_target_macro_override(self):
     """Tests that we can "wrap" an existing target type with additional functionality.
 


### PR DESCRIPTION
### Problem

As described on #4439, `implicit_sources` are a fantastic feature, but need to be enabled carefully. Targets which pass no sources arg currently (and which rely on that resulting in the empty set of sources) would be broken by turning on `implicit_sources` by default.

Additionally, the `implicit_sources` arg was not implemented in the v2 engine, so `implicit_sources` were always enabled there.

### Solution

Add support for the `implicit_sources` arg in v2, and warn on a target-by-target basis if `implicit_sources` is not enabled, and no sources were passed.

### Result

Fixes the issue with v2 not supporting the `implicit_sources` option, and opens the door to fixing #4439 in the future.