### PR TITLE
Re-enable lint checks in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,9 +116,9 @@ matrix:
       before_script:
         - ./build-support/bin/install-android-sdk.sh
       env:
-        - SHARD="Various pants self checks"
+        - SHARD="Various pants self checks and lint"
       script:
-        - ./build-support/bin/ci.sh -x -cjlpn 'Various pants self checks'
+        - ./build-support/bin/ci.sh -x -cjlpn 'Various pants self checks and lint'
 
     - os: linux
       dist: trusty
@@ -145,7 +145,7 @@ matrix:
       env:
         - SHARD="Unit tests for pants and pants-plugins - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrcn -u 0/2 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrcnt -u 0/2 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -172,7 +172,7 @@ matrix:
       env:
         - SHARD="Unit tests for pants and pants-plugins - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrcn -u 1/2 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrcnt -u 1/2 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -199,7 +199,7 @@ matrix:
       env:
         - SHARD="Python contrib tests - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrcjlp -y 0/2 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrcjlpt -y 0/2 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -226,7 +226,7 @@ matrix:
       env:
         - SHARD="Python contrib tests - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrcjlp -y 1/2 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrcjlpt -y 1/2 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -253,7 +253,7 @@ matrix:
       env:
         - SHARD="Python integration tests for pants - shard 1"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 0/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrjlpnt -i 0/7 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -280,7 +280,7 @@ matrix:
       env:
         - SHARD="Python integration tests for pants - shard 2"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 1/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrjlpnt -i 1/7 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -307,7 +307,7 @@ matrix:
       env:
         - SHARD="Python integration tests for pants - shard 3"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 2/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrjlpnt -i 2/7 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -334,7 +334,7 @@ matrix:
       env:
         - SHARD="Python integration tests for pants - shard 4"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 3/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrjlpnt -i 3/7 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -361,7 +361,7 @@ matrix:
       env:
         - SHARD="Python integration tests for pants - shard 5"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 4/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrjlpnt -i 4/7 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -388,7 +388,7 @@ matrix:
       env:
         - SHARD="Python integration tests for pants - shard 6"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 5/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrjlpnt -i 5/7 "${SHARD}"
 
     - os: linux
       dist: trusty
@@ -415,7 +415,7 @@ matrix:
       env:
         - SHARD="Python integration tests for pants - shard 7"
       script:
-        - ./build-support/bin/ci.sh -x -fkmsrjlpn -i 6/7 "${SHARD}"
+        - ./build-support/bin/ci.sh -x -fkmsrjlpnt -i 6/7 "${SHARD}"
 
 deploy:
   # See: https://docs.travis-ci.com/user/deployment/bintray/

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -58,7 +58,7 @@ python_unit_shard="0/1"
 python_contrib_shard="0/1"
 python_intg_shard="0/1"
 
-while getopts "hfxbkmsrjlpu:ny:ci:a" opt; do
+while getopts "hfxbkmsrjlpu:ny:ci:at" opt; do
   case ${opt} in
     h) usage ;;
     f) skip_pre_commit_checks="true" ;;
@@ -72,12 +72,12 @@ while getopts "hfxbkmsrjlpu:ny:ci:a" opt; do
     l) skip_internal_backends="true" ;;
     p) skip_python="true" ;;
     u) python_unit_shard=${OPTARG} ;;
-    a) skip_android="true" ;;
     n) skip_contrib="true" ;;
     y) python_contrib_shard=${OPTARG} ;;
     c) skip_integration="true" ;;
     i) python_intg_shard=${OPTARG} ;;
     a) skip_android="true" ;;
+    t) skip_lint="true" ;;
     *) usage "Invalid option: -${OPTARG}" ;;
   esac
 done
@@ -156,6 +156,14 @@ if [[ "${skip_sanity_checks:-false}" == "false" ]]; then
     echo "* Executing command '${cmd}' as a sanity test"
     ${cmd} >/dev/null 2>&1 || die "Failed to execute '${cmd}'."
   done
+  end_travis_section
+fi
+
+if [[ "${skip_lint:-false}" == "false" ]]; then
+  start_travis_section "Lint" "Running lint checks"
+  (
+    ./pants.pex ${PANTS_ARGS[@]} lint contrib:: examples:: src:: tests:: zinc::
+  ) || die "Lint check failure"
   end_travis_section
 fi
 

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -23,6 +23,7 @@ from pants.contrib.scrooge.tasks.scrooge_gen import ScroogeGen
 
 GEN_ADAPT = '--gen-adapt'
 
+
 class ScroogeGenTest(NailgunTaskTestBase):
   @classmethod
   def task_type(cls):

--- a/pants.ini
+++ b/pants.ini
@@ -165,6 +165,11 @@ no_warning_args: [
 [lint.checkstyle]
 configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 
+[lint.python-eval]
+# After we fix the cycles from the engine refactor we should re-enable this.
+# https://github.com/pantsbuild/pants/issues/4601
+skip: True
+
 [lint.scalafmt]
 skip: True
 

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -12,7 +12,7 @@ from hashlib import sha1
 
 from pants.build_graph.build_graph import sort_targets
 from pants.build_graph.target import Target
-from pants.invalidation.build_invalidator import BuildInvalidator, CacheKeyGenerator
+from pants.invalidation.build_invalidator import CacheKeyGenerator
 from pants.util.dirutil import relative_symlink, safe_delete, safe_mkdir, safe_rmtree
 from pants.util.memo import memoized_method
 


### PR DESCRIPTION
### Problem

When the lint goal was added the lint checks stopped being run in CI https://github.com/pantsbuild/pants/issues/4601

### Solution

Start running most Lint checks in CI again.  There are still too many cycles in core dependencies to re-enable python-eval checks
