### PR TITLE
ScroogeGen passes through fatal_warnings argument

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -298,4 +298,4 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
   @property
   def _copy_target_attributes(self):
-    return ['provides', 'strict_deps']
+    return ['provides', 'strict_deps', 'fatal_warnings']

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -114,6 +114,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
           language='{language}',
           compiler_args={compiler_args},
           strict_deps=True,
+          fatal_warnings=False,
         )
       '''.format(language=language, compiler_args=compiler_args_str))
     else:
@@ -126,6 +127,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
           rpc_style='{rpc_style}',
           compiler_args={compiler_args},
           strict_deps=True,
+          fatal_warnings=False,
         )
       '''.format(language=language, rpc_style=rpc_style, compiler_args=compiler_args_str))
 
@@ -164,6 +166,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
       self.assertEquals(call_kwargs['sources'], [])
       self.assertEquals(call_kwargs['derived_from'], target)
       self.assertEquals(call_kwargs['strict_deps'], True)
+      self.assertEquals(call_kwargs['fatal_warnings'], False)
 
     finally:
       Context.add_new_target = saved_add_new_target


### PR DESCRIPTION
### Problem

We want to make unused imports a fatal warning for our code. The generated Scrooge code ends up with several unused imports per source file. When that code is compiled with fatal unused imports, it fails.

### Solution

Copy the `fatal_warnings` attribute to the synthetic target, so users can opt into disabling them for thrift targets. 