### PR TITLE
Exclude only roots for exclude-target-regexp in v2

### DIFF
--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -39,16 +39,8 @@ class AddressMap(datatype('AddressMap', ['path', 'objects_by_name'])):
   :param objects_by_name: A dict mapping from object name to the parsed 'thin' addressable object.
   """
 
-  @staticmethod
-  def exclude_target(target_address, exclude_patterns):
-    if exclude_patterns:
-      for pattern in exclude_patterns:
-        if pattern.search(target_address) is not None:
-          return True
-    return False
-
   @classmethod
-  def parse(cls, filepath, filecontent, symbol_table_cls, parser_cls, exclude_patterns=None):
+  def parse(cls, filepath, filecontent, symbol_table_cls, parser_cls):
     """Parses a source for addressable Serializable objects.
 
     No matter the parser used, the parsed and mapped addressable objects are all 'thin'; ie: any
@@ -61,7 +53,6 @@ class AddressMap(datatype('AddressMap', ['path', 'objects_by_name'])):
     :type symbol_table_cls: A :class:`pants.engine.parser.SymbolTable`.
     :param parser_cls: The parser cls to use.
     :type parser_cls: A :class:`pants.engine.parser.Parser`.
-    :param list exclude_patterns: A list of compiled regular expression objects.
     """
     try:
       objects = parser_cls.parse(filepath, filecontent, symbol_table_cls)
@@ -80,10 +71,7 @@ class AddressMap(datatype('AddressMap', ['path', 'objects_by_name'])):
       if name in objects_by_name:
         raise DuplicateNameError('An object already exists at {!r} with name {!r}: {!r}.  Cannot '
                                  'map {!r}'.format(filepath, name, objects_by_name[name], obj))
-
-      target_address = '{}:{}'.format(os.path.dirname(filepath), name)
-      if not AddressMap.exclude_target(target_address, exclude_patterns):
-        objects_by_name[name] = obj
+      objects_by_name[name] = obj
     return cls(filepath, OrderedDict(sorted(objects_by_name.items())))
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -163,8 +163,7 @@ class GlobalOptionsRegistrar(Optionable):
                   "are used.  Multiple constraints may be added.  They will be ORed together.")
     register('--exclude-target-regexp', advanced=True, type=list, default=[],
              metavar='<regexp>',
-             help='Exclude targets that match these regexes.',
-             recursive=True)  # TODO: Does this need to be recursive? What does that even mean?
+             help='Exclude target roots that match these regexes.')
     # Relative pants_distdir to buildroot. Requires --pants-distdir to be bootstrapped above first.
     # e.g. '/dist/'
     rel_distdir = '/{}/'.format(os.path.relpath(register.bootstrap.pants_distdir, get_buildroot()))

--- a/testprojects/src/java/org/pantsbuild/testproject/phrases/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/phrases/BUILD
@@ -19,4 +19,11 @@ jvm_binary(name='ten-thousand',
 jvm_binary(name='there-was-a-duck',
   main='org.pantsbuild.testproject.phrases.ThereWasADuck',
   source='ThereWasADuck.java',
+  dependencies=[
+    ':with-her-trusty-companion',
+  ]
+)
+
+java_library(name='with-her-trusty-companion',
+  sources=['TrustyCompanion.java'],
 )

--- a/testprojects/src/java/org/pantsbuild/testproject/phrases/ThereWasADuck.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/phrases/ThereWasADuck.java
@@ -5,6 +5,6 @@ package org.pantsbuild.testproject.phrases;
  */
 public class ThereWasADuck {
   public static void main(String[] args) {
-    System.out.println("And also, there was a duck.");
+    System.out.println("And also, there was a duck, with her " + TrustyCompanion.VALUE +  ".");
   }
 }

--- a/testprojects/src/java/org/pantsbuild/testproject/phrases/TrustyCompanion.java
+++ b/testprojects/src/java/org/pantsbuild/testproject/phrases/TrustyCompanion.java
@@ -1,0 +1,5 @@
+package org.pantsbuild.testproject.phrases;
+
+public class TrustyCompanion {
+  public static String VALUE = "trusty companion";
+}

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -33,8 +33,8 @@ python_tests(
 )
 
 python_tests(
-  name = 'bundle_integration',
-  sources = [ 'test_bundle_integration.py' ],
+  name = 'exclude_target_regexp_integration',
+  sources = [ 'test_exclude_target_regexp_integration.py' ],
   dependencies = [
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
+++ b/tests/python/pants_test/base/test_exclude_target_regexp_integration.py
@@ -40,13 +40,15 @@ class Bundles(object):
   ten_thousand = Bundle('ten-thousand',
       "And now you must face my army of ten thousand BUILD files.")
   there_was_a_duck = Bundle('there-was-a-duck',
-      "And also, there was a duck.")
+      "And also, there was a duck, with her trusty companion.")
+
+  trusty_companion = 'with-her-trusty-companion'
 
   all_bundles = [lesser_of_two, once_upon_a_time, ten_thousand, there_was_a_duck]
 
 
-class BundleIntegrationTest(PantsRunIntegrationTest):
-  """Tests the functionality of the --spec-exclude flag in pants."""
+class ExcludeTargetRegexpIntegrationTest(PantsRunIntegrationTest):
+  """Tests the functionality of the --exclude-target-regexp flag."""
 
   def _bundle_path(self, bundle):
     return os.path.join(get_buildroot(), 'dist',
@@ -135,12 +137,11 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
     )
 
   @ensure_engine
-  def test_bundle_resource_ordering(self):
-    """Ensures that `resources=` ordering is respected."""
-    pants_run = self.run_pants(
-      ['-q',
-       'run',
-       'testprojects/src/java/org/pantsbuild/testproject/bundle:bundle-resource-ordering']
+  def test_only_exclude_roots(self):
+    # You cannot exclude the trusty companion (ie dependency) of an included root.
+    self._test_bundle_existences([
+          '{}:{}'.format(Bundles.phrase_path, Bundles.there_was_a_duck.spec),
+          '--exclude-target-regexp={}:{}'.format(Bundles.phrase_path, Bundles.trusty_companion),
+        ],
+        set([Bundles.there_was_a_duck]),
     )
-    self.assert_success(pants_run)
-    self.assertEquals(pants_run.stdout_data, 'Hello world from Foo\n\n')

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -31,7 +31,8 @@ python_tests(
   dependencies = [
     'tests/python/pants_test:int-test'
   ],
-  tags = {'integration'}
+  tags = {'integration'},
+  timeout = 240,
 )
 
 python_tests(
@@ -65,7 +66,7 @@ python_tests(
     'tests/python/pants_test:int-test'
   ],
   tags = {'integration'},
-  timeout = 90,
+  timeout = 30,
 )
 
 python_tests(

--- a/tests/python/pants_test/engine/legacy/test_bundle_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_bundle_integration.py
@@ -54,3 +54,14 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
         self.assert_success(pants_run)
         self.assertTrue(os.path.isfile(
           '{}/{}.rel_path-bundle/b/file1.txt'.format(temp_distdir, self.TARGET_PATH.replace('/', '.'))))
+
+  @ensure_engine
+  def test_bundle_resource_ordering(self):
+    """Ensures that `resources=` ordering is respected."""
+    pants_run = self.run_pants(
+      ['-q',
+       'run',
+       'testprojects/src/java/org/pantsbuild/testproject/bundle:bundle-resource-ordering']
+    )
+    self.assert_success(pants_run)
+    self.assertEquals(pants_run.stdout_data, 'Hello world from Foo\n\n')

--- a/tests/python/pants_test/help/test_help_integration.py
+++ b/tests/python/pants_test/help/test_help_integration.py
@@ -47,7 +47,7 @@ class TestHelpIntegration(PantsRunIntegrationTest):
     self.assertIn('cache.test.junit advanced options:', pants_run.stdout_data)
     # Spot check to see that full args for all options are printed
     self.assertIn('--binary-dup-max-dups', pants_run.stdout_data)
-    self.assertIn('--cache-test-junit-exclude-target-regexp', pants_run.stdout_data)
+    self.assertIn('--cache-test-junit-read', pants_run.stdout_data)
     # Spot check to see that subsystem options are printing
     self.assertIn('--jvm-options', pants_run.stdout_data)
     # Spot check to see that advanced subsystem options are printing


### PR DESCRIPTION
### Problem

The `v2` engine implemented the `exclude-target-regexp` option differently from the `v1` engine, in that it completely excluded targets immediately after parsing. While that arguably aligned with the option's docstring, it did not align with the implementation in the `v1` engine, which had the effect of only filtering target roots.

Real usecases in the wild (see https://github.com/twitter/commons/pull/451) were depending on the behaviour of filtering only roots, and the result of filtering targets completely out of the graph when other things are depending on them is always some sort of error.

### Solution

Align the behaviour of `v2` with `v1` by only filtering root targets, clarify the doc string, and add a test that excluding a dependency still allows the dependee to be built.

### Result

The behaviour of the `v1` engine for this case is preserved in `v2`. Users who want to completely ignore a BUILD file can use the more granular `--build-ignore` option to do so. Fixes #4573