### PR TITLE
Fingerprint a bunch of go options

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/fetcher_factory.py
@@ -48,11 +48,12 @@ class FetcherFactory(Subsystem):
   def register_options(cls, register):
     super(FetcherFactory, cls).register_options(register)
     register('--disallow-cloning-fetcher', type=bool, default=False, advanced=True,
+             fingerprint=True,
              help="If True, we only fetch archives explicitly matched by --matchers."
                   "Otherwise we fall back to cloning the remote repos, using Go's standard "
                   "remote dependency resolution protocol.")
     register('--matchers', metavar='<mapping>', type=dict,
-             default=cls._DEFAULT_MATCHERS, advanced=True,
+             default=cls._DEFAULT_MATCHERS, advanced=True, fingerprint=True,
              help="A mapping from a remote import path matching regex to an UrlInfo struct "
                   "describing how to fetch and unpack an archive of that remote import path.  "
                   "The regex must match the beginning of the remote import path (no '^' anchor is "

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_test.py
@@ -26,6 +26,7 @@ class GoTest(GoWorkspaceTask):
   def register_options(cls, register):
     super(GoTest, cls).register_options(register)
     register('--build-and-test-flags', default='',
+             fingerprint=True,
              help='Flags to pass in to `go test` tool.')
 
   @classmethod

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
@@ -13,6 +13,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnitLabel
 from pants.binaries.thrift_binary import ThriftBinary
+from pants.option.custom_types import target_option
 from pants.task.simple_codegen_task import SimpleCodegenTask
 from pants.util.dirutil import safe_mkdir
 from pants.util.memo import memoized_property
@@ -31,9 +32,9 @@ class GoThriftGen(SimpleCodegenTask):
              help='Run thrift compiler with strict warnings.')
     register('--gen-options', advanced=True, fingerprint=True,
             help='Use these apache thrift go gen options.')
-    register('--thrift-import', advanced=True,
+    register('--thrift-import', type=str, advanced=True, fingerprint=True,
              help='Use this thrift-import gen option to thrift.')
-    register('--thrift-import-target', advanced=True,
+    register('--thrift-import-target', type=target_option, advanced=True,
              help='Use this thrift import on symbolic defs.')
 
   @classmethod


### PR DESCRIPTION
### Problem

The `--thrift-import` option, which gets rendered into the generate go sources was not fingerprinted.

### Solution

Fingerprint it and a few others, some of which should have immediate impact, and others which will only take effect once go has test caching.