### PR TITLE
Ensure that invalidation works correctly when state is reverted.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -583,10 +583,6 @@ class JvmCompile(NailgunTaskBase):
         progress_message,
         ').')
       with self.context.new_workunit('compile', labels=[WorkUnitLabel.COMPILER]) as compile_workunit:
-        # The compiler may delete classfiles, then later exit on a compilation error. Then if the
-        # change triggering the error is reverted, we won't rebuild to restore the missing
-        # classfiles. So we force-invalidate here, to be on the safe side.
-        vts.force_invalidate()
         if self.get_options().capture_classpath:
           self._record_compile_classpath(classpath, vts.targets, outdir)
 

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -48,6 +48,7 @@ python_tests(
   sources=['test_task.py'],
   dependencies=[
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:exceptions',
     'src/python/pants/base:payload',
     'src/python/pants/build_graph',
     'src/python/pants/cache:cache',


### PR DESCRIPTION
Previously, a failing task could make changes to the workdir,
but wouldn't have its invalidation key recorded, so reverting to
the input state at the previous successful build would make it look
as if the output state was valid when it wasn't.

We used to special-case this in JvmCompile. Now we solve this
globally.
