### PR TITLE
Improve safe_concurrent_creation contextmanager.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,9 @@ matrix:
       services:
         - docker
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       env:
         - SHARD="Linux Bintray Builder"
         # Use the standard python manylinux image for ideal binary compatibility.
@@ -104,7 +106,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -130,7 +134,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -156,7 +162,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -182,7 +190,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -208,7 +218,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -234,7 +246,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -260,7 +274,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -286,7 +302,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -312,7 +330,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -338,7 +358,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -364,7 +386,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -390,7 +414,9 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python: "2.7.13"
+      python:
+        "2.6"
+        "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,8 @@ matrix:
         - docker
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       env:
         - SHARD="Linux Bintray Builder"
         # Use the standard python manylinux image for ideal binary compatibility.
@@ -107,8 +107,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -135,8 +135,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -163,8 +163,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -191,8 +191,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -219,8 +219,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -247,8 +247,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -275,8 +275,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -303,8 +303,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -331,8 +331,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -359,8 +359,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -387,8 +387,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -415,8 +415,8 @@ matrix:
             - python-dev
       language: python
       python:
-        "2.6"
-        "2.7.13"
+        - "2.6"
+        - "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,15 +64,14 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       # Docker runs will write files as root, so avoid caching for this shard.
       cache: false
       services:
         - docker
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       env:
         - SHARD="Linux Bintray Builder"
         # Use the standard python manylinux image for ideal binary compatibility.
@@ -96,6 +95,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -106,9 +106,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -124,6 +122,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -134,9 +133,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -152,6 +149,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -162,9 +160,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -180,6 +176,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -190,9 +187,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -208,6 +203,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -218,9 +214,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -236,6 +230,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -246,9 +241,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -264,6 +257,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -274,9 +268,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -292,6 +284,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -302,9 +295,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -320,6 +311,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -330,9 +322,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -348,6 +338,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -358,9 +349,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -376,6 +365,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -386,9 +376,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.
@@ -404,6 +392,7 @@ matrix:
 
     - os: linux
       dist: trusty
+      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -414,9 +403,7 @@ matrix:
             - gcc-multilib
             - python-dev
       language: python
-      python:
-        - "2.6"
-        - "2.7.13"
+      python: "2.7.13"
       before_install:
         # Remove bad openjdk6 from trusty image, so
         # Pants will pick up oraclejdk6 from `packages` above.

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -250,7 +250,10 @@ def safe_concurrent_creation(target_path):
   tmp_path = '{}.tmp.{}'.format(target_path, uuid.uuid4().hex)
   try:
     yield tmp_path
-  finally:
+  except Exception:
+    rm_rf(tmp_path)
+    raise
+  else:
     if os.path.exists(tmp_path):
       safe_concurrent_rename(tmp_path, target_path)
 

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -264,7 +264,7 @@ class DirutilTest(unittest.TestCase):
       self.assertFalse(os.path.exists(expected_file))
       self.assertTrue(os.path.exists(os.path.dirname(expected_file)))
 
-  def test_safe_concurrent_creation_exception_still_renames(self):
+  def test_safe_concurrent_creation_exception_cleanup(self):
     with temporary_dir() as td:
       expected_file = os.path.join(td, 'expected_file')
 
@@ -275,7 +275,7 @@ class DirutilTest(unittest.TestCase):
           raise ZeroDivisionError('zomg')
 
       self.assertFalse(os.path.exists(safe_path))
-      self.assertTrue(os.path.exists(expected_file))
+      self.assertFalse(os.path.exists(expected_file))
 
   def test_safe_rm_oldest_items_in_dir(self):
     with temporary_dir() as td:

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -264,7 +264,7 @@ class DirutilTest(unittest.TestCase):
       self.assertFalse(os.path.exists(expected_file))
       self.assertTrue(os.path.exists(os.path.dirname(expected_file)))
 
-  def test_safe_concurrent_creation_exception_cleanup(self):
+  def test_safe_concurrent_creation_exception_handling(self):
     with temporary_dir() as td:
       expected_file = os.path.join(td, 'expected_file')
 


### PR DESCRIPTION
Fixes #4640

### Problem

Currently, the `safe_concurrent_creation` contextmgr does the final directory rename in a `finally` block, which can lead to empty directory creation in the face of error handling.

### Solution

Move the rename into a try/except/else block.

### Result

No longer able to repro #4640.