### PR TITLE
Break `py.test` execution into two stages.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -14,6 +14,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.pytest_prep import PytestPrep
 from pants.backend.python.tasks2.pytest_run import PytestRun
 from pants.backend.python.tasks2.python_binary_create import PythonBinaryCreate
 from pants.backend.python.tasks2.python_repl import PythonRepl
@@ -53,6 +54,7 @@ def register_goals():
   task(name='requirements', action=ResolveRequirements).install('pyprep')
   task(name='sources', action=GatherSources).install('pyprep')
   task(name='py', action=PythonRun).install('run')
+  task(name='pytest-prep', action=PytestPrep).install('test')
   task(name='pytest', action=PytestRun).install('test')
   task(name='py', action=PythonRepl).install('repl')
   task(name='setup-py', action=SetupPy).install()

--- a/src/python/pants/backend/python/tasks2/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks2/pytest_prep.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pex.pex_info import PexInfo
+
+from pants.backend.python.subsystems.pytest import PyTest
+from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
+
+
+class PytestPrep(PythonExecutionTaskBase):
+  """Prepares a pex binary for the current test context with py.test as its entry-point."""
+
+  PYTEST_BINARY = 'pytest_binary'
+
+  @classmethod
+  def product_types(cls):
+    return [cls.PYTEST_BINARY]
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(PytestPrep, cls).subsystem_dependencies() + (PyTest,)
+
+  def extra_requirements(self):
+    return PyTest.global_instance().get_requirement_strings()
+
+  def execute(self):
+    pex_info = PexInfo.default()
+    pex_info.entry_point = 'pytest'
+    pytest_binary = self.create_pex(pex_info)
+    self.context.products.get_data(self.PYTEST_BINARY, init_func=lambda: pytest_binary)

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -133,8 +133,12 @@ class PytestRun(TestRunnerTaskMixin, Task):
   class InvalidShardSpecification(TaskError):
     """Indicates an invalid `--test-shard` option."""
 
+  def _ensure_workdir(self):
+    safe_mkdir(self.workdir)
+    return self.workdir
+
   def _get_junit_xml_path(self, targets):
-    xml_path = os.path.join(self.workdir, 'junitxml',
+    xml_path = os.path.join(self._ensure_workdir(), 'junitxml',
                             'TEST-{}.xml'.format(Target.maybe_readable_identify(targets)))
     safe_mkdir_for(xml_path)
     return xml_path
@@ -207,7 +211,7 @@ class PytestRun(TestRunnerTaskMixin, Task):
     # Note that it's important to put the tmpfile under the workdir, because pytest
     # uses all arguments that look like paths to compute its rootdir, and we want
     # it to pick the buildroot.
-    with temporary_file(root_dir=self.workdir) as fp:
+    with temporary_file(root_dir=self._ensure_workdir()) as fp:
       cp.write(fp)
       fp.close()
       coverage_rc = fp.name
@@ -392,7 +396,7 @@ class PytestRun(TestRunnerTaskMixin, Task):
     # Note that it's important to put the tmpdir under the workdir, because pytest
     # uses all arguments that look like paths to compute its rootdir, and we want
     # it to pick the buildroot.
-    with temporary_dir(root_dir=self.workdir) as conftest_dir:
+    with temporary_dir(root_dir=self._ensure_workdir()) as conftest_dir:
       conftest = os.path.join(conftest_dir, 'conftest.py')
       with open(conftest, 'w') as fp:
         fp.write(conftest_content)

--- a/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_pytest_run.py
@@ -12,6 +12,7 @@ import coverage
 from mock import patch
 
 from pants.backend.python.tasks2.gather_sources import GatherSources
+from pants.backend.python.tasks2.pytest_prep import PytestPrep
 from pants.backend.python.tasks2.pytest_run import PytestRun
 from pants.backend.python.tasks2.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks2.select_interpreter import SelectInterpreter
@@ -58,12 +59,14 @@ class PytestTestBase(PythonTaskTestBase):
     si_task_type = self.synthesize_task_subtype(SelectInterpreter, 'si_scope')
     rr_task_type = self.synthesize_task_subtype(ResolveRequirements, 'rr_scope')
     gs_task_type = self.synthesize_task_subtype(GatherSources, 'gs_scope')
-    context = self.context(for_task_types=[si_task_type, rr_task_type, gs_task_type],
+    pp_task_type = self.synthesize_task_subtype(PytestPrep, 'pp_scope')
+    context = self.context(for_task_types=[si_task_type, rr_task_type, gs_task_type, pp_task_type],
                            target_roots=targets,
                            passthru_args=list(passthru_args))
     si_task_type(context, os.path.join(self.pants_workdir, 'si')).execute()
     rr_task_type(context, os.path.join(self.pants_workdir, 'rr')).execute()
     gs_task_type(context, os.path.join(self.pants_workdir, 'gs')).execute()
+    pp_task_type(context, os.path.join(self.pants_workdir, 'pp')).execute()
     return context
 
   def _do_run_tests(self, context):


### PR DESCRIPTION
In order to support test caching using the standard invalidation and
caching infrastructure, `py.test` pex creation and caching needs to be
separated from test execution across a task barrier to avoid thrashing
target cache keys. Break out a small task that just preps the `py.test`
pex binary for the `PytestRun` task to use.