### PR TITLE
Fix a pytest path mangling bug.

### DIFF
--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -365,7 +365,7 @@ class PytestRun(TestRunnerTaskMixin, PythonExecutionTaskBase):
         real_nodeid = item.nodeid
         real_path = real_nodeid.split('::', 1)[0]
         fixed_path = _SOURCES_MAP.get(real_path, real_path)
-        fixed_nodeid = fixed_path + real_path[len(real_path):]
+        fixed_nodeid = fixed_path + real_nodeid[len(real_path):]
         try:
           item._nodeid = fixed_nodeid
           yield


### PR DESCRIPTION
Restores the ability to see the entire test location (including
class and method) when running in verbose mode.

Addresses https://github.com/pantsbuild/pants/issues/4560