### PR TITLE
Don't require an scm for local publishes.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_publish.py
+++ b/src/python/pants/backend/jvm/tasks/jar_publish.py
@@ -367,7 +367,6 @@ class JarPublish(ScmPublishMixin, JarTask):
 
     self._jvm_options = self.get_options().jvm_options
 
-    self.scm = get_scm()
     self.log = self.context.log
 
     if self.get_options().local:
@@ -400,6 +399,8 @@ class JarPublish(ScmPublishMixin, JarTask):
       self.push_postscript = self.get_options().push_postscript or ''
       self.local_snapshot = False
 
+    self.scm = get_scm() if self.commit else None
+
     self.named_snapshot = self.get_options().named_snapshot
     if self.named_snapshot:
       self.named_snapshot = Namedver.parse(self.named_snapshot)
@@ -407,7 +408,7 @@ class JarPublish(ScmPublishMixin, JarTask):
     self.dryrun = self.get_options().dryrun
     self.transitive = self.get_options().transitive
     self.force = self.get_options().force
-    self.publish_changelog = self.get_options().changelog
+    self.publish_changelog = self.get_options().changelog and self.scm
 
     def parse_jarcoordinate(coordinate):
       components = coordinate.split('#', 1)
@@ -674,7 +675,7 @@ class JarPublish(ScmPublishMixin, JarTask):
       for (org, name), rev in self.overrides.items():
         print('{0}={1}'.format(coordinate(org, name), rev))
 
-    head_sha = self.scm.commit_id
+    head_sha = self.scm.commit_id if self.scm else None
 
     safe_rmtree(self.workdir)
     published = []

--- a/src/python/pants/task/scm_publish_mixin.py
+++ b/src/python/pants/task/scm_publish_mixin.py
@@ -198,7 +198,7 @@ class ScmPublishMixin(object):
       if changed_files:
         raise self.DirtyWorkspaceError('Can only push from a clean branch, found : {}'
                                        .format(' '.join(changed_files)))
-    else:
+    elif self.scm:
       self.log.info('Skipping check for a clean {} branch in test mode.'
                     .format(self.scm.branch_name))
 

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish.py
@@ -35,7 +35,6 @@ class JarPublishTest(TaskTestBase):
     with temporary_dir() as publish_dir:
       self.set_options(local=publish_dir)
       task = self.create_task(self.context())
-      task.scm = Mock()
       task.execute()
 
   @property

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
@@ -84,7 +84,6 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
                        'org.pantsbuild.testproject.publish/jvm-example-lib_2.11/publish.properties',
                        'org.pantsbuild.testproject.publish.hello/welcome_2.11/publish.properties'],
                       extra_options=['--doc-scaladoc-skip'],
-                      expected_primary_artifact_count=3,
                       assert_publish_config_contents=True)
 
   def test_java_publish(self):
@@ -109,8 +108,7 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
                       ['org.pantsbuild.testproject.publish.protobuf/protobuf-java/'
                        'publish.properties',
                        'org.pantsbuild.testproject.protobuf/distance/publish.properties'],
-                      extra_options=['--doc-javadoc-skip'],
-                      expected_primary_artifact_count=2)
+                      extra_options=['--doc-javadoc-skip'])
 
   def test_named_snapshot(self):
     name = "abcdef0123456789"
@@ -220,8 +218,7 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
       assert_publish_config_contents=True)
 
   def publish_test(self, target, artifacts, pushdb_files, extra_options=None, extra_config=None,
-                   extra_env=None, expected_primary_artifact_count=1, success_expected=True,
-                   assert_publish_config_contents=False):
+                   extra_env=None, success_expected=True, assert_publish_config_contents=False):
     """Tests that publishing the given target results in the expected output.
 
     :param target: Target to test.
@@ -229,7 +226,6 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
     :param pushdb_files: list of pushdb files that would be created if this weren't a local publish
     :param extra_options: Extra command-line options to the pants run.
     :param extra_config: Extra pants.ini configuration for the pants run.
-    :param expected_primary_artifact_count: Number of artifacts we expect to be published.
     :param extra_env: Extra environment variables for the pants run.
     :param assert_publish_config_contents: Test the contents of the generated ivy and pom file.
            If set to True, compares the generated ivy.xml and pom files in

--- a/tests/python/pants_test/task/test_scm_publish_mixin.py
+++ b/tests/python/pants_test/task/test_scm_publish_mixin.py
@@ -14,10 +14,10 @@ from pants.task.scm_publish_mixin import Namedver, ScmPublishMixin
 
 class ScmPublishMixinTest(unittest.TestCase):
   class ScmPublish(ScmPublishMixin):
-    def __init__(self, restrict_push_branches=None, restrict_push_urls=None):
+    def __init__(self, restrict_push_branches=None, restrict_push_urls=None, scm_available=True):
       self._restrict_push_branches = restrict_push_branches
       self._restrict_push_urls = restrict_push_urls
-      self._scm = mock.Mock()
+      self._scm = mock.Mock() if scm_available else None
       self._log = mock.MagicMock()
 
     @property
@@ -39,6 +39,10 @@ class ScmPublishMixinTest(unittest.TestCase):
     @property
     def log(self):
       return self._log
+
+  def test_check_clean_master_no_scm(self):
+    scm_publish = self.ScmPublish(scm_available=False)
+    scm_publish.check_clean_master(commit=False)
 
   def test_check_clean_master_dry_run_bad_branch(self):
     scm_publish = self.ScmPublish(restrict_push_branches=['bob'])
@@ -77,7 +81,7 @@ class ScmPublishMixinTest(unittest.TestCase):
 
   def test_check_clean_master_bad_remote(self):
     scm_publish = self.ScmPublish(restrict_push_urls=['amy'])
-    scm_publish.scm.serveer_url = 'https://amy'
+    scm_publish.scm.server_url = 'https://amy'
     with self.assertRaises(scm_publish.InvalidRemoteError):
       scm_publish.check_clean_master(commit=True)
 

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish.hello/welcome_2.11/ivy-0.0.1-SNAPSHOT.xml
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish.hello/welcome_2.11/ivy-0.0.1-SNAPSHOT.xml
@@ -11,7 +11,6 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
   <publications>
     <artifact/>
     <artifact m:classifier="sources"/>
-    <artifact m:classifier="CHANGELOG" ext="txt"/>
     <artifact type="pom"/>
   </publications>
 </ivy-module>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/ivy-0.0.1-SNAPSHOT.xml
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/ivy-0.0.1-SNAPSHOT.xml
@@ -12,7 +12,6 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
     <artifact/>
     <artifact m:classifier="sources"/>
     <artifact m:classifier="javadoc"/>
-    <artifact m:classifier="CHANGELOG" ext="txt"/>
     <artifact type="pom"/>
   </publications>
 </ivy-module>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/ivy-1.2.3-SNAPSHOT.xml
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/classifiers_2.11/ivy-1.2.3-SNAPSHOT.xml
@@ -12,7 +12,6 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
     <artifact/>
     <artifact m:classifier="sources"/>
     <artifact m:classifier="javadoc"/>
-    <artifact m:classifier="CHANGELOG" ext="txt"/>
     <artifact type="pom"/>
   </publications>
 </ivy-module>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/hello-greet/ivy-0.0.1-SNAPSHOT.xml
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/hello-greet/ivy-0.0.1-SNAPSHOT.xml
@@ -12,7 +12,6 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
     <artifact/>
     <artifact m:classifier="sources"/>
     <artifact m:classifier="javadoc"/>
-    <artifact m:classifier="CHANGELOG" ext="txt"/>
     <artifact type="pom"/>
   </publications>
 </ivy-module>

--- a/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/jvm-example-lib_2.11/ivy-0.0.1-SNAPSHOT.xml
+++ b/tests/python/pants_test/tasks/jar_publish_resources/org.pantsbuild.testproject.publish/jvm-example-lib_2.11/ivy-0.0.1-SNAPSHOT.xml
@@ -11,7 +11,6 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
   <publications>
     <artifact/>
     <artifact m:classifier="sources"/>
-    <artifact m:classifier="CHANGELOG" ext="txt"/>
     <artifact type="pom"/>
   </publications>
 </ivy-module>


### PR DESCRIPTION
The scm conceptually went unused anyway; so, guard a few corner cases
and add regression coverage.

Fixes #4772