### PR TITLE
scalafmt: pass jvm options to jvm

### DIFF
--- a/src/python/pants/backend/jvm/tasks/scalafmt.py
+++ b/src/python/pants/backend/jvm/tasks/scalafmt.py
@@ -67,6 +67,7 @@ class ScalaFmt(NailgunTask, AbstractClass):
       result = self.runjava(classpath=self.tool_classpath('scalafmt'),
                    main=self._SCALAFMT_MAIN,
                    args=self.get_command_args(files),
+                   jvm_options=self.get_options().jvm_options,
                    workunit_name='scalafmt')
 
       self.process_results(result)

--- a/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_scalafmt.py
@@ -70,3 +70,19 @@ class ScalaFmtIntegrationTests(PantsRunIntegrationTest):
       {'lint.scalafmt':{'skip':'False',
       'configuration':'%(pants_supportdir)s/scalafmt/config'}})
     self.assert_success(run)
+
+  def test_scalafmt_jvm_options(self):
+    target = '{}/badscalastyle'.format(TEST_DIR)
+    jvm_options = '-foobar'
+    # checking for invalid option making it to jvm output rather than mocking out jvm to verify correct args passed
+    options = {
+      'fmt.scalafmt': {
+        'jvm_options': jvm_options,
+        'use_nailgun': False,
+        'skip': False,
+      }
+    }
+    run = self.run_pants(['fmt', target], options)
+    self.assert_failure(run)
+    expected_message = "Unrecognized option: {}".format(jvm_options)
+    self.assertTrue(expected_message in run.stdout_data, "expected to find '{}' in stdout '{}' (stderr: '{}')".format(expected_message, run.stdout_data, run.stderr_data))


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/issues/4778 - the scalafmt task does not pass the configured jvm options when invoking the jvm. This is problematic since it can lead to scalafmt nailgun processes consuming >10gb.

### Solution

change the scalafmt task to pass the configured jvm options when invoking the jvm

### Result

when scalafmt invokes the jvm, it will now pass the configured jvm options