### PR TITLE
Format suggested deps for easy cut & paste into BUILD file

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -790,11 +790,10 @@ class JvmCompile(NailgunTaskBase):
 
         # We format the suggested deps with single quotes and commas so that
         # they can be easily cut/pasted into a BUILD file.
-        formatted_suggested_deps = ["'%s'," % dep for dep in suggested_deps]  
+        formatted_suggested_deps = ["'%s'," % dep for dep in suggested_deps]
         suggestion_msg = (
           '\nIf the above information is correct, '
-          'please add the following to the dependencies of ({}):\n  {}\n\n'
-          'Remember to sort the dependencies in your BUILD file for easier maintenance.\n'
+          'please add the following to the dependencies of ({}):\n  {}\n'
             .format(target.address.spec, '\n  '.join(sorted(list(formatted_suggested_deps))))
         )
         self.context.log.info(suggestion_msg)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -794,7 +794,7 @@ class JvmCompile(NailgunTaskBase):
         suggestion_msg = (
           '\nIf the above information is correct, '
           'please add the following to the dependencies of ({}):\n  {}\n\n'
-          'Remember to sort the dependencies in your BUILD file for easier maintanence.\n'
+          'Remember to sort the dependencies in your BUILD file for easier maintenance.\n'
             .format(target.address.spec, '\n  '.join(sorted(list(formatted_suggested_deps))))
         )
         self.context.log.info(suggestion_msg)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -788,10 +788,13 @@ class JvmCompile(NailgunTaskBase):
           suggested_deps.add(list(candidates)[0])
           self.context.log.info('  {}: {}'.format(classname, ', '.join(candidates)))
 
+        # We format the suggested deps with single quotes and commas so that
+        # they can be easily cut/pasted into a BUILD file.
         formatted_suggested_deps = ["'%s'," % dep for dep in suggested_deps]  
         suggestion_msg = (
           '\nIf the above information is correct, '
-          'please add the following to the dependencies of ({}):\n  {}\n'
+          'please add the following to the dependencies of ({}):\n  {}\n\n'
+          'Remember to sort the dependencies in your BUILD file for easier maintanence.\n'
             .format(target.address.spec, '\n  '.join(sorted(list(formatted_suggested_deps))))
         )
         self.context.log.info(suggestion_msg)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -787,10 +787,12 @@ class JvmCompile(NailgunTaskBase):
         for classname, candidates in missing_dep_suggestions.items():
           suggested_deps.add(list(candidates)[0])
           self.context.log.info('  {}: {}'.format(classname, ', '.join(candidates)))
+
+        formatted_suggested_deps = ["'%s'," % dep for dep in suggested_deps]  
         suggestion_msg = (
           '\nIf the above information is correct, '
           'please add the following to the dependencies of ({}):\n  {}\n'
-            .format(target.address.spec, '\n  '.join(sorted(list(suggested_deps))))
+            .format(target.address.spec, '\n  '.join(sorted(list(formatted_suggested_deps))))
         )
         self.context.log.info(suggestion_msg)
 

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/test_missing_dependency_finder_integration.py
@@ -20,6 +20,9 @@ class MissingDependencyFinderIntegrationTest(PantsRunIntegrationTest):
                               'that provide the missing classes:.*'
                               'com.google.common.io.Closer: 3rdparty:guava', run.stdout_data,
                               re.DOTALL))
+    self.assertTrue(re.search('please add the following to the dependencies of.*'
+                              '\'3rdparty:guava\',', run.stdout_data,
+                              re.DOTALL))
 
   def test_missing_deps_not_found(self):
     target = 'testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target'


### PR DESCRIPTION
### Problem

The suggested deps are great, but when I get them I have to manually reformat them
for use in the dependencies array of my BUILD file.

### Solution

Format the suggested dependencies in a way that can be easily cut & pasted into a BUILD file. Also added a reminder to keep the dependencies in the BUILD file sorted, because if someone is doing a cut & paste of these additional dependencies they might forget to resort their dependencies.

### Result

```
./pants compile testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist --compile-zinc-suggest-missing-deps
...
13:55:30 00:05         [zinc]
                       [info] Compiling 1 Java source to /Users/sbrenn/workspace/pants/.pants.d/compile/zinc/c95338cea9cc/testprojects.src.java.org.pantsbuild.testproject.missingjardepswhitelist.missingjardepswhitelist/current/classes...
                       [error] /Users/sbrenn/workspace/pants/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/MissingJarDepsWhitelist.java:4:1: package com.google.common.io does not exist
                       [error] import com.google.common.io.Closer;
                       [error] /Users/sbrenn/workspace/pants/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/MissingJarDepsWhitelist.java:8:1: cannot find symbol
                       [error]   symbol:   class Closer
                       [error]   location: class org.pantsbuild.testproject.missingjardepswhitelist.MissingJarDepsWhitelist
                       [error]     Closer c = Closer.create();
                       [error] /Users/sbrenn/workspace/pants/testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist/MissingJarDepsWhitelist.java:8:1: cannot find symbol
                       [error]   symbol:   variable Closer
                       [error]   location: class org.pantsbuild.testproject.missingjardepswhitelist.MissingJarDepsWhitelist
                       [error]     Closer c = Closer.create();
                       [error] Compile failed at Jun 28, 2017 1:55:30 PM [0.079s]

13:55:30 00:05         [missing-deps-suggest]

                       Found the following deps from target's transitive dependencies that provide the missing classes:
                         com.google.common.io.Closer: 3rdparty:guava

                       If the above information is correct, please add the following to the dependencies of (testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist):
                         '3rdparty:guava',

                   compile(testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist) failed: Zinc compile failed.
FAILURE: Compilation failure: Failed jobs: compile(testprojects/src/java/org/pantsbuild/testproject/missingjardepswhitelist:missingjardepswhitelist)
```