### PR TITLE
Revert "Enable --compile-zinc-use-classpath-jars by default (#4525)"

### DIFF
--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,4 +33,4 @@ do
   esac
 done
 
-./pants -q --changed-parent=HEAD fmt.isort -- ${isort_args[@]}
+./pants -q --changed-parent=master fmt.isort -- ${isort_args[@]}

--- a/build-support/bin/isort.sh
+++ b/build-support/bin/isort.sh
@@ -33,4 +33,4 @@ do
   esac
 done
 
-./pants -q --changed-parent=master fmt.isort -- ${isort_args[@]}
+./pants -q --changed-parent=HEAD fmt.isort -- ${isort_args[@]}

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -193,12 +193,9 @@ class JvmCompile(NailgunTaskBase):
              help='List of regular expression patterns that extract class not found '
                   'compile errors.')
 
-    register('--use-classpath-jars', advanced=True, type=bool, fingerprint=True, default=True,
-             removal_hint='Since zinc 1.0.0-X was incorporated using classpath jars is faster '
-                          'for all usecases, including incremental compile. It is now enabled '
-                          'by default.',
-             removal_version='1.5.0.dev0',
-             help='Use jar files on the compile_classpath.')
+    register('--use-classpath-jars', advanced=True, type=bool, fingerprint=True,
+             help='Use jar files on the compile_classpath. Note: Using this option degrades '
+                  'incremental compile between targets.')
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -553,21 +550,23 @@ class JvmCompile(NailgunTaskBase):
       with open(path, 'w') as f:
         f.write(text.encode('utf-8'))
 
-  def _compile_vts(self, vts, ctx, upstream_analysis, classpath,
-                   log_file, progress_message, settings, fatal_warnings,
+  def _compile_vts(self, vts, target, sources, analysis_file, upstream_analysis, classpath, outdir,
+                   log_file, zinc_args_file, progress_message, settings, fatal_warnings,
                    zinc_file_manager, counter):
     """Compiles sources for the given vts into the given output dir.
 
     vts - versioned target set
-    ctx - CompileContext for the target
+    sources - sources for this target set
+    analysis_file - the analysis file to manipulate
     classpath - a list of classpath entries
+    outdir - the output dir to send classes to
 
     May be invoked concurrently on independent target sets.
 
     Postcondition: The individual targets in vts are up-to-date, as if each were
                    compiled individually.
     """
-    if not ctx.sources:
+    if not sources:
       self.context.log.warn('Skipping {} compile for targets with no sources:\n  {}'
                             .format(self.name(), vts.targets))
     else:
@@ -577,7 +576,7 @@ class JvmCompile(NailgunTaskBase):
       self.context.log.info(
         counter_str,
         'Compiling ',
-        items_to_report_element(ctx.sources, '{} source'.format(self.name())),
+        items_to_report_element(sources, '{} source'.format(self.name())),
         ' in ',
         items_to_report_element([t.address.reference() for t in vts.targets], 'target'),
         ' (',
@@ -589,18 +588,18 @@ class JvmCompile(NailgunTaskBase):
         # classfiles. So we force-invalidate here, to be on the safe side.
         vts.force_invalidate()
         if self.get_options().capture_classpath:
-          self._record_compile_classpath(classpath, vts.targets, ctx.classes_dir)
+          self._record_compile_classpath(classpath, vts.targets, outdir)
 
         try:
-          self.compile(self._args, classpath, ctx, upstream_analysis,
-                       log_file, settings, fatal_warnings, zinc_file_manager,
-                       self._get_plugin_map('javac', ctx.target),
-                       self._get_plugin_map('scalac', ctx.target))
+          self.compile(self._args, classpath, sources, outdir, upstream_analysis, analysis_file,
+                       log_file, zinc_args_file, settings, fatal_warnings, zinc_file_manager,
+                       self._get_plugin_map('javac', target),
+                       self._get_plugin_map('scalac', target))
         except TaskError:
           if self.get_options().suggest_missing_deps:
             logs = self._find_failed_compile_logs(compile_workunit)
             if logs:
-              self._find_missing_deps('\n'.join([read_file(log).decode('utf-8') for log in logs]), ctx.target)
+              self._find_missing_deps('\n'.join([read_file(log).decode('utf-8') for log in logs]), target)
           raise
 
   def _get_plugin_map(self, compiler, target):
@@ -892,10 +891,14 @@ class JvmCompile(NailgunTaskBase):
         fatal_warnings = self._compute_language_property(tgt, lambda x: x.fatal_warnings)
         zinc_file_manager = self._compute_language_property(tgt, lambda x: x.zinc_file_manager)
         self._compile_vts(vts,
-                          ctx,
+                          ctx.target,
+                          ctx.sources,
+                          ctx.analysis_file,
                           upstream_analysis,
                           cp_entries,
+                          ctx.classes_dir,
                           log_file,
+                          ctx.zinc_args_file,
                           progress_message,
                           tgt.platform,
                           fatal_warnings,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -301,8 +301,8 @@ class BaseZincCompile(JvmCompile):
     key = hasher.hexdigest()[:12]
     return os.path.join(self.get_options().pants_bootstrapdir, 'zinc', key)
 
-  def compile(self, args, classpath, ctx, upstream_analysis,
-              log_file, settings, fatal_warnings, zinc_file_manager,
+  def compile(self, args, classpath, sources, classes_output_dir, upstream_analysis, analysis_file,
+              log_file, zinc_args_file, settings, fatal_warnings, zinc_file_manager,
               javac_plugin_map, scalac_plugin_map):
     self._verify_zinc_classpath(classpath)
     self._verify_zinc_classpath(upstream_analysis.keys())
@@ -311,9 +311,9 @@ class BaseZincCompile(JvmCompile):
 
     zinc_args.extend([
       '-log-level', self.get_options().level,
-      '-analysis-cache', ctx.analysis_file,
+      '-analysis-cache', analysis_file,
       '-classpath', ':'.join(classpath),
-      '-d', ctx.classes_dir
+      '-d', classes_output_dir
     ])
     if not self.get_options().colors:
       zinc_args.append('-no-color')
@@ -333,11 +333,11 @@ class BaseZincCompile(JvmCompile):
     #   appended to it, so those will also get searched here.
     # - In scala 2.11 and up, the plugin's classpath element can be a dir, but for 2.10 it must be
     #   a jar.  So in-repo plugins will only work with 2.10 if --use-classpath-jars is true.
-    # - We exclude our own ctx.output_dir and ctx.jar_file, because if we're a plugin ourselves,
-    #   then we don't have scalac-plugin.xml yet, and we don't want that fact to get
+    # - We exclude our own classes_output_dir, because if we're a plugin ourselves, then our
+    #   classes_output_dir doesn't have scalac-plugin.xml yet, and we don't want that fact to get
     #   memoized (which in practice will only happen if this plugin uses some other plugin, thus
     #   triggering the plugin search mechanism, which does the memoizing).
-    scalac_plugin_search_classpath = set(classpath) - {ctx.classes_dir, ctx.jar_file}
+    scalac_plugin_search_classpath = set(classpath) - {classes_output_dir}
     zinc_args.extend(self._scalac_plugin_args(scalac_plugin_map, scalac_plugin_search_classpath))
     if upstream_analysis:
       zinc_args.extend(['-analysis-map',
@@ -369,10 +369,10 @@ class BaseZincCompile(JvmCompile):
 
     jvm_options.extend(self._jvm_options)
 
-    zinc_args.extend(ctx.sources)
+    zinc_args.extend(sources)
 
-    self.log_zinc_file(ctx.analysis_file)
-    with open(ctx.zinc_args_file, 'w') as fp:
+    self.log_zinc_file(analysis_file)
+    with open(zinc_args_file, 'w') as fp:
       for arg in zinc_args:
         fp.write(arg)
         fp.write(b'\n')

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_cache_compile_integration.py
@@ -219,5 +219,5 @@ class CacheCompileIntegrationTest(BaseCompileIT):
         self.assertEquals(c.artifact_count, len(os.listdir(artifact_dir)))
 
 
-class CacheCompileIntegrationWithoutZjarsTest(CacheCompileIntegrationTest):
-  _EXTRA_TASK_ARGS = ['--no-compile-zinc-use-classpath-jars']
+class CacheCompileIntegrationWithZjarsTest(CacheCompileIntegrationTest):
+  _EXTRA_TASK_ARGS = ['--compile-zinc-use-classpath-jars']

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/java/test_java_compile_integration.py
@@ -213,5 +213,5 @@ class JavaCompileIntegrationTest(BaseCompileIT):
         self.assertTrue("Compiling" in third_run.stdout_data)
 
 
-class JavaCompileIntegrationTestWithoutZjar(JavaCompileIntegrationTest):
-  _EXTRA_TASK_ARGS = ['--no-compile-zinc-use-classpath-jars']
+class JavaCompileIntegrationTestWithZjar(JavaCompileIntegrationTest):
+  _EXTRA_TASK_ARGS = ['--compile-zinc-use-classpath-jars']


### PR DESCRIPTION

### Problem

With the 1.0.0-X5 version of sbt, there's a case where having use-classpath-jars enabled causes runtime failures because zinc/sbt incorrectly detect interface changes. (See #4596).

### Solution

Revert the commit making use-classpath-jars the default: 94775d9584df3e39a7d8fd7e6bbfc21691705619.

### Result

#4596 is fixed.