### PR TITLE
Cleanup CI deprecation warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - PANTS_CONFIG_OVERRIDE="['pants.travis-ci.ini']"
+    - PANTS_CONFIG_FILES="pants.travis-ci.ini"
     - ANDROID_SDK_INSTALL_LOCATION="${HOME}/opt/android-sdk-install"
     - ANDROID_HOME="$ANDROID_SDK_INSTALL_LOCATION/android-sdk-linux"
     # Credentials for OSX syncing: GH_USER, GH_EMAIL, GH_TOKEN

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -49,7 +49,7 @@ function usage() {
 }
 
 bootstrap_compile_args=(
-  compile.python-eval
+  lint.python-eval
   --closure
 )
 
@@ -192,7 +192,7 @@ fi
 if [[ "${skip_internal_backends:-false}" == "false" ]]; then
   start_travis_section "BackendTests" "Running internal backend python tests"
   (
-    ./pants.pex ${PANTS_ARGS[@]} test.pytest --compile-python-eval-skip \
+    ./pants.pex ${PANTS_ARGS[@]} test.pytest \
     pants-plugins/tests/python::
   ) || die "Internal backend python test failure"
   end_travis_section
@@ -207,7 +207,6 @@ if [[ "${skip_python:-false}" == "false" ]]; then
     ./pants.pex --tag='-integration' ${PANTS_ARGS[@]} test.pytest \
       --coverage=pants \
       --test-pytest-test-shard=${python_unit_shard} \
-      --compile-python-eval-skip \
       tests/python::
   ) || die "Core python test failure"
   end_travis_section
@@ -222,7 +221,6 @@ if [[ "${skip_contrib:-false}" == "false" ]]; then
     ./pants.pex ${PANTS_ARGS[@]} --exclude-target-regexp='.*/testprojects/.*' \
     --build-ignore=$SKIP_ANDROID_PATTERN test.pytest \
     --test-pytest-test-shard=${python_contrib_shard} \
-    --compile-python-eval-skip \
     contrib:: \
   ) || die "Contrib python test failure"
   end_travis_section
@@ -235,7 +233,6 @@ if [[ "${skip_integration:-false}" == "false" ]]; then
   start_travis_section "IntegrationTests" "Running Pants Integration tests${shard_desc}"
   (
     ./pants.pex ${PANTS_ARGS[@]} --tag='+integration' test.pytest \
-      --compile-python-eval-skip \
       --test-pytest-test-shard=${python_intg_shard} \
       tests/python::
   ) || die "Pants Integration test failure"

--- a/pants.daemon.ini
+++ b/pants.daemon.ini
@@ -21,7 +21,7 @@
 #
 # You can also export this for all pants runs using environment variables:
 #
-#    $ export PANTS_CONFIG_OVERRIDE="$(pwd)/pants.daemon.ini"
+#    $ export PANTS_CONFIG_FILES="$(pwd)/pants.daemon.ini"
 #
 
 [GLOBAL]

--- a/tests/python/pants_test/java/test_nailgun_integration.py
+++ b/tests/python/pants_test/java/test_nailgun_integration.py
@@ -20,7 +20,7 @@ class TestNailgunIntegration(PantsRunIntegrationTest):
         'import org.pantsbuild.example.hello.welcome.WelcomeEverybody\n'
         'println(WelcomeEverybody("World" :: Nil).head)\n'
       ),
-      # Override the PANTS_CONFIG_OVERRIDE="['pants.travis-ci.ini']" used within TravisCI to enable
+      # Override the PANTS_CONFIG_FILES="pants.travis-ci.ini" used within TravisCI to enable
       # nailgun usage for the purpose of exercising that stack in the integration test.
       config={'DEFAULT': {'use_nailgun': True}}
     )

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -186,7 +186,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
       ini_file_name = os.path.join(workdir, 'pants.ini')
       with safe_open(ini_file_name, mode='w') as fp:
         ini.write(fp)
-      args.append('--config-override=' + ini_file_name)
+      args.append('--pants-config-files=' + ini_file_name)
 
     pants_script = os.path.join(build_root or get_buildroot(), self.PANTS_SCRIPT_NAME)
 


### PR DESCRIPTION
The fixes both deprecated `--config-override` usage (via env var) and
deprecated `--compile-python-eval` usage.