### PR TITLE
Fix export-classpath exclude behavior

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -33,7 +33,7 @@ class RuntimeClasspathPublisher(Task):
   def execute(self):
     basedir = os.path.join(self.get_options().pants_distdir, self._output_folder)
     runtime_classpath = self.context.products.get_data('runtime_classpath')
-    targets = self.context.targets()
+    targets = self.context.target_roots
     if self.get_options().manifest_jar_only:
       classpath = ClasspathUtil.classpath(targets, runtime_classpath)
       # Safely create e.g. dist/export-classpath/manifest.jar

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -708,8 +708,10 @@ python_tests(
   sources = ['test_export_classpath_integration.py'],
   dependencies = [
     'tests/python/pants_test/tasks:task_test_base',
+    'tests/python/pants_test:int-test',
   ],
   tags = {'integration'},
+  timeout = 300
 )
 
 python_tests(

--- a/tests/python/pants_test/backend/jvm/tasks/test_export_classpath_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_export_classpath_integration.py
@@ -8,6 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import time
 
+from pants.java.jar.manifest import Manifest
+from pants.util.contextutil import open_zip
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -27,3 +29,17 @@ class ExportClasspathIntegrationTest(PantsRunIntegrationTest):
       time.sleep(1)
 
     self.assertTrue(ctimes[1] > ctimes[0], "{} is not overwritten.".format(manifest_jar_path))
+
+  def test_export_classpath_file_with_excludes(self):
+    manifest_jar_path = "dist/export-classpath/manifest.jar"
+    pants_run = self.run_pants(["export-classpath",
+      "--manifest-jar-only",
+      "testprojects/src/java/org/pantsbuild/testproject/exclude:foo"])
+    self.assert_success(pants_run)
+    self.assertTrue(os.path.exists(manifest_jar_path))
+
+    with open_zip(manifest_jar_path) as synthetic_jar:
+      self.assertListEqual([Manifest.PATH], synthetic_jar.namelist())
+      oneline_classpath = synthetic_jar.read(Manifest.PATH).replace('\n', '')
+      self.assertNotIn('sbt', oneline_classpath)
+      self.assertIn('foo', oneline_classpath)


### PR DESCRIPTION
### Problem

Excluded jars were being included in the manifest jar created by export-classpath.

### Solution

Use the root targets as the starting point instead of the full closure when generating the classpath. When the whole closure was passed, it meant that even the jar_library targets were treated as root targets for the purposes of applying excludes, which meant that the least constrained excludes were always used.

### Result

Excludes are properly respected by classpaths from export-classpath.
