### PR TITLE
Add classname to target data reported by pytest

### DIFF
--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -592,7 +592,8 @@ class PytestRun(TestRunnerTaskMixin, Task):
         raise TaskError('Error parsing xml file at {}: {}'
           .format(parse_error.xml_path, parse_error.cause))
 
-      all_tests_info = self.parse_test_info(junitxml_path, parse_error_handler, ['file', 'name'])
+      all_tests_info = self.parse_test_info(junitxml_path, parse_error_handler,
+                                            ['file', 'name', 'classname'])
       for test_name, test_info in all_tests_info.items():
         test_target = self._get_target_from_test(test_info, targets)
         self.report_all_info_for_single_test(self.options_scope, test_target, test_name, test_info)

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -144,7 +144,10 @@ class TestRunnerTaskMixin(object):
             test_info.update({'time': None})
 
           for attribute in testcase_attributes:
-            test_info[attribute] = testcase.getAttribute(attribute)
+            attribute_value = testcase.getAttribute(attribute)
+            if not attribute_value:
+              attribute_value = None
+            test_info[attribute] = attribute_value
 
           test_error = testcase.getElementsByTagName('error')
           test_fail = testcase.getElementsByTagName('failure')

--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -544,7 +544,7 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
             'time': 1.290
           },
           'testOK2': {
-            'file': '',
+            'file': None,
             'classname': 'org.pantsbuild.Green',
             'result_code': 'success',
             'time': 1.12
@@ -557,13 +557,13 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
           },
           'testOK4': {
             'file': 'file.py',
-            'classname': '',
+            'classname': None,
             'result_code': 'success',
             'time': 1.79
           },
           'testOK5': {
-            'file': '',
-            'classname': '',
+            'file': None,
+            'classname': None,
             'result_code': 'success',
             'time': 0.832
           },


### PR DESCRIPTION
### Problem

The target data being reported by pytest and junit are inconsistent. 

### Solution

In order to make the reports consistent, we need to add the classname to the test data being reported. 

### Result

The result is that there is a classname field in the test data being reported. 