### PR TITLE
Introduce `dirutil.mergetree`.

### DIFF
--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -150,6 +150,9 @@ def mergetree(src, dst, symlinks=False, ignore=None):
 
     visit_dirs = []
     for dirname in dirnames:
+      if dirname in ignorenames:
+        continue
+
       src_dir = os.path.join(src_path, dirname)
       dst_dir = os.path.join(dst_path, dirname)
       if os.path.exists(dst_dir):
@@ -173,6 +176,7 @@ def mergetree(src, dst, symlinks=False, ignore=None):
     for filename in filenames:
       if filename in ignorenames:
         continue
+
       dst_filename = os.path.join(dst_path, filename)
       if os.path.exists(dst_filename):
         if not os.path.isfile(dst_filename):

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -130,11 +130,12 @@ class ExistingDirError(ValueError):
   """Indicates a copy operation would over-write a directory with a file."""
 
 
-def copytree(src, dst, symlinks=False, ignore=None):
+def mergetree(src, dst, symlinks=False, ignore=None):
   """Just like `shutil.copytree`, except the `dst` dir may exist.
 
   The `src` directory will be walked and its contents copied into `dst`. If `dst` already exists the
-  `src` tree will be overlayed in it.
+  `src` tree will be overlayed in it; ie: existing files in `dst` will be over-written with files
+  from `src` when they have the same subtree path.
   """
   safe_mkdir(dst)
 

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -27,8 +27,9 @@ python_tests(
   dependencies = [
     '3rdparty/python:mock',
     '3rdparty/python:six',
-    'src/python/pants/util:dirutil',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:objects',
   ]
 )
 

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -9,17 +9,20 @@ import errno
 import os
 import time
 import unittest
+from contextlib import contextmanager
 
 import mock
 import six
 
 from pants.util import dirutil
 from pants.util.contextutil import pushd, temporary_dir
-from pants.util.dirutil import (_mkdtemp_unregister_cleaner, absolute_symlink, fast_relpath,
-                                get_basedir, longest_dir_prefix, read_file, relative_symlink,
-                                relativize_paths, rm_rf, safe_concurrent_creation, safe_file_dump,
-                                safe_mkdir, safe_mkdtemp, safe_rm_oldest_items_in_dir, safe_rmtree,
+from pants.util.dirutil import (ExistingDirError, ExistingFileError, _mkdtemp_unregister_cleaner,
+                                absolute_symlink, copytree, fast_relpath, get_basedir,
+                                longest_dir_prefix, read_file, relative_symlink, relativize_paths,
+                                rm_rf, safe_concurrent_creation, safe_file_dump, safe_mkdir,
+                                safe_mkdtemp, safe_open, safe_rm_oldest_items_in_dir, safe_rmtree,
                                 touch)
+from pants.util.objects import datatype
 
 
 def strict_patch(target, **kwargs):
@@ -122,6 +125,145 @@ class DirutilTest(unittest.TestCase):
         tmpdir = tmpdir.encode('utf-8')
       for _, dirs, _ in dirutil.safe_walk(tmpdir):
         self.assertTrue(all(isinstance(dirname, six.text_type) for dirname in dirs))
+
+  @contextmanager
+  def tree(self):
+    # root/
+    #   a/
+    #     b/
+    #       1
+    #       2
+    #     2 -> root/a/b/2
+    #   b -> root/a/b
+    with temporary_dir() as root:
+      with safe_open(os.path.join(root, 'a', 'b', '1'), 'wb') as fp:
+        fp.write(b'1')
+      touch(os.path.join(root, 'a', 'b', '2'))
+      os.symlink(os.path.join(root, 'a', 'b', '2'), os.path.join(root, 'a', '2'))
+      os.symlink(os.path.join(root, 'a', 'b'), os.path.join(root, 'b'))
+      with temporary_dir() as dst:
+        yield root, dst
+
+  class Dir(datatype('Dir', ['path'])):
+    pass
+
+  class File(datatype('File', ['path', 'contents'])):
+    @classmethod
+    def empty(cls, path):
+      return cls(path, contents=b'')
+
+    @classmethod
+    def read(cls, root, relpath):
+      with open(os.path.join(root, relpath)) as fp:
+        return cls(relpath, fp.read())
+
+  class Symlink(datatype('Symlink', ['path'])):
+    pass
+
+  def assert_tree(self, root, *expected):
+    def collect_tree():
+      for path, dirnames, filenames in os.walk(root, followlinks=False):
+        relpath = os.path.relpath(path, root)
+        if relpath == os.curdir:
+          relpath = ''
+        for dirname in dirnames:
+          dirpath = os.path.join(relpath, dirname)
+          if os.path.islink(os.path.join(path, dirname)):
+            yield self.Symlink(dirpath)
+          else:
+            yield self.Dir(dirpath)
+        for filename in filenames:
+          filepath = os.path.join(relpath, filename)
+          if os.path.islink(os.path.join(path, filename)):
+            yield self.Symlink(filepath)
+          else:
+            yield self.File.read(root, filepath)
+
+    self.assertEqual(frozenset(expected), frozenset(collect_tree()))
+
+  def test_copytree_existing(self):
+    with self.tree() as (src, dst):
+      # Existing empty files
+      touch(os.path.join(dst, 'c', '1'))
+      touch(os.path.join(dst, 'a', 'b', '1'))
+
+      copytree(src, dst)
+
+      self.assert_tree(dst,
+                       self.Dir('a'),
+                       self.File.empty('a/2'),
+                       self.Dir('a/b'),
+
+                       # Existing overlapping file should be overlayed.
+                       self.File('a/b/1', contents=b'1'),
+
+                       self.File.empty('a/b/2'),
+                       self.Dir('b'),
+                       self.File('b/1', contents=b'1'),
+                       self.File.empty('b/2'),
+                       self.Dir('c'),
+
+                       # Existing non-overlapping file should be preserved.
+                       self.File.empty('c/1'))
+
+  def test_copytree_existing_file_mismatch(self):
+    with self.tree() as (src, dst):
+      touch(os.path.join(dst, 'a'))
+      with self.assertRaises(ExistingFileError):
+        copytree(src, dst)
+
+  def test_copytree_existing_dir_mismatch(self):
+    with self.tree() as (src, dst):
+      os.makedirs(os.path.join(dst, 'b', '1'))
+      with self.assertRaises(ExistingDirError):
+        copytree(src, dst)
+
+  def test_copytree_new(self):
+    with self.tree() as (src, dst_root):
+      dst = os.path.join(dst_root, 'dst')
+
+      copytree(src, dst)
+
+      self.assert_tree(dst,
+                       self.Dir('a'),
+                       self.File.empty('a/2'),
+                       self.Dir('a/b'),
+                       self.File('a/b/1', contents=b'1'),
+                       self.File.empty('a/b/2'),
+                       self.Dir('b'),
+                       self.File('b/1', contents=b'1'),
+                       self.File.empty('b/2'))
+
+  def test_copytree_ignore(self):
+    with self.tree() as (src, dst):
+      def ignore(root, names):
+        if root == os.path.join(src, 'a', 'b'):
+          return ['1', '2']
+
+      copytree(src, dst, ignore=ignore)
+
+      self.assert_tree(dst,
+                       self.Dir('a'),
+                       self.File.empty('a/2'),
+                       self.Dir('a/b'),
+                       self.Dir('b'),
+                       self.File('b/1', contents=b'1'),
+                       self.File.empty('b/2'))
+
+  def test_copytree_symlink(self):
+    with self.tree() as (src, dst):
+      copytree(src, dst, symlinks=True)
+
+      self.assert_tree(dst,
+                       self.Dir('a'),
+                       self.Symlink('a/2'),
+                       self.Dir('a/b'),
+                       self.File('a/b/1', contents=b'1'),
+                       self.File.empty('a/b/2'),
+
+                       # NB: assert_tree does not follow symlinks and so does not descend into the
+                       # symlinked b/ dir to find b/1 and b/2
+                       self.Symlink('b'))
 
   def test_relativize_paths(self):
     build_root = '/build-root'

--- a/tests/python/pants_test/util/test_dirutil.py
+++ b/tests/python/pants_test/util/test_dirutil.py
@@ -233,7 +233,7 @@ class DirutilTest(unittest.TestCase):
                        self.File('b/1', contents=b'1'),
                        self.File.empty('b/2'))
 
-  def test_mergetree_ignore(self):
+  def test_mergetree_ignore_files(self):
     with self.tree() as (src, dst):
       def ignore(root, names):
         if root == os.path.join(src, 'a', 'b'):
@@ -245,6 +245,21 @@ class DirutilTest(unittest.TestCase):
                        self.Dir('a'),
                        self.File.empty('a/2'),
                        self.Dir('a/b'),
+                       self.Dir('b'),
+                       self.File('b/1', contents=b'1'),
+                       self.File.empty('b/2'))
+
+  def test_mergetree_ignore_dirs(self):
+    with self.tree() as (src, dst):
+      def ignore(root, names):
+        if root == os.path.join(src, 'a'):
+          return ['b']
+
+      mergetree(src, dst, ignore=ignore)
+
+      self.assert_tree(dst,
+                       self.Dir('a'),
+                       self.File.empty('a/2'),
                        self.Dir('b'),
                        self.File('b/1', contents=b'1'),
                        self.File.empty('b/2'))


### PR DESCRIPTION
This is just like `shutil.copytree` except that it allows for the
destination directory to exist, in which case it overlays the source
tree in the existing destination directory, replacing any existing files
that overlap.