### PR TITLE
Check that test case attribute exists in junit xml file before converting it

### DIFF
--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -133,7 +133,12 @@ class TestRunnerTaskMixin(object):
       try:
         xml = XmlParser.from_file(path)
         for testcase in xml.parsed.getElementsByTagName('testcase'):
-          test_info = {'time': float(testcase.getAttribute('time'))}
+          test_info = {'time': testcase.getAttribute('time')}
+
+          time_to_float = test_info.get('time')
+          if time_to_float:
+            test_info['time'] = float(time_to_float)
+
           for attribute in testcase_attributes:
             test_info[attribute] = testcase.getAttribute(attribute)
 

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -133,11 +133,12 @@ class TestRunnerTaskMixin(object):
       try:
         xml = XmlParser.from_file(path)
         for testcase in xml.parsed.getElementsByTagName('testcase'):
-          test_info = {'time': testcase.getAttribute('time')}
+          test_info = {}
 
-          time_to_float = test_info.get('time')
-          if time_to_float:
-            test_info['time'] = float(time_to_float)
+          try:
+            test_info.update({'time': float(testcase.getAttribute('time'))})
+          except:
+            test_info.update({'time': None})
 
           for attribute in testcase_attributes:
             test_info[attribute] = testcase.getAttribute(attribute)

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -101,9 +101,12 @@ class TestRunnerTaskMixin(object):
     """Parses the junit file for information needed about each test.
 
     Will include:
-      - test result
-      - test run time duration
       - test name
+      - test result
+      - test run time duration or None if not a parsable float
+
+    If additional test case attributes are defined, then it will include those as well.
+
     :param string xml_path: The path of the xml file to be parsed.
     :param function error_handler: The error handler function.
     :param list of string additional_testcase_attributes: A list of additional attributes belonging

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -433,6 +433,38 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
           }
         }, tests_info)
 
+  def test_parse_test_info_with_missing_attributes(self):
+    with temporary_dir() as xml_dir:
+      with open(os.path.join(xml_dir, 'TEST-a.xml'), 'w') as fp:
+        fp.write("""
+        <testsuite failures="1">
+          <testcase classname="org.pantsbuild.Green" name="testOK"/>
+          <testcase classname="org.pantsbuild.Failure" time="0.27">
+            <failure/>
+          </testcase>
+          <testcase classname="org.pantsbuild.Skipped" name="testSkipped" time="0.1" extra="">
+            <skipped/>
+          </testcase>
+        </testsuite>
+        """)
+
+      tests_info = self.parse_test_info(xml_dir, self._raise_handler)
+      self.assertEqual(
+        {
+          'testOK': {
+            'result_code': 'success',
+            'time': ''
+          },
+          '': {
+            'result_code': 'failure',
+            'time': 0.27
+          },
+          'testSkipped': {
+            'result_code': 'skipped',
+            'time': 0.1
+          }
+        }, tests_info)
+
   def test_parse_test_info_invalid_file_name(self):
     with temporary_dir() as xml_dir:
       with open(os.path.join(xml_dir, 'random.xml'), 'w') as fp:

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -453,7 +453,7 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
         {
           'testOK': {
             'result_code': 'success',
-            'time': ''
+            'time': None
           },
           '': {
             'result_code': 'failure',
@@ -495,13 +495,7 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
     with temporary_dir() as xml_dir:
       bad_file1 = os.path.join(xml_dir, 'TEST-bad1.xml')
       with open(bad_file1, 'w') as fp:
-        fp.write("""
-        <testsuite failures="0" errors="1">
-          <testcase classname="org.pantsbuild.Error" name="testError" time="zero">
-            <error/>
-          </testcase>
-        </testsuite>
-        """)
+        fp.write('<invalid></xml>')
       with open(os.path.join(xml_dir, 'TEST-good.xml'), 'w') as fp:
         fp.write("""
         <testsuite failures="0" errors="1">
@@ -510,14 +504,11 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
           </testcase>
         </testsuite>
         """)
-      bad_file2 = os.path.join(xml_dir, 'TEST-bad2.xml')
-      with open(bad_file2, 'w') as fp:
-        fp.write('<invalid></xml>')
 
       collect_handler = self.CollectHandler()
       tests_info = self.parse_test_info(xml_dir, collect_handler)
-      self.assertEqual(2, len(collect_handler.errors))
-      self.assertEqual({bad_file1, bad_file2}, {e.xml_path for e in collect_handler.errors})
+      self.assertEqual(1, len(collect_handler.errors))
+      self.assertEqual({bad_file1}, {e.xml_path for e in collect_handler.errors})
 
       self.assertEqual(
         {'testError':
@@ -562,7 +553,7 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
             'file': 'file.py',
             'classname': 'org.pantsbuild.Green',
             'result_code': 'success',
-            'time': ''
+            'time': None
           },
           'testOK4': {
             'file': 'file.py',

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -532,7 +532,11 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
       with open(os.path.join(xml_dir, 'TEST-a.xml'), 'w') as fp:
         fp.write("""
         <testsuite errors="1">
-          <testcase classname="org.pantsbuild.Green" name="testOK" time="1.290" file="file.py"/>
+          <testcase classname="org.pantsbuild.Green" name="testOK1" time="1.290" file="file.py"/>
+          <testcase classname="org.pantsbuild.Green" name="testOK2" time="1.12"/>
+          <testcase classname="org.pantsbuild.Green" name="testOK3" file="file.py"/>
+          <testcase name="testOK4" time="1.79" file="file.py"/>
+          <testcase name="testOK5" time="0.832"/>
           <testcase classname="org.pantsbuild.Error" name="testError" time="0.27" file="file.py">
             <error/>
           </testcase>
@@ -542,11 +546,35 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
       tests_info = self.parse_test_info(xml_dir, self._raise_handler, ['file', 'classname'])
       self.assertEqual(
         {
-          'testOK': {
+          'testOK1': {
             'file': 'file.py',
             'classname': 'org.pantsbuild.Green',
             'result_code': 'success',
             'time': 1.290
+          },
+          'testOK2': {
+            'file': '',
+            'classname': 'org.pantsbuild.Green',
+            'result_code': 'success',
+            'time': 1.12
+          },
+          'testOK3': {
+            'file': 'file.py',
+            'classname': 'org.pantsbuild.Green',
+            'result_code': 'success',
+            'time': ''
+          },
+          'testOK4': {
+            'file': 'file.py',
+            'classname': '',
+            'result_code': 'success',
+            'time': 1.79
+          },
+          'testOK5': {
+            'file': '',
+            'classname': '',
+            'result_code': 'success',
+            'time': 0.832
           },
           'testError': {
             'file': 'file.py',


### PR DESCRIPTION
### Problem

[Issue 4619](https://github.com/pantsbuild/pants/issues/4619) was opened because an error is thrown when the time attribute is missing from a testcase in the junit xml file.

### Solution

I added a check that will verify the time attribute has contents before trying to convert it to a float and added a test to ensure other missing attributes don't cause problems. 

### Result

With this change, users will not see parsing errors when running their tests. Fixes #4619.