### PR TITLE
Include passthru args in task option fingerprints.

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -317,14 +317,25 @@ class Options(object):
 
     return values
 
-  def get_fingerprintable_for_scope(self, scope):
+  def get_fingerprintable_for_scope(self, scope, include_passthru=False):
     """Returns a list of fingerprintable (option type, option value) pairs for the given scope.
 
     Fingerprintable options are options registered via a "fingerprint=True" kwarg.
 
+    :param str scope: The scope to gather fingerprintable options for.
+    :param bool include_passthru: Whether to include passthru args captured by `scope` in the
+                                  fingerprintable options.
+
     :API: public
     """
     pairs = []
+
+    if include_passthru:
+      # Passthru args can only be sent to outermost scopes so we gather them once here up-front.
+      passthru_args = self.passthru_args_for_scope(scope)
+      # NB: We can't sort passthru args, the underlying consumer may be order-sensitive.
+      pairs.extend((str, passthru_arg) for passthru_arg in passthru_args)
+
     # Note that we iterate over options registered at `scope` and at all enclosing scopes, since
     # option-using code can read those values indirectly via its own OptionValueContainer, so
     # they can affect that code's output.

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -214,7 +214,10 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     return self._workdir
 
   def _options_fingerprint(self, scope):
-    pairs = self.context.options.get_fingerprintable_for_scope(scope)
+    pairs = self.context.options.get_fingerprintable_for_scope(
+      scope,
+      include_passthru=self.supports_passthru_args()
+    )
     hasher = sha1()
     for (option_type, option_val) in pairs:
       fp = self._options_fingerprinter.fingerprint(option_type, option_val)

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -109,10 +109,14 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
     def scope_to_flags(self):
       return {}
 
-    def get_fingerprintable_for_scope(self, scope):
+    def get_fingerprintable_for_scope(self, scope, include_passthru=False):
+      pairs = []
+      if include_passthru and passthru_args:
+        pairs.extend((str, passthru_arg) for passthru_arg in passthru_args)
       option_values = self.for_scope(scope)
-      return [(option_type, option_values[option_name])
-              for option_name, option_type in fingerprintable[scope].items()]
+      pairs.extend((option_type, option_values[option_name])
+                   for option_name, option_type in fingerprintable[scope].items())
+      return pairs
 
     def __getitem__(self, key):
       return self.for_scope(key)


### PR DESCRIPTION
This is the only safe thing to do, passthru arguments affect an
underlying tool; so outputs cannot be trusted to be the same given fixed
inputs and a varying passthru argument set.

Fixes #4741