### PR TITLE
Fix has_sources.

### DIFF
--- a/src/python/pants/build_graph/resources.py
+++ b/src/python/pants/build_graph/resources.py
@@ -28,9 +28,8 @@ class Resources(Target):
     """
     :API: public
 
-    :param sources: Files to "include". Paths are relative to the
-      BUILD file's directory.
-    :type sources: ``Fileset`` or list of strings
+    :param sources: Files to "include". Paths are relative to the BUILD file's directory.
+    :type sources: :class:`pants.source.wrapped_globs.FilesetWithSpec` or list of strings
     """
     payload = payload or Payload()
     payload.add_fields({
@@ -40,10 +39,21 @@ class Resources(Target):
     super(Resources, self).__init__(address=address, payload=payload, **kwargs)
 
   def has_sources(self, extension=None):
-    """``Resources`` never own sources of any particular native type, like for example
-    ``JavaLibrary``.
+    """`Resources` targets never logically "own" sources of any particular type (extension).
+
+    `JavaLibrary` targets, in contrast, logically "own" `.java` files and so target consumers
+    (tasks) may collect targets to operate on by checking `has_sources('.java')` instead of
+    performing a target type test.
+
+    A `Resources` target may have `.java` sources - for example, a java compiler test might use
+    loose `.java` source files in the test tree as compiler inputs - but it does not logically
+    "own" `.java` sources like `JavaLibrary` and so any query of `has_sources` with an `extension`
+    will return `False` to prevent standard compilation by a `javac` task in this example.
 
     :API: public
+
+    :param string extension: Suffix of filenames to test for.
+    :return: `True` if this target owns at least one source file and `extension` is `None`.
+    :rtype: bool
     """
-    # TODO(John Sirois): track down the reason for this hack and kill or explain better.
-    return extension is None
+    return extension is None and super(Resources, self).has_sources()

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -542,12 +542,13 @@ class Target(AbstractTarget):
       return sources_field
     return SourcesField(sources=FilesetWithSpec.empty(self.address.spec_path))
 
-  def has_sources(self, extension=''):
-    """
+  def has_sources(self, extension=None):
+    """Return `True` if this target owns sources; optionally of the given `extension`.
+
     :API: public
 
-    :param string extension: suffix of filenames to test for
-    :return: True if the target contains sources that match the optional extension suffix
+    :param string extension: Optional suffix of filenames to test for.
+    :return: `True` if the target contains sources that match the optional extension suffix.
     :rtype: bool
     """
     return self._sources_field.has_sources(extension)

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -64,13 +64,6 @@ class SourcesField(PayloadField):
     """Returns the address this sources field refers to (used by some derived classes)"""
     return self._ref_address
 
-  def has_sources(self, extension=None):
-    if not self.source_paths:
-      return False
-    if not extension:
-      return True
-    return any(source.endswith(extension) for source in self.source_paths)
-
   def relative_to_buildroot(self):
     """All sources joined with their relative paths."""
     return list(self.sources.paths_from_buildroot_iter())

--- a/src/python/pants/source/payload_fields.py
+++ b/src/python/pants/source/payload_fields.py
@@ -17,6 +17,13 @@ from pants.util.memo import memoized_property
 class SourcesField(PayloadField):
   """A PayloadField encapsulating specified sources."""
 
+  @staticmethod
+  def _validate_sources(sources):
+    if not isinstance(sources, FilesetWithSpec):
+      raise ValueError('Expected a FilesetWithSpec. `sources` should be '
+                       'instantiated via `create_sources_field`.')
+    return sources
+
   def __init__(self, sources, ref_address=None):
     """
     :param sources: FilesetWithSpec representing the underlying sources.
@@ -54,12 +61,14 @@ class SourcesField(PayloadField):
 
   @property
   def address(self):
-    """Returns the address this sources field refers to (used by some derived classses)"""
+    """Returns the address this sources field refers to (used by some derived classes)"""
     return self._ref_address
 
   def has_sources(self, extension=None):
     if not self.source_paths:
       return False
+    if not extension:
+      return True
     return any(source.endswith(extension) for source in self.source_paths)
 
   def relative_to_buildroot(self):
@@ -71,9 +80,3 @@ class SourcesField(PayloadField):
     hasher.update(self.rel_path)
     hasher.update(self.sources.files_hash)
     return hasher.hexdigest()
-
-  def _validate_sources(self, sources):
-    if not isinstance(sources, FilesetWithSpec):
-      raise ValueError('Expected a FilesetWithSpec. `sources` should be '
-                       'instantiated via `create_sources_field`.')
-    return sources

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -123,6 +123,7 @@ python_tests(
     'src/python/pants/base:fingerprint_strategy',
     'src/python/pants/base:payload',
     'src/python/pants/build_graph',
+    'src/python/pants/source',
     'tests/python/pants_test:base_test',
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -127,3 +127,13 @@ python_tests(
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
+
+python_tests(
+  name = 'resources',
+  sources = ['test_resources.py'],
+  dependencies = [
+    'src/python/pants/build_graph',
+    'src/python/pants/source',
+    'tests/python/pants_test:base_test',
+  ]
+)

--- a/tests/python/pants_test/build_graph/test_resources.py
+++ b/tests/python/pants_test/build_graph/test_resources.py
@@ -11,17 +11,22 @@ from pants_test.base_test import BaseTest
 
 
 class ResourcesTest(BaseTest):
+  @staticmethod
+  def sources(rel_path, *globs):
+    return Globs.create_fileset_with_spec(rel_path, *globs)
+
   def test_has_sources(self):
     self.create_files('resources', ['a.txt', 'B.java'])
 
     no_resources = self.make_target('resources:none',
                                     Resources,
-                                    sources=Globs.create_fileset_with_spec('resources', '*.rs'))
+                                    sources=self.sources('resources', '*.rs'))
     self.assertFalse(no_resources.has_sources())
-    self.assertFalse(no_resources.has_sources('*.java'))
+    self.assertFalse(no_resources.has_sources('.java'))
 
     resources = self.make_target('resources:some',
                                  Resources,
-                                 sources=Globs.create_fileset_with_spec('resources', '*.java'))
+                                 sources=self.sources('resources', '*.java'))
     self.assertTrue(resources.has_sources())
-    self.assertFalse(resources.has_sources('*.java'))
+    self.assertEqual(['resources/B.java'], resources.sources_relative_to_buildroot())
+    self.assertFalse(resources.has_sources('.java'))

--- a/tests/python/pants_test/build_graph/test_resources.py
+++ b/tests/python/pants_test/build_graph/test_resources.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.build_graph.resources import Resources
+from pants.source.wrapped_globs import Globs
+from pants_test.base_test import BaseTest
+
+
+class ResourcesTest(BaseTest):
+  def test_has_sources(self):
+    self.create_files('resources', ['a.txt', 'B.java'])
+
+    no_resources = self.make_target('resources:none',
+                                    Resources,
+                                    sources=Globs.create_fileset_with_spec('resources', '*.rs'))
+    self.assertFalse(no_resources.has_sources())
+    self.assertFalse(no_resources.has_sources('*.java'))
+
+    resources = self.make_target('resources:some',
+                                 Resources,
+                                 sources=Globs.create_fileset_with_spec('resources', '*.java'))
+    self.assertTrue(resources.has_sources())
+    self.assertFalse(resources.has_sources('*.java'))

--- a/tests/python/pants_test/build_graph/test_target.py
+++ b/tests/python/pants_test/build_graph/test_target.py
@@ -14,7 +14,6 @@ from pants.base.payload import Payload
 from pants.build_graph.address import Address
 from pants.build_graph.target import Target
 from pants.source.wrapped_globs import Globs
-
 from pants_test.base_test import BaseTest
 from pants_test.subsystem.subsystem_util import init_subsystem
 

--- a/tests/python/pants_test/source/test_payload_fields.py
+++ b/tests/python/pants_test/source/test_payload_fields.py
@@ -82,3 +82,16 @@ class PayloadTest(BaseTest):
     self.assertIs(fileset, sf.sources)
     self.assertEqual(['foo/a.txt'], list(sf.source_paths))
     self.assertEqual(['foo/foo/a.txt'], list(sf.relative_to_buildroot()))
+
+  def test_has_sources(self):
+    self.create_file('foo/bar/a.txt', 'a_contents')
+
+    txt_sources = SourcesField(sources=self.sources('foo/bar', 'a.txt'))
+    self.assertTrue(txt_sources.has_sources())
+    self.assertTrue(txt_sources.has_sources('.txt'))
+    self.assertFalse(txt_sources.has_sources('.rs'))
+
+    no_sources = SourcesField(sources=self.sources('foo/bar', '*.rs'))
+    self.assertFalse(no_sources.has_sources())
+    self.assertFalse(no_sources.has_sources('.txt'))
+    self.assertFalse(no_sources.has_sources('.rs'))

--- a/tests/python/pants_test/source/test_payload_fields.py
+++ b/tests/python/pants_test/source/test_payload_fields.py
@@ -82,16 +82,3 @@ class PayloadTest(BaseTest):
     self.assertIs(fileset, sf.sources)
     self.assertEqual(['foo/a.txt'], list(sf.source_paths))
     self.assertEqual(['foo/foo/a.txt'], list(sf.relative_to_buildroot()))
-
-  def test_has_sources(self):
-    self.create_file('foo/bar/a.txt', 'a_contents')
-
-    txt_sources = SourcesField(sources=self.sources('foo/bar', 'a.txt'))
-    self.assertTrue(txt_sources.has_sources())
-    self.assertTrue(txt_sources.has_sources('.txt'))
-    self.assertFalse(txt_sources.has_sources('.rs'))
-
-    no_sources = SourcesField(sources=self.sources('foo/bar', '*.rs'))
-    self.assertFalse(no_sources.has_sources())
-    self.assertFalse(no_sources.has_sources('.txt'))
-    self.assertFalse(no_sources.has_sources('.rs'))


### PR DESCRIPTION
Previously the default implementation failed to handle an extension of `None`
even though it accepted the argument first class. This is fixed with test
coverage added and `Resources` is fixed to delegate to the fixed implementation
after performing its special check.