### PR TITLE
Fix splitting of the build_flags.

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -6,10 +6,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import re
 
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.util.dirutil import safe_mkdir
+from pants.util.strutil import safe_shlex_split
 
 from pants.contrib.go.targets.go_target import GoTarget
 from pants.contrib.go.tasks.go_workspace_task import GoWorkspaceTask
@@ -58,7 +60,8 @@ class GoCompile(GoWorkspaceTask):
                                                    vt.target.import_path + '.a')
 
   def _go_install(self, target, gopath):
-    args = self.get_options().build_flags.split() + [target.import_path]
+    build_flags = re.sub(r'^"|"$', '', self.get_options().build_flags)
+    args = safe_shlex_split(build_flags) + [target.import_path]
     result, go_cmd = self.go_dist.execute_go_cmd(
       'install', gopath=gopath, args=args,
       workunit_factory=self.context.new_workunit,

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_compile_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_compile_integration.py
@@ -42,3 +42,8 @@ class GoCompileIntegrationTest(PantsRunIntegrationTest):
     args = ['compile', 'contrib/go/examples/src/go/server']
     pants_run = self.run_pants(args)
     self.assert_success(pants_run)
+
+  def test_go_compile_fully_static(self):
+    args = ['compile', 'contrib/go/examples/src/go/server', '--compile-go-build-flags="--ldflags \'-extldflags \"-static\"\'"']
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)


### PR DESCRIPTION
With this change one can supply more complex build flags as demonstrated by the test.

### Problem

Previously the option handling did not properly un-escape the flags.
Fixes #4563

### Solution

Use safe_shlex_split() instead of spit() and handle top-level quotes.
