### PR TITLE
Add support for compiling thrift split across multiple files in go

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_thrift_gen.py
@@ -131,16 +131,16 @@ class GoThriftGen(SimpleCodegenTask):
     if len(all_sources) != 1:
       self._validate_supports_more_than_one_source()
 
-    source = all_sources[0]
-    target_cmd.append(os.path.join(get_buildroot(), source))
-    with self.context.new_workunit(name=source,
-                                   labels=[WorkUnitLabel.TOOL],
-                                   cmd=' '.join(target_cmd)) as workunit:
-      result = subprocess.call(target_cmd,
-                               stdout=workunit.output('stdout'),
-                              stderr=workunit.output('stderr'))
-      if result != 0:
-        raise TaskError('{} ... exited non-zero ({})'.format(self._thrift_binary.path, result))
+    for source in all_sources:
+      file_cmd = target_cmd + [os.path.join(get_buildroot(), source)]
+      with self.context.new_workunit(name=source,
+                                     labels=[WorkUnitLabel.TOOL],
+                                     cmd=' '.join(file_cmd)) as workunit:
+        result = subprocess.call(file_cmd,
+                                 stdout=workunit.output('stdout'),
+                                 stderr=workunit.output('stderr'))
+        if result != 0:
+          raise TaskError('{} ... exited non-zero ({})'.format(self._thrift_binary.path, result))
 
     gen_dir = os.path.join(target_workdir, 'gen-go')
     src_dir = os.path.join(target_workdir, 'src')


### PR DESCRIPTION
### Problem

#4759 unblocked compiling multiple files in one thrift target, but (embarassingly) still only compiled one file.

### Solution

Compile each thrift file in a target, and add an integration test that splits the existing example into two files and then confirms that they end up consumable.

### Result
Multiple thrift files in one target are supported for go.