### PR TITLE
Fix rpc style in compiler_args check.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -140,7 +140,7 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     self._must_have_sources(target)
 
     def compiler_args_has_rpc_style(compiler_args):
-      return bool(_RPC_STYLES & set(compiler_args))
+      return "--finagle" in compiler_args or "--ostrich" in compiler_args
 
     def merge_rpc_style_with_compiler_args(compiler_args, rpc_style):
       new_compiler_args = list(compiler_args)

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen_integration.py
@@ -39,6 +39,12 @@ class ScroogeGenTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
 
+  def test_both_compiler_args_and_rpc_style(self):
+    # scrooge_gen should pass when both compiler_args and rpc_style are specified
+    cmd = ['gen', self.thrift_test_target('both-compiler-args-and-rpc-style')]
+    pants_run = self.run_pants(cmd)
+    self.assert_success(pants_run)
+
   def test_namespace_map(self):
     # scrooge_gen should pass with namespace_map specified
     cmd = ['gen', self.thrift_test_target('namespace-map-thrift')]

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/scrooge_gen/BUILD
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/scrooge_gen/BUILD
@@ -39,3 +39,12 @@ java_thrift_library(
     'some_dir',
   ],
 )
+
+java_thrift_library(
+  name = 'both-compiler-args-and-rpc-style',
+  sources = ['good.thrift'],
+  compiler='scrooge',
+  language='scala',
+  compiler_args=['--finagle'],
+  rpc_style='finagle',
+)


### PR DESCRIPTION
### Problem
While trying to test the pants build in source repo I realizes that the compiler_args_has_rpc_style is broken because the compiler args will have double dash in front e.g. --finagle whereas values in _RPC_STYLES don't. This results in scrooge generation failing if both compiler_args and rpc_style specify rpc style.

### Solution

Fixed the check.

### Result

Setting compiler args to --finagle in java_thrift_libraries pants targets now succeeds even if rpc_style is defined.