### PR TITLE
Support fingerprinting of `UnsetBool` options.

### DIFF
--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -5,16 +5,26 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import inspect
 import json
 import os
 from hashlib import sha1
 
 from pants.base.build_environment import get_buildroot
-from pants.option.custom_types import dict_with_files_option, file_option, target_option
+from pants.option.custom_types import UnsetBool, dict_with_files_option, file_option, target_option
+
+
+class Encoder(json.JSONEncoder):
+  _UNSET_BOOL_ENCODING = '__type::{}::{}'.format(inspect.getmodule(UnsetBool), UnsetBool.__name__)
+
+  def default(self, o):
+    if o is UnsetBool:
+      return self._UNSET_BOOL_ENCODING
+    return super(Encoder, self).default(o)
 
 
 def stable_json_dumps(obj):
-  return json.dumps(obj, ensure_ascii=True, allow_nan=False, sort_keys=True)
+  return json.dumps(obj, ensure_ascii=True, allow_nan=False, sort_keys=True, cls=Encoder)
 
 
 def stable_json_sha1(obj):

--- a/tests/python/pants_test/option/test_options_fingerprinter.py
+++ b/tests/python/pants_test/option/test_options_fingerprinter.py
@@ -9,7 +9,8 @@ import os
 
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
-from pants.option.custom_types import dict_option, file_option, list_option, target_option
+from pants.option.custom_types import (UnsetBool, dict_option, file_option, list_option,
+                                       target_option)
 from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants.util.contextutil import temporary_dir
 from pants_test.base_test import BaseTest
@@ -95,3 +96,8 @@ class OptionsFingerprinterTest(BaseTest):
   def test_fingerprint_primitive(self):
     fp1, fp2 = (self.options_fingerprinter.fingerprint('', v) for v in ('foo', 5))
     self.assertNotEquals(fp1, fp2)
+
+  def test_fingerprint_unset_bool(self):
+    fp1 = self.options_fingerprinter.fingerprint(UnsetBool, UnsetBool)
+    fp2 = self.options_fingerprinter.fingerprint(UnsetBool, UnsetBool)
+    self.assertEqual(fp1, fp2)


### PR DESCRIPTION
This was a landmine waiting to go off. All other supported option custom
types were handled.