### PR TITLE
Use ElementTree to parse JUnit XML files because it is much faster than minidom

### DIFF
--- a/tests/python/pants_test/task/test_testrunner_task_mixin.py
+++ b/tests/python/pants_test/task/test_testrunner_task_mixin.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import collections
 import os
 from unittest import TestCase
+from xml.etree.ElementTree import ParseError
 
 from mock import patch
 
@@ -18,7 +19,6 @@ from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_open
 from pants.util.process_handler import ProcessHandler
 from pants.util.timeout import TimeoutReached
-from pants.util.xml_parser import XmlParser
 from pants_test.tasks.task_test_base import TaskTestBase
 
 
@@ -489,7 +489,7 @@ class TestRunnerTaskMixinXmlParsing(TestRunnerTaskMixin, TestCase):
       with self.assertRaises(Exception) as exc:
         self.parse_test_info(xml_dir, self._raise_handler)
       self.assertEqual(xml_file, exc.exception.xml_path)
-      self.assertIsInstance(exc.exception.cause, XmlParser.XmlError)
+      self.assertIsInstance(exc.exception.cause, ParseError)
 
   def test_parse_test_info_error_continue(self):
     with temporary_dir() as xml_dir:


### PR DESCRIPTION
### Problem

The new stat collecting code in 1.3+ https://github.com/pantsbuild/pants/pull/4561 uses `pants.util.xml_parser` which uses minidom to parse XML files.  minidom loads the whole xml file into memory so when the xml files are large it can take minutes to load individual xml files.

### Solution

Change testrunner_task_mixin.py to use ElementTree for parsing XML instead of pants.util.xml_parser.  This is much faster for parsing large xml files. 

### Result

Without this change we had tests generating xml files of up to 40MB which were taking an additional 3 minutes to run for each test and effectively timing out in the build system.  The change to ElementTree got the XML parsing down to sub-second.

This change is the minimal change that will get our tests working again.  It would be nice to consolidate the JUnit XML parsing that is done in `src/python/pants/backend/jvm/tasks/reports/junit_html_report.py` with similar code that is in `src/python/pants/task/testrunner_task_mixin.py`.

It would also be good to have an option to turn off stats gathering in case it affects performance in the future. 

cc: @dotordogh 