### PR TITLE
Update to zinc 1.0.0-RC3

### DIFF
--- a/3rdparty/jvm/org/scala-sbt/BUILD
+++ b/3rdparty/jvm/org/scala-sbt/BUILD
@@ -4,7 +4,7 @@
 jar_library(
   name='zinc',
   jars=[
-    scala_jar(org='org.scala-sbt', name='zinc', rev='1.0.0-X20',
+    scala_jar(org='org.scala-sbt', name='zinc', rev='1.0.0-RC3',
               excludes=[
                 exclude(org='org.scala-sbt', name='io_2.11'),
                 exclude(org='org.scala-sbt', name='util-logging_2.11'),
@@ -21,7 +21,7 @@ jar_library(
   jars=[
     # TODO: `zinc` only declares a dep on the `tests` classifier for
     # util-logging for some reason. We redefine the dep here to get the full package.
-    scala_jar(org='org.scala-sbt', name='util-logging', rev='1.0.0-M27', force=True),
+    scala_jar(org='org.scala-sbt', name='util-logging', rev='1.0.0-RC3', force=True),
   ],
 )
 
@@ -30,6 +30,6 @@ jar_library(
   jars=[
     # TODO: `zinc` only declares a dep on the `tests` classifier for
     # io. We redefine the dep here to get the full package.
-    scala_jar(org='org.scala-sbt', name='io', rev='1.0.0-M13', force=True),
+    scala_jar(org='org.scala-sbt', name='io', rev='1.0.0-RC3', force=True),
   ],
 )


### PR DESCRIPTION
### Problem

The current version of zinc used in pants suffers from https://github.com/sbt/zinc/issues/355, and thus hasn't been pulled in and released via #4729

### Solution

Bump to zinc 1.0.0-RC3, which pulls in the fix for https://github.com/sbt/zinc/issues/355.