### PR TITLE
Pass env vars through in ./pants run for python

### DIFF
--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import signal
 
 from pants.backend.python.targets.python_binary import PythonBinary
@@ -40,7 +41,7 @@ class PythonRun(PythonExecutionTaskBase):
         for arg in self.get_options().args:
           args.extend(safe_shlex_split(arg))
         args += self.get_passthru_args()
-        po = pex.run(blocking=False, args=args)
+        po = pex.run(blocking=False, args=args) #, env=os.environ
         try:
           result = po.wait()
           if result != 0:

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -41,7 +41,7 @@ class PythonRun(PythonExecutionTaskBase):
         for arg in self.get_options().args:
           args.extend(safe_shlex_split(arg))
         args += self.get_passthru_args()
-        po = pex.run(blocking=False, args=args) #, env=os.environ
+        po = pex.run(blocking=False, args=args, env=os.environ.copy())
         try:
           result = po.wait()
           if result != 0:

--- a/testprojects/src/python/print_env/BUILD
+++ b/testprojects/src/python/print_env/BUILD
@@ -1,0 +1,4 @@
+python_binary(
+  entry_point = 'print_env.main',
+  source = 'main.py',
+)

--- a/testprojects/src/python/print_env/main.py
+++ b/testprojects/src/python/print_env/main.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import sys
+
+
+if __name__ == '__main__':
+  # Print the content of the env var given on the command line.
+  print(os.environ[sys.argv[1]])

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -43,6 +43,17 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(command=command)
     assert pants_run.returncode == 57
 
+  def test_get_env_var(self):
+    var_key = 'SOME_MAGICAL_VAR'
+    var_val = 'a value'
+    command = ['run',
+               'testprojects/src/python/print_env',
+               '--',
+               var_key]
+    pants_run = self.run_pants(command=command, extra_env={var_key: var_val})
+    self.assert_success(pants_run)
+    self.assertEquals(var_val, pants_run.stdout_data.strip())
+
   def _maybe_run_version(self, version):
     if self.has_python_version(version):
       print('Found python {}. Testing running on it.'.format(version))

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -46,7 +46,8 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
   def test_get_env_var(self):
     var_key = 'SOME_MAGICAL_VAR'
     var_val = 'a value'
-    command = ['run',
+    command = ['-q',
+               'run',
                'testprojects/src/python/print_env',
                '--',
                var_key]


### PR DESCRIPTION
### Problem

As explained in #4590, environment variables are not passed to the pex-invoked subprocess during `./pants run` in the python backend. That is a behaviour change from `python_old`.

### Solution

Copy and propagate the environment into `pex.run`.

### Result

Environment variables are passed through to the subprocess during `./pants run`. Fixes #4590.