### PR TITLE
Switch crate-type from dylib to cdylib

### DIFF
--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -10,7 +10,7 @@ build = "src/cffi_build.rs"
 debug = true
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [build-dependencies]
 gcc = "0.3"


### PR DESCRIPTION
Apparently, from #rust on IRC, "dylib is almost never what you want unless you're writing rustc plugins" (paraphrased) and `cdylib` was made specifically for linkage against C programs (like Python in our case).

More importantly to me, this switch fixes a really obscure crash in rustc when trying to build the engine. I don't like just blindly changing things without understanding the underlying cause but it's been a huge pain to debug the compiler crash so I'm hoping we can get this in for now and maybe figure out the cause later.
