### PR TITLE
Remove Download Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Friendly documentation: http://www.pantsbuild.org/
 We release to [PyPI](https://pypi.python.org/pypi)
 [![version](https://img.shields.io/pypi/v/pantsbuild.pants.svg)](https://pypi.python.org/pypi/pantsbuild.pants)
 [![license](https://img.shields.io/pypi/l/pantsbuild.pants.svg)](https://pypi.python.org/pypi/pantsbuild.pants)
-[![downloads](https://img.shields.io/pypi/dm/pantsbuild.pants.svg)](https://pypi.python.org/pypi/pantsbuild.pants)
 
 We use [Travis CI](https://travis-ci.org) to verify the build
 [![Build Status](https://travis-ci.org/pantsbuild/pants.svg?branch=master)](https://travis-ci.org/pantsbuild/pants/branches).


### PR DESCRIPTION
### Problem

This badge has been broken for over a year (https://github.com/badges/shields/issues/716). Seeing "Downloads: 0/month" sends the wrong message to people viewing this project for the first time.

### Solution

Remove the badge until the problem is fixed or a new badge is found.