### PR TITLE
[engine] Check for duplicate deps in v2 graph construction.

### DIFF
--- a/src/python/pants/build_graph/mutable_build_graph.py
+++ b/src/python/pants/build_graph/mutable_build_graph.py
@@ -69,7 +69,7 @@ class MutableBuildGraph(BuildGraph):
       for dep_address in dep_addresses:
         if dep_address in deps_seen:
           raise self.DuplicateAddressError(
-            'Addresses in dependencies must be unique. \'{spec}\' is referenced more than once.'
+            "Addresses in dependencies must be unique. '{spec}' is referenced more than once."
             .format(spec=dep_address.spec))
         deps_seen.add(dep_address)
         self.inject_address_closure(dep_address)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -144,9 +144,15 @@ class LegacyBuildGraph(BuildGraph):
     target = self._instantiate_target(target_adaptor)
     self._target_by_address[address] = target
 
-    # Link its declared dependencies, which will be indexed independently.
-    self._target_dependencies_by_address[address].update(target_adaptor.dependencies)
     for dependency in target_adaptor.dependencies:
+      if dependency in self._target_dependencies_by_address[address]:
+        raise self.DuplicateAddressError(
+          'Addresses in dependencies must be unique. '
+          "'{spec}' is referenced more than once by target '{target}'."
+          .format(spec=dependency.spec, target=address.spec)
+        )
+      # Link its declared dependencies, which will be indexed independently.
+      self._target_dependencies_by_address[address].add(dependency)
       self._target_dependees_by_address[dependency].add(address)
     return target
 


### PR DESCRIPTION
Fixes #4613

### Problem

Currently, the v2 path does not safeguard against duplicate dependencies listed in BUILD files.

### Solution

Check for duplicates.

### Result

```
[omerta pants (kwlzn/dupe_deps)]$ cat BUILD
target(name='world')

target(name='test',
  dependencies=[
    ':world',
    ':world'
  ]
)
[omerta pants (kwlzn/dupe_deps)]$ ./pants list :
Exception caught: (<class 'pants.build_graph.build_graph.DuplicateAddressError'>)
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_exe.py", line 50, in <module>
    main()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_exe.py", line 44, in main
    PantsRunner(exiter).run()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_runner.py", line 57, in run
    options_bootstrapper=options_bootstrapper)
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_runner.py", line 46, in _run
    return LocalPantsRunner(exiter, args, env, options_bootstrapper=options_bootstrapper).run()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/local_pants_runner.py", line 37, in run
    self._run()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/local_pants_runner.py", line 77, in _run
    self._exiter).setup()
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 199, in setup
    goals, context = self._setup_context(pantsd_launcher)
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 171, in _setup_context
    self._global_options.subproject_roots,
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 113, in _init_graph
    include_trace_on_error=self._global_options.print_exception_stacktrace)
  File "/Users/kwilson/dev/pants/src/python/pants/bin/engine_initializer.py", line 101, in create_build_graph
    for _ in graph.inject_specs_closure(target_roots.as_specs()):
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/graph.py", line 233, in inject_specs_closure
    for address in self._inject(specs):
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/graph.py", line 253, in _inject
    self._index(target_entries)
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/graph.py", line 103, in _index
    new_targets.append(self._index_target(target_adaptor))
  File "/Users/kwilson/dev/pants/src/python/pants/engine/legacy/graph.py", line 152, in _index_target
    .format(spec=dependency.spec, target=address.spec)

Exception message: Addresses in dependencies must be unique. '//:world' is referenced more than once by target '//:test'.
```