### PR TITLE
Fix ownership check to be case-insensitive.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -376,7 +376,8 @@ function check_owner() {
 
    for owner in $(get_owners ${package_name})
    do
-     if [[ "${username}" == "${owner}" ]]
+     # NB: A case-insensitive comparison is done since pypi is case-insensitive wrt usernames.
+     if [[ "${username^^}" == "${owner^^}" ]]
      then
        return 0
      fi


### PR DESCRIPTION
This matches pypi's view of usernames.

Fixes #4628