### PR TITLE
Fix pythonstyle warnings and some python-eval warnings

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -11,7 +11,6 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.build_graph.address import Address
 from pants.java.jar.jar_dependency import JarDependency
 from pants.subsystem.subsystem import Subsystem
-from pants.util.memo import memoized_method
 
 
 class JUnit(JvmToolMixin, Subsystem):

--- a/src/python/pants/backend/jvm/targets/javac_plugin.py
+++ b/src/python/pants/backend/jvm/targets/javac_plugin.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.targets.java_library import JavaLibrary
-from pants.build_graph.address import Address
 
 
 class JavacPlugin(JavaLibrary):

--- a/src/python/pants/backend/jvm/targets/junit_tests.py
+++ b/src/python/pants/backend/jvm/targets/junit_tests.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.jvm.subsystems.junit import JUnit
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
-from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload

--- a/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
+++ b/src/python/pants/backend/jvm/targets/managed_jar_dependencies.py
@@ -40,7 +40,7 @@ class ManagedJarDependencies(Target):
       yield spec
 
     if kwargs:
-      _, specs = self._split_jars_and_specs(kwargs.get('artifacts', ()))
+      _, specs = cls._split_jars_and_specs(kwargs.get('artifacts', ()))
       for spec in specs:
         yield spec
     elif payload:

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-
 from pex.interpreter import PythonIdentity
 from twitter.common.collections import maybe_list
 
@@ -19,7 +17,6 @@ from pants.build_graph.address import Address
 from pants.build_graph.resources import Resources
 from pants.build_graph.target import Target
 from pants.build_graph.target_addressable import TargetAddressable
-from pants.util.memo import memoized_property
 
 
 class PythonTarget(Target):

--- a/src/python/pants/base/payload.py
+++ b/src/python/pants/base/payload.py
@@ -7,8 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from hashlib import sha1
 
-from pants.base.payload_field import PayloadField
-
 
 class PayloadFieldAlreadyDefinedError(Exception): pass
 

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 from collections import namedtuple
 
-from pants.base.deprecated import deprecated, deprecated_conditional
+from pants.base.deprecated import deprecated
 from pants.util.dirutil import longest_dir_prefix
 from pants.util.strutil import strip_prefix
 

--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -13,7 +13,6 @@ from collections import namedtuple
 from six.moves import range
 
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional
 from pants.cache.artifact_cache import ArtifactCacheError
 from pants.cache.local_artifact_cache import LocalArtifactCache, TempLocalArtifactCache
 from pants.cache.pinger import BestUrlSelector, Pinger

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -11,6 +11,7 @@ python_library(
     'src/python/pants/engine:build_files',
     'src/python/pants/engine:fs',
     'src/python/pants/engine:mapper',
+    'src/python/pants/engine:nodes',
     'src/python/pants/engine:selectors',
     'src/python/pants/util:dirutil',
   ],

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -23,7 +23,6 @@ from pants.engine.addressable import BuildFileAddresses, Collection
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, SourcesField, TargetAdaptor
 from pants.engine.mapper import ResolveError
-from pants.engine.nodes import Return
 from pants.engine.rules import TaskRule, rule
 from pants.engine.selectors import Select, SelectDependencies, SelectProjection, SelectTransitive
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper

--- a/src/python/pants/engine/legacy/structs.py
+++ b/src/python/pants/engine/legacy/structs.py
@@ -18,7 +18,6 @@ from pants.engine.objects import Locatable
 from pants.engine.struct import Struct, StructWithDeps
 from pants.source import wrapped_globs
 from pants.util.contextutil import exception_logging
-from pants.util.memo import memoized_method
 from pants.util.meta import AbstractClass
 from pants.util.objects import datatype
 

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
 import re
 from collections import OrderedDict
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -12,17 +12,13 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 
-from twitter.common.collections import maybe_list
-
 from pants.base.exceptions import TaskError
 from pants.base.project_tree import Dir, File, Link
-from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAddresses,
-                              SingleAddress)
-from pants.build_graph.address import Address, BuildFileAddress
+from pants.build_graph.address import Address
 from pants.engine.addressable import SubclassesOf
 from pants.engine.fs import FileContent, FilesContent, Path, PathGlobs, Snapshot
 from pants.engine.isolated_process import _Snapshots, create_snapshot_rules
-from pants.engine.nodes import Return, Throw
+from pants.engine.nodes import Return, State, Throw
 from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
 from pants.engine.selectors import (Select, SelectDependencies, SelectProjection, SelectTransitive,
                                     SelectVariant, constraint_for)

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -439,7 +439,6 @@ class RunTracker(Subsystem):
     else:
       raise ValueError('Keys must contain at least one key.')
 
-
   @classmethod
   def _merge_list_of_keys_into_dict(cls, data, keys, value, index=0):
     """Recursively merge list of keys that points to the given value into data.

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
 from hashlib import sha1
 
 from pants.base.payload_field import PayloadField

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -250,6 +250,6 @@ class Subsystem(SubsystemClientMixin, Optionable):
     if specs_len == 0:
       return None
     if specs_len != 1:
-      raise TooManySpecsForKey('injectables spec mapping for key included {} elements, expected 1'
+      raise self.TooManySpecsForKey('injectables spec mapping for key included {} elements, expected 1'
                                .format(specs_len))
     return specs[0]

--- a/src/python/pants/task/testrunner_task_mixin.py
+++ b/src/python/pants/task/testrunner_task_mixin.py
@@ -140,7 +140,7 @@ class TestRunnerTaskMixin(object):
 
           try:
             test_info.update({'time': float(testcase.attrib.get('time'))})
-          except:
+          except (TypeError, ValueError):
             test_info.update({'time': None})
 
           for attribute in testcase_attributes:

--- a/tests/python/pants_test/backend/codegen/protobuf/java/test_java_protobuf_library.py
+++ b/tests/python/pants_test/backend/codegen/protobuf/java/test_java_protobuf_library.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import unittest
 from textwrap import dedent
 
 from pants.backend.codegen.protobuf.java.java_protobuf_library import JavaProtobufLibrary
@@ -85,7 +84,7 @@ class JavaProtobufLibraryTest(BaseTest):
       )
       '''))
     with self.assertRaises(JarLibrary.ExpectedAddressError):
-      target = self.target('//:foo')
+      self.target('//:foo')
 
   def test_traversable_specs(self):
     self.add_to_build_file('BUILD', dedent('''

--- a/tests/python/pants_test/backend/jvm/targets/test_jar_dependency_integration.py
+++ b/tests/python/pants_test/backend/jvm/targets/test_jar_dependency_integration.py
@@ -5,9 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-import unittest
-
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 

--- a/tests/python/pants_test/base/context_utils.py
+++ b/tests/python/pants_test/base/context_utils.py
@@ -57,7 +57,6 @@ class TestContext(Context):
 
     def report_target_info(self, scope, target, keys, val): pass
 
-
   @contextmanager
   def new_workunit(self, name, labels=None, cmd='', log_config=None):
     """

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import unittest
 
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 

--- a/tests/python/pants_test/core_tasks/test_what_changed.py
+++ b/tests/python/pants_test/core_tasks/test_what_changed.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import unittest
 from textwrap import dedent
 
 from pants.backend.codegen.protobuf.java.java_protobuf_library import JavaProtobufLibrary

--- a/tests/python/pants_test/engine/examples/visualizer.py
+++ b/tests/python/pants_test/engine/examples/visualizer.py
@@ -12,7 +12,6 @@ from textwrap import dedent
 
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.engine.fs import PathGlobs
-from pants.engine.storage import Storage
 from pants.engine.subsystem.native import Native
 from pants.util import desktop
 from pants.util.contextutil import temporary_file_path

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -7,13 +7,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import unittest
-from contextlib import contextmanager
 from textwrap import dedent
 
 from pants.build_graph.address import Address
 from pants.engine.nodes import Return
 from pants.engine.rules import RootRule, TaskRule
-from pants.engine.scheduler import ExecutionRequest
 from pants.engine.selectors import Select
 from pants_test.engine.examples.planners import Classpath, setup_json_scheduler
 from pants_test.engine.scheduler_test_base import SchedulerTestBase

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import re
 import unittest
 from contextlib import contextmanager
 from textwrap import dedent
@@ -21,7 +20,7 @@ from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, Diffe
 from pants.engine.nodes import Throw
 from pants.engine.parser import SymbolTable
 from pants.engine.rules import TaskRule
-from pants.engine.selectors import Select, SelectDependencies
+from pants.engine.selectors import SelectDependencies
 from pants.engine.struct import Struct
 from pants.util.dirutil import safe_open
 from pants_test.engine.examples.parsers import JsonParser

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -8,14 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import unittest
 from textwrap import dedent
 
-from twitter.common.collections import OrderedSet
-
-from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAddresses,
-                              SingleAddress)
-from pants.build_graph.address import Address
 from pants.engine.addressable import Exactly
 from pants.engine.build_files import create_graph_rules
-from pants.engine.fs import PathGlobs, create_fs_rules
+from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import AddressMapper
 from pants.engine.rules import RootRule, RuleIndex, SingletonRule, TaskRule
 from pants.engine.scheduler import WrappedNativeScheduler
@@ -23,9 +18,7 @@ from pants.engine.selectors import Select, SelectDependencies, SelectProjection,
 from pants.engine.subsystem.native import Native
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.examples.planners import Goal
-from pants_test.engine.util import (TargetTable, assert_equal_with_printing,
-                                    create_native_scheduler, init_native)
-from pants_test.subsystem.subsystem_util import init_subsystem
+from pants_test.engine.util import TargetTable, assert_equal_with_printing, create_native_scheduler
 
 
 class AGoal(Goal):


### PR DESCRIPTION
### Problem

Fix warnings from running `./pants lint src:: tests:: --lint-python-eval-skip`.  

Should we add these checks into CI or were they intentionally removed?  If so, should they at least be run before a release?
