### PR TITLE
Allow python tasks to request target roots partitioning types

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -14,6 +14,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.pytest_prep import PytestPrep
 from pants.backend.python.tasks2.pytest_run import PytestRun
 from pants.backend.python.tasks2.python_binary_create import PythonBinaryCreate
@@ -50,6 +51,7 @@ def build_file_aliases():
 
 
 def register_goals():
+  task(name='partition', action=PartitionTargets).install('pyprep')
   task(name='interpreter', action=SelectInterpreter).install('pyprep')
   task(name='requirements', action=ResolveRequirements).install('pyprep')
   task(name='sources', action=GatherSources).install('pyprep')

--- a/src/python/pants/backend/python/tasks2/gather_sources.py
+++ b/src/python/pants/backend/python/tasks2/gather_sources.py
@@ -11,24 +11,29 @@ from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.pex_build_util import dump_sources, has_python_sources
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.build_graph.target import Target
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task
 from pants.util.dirutil import safe_concurrent_creation
 
 
 class GatherSources(Task):
-  """Gather local Python sources.
+  """Gather local Python sources for each subset in the partition.
 
-  Creates an (unzipped) PEX on disk containing the local Python sources.
-  This PEX can be merged with a requirements PEX to create a unified Python environment
-  for running the relevant python code.
+  For each target subset, this task creates an (unzipped) PEX on disk containing the
+  local Python sources of the closure of that subset.  This PEX can be merged with a requirements
+  PEX to create a unified Python environment for running the relevant python code.
+
+  Produces PYTHON_SOURCES, a mapping between subsets and the corresponding pex.
   """
   PYTHON_SOURCES = 'python_sources'
 
   @classmethod
   def implementation_version(cls):
-    return super(GatherSources, cls).implementation_version() + [('GatherSources', 3)]
+    return super(GatherSources, cls).implementation_version() + [('GatherSources', 4)]
 
   @classmethod
   def product_types(cls):
@@ -36,16 +41,22 @@ class GatherSources(Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
-    round_manager.require_data(PythonInterpreter)
+    round_manager.require_data(PartitionTargets.TARGETS_PARTITION)
+    round_manager.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
     round_manager.require_data('python')  # For codegen.
 
   def execute(self):
-    targets = self.context.targets(predicate=has_python_sources)
-    interpreter = self.context.products.get_data(PythonInterpreter)
-
-    with self.invalidated(targets) as invalidation_check:
-      pex = self._get_pex_for_versioned_targets(interpreter, invalidation_check.all_vts)
-      self.context.products.register_data(self.PYTHON_SOURCES, pex)
+    if not self.context.products.is_required_data(self.PYTHON_SOURCES):
+      return
+    interpreters = self.context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)
+    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    python_sources = {}
+    for subset in partition.subsets:
+      target_set = filter(has_python_sources, Target.closure_for_targets(subset))
+      with self.invalidated(target_set) as invalidation_check:
+         python_sources[subset] = self._get_pex_for_versioned_targets(
+             interpreters[subset], invalidation_check.all_vts)
+    self.context.products.register_data(self.PYTHON_SOURCES, python_sources)
 
   def _get_pex_for_versioned_targets(self, interpreter, versioned_targets):
     if versioned_targets:

--- a/src/python/pants/backend/python/tasks2/partition_targets.py
+++ b/src/python/pants/backend/python/tasks2/partition_targets.py
@@ -1,0 +1,123 @@
+# coding=utf-8
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import namedtuple
+
+from pants.build_graph.target import Target
+from pants.task.task import Task
+
+
+class TargetsPartition(object):
+  """Represents a grouping of targets into non-empty subsets."""
+  def __init__(self, subsets):
+    """Constructs a new TargetsPartition from a given collection of subsets.
+
+    :param subsets: an iterable of iterables of targets.
+    """
+    if any(len(subset) == 0 for subset in subsets):
+      raise ValueError('Subsets must be non-empty.')
+    self._subsets = frozenset(frozenset(subset) for subset in subsets)
+    if self._subsets and (
+        len(frozenset.union(*self._subsets)) != sum(len(subset) for subset in self._subsets)):
+      raise ValueError('Subsets must be disjoint.')
+    self._subset_by_target = {target: subset for subset in self._subsets for target in subset}
+
+  @property
+  def subsets(self):
+    return self._subsets
+
+  def find_subset_for_target(self, target):
+    """Returns a subset containing the given targets.
+
+    Raises a KeyError if such target does not exist."""
+    return self._subset_by_target[target]
+
+  def find_subset_for_targets(self, targets):
+    """Returns a single subset that contains all given targets.
+
+    If such subset does not exists within the partition a ValueError is raised."""
+    if not self._subsets:
+      raise ValueError('No subsets.')
+    if not targets:
+      # Any subset will do
+      return next(iter(self._subsets))
+    subset = self._subset_by_target.get(next(iter(targets)))
+    if not subset or not subset.issuperset(set(targets)):
+      raise ValueError('No subset contains all targets')
+    return subset
+
+
+class PartitionTargets(Task):
+  TARGETS_PARTITION = 'targets_partition'
+
+  STRATEGY_MINIMAL = 'minimal'
+  STRATEGY_PER_TARGET = 'per_target'
+  STRATEGY_GLOBAL = 'global'
+
+  @classmethod
+  def product_types(cls):
+    return [cls.TARGETS_PARTITION]
+
+  @classmethod
+  def register_options(cls, register):
+    super(PartitionTargets, cls).register_options(register)
+    register(
+        '--strategy',
+        choices=[cls.STRATEGY_MINIMAL, cls.STRATEGY_PER_TARGET, cls.STRATEGY_GLOBAL],
+        help='Specifies how to partition the targets into subsets. '
+             '"global": creates a single subset for all target roots. This means a single '
+             'source tree, interpreter and external requirements pex will be provided for all '
+             'targets, and therefore the targets must be compatible with each other. '
+             '"minimal": groups the target roots into the smallest possible number of subsets '
+             'such that if one target root depends on another, then both of them will be in the '
+             'subset. This ensures that incompatible target roots will fall into different subsets '
+             'while minimizing the number of chroots. '
+             '"per_target": each target root will be in its own isolated group. This provides '
+             'maximal isolation but can be slower if there are many target roots.',
+        default=cls.STRATEGY_GLOBAL)
+
+  @classmethod
+  def _minimal_partition(cls, targets):
+    groups_by_head = {}
+
+    closures = {target: target.closure() for target in targets}
+
+    for target in targets:
+      is_head = all(target not in closures[other] or other == target
+                   for other in targets)
+      if is_head:
+        groups_by_head[target] = {target}
+
+    for target in targets:
+      for head in groups_by_head:
+        if target in closures[head]:
+          groups_by_head[head].add(target)
+          break
+      else:
+        assert False, 'Target not in closure of any head.'
+
+    return TargetsPartition(groups_by_head.values())
+
+  @classmethod
+  def _per_target_partition(cls, targets):
+    return TargetsPartition([[t] for t in targets])
+
+  @classmethod
+  def _global_partition(cls, targets):
+    return TargetsPartition([targets] if targets else [])
+
+  def execute(self):
+    strategy = self.get_options().strategy
+    if strategy == self.STRATEGY_MINIMAL:
+      partition = self._minimal_partition(self.context.target_roots)
+    elif strategy == self.STRATEGY_PER_TARGET:
+      partition = self._per_target_partition(self.context.target_roots)
+    elif strategy == self.STRATEGY_GLOBAL:
+      partition = self._global_partition(self.context.target_roots)
+    else:
+      assert False, 'Unexpected partitioning strategy.'
+    self.context.products.get_data(self.TARGETS_PARTITION, lambda: partition)

--- a/src/python/pants/backend/python/tasks2/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks2/pytest_prep.py
@@ -12,13 +12,13 @@ from pants.backend.python.tasks2.python_execution_task_base import PythonExecuti
 
 
 class PytestPrep(PythonExecutionTaskBase):
-  """Prepares a pex binary for the current test context with py.test as its entry-point."""
+  """Prepares pex binaries for the current test context with py.test as its entry-point."""
 
-  PYTEST_BINARY = 'pytest_binary'
+  PYTEST_BINARIES = 'pytest_binaries'
 
   @classmethod
   def product_types(cls):
-    return [cls.PYTEST_BINARY]
+    return [cls.PYTEST_BINARIES]
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -30,5 +30,9 @@ class PytestPrep(PythonExecutionTaskBase):
   def execute(self):
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
-    pytest_binary = self.create_pex(pex_info)
-    self.context.products.register_data(self.PYTEST_BINARY, pytest_binary)
+    pytest_binaries = self.context.products.register_data(self.PYTEST_BINARIES, {})
+    for partition_name in self.target_roots_partitions():
+      pytest_binaries[partition_name] = {}
+      for targets_subset in target_roots_subsets(partition_name):
+         pytest_binaries[partition_name][targets_subset] = self.create_pex(
+             targets, pex_info=pex_info)

--- a/src/python/pants/backend/python/tasks2/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks2/pytest_prep.py
@@ -33,6 +33,6 @@ class PytestPrep(PythonExecutionTaskBase):
     pytest_binaries = self.context.products.register_data(self.PYTEST_BINARIES, {})
     for partition_name in self.target_roots_partitions():
       pytest_binaries[partition_name] = {}
-      for targets_subset in target_roots_subsets(partition_name):
+      for targets_subset in self.target_roots_subsets(partition_name):
          pytest_binaries[partition_name][targets_subset] = self.create_pex(
-             targets, pex_info=pex_info)
+             partition_name, targets_subset, pex_info=pex_info)

--- a/src/python/pants/backend/python/tasks2/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks2/python_binary_create.py
@@ -43,9 +43,10 @@ class PythonBinaryCreate(PythonTaskMixin, Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
-    round_manager.require_data(PartitionTargets.TARGETS_PARTITION)
+    round_manager.require_data(PartitionTargets.STRATEGY_MINIMAL)
     round_manager.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
     round_manager.require_data('python')  # For codegen.
+
 
   @staticmethod
   def is_binary(target):
@@ -95,7 +96,7 @@ class PythonBinaryCreate(PythonTaskMixin, Task):
     # and PYTHON_SOURCES products, because those products are already-built pexes, and there's
     # no easy way to merge them into a single pex file (for example, they each have a __main__.py,
     # metadata, and so on, which the merging code would have to handle specially).
-    interpreter = self.interpreter_for_targets([binary_tgt])
+    interpreter = self.interpreter_for_targets(PartitionTargets.STRATEGY_MINIMAL, [binary_tgt])
     with temporary_dir() as tmpdir:
       # Create the pex_info for the binary.
       run_info_dict = self.context.run_tracker.run_info.get_as_dict()

--- a/src/python/pants/backend/python/tasks2/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks2/python_binary_create.py
@@ -15,7 +15,7 @@ from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.pex_build_util import (dump_requirements, dump_sources,
                                                         has_python_requirements, has_python_sources,
                                                         has_resources)
-from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
+from pants.backend.python.tasks2.python_task import PythonTask
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
@@ -26,7 +26,7 @@ from pants.util.dirutil import safe_mkdir_for
 from pants.util.fileutil import atomic_copy
 
 
-class PythonBinaryCreate(PythonTaskMixin, Task):
+class PythonBinaryCreate(PythonTask):
   """Create an executable .pex file."""
 
   @classmethod

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -97,7 +97,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
 
   def create_pex(self, partition_name, targets, pex_info=None):
     """Returns a wrapped pex that "merges" the other pexes via PEX_PATH."""
-    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)[partition_name]
+    partition = self.target_roots_partitions()[partition_name]
     subset = partition.find_subset_for_targets(targets)
     relevant_targets = filter(
       lambda tgt: isinstance(tgt, (PythonRequirementLibrary, PythonTarget, Resources)),

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -16,10 +16,13 @@ from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.build_graph.address import Address
 from pants.build_graph.resources import Resources
+from pants.build_graph.target import Target
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.util.dirutil import safe_concurrent_creation
 
@@ -80,7 +83,8 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
   @classmethod
   def prepare(cls, options, round_manager):
     super(PythonExecutionTaskBase, cls).prepare(options, round_manager)
-    round_manager.require_data(PythonInterpreter)
+    round_manager.require_data(PartitionTargets.TARGETS_PARTITION)
+    round_manager.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
     round_manager.require_data(ResolveRequirements.REQUIREMENTS_PEX)
     round_manager.require_data(GatherSources.PYTHON_SOURCES)
 
@@ -91,10 +95,13 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
     """
     return []
 
-  def create_pex(self, pex_info=None):
+  def create_pex(self, targets, pex_info=None):
     """Returns a wrapped pex that "merges" the other pexes via PEX_PATH."""
-    relevant_targets = self.context.targets(
-      lambda tgt: isinstance(tgt, (PythonRequirementLibrary, PythonTarget, Resources)))
+    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    subset = partition.find_subset_for_targets(targets)
+    relevant_targets = filter(
+      lambda tgt: isinstance(tgt, (PythonRequirementLibrary, PythonTarget, Resources)),
+      Target.closure_for_targets(subset))
     with self.invalidated(relevant_targets) as invalidation_check:
 
       # If there are no relevant targets, we still go through the motions of resolving
@@ -106,7 +113,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
       else:
         target_set_id = 'no_targets'
 
-      interpreter = self.context.products.get_data(PythonInterpreter)
+      interpreter = self.context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)[subset]
       path = os.path.join(self.workdir, str(interpreter.identity), target_set_id)
       extra_pex_paths_file_path = path + '.extra_pex_paths'
       extra_pex_paths = None
@@ -115,18 +122,20 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
       # to cover the empty case.
       if not os.path.isdir(path):
         pexes = [
-          self.context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX),
-          self.context.products.get_data(GatherSources.PYTHON_SOURCES)
+          self.context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX)[subset],
+          self.context.products.get_data(GatherSources.PYTHON_SOURCES)[subset]
         ]
 
         if self.extra_requirements():
           extra_reqs = [PythonRequirement(req_str) for req_str in self.extra_requirements()]
+          import random
           addr = Address.parse('{}_extra_reqs'.format(self.__class__.__name__))
           self.context.build_graph.inject_synthetic_target(
             addr, PythonRequirementLibrary, requirements=extra_reqs)
           # Add the extra requirements first, so they take precedence over any colliding version
           # in the target set's dependency closure.
-          pexes = [self.resolve_requirements([self.context.build_graph.get_target(addr)])] + pexes
+          pexes = [self.resolve_requirements(
+              [self.context.build_graph.get_target(addr)], interpreter=interpreter)] + pexes
 
         extra_pex_paths = [pex.path() for pex in pexes if pex]
 

--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -11,11 +11,10 @@ from pants.backend.python.targets.python_requirement_library import PythonRequir
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
-from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
 from pants.task.repl_task_mixin import ReplTaskMixin
 
 
-class PythonRepl(ReplTaskMixin, PythonTaskMixin, PythonExecutionTaskBase):
+class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
   """Launch an interactive Python interpreter session."""
 
   @classmethod
@@ -32,7 +31,7 @@ class PythonRepl(ReplTaskMixin, PythonTaskMixin, PythonExecutionTaskBase):
 
   @classmethod
   def prepare(cls, options, round_manager):
-    super(cls, PythonRepl).prepare(options, round_manager)
+    super(PythonRepl, cls).prepare(options, round_manager)
     round_manager.require_data(PartitionTargets.STRATEGY_GLOBAL)
 
   @classmethod

--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -10,10 +10,11 @@ from pex.pex_info import PexInfo
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
+from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
 from pants.task.repl_task_mixin import ReplTaskMixin
 
 
-class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
+class PythonRepl(ReplTaskMixin, PythonTaskMixin, PythonExecutionTaskBase):
   """Launch an interactive Python interpreter session."""
 
   @classmethod
@@ -45,7 +46,7 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
       entry_point = 'code:interact'
     pex_info = PexInfo.default()
     pex_info.entry_point = entry_point
-    return self.create_pex(pex_info)
+    return self.create_pex(targets, pex_info=pex_info)
 
   # NB: **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):

--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -9,6 +9,7 @@ from pex.pex_info import PexInfo
 
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
 from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
 from pants.task.repl_task_mixin import ReplTaskMixin
@@ -30,6 +31,11 @@ class PythonRepl(ReplTaskMixin, PythonTaskMixin, PythonExecutionTaskBase):
              help='The IPython interpreter version to use.')
 
   @classmethod
+  def prepare(cls, options, round_manager):
+    super(cls, PythonRepl).prepare(options, round_manager)
+    round_manager.require_data(PartitionTargets.STRATEGY_GLOBAL)
+
+  @classmethod
   def select_targets(cls, target):
     return isinstance(target, (PythonTarget, PythonRequirementLibrary))
 
@@ -46,7 +52,7 @@ class PythonRepl(ReplTaskMixin, PythonTaskMixin, PythonExecutionTaskBase):
       entry_point = 'code:interact'
     pex_info = PexInfo.default()
     pex_info.entry_point = entry_point
-    return self.create_pex(targets, pex_info=pex_info)
+    return self.create_pex(PartitionTargets.STRATEGY_GLOBAL, targets, pex_info=pex_info)
 
   # NB: **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -9,6 +9,7 @@ import os
 import signal
 
 from pants.backend.python.targets.python_binary import PythonBinary
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
@@ -17,6 +18,11 @@ from pants.util.strutil import safe_shlex_split
 
 class PythonRun(PythonExecutionTaskBase):
   """Run a Python executable."""
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(PythonRun, cls).prepare(options, round_manager)
+    round_manager.require_data(PartitionTargets.STRATEGY_GLOBAL)
 
   @classmethod
   def register_options(cls, register):
@@ -34,7 +40,7 @@ class PythonRun(PythonExecutionTaskBase):
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
       # TODO(benjy): Use MutexTask to coordinate this.
 
-      pex = self.create_pex([binary], pex_info=binary.pexinfo)
+      pex = self.create_pex(PartitionTargets.STRATEGY_GLOBAL, [binary], pex_info=binary.pexinfo)
       args = []
       for arg in self.get_options().args:
         args.extend(safe_shlex_split(arg))

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -34,7 +34,7 @@ class PythonRun(PythonExecutionTaskBase):
       # jvm_binary, in which case we have to no-op and let jvm_run do its thing.
       # TODO(benjy): Use MutexTask to coordinate this.
 
-      pex = self.create_pex(binary.pexinfo)
+      pex = self.create_pex([binary], pex_info=binary.pexinfo)
       args = []
       for arg in self.get_options().args:
         args.extend(safe_shlex_split(arg))

--- a/src/python/pants/backend/python/tasks2/python_task.py
+++ b/src/python/pants/backend/python/tasks2/python_task.py
@@ -8,10 +8,17 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.task.task import Task
 
 
-class PythonTaskMixin(object):
-  """Mixin for tasks that provides convenient access to intermediate products."""
+class PythonTask(Task):
+  """Base class for tasks that provides convenient access to pyprep products.
+
+  During the pyprep goal, the Python pipeline computes partitions of the targets. Then it
+  selects interpreters and resolves requirements for each subset in each of computed partitions.
+
+  This base class provides convenient access to these products.
+  """
 
   def target_roots_partitions(self):
     partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
@@ -22,20 +29,24 @@ class PythonTaskMixin(object):
     partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
     return partitions[partition_name].subsets
 
+  def find_subset_for_targets(self, partition_name, targets):
+    """Return a subset of the partition containing all targets."""
+    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
+    partition = partitions[partition_name]
+    return partition.find_subset_for_targets(targets)
+
   def interpreter_for_targets(self, partition_name, targets):
     """Returns an interpreter that is compatible with the given targets.
 
-    All targets must be within the same subset in the partition."""
-    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
+    All targets must be within the same subset in the partition.
+    """
     interpreters = self.context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)
-    partition = partitions[partition_name]
-    return interpreters[partition_name][partition.find_subset_for_targets(targets)]
+    return interpreters[partition_name][self.find_subset_for_targets(partition_name, targets)]
 
   def sources_for_targets(self, partition_name, targets):
     """Returns a source pex that contains sources for all given targets.
 
-    All targets must be within the same subset in the partition."""
-    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
-    partition = partitions[partition_name]
+    All targets must be within the same subset in the partition.
+    """
     sources = self.context.products.get_data(GatherSources.PYTHON_SOURCES)
-    return sources[partition_name][partition.find_subset_for_targets(targets)]
+    return sources[partition_name][self.find_subset_for_targets(partition_name, targets)]

--- a/src/python/pants/backend/python/tasks2/python_task_mixin.py
+++ b/src/python/pants/backend/python/tasks2/python_task_mixin.py
@@ -13,23 +13,29 @@ from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 class PythonTaskMixin(object):
   """Mixin for tasks that provides convenient access to intermediate products."""
 
-  def target_roots_subsets(self):
-    """Returns the subsets in the target roots partition."""
-    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
-    return partition.subsets
+  def target_roots_partitions(self):
+    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
+    return partitions
 
-  def interpreter_for_targets(self, targets):
+  def target_roots_subsets(self, partition_name):
+    """Returns the subsets in the target roots partition."""
+    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
+    return partitions[partition_name].subsets
+
+  def interpreter_for_targets(self, partition_name, targets):
     """Returns an interpreter that is compatible with the given targets.
 
     All targets must be within the same subset in the partition."""
-    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
     interpreters = self.context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)
-    return interpreters[partition.find_subset_for_targets(targets)]
+    partition = partitions[partition_name]
+    return interpreters[partition_name][partition.find_subset_for_targets(targets)]
 
-  def sources_for_targets(self, targets):
+  def sources_for_targets(self, partition_name, targets):
     """Returns a source pex that contains sources for all given targets.
 
     All targets must be within the same subset in the partition."""
-    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
+    partition = partitions[partition_name]
     sources = self.context.products.get_data(GatherSources.PYTHON_SOURCES)
-    return sources[partition.find_subset_for_targets(targets)]
+    return sources[partition_name][partition.find_subset_for_targets(targets)]

--- a/src/python/pants/backend/python/tasks2/python_task_mixin.py
+++ b/src/python/pants/backend/python/tasks2/python_task_mixin.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+
+
+class PythonTaskMixin(object):
+  """Mixin for tasks that provides convenient access to intermediate products."""
+
+  def target_roots_subsets(self):
+    """Returns the subsets in the target roots partition."""
+    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    return partition.subsets
+
+  def interpreter_for_targets(self, targets):
+    """Returns an interpreter that is compatible with the given targets.
+
+    All targets must be within the same subset in the partition."""
+    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    interpreters = self.context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)
+    return interpreters[partition.find_subset_for_targets(targets)]
+
+  def sources_for_targets(self, targets):
+    """Returns a source pex that contains sources for all given targets.
+
+    All targets must be within the same subset in the partition."""
+    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    sources = self.context.products.get_data(GatherSources.PYTHON_SOURCES)
+    return sources[partition.find_subset_for_targets(targets)]

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -5,19 +5,32 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.pex_build_util import has_python_requirements
+from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
 from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
+from pants.build_graph.target import Target
 
 
-class ResolveRequirements(ResolveRequirementsTaskBase):
+class ResolveRequirements(PythonTaskMixin, ResolveRequirementsTaskBase):
   """Resolve external Python requirements."""
   REQUIREMENTS_PEX = 'python_requirements_pex'
+
+  @classmethod
+  def prepare(self, options, round_manager):
+    round_manager.require_data(PartitionTargets.TARGETS_PARTITION)
+    round_manager.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
 
   @classmethod
   def product_types(cls):
     return [cls.REQUIREMENTS_PEX]
 
   def execute(self):
-    req_libs = self.context.targets(has_python_requirements)
-    pex = self.resolve_requirements(req_libs)
-    self.context.products.register_data(self.REQUIREMENTS_PEX, pex)
+    pex = {}
+    self.context.products.get_data(self.REQUIREMENTS_PEX, lambda: {})
+    for subset in self.target_roots_subsets():
+      req_libs = filter(has_python_requirements, Target.closure_for_targets(subset))
+      requirements_pex[subset] = self.resolve_requirements(
+          req_libs, interpreter=self.interpreter_for_targets(subset))
+    self.context.products.register_data(self.REQUIREMENTS_PEX, requirements_pex)

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -7,13 +7,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.pex_build_util import has_python_requirements
-from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
 from pants.backend.python.tasks2.resolve_requirements_task_base import ResolveRequirementsTaskBase
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.build_graph.target import Target
 
 
-class ResolveRequirements(PythonTaskMixin, ResolveRequirementsTaskBase):
+class ResolveRequirements(ResolveRequirementsTaskBase):
   """Resolve external Python requirements."""
   REQUIREMENTS_PEX = 'python_requirements_pex'
 

--- a/src/python/pants/backend/python/tasks2/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements_task_base.py
@@ -12,12 +12,12 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 
 from pants.backend.python.tasks2.pex_build_util import dump_requirements, has_python_requirements
+from pants.backend.python.tasks2.python_task import PythonTask
 from pants.invalidation.cache_manager import VersionedTargetSet
-from pants.task.task import Task
 from pants.util.dirutil import safe_concurrent_creation
 
 
-class ResolveRequirementsTaskBase(Task):
+class ResolveRequirementsTaskBase(PythonTask):
   """Base class for tasks that resolve 3rd-party Python requirements.
 
   Creates an (unzipped) PEX on disk containing all the resolved requirements.

--- a/src/python/pants/backend/python/tasks2/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks2/select_interpreter.py
@@ -52,7 +52,7 @@ class SelectInterpreter(Task):
 
   @classmethod
   def prepare(cls, options, round_manager):
-    round_manager.require_data(PartitionTargets.TARGETS_PARTITION)
+    round_manager.require_data(PartitionTargets.TARGETS_PARTITIONS)
 
   @classmethod
   def product_types(cls):
@@ -77,13 +77,14 @@ class SelectInterpreter(Task):
 
       return self._get_interpreter(interpreter_path_file)
 
-    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    partitions = self.context.products.get_data(PartitionTargets.TARGETS_PARTITIONS)
     if self.context.products.is_required_data(self.PYTHON_INTERPRETERS):
-      interpreters = {}
-      for subset in partition.subsets:
-          interpreters[subset] = _get_interpreter_for_target_set(
-              Target.closure_for_targets(subset))
-      self.context.products.register_data(self.PYTHON_INTERPRETERS,interpreters)
+      interpreters_by_partition = self.context.products.register_data(self.PYTHON_INTERPRETERS, {})
+      for partition_name, partition in partitions.items():
+        interpreters = interpreters_by_partition[partition_name] = {}
+        for subset in partition.subsets:
+            interpreters[subset] = _get_interpreter_for_target_set(
+                Target.closure_for_targets(subset))
 
   @memoized_method
   def _interpreter_cache(self):

--- a/src/python/pants/backend/python/tasks2/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks2/select_interpreter.py
@@ -43,7 +43,8 @@ class SelectInterpreter(Task):
   """Select a Python interpreter for each root target.
 
   Produces under PYTHON_INTERPRETERS a mapping between each partition subset and interpreters
-  that matches the transitive constraints of that subset."""
+  that matches the transitive constraints of that subset.
+  """
   PYTHON_INTERPRETERS = 'PYTHON_INTERPRETERS'
 
   @classmethod

--- a/src/python/pants/backend/python/tasks2/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks2/select_interpreter.py
@@ -13,7 +13,9 @@ from pex.interpreter import PythonIdentity, PythonInterpreter
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_target import PythonTarget
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.base.fingerprint_strategy import DefaultFingerprintHashingMixin, FingerprintStrategy
+from pants.build_graph.target import Target
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.python.python_repos import PythonRepos
 from pants.task.task import Task
@@ -38,36 +40,50 @@ class PythonInterpreterFingerprintStrategy(DefaultFingerprintHashingMixin, Finge
 
 
 class SelectInterpreter(Task):
-  """Select an Python interpreter that matches the constraints of all targets in the working set."""
+  """Select a Python interpreter for each root target.
+
+  Produces under PYTHON_INTERPRETERS a mapping between each partition subset and interpreters
+  that matches the transitive constraints of that subset."""
+  PYTHON_INTERPRETERS = 'PYTHON_INTERPRETERS'
 
   @classmethod
   def subsystem_dependencies(cls):
     return super(SelectInterpreter, cls).subsystem_dependencies() + (PythonSetup, PythonRepos)
 
   @classmethod
+  def prepare(cls, options, round_manager):
+    round_manager.require_data(PartitionTargets.TARGETS_PARTITION)
+
+  @classmethod
   def product_types(cls):
-    return [PythonInterpreter]
+    return [cls.PYTHON_INTERPRETERS]
 
   def execute(self):
-    interpreter = None
-    python_tgts = self.context.targets(lambda tgt: isinstance(tgt, PythonTarget))
     fs = PythonInterpreterFingerprintStrategy()
-    with self.invalidated(python_tgts, fingerprint_strategy=fs) as invalidation_check:
-      # If there are no relevant targets, we still go through the motions of selecting
-      # an interpreter, to prevent downstream tasks from having to check for this special case.
-      if invalidation_check.all_vts:
-        target_set_id = VersionedTargetSet.from_versioned_targets(
-            invalidation_check.all_vts).cache_key.hash
-      else:
-        target_set_id = 'no_targets'
-      interpreter_path_file = self._interpreter_path_file(target_set_id)
-      if not os.path.exists(interpreter_path_file):
-        self._create_interpreter_path_file(interpreter_path_file, python_tgts)
 
-    if not interpreter:
-      interpreter = self._get_interpreter(interpreter_path_file)
+    def _get_interpreter_for_target_set(target_set):
+      python_tgts = filter(lambda tgt: isinstance(tgt, PythonTarget), target_set)
+      with self.invalidated(python_tgts, fingerprint_strategy=fs) as invalidation_check:
+        # If there are no relevant targets, we still go through the motions of selecting
+        # an interpreter, to prevent downstream tasks from having to check for this special case.
+        if invalidation_check.all_vts:
+          target_set_id = VersionedTargetSet.from_versioned_targets(
+              invalidation_check.all_vts).cache_key.hash
+        else:
+          target_set_id = 'no_targets'
+        interpreter_path_file = self._interpreter_path_file(target_set_id)
+        if not os.path.exists(interpreter_path_file):
+          self._create_interpreter_path_file(interpreter_path_file, target_set)
 
-    self.context.products.register_data(PythonInterpreter, interpreter)
+      return self._get_interpreter(interpreter_path_file)
+
+    partition = self.context.products.get_data(PartitionTargets.TARGETS_PARTITION)
+    if self.context.products.is_required_data(self.PYTHON_INTERPRETERS):
+      interpreters = {}
+      for subset in partition.subsets:
+          interpreters[subset] = _get_interpreter_for_target_set(
+              Target.closure_for_targets(subset))
+      self.context.products.register_data(self.PYTHON_INTERPRETERS,interpreters)
 
   @memoized_method
   def _interpreter_cache(self):

--- a/src/python/pants/backend/python/tasks2/setup_py.py
+++ b/src/python/pants/backend/python/tasks2/setup_py.py
@@ -23,7 +23,7 @@ from pants.backend.python.targets.python_requirement_library import PythonRequir
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.gather_sources import GatherSources
 from pants.backend.python.tasks2.partition_targets import PartitionTargets
-from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
+from pants.backend.python.tasks2.python_task import PythonTask
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
@@ -275,7 +275,7 @@ class ExportedTargetDependencyCalculator(AbstractClass):
     return reduced_dependencies
 
 
-class SetupPy(PythonTaskMixin, Task):
+class SetupPy(PythonTask):
   """Generate setup.py-based Python projects."""
 
   SOURCE_ROOT = b'src'
@@ -603,7 +603,6 @@ class SetupPy(PythonTaskMixin, Task):
     for target in targets:
       create(target, self.interpreter_for_targets(PartitionTargets.STRATEGY_MINIMAL, [target]))
 
-    interpreter = self.context.products.get_data(PythonInterpreter)
     python_dists = self.context.products.register_data(self.PYTHON_DISTS_PRODUCT, {})
     for target in reversed(sort_targets(created.keys())):
       if target in created:

--- a/src/python/pants/backend/python/tasks2/setup_py.py
+++ b/src/python/pants/backend/python/tasks2/setup_py.py
@@ -15,7 +15,6 @@ from collections import OrderedDict, defaultdict
 
 from pex.compatibility import string, to_bytes
 from pex.installer import InstallerBase, Packager
-from pex.interpreter import PythonInterpreter
 from twitter.common.collections import OrderedSet
 from twitter.common.dirutil.chroot import Chroot
 
@@ -23,6 +22,8 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.base.specs import SiblingAddresses
@@ -273,7 +274,7 @@ class ExportedTargetDependencyCalculator(AbstractClass):
     return reduced_dependencies
 
 
-class SetupPy(Task):
+class SetupPy(PythonTaskMixin, Task):
   """Generate setup.py-based Python projects."""
 
   SOURCE_ROOT = b'src'
@@ -321,7 +322,7 @@ class SetupPy(Task):
   @classmethod
   def prepare(cls, options, round_manager):
     round_manager.require_data(GatherSources.PYTHON_SOURCES)
-    round_manager.require_data(PythonInterpreter)
+    round_manager.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
 
   @classmethod
   def register_options(cls, register):
@@ -587,24 +588,24 @@ class SetupPy(Task):
 
     created = {}
 
-    def create(target):
+    def create(target, interpreter):
       if target not in created:
         self.context.log.info('Creating setup.py project for {}'.format(target))
         setup_dir, dependencies = self.create_setup_py(target, dist_dir)
-        created[target] = setup_dir
+        created[target] = (setup_dir, interpreter)
         if self._recursive:
           for dep in dependencies:
             if self.has_provides(dep):
-              create(dep)
+              create(dep, interpreter)
 
     for target in targets:
-      create(target)
+      create(target, self.interpreter_for_targets([target]))
 
     interpreter = self.context.products.get_data(PythonInterpreter)
     python_dists = self.context.products.register_data(self.PYTHON_DISTS_PRODUCT, {})
     for target in reversed(sort_targets(created.keys())):
-      setup_dir = created.get(target)
-      if setup_dir:
+      if target in created:
+        setup_dir, interpreter = created.get(target)
         if not self._run:
           self.context.log.info('Running packager against {}'.format(setup_dir))
           setup_runner = Packager(setup_dir, interpreter=interpreter)

--- a/src/python/pants/backend/python/tasks2/setup_py.py
+++ b/src/python/pants/backend/python/tasks2/setup_py.py
@@ -22,6 +22,7 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.python_task_mixin import PythonTaskMixin
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.base.build_environment import get_buildroot
@@ -322,6 +323,7 @@ class SetupPy(PythonTaskMixin, Task):
   @classmethod
   def prepare(cls, options, round_manager):
     round_manager.require_data(GatherSources.PYTHON_SOURCES)
+    round_manager.require_data(PartitionTargets.STRATEGY_MINIMAL)
     round_manager.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
 
   @classmethod
@@ -599,7 +601,7 @@ class SetupPy(PythonTaskMixin, Task):
               create(dep, interpreter)
 
     for target in targets:
-      create(target, self.interpreter_for_targets([target]))
+      create(target, self.interpreter_for_targets(PartitionTargets.STRATEGY_MINIMAL, [target]))
 
     interpreter = self.context.products.get_data(PythonInterpreter)
     python_dists = self.context.products.register_data(self.PYTHON_DISTS_PRODUCT, {})

--- a/tests/python/pants_test/backend/python/tasks2/test_gather_sources.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_gather_sources.py
@@ -13,25 +13,27 @@ from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.partition_targets import PartitionTargets, TargetsPartition
+from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.build_graph.resources import Resources
 from pants.python.python_repos import PythonRepos
+from pants.util.dirutil import read_file
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
 class GatherSourcesTest(TaskTestBase):
-  @classmethod
-  def task_type(cls):
-    return GatherSources
+  def setUp(self):
+      super(GatherSourcesTest, self).setUp()
 
-  def test_gather_sources(self):
-    filemap = {
-      'src/python/foo.py': 'foo_py_content',
-      'src/python/bar.py': 'bar_py_content',
-      'src/python/baz.py': 'baz_py_content',
-      'resources/qux/quux.txt': 'quux_txt_content',
-    }
+  filemap = {
+    'src/python/foo.py': 'foo_py_content',
+    'src/python/bar.py': 'bar_py_content',
+    'src/python/baz.py': 'baz_py_content',
+    'resources/qux/quux.txt': 'quux_txt_content',
+  }
 
-    for rel_path, content in filemap.items():
+  def make_targets(self):
+    for rel_path, content in self.filemap.items():
       self.create_file(rel_path, content)
 
     sources1 = self.make_target(spec='//:sources1_tgt', target_type=PythonLibrary,
@@ -40,17 +42,55 @@ class GatherSourcesTest(TaskTestBase):
                                 sources=['src/python/baz.py'])
     resources = self.make_target(spec='//:resources_tgt', target_type=Resources,
                                  sources=['resources/qux/quux.txt'])
-    pex = self._gather_sources([sources1, sources2, resources])
-    pex_root = pex.cmdline()[1]
+    return [sources1, sources2, resources]
 
-    for rel_path, expected_content in filemap.items():
-      with open(os.path.join(pex_root, rel_path)) as infile:
-        content = infile.read()
-      self.assertEquals(expected_content, content)
+  @classmethod
+  def task_type(cls):
+    return GatherSources
 
-  def _gather_sources(self, target_roots):
-    context = self.context(target_roots=target_roots, for_subsystems=[PythonSetup, PythonRepos])
+  @staticmethod
+  def pex_root(pex):
+      return pex.cmdline()[1]
 
+  def test_gather_sources_global(self):
+    targets = self.make_targets()
+    sources = self._gather_sources([targets])
+    self.assertEquals([frozenset(targets)], sources.keys())
+    pex_root = sources.items()[0][1]
+
+    for target in targets:
+      for source in target.sources_relative_to_source_root():
+        content = read_file(os.path.join(pex_root, source))
+        expected_content = self.filemap[source]
+        self.assertEquals(expected_content, content)
+
+  def test_gather_sources_singleton(self):
+    targets = self.make_targets()
+    sources = self._gather_sources([[t] for t in targets])
+    for target in targets:
+      pex_root = sources[frozenset([target])]
+      for source in target.sources_relative_to_source_root():
+        content = read_file(os.path.join(pex_root, source))
+        expected_content = self.filemap[source]
+        self.assertEquals(expected_content, content)
+
+    self.assertFalse(
+      os.path.exists(
+        os.path.join(sources[frozenset([targets[0]])], 'src/python/baz.py')))
+
+  def test_gather_sources_transitive(self):
+    targets = self.make_targets()
+    a = self.make_target(spec='//:a', target_type=Resources, dependencies=targets)
+    pexes = self._gather_sources([[a]])
+
+    for target in targets:
+      for source in target.sources_relative_to_source_root():
+        content = read_file(os.path.join(pexes[frozenset([a])], source))
+        expected_content = self.filemap[source]
+        self.assertEquals(expected_content, content)
+
+  @staticmethod
+  def _get_interpreter(context):
     # We must get an interpreter via the cache, instead of using PythonInterpreter.get() directly,
     # to ensure that the interpreter has setuptools and wheel support.
     interpreter = PythonInterpreter.get()
@@ -59,9 +99,24 @@ class GatherSourcesTest(TaskTestBase):
                                                logger=context.log.debug)
     interpreters = interpreter_cache.setup(paths=[os.path.dirname(interpreter.binary)],
                                            filters=[str(interpreter.identity.requirement)])
-    context.products.get_data(PythonInterpreter, lambda: interpreters[0])
+    return interpreters[0]
+
+  def _gather_sources(self, groups):
+    context = self.context(target_roots=[tgt for group in groups for tgt in group],
+                           for_subsystems=[PythonSetup, PythonRepos])
+    interpreter = self._get_interpreter(context)
+    partition = TargetsPartition(groups)
+    context.products.get_data(PartitionTargets.TARGETS_PARTITION, lambda: partition)
+
+    context.products.get_data(
+        SelectInterpreter.PYTHON_INTERPRETERS,
+        lambda: {subset: interpreter for subset in partition.subsets})
+
+    context.products.require_data(GatherSources.PYTHON_SOURCES)
 
     task = self.create_task(context)
     task.execute()
 
-    return context.products.get_data(GatherSources.PYTHON_SOURCES)
+    sources = context.products.get_data(GatherSources.PYTHON_SOURCES)
+
+    return {subset: pex.cmdline()[1] for (subset, pex) in sources.items()}

--- a/tests/python/pants_test/backend/python/tasks2/test_gather_sources.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_gather_sources.py
@@ -105,18 +105,18 @@ class GatherSourcesTest(TaskTestBase):
     context = self.context(target_roots=[tgt for group in groups for tgt in group],
                            for_subsystems=[PythonSetup, PythonRepos])
     interpreter = self._get_interpreter(context)
-    partition = TargetsPartition(groups)
-    context.products.get_data(PartitionTargets.TARGETS_PARTITION, lambda: partition)
+    partitions = {'p1': TargetsPartition(groups)}
+    context.products.get_data(PartitionTargets.TARGETS_PARTITIONS, lambda: partitions)
 
     context.products.get_data(
         SelectInterpreter.PYTHON_INTERPRETERS,
-        lambda: {subset: interpreter for subset in partition.subsets})
+        lambda: {'p1': {subset: interpreter for subset in partitions['p1'].subsets}})
 
     context.products.require_data(GatherSources.PYTHON_SOURCES)
 
     task = self.create_task(context)
     task.execute()
 
-    sources = context.products.get_data(GatherSources.PYTHON_SOURCES)
+    sources = context.products.get_data(GatherSources.PYTHON_SOURCES)['p1']
 
     return {subset: pex.cmdline()[1] for (subset, pex) in sources.items()}

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
@@ -66,7 +66,7 @@ class PytestTestBase(PythonTaskTestBase):
         for_task_types=[pt_task_type, si_task_type, rr_task_type, gs_task_type, pp_task_type],
         target_roots=targets,
         passthru_args=list(passthru_args))
-    context.products.require_data(PartitionTargets.TARGETS_PARTITION)
+    context.products.require_data(PartitionTargets.STRATEGY_GLOBAL)
     context.products.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
     context.products.require_data(GatherSources.PYTHON_SOURCES)
     context.products.require_data(ResolveRequirements.REQUIREMENTS_PEX)

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
@@ -12,6 +12,7 @@ import coverage
 from mock import patch
 
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.pytest_prep import PytestPrep
 from pants.backend.python.tasks2.pytest_run import PytestRun
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
@@ -56,13 +57,20 @@ class PytestTestBase(PythonTaskTestBase):
 
     # The easiest way to create products required by the PythonTest task is to
     # execute the relevant tasks.
+    pt_task_type = self.synthesize_task_subtype(PartitionTargets, 'pt_scope')
     si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
     rr_task_type = self.synthesize_task_subtype(ResolveRequirements, 'rr_scope')
     gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
     pp_task_type = self.synthesize_task_subtype(PytestPrep, 'pp_scope')
-    context = self.context(for_task_types=[si_task_type, rr_task_type, gs_task_type, pp_task_type],
-                           target_roots=targets,
-                           passthru_args=list(passthru_args))
+    context = self.context(
+        for_task_types=[pt_task_type, si_task_type, rr_task_type, gs_task_type, pp_task_type],
+        target_roots=targets,
+        passthru_args=list(passthru_args))
+    context.products.require_data(PartitionTargets.TARGETS_PARTITION)
+    context.products.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
+    context.products.require_data(GatherSources.PYTHON_SOURCES)
+    context.products.require_data(ResolveRequirements.REQUIREMENTS_PEX)
+    pt_task_type(context, os.path.join(self.pants_workdir, 'pt')).execute()
     si_task_type(context, os.path.join(self.pants_workdir, 'si')).execute()
     rr_task_type(context, os.path.join(self.pants_workdir, 'rr')).execute()
     gs_task_type(context, os.path.join(self.pants_workdir, 'gs')).execute()
@@ -318,13 +326,31 @@ class PytestTest(PytestTestBase):
   def test_red(self):
     self.run_failing_tests(targets=[self.red], failed_targets=[self.red])
 
-  def test_fail_fast_skips_second_red_test_with_single_chroot(self):
-    self.run_failing_tests(targets=[self.red, self.red_in_class], failed_targets=[self.red],
-                           fail_fast=True, fast=False)
+  def test_fail_fast_skips_second_red_test_with_single_chroot_run_per_target(self):
+    self.run_failing_tests(targets=[self.red, self.red_in_class],
+                           failed_targets=[self.red],
+                           fail_fast=True,
+                           run_per_target=True,
+                           partition_strategy=PartitionTargets.STRATEGY_GLOBAL)
+    self.run_failing_tests(targets=[self.red_in_class, self.red],
+                           failed_targets=[self.red_in_class],
+                           fail_fast=True,
+                           run_per_target=True,
+                           partition_strategy=PartitionTargets.STRATEGY_GLOBAL)
 
-  def test_fail_fast_skips_second_red_test_with_isolated_chroot(self):
-    self.run_failing_tests(targets=[self.red, self.red_in_class], failed_targets=[self.red_in_class],
-                           fail_fast=True, fast=True)
+  def test_fail_fast_skips_second_red_test_with_single_chroot_single_run(self):
+    # We pass the sources to pytest sorted by lexicgraphic order, so the same
+    # tests fail regardless of target order.
+    self.run_failing_tests(targets=[self.red, self.red_in_class],
+                           failed_targets=[self.red],
+                           fail_fast=True,
+                           run_per_target=False,
+                           partition_strategy=PartitionTargets.STRATEGY_GLOBAL)
+    self.run_failing_tests(targets=[self.red_in_class, self.red],
+                           failed_targets=[self.red],
+                           fail_fast=True,
+                           run_per_target=False,
+                           partition_strategy=PartitionTargets.STRATEGY_GLOBAL)
 
   def test_red_test_in_class(self):
     # for test in a class, the failure line is in the following format
@@ -370,7 +396,10 @@ class PytestTest(PytestTestBase):
     return all_statements, not_run_statements
 
   def test_coverage_auto_option(self):
-    simple_coverage_kwargs = {'coverage': 'auto'}
+    simple_coverage_kwargs = {
+        'coverage': 'auto',
+        'partition_strategy': PartitionTargets.STRATEGY_GLOBAL
+    }
 
     self.assertFalse(os.path.isfile(self.coverage_data_file()))
 
@@ -430,9 +459,9 @@ class PytestTest(PytestTestBase):
     self.assertEqual([], not_run_statements)
 
   def test_sharding(self):
-    self.run_tests(targets=[self.red, self.green], test_shard='1/2')
+    self.run_tests(targets=[self.red, self.green], test_shard='0/2')
     self.run_failing_tests(targets=[self.red, self.green], failed_targets=[self.red],
-                           test_shard='0/2')
+                           test_shard='1/2')
 
   def test_sharding_single(self):
     self.run_failing_tests(targets=[self.red], failed_targets=[self.red], test_shard='0/1')

--- a/tests/python/pants_test/backend/python/tasks2/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_binary_create.py
@@ -9,6 +9,7 @@ import os
 from textwrap import dedent
 
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.partition_targets import PartitionTargets
 from pants.backend.python.tasks2.python_binary_create import PythonBinaryCreate
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.base.run_info import RunInfo
@@ -36,16 +37,17 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
 
     # The easiest way to create products required by the PythonBinaryCreate task is to
     # execute the relevant tasks.
+    pt_task_type = self.synthesize_task_subtype(PartitionTargets, 'pt_scope')
     si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
-    gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
 
-    self.task_context = self.context(for_task_types=[si_task_type, gs_task_type],
+    self.task_context = self.context(for_task_types=[pt_task_type, si_task_type],
                                      target_roots=[self.binary])
+    self.task_context.products.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
     self.run_info_dir = os.path.join(self.pants_workdir, self.options_scope, 'test/info')
     self.task_context.run_tracker.run_info = RunInfo(self.run_info_dir)
 
+    pt_task_type(self.task_context, os.path.join(self.pants_workdir, 'pt')).execute()
     si_task_type(self.task_context, os.path.join(self.pants_workdir, 'si')).execute()
-    gs_task_type(self.task_context, os.path.join(self.pants_workdir, 'gs')).execute()
 
     self.test_task = self.create_task(self.task_context)
     self.dist_root = os.path.join(self.build_root, 'dist')

--- a/tests/python/pants_test/backend/python/tasks2/test_python_binary_create.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_binary_create.py
@@ -43,6 +43,7 @@ class PythonBinaryCreateTest(PythonTaskTestBase):
     self.task_context = self.context(for_task_types=[pt_task_type, si_task_type],
                                      target_roots=[self.binary])
     self.task_context.products.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
+    self.task_context.products.require_data(PartitionTargets.STRATEGY_MINIMAL)
     self.run_info_dir = os.path.join(self.pants_workdir, self.options_scope, 'test/info')
     self.task_context.run_tracker.run_info = RunInfo(self.run_info_dir)
 

--- a/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
@@ -118,7 +118,8 @@ class PythonReplTest(PythonTaskTestBase):
     gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
     context = self.context(for_task_types=[pt_task_type, si_task_type, rr_task_type, gs_task_type],
                            target_roots=targets)
-    context.products.require_data(PartitionTargets.TARGETS_PARTITION)
+    context.products.require_data(PartitionTargets.STRATEGY_GLOBAL)
+    context.products.require_data(PartitionTargets.TARGETS_PARTITIONS)
     context.products.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
     context.products.require_data(GatherSources.PYTHON_SOURCES)
     context.products.require_data(ResolveRequirements.REQUIREMENTS_PEX)

--- a/tests/python/pants_test/backend/python/tasks2/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_resolve_requirements.py
@@ -109,8 +109,8 @@ class ResolveRequirementsTest(TaskTestBase):
   def _resolve_requirements(self, target_roots, options=None):
     context = self.context(target_roots=target_roots, options=options,
                            for_subsystems=[PythonSetup, PythonRepos])
-    partition = TargetsPartition([target_roots])
-    context.products.get_data(PartitionTargets.TARGETS_PARTITION, lambda: partition)
+    partitions = {'x': TargetsPartition([target_roots])}
+    context.products.get_data(PartitionTargets.TARGETS_PARTITIONS, lambda: partitions)
 
     # We must get an interpreter via the cache, instead of using PythonInterpreter.get() directly,
     # to ensure that the interpreter has setuptools and wheel support.
@@ -122,15 +122,12 @@ class ResolveRequirementsTest(TaskTestBase):
                                            filters=[str(interpreter.identity.requirement)])
     context.products.get_data(
         SelectInterpreter.PYTHON_INTERPRETERS,
-        lambda: {subset: interpreters[0] for subset in partition.subsets})
-    context.products.get_data(
-        SelectInterpreter.PYTHON_INTERPRETERS,
-        lambda: {tgt: interpreters[0] for tgt in target_roots})
+        lambda: {'x': {subset: interpreters[0] for subset in partitions['x'].subsets}})
 
     task = self.create_task(context)
     task.execute()
 
-    return context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX).items()[0][1]
+    return context.products.get_data(ResolveRequirements.REQUIREMENTS_PEX)['x'].items()[0][1]
 
   def _exercise_module(self, pex, expected_module):
     with temporary_file() as f:

--- a/tests/python/pants_test/backend/python/tasks2/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_select_interpreter.py
@@ -11,9 +11,14 @@ from pex.interpreter import PythonIdentity, PythonInterpreter
 from pants.backend.python.interpreter_cache import PythonInterpreterCache
 from pants.backend.python.subsystems.python_setup import PythonSetup
 from pants.backend.python.targets.python_library import PythonLibrary
+from pants.backend.python.tasks2.partition_targets import PartitionTargets, TargetsPartition
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
 from pants.base.exceptions import TaskError
 from pants_test.tasks.task_test_base import TaskTestBase
+
+
+def fs(*args):
+  return frozenset(args)
 
 
 class SelectInterpreterTest(TaskTestBase):
@@ -43,14 +48,19 @@ class SelectInterpreterTest(TaskTestBase):
     self.tgt20 = self._fake_target('tgt20', dependencies=[self.tgt2])
     self.tgt30 = self._fake_target('tgt30', dependencies=[self.tgt3])
     self.tgt40 = self._fake_target('tgt40', dependencies=[self.tgt4])
+    self.tgt50 = self._fake_target('tgt50', dependencies=[self.tgt3, self.tgt4])
 
   def _fake_target(self, spec, compatibility=None, sources=None, dependencies=None):
     return self.make_target(spec=spec, target_type=PythonLibrary, sources=sources or [],
                             dependencies=dependencies, compatibility=compatibility)
 
-  def _select_interpreter(self, target_roots, should_invalidate=None):
+  def _select_interpreter(self, groups, should_invalidate=None):
     """Return the version string of the interpreter selected for the target roots."""
-    context = self.context(target_roots=target_roots)
+    context = self.context(target_roots=[tgt for group in groups for tgt in group])
+    context.products.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
+    partition = TargetsPartition(groups)
+    context.products.get_data(PartitionTargets.TARGETS_PARTITION, lambda: partition)
+
     task = self.create_task(context)
     if should_invalidate is not None:
       task._create_interpreter_path_file = mock.MagicMock(wraps=task._create_interpreter_path_file)
@@ -70,36 +80,59 @@ class SelectInterpreterTest(TaskTestBase):
       else:
         task._create_interpreter_path_file.assert_not_called()
 
-    interpreter = context.products.get_data(PythonInterpreter)
-    self.assertTrue(isinstance(interpreter, PythonInterpreter))
-    return interpreter.version_string
+    interpreters = context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)
+    for interpreter in interpreters.values():
+      self.assertTrue(isinstance(interpreter, PythonInterpreter))
+    return {subset: i.version_string for (subset, i) in interpreters.items()}
 
   def test_interpreter_selection(self):
-    self.assertEquals('FakePython-2.77.777', self._select_interpreter([]))
-    self.assertEquals('FakePython-2.77.777', self._select_interpreter([self.tgt1]))
-    self.assertEquals('FakePython-2.88.888', self._select_interpreter([self.tgt2]))
-    self.assertEquals('FakePython-2.99.999', self._select_interpreter([self.tgt3]))
-    self.assertEquals('FakePython-2.77.777', self._select_interpreter([self.tgt4]))
-    self.assertEquals('FakePython-2.88.888', self._select_interpreter([self.tgt20]))
-    self.assertEquals('FakePython-2.99.999', self._select_interpreter([self.tgt30]))
-    self.assertEquals('FakePython-2.77.777', self._select_interpreter([self.tgt40]))
-    self.assertEquals('FakePython-2.99.999', self._select_interpreter([self.tgt2, self.tgt3]))
-    self.assertEquals('FakePython-2.88.888', self._select_interpreter([self.tgt2, self.tgt4]))
+    self.assertEquals({}, self._select_interpreter([]))
+    self.assertEquals({fs(self.tgt1): 'FakePython-2.77.777'}, self._select_interpreter([[self.tgt1]]))
+    self.assertEquals({fs(self.tgt2): 'FakePython-2.88.888'}, self._select_interpreter([[self.tgt2]]))
+    self.assertEquals({fs(self.tgt3): 'FakePython-2.99.999'}, self._select_interpreter([[self.tgt3]]))
+    self.assertEquals({fs(self.tgt4): 'FakePython-2.77.777'}, self._select_interpreter([[self.tgt4]]))
+    self.assertEquals({fs(self.tgt20): 'FakePython-2.88.888'}, self._select_interpreter([[self.tgt20]]))
+    self.assertEquals({fs(self.tgt30): 'FakePython-2.99.999'}, self._select_interpreter([[self.tgt30]]))
+    self.assertEquals({fs(self.tgt40): 'FakePython-2.77.777'}, self._select_interpreter([[self.tgt40]]))
+    self.assertEquals({
+        fs(self.tgt2): 'FakePython-2.88.888',
+        fs(self.tgt3): 'FakePython-2.99.999'
+        },
+        self._select_interpreter([[self.tgt2], [self.tgt3]]))
+    self.assertEquals({
+        fs(self.tgt2): 'FakePython-2.88.888',
+        fs(self.tgt4): 'FakePython-2.77.777'
+        },
+        self._select_interpreter([[self.tgt2], [self.tgt4]]))
+    self.assertEquals({
+        fs(self.tgt2, self.tgt4): 'FakePython-2.88.888',
+        },
+        self._select_interpreter([[self.tgt2, self.tgt4]]))
+    self.assertEquals({
+        fs(self.tgt2): 'FakePython-2.88.888',
+        fs(self.tgt3): 'FakePython-2.99.999',
+        },
+        self._select_interpreter([[self.tgt2], [self.tgt3]]))
 
     with self.assertRaises(TaskError) as cm:
-      self._select_interpreter([self.tgt3, self.tgt4])
+      self._select_interpreter([[self.tgt3, self.tgt4]])
+    self.assertIn('Unable to detect a suitable interpreter for compatibilities: '
+                  'FakePython<2.99.999 && FakePython>2.88.888', str(cm.exception))
+
+    with self.assertRaises(TaskError) as cm:
+      self._select_interpreter([[self.tgt50]])
     self.assertIn('Unable to detect a suitable interpreter for compatibilities: '
                   'FakePython<2.99.999 && FakePython>2.88.888', str(cm.exception))
 
   def test_interpreter_selection_invalidation(self):
     tgta = self._fake_target('tgta', compatibility=['FakePython>2.77.777'],
                              dependencies=[self.tgt3])
-    self.assertEquals('FakePython-2.99.999',
-                      self._select_interpreter([tgta], should_invalidate=True))
+    self.assertEquals({fs(tgta): 'FakePython-2.99.999'},
+                      self._select_interpreter([[tgta]], should_invalidate=True))
 
     # A new target with different sources, but identical compatibility, shouldn't invalidate.
     self.create_file('tgtb/foo/bar/baz.py', 'fake content')
     tgtb = self._fake_target('tgtb', compatibility=['FakePython>2.77.777'],
                              dependencies=[self.tgt3], sources=['foo/bar/baz.py'])
-    self.assertEquals('FakePython-2.99.999',
-                      self._select_interpreter([tgtb], should_invalidate=False))
+    self.assertEquals({fs(tgtb): 'FakePython-2.99.999'},
+                      self._select_interpreter([[tgtb]], should_invalidate=False))

--- a/tests/python/pants_test/backend/python/tasks2/test_select_interpreter.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_select_interpreter.py
@@ -58,8 +58,8 @@ class SelectInterpreterTest(TaskTestBase):
     """Return the version string of the interpreter selected for the target roots."""
     context = self.context(target_roots=[tgt for group in groups for tgt in group])
     context.products.require_data(SelectInterpreter.PYTHON_INTERPRETERS)
-    partition = TargetsPartition(groups)
-    context.products.get_data(PartitionTargets.TARGETS_PARTITION, lambda: partition)
+    partition = {'p1': TargetsPartition(groups)}
+    context.products.get_data(PartitionTargets.TARGETS_PARTITIONS, lambda: partition)
 
     task = self.create_task(context)
     if should_invalidate is not None:
@@ -80,7 +80,7 @@ class SelectInterpreterTest(TaskTestBase):
       else:
         task._create_interpreter_path_file.assert_not_called()
 
-    interpreters = context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)
+    interpreters = context.products.get_data(SelectInterpreter.PYTHON_INTERPRETERS)['p1']
     for interpreter in interpreters.values():
       self.assertTrue(isinstance(interpreter, PythonInterpreter))
     return {subset: i.version_string for (subset, i) in interpreters.items()}

--- a/tests/python/pants_test/backend/python/tasks2/test_setup_py.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_setup_py.py
@@ -88,10 +88,11 @@ class TestSetupPy(PythonTaskTestBase):
     context = self.context(target_roots=[target])
 
     partition = TargetsPartition([[target]])
-    context.products.get_data(PartitionTargets.TARGETS_PARTITION, lambda: partition)
+    context.products.get_data(PartitionTargets.TARGETS_PARTITIONS,
+                              lambda: {PartitionTargets.STRATEGY_MINIMAL: partition})
     context.products.get_data(
         SelectInterpreter.PYTHON_INTERPRETERS,
-        lambda: {subset: None for subset in partition.subsets})
+        lambda: {PartitionTargets.STRATEGY_MINIMAL: {subset: None for subset in partition.subsets}})
 
     setup_py = self.create_task(context)
     setup_py.execute()


### PR DESCRIPTION
### Problem

Currently, when running a Python task over a set of targets (for example testing multiple targets, or running setup_py for multiple libraries), all the targets in play need to be compatible. That means they need to agree on a version of Python, and version ranges for external requirements.

As a user, I'd like to be able to test a whole subdirectory, `pants test dir/dir/dir::` and have pants executes all the tests with the right interpreter for each test target. Our current workaround is `pants filter --filter-type=python_library dir/dir/dir | xargs ./pants test` which is slow.

## Solution

This PR adds a new task `PartitionTargets` that implements three partitioning algorithms. Two of them are trivial: a partition into one group and a partition into singletons. The third algorithm is a partition of the target roots into the smallest number of subsets such that all targets in the subset are in the transitive closure of one of the targets in the subset. This ensures that all targets in each subset are compatible.
`PartitionTargets` provides these algorithms as products that other tasks can order via `request_data`.

The SelectInterpreter/ResolveRequirements/GatherSources perform their original operations for each partition and for each subset in that partition. Then higher level tasks (like SetupPy, BinaryCreate, PytestRun) request a specific partitioning algorithm(s) from the PartitionTargets tasks and the intermediate tasks would perform their operations on them (select interpreter for each subset, resolve requirements, and so on)

### Result

With this change, users can specify --no-single-source-root so the third algorithm above runs (otherwise the global strategy is run - a single subset with all targets for compatibility with current behavior). The --fast flag is replaced with --run-per-target (which inovkes pytest once for each target). Off by default.