### PR TITLE
Ensure `Task.workdir` is available when needed.

### DIFF
--- a/contrib/android/src/python/pants/contrib/android/tasks/BUILD
+++ b/contrib/android/src/python/pants/contrib/android/tasks/BUILD
@@ -33,7 +33,6 @@ python_library(
     'contrib/android/src/python/pants/contrib/android/tasks:aapt_task',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
-    'src/python/pants/util:dirutil',
   ],
 )
 

--- a/contrib/android/src/python/pants/contrib/android/tasks/aapt_builder.py
+++ b/contrib/android/src/python/pants/contrib/android/tasks/aapt_builder.py
@@ -11,7 +11,6 @@ import subprocess
 
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
-from pants.util.dirutil import safe_mkdir
 
 from pants.contrib.android.targets.android_resources import AndroidResources
 from pants.contrib.android.tasks.aapt_task import AaptTask
@@ -67,7 +66,6 @@ class AaptBuilder(AaptTask):
     return args
 
   def execute(self):
-    safe_mkdir(self.workdir)
     binaries = self.context.targets(self.is_android_binary)
     with self.invalidated(binaries) as invalidation_check:
       invalid_targets = []

--- a/examples/src/python/example/pants_publish_plugin/BUILD
+++ b/examples/src/python/example/pants_publish_plugin/BUILD
@@ -7,6 +7,5 @@ python_library(
     'src/python/pants/backend/jvm/targets:java',
     'src/python/pants/backend/jvm/tasks:jar_task',
     'src/python/pants/goal:task_registrar',
-    'src/python/pants/util:dirutil',
   ],
 )

--- a/examples/src/python/example/pants_publish_plugin/extra_test_jar_example.py
+++ b/examples/src/python/example/pants_publish_plugin/extra_test_jar_example.py
@@ -9,7 +9,6 @@ import os
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.jar_task import JarTask
-from pants.util.dirutil import safe_mkdir
 
 
 ##
@@ -34,9 +33,6 @@ class ExtraTestJarExample(JarTask):
   # This method is called by pants, when the RoundEngine gets to the phase where your task is
   # attached.
   def execute(self):
-    # Ensure that we have a work directory to create a temporary jar.
-    safe_mkdir(self.workdir)
-
     # For each node in the graph that was selected below, create a jar, and store a reference to
     # the jar in the product map.
     def process(target):

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -244,8 +244,6 @@ class IvyResolveStep(IvyResolutionStep):
     return result
 
   def _do_resolve(self, executor, extra_args, targets, jvm_options, workunit_name, workunit_factory):
-    safe_mkdir(self.workdir)
-
     ivyxml = self.ivy_xml_path
     hash_name = '{}-resolve'.format(self.hash_name)
     self._prepare_ivy_xml(targets, ivyxml, hash_name)

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -103,8 +103,6 @@ class JvmdocGen(JvmTask):
       return
 
     with self.invalidated(targets) as invalidation_check:
-      safe_mkdir(self.workdir)
-
       def find_jvmdoc_targets():
         invalid_targets = set()
         for vt in invalidation_check.invalid_vts:

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -133,12 +133,8 @@ class PytestRun(TestRunnerTaskMixin, Task):
   class InvalidShardSpecification(TaskError):
     """Indicates an invalid `--test-shard` option."""
 
-  def _ensure_workdir(self):
-    safe_mkdir(self.workdir)
-    return self.workdir
-
   def _get_junit_xml_path(self, targets):
-    xml_path = os.path.join(self._ensure_workdir(), 'junitxml',
+    xml_path = os.path.join(self.workdir, 'junitxml',
                             'TEST-{}.xml'.format(Target.maybe_readable_identify(targets)))
     safe_mkdir_for(xml_path)
     return xml_path
@@ -211,7 +207,7 @@ class PytestRun(TestRunnerTaskMixin, Task):
     # Note that it's important to put the tmpfile under the workdir, because pytest
     # uses all arguments that look like paths to compute its rootdir, and we want
     # it to pick the buildroot.
-    with temporary_file(root_dir=self._ensure_workdir()) as fp:
+    with temporary_file(root_dir=self.workdir) as fp:
       cp.write(fp)
       fp.close()
       coverage_rc = fp.name
@@ -396,7 +392,7 @@ class PytestRun(TestRunnerTaskMixin, Task):
     # Note that it's important to put the tmpdir under the workdir, because pytest
     # uses all arguments that look like paths to compute its rootdir, and we want
     # it to pick the buildroot.
-    with temporary_dir(root_dir=self._ensure_workdir()) as conftest_dir:
+    with temporary_dir(root_dir=self.workdir) as conftest_dir:
       conftest = os.path.join(conftest_dir, 'conftest.py')
       with open(conftest, 'w') as fp:
         fp.write(conftest_content)

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -23,7 +23,7 @@ from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants.option.scope import ScopeInfo
 from pants.reporting.reporting_utils import items_to_report_element
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.dirutil import safe_rm_oldest_items_in_dir
+from pants.util.dirutil import safe_mkdir, safe_rm_oldest_items_in_dir
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.meta import AbstractClass
 
@@ -201,15 +201,16 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     else:
       return self.context.options.passthru_args_for_scope(self.options_scope)
 
-  @property
+  @memoized_property
   def workdir(self):
     """A scratch-space for this task that will be deleted by `clean-all`.
 
-    It's not guaranteed that the workdir exists, just that no other task has been given this
-    workdir path to use.
+    It's guaranteed that no other task has been given this workdir path to use and that the workdir
+    exists.
 
     :API: public
     """
+    safe_mkdir(self._workdir)
     return self._workdir
 
   def _options_fingerprint(self, scope):


### PR DESCRIPTION
To avoid boilerplate and meet reasonable expectations, ensure a task's
workdir is available when queried. This is a backwards compatible
behavior change to a public API.