### PR TITLE
Specify a workunit for node.js test and run

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
@@ -37,7 +37,9 @@ class NodeRun(NodeTask):
         args = ['run-script', self.get_options().script_name, '--'] + self.get_passthru_args()
 
         with pushd(node_path):
-          result, npm_run = self.execute_npm(args, workunit_labels=[WorkUnitLabel.RUN])
+          result, npm_run = self.execute_npm(args,
+                                             workunit_name=target.address.reference(),
+                                             workunit_labels=[WorkUnitLabel.RUN])
           if result != 0:
             raise TaskError('npm run script failed:\n'
                             '\t{} failed with exit code {}'.format(npm_run, result))
@@ -45,7 +47,9 @@ class NodeRun(NodeTask):
         args = ['run', self.get_options().script_name, '--'] + self.get_passthru_args()
         with pushd(node_path):
           returncode, yarnpkg_run_command = self.execute_yarnpkg(
-            args=args, workunit_labels=[WorkUnitLabel.RUN])
+            args=args,
+            workunit_name=target.address.reference(),
+            workunit_labels=[WorkUnitLabel.RUN])
           if returncode != 0:
             raise TaskError('yarnpkg run script failed:\n'
                             '\t{} failed with exit code {}'.format(yarnpkg_run_command, returncode))

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -61,7 +61,7 @@ class NodeTask(Task):
     ) if package_manager else self.node_distribution.package_manager
     return package_manager
 
-  def execute_node(self, args, workunit_name=None, workunit_labels=None):
+  def execute_node(self, args, workunit_name, workunit_labels=None):
     """Executes node passing the given args.
 
     :param list args: The command line args to pass to `node`.
@@ -76,7 +76,7 @@ class NodeTask(Task):
                                  workunit_name=workunit_name,
                                  workunit_labels=workunit_labels)
 
-  def execute_npm(self, args, workunit_name=None, workunit_labels=None):
+  def execute_npm(self, args, workunit_name, workunit_labels=None):
     """Executes npm passing the given args.
 
     :param list args: The command line args to pass to `npm`.
@@ -92,7 +92,7 @@ class NodeTask(Task):
                                  workunit_name=workunit_name,
                                  workunit_labels=workunit_labels)
 
-  def execute_yarnpkg(self, args, workunit_name=None, workunit_labels=None):
+  def execute_yarnpkg(self, args, workunit_name, workunit_labels=None):
     """Executes npm passing the given args.
 
     :param list args: The command line args to pass to `yarnpkg`.
@@ -108,7 +108,7 @@ class NodeTask(Task):
                                  workunit_name=workunit_name,
                                  workunit_labels=workunit_labels)
 
-  def _execute_command(self, command, workunit_name=None, workunit_labels=None):
+  def _execute_command(self, command, workunit_name, workunit_labels=None):
     """Executes a node or npm command via self._run_node_distribution_command.
 
     :param NodeDistribution.Command command: The command to run.

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -74,7 +74,9 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
 
         with pushd(node_path):
           self._currently_executing_test_targets = [target]
-          result, npm_test_command = self.execute_npm(args, workunit_labels=[WorkUnitLabel.TEST])
+          result, npm_test_command = self.execute_npm(args,
+                                                      workunit_name=target.address.reference(),
+                                                      workunit_labels=[WorkUnitLabel.TEST])
           if result != 0:
             raise TaskError('npm test script failed:\n'
                             '\t{} failed with exit code {}'.format(npm_test_command, result))
@@ -83,7 +85,9 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
         with pushd(node_path):
           self._currently_executing_test_targets = [target]
           result, npm_test_command = self.execute_yarnpkg(
-            args=args, workunit_labels=[WorkUnitLabel.TEST])
+            args=args,
+            workunit_name=target.address.reference(),
+            workunit_labels=[WorkUnitLabel.TEST])
           if result != 0:
             raise TaskError('npm test script failed:\n'
                             '\t{} failed with exit code {}'.format(npm_test_command, result))

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
@@ -93,7 +93,7 @@ class NodeTaskTest(TaskTestBase):
           fs.writeFile("{proof}", "Hello World!", function(err) {{}});
           """).format(proof=proof))
       self.assertFalse(os.path.exists(proof))
-      returncode, command = task.execute_node([script])
+      returncode, command = task.execute_node([script], workunit_name='test')
 
       self.assertEqual(0, returncode)
       self.assertTrue(os.path.exists(proof))
@@ -115,7 +115,7 @@ class NodeTaskTest(TaskTestBase):
       with open(os.path.join(chroot, 'package.json'), 'wb') as fp:
         json.dump(package, fp)
       with pushd(chroot):
-        returncode, _ = task.execute_npm(['run-script', 'proof'])
+        returncode, _ = task.execute_npm(['run-script', 'proof'], workunit_name='test')
 
       self.assertEqual(0, returncode)
       self.assertTrue(os.path.exists(proof))
@@ -137,7 +137,7 @@ class NodeTaskTest(TaskTestBase):
       with open(os.path.join(chroot, 'package.json'), 'wb') as fp:
         json.dump(package, fp)
       with pushd(chroot):
-        returncode, _ = task.execute_yarnpkg(['run', 'proof'])
+        returncode, _ = task.execute_yarnpkg(['run', 'proof'], workunit_name='test')
 
       self.assertEqual(0, returncode)
       self.assertTrue(os.path.exists(proof))


### PR DESCRIPTION
### Problem

Not specifying the workunit for these tasks resulted in the binary name being used as the workunit name, which was very long (especially in CI environments) and not particularly readable. And because the workunit name ends up used as a filename, it was also possible to trip filename length limits this way.

### Solution

Align with the other node tasks in using the target address as the workunit name.

### Result

Output looks like
```
11:02:45 00:03     [node]
11:02:48 00:06       [examplebird/intake-service:node-lint]

                     > ...
```
rather than:
```
11:02:45 00:03     [node]
11:02:48 00:06       [/Users/stuhood/.cache/pants/bin/node/mac/10.11/v6.9.5/node/bin/npm]

                    > ...
```

And filename length limits aren't triggered in cases where the HOME directory path is very long.