### PR TITLE
Fix option bootstrapping config application order.

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -218,7 +218,8 @@ class _ChainedConfig(Config):
     return self._configs
 
   def sources(self):
-    return list(itertools.chain.from_iterable(cfg.sources() for cfg in self._configs))
+    # NB: Present the sources in the order we were given them.
+    return list(itertools.chain.from_iterable(cfg.sources() for cfg in reversed(self._configs)))
 
   def sections(self):
     ret = OrderedSet()

--- a/tests/python/pants_test/option/test_config.py
+++ b/tests/python/pants_test/option/test_config.py
@@ -56,6 +56,7 @@ class ConfigTest(unittest.TestCase):
           """))
         ini2.close()
         self.config = Config.load(configpaths=[ini1.name, ini2.name])
+        self.assertEqual([ini1.name, ini2.name], self.config.sources())
 
   def test_getstring(self):
     self.assertEquals('/a/b/42', self.config.get('a', 'path'))


### PR DESCRIPTION
Previously config supplied via `--pants-config-files` was re-applied
post-bootstrapping in reverse order. Add two tests that failed
previously to ensure the proper config source iteration order.

Fixes #4713