### PR TITLE
 Add compiler_args property to JavaThriftLibrary target. 

### DIFF
--- a/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
+++ b/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/android_generator/BUILD
@@ -2,7 +2,7 @@ java_thrift_library(
   sources=['struct.thrift'],
   compiler='scrooge',
   language='android',
-  rpc_style='finagle',
+  compiler_args=['--finagle'],
   dependencies=[
   '3rdparty:thrift-0.6.1',
   'contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/dummy_generator:dummy_generator'

--- a/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/dummy_generator/BUILD
+++ b/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/dummy_generator/BUILD
@@ -2,6 +2,6 @@ java_thrift_library(
   sources=['dummy.thrift'],
   compiler='scrooge',
   language='android',
-  rpc_style='finagle',
+  compiler_args=['--finagle'],
   dependencies=['3rdparty:thrift-0.6.1']
 )

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/java_thrift_library_fingerprint_strategy.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/java_thrift_library_fingerprint_strategy.py
@@ -31,6 +31,8 @@ class JavaThriftLibraryFingerprintStrategy(FingerprintStrategy):
     hasher.update(self._thrift_defaults.language(target))
     hasher.update(self._thrift_defaults.rpc_style(target))
 
+    hasher.update(str(self._thrift_defaults.compiler_args(target)))
+
     namespace_map = self._thrift_defaults.namespace_map(target)
     if namespace_map:
       hasher.update(str(sorted(namespace_map.items())))

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -34,7 +34,6 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
   DepInfo = namedtuple('DepInfo', ['service', 'structs'])
   PartialCmd = namedtuple('PartialCmd', [
     'language', 
-    'rpc_style', 
     'namespace_map', 
     'default_java_namespace', 
     'include_paths', 
@@ -140,12 +139,27 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     self._validate_compiler_configs([target])
     self._must_have_sources(target)
 
+    def compiler_args_has_rpc_style(compiler_args):
+      return bool(_RPC_STYLES & set(compiler_args))
+
+    def merge_rpc_style_with_compiler_args(compiler_args, rpc_style):
+      new_compiler_args = list(compiler_args)
+      # ignore rpc_style if we think compiler_args is setting it
+      if not compiler_args_has_rpc_style(compiler_args):
+        if rpc_style == 'ostrich':
+          new_compiler_args.append('--finagle')
+          new_compiler_args.append('--ostrich')
+        elif rpc_style == 'finagle':
+          new_compiler_args.append('--finagle')
+      return new_compiler_args
+
     namespace_map = self._thrift_defaults.namespace_map(target)
-    compiler_args = self._thrift_defaults.compiler_args(target)
+    compiler_args = merge_rpc_style_with_compiler_args(
+        self._thrift_defaults.compiler_args(target), 
+        self._validate_rpc_style(target))
 
     partial_cmd = self.PartialCmd(
         language=self._validate_language(target),
-        rpc_style=self._validate_rpc_style(target),
         namespace_map=tuple(sorted(namespace_map.items())) if namespace_map else (),
         default_java_namespace=self._thrift_defaults.default_java_namespace(target),
         include_paths=target.include_paths,
@@ -158,9 +172,6 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
     args = list(partial_cmd.compiler_args)
 
-    def compiler_args_has_rpc_style():
-      return bool(_RPC_STYLES & set(partial_cmd.compiler_args))
-
     if partial_cmd.default_java_namespace:
       args.extend(['--default-java-namespace', partial_cmd.default_java_namespace])
 
@@ -171,14 +182,6 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
     for lhs, rhs in partial_cmd.namespace_map:
       args.extend(['--namespace-map', '%s=%s' % (lhs, rhs)])
-
-    # ignore rpc_style if we think compiler_args is setting it
-    if not compiler_args_has_rpc_style():
-      if partial_cmd.rpc_style == 'ostrich':
-        args.append('--finagle')
-        args.append('--ostrich')
-      elif partial_cmd.rpc_style == 'finagle':
-        args.append('--finagle')
 
     args.extend(['--dest', target_workdir])
 

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -150,7 +150,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
   def gen(self, partial_cmd, target, target_workdir):
     import_paths, _ = calculate_compile_sources([target], self.is_gentarget)
 
-    args = partial_cmd.compiler_args
+    args = list(partial_cmd.compiler_args)
 
     if partial_cmd.default_java_namespace:
       args.extend(['--default-java-namespace', partial_cmd.default_java_namespace])

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -33,7 +33,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
   DepInfo = namedtuple('DepInfo', ['service', 'structs'])
   PartialCmd = namedtuple('PartialCmd',
-    ['language', 'rpc_style', 'namespace_map', 'default_java_namespace', 'include_paths'])
+    ['language', 'rpc_style', 'namespace_map', 'default_java_namespace', 'include_paths', 'compiler_args'])
 
   @classmethod
   def register_options(cls, register):
@@ -135,20 +135,22 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     self._must_have_sources(target)
 
     namespace_map = self._thrift_defaults.namespace_map(target)
+    compiler_args = self._thrift_defaults.compiler_args(target)
 
     partial_cmd = self.PartialCmd(
         language=self._validate_language(target),
         rpc_style=self._validate_rpc_style(target),
         namespace_map=tuple(sorted(namespace_map.items())) if namespace_map else (),
         default_java_namespace=self._thrift_defaults.default_java_namespace(target),
-        include_paths=target.include_paths)
+        include_paths=target.include_paths,
+        compiler_args=compiler_args)
 
     self.gen(partial_cmd, target, target_workdir)
 
   def gen(self, partial_cmd, target, target_workdir):
     import_paths, _ = calculate_compile_sources([target], self.is_gentarget)
 
-    args = []
+    args = partial_cmd.compiler_args
 
     if partial_cmd.default_java_namespace:
       args.extend(['--default-java-namespace', partial_cmd.default_java_namespace])

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -32,8 +32,14 @@ _RPC_STYLES = frozenset(['sync', 'finagle', 'ostrich'])
 class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
   DepInfo = namedtuple('DepInfo', ['service', 'structs'])
-  PartialCmd = namedtuple('PartialCmd',
-    ['language', 'rpc_style', 'namespace_map', 'default_java_namespace', 'include_paths', 'compiler_args'])
+  PartialCmd = namedtuple('PartialCmd', [
+    'language', 
+    'rpc_style', 
+    'namespace_map', 
+    'default_java_namespace', 
+    'include_paths', 
+    'compiler_args'
+  ])
 
   @classmethod
   def register_options(cls, register):
@@ -152,6 +158,9 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
     args = list(partial_cmd.compiler_args)
 
+    def compiler_args_has_rpc_style():
+      return bool(_RPC_STYLES & set(partial_cmd.compiler_args))
+
     if partial_cmd.default_java_namespace:
       args.extend(['--default-java-namespace', partial_cmd.default_java_namespace])
 
@@ -163,11 +172,13 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     for lhs, rhs in partial_cmd.namespace_map:
       args.extend(['--namespace-map', '%s=%s' % (lhs, rhs)])
 
-    if partial_cmd.rpc_style == 'ostrich':
-      args.append('--finagle')
-      args.append('--ostrich')
-    elif partial_cmd.rpc_style == 'finagle':
-      args.append('--finagle')
+    # ignore rpc_style if we think compiler_args is setting it
+    if not compiler_args_has_rpc_style():
+      if partial_cmd.rpc_style == 'ostrich':
+        args.append('--finagle')
+        args.append('--ostrich')
+      elif partial_cmd.rpc_style == 'finagle':
+        args.append('--finagle')
 
     args.extend(['--dest', target_workdir])
 

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_java_thrift_library_fingerprint_strategy.py
@@ -17,7 +17,8 @@ class JavaThriftLibraryFingerprintStrategyTest(BaseTest):
 
   options1 = {'compiler': 'scrooge',
               'language': 'java',
-              'rpc_style': 'async'}
+              'rpc_style': 'async',
+              'compiler_args': []}
 
   def create_strategy(self, option_values):
     self.context(for_subsystems=[ThriftDefaults], options={
@@ -39,6 +40,14 @@ class JavaThriftLibraryFingerprintStrategyTest(BaseTest):
   def test_fp_diffs_due_to_target_change(self):
     a = self.make_target(':a', target_type=JavaThriftLibrary, rpc_style='sync', dependencies=[])
     b = self.make_target(':b', target_type=JavaThriftLibrary, rpc_style='finagle', dependencies=[])
+
+    fp1 = self.create_strategy(self.options1).compute_fingerprint(a)
+    fp2 = self.create_strategy(self.options1).compute_fingerprint(b)
+    self.assertNotEquals(fp1, fp2)
+
+  def test_fp_diffs_due_to_compiler_args_change(self):
+    a = self.make_target(':a', target_type=JavaThriftLibrary, compiler_args=['--foo'], dependencies=[])
+    b = self.make_target(':b', target_type=JavaThriftLibrary, compiler_args=['--bar'], dependencies=[])
 
     fp1 = self.create_strategy(self.options1).compute_fingerprint(a)
     fp2 = self.create_strategy(self.options1).compute_fingerprint(b)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -84,32 +84,60 @@ class ScroogeGenTest(TaskTestBase):
 
   def test_scala(self):
     sources = [os.path.join(self.task_outdir, 'org/pantsbuild/example/Example.scala')]
-    self._test_help('scala', 'finagle', ScalaLibrary, [GEN_ADAPT], sources)
+    self._test_help('scala', ScalaLibrary, [GEN_ADAPT], sources, 'finagle')
+
+  def test_compiler_args_no_rpc_style(self):
+    sources = [os.path.join(self.task_outdir, 'org/pantsbuild/example/Example.scala')]
+    self._test_help('scala', ScalaLibrary, [GEN_ADAPT], sources)
 
   def test_android(self):
     sources = [os.path.join(self.task_outdir, 'org/pantsbuild/android_example/Example.java')]
-    self._test_help('android', 'finagle', JavaLibrary, [GEN_ADAPT], sources)
+    self._test_help('android', JavaLibrary, [GEN_ADAPT], sources, 'finagle')
 
   def test_invalid_lang(self):
     with self.assertRaises(TargetDefinitionException):
-      self._test_help('not-a-lang', 'finagle', JavaLibrary, [GEN_ADAPT], [])
+      self._test_help('not-a-lang', JavaLibrary, [GEN_ADAPT], [], 'finagle')
 
   def test_invalid_style(self):
     with self.assertRaises(TargetDefinitionException):
-      self._test_help('scala', 'not-a-style', JavaLibrary, [GEN_ADAPT], [])
+      self._test_help('scala', JavaLibrary, [GEN_ADAPT], [], 'not-a-style')
 
   def test_empty_compiler_args(self):
     sources = [os.path.join(self.task_outdir, 'org/pantsbuild/example/Example.scala')]
-    self._test_help('scala', 'finagle', ScalaLibrary, [], sources)
+    self._test_help('scala', ScalaLibrary, [], sources, 'finagle')
 
   def compiler_args_to_string(self, compiler_args):
     quoted = map(lambda x: "'{}'".format(x), compiler_args)
     comma_separated = ', '.join(quoted)
     return '[{}]'.format(comma_separated)
 
-  def _test_help(self, language, rpc_style, library_type, compiler_args, sources):
+  def _test_create_build_str(self, language, compiler_args, rpc_style=None):
     compiler_args_str = self.compiler_args_to_string(compiler_args)
-    print(compiler_args_str)
+    if rpc_style is None:
+      return dedent('''
+        java_thrift_library(name='a',
+          sources=['a.thrift'],
+          dependencies=[],
+          compiler='scrooge',
+          language='{language}',
+          compiler_args={compiler_args},
+          strict_deps=True,
+        )
+      '''.format(language=language, compiler_args=compiler_args_str))
+    else:
+      return dedent('''
+        java_thrift_library(name='a',
+          sources=['a.thrift'],
+          dependencies=[],
+          compiler='scrooge',
+          language='{language}',
+          rpc_style='{rpc_style}',
+          compiler_args={compiler_args},
+          strict_deps=True,
+        )
+      '''.format(language=language, rpc_style=rpc_style, compiler_args=compiler_args_str))
+
+  def _test_help(self, language, library_type, compiler_args, sources, rpc_style = None):
     contents = dedent('''#@namespace android org.pantsbuild.android_example
       namespace java org.pantsbuild.example
       struct Example {
@@ -117,19 +145,8 @@ class ScroogeGenTest(TaskTestBase):
       }
     ''')
 
-    build_string = dedent('''
-      java_thrift_library(name='a',
-        sources=['a.thrift'],
-        dependencies=[],
-        compiler='scrooge',
-        language='{language}',
-        rpc_style='{rpc_style}',
-        compiler_args={compiler_args},
-        strict_deps=True,
-      )
-    '''.format(language=language, rpc_style=rpc_style, compiler_args=compiler_args_str))
-
     self.create_file(relpath='test_smoke/a.thrift', contents=contents)
+    build_string = self._test_create_build_str(language, compiler_args, rpc_style)
     self.add_to_build_file('test_smoke', build_string)
 
     target = self.target('test_smoke:a')

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/scrooge_gen/BUILD
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/scrooge_gen/BUILD
@@ -6,7 +6,7 @@ java_thrift_library(
   sources = ['good.thrift'],
   compiler='scrooge',
   language='scala',
-  rpc_style='finagle',
+  compiler_args=['--finagle'],
 )
 
 java_thrift_library(
@@ -14,7 +14,7 @@ java_thrift_library(
   sources = ['good.thrift'],
   compiler='scrooge',
   language='scala',
-  rpc_style='finagle',
+  compiler_args=['--finagle'],
   namespace_map = {
     'old': 'new',
   },
@@ -25,7 +25,7 @@ java_thrift_library(
   sources = ['good.thrift'],
   compiler='scrooge',
   language='scala',
-  rpc_style='finagle',
+  compiler_args=['--finagle'],
   default_java_namespace = 'the_namespace',
 )
 
@@ -34,7 +34,7 @@ java_thrift_library(
   sources = ['good.thrift'],
   compiler='scrooge',
   language='scala',
-  rpc_style='finagle',
+  compiler_args=['--finagle'],
   include_paths = [
     'some_dir',
   ],

--- a/src/docs/pants_essentials_thrift.asc
+++ b/src/docs/pants_essentials_thrift.asc
@@ -4,7 +4,7 @@ java_thrift_library(name='myproj-scala',
   dependencies=['src/thrift/included:includedproj-scala',],
   compiler='scrooge',
   language='scala',
-  rpc_style='finagle',
+  compiler_args=['--finagle'],
 )
 ----
 

--- a/src/python/pants/backend/codegen/thrift/java/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/thrift/java/java_thrift_library.py
@@ -63,11 +63,15 @@ class JavaThriftLibrary(JvmTarget):
 
     deprecated_conditional(
       lambda: rpc_style is not None,
-      '1.5.0.dev0',
+      '1.6.0.dev0',
       'rpc_style', 
-      'Pass rpc_style as compiler_args instead e.g. [ \'--finagle\'] for \'finagle\' rpc_style.' 
-      'If both rpc_style and compiler_args are set then only compiler_args is used,'
-      ' rpc_style is discarded.'
+      '''
+      Deprecated property rpc_style used for {target}, use compiler_args instead.
+      e.g. [ \'--finagle\'] for \'finagle\'
+      and [\'--finagle\', \'--ostrich\'] for \'ostrich\'. 
+      If both rpc_style and compiler_args are set then only compiler_args is used
+      and rpc_style is discarded.
+      '''.format(target=self.address.spec)
     )
 
     self._rpc_style = rpc_style

--- a/src/python/pants/backend/codegen/thrift/java/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/thrift/java/java_thrift_library.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.jvm.targets.jvm_target import JvmTarget
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TargetDefinitionException
 
 
@@ -59,6 +60,16 @@ class JavaThriftLibrary(JvmTarget):
     # values impact the outcome of the task.  See JavaThriftLibraryFingerprintStrategy.
     self._compiler = check_value_for_arg('compiler', compiler, self._COMPILERS)
     self._language = language
+
+    deprecated_conditional(
+      lambda: rpc_style is not None,
+      '1.5.0.dev0',
+      'rpc_style', 
+      'Pass rpc_style as compiler_args instead e.g. [ \'--finagle\'] for \'finagle\' rpc_style.' 
+      'If both rpc_style and compiler_args are set then only compiler_args is used,'
+      ' rpc_style is discarded.'
+    )
+
     self._rpc_style = rpc_style
 
     self.namespace_map = namespace_map

--- a/src/python/pants/backend/codegen/thrift/java/java_thrift_library.py
+++ b/src/python/pants/backend/codegen/thrift/java/java_thrift_library.py
@@ -29,6 +29,7 @@ class JavaThriftLibrary(JvmTarget):
                thrift_linter_strict=None,
                default_java_namespace=None,
                include_paths=None,
+               compiler_args=None,
                **kwargs):
     """
     :API: public
@@ -44,6 +45,7 @@ class JavaThriftLibrary(JvmTarget):
     :param default_java_namespace: The namespace used for Java generated code when a Java
       namespace is not explicitly specified in the IDL. The default is defined in the global
       options under ``--thrift-default-default-java-namespace``.
+    :param compiler_args: Extra arguments to the compiler.
     """
     super(JavaThriftLibrary, self).__init__(**kwargs)
 
@@ -63,6 +65,7 @@ class JavaThriftLibrary(JvmTarget):
     self.thrift_linter_strict = thrift_linter_strict
     self._default_java_namespace = default_java_namespace
     self._include_paths = include_paths
+    self._compiler_args = compiler_args
 
   @property
   def compiler(self):
@@ -75,6 +78,10 @@ class JavaThriftLibrary(JvmTarget):
   @property
   def rpc_style(self):
     return self._rpc_style
+
+  @property
+  def compiler_args(self):
+    return self._compiler_args
 
   @property
   def default_java_namespace(self):

--- a/src/python/pants/backend/codegen/thrift/java/thrift_defaults.py
+++ b/src/python/pants/backend/codegen/thrift/java/thrift_defaults.py
@@ -24,6 +24,8 @@ class ThriftDefaults(Subsystem):
     register('--language', type=str, advanced=True, default='java',
              help='The default language to generate for java_thrift_library targets.')
     register('--rpc-style', type=str, advanced=True, default='sync',
+             removal_version='1.6.0.dev0',
+             removal_hint='Use --compiler-args instead of --rpc-style.',
              help='The default rpc-style to generate for java_thrift_library targets.')
     register('--default-java-namespace', type=str, advanced=True, default=None,
              help='The default Java namespace to generate for java_thrift_library targets.')

--- a/src/python/pants/backend/codegen/thrift/java/thrift_defaults.py
+++ b/src/python/pants/backend/codegen/thrift/java/thrift_defaults.py
@@ -29,6 +29,8 @@ class ThriftDefaults(Subsystem):
              help='The default Java namespace to generate for java_thrift_library targets.')
     register('--namespace-map', type=dict, advanced=True, default={},
              help='The default namespace map to generate for java_thrift_library targets, {old: new}.')
+    register('--compiler-args', type=list, advanced=True, default=[],
+             help='Extra arguments for the thrift compiler.')
 
   def __init__(self, *args, **kwargs):
     super(ThriftDefaults, self).__init__(*args, **kwargs)
@@ -37,6 +39,7 @@ class ThriftDefaults(Subsystem):
     self._default_rpc_style = self.get_options().rpc_style
     self._default_default_java_namespace = self.get_options().default_java_namespace
     self._default_namespace_map = self.get_options().namespace_map
+    self._default_compiler_args = self.get_options().compiler_args
 
   def compiler(self, target):
     """Returns the thrift compiler to use for the given target.
@@ -70,6 +73,17 @@ class ThriftDefaults(Subsystem):
     """
     self._check_target(target)
     return target.namespace_map or self._default_namespace_map
+
+  def compiler_args(self, target):
+    """Returns the compiler_args used for Thrift generation.
+
+    :param target: The target to extract the compiler args from.
+    :type target: :class:`pants.backend.codegen.targets.java_thrift_library.JavaThriftLibrary`
+    :returns: Extra arguments for the thrift compiler
+    :rtype: list
+    """
+    self._check_target(target)
+    return target.compiler_args or self._default_compiler_args
 
   def default_java_namespace(self, target):
     """Returns the default_java_namespace used for Thrift generation.

--- a/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
+++ b/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
@@ -72,7 +72,7 @@ class ApacheThriftGenBase(SimpleCodegenTask):
       target_cmd.extend(('-I', base))
 
     if hasattr(target, 'compiler_args'):
-      target_cmd.extend(list(target.compiler_args))
+      target_cmd.extend(list(target.compiler_args or []))
 
     target_cmd.extend(('-o', target_workdir))
 

--- a/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
+++ b/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
@@ -71,6 +71,8 @@ class ApacheThriftGenBase(SimpleCodegenTask):
     for base in bases:
       target_cmd.extend(('-I', base))
 
+    target_cmd.extend(list(target.compiler_args or []))
+
     target_cmd.extend(('-o', target_workdir))
 
     for source in target.sources_relative_to_buildroot():

--- a/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
+++ b/src/python/pants/backend/codegen/thrift/lib/apache_thrift_gen_base.py
@@ -71,7 +71,8 @@ class ApacheThriftGenBase(SimpleCodegenTask):
     for base in bases:
       target_cmd.extend(('-I', base))
 
-    target_cmd.extend(list(target.compiler_args or []))
+    if hasattr(target, 'compiler_args'):
+      target_cmd.extend(list(target.compiler_args))
 
     target_cmd.extend(('-o', target_workdir))
 

--- a/tests/python/pants_test/backend/codegen/thrift/java/test_apache_thrift_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/thrift/java/test_apache_thrift_java_gen.py
@@ -41,7 +41,8 @@ class ApacheThriftJavaGenTest(TaskTestBase):
     one = self.make_target(spec='src/thrift/com/foo:one',
                            target_type=JavaThriftLibrary,
                            sources=['one.thrift'],
-                           compiler='thrift')
+                           compiler='thrift',
+                           compiler_args = [])
     synthetic_target = self.generate_single_thrift_target(one)
     self.assertEqual(['com/foo/One.java'], list(synthetic_target.sources_relative_to_source_root()))
 


### PR DESCRIPTION
 compiler_args are any extra arguments to thrift compiler that are not covered by
 standard properties such as rpc_style, language etc.

### Problem

For supporting the generation of adaptive scrooge code a flag "gen-adapt" needs to be passed to the scrooge compiler.
### Solution

 Instead of adding another special option to JavaThriftLibrary target, I've added an option to specify any compiler arguments.

### Result

Users will now be able to specify any compiler arguments that they need to pass to the thrift compiler. compiler_args is only supported by the scrooge compiler. In a previous discussion with pants team we talked about removing rpc_style, which can be specified as a compiler arg. But I wasn't sure about removing it, since namespace_map is similar. Please suggest if I should remove rpc_style.