### PR TITLE
Fix broken export-classpath

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_classpath_publisher.py
@@ -33,7 +33,7 @@ class RuntimeClasspathPublisher(Task):
   def execute(self):
     basedir = os.path.join(self.get_options().pants_distdir, self._output_folder)
     runtime_classpath = self.context.products.get_data('runtime_classpath')
-    targets = self.context.target_roots
+    targets = self.context.targets()
     if self.get_options().manifest_jar_only:
       classpath = ClasspathUtil.classpath(targets, runtime_classpath)
       # Safely create e.g. dist/export-classpath/manifest.jar

--- a/testprojects/src/java/org/pantsbuild/testproject/exclude/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/exclude/BUILD
@@ -18,6 +18,7 @@ jar_library(name = 'zinc',
 java_library(name='foo',
   sources=globs('Main.java'),
   dependencies=[
+    ':baz',
     ':zinc',
   ],
   excludes=[
@@ -34,4 +35,8 @@ java_library(name='bar',
     ':nailgun-server',
     ':jmake',
   ]
+)
+
+java_library(name='baz',
+  sources=globs('Main.java'),
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_export_classpath_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_export_classpath_integration.py
@@ -40,6 +40,7 @@ class ExportClasspathIntegrationTest(PantsRunIntegrationTest):
 
     with open_zip(manifest_jar_path) as synthetic_jar:
       self.assertListEqual([Manifest.PATH], synthetic_jar.namelist())
-      oneline_classpath = synthetic_jar.read(Manifest.PATH).replace('\n', '')
-      self.assertNotIn('sbt', oneline_classpath)
+      oneline_classpath = synthetic_jar.read(Manifest.PATH).replace('\n', '').replace(' ', '')
+      self.assertNotIn('sbt-interface', oneline_classpath)
       self.assertIn('foo', oneline_classpath)
+      self.assertIn('baz', oneline_classpath)


### PR DESCRIPTION
### Problem

I'd assumed that ClassPathUtils.classpath would take just the root targets, and that it didn't apply excludes correctly when the closure was passed. That was incorrect.

Doing that would cause export-classpath to return an invalid classpath

### Solution

Revert that change, and update the regression test to be more comprehensive.

### Result

export-classpath works correctly again, and the regression test covers the excludes case more effectively.