### PR TITLE
Don't register newpython tasks in the oldpython backend

### DIFF
--- a/src/python/pants/backend/python_old/BUILD
+++ b/src/python/pants/backend/python_old/BUILD
@@ -7,7 +7,6 @@ python_library(
   dependencies = [
     'src/python/pants/backend/python:plugin',
     'src/python/pants/backend/python/tasks:python',
-    'src/python/pants/backend/python/tasks2',
     'src/python/pants/base:deprecated',
     'src/python/pants/goal:task_registrar',
   ]

--- a/src/python/pants/backend/python_old/register.py
+++ b/src/python/pants/backend/python_old/register.py
@@ -6,9 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.python.register import build_file_aliases as orig_build_file_aliases
-from pants.backend.python.tasks2.gather_sources import GatherSources
-from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
-from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.backend.python.tasks.pytest_run import PytestRun
 from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
 from pants.backend.python.tasks.python_isort import IsortPythonTask
@@ -32,7 +29,3 @@ def register_goals():
   task(name='py', action=PythonRepl).install('repl')
   task(name='setup-py', action=SetupPy).install()
   task(name='isort', action=IsortPythonTask).install('fmt')
-
-  task(name='interpreter', action=SelectInterpreter).install('pyprep')
-  task(name='requirements', action=ResolveRequirements).install('pyprep')
-  task(name='sources', action=GatherSources).install('pyprep')


### PR DESCRIPTION
### Problem

The "oldpython" backend (which we are slowly weaning ourselves off of at Twitter) still registers some "newpython" tasks, which take up a non-trivial amount of time that we noticed in our benchmark suite during release prep.

### Solution

Remove them.