### PR TITLE
Skip a test that assumes the current version is a pre-release version.

### DIFF
--- a/tests/python/pants_test/base/test_deprecated.py
+++ b/tests/python/pants_test/base/test_deprecated.py
@@ -13,7 +13,7 @@ from pants.base.deprecated import (BadDecoratorNestingError, BadRemovalVersionEr
                                    CodeRemovedError, MissingRemovalVersionError,
                                    NonDevRemovalVersionError, deprecated, deprecated_conditional,
                                    deprecated_module, warn_or_error)
-from pants.version import VERSION
+from pants.version import PANTS_SEMVER, VERSION
 
 
 class DeprecatedTest(unittest.TestCase):
@@ -151,6 +151,9 @@ class DeprecatedTest(unittest.TestCase):
       def test_func1a():
         pass
 
+  @unittest.skipIf(not PANTS_SEMVER.is_prerelease,
+                   'Uses the current version as a deprecation version, which is only valid '
+                   'for prereleases.')
   def test_removal_version_same(self):
     with self.assertRaises(CodeRemovedError):
       warn_or_error(VERSION, 'dummy description')


### PR DESCRIPTION
### Problem

Sometime during the `1.3.0.dev` cycle we added validation that deprecation versions are `dev`/prerelease versions (to avoid having a bunch of deprecations fire the instant a stable release was cut). But one test was not updated for this validation, and so bumping the version to `1.3.0` in the stable branch caused it to fail.

### Solution

Skip that test if the assumption (that the current version is a prerelease version) does not hold. Another approach would have been to add arguments to the deprecation package to allow for spoofing the current version, but that would have pretty wide-ranging impacts for something that can be easily ignored.