### PR TITLE
Improve transitive package checking in python resolver tests.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks2/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_resolve_requirements.py
@@ -90,7 +90,16 @@ class ResolveRequirementsTest(TaskTestBase):
     # pycparser is a dependency of cffi only on CPython.  We might as well check for it,
     # as extra verification that we correctly fetch transitive dependencies.
     if PythonInterpreter.get().identity.interpreter == 'CPython':
-      expected_name_and_platforms.add(('pycparser-2.18', 'any'))
+      # N.B. Since pycparser is a floating transitive dep of cffi, we do a version-agnostic
+      # check here to avoid master breakage as new pycparser versions are released on pypi.
+      self.assertTrue(
+        any(
+          (package.startswith('pycparser-') and platform == 'any')
+          for package, platform
+          in names_and_platforms
+        ),
+        'could not find pycparser in transitive dependencies!'
+      )
 
     self.assertTrue(expected_name_and_platforms.issubset(names_and_platforms),
                     '{} is not a subset of {}'.format(expected_name_and_platforms,


### PR DESCRIPTION
### Problem

Currently, `tests/python/pants_test/backend/python/tasks2/test_resolve_requirements.py::ResolveRequirementsTest::test_resolve_multiplatform_requirements` performs a version-constrained check against an unpinned transitive dependency of CFFI. When new versions of this dep are released on pypi, pants master breaks as seen in https://travis-ci.org/pantsbuild/pants/builds/252126179.

### Solution

Perform a version agnostic check.

### Result

Improved test durability.