### PR TITLE
[pantsd] Add faulthandler support for stacktrace dumps.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -4,6 +4,7 @@ cffi==1.7.0
 coverage>=4.3.4,<4.4
 docutils>=0.12,<0.13
 fasteners==0.14.1
+faulthandler==2.6
 futures==3.0.5
 isort==4.2.5
 Markdown==2.1.1

--- a/src/docs/tshoot.md
+++ b/src/docs/tshoot.md
@@ -135,6 +135,17 @@ by expanding the `stderr` nodes.
 2015/03/12 03:55:57:451 PDT [DEBUG] header - -<< "X-Timer: S1426157757.333469,VS0,VE36[\r][\n]"
 ```
 
+Getting a stack trace from a running pants process
+--------------------------------------------------
+
+Pants implements `faulthandler` support in all execution contexts. To get a stack trace from a running pants process, send a `SIGUSR2` signal like so:
+
+```
+$ kill -31 <pid>
+```
+
+For traditional pants runs, this will dump a stack trace (for all threads) to stderr. For pantsd-based runs and for pantsd itself, the traces will end up in the `.pantsd/pantsd/pantsd.log` file.
+
 Questions, Issues, Bug Reports
 ------------------------------
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -187,3 +187,12 @@ python_library(
     '3rdparty/python:six',
   ],
 )
+
+python_library(
+  name='exiter',
+  sources=['exiter.py'],
+  dependencies=[
+    '3rdparty/python:faulthandler',
+    'src/python/pants/util:dirutil'
+  ]
+)

--- a/src/python/pants/base/exiter.py
+++ b/src/python/pants/base/exiter.py
@@ -115,8 +115,8 @@ class Exiter(object):
 
   def _setup_faulthandler(self, trace_stream):
     faulthandler.enable(trace_stream)
-    # This permits a non-fatal `kill -29 <pants pid>` for stacktrace retrieval.
-    faulthandler.register(signal.SIGINFO, trace_stream, chain=True)
+    # This permits a non-fatal `kill -31 <pants pid>` for stacktrace retrieval.
+    faulthandler.register(signal.SIGUSR2, trace_stream, chain=True)
 
   def set_except_hook(self, trace_stream=None):
     """Sets the global exception hook."""

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -9,6 +9,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:build_file',
     'src/python/pants/base:cmd_line_spec_parser',
+    'src/python/pants/base:exiter',
     'src/python/pants/base:project_tree',
     'src/python/pants/base:specs',
     'src/python/pants/base:workunit',

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.bin.exiter import Exiter
+from pants.base.exiter import Exiter
 from pants.bin.pants_runner import PantsRunner
 
 

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -110,3 +110,6 @@ class NailgunStreamWriter(object):
 
   def isatty(self):
     return self._isatty
+
+  def fileno(self):
+    return self._socket.fileno()

--- a/src/python/pants/logging/setup.py
+++ b/src/python/pants/logging/setup.py
@@ -5,10 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from collections import namedtuple
 import logging
 import os
 import time
+from collections import namedtuple
 from logging import Formatter, StreamHandler
 from logging.handlers import RotatingFileHandler
 

--- a/src/python/pants/logging/setup.py
+++ b/src/python/pants/logging/setup.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from collections import namedtuple
 import logging
 import os
 import time
@@ -12,6 +13,10 @@ from logging import Formatter, StreamHandler
 from logging.handlers import RotatingFileHandler
 
 from pants.util.dirutil import safe_mkdir
+
+
+class LoggingSetupResult(namedtuple('LoggingSetupResult', ['log_filename', 'log_stream'])):
+  """A structured result for logging setup."""
 
 
 # TODO: Once pantsd had a separate launcher entry point, and so no longer needs to call this
@@ -42,12 +47,14 @@ def setup_logging(level, console_stream=None, log_dir=None, scope=None, log_name
   # logging control and we don't need to be the middleman plumbing an option for each python
   # standard logging knob.
 
+  log_filename = None
+  log_stream = None
+
   logger = logging.getLogger(scope)
   for handler in logger.handlers:
     logger.removeHandler(handler)
 
   if console_stream:
-    log_file = None
     console_handler = StreamHandler(stream=console_stream)
     console_handler.setFormatter(Formatter(fmt='%(levelname)s] %(message)s'))
     console_handler.setLevel(level)
@@ -55,8 +62,9 @@ def setup_logging(level, console_stream=None, log_dir=None, scope=None, log_name
 
   if log_dir:
     safe_mkdir(log_dir)
-    log_file = os.path.join(log_dir, log_name or 'pants.log')
-    file_handler = RotatingFileHandler(log_file, maxBytes=10 * 1024 * 1024, backupCount=4)
+    log_filename = os.path.join(log_dir, log_name or 'pants.log')
+    file_handler = RotatingFileHandler(log_filename, maxBytes=10 * 1024 * 1024, backupCount=4)
+    log_stream = file_handler.stream
 
     class GlogFormatter(Formatter):
       LEVEL_MAP = {
@@ -87,4 +95,4 @@ def setup_logging(level, console_stream=None, log_dir=None, scope=None, log_name
   # This routes warnings through our loggers instead of straight to raw stderr.
   logging.captureWarnings(True)
 
-  return log_file
+  return LoggingSetupResult(log_filename, log_stream)

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -47,6 +47,7 @@ python_library(
   sources = ['pants_daemon.py'],
   dependencies = [
     '3rdparty/python:setproctitle',
+    'src/python/pants/base:exiter',
     'src/python/pants/goal:run_tracker',
     'src/python/pants/logging',
     ':process_manager',

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -12,21 +12,25 @@ import threading
 
 from setproctitle import setproctitle as set_process_title
 
+from pants.base.exiter import Exiter
 from pants.goal.run_tracker import RunTracker
 from pants.logging.setup import setup_logging
 from pants.pantsd.process_manager import ProcessManager
 
 
-class _StreamLogger(object):
+class _LoggerStream(object):
   """A sys.{stdout,stderr} replacement that pipes output to a logger."""
 
-  def __init__(self, logger, log_level):
+  def __init__(self, logger, log_level, logger_stream):
     """
     :param logging.Logger logger: The logger instance to emit writes to.
     :param int log_level: The log level to use for the given logger.
+    :param file logger_stream: The underlying file object the logger is writing to, for
+                               determining the fileno to support faulthandler logging.
     """
     self._logger = logger
     self._log_level = log_level
+    self._stream = logger_stream
 
   def write(self, msg):
     for line in msg.rstrip().splitlines():
@@ -37,6 +41,9 @@ class _StreamLogger(object):
 
   def isatty(self):
     return False
+
+  def fileno(self):
+    return self._stream.fileno()
 
 
 class PantsDaemon(ProcessManager):
@@ -58,7 +65,6 @@ class PantsDaemon(ProcessManager):
     :param tuple services: A tuple of PantsService instances to launch/manage. (Optional)
     :param callable reset_func: Called after the daemon is forked to reset
                                 any state inherited from the parent process. (Optional)
-
     """
     super(PantsDaemon, self).__init__(name='pantsd', metadata_base_dir=metadata_base_dir)
     self._logger = logging.getLogger(__name__)
@@ -72,6 +78,7 @@ class PantsDaemon(ProcessManager):
     self._socket_map = {}
     # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
     self._kill_switch = threading.Event()
+    self._exiter = Exiter()
 
   @property
   def is_killed(self):
@@ -116,16 +123,18 @@ class PantsDaemon(ProcessManager):
     logging.shutdown()
 
     # Reinitialize logging for the daemon context.
-    setup_logging(log_level, console_stream=None, log_dir=self._log_dir, log_name=self.LOG_NAME)
+    result = setup_logging(log_level, log_dir=self._log_dir, log_name=self.LOG_NAME)
 
     # Close out pre-fork file descriptors.
     self._close_fds()
 
     # Redirect stdio to the root logger.
-    sys.stdout = _StreamLogger(logging.getLogger(), logging.INFO)
-    sys.stderr = _StreamLogger(logging.getLogger(), logging.WARN)
+    sys.stdout = _LoggerStream(logging.getLogger(), logging.INFO, result.log_stream)
+    sys.stderr = _LoggerStream(logging.getLogger(), logging.WARN, result.log_stream)
 
     self._logger.debug('logging initialized')
+
+    return result.log_stream
 
   def _setup_services(self, services):
     for service in services:
@@ -167,7 +176,8 @@ class PantsDaemon(ProcessManager):
   def _run(self):
     """Synchronously run pantsd."""
     # Switch log output to the daemon's log stream from here forward.
-    self._setup_logging(self._log_level)
+    log_stream = self._setup_logging(self._log_level)
+    self._exiter.set_except_hook(log_stream)
     self._logger.info('pantsd starting, log level is {}'.format(self._log_level))
 
     # Purge as much state as possible from the pants run that launched us.

--- a/tests/python/pants_test/base/BUILD
+++ b/tests/python/pants_test/base/BUILD
@@ -218,3 +218,13 @@ python_tests(
     'src/python/pants/base:validation',
   ]
 )
+
+python_tests(
+  name = 'exiter',
+  sources = ['test_exiter.py'],
+  dependencies = [
+    'src/python/pants/bin',
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test/option:testing',
+  ],
+)

--- a/tests/python/pants_test/base/test_exiter.py
+++ b/tests/python/pants_test/base/test_exiter.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import unittest
 
-from pants.bin.exiter import Exiter
+from pants.base.exiter import Exiter
 from pants.util.contextutil import temporary_dir
 from pants_test.option.util.fakes import create_options
 

--- a/tests/python/pants_test/bin/BUILD
+++ b/tests/python/pants_test/bin/BUILD
@@ -2,16 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_tests(
-  name = 'exiter',
-  sources = ['test_exiter.py'],
-  dependencies = [
-    'src/python/pants/bin',
-    'src/python/pants/util:contextutil',
-    'tests/python/pants_test/option:testing',
-  ],
-)
-
-python_tests(
   name='loader_integration',
   sources=['test_loader_integration.py'],
   dependencies=[

--- a/tests/python/pants_test/logging/test_setup.py
+++ b/tests/python/pants_test/logging/test_setup.py
@@ -31,7 +31,7 @@ class SetupTest(unittest.TestCase):
     with closing(six.StringIO()) as stream:
       with self.log_dir(file_logging) as log_dir:
         log_file = setup_logging(level, console_stream=stream, log_dir=log_dir, scope=logger.name)
-        yield logger, stream, log_file
+        yield logger, stream, log_file.log_filename
 
   def assertWarnInfoOutput(self, lines):
     """Check to see that only warn and info output appears in the stream.

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -9,7 +9,7 @@ import logging
 
 import mock
 
-from pants.pantsd.pants_daemon import PantsDaemon, _StreamLogger
+from pants.pantsd.pants_daemon import PantsDaemon, _LoggerStream
 from pants.pantsd.service.pants_service import PantsService
 from pants.util.contextutil import stdio_as
 from pants_test.base_test import BaseTest
@@ -24,12 +24,12 @@ class StreamLoggerTest(BaseTest):
 
   def test_write(self):
     mock_logger = mock.Mock()
-    _StreamLogger(mock_logger, self.TEST_LOG_LEVEL).write('testing 1 2 3')
+    _LoggerStream(mock_logger, self.TEST_LOG_LEVEL).write('testing 1 2 3')
     mock_logger.log.assert_called_once_with(self.TEST_LOG_LEVEL, 'testing 1 2 3')
 
   def test_write_multiline(self):
     mock_logger = mock.Mock()
-    _StreamLogger(mock_logger, self.TEST_LOG_LEVEL).write('testing\n1\n2\n3\n\n')
+    _LoggerStream(mock_logger, self.TEST_LOG_LEVEL).write('testing\n1\n2\n3\n\n')
     mock_logger.log.assert_has_calls([
       mock.call(self.TEST_LOG_LEVEL, 'testing'),
       mock.call(self.TEST_LOG_LEVEL, '1'),
@@ -38,7 +38,7 @@ class StreamLoggerTest(BaseTest):
     ])
 
   def test_flush(self):
-    _StreamLogger(mock.Mock(), self.TEST_LOG_LEVEL).flush()
+    _LoggerStream(mock.Mock(), self.TEST_LOG_LEVEL).flush()
 
 
 class PantsDaemonTest(BaseTest):

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -18,18 +18,18 @@ from pants_test.base_test import BaseTest
 PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
-class StreamLoggerTest(BaseTest):
+class LoggerStreamTest(BaseTest):
 
   TEST_LOG_LEVEL = logging.INFO
 
   def test_write(self):
     mock_logger = mock.Mock()
-    _LoggerStream(mock_logger, self.TEST_LOG_LEVEL).write('testing 1 2 3')
+    _LoggerStream(mock_logger, self.TEST_LOG_LEVEL, None).write('testing 1 2 3')
     mock_logger.log.assert_called_once_with(self.TEST_LOG_LEVEL, 'testing 1 2 3')
 
   def test_write_multiline(self):
     mock_logger = mock.Mock()
-    _LoggerStream(mock_logger, self.TEST_LOG_LEVEL).write('testing\n1\n2\n3\n\n')
+    _LoggerStream(mock_logger, self.TEST_LOG_LEVEL, None).write('testing\n1\n2\n3\n\n')
     mock_logger.log.assert_has_calls([
       mock.call(self.TEST_LOG_LEVEL, 'testing'),
       mock.call(self.TEST_LOG_LEVEL, '1'),
@@ -38,7 +38,7 @@ class StreamLoggerTest(BaseTest):
     ])
 
   def test_flush(self):
-    _LoggerStream(mock.Mock(), self.TEST_LOG_LEVEL).flush()
+    _LoggerStream(mock.Mock(), self.TEST_LOG_LEVEL, None).flush()
 
 
 class PantsDaemonTest(BaseTest):


### PR DESCRIPTION
Fixes #4626

### Problem

Early reports from alpha testers of pantsd revealed that some `pantsd-runner` processes were getting hung in the background on their machine with no apparent cause or repro. In order to better diagnose hangs or other such issues in pantsd itself or either normal pants or pantsd based runs, we need a way to easily collect a python stacktrace.

### Solution

Add `faulthandler` support to pants, which is a C-level stack trace dumper. This permits us to `kill -31 <pants|pantsd|pantsd-runner pid>` to get stack trace per thread from any of these 3 runtime contexts even if python is deadlocked. This will also automatically dump stacktraces on c/rust-level segfaults among other features described here: https://faulthandler.readthedocs.io/

### Result

```
[omerta pants (kwlzn/faulthandler)]$ ps -ef |grep "pantsd \[" 
  501 94833     1   0  4:26PM ??         0:04.91 pantsd [/Users/kwilson/dev/pants] 
[omerta pants (kwlzn/faulthandler)]$ tail -0 -F .pants.d/pantsd/pantsd.log &
[1] 72279
[omerta pants (kwlzn/faulthandler)]$ kill -31 94833
Thread 0x0000700010b98000 (most recent call first):
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 340 in wait
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/Queue.py", line 168 in get
  File "/Users/kwilson/dev/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/concurrent/futures/thread.py", line 65 in _worker
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 754 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x0000700010795000 (most recent call first):
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 340 in wait
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/Queue.py", line 168 in get
  File "/Users/kwilson/dev/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/concurrent/futures/thread.py", line 65 in _worker
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 754 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/k[omerta pants (kwlzn/faulthandler)]$ wilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x0000700010392000 (most recent call first):
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 340 in wait
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/Queue.py", line 168 in get
  File "/Users/kwilson/dev/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/concurrent/futures/thread.py", line 65 in _worker
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 754 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x000070000ff8f000 (most recent call first):
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 340 in wait
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/Queue.py", line 168 in get
  File "/Users/kwilson/dev/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/concurrent/futures/thread.py", line 65 in _worker
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 754 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x000070000fb8c000 (most recent call first):
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/SocketServer.py", line 150 in _eintr_retry
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/SocketServer.py", line 271 in handle_request
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/service/pailgun_service.py", line 101 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 754 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x000070000f789000 (most recent call first):
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 359 in wait
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/Queue.py", line 177 in get
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/service/scheduler_service.py", line 73 in _process_event_queue
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/service/scheduler_service.py", line 103 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 754 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x000070000f386000 (most recent call first):
  File "/Users/kwilson/dev/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pywatchman/__init__.py", line 168 in readBytes
  File "/Users/kwilson/dev/pants/build-support/pants_dev_deps.venv/lib/python2.7/site-packages/pywatchman/__init__.py", line 272 in receive
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/watchman_client.py", line 49 in stream_query
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/watchman.py", line 167 in subscribed
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/service/fs_event_service.py", line 115 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 754 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x0000700002674000 (most recent call first):
  File "/Users/kwilson/dev/pants/src/python/pants/reporting/report.py", line 34 in run
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 774 in __bootstrap

Current thread 0x00007fff98cfe3c0 (most recent call first):
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 359 in wait
  File "/Users/kwilson/Python/CPython-2.7.13/lib/python2.7/threading.py", line 951 in join
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/pants_daemon.py", line 169 in _run_services
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/pants_daemon.py", line 195 in _run
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/pants_daemon.py", line 210 in post_fork_child
  File "/Users/kwilson/dev/pants/src/python/pants/pantsd/process_manager.py", line 433 in daemonize
  File "/Users/kwilson/dev/pants/src/python/pants/init/pants_daemon_launcher.py", line 176 in _launch_pantsd
  File "/Users/kwilson/dev/pants/src/python/pants/init/pants_daemon_launcher.py", line 186 in maybe_launch
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 158 in _maybe_launch_pantsd
  File "/Users/kwilson/dev/pants/src/python/pants/bin/goal_runner.py", line 196 in setup
  File "/Users/kwilson/dev/pants/src/python/pants/bin/local_pants_runner.py", line 77 in _run
  File "/Users/kwilson/dev/pants/src/python/pants/bin/local_pants_runner.py", line 37 in run
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_runner.py", line 46 in _run
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_runner.py", line 57 in run
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_exe.py", line 26 in main
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_loader.py", line 58 in load_and_execute
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_loader.py", line 65 in run
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_loader.py", line 69 in main
  File "/Users/kwilson/dev/pants/src/python/pants/bin/pants_loader.py", line 73 in <module>

[omerta pants (kwlzn/faulthandler)]$ fg
tail -0 -F .pants.d/pantsd/pantsd.log
^C
```