### PR TITLE
Use link.checkstyle target for checkstyle integration

### DIFF
--- a/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_checkstyle_integration.py
@@ -53,7 +53,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
           self._create_config_file(config_file, config)
           args = [
             'clean-all',
-            'lint',
+            'lint.checkstyle',
             cache_args,
             'examples/src/java/org/pantsbuild/example/hello/simple',
             '--lint-checkstyle-configuration={}'.format(config_file)
@@ -77,7 +77,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
           config_file = os.path.join(tmp, config_name)
           self._create_config_file(config_file, config)
           args = [
-            'lint',
+            'lint.checkstyle',
             cache_args,
             'examples/src/java/org/pantsbuild/example/hello/simple',
             '--lint-checkstyle-configuration={}'.format(config_file)
@@ -142,7 +142,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
         previous_names.add(config_file)
         self._create_config_file(config_file, config)
         args = [
-          'lint',
+          'lint.checkstyle',
           cache_args,
           'examples/src/java/org/pantsbuild/example/hello/simple',
           '--lint-checkstyle-configuration={}'.format(config_file),
@@ -173,7 +173,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
             'checkstyle.suppression.files': suppression_file,
           }
           args = [
-            'lint',
+            'lint.checkstyle',
             cache_args,
             'examples/src/java/org/pantsbuild/example/hello/simple',
             "--lint-checkstyle-properties={}".format(json.dumps(properties)),
@@ -216,7 +216,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
             'checkstyle.suppression.files': suppression_file,
           }
           args = [
-            'lint',
+            'lint.checkstyle',
             cache_args,
             'examples/src/java/org/pantsbuild/example/hello/simple',
             "--lint-checkstyle-properties={}".format(json.dumps(properties)),
@@ -235,7 +235,7 @@ class CheckstyleIntegrationTest(PantsRunIntegrationTest):
             'my.value': value,
           }
           args = [
-            'lint',
+            'lint.checkstyle',
             cache_args,
             'examples/src/java/org/pantsbuild/example/hello/simple',
             "--lint-checkstyle-properties={}".format(json.dumps(properties)),

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -54,7 +54,7 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
     fmt_result = self.run_pants(['fmt', target], {'fmt.scalafmt':options})
     self.assert_success(fmt_result)
 
-    # verify that the compile check passes.
+    # verify that the lint check passes.
     test_fmt = self.run_pants(['lint', target], {'lint.scalafmt':options})
     self.assert_success(test_fmt)
 


### PR DESCRIPTION
Just keeping the test targets consistent with other lint test and how it was done before checkstyle was moved to the lint goal