### PR TITLE
Support registering product data from one task.

### DIFF
--- a/src/python/pants/backend/python/tasks2/gather_sources.py
+++ b/src/python/pants/backend/python/tasks2/gather_sources.py
@@ -45,7 +45,7 @@ class GatherSources(Task):
 
     with self.invalidated(targets) as invalidation_check:
       pex = self._get_pex_for_versioned_targets(interpreter, invalidation_check.all_vts)
-      self.context.products.get_data(self.PYTHON_SOURCES, lambda: pex)
+      self.context.products.register_data(self.PYTHON_SOURCES, pex)
 
   def _get_pex_for_versioned_targets(self, interpreter, versioned_targets):
     if versioned_targets:

--- a/src/python/pants/backend/python/tasks2/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks2/pytest_prep.py
@@ -31,4 +31,4 @@ class PytestPrep(PythonExecutionTaskBase):
     pex_info = PexInfo.default()
     pex_info.entry_point = 'pytest'
     pytest_binary = self.create_pex(pex_info)
-    self.context.products.get_data(self.PYTEST_BINARY, init_func=lambda: pytest_binary)
+    self.context.products.register_data(self.PYTEST_BINARY, pytest_binary)

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -20,4 +20,4 @@ class ResolveRequirements(ResolveRequirementsTaskBase):
   def execute(self):
     req_libs = self.context.targets(has_python_requirements)
     pex = self.resolve_requirements(req_libs)
-    self.context.products.get_data(self.REQUIREMENTS_PEX, lambda: pex)
+    self.context.products.register_data(self.REQUIREMENTS_PEX, pex)

--- a/src/python/pants/backend/python/tasks2/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks2/select_interpreter.py
@@ -67,7 +67,7 @@ class SelectInterpreter(Task):
     if not interpreter:
       interpreter = self._get_interpreter(interpreter_path_file)
 
-    self.context.products.get_data(PythonInterpreter, lambda: interpreter)
+    self.context.products.register_data(PythonInterpreter, interpreter)
 
   @memoized_method
   def _interpreter_cache(self):

--- a/src/python/pants/backend/python/tasks2/setup_py.py
+++ b/src/python/pants/backend/python/tasks2/setup_py.py
@@ -601,7 +601,7 @@ class SetupPy(Task):
       create(target)
 
     interpreter = self.context.products.get_data(PythonInterpreter)
-    python_dists = self.context.products.get_data(self.PYTHON_DISTS_PRODUCT, lambda: {})
+    python_dists = self.context.products.register_data(self.PYTHON_DISTS_PRODUCT, {})
     for target in reversed(sort_targets(created.keys())):
       setup_dir = created.get(target)
       if setup_dir:

--- a/src/python/pants/goal/products.py
+++ b/src/python/pants/goal/products.py
@@ -407,6 +407,22 @@ class Products(object):
     """
     return typename in self.required_data_products
 
+  def register_data(self, typename, value):
+    """Registers a data product, raising if a product was already registered.
+
+    :API: public
+
+    :param typename: The type of product to register a value for.
+    :param value: The data product to register under `typename`.
+    :returns: The registered `value`.
+    :raises: :class:`ProductError` if a value for the given product `typename` is already
+             registered.
+    """
+    if typename in self.data_products:
+      raise ProductError('Already have a product registered for {}, cannot over-write with {}'
+                         .format(typename, value))
+    return self.safe_create_data(typename, lambda: value)
+
   def safe_create_data(self, typename, init_func):
     """Ensures that a data item is created if it doesn't already exist.
 
@@ -416,7 +432,7 @@ class Products(object):
     return self.get_data(typename, init_func)
 
   def get_data(self, typename, init_func=None):
-    """ Returns a data product.
+    """Returns a data product.
 
     :API: public
 

--- a/tests/python/pants_test/goal/test_products.py
+++ b/tests/python/pants_test/goal/test_products.py
@@ -9,7 +9,7 @@ import os
 from collections import defaultdict
 from contextlib import contextmanager
 
-from pants.goal.products import MultipleRootedProducts, Products
+from pants.goal.products import MultipleRootedProducts, ProductError, Products
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open
 from pants_test.base_test import BaseTest
@@ -69,6 +69,12 @@ class ProductsTest(BaseTest):
     self.assertFalse(self.products.is_required_data('foo'))
     self.products.require_data('foo')
     self.assertTrue(self.products.is_required_data('foo'))
+
+  def test_register_data(self):
+    data = {}
+    self.assertIs(data, self.products.register_data('foo', data))
+    with self.assertRaises(ProductError):
+      self.products.register_data('foo', data)
 
   def test_empty_products(self):
     foo_product_mapping = self.products.get('foo')


### PR DESCRIPTION
The common case is that exactly one task should ever be the source of
any particular data product. Support this case directly with a data
product registration API.