### PR TITLE
Bump pantsbuild/pants to scala 2.12.x

### DIFF
--- a/3rdparty/jvm/org/scala-sbt/BUILD
+++ b/3rdparty/jvm/org/scala-sbt/BUILD
@@ -1,10 +1,10 @@
 jar_library(
   name='zinc',
   jars=[
-    scala_jar(org='org.scala-sbt', name='zinc', rev='1.0.0-X7',
+    scala_jar(org='org.scala-sbt', name='zinc', rev='1.0.0-X8',
               excludes=[
-                exclude(org='org.scala-sbt', name='io_2.11'),
-                exclude(org='org.scala-sbt', name='util-logging_2.11'),
+                exclude(org='org.scala-sbt', name='io_2.12'),
+                exclude(org='org.scala-sbt', name='util-logging_2.12'),
               ]),
   ],
 )

--- a/3rdparty/jvm/org/specs2/BUILD
+++ b/3rdparty/jvm/org/specs2/BUILD
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 jar_library(
-  name='specs2-junit_2.11',
+  name='specs2-junit',
   jars=[
-    jar(org='org.specs2', name='specs2-junit_2.11', rev='3.8.9'),
+    scala_jar(org='org.specs2', name='specs2-junit', rev='3.8.9'),
   ],
 )

--- a/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
+++ b/examples/tests/scala/org/pantsbuild/example/specs2/BUILD
@@ -3,6 +3,6 @@
 
 junit_tests(
   dependencies=[
-    '3rdparty/jvm/org/specs2:specs2-junit_2.11',
+    '3rdparty/jvm/org/specs2:specs2-junit',
   ],
 )

--- a/pants.ini
+++ b/pants.ini
@@ -199,7 +199,7 @@ skip: True
 skip: True
 
 [scala-platform]
-version: 2.11
+version: 2.12
 
 
 [java]


### PR DESCRIPTION
### Problem

As previously discussed on pants-devel@, pants 1.4.0 will be the first stable release that requires JDK8. This means that the scala tools in pants can begin to use scala 2.12 (and should, as it results in smaller artifact sizes, which should allow for shorter bootstrap times).

### Solution

Upgrade to scala 2.12.

### Result

No immediate impact, but once we begin consuming the first tool published using this version of scala, we will have a JDK8 requirement.