### PR TITLE
Change method of reporting target data

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -434,9 +434,8 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
           for test_name, test_info in tests_info.items():
             test_item = Test(test_info['classname'], test_name)
             test_target = test_registry.get_owning_target(test_item)
-            for test_info_key, test_info_val in test_info.items():
-              key_list = [test_name, test_info_key]
-              self.report_test_info(self.options_scope, test_target, key_list, test_info_val)
+            self.report_all_info_for_single_test(self.options_scope, test_target,
+                                                 test_name, test_info)
 
           if result != 0 and self._fail_fast:
             break

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -434,7 +434,9 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
           for test_name, test_info in tests_info.items():
             test_item = Test(test_info['classname'], test_name)
             test_target = test_registry.get_owning_target(test_item)
-            self.report_test_info(self.options_scope, test_target, test_name, test_info)
+            for test_info_key, test_info_val in test_info.items():
+              key_list = [test_name, test_info_key]
+              self.report_test_info(self.options_scope, test_target, key_list, test_info_val)
 
           if result != 0 and self._fail_fast:
             break

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -547,7 +547,9 @@ class PytestRun(TestRunnerTaskMixin, PythonExecutionTaskBase):
       all_tests_info = self.parse_test_info(junitxml_path, parse_error_handler, ['file', 'name'])
       for test_name, test_info in all_tests_info.items():
         test_target = self._get_target_from_test(test_info, targets)
-        self.report_test_info(self.options_scope, test_target, test_name, test_info)
+        for test_info_key, test_info_val in test_info.items():
+          key_list = [test_name, test_info_key]
+          self.report_test_info(self.options_scope, test_target, key_list, test_info_val)
 
       return result.with_failed_targets(failed_targets)
 

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -547,9 +547,7 @@ class PytestRun(TestRunnerTaskMixin, PythonExecutionTaskBase):
       all_tests_info = self.parse_test_info(junitxml_path, parse_error_handler, ['file', 'name'])
       for test_name, test_info in all_tests_info.items():
         test_target = self._get_target_from_test(test_info, targets)
-        for test_info_key, test_info_val in test_info.items():
-          key_list = [test_name, test_info_key]
-          self.report_test_info(self.options_scope, test_target, key_list, test_info_val)
+        self.report_all_info_for_single_test(self.options_scope, test_target, test_name, test_info)
 
       return result.with_failed_targets(failed_targets)
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -442,9 +442,9 @@ class RunTracker(Subsystem):
     :param primitive value: The value of the information being stored.
     :param int index: The index into the list of keys (starting from the beginning).
     """
-    if len(keys) == 0 or index >= len(keys):
+    if len(keys) == 0 or index < 0 or index >= len(keys):
       raise ValueError('Keys must contain at least one key and index must be'
-                       'an integer less than the length of the keys.')
+                       'an integer greater than 0 and less than the number of keys.')
     if len(keys) < 2 or not data:
       new_data_to_add = RunTracker.create_dict_with_nested_keys_and_val(keys, value, len(keys) - 1)
       data.update(new_data_to_add)

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -429,14 +429,16 @@ class RunTracker(Subsystem):
     :param primitive value: The value of the information being stored.
     :return: dict of nested keys leading to the value.
     """
-    current_index = len(keys) - 1
 
     if len(keys) > 1:
-      new_val = {keys[current_index]: value}
-      new_keys = keys[:current_index]
+      new_keys = keys[:-1]
+      new_val = {keys[-1]: value}
       return cls._create_dict_with_nested_keys_and_val(new_keys, new_val)
     elif len(keys) == 1:
-      return {keys[current_index]: value}
+      return {keys[0]: value}
+    else:
+      raise ValueError('Keys must contain at least one key.')
+
 
   @classmethod
   def _merge_list_of_keys_into_dict(cls, data, keys, value, index=0):

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -66,19 +66,19 @@ class TestRunnerTaskMixin(object):
       all_targets = self._get_targets()
       self._execute(all_targets)
 
-  def report_test_info(self, scope, target, test_name, test_info):
+  def report_test_info(self, scope, target, keys, test_info):
     """Add test information to target information.
 
     :param string scope: The scope for which we are reporting information.
     :param Target target: The target that we want to store the test information under.
-    :param string test_name: The key (test name) for the information being stored.
-    :param dict test_info: The information being stored.
+    :param list of string keys: The keys that will point to the information being stored.
+    :param primitive test_info: The information being stored.
     """
     if target and scope:
       address = target.address.spec
       target_type = target.type_alias
-      self.context.run_tracker.report_target_info('GLOBAL', address, 'target_type', target_type)
-      self.context.run_tracker.report_target_info(scope, address, test_name, test_info)
+      self.context.run_tracker.report_target_info('GLOBAL', address, ['target_type'], target_type)
+      self.context.run_tracker.report_target_info(scope, address, keys, test_info)
 
   @staticmethod
   def parse_test_info(xml_path, error_handler, additional_testcase_attributes=None):

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -77,9 +77,7 @@ class TestRunnerTaskMixin(object):
     if target and scope:
       address = target.address.spec
       target_type = target.type_alias
-      if not self.context.run_tracker.check_key_existence_in_scope_level_target_data('GLOBAL',
-        address, 'target_type'):
-        self.context.run_tracker.report_target_info('GLOBAL', address, ['target_type'], target_type)
+      self.context.run_tracker.report_target_info('GLOBAL', address, ['target_type'], target_type)
       self.context.run_tracker.report_target_info(scope, address, keys, test_info)
 
   @staticmethod

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -66,6 +66,22 @@ class TestRunnerTaskMixin(object):
       all_targets = self._get_targets()
       self._execute(all_targets)
 
+  def report_all_info_for_single_test(self, scope, target, test_name, test_info):
+    """Add all of the test information for a single test.
+
+    Given the dict of test information
+    {'time': 0.124, 'result_code': 'success', 'classname': 'some.test.class'}
+    iterate through each item and report the single item with report_test_info.
+
+    :param string scope: The scope for which we are reporting the information.
+    :param Target target: The target that we want to store the test information under.
+    :param string test_name: The test's name.
+    :param dict test_info: The test's information, including run duration and result.
+    """
+    for test_info_key, test_info_val in test_info.items():
+      key_list = [test_name, test_info_key]
+      self.report_test_info(scope, target, key_list, test_info_val)
+
   def report_test_info(self, scope, target, keys, test_info):
     """Add test information to target information.
 

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -71,7 +71,7 @@ class TestRunnerTaskMixin(object):
 
     Given the dict of test information
     {'time': 0.124, 'result_code': 'success', 'classname': 'some.test.class'}
-    iterate through each item and report the single item with report_test_info.
+    iterate through each item and report the single item with _report_test_info.
 
     :param string scope: The scope for which we are reporting the information.
     :param Target target: The target that we want to store the test information under.
@@ -80,9 +80,9 @@ class TestRunnerTaskMixin(object):
     """
     for test_info_key, test_info_val in test_info.items():
       key_list = [test_name, test_info_key]
-      self.report_test_info(scope, target, key_list, test_info_val)
+      self._report_test_info(scope, target, key_list, test_info_val)
 
-  def report_test_info(self, scope, target, keys, test_info):
+  def _report_test_info(self, scope, target, keys, test_info):
     """Add test information to target information.
 
     :param string scope: The scope for which we are reporting information.

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -77,7 +77,9 @@ class TestRunnerTaskMixin(object):
     if target and scope:
       address = target.address.spec
       target_type = target.type_alias
-      self.context.run_tracker.report_target_info('GLOBAL', address, ['target_type'], target_type)
+      if not self.context.run_tracker.check_key_existence_in_scope_level_target_data('GLOBAL',
+        address, 'target_type'):
+        self.context.run_tracker.report_target_info('GLOBAL', address, ['target_type'], target_type)
       self.context.run_tracker.report_target_info(scope, address, keys, test_info)
 
   @staticmethod

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -151,3 +151,14 @@ class RunTrackerTest(BaseTest):
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })
+
+    keys = ['one', 'two', 'a']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'L-A-L-A', index)
+    self.assertEquals(data, {
+      'one': {'two': {'a': 'L-A-L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
+      'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
+    })
+
+    keys = ['one', 'two', 'a', 'b', 'c']
+    with self.assertRaises(ValueError):
+      RunTracker.merge_list_of_keys_into_dict(data, keys, 'new A', index)

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -98,6 +98,13 @@ class RunTrackerTest(BaseTest):
     with self.assertRaises(ValueError):
       RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', index)
 
+    with self.assertRaises(ValueError):
+      RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', -1)
+
+    keys = ['key']
+    with self.assertRaises(ValueError):
+      RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', 1)
+
     keys = ['a']
     RunTracker.merge_list_of_keys_into_dict(data, keys, 'O-N-E', index)
     self.assertEquals(data, {'a': 'O-N-E'})

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -62,105 +62,104 @@ class RunTrackerTest(BaseTest):
     keys = []
 
     self.assertEquals(
-      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       None
     )
 
     keys += ['one']
     self.assertEquals(
-      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': 'something'}
     )
 
     keys += ['two']
     self.assertEquals(
-      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': {'two': 'something'}}
     )
 
     keys += ['three']
     self.assertEquals(
-      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': {'two': {'three': 'something'}}}
     )
 
     keys += ['four']
     self.assertEquals(
-      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
       {'one': {'two': {'three': {'four': 'something'}}}}
     )
 
   def test_merge_list_of_keys_into_dict(self):
     data = {}
     keys = []
-    index = 0
 
     with self.assertRaises(ValueError):
-      RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', index)
+      RunTracker._merge_list_of_keys_into_dict(data, keys, 'something')
 
     with self.assertRaises(ValueError):
-      RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', -1)
+      RunTracker._merge_list_of_keys_into_dict(data, keys, 'something', -1)
 
     keys = ['key']
     with self.assertRaises(ValueError):
-      RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', 1)
+      RunTracker._merge_list_of_keys_into_dict(data, keys, 'something', 1)
 
     keys = ['a']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'O-N-E', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'O-N-E')
     self.assertEquals(data, {'a': 'O-N-E'})
 
     keys = ['one', 'two', 'three']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'T-H-R-E-E', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'T-H-R-E-E')
     self.assertEquals(data, {'one': {'two': {'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
 
     keys = ['one', 'two', 'a']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'L-A', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'L-A')
     self.assertEquals(data, {'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
 
     keys = ['c', 'd', 'e', 'f']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'F-O-U-R', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'F-O-U-R')
     self.assertEquals(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E'}}, 'a': 'O-N-E',
       'c': {'d': {'e': {'f': 'F-O-U-R'}}}
     })
 
     keys = ['one', 'two', 'x', 'y']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'W-H-Y', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'W-H-Y')
     self.assertEquals(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y'}}}, 'a': 'O-N-E',
       'c': {'d': {'e': {'f': 'F-O-U-R'}}}
     })
 
     keys = ['c', 'd', 'e', 'g', 'h']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'H-E-L-L-O', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'H-E-L-L-O')
     self.assertEquals(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y'}}}, 'a': 'O-N-E',
       'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O'}}}}
     })
 
     keys = ['one', 'two', 'x', 'z']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'Z-E-D', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'Z-E-D')
     self.assertEquals(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O'}}}}
     })
 
     keys = ['c', 'd', 'e', 'g', 'i']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'E-Y-E', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'E-Y-E')
     self.assertEquals(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })
 
     keys = ['a']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'new O-N-E', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'new O-N-E')
     self.assertEquals(data, {
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })
 
     keys = ['one', 'two', 'a']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'L-A-L-A', index)
+    RunTracker._merge_list_of_keys_into_dict(data, keys, 'L-A-L-A')
     self.assertEquals(data, {
       'one': {'two': {'a': 'L-A-L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
@@ -168,4 +167,4 @@ class RunTrackerTest(BaseTest):
 
     keys = ['one', 'two', 'a', 'b', 'c']
     with self.assertRaises(ValueError):
-      RunTracker.merge_list_of_keys_into_dict(data, keys, 'new A', index)
+      RunTracker._merge_list_of_keys_into_dict(data, keys, 'new A')

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -151,7 +151,3 @@ class RunTrackerTest(BaseTest):
       'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
       'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })
-
-    keys = ['one', 'two', 'three']
-    with self.assertRaises(ValueError):
-      RunTracker.merge_list_of_keys_into_dict(data, keys, 'new T-H-R-E-E', index)

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -61,10 +61,8 @@ class RunTrackerTest(BaseTest):
   def test_create_dict_with_nested_keys_and_val(self):
     keys = []
 
-    self.assertEquals(
-      RunTracker._create_dict_with_nested_keys_and_val(keys, 'something'),
-      None
-    )
+    with self.assertRaises(ValueError):
+      RunTracker._create_dict_with_nested_keys_and_val(keys, 'something')
 
     keys += ['one']
     self.assertEquals(

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -98,56 +98,60 @@ class RunTrackerTest(BaseTest):
     with self.assertRaises(ValueError):
       RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', index)
 
-    keys += ['one']
+    keys = ['a']
     RunTracker.merge_list_of_keys_into_dict(data, keys, 'O-N-E', index)
-    self.assertEquals(data, {'one': 'O-N-E'})
-
-    keys += ['two']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'T-W-O', index)
-    self.assertEquals(data, {'one': {'two': 'T-W-O'}})
-
-    keys += ['three']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'T-H-R-E-E', index)
-    self.assertEquals(data, {'one': {'two': {'three': 'T-H-R-E-E'}}})
-
-    keys = ['one', 'two', 'a']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'A-E', index)
-    self.assertEquals(data, {'one': {'two': {'a': 'A-E', 'three': 'T-H-R-E-E'}}})
-
-    keys = ['one', 'two', 'a', 'b']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'B-E', index)
-    self.assertEquals(data, {'one': {'two': {'a': {'b': 'B-E'}, 'three': 'T-H-R-E-E'}}})
+    self.assertEquals(data, {'a': 'O-N-E'})
 
     keys = ['one', 'two', 'three']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'new T-H-R-E-E', index)
-    self.assertEquals(data, {'one': {'two': {'a': {'b': 'B-E'}, 'three': 'new T-H-R-E-E'}}})
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'T-H-R-E-E', index)
+    self.assertEquals(data, {'one': {'two': {'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
 
-    keys = ['one', 'two', 'hi', 'hey', 'hola']
+    keys = ['one', 'two', 'a']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'L-A', index)
+    self.assertEquals(data, {'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E'}}, 'a': 'O-N-E'})
+
+    keys = ['c', 'd', 'e', 'f']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'F-O-U-R', index)
+    self.assertEquals(data, {
+      'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E'}}, 'a': 'O-N-E',
+      'c': {'d': {'e': {'f': 'F-O-U-R'}}}
+    })
+
+    keys = ['one', 'two', 'x', 'y']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'W-H-Y', index)
+    self.assertEquals(data, {
+      'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y'}}}, 'a': 'O-N-E',
+      'c': {'d': {'e': {'f': 'F-O-U-R'}}}
+    })
+
+    keys = ['c', 'd', 'e', 'g', 'h']
     RunTracker.merge_list_of_keys_into_dict(data, keys, 'H-E-L-L-O', index)
     self.assertEquals(data, {
-      'one': {
-        'two': {'hi': {'hey': {'hola': 'H-E-L-L-O'}}, 'a': {'b': 'B-E'}, 'three': 'new T-H-R-E-E'}
-      }
+      'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y'}}}, 'a': 'O-N-E',
+      'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O'}}}}
     })
 
-    keys = ['one', 'two', 'hi', 'hey', 'yeah']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'Y-E-A-H', index)
+    keys = ['one', 'two', 'x', 'z']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'Z-E-D', index)
     self.assertEquals(data, {
-      'one': {
-        'two': {
-          'hi': {'hey': {'hola': 'H-E-L-L-O', 'yeah': 'Y-E-A-H'}}, 'a': {'b': 'B-E'},
-          'three': 'new T-H-R-E-E'
-        }
-      }
+      'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
+      'a': 'O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O'}}}}
     })
 
-    keys = ['one', 'two', 'a', 'c']
-    RunTracker.merge_list_of_keys_into_dict(data, keys, 'S-E-E', index)
+    keys = ['c', 'd', 'e', 'g', 'i']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'E-Y-E', index)
     self.assertEquals(data, {
-      'one': {
-        'two': {
-          'hi': {'hey': {'hola': 'H-E-L-L-O', 'yeah': 'Y-E-A-H'}}, 'a': {'b': 'B-E', 'c': 'S-E-E'},
-          'three': 'new T-H-R-E-E'
-        }
-      }
+      'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
+      'a': 'O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
     })
+
+    keys = ['a']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'new O-N-E', index)
+    self.assertEquals(data, {
+      'one': {'two': {'a': 'L-A', 'three': 'T-H-R-E-E', 'x': {'y': 'W-H-Y', 'z': 'Z-E-D'}}},
+      'a': 'new O-N-E', 'c': {'d': {'e': {'f': 'F-O-U-R', 'g': {'h': 'H-E-L-L-O', 'i': 'E-Y-E'}}}}
+    })
+
+    keys = ['one', 'two', 'three']
+    with self.assertRaises(ValueError):
+      RunTracker.merge_list_of_keys_into_dict(data, keys, 'new T-H-R-E-E', index)

--- a/tests/python/pants_test/goal/test_run_tracker.py
+++ b/tests/python/pants_test/goal/test_run_tracker.py
@@ -57,3 +57,97 @@ class RunTrackerTest(BaseTest):
       with open(file_name) as f:
         result = json.load(f)
         self.assertEquals(stats, result)
+
+  def test_create_dict_with_nested_keys_and_val(self):
+    keys = []
+
+    self.assertEquals(
+      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      None
+    )
+
+    keys += ['one']
+    self.assertEquals(
+      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      {'one': 'something'}
+    )
+
+    keys += ['two']
+    self.assertEquals(
+      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      {'one': {'two': 'something'}}
+    )
+
+    keys += ['three']
+    self.assertEquals(
+      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      {'one': {'two': {'three': 'something'}}}
+    )
+
+    keys += ['four']
+    self.assertEquals(
+      RunTracker.create_dict_with_nested_keys_and_val(keys, 'something', len(keys) - 1),
+      {'one': {'two': {'three': {'four': 'something'}}}}
+    )
+
+  def test_merge_list_of_keys_into_dict(self):
+    data = {}
+    keys = []
+    index = 0
+
+    with self.assertRaises(ValueError):
+      RunTracker.merge_list_of_keys_into_dict(data, keys, 'something', index)
+
+    keys += ['one']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'O-N-E', index)
+    self.assertEquals(data, {'one': 'O-N-E'})
+
+    keys += ['two']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'T-W-O', index)
+    self.assertEquals(data, {'one': {'two': 'T-W-O'}})
+
+    keys += ['three']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'T-H-R-E-E', index)
+    self.assertEquals(data, {'one': {'two': {'three': 'T-H-R-E-E'}}})
+
+    keys = ['one', 'two', 'a']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'A-E', index)
+    self.assertEquals(data, {'one': {'two': {'a': 'A-E', 'three': 'T-H-R-E-E'}}})
+
+    keys = ['one', 'two', 'a', 'b']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'B-E', index)
+    self.assertEquals(data, {'one': {'two': {'a': {'b': 'B-E'}, 'three': 'T-H-R-E-E'}}})
+
+    keys = ['one', 'two', 'three']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'new T-H-R-E-E', index)
+    self.assertEquals(data, {'one': {'two': {'a': {'b': 'B-E'}, 'three': 'new T-H-R-E-E'}}})
+
+    keys = ['one', 'two', 'hi', 'hey', 'hola']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'H-E-L-L-O', index)
+    self.assertEquals(data, {
+      'one': {
+        'two': {'hi': {'hey': {'hola': 'H-E-L-L-O'}}, 'a': {'b': 'B-E'}, 'three': 'new T-H-R-E-E'}
+      }
+    })
+
+    keys = ['one', 'two', 'hi', 'hey', 'yeah']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'Y-E-A-H', index)
+    self.assertEquals(data, {
+      'one': {
+        'two': {
+          'hi': {'hey': {'hola': 'H-E-L-L-O', 'yeah': 'Y-E-A-H'}}, 'a': {'b': 'B-E'},
+          'three': 'new T-H-R-E-E'
+        }
+      }
+    })
+
+    keys = ['one', 'two', 'a', 'c']
+    RunTracker.merge_list_of_keys_into_dict(data, keys, 'S-E-E', index)
+    self.assertEquals(data, {
+      'one': {
+        'two': {
+          'hi': {'hey': {'hola': 'H-E-L-L-O', 'yeah': 'Y-E-A-H'}}, 'a': {'b': 'B-E', 'c': 'S-E-E'},
+          'three': 'new T-H-R-E-E'
+        }
+      }
+    })


### PR DESCRIPTION
### Problem

In a previous version we were reporting target information by providing a string that is a key and a value which was a dict containing a lot of information. We want to be able to provide a list of keys that will recursively find the right place in a nested dict to store a primitive value (rather than a dictionary) to the reporting method.

### Solution

I created to helper methods to do this work. One recursively nests they keys with the value, and another does the work of finding the correctly place in an existing dictionary to update with the new nested dict. 

### Result

These changes will affect how developers call the report_target_info API. As far as I know, no one is using it yet, so we don't need to make any changes to the dev documentation (apart from the method docs itself).