### PR TITLE
Conditionally support multiple thrift files for go_thrift_gen

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
@@ -11,14 +11,14 @@ import subprocess
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
+from pants.base.revision import Revision
 from pants.base.workunit import WorkUnitLabel
 from pants.binaries.thrift_binary import ThriftBinary
 from pants.option.custom_types import target_option
 from pants.task.simple_codegen_task import SimpleCodegenTask
 from pants.util.dirutil import safe_mkdir
-from pants.util.memo import memoized_property, memoized_method
+from pants.util.memo import memoized_method, memoized_property
 from twitter.common.collections import OrderedSet
-from pants.base.revision import Revision
 
 from pants.contrib.go.targets.go_thrift_library import GoThriftGenLibrary, GoThriftLibrary
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
@@ -93,12 +93,7 @@ class GoThriftGen(SimpleCodegenTask):
     # https://issues.apache.org/jira/browse/THRIFT-3776; first available in 0.10.0
     if self.get_options().multiple_files_per_target_override:
       return
-    try:
-      actual_revision = Revision.semver(self._thrift_binary.version)
-    except Exception as e:
-      self.context.log.warn('Assuming that unparseable thrift version `{}` '
-                            'supports more than one source.'.format(self._thrift_binary.version))
-      return
+    actual_revision = Revision.semver(self._thrift_binary.version)
     required_version = '0.10.0'
     if Revision.semver(required_version) <= actual_revision:
       return

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/BUILD
@@ -4,14 +4,15 @@
 python_tests(
   sources = globs('*.py', exclude=[globs('*_integration.py')]),
   dependencies=[
-    'contrib/go/src/python/pants/contrib/go:plugin',
     'contrib/go/src/python/pants/contrib/go/subsystems',
     'contrib/go/src/python/pants/contrib/go/targets',
     'contrib/go/src/python/pants/contrib/go/tasks',
+    'contrib/go/src/python/pants/contrib/go:plugin',
     'src/python/pants/base:exceptions',
     'src/python/pants/build_graph',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ]
 )

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen.py
@@ -31,6 +31,10 @@ class GoThriftGenTest(TaskTestBase):
     self.set_options(multiple_files_per_target_override=True)
     self._validate_for('0.9.0')
 
+  def test_validate_source_unparseable_but_overridden(self):
+    self.set_options(multiple_files_per_target_override=True)
+    self._validate_for('not_a_semver_version')
+
   def test_validate_source_sufficient(self):
     self.set_options(multiple_files_per_target_override=False)
     self._validate_for('0.10.1')

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen.py
@@ -5,10 +5,9 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants_test.tasks.task_test_base import TaskTestBase
-from pants_test.subsystem.subsystem_util import init_subsystem
-from pants.binaries.thrift_binary import ThriftBinary
 from pants.base.exceptions import TaskError
+from pants.binaries.thrift_binary import ThriftBinary
+from pants_test.tasks.task_test_base import TaskTestBase
 
 from pants.contrib.go.tasks.go_thrift_gen import GoThriftGen
 

--- a/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/tasks/test_go_thrift_gen.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.tasks.task_test_base import TaskTestBase
+from pants_test.subsystem.subsystem_util import init_subsystem
+from pants.binaries.thrift_binary import ThriftBinary
+from pants.base.exceptions import TaskError
+
+from pants.contrib.go.tasks.go_thrift_gen import GoThriftGen
+
+
+class GoThriftGenTest(TaskTestBase):
+
+  @classmethod
+  def task_type(cls):
+    return GoThriftGen
+
+  def _validate_for(self, version):
+    options = {ThriftBinary.Factory.options_scope: {'version': version}}
+    self.create_task(self.context(options=options))._validate_supports_more_than_one_source()
+
+  def test_validate_source_too_low(self):
+    self.set_options(multiple_files_per_target_override=False)
+    with self.assertRaises(TaskError):
+      self._validate_for('0.9.0')
+
+  def test_validate_source_too_low_but_overridden(self):
+    self.set_options(multiple_files_per_target_override=True)
+    self._validate_for('0.9.0')
+
+  def test_validate_source_sufficient(self):
+    self.set_options(multiple_files_per_target_override=False)
+    self._validate_for('0.10.1')


### PR DESCRIPTION
### Problem

Thrift versions after `0.10.0` have a different layout for go sources that supports compiling multiple files at once.

### Solution

Conditionally allow multiple files if a version greater than `0.10.0` is used.