### PR TITLE
Include transitive Resources targets in PrepareResources

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -266,9 +266,8 @@ class JvmTarget(Target, Jarable):
 
   @property
   def resources(self):
-    # TODO(John Sirois): Consider removing this convenience:
-    #   https://github.com/pantsbuild/pants/issues/346
-    # TODO(John Sirois): Introduce a label and replace the type test?
+    # TODO: We should deprecate this method, but doing so will require changes to JVM publishing.
+    #   see https://github.com/pantsbuild/pants/issues/4568
     return [dependency for dependency in self.dependencies if isinstance(dependency, Resources)]
 
   @property

--- a/tests/python/pants_test/backend/jvm/tasks/test_prepare_resources.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_prepare_resources.py
@@ -60,6 +60,20 @@ class PrepareResourcesTest(TaskTestBase):
     self.assertEqual(sorted([self.target('resources:target1'), self.target('resources:target4')]),
                      sorted(relevant_resources_targets))
 
+  def test_find_all_relevant_resources_targets_transitive(self):
+    # Insert a target alias between the resources and the jvm target.
+    resources_target = self.make_target('resources:target', target_type=Resources)
+    alias_target = self.make_target('alias:target',
+                                    target_type=Target,
+                                    dependencies=[resources_target])
+    jvm_target = self.make_target('jvm:target',
+                                  target_type=JvmTarget,
+                                  dependencies=[alias_target])
+
+    task = self.create_task(self.context(target_roots=[jvm_target]))
+    relevant_resources_targets = task.find_all_relevant_resources_targets()
+    self.assertEqual(sorted([resources_target]), sorted(relevant_resources_targets))
+
   def test_prepare_resources_none(self):
     task = self.create_task(self.context())
     resources = self.make_target('resources:target', target_type=Resources)


### PR DESCRIPTION
### Problem

The `resources` arg on JVM and Python targets is now deprecated, but the previous behaviour of only collecting directly declared resources onto the runtime classpath remains. The result for the JVM is that resources are only collected if they are directly depended on by a `JvmTarget`, rather than if they are located anywhere in the transitive dependencies of that target.

While this behaviour has existed for a while, it was difficult to run into it when resources were directly declared as "owned" by a particular target.

### Solution

Transitively collect the relevant `Resources` targets below `JvmTarget` roots in `PrepareResources`.

Also, I've verified on a very large codebase that this did not result in any adverse effects on resource availability.

### Result

`Resources` act (more: see #4568) like other dependencies generally do. Fixes #4567