### PR TITLE
Ensure that target root order is preserved

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -87,7 +87,7 @@ class LegacyBuildGraph(BuildGraph):
     new_targets = list()
 
     # Index the ProductGraph.
-    for product in roots.values():
+    for product in roots:
       # We have a successful HydratedTargets value (for a particular input Spec).
       for hydrated_target in product.dependencies:
         target_adaptor = hydrated_target.adaptor
@@ -247,13 +247,10 @@ class LegacyBuildGraph(BuildGraph):
       )
 
     # Update the base class indexes for this request.
-    address_entries = dict(zip(subjects, product_results[BuildFileAddresses]))
-    target_entries = dict(zip(subjects, product_results[HydratedTargets]))
-
-    self._index(target_entries)
+    self._index(product_results[HydratedTargets])
 
     yielded_addresses = set()
-    for subject, product in address_entries.items():
+    for subject, product in zip(subjects, product_results[BuildFileAddresses]):
       if not product.dependencies:
         raise self.InvalidCommandLineSpecError(
           'Spec {} does not match any targets.'.format(subject))

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -112,6 +112,15 @@ python_tests(
 )
 
 python_tests(
+  name='paths_integration',
+  sources=['test_paths_integration.py'],
+  dependencies=[
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
   name = 'sorttargets',
   sources = ['test_sorttargets.py'],
   dependencies = [

--- a/tests/python/pants_test/backend/graph_info/tasks/test_paths_integration.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_paths_integration.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+# TODO: These tests duplicate the unit tests in `test_paths.py`, and should be removed in
+# their favor once #4401 lands and allows unit tests to cover the v2 engine.
+class PathsIntegrationTest(PantsRunIntegrationTest):
+  def test_paths_single(self):
+    pants_run = self.run_pants(['paths',
+                                'testprojects/src/python/python_targets:test_library_direct_dependee',
+                                'testprojects/src/python/python_targets:test_library'])
+    self.assert_success(pants_run)
+    self.assertIn('Found 1 path', pants_run.stdout_data)
+
+  def test_paths_none(self):
+    pants_run = self.run_pants(['paths',
+                                'testprojects/src/python/python_targets:test_library',
+                                'testprojects/src/python/python_targets:test_library_direct_dependee'])
+    self.assert_success(pants_run)
+    self.assertIn('Found 0 paths', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/graph_info/tasks/test_paths_integration.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_paths_integration.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,


### PR DESCRIPTION
### Problem

The 1.3.0 stable branch contains an issue where target root order is not always preserved, which leads to `./pants paths $X $Y` looking for paths from `$Y` to `$X` ~50% of the time. Apparently `paths` is (one of?) the only tasks that is order-dependent with regard to target roots. There are unit tests to validate that roots are ordered correctly, but due to #4401 they are not all providing coverage yet.

This bug does not actually exist in master (because it was fixed in #4679), but while looking for the bug I noticed that the relevant code could use further cleanup, which will be cherry-picked to the `1.3.0` branch.

### Solution

Add integration test coverage for `paths`, with a comment to remove it in favor of the unit tests once #4401 lands.