### PR TITLE
Switch to a conditional deprecation for the list-targets behaviour change

### DIFF
--- a/src/python/pants/task/BUILD
+++ b/src/python/pants/task/BUILD
@@ -6,6 +6,7 @@ python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/base:worker_pool',

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat
 
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
@@ -566,11 +567,12 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     :param string goal_name: The goal name to use for any warning emissions.
     :param callable predicate: The predicate to pass to `context.scan().targets(predicate=X)`.
     """
+    deprecated_conditional(
+        lambda: not self.context.target_roots,
+        '1.5.0.dev0',
+        '`./pants {0}` (with no explicit targets) will soon become an error. Please specify '
+        'one or more explicit target specs (e.g. `./pants {0} ::`).'.format(goal_name))
     if not self.context.target_roots and not self.get_options().enable_v2_engine:
-      self.context.log.warn(
-        'The behavior of `./pants {0}` (no explicit targets) will soon become a no-op. '
-        'To remove this warning, please specify one or more explicit target specs (e.g. '
-        '`./pants {0} ::`).'.format(goal_name))
       # For the v1 path, continue the behavior of e.g. `./pants list` implies `./pants list ::`.
       return self.context.scan().targets(predicate=predicate)
 


### PR DESCRIPTION
### Problem

The behaviour of scanning the entire repo when `./pants list` is called with no arguments is going away. We had a warning in place, but because `./pants list` is a console task, all logging was silenced.

### Solution

The warning should actually be a deprecation anyway, so switch to deprecated conditional. Additionally, make an executive decision as to the final behaviour: `./pants list` doing nothing at all would be more confusing than just throwing an error, so let's commit to throwing an error in the future.

### Result

Fixes #4597.