### PR TITLE
Revert "Alias `--pants-config-files` to `-c`."

### DIFF
--- a/pants.daemon.ini
+++ b/pants.daemon.ini
@@ -5,19 +5,19 @@
 # Development Usage:
 #
 #    # Launch the daemon via an initial invocation with `-ldebug` for better logging:
-#    $ ./pants -ldebug -c=pants.daemon.ini help
+#    $ ./pants -ldebug --pants-config-files=pants.daemon.ini help
 #
 #    # In another window, tail the pantsd log file:
 #    $ tail -F .pants.d/pantsd/pantsd.log
 #
 #    # Populate the resident scheduler with an initial pantsd-based run:
-#    $ ./pants -c=pants.daemon.ini list 3rdparty::
+#    $ ./pants --pants-config-files=pants.daemon.ini list 3rdparty::
 #
 #    # Re-run to utilize the buildgraph caching:
-#    $ ./pants -c=pants.daemon.ini list 3rdparty::
+#    $ ./pants --pants-config-files=pants.daemon.ini list 3rdparty::
 #
 #    # Kill pantsd and watchman:
-#    $ ./pants -ldebug -c=pants.daemon.ini clean-all
+#    $ ./pants -ldebug --pants-config-files=pants.daemon.ini clean-all
 #
 # You can also export this for all pants runs using environment variables:
 #

--- a/src/docs/howto_develop.md
+++ b/src/docs/howto_develop.md
@@ -122,7 +122,7 @@ To (re-)generate a `pants.pex` you then run these 2 commands:
 2. In your own repo the following command will create a locally built `pants.pex` for all platforms:
 
         :::bash
-        $ /tmp/pantsbuild/pants -c=pants-production.ini clean-all binary //:pants
+        $ /tmp/pantsbuild/pants --pants-config-files=pants-production.ini clean-all binary //:pants
 
 The resulting `pants.pex` will be in the `dist/` directory:
 

--- a/src/docs/options.md
+++ b/src/docs/options.md
@@ -230,15 +230,15 @@ command line:
 Sometimes it's convenient to keep `.ini` settings in more than one file. Perhaps you usually
 operate Pants in one "mode", but occasionally need to use a tweaked set of settings.
 
-Use the `--pants-config-files` command-line option (`-c` for short) to specify a second `.ini` file.
-Each of this `.ini` file's values override the corresponding value in `pants.ini`, if any.
+Use the `--pants-config-files` command-line option to specify a second `.ini` file. Each of
+this `.ini` file's values override the corresponding value in `pants.ini`, if any.
 For example, if your `pants.ini` contains the section
 
     [test.junit]
     coverage_html_open: True
     debug: False
 
-...and you invoke `-c=quick.ini` and your `quick.ini` says
+...and you invoke `--pants-config-files=quick.ini` and your `quick.ini` says
 
     [test.junit]
     coverage_html_open: False
@@ -251,9 +251,10 @@ For example, if your `pants.ini` contains the section
     skip: True
     debug: False
 
-Note that `--pants-config-files` is a list-valued option, so all the idioms of lists work. You can
-add a third file with another invocation of `-c=<path>`, or you can replace the standard one
-entirely with `-c=[<list>]`.
+Note that `--pants-config-files` is a list-valued option, so all the
+idioms of lists work. You can add a third file with another invocation
+of `--pants-config-files=<path>`, or you can replace the standard one
+entirely with `--pants-config-files=[<list>]`.
 
 Troubleshooting Config Files
 ----------------------------

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -94,14 +94,14 @@ class GlobalOptionsRegistrar(Optionable):
              help='The directory to use for tracking subprocess metadata, if any. This should '
                   'live outside of the dir used by `--pants-workdir` to allow for tracking '
                   'subprocesses that outlive the workdir data (e.g. `./pants server`).')
-    register('-c', '--pants-config-files', advanced=True, type=list,
+    register('--pants-config-files', advanced=True, type=list,
              default=[get_default_pants_config_file()], help='Paths to Pants config files.')
-    register('--config-override', advanced=True, type=list, metavar='<path>',
-             removal_version='1.6.0.dev0',
-             removal_hint='Use -c=<second config file path> instead.',
-             help='A second config file, to override pants.ini.')
     # TODO: Deprecate the --pantsrc/--pantsrc-files options?  This would require being able
     # to set extra config file locations in an initial bootstrap config file.
+    register('--config-override', advanced=True, type=list, metavar='<path>',
+             removal_version='1.6.0.dev0',
+             removal_hint='Use --pants-config-files=<second config file path> instead.',
+             help='A second config file, to override pants.ini.')
     register('--pantsrc', advanced=True, type=bool, default=True,
              help='Use pantsrc files.')
     register('--pantsrc-files', advanced=True, type=list, metavar='<path>',


### PR DESCRIPTION
This reverts commit 1945abdd23ca555baccd4f108eb5e637086be270.

The second commit in #4715 was premature, more work needs to be done to
support a `-c` short form for `--pants-config-files` sanely.

Fixes #4717