### PR TITLE
Fix pytest result summary colors.

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -138,8 +138,9 @@ class PytestRun(TestRunnerTaskMixin, PythonTask):
         if not rv.success and self.get_options().fail_fast:
           break
 
-      for target in sorted(results):
-        self.context.log.info('{0:80}.....{1:>10}'.format(target.id, str(results[target])))
+      for target, rv in sorted(results.items()):
+        log = self.context.log.info if rv.success else self.context.log.error
+        log('{0:80}.....{1:>10}'.format(target.id, rv))
 
       failed_targets = [target for target, _rv in results.items() if not _rv.success]
       if failed_targets:

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -522,9 +522,10 @@ class PytestRun(TestRunnerTaskMixin, Task):
         break
 
     for partition in sorted(results):
-      rv = str(results[partition])
+      rv = results[partition]
       for target in partition:
-        self.context.log.info('{0:80}.....{1:>10}'.format(target.id, rv))
+        log = self.context.log.info if rv.success else self.context.log.error
+        log('{0:80}.....{1:>10}'.format(target.id, rv))
 
     failed_targets = [target
                       for _rv in results.values() if not _rv.success


### PR DESCRIPTION
Previously both the old and new `PytestRun` tasks neglected to color
summary output in accordance with test success or failure.

Fixes #4678