### PR TITLE
Pass JVM options to scalafmt

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -31,7 +31,7 @@ class ScalaFmt(NailgunTask, AbstractClass):
   def register_options(cls, register):
     super(ScalaFmt, cls).register_options(register)
     register('--skip', type=bool, fingerprint=False, help='Skip Scalafmt Check')
-    register('--configuration', advanced=True, type=file_option, fingerprint=False,
+    register('--configuration', advanced=True, type=file_option, fingerprint=True,
               help='Path to scalafmt config file, if not specified default scalafmt config used')
     register('--target-types',
              default=['scala_library', 'junit_tests', 'java_tests'],

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -67,7 +67,8 @@ class ScalaFmt(NailgunTask, AbstractClass):
       result = self.runjava(classpath=self.tool_classpath('scalafmt'),
                    main=self._SCALAFMT_MAIN,
                    args=self.get_command_args(files),
-                   workunit_name='scalafmt')
+                   workunit_name='scalafmt',
+                   jvm_options=self.get_options().jvm_options)
 
       self.process_results(result)
 

--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -65,10 +65,10 @@ class ScalaFmt(NailgunTask, AbstractClass):
       files = ",".join(sources)
 
       result = self.runjava(classpath=self.tool_classpath('scalafmt'),
-                   main=self._SCALAFMT_MAIN,
-                   args=self.get_command_args(files),
-                   workunit_name='scalafmt',
-                   jvm_options=self.get_options().jvm_options)
+                            main=self._SCALAFMT_MAIN,
+                            args=self.get_command_args(files),
+                            workunit_name='scalafmt',
+                            jvm_options=self.get_options().jvm_options)
 
       self.process_results(result)
 


### PR DESCRIPTION
### Problem

JVM options were not being passed to scalafmt, so it wasn't possible to increase/decrease allocated memory. Additionally, in cases where large sets of files were in use, we could run into argument-list-too-long errors.

### Solution

Pass JVM options, and use `Xargs`. Finally, enable caching for the `Check` task, which is sideeffect free.

### Result

scalafmt will run for bite-size chunks, and will cache when checking files.