### PR TITLE
Move support for `sources` into `Target`.

### DIFF
--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_binary.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_binary.py
@@ -14,19 +14,14 @@ from pants.contrib.cpp.targets.cpp_target import CppTarget
 class CppBinary(CppTarget):
   """A C++ binary."""
 
-  def __init__(self,
-               libraries=None,
-               *args,
-               **kwargs):
+  def __init__(self, libraries=None, payload=None, **kwargs):
     """
     :param libraries: Libraries that this target depends on that are not pants targets.
     For example, 'm' or 'rt' that are expected to be installed on the local system.
     :type libraries: List of libraries to link against.
     """
-    payload = Payload()
-    payload.add_fields({
-      'libraries': PrimitiveField(libraries)
-    })
+    payload = payload or Payload()
+    payload.add_field('libraries', PrimitiveField(libraries))
     super(CppBinary, self).__init__(payload=payload, **kwargs)
 
   @property

--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_library.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_library.py
@@ -10,9 +10,3 @@ from pants.contrib.cpp.targets.cpp_target import CppTarget
 
 class CppLibrary(CppTarget):
   """A statically linked C++ library."""
-
-  # TODO: public headers
-  def __init__(self,
-               *args,
-               **kwargs):
-    super(CppLibrary, self).__init__(*args, **kwargs)

--- a/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_target.py
+++ b/contrib/cpp/src/python/pants/contrib/cpp/targets/cpp_target.py
@@ -5,23 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.payload import Payload
 from pants.build_graph.target import Target
 
 
 class CppTarget(Target):
   """A base class for all cpp targets."""
-
-  def __init__(self, address=None, payload=None, sources=None, **kwargs):
-    """
-    :param sources: Source code files to build. Paths are relative to the BUILD
-      file's directory.
-    :type sources: ``Fileset`` (from globs or rglobs) or list of strings
-    """
-    payload = payload or Payload()
-    payload.add_fields({
-      'sources': self.create_sources_field(sources=sources,
-                                           sources_rel_path=address.spec_path,
-                                           key_arg='sources'),
-    })
-    super(CppTarget, self).__init__(address=address, payload=payload, **kwargs)

--- a/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_local_source.py
@@ -64,11 +64,9 @@ class GoLocalSource(GoTarget):
                                     globs('*/**')])
 
     payload = payload or Payload()
-    payload.add_fields({
-      'sources': self.create_sources_field(sources=sources,
-                                           sources_rel_path=address.spec_path,
-                                           key_arg='sources'),
-    })
+    payload.add_field('sources', self.create_sources_field(sources=sources,
+                                                           sources_rel_path=address.spec_path,
+                                                           key_arg='sources'))
     super(GoLocalSource, self).__init__(address=address, payload=payload, **kwargs)
 
   @property

--- a/contrib/go/src/python/pants/contrib/go/targets/go_thrift_library.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_thrift_library.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.payload import Payload
+from pants.base.deprecated import deprecated_conditional
 from pants.build_graph.target import Target
 
 from pants.contrib.go.targets.go_local_source import GoLocalSource
@@ -15,25 +15,13 @@ from pants.contrib.go.targets.go_target import GoTarget
 class GoThriftLibrary(Target):
   """A Go library generated from Thrift IDL files."""
 
-  def __init__(self,
-               address=None,
-               payload=None,
-               import_path=None,
-               sources=None,
-               **kwargs):
-    """
-    :param sources: thrift source files
-    :type sources: ``Fileset`` or list of strings. Paths are relative to the
-      BUILD file's directory.
-    :param import_path: Go code will import this
-    """
+  def __init__(self, import_path=None, **kwargs):
+    deprecated_conditional(lambda: import_path is not None,
+                           removal_version='1.6.0.dev0',
+                           entity_description='import_path',
+                           hint_message='Remove this unused {} parameter'.format(self.alias()))
 
-    payload = payload or Payload()
-    payload.add_fields({
-      'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
-    })
-
-    super(GoThriftLibrary, self).__init__(payload=payload, address=address, **kwargs)
+    super(GoThriftLibrary, self).__init__(**kwargs)
 
   @classmethod
   def alias(cls):
@@ -41,16 +29,6 @@ class GoThriftLibrary(Target):
 
 
 class GoThriftGenLibrary(GoTarget):
-
-  def __init__(self, sources=None, address=None, payload=None, **kwargs):
-    payload = payload or Payload()
-    payload.add_fields({
-      'sources': self.create_sources_field(sources=sources,
-                                           sources_rel_path=address.spec_path,
-                                           key_arg='sources'),
-    })
-    super(GoThriftGenLibrary, self).__init__(address=address, payload=payload, **kwargs)
-
   @property
   def import_path(self):
     """The import path as used in import statements in `.go` source files."""

--- a/contrib/node/src/python/pants/contrib/node/targets/node_module.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_module.py
@@ -19,14 +19,14 @@ logger = logging.getLogger(__name__)
 class NodeModule(NodePackage):
   """A Node module."""
 
-  def __init__(
-    self, package_manager=None, sources=None, build_script=None, output_dir='dist',
-    dev_dependency=False, address=None, payload=None, **kwargs):
+  def __init__(self,
+               package_manager=None,
+               build_script=None,
+               output_dir='dist',
+               dev_dependency=False,
+               payload=None,
+               **kwargs):
     """
-    :param sources: Javascript and other source code files that make up this module; paths are
-                    relative to the BUILD file's directory.
-    :type sources: `globs`, `rglobs` or a list of strings
-
     :param package_manager: choose among supported package managers (npm or yarn).
     :param build_script: build script name as defined in package.json.  All files that are needed
       for the build script must be included in sources.  The script should output build results
@@ -46,12 +46,10 @@ class NodeModule(NodePackage):
     # of pre-existing package.json files as node_module targets will require this.
     payload = payload or Payload()
     payload.add_fields({
-      'sources': self.create_sources_field(
-        sources=sources, sources_rel_path=address.spec_path, key_arg='sources'),
       'build_script': PrimitiveField(build_script),
       'package_manager': PrimitiveField(package_manager),
       'output_dir': PrimitiveField(output_dir),
       'dev_dependency': PrimitiveField(dev_dependency),
     })
     logger.debug('NodeModule payload: %s', payload.fields)
-    super(NodeModule, self).__init__(address=address, payload=payload, **kwargs)
+    super(NodeModule, self).__init__(payload=payload, **kwargs)

--- a/contrib/scalajs/src/python/pants/contrib/scalajs/targets/scala_js_library.py
+++ b/contrib/scalajs/src/python/pants/contrib/scalajs/targets/scala_js_library.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.payload import Payload
 from pants.build_graph.target import Target
 
 from pants.contrib.scalajs.targets.scala_js_target import ScalaJSTarget
@@ -17,17 +16,3 @@ class ScalaJSLibrary(ScalaJSTarget, Target):
   Linking multiple libraries together into a shippable blob additionally requires a
   ScalaJSBinary target.
   """
-
-  def __init__(self, sources=None, address=None, payload=None, **kwargs):
-    """
-    :param sources: Scala source that makes up this module; paths are relative to the BUILD
-                    file's directory.
-    :type sources: `globs`, `rglobs` or a list of strings
-    """
-    payload = payload or Payload()
-    payload.add_fields({
-      'sources': self.create_sources_field(sources=sources,
-                                           sources_rel_path=address.spec_path,
-                                           key_arg='sources'),
-    })
-    super(ScalaJSLibrary, self).__init__(address=address, payload=payload, **kwargs)

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -33,7 +33,6 @@ class JvmTarget(Target, Jarable):
   def __init__(self,
                address=None,
                payload=None,
-               sources=None,
                provides=None,
                excludes=None,
                resources=None,
@@ -101,7 +100,6 @@ class JvmTarget(Target, Jarable):
     payload = payload or Payload()
     excludes = ExcludesField(self.assert_list(excludes, expected_type=Exclude, key_arg='excludes'))
     payload.add_fields({
-      'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
       'provides': provides,
       'excludes': excludes,
       'resources': PrimitiveField(self.assert_list(resources, key_arg='resources')),

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -57,7 +57,6 @@ class PythonTarget(Target):
   def __init__(self,
                address=None,
                payload=None,
-               sources=None,
                resources=None,  # Old-style resources (file list, Fileset).
                resource_targets=None,  # New-style resources (Resources target specs).
                provides=None,
@@ -70,9 +69,6 @@ class PythonTarget(Target):
       ``python_thrift_library``, ``python_antlr_library`` and so forth) or
       ``python_requirement_library`` targets.
     :type dependencies: list of strings
-    :param sources: Files to "include". Paths are relative to the
-      BUILD file's directory.
-    :type sources: ``Fileset`` or list of strings
     :param resources: non-Python resources, e.g. templates, keys, other data
       (it is
       recommended that your application uses the pkgutil package to access these
@@ -90,14 +86,17 @@ class PythonTarget(Target):
       format, e.g. ``'CPython>=3', or just ['>=2.7','<3']`` for requirements
       agnostic to interpreter class.
     """
-    deprecated_conditional(lambda: resources is not None, '1.5.0.dev0',
-                           'The `resources=` Python target argument', 'Depend on resources targets instead.')
-    deprecated_conditional(lambda: resource_targets is not None, '1.5.0.dev0',
-                           'The `resource_targets=` Python target argument', 'Use `dependencies=` instead.')
+    deprecated_conditional(lambda: resources is not None,
+                           removal_version='1.5.0.dev0',
+                           entity_description='The `resources=` Python target argument',
+                           hint_message='Depend on resources targets instead.')
+    deprecated_conditional(lambda: resource_targets is not None,
+                           removal_version='1.5.0.dev0',
+                           entity_description='The `resource_targets=` Python target argument',
+                           hint_message='Use `dependencies=` instead.')
     self.address = address
     payload = payload or Payload()
     payload.add_fields({
-      'sources': self.create_sources_field(sources, address.spec_path, key_arg='sources'),
       'resources': self.create_sources_field(resources, address.spec_path, key_arg='resources'),
       'resource_targets': PrimitiveField(resource_targets),
       'provides': provides,

--- a/src/python/pants/build_graph/resources.py
+++ b/src/python/pants/build_graph/resources.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.base.payload import Payload
 from pants.build_graph.target import Target
 
 
@@ -23,21 +22,6 @@ class Resources(Target):
   @classmethod
   def alias(cls):
     return 'resources'
-
-  def __init__(self, address=None, payload=None, sources=None, **kwargs):
-    """
-    :API: public
-
-    :param sources: Files to "include". Paths are relative to the
-      BUILD file's directory.
-    :type sources: ``Fileset`` or list of strings
-    """
-    payload = payload or Payload()
-    payload.add_fields({
-      'sources': self.create_sources_field(sources,
-                                           sources_rel_path=address.spec_path, key_arg='sources'),
-    })
-    super(Resources, self).__init__(address=address, payload=payload, **kwargs)
 
   def has_sources(self, extension=None):
     """``Resources`` never own sources of any particular native type, like for example

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -295,14 +295,15 @@ python_tests(
   name = 'ivy_utils',
   sources = ['test_ivy_utils.py'],
   dependencies = [
+    'src/python/pants/backend/jvm:ivy_utils',
+    'src/python/pants/backend/jvm:plugin',
     'src/python/pants/backend/jvm/subsystems:jar_dependency_management',
     'src/python/pants/backend/jvm/targets:jvm',
-    'src/python/pants/backend/jvm:ivy_utils',
-    'src/python/pants/java/jar',
-    'src/python/pants/backend/jvm:plugin',
     'src/python/pants/build_graph',
     'src/python/pants/ivy',
+    'src/python/pants/java/jar',
     'src/python/pants/util:contextutil',
+    'tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]

--- a/tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/ivy_utils_resources/BUILD
@@ -1,0 +1,1 @@
+target(sources=globs('*.xml'))


### PR DESCRIPTION
There were several target subclasses re-implementing the boilerplate and
`Target` otherwise had intimiate knowledge of sources and an expectation
that the field existed for auxially methods.

This also allows for a general `sources` bag that can be used to express
file dependencies with no other expectation about the files' type or
purpose.