### PR TITLE
Add integration test for hidden directories in resources and add debug logging to prepare_resources

### DIFF
--- a/testprojects/src/resources/org/pantsbuild/testproject/fileresources/.hidden/Hidden.java
+++ b/testprojects/src/resources/org/pantsbuild/testproject/fileresources/.hidden/Hidden.java
@@ -1,0 +1,6 @@
+
+public class Hidden {
+  public static void main(String[] args) {
+    System.out.println("Hello, World");
+  }
+}

--- a/testprojects/src/resources/org/pantsbuild/testproject/fileresources/.hidden/Hidden.txt
+++ b/testprojects/src/resources/org/pantsbuild/testproject/fileresources/.hidden/Hidden.txt
@@ -1,0 +1,1 @@
+Text File in .hidden directory

--- a/testprojects/src/resources/org/pantsbuild/testproject/fileresources/BUILD
+++ b/testprojects/src/resources/org/pantsbuild/testproject/fileresources/BUILD
@@ -1,0 +1,24 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+java_library(name='lib',
+  dependencies=[
+    ':all-files',
+  ],
+)
+
+resources(name='all-files',
+  sources=rglobs('*', exclude=[globs('BUILD*')]),
+)
+
+resources(name='java-files',
+  sources=rglobs('*/*.java'),
+)
+
+resources(name='scala-files',
+  sources=rglobs('*/*.scala'),
+)
+
+resources(name='text-files',
+  sources=rglobs('*/*.txt'),
+)

--- a/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/File.java
+++ b/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/File.java
@@ -1,0 +1,6 @@
+
+public class HelloWorld {
+  public static void main(String[] args) {
+    System.out.println("Hello, World");
+  }
+}

--- a/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/File.scala
+++ b/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/File.scala
@@ -1,0 +1,6 @@
+
+object HelloWorld {
+  def main(args: Array[String]): Unit = {
+    println("Hello, world!")
+  }
+}

--- a/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/File.txt
+++ b/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/File.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/subdirectory/subdirectory.txt
+++ b/testprojects/src/resources/org/pantsbuild/testproject/fileresources/src/subdirectory/subdirectory.txt
@@ -1,0 +1,1 @@
+Text file in a subdirectory

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -619,6 +619,15 @@ python_tests(
 )
 
 python_tests(
+  name = 'resources_integration',
+  sources = ['test_resources_integration.py'],
+  dependencies = [
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
   name = 'scalafmt',
   sources = ['test_scalafmt.py'],
   dependencies = [

--- a/tests/python/pants_test/backend/jvm/tasks/test_resources_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_resources_integration.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class ResourcesIntegrationTest(PantsRunIntegrationTest):
+
+  def test_resources_all(self):
+    with self.temporary_workdir() as workdir:
+      pants_run = self.run_pants_with_workdir([
+        'resources',
+        'testprojects/src/resources/org/pantsbuild/testproject/fileresources:lib'],
+        workdir)
+      self.assert_success(pants_run)
+      out_dir = os.path.join(workdir, 'resources', 'prepare',
+                             'current', 'testprojects.src.resources.org.pantsbuild.testproject.fileresources.all-files',
+                             'current', 'org', 'pantsbuild', 'testproject', 'fileresources')
+      self.assertFalse(os.path.exists(os.path.join(out_dir, 'BUILD')))
+      self.assertTrue(os.path.exists(os.path.join(out_dir, 'src', 'File.java')))
+      self.assertTrue(os.path.exists(os.path.join(out_dir, 'src', 'File.txt')))
+      self.assertTrue(os.path.exists(os.path.join(out_dir, 'src', 'subdirectory', 'subdirectory.txt')))
+      # Hidden files are excluded from Globs by default in 1.3+
+      self.assertFalse(os.path.exists(os.path.join(out_dir, '.hidden', 'Hidden.java')))

--- a/tests/python/pants_test/source/test_wrapped_globs.py
+++ b/tests/python/pants_test/source/test_wrapped_globs.py
@@ -44,6 +44,7 @@ class FilesetRelPathWrapperTest(BaseTest):
     self.create_file('y/morx.java')
     self.create_file('y/fleem.java')
     self.create_file('z/w/foo.java')
+    self.create_file('z/.u/bar.java')
     os.symlink('../../y', os.path.join(self.build_root, 'z/w/y'))
 
   def test_no_dir_glob(self):
@@ -210,6 +211,12 @@ class FilesetRelPathWrapperTest(BaseTest):
     self.add_to_build_file('y/BUILD', 'dummy_target(name="y", sources=globs("/root/?.scala"))')
     with self.assertRaises(AddressLookupError):
       self.context().scan()
+
+  def test_rglob_finds_dot_directories(self):
+    self.add_to_build_file('z/BUILD', 'dummy_target(name="z", sources=rglobs("*.java"))')
+    graph = self.context().scan()
+    relative_sources = list(graph.get_target_from_spec('z').sources_relative_to_source_root())
+    assert ['.u/bar.java', 'w/y/morx.java', 'w/foo.java', 'w/y/fleem.java'] == relative_sources
 
   def test_rglob_follows_symlinked_dirs_by_default(self):
     self.add_to_build_file('z/w/BUILD', 'dummy_target(name="w", sources=rglobs("*.java"))')


### PR DESCRIPTION
### Problem

In 1.2.1 using '*' in a resource glob would find files in directories beginning with '.' and add them to the sources fileset.

In 1.3.0rc3 this is no longer working.  There doesn't seem to be any glob patterns that will include files in hidden directories.

### Solution

I don't have a solution yet, it looks like it comes down to the following code in graph.py
```
@rule(HydratedField,
      [Select(SourcesField),
       SelectProjection(Snapshot, PathGlobs, 'path_globs', SourcesField)])
def hydrate_sources(sources_field, snapshot):
  """Given a SourcesField and a Snapshot for its path_globs, create an EagerFilesetWithSpec."""
  fileset_with_spec = _eager_fileset_with_spec(sources_field.address.spec_path,
                                               sources_field.filespecs,
                                               snapshot)
  return HydratedField(sources_field.arg, fileset_with_spec)
```

Where the files in the hidden directory are not part of the snapshot.files field.

The `test_resources_integration.py` in this PR has a failing test for the problem.
