### PR TITLE
Improve performance (hopefully) by not re-fingerprinting codegen'd sources

### DIFF
--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -15,6 +15,7 @@ from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.goal.context import Context
+from pants.source.wrapped_globs import EagerFilesetWithSpec
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 from twitter.common.collections import OrderedSet
 
@@ -163,10 +164,15 @@ class ScroogeGenTest(NailgunTaskTestBase):
       self.assertEquals(call_kwargs['target_type'], library_type)
       self.assertEquals(call_kwargs['dependencies'], OrderedSet())
       self.assertEquals(call_kwargs['provides'], None)
-      self.assertEquals(call_kwargs['sources'], [])
       self.assertEquals(call_kwargs['derived_from'], target)
       self.assertEquals(call_kwargs['strict_deps'], True)
       self.assertEquals(call_kwargs['fatal_warnings'], False)
+
+      sources = call_kwargs['sources']
+      if isinstance(sources, EagerFilesetWithSpec):
+        self.assertEquals(sources.files, [])
+      else:
+        self.assertEquals(sources, [])
 
     finally:
       Context.add_new_target = saved_add_new_target

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -228,8 +228,7 @@ class SimpleCodegenTask(Task):
     return EagerFilesetWithSpec(results_dir_relpath, filespec=filespec,
       files=files, files_hash='{}.{}'.format(fingerprint.id, fingerprint.hash))
 
-
-  def _inject_synthetic_target(self, target, target_workdir, fingerprint=None):
+  def _inject_synthetic_target(self, target, target_workdir, fingerprint):
     """Create, inject, and return a synthetic target for the given target and workdir.
 
     :param target: The target to inject a synthetic target for.

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -240,6 +240,8 @@ class SimpleCodegenTask(Task):
     for attribute in self._copy_target_attributes:
       copied_attributes[attribute] = getattr(target, attribute)
 
+    target_workdir = self.synthetic_target_dir(target, target_workdir)
+
     sources = list(self.find_sources(target, target_workdir))
     if fingerprint:
       sources = self._create_sources_with_fingerprint(target_workdir, fingerprint, sources)

--- a/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
+++ b/tests/python/pants_test/backend/codegen/antlr/java/test_antlr_java_gen.py
@@ -16,6 +16,7 @@ from pants.backend.codegen.antlr.java.antlr_java_gen import AntlrJavaGen
 from pants.backend.codegen.antlr.java.java_antlr_library import JavaAntlrLibrary
 from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.invalidation.build_invalidator import CacheKey
 from pants.util.dirutil import safe_mkdtemp
 from pants_test.jvm.nailgun_task_test_base import NailgunTaskTestBase
 
@@ -77,7 +78,8 @@ class AntlrJavaGenTest(NailgunTaskTestBase):
 
     # Generate code, then create a synthetic target.
     task.execute_codegen(target, target_workdir)
-    syn_target = task._inject_synthetic_target(target, target_workdir)
+    fingerprint = CacheKey("test", target.invalidation_hash())
+    syn_target = task._inject_synthetic_target(target, target_workdir, fingerprint)
 
     actual_sources = [s for s in Fileset.rglobs('*.java', root=target_workdir)]
     expected_sources = syn_target.sources_relative_to_source_root()

--- a/tests/python/pants_test/task/test_simple_codegen_task.py
+++ b/tests/python/pants_test/task/test_simple_codegen_task.py
@@ -268,3 +268,37 @@ class SimpleCodegenTaskTest(TaskTestBase):
     task = self._create_dummy_task(target_roots=targets, strategy='isolated')
     task.execute()
     self.assertEqual('copythis', task.codegen_targets()[0].copied)
+
+  def test_invalidation_of_generated_sources(self):
+    self.create_file('src/thrift/com/foo/one.thrift', 'initial state')
+
+    t1 = self.make_target(spec='src/thrift/com/foo:one',
+                          target_type=DummyLibrary,
+                          sources=['one.thrift'])
+
+    task1 = self._create_dummy_task(target_roots=t1, strategy='isolated')
+    task1.execute()
+
+    gen_targets = [self.build_graph.get_target(syn_addr)
+                   for syn_addr in self.build_graph.synthetic_addresses]
+    syn_targets_for_t1 = [target for target in gen_targets if target.derived_from == t1]
+
+    t1_hash = syn_targets_for_t1[0].invalidation_hash()
+
+    self.reset_build_graph()
+
+    self.create_file('src/thrift/com/foo/one.thrift', 'changed state')
+
+    t2 = self.make_target(spec='src/thrift/com/foo:one',
+                          target_type=DummyLibrary,
+                          sources=['one.thrift'])
+
+    task2 = self._create_dummy_task(target_roots=t2, strategy='isolated')
+    task2.execute()
+
+    gen_targets = [self.build_graph.get_target(syn_addr)
+                   for syn_addr in self.build_graph.synthetic_addresses]
+    syn_targets_for_t2 = [target for target in gen_targets if target.derived_from == t2]
+
+    t2_hash = syn_targets_for_t2[0].invalidation_hash()
+    self.assertNotEqual(t1_hash, t2_hash)

--- a/tests/python/pants_test/task/test_simple_codegen_task.py
+++ b/tests/python/pants_test/task/test_simple_codegen_task.py
@@ -12,6 +12,7 @@ from pants.base.payload import Payload
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.register import build_file_aliases as register_core
 from pants.build_graph.target import Target
+from pants.invalidation.build_invalidator import CacheKey
 from pants.task.simple_codegen_task import SimpleCodegenTask
 from pants.util.dirutil import safe_mkdtemp
 from pants_test.tasks.task_test_base import TaskTestBase, ensure_cached
@@ -213,7 +214,8 @@ class SimpleCodegenTaskTest(TaskTestBase):
         target_workdir = target_workdirs[target]
         task.execute_codegen(target, target_workdir)
         task._handle_duplicate_sources(target, target_workdir)
-        syn_targets.append(task._inject_synthetic_target(target, target_workdir))
+        fingerprint = CacheKey("test", target.invalidation_hash())
+        syn_targets.append(task._inject_synthetic_target(target, target_workdir, fingerprint))
 
     if should_fail:
       # If we're expected to fail, validate the resulting message.


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/issues/4598

### Solution

Passing an EagerFilsetWithSpec as the sources to the synthetic target should avoid re-fingerprinting the output sources which should improve performance. 

### Result

Internally, we have seen an approximate improvement of 2-3 seconds outside the daemon (from 33 seconds to 30), and a 1-2 second improvement (from ~12 seconds to 10 or 11) with the daemon. 