### PR TITLE
Switch default binary-baseurls to s3

### DIFF
--- a/contrib/node/examples/src/node/preinstalled-project/BUILD
+++ b/contrib/node/examples/src/node/preinstalled-project/BUILD
@@ -3,9 +3,6 @@
 
 node_preinstalled_module(
   sources=globs('package.json', 'src/*.js', 'test/*.js'),
-  # TODO(John Sirois): Update https://github.com/pantsbuild/node-preinstalled-modules to have a
-  # `sync-s3.sh` in place of the current `sync-bintray.sh`.
-  # See: https://github.com/pantsbuild/pants/issues/4800
   dependencies_archive_url=
     'https://s3.amazonaws.com/node-preinstalled-modules.pantsbuild.org/node_modules.tar.gz'
 )

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -55,7 +55,7 @@ class BinaryUtil(object):
     @classmethod
     def register_options(cls, register):
       register('--baseurls', type=list, advanced=True,
-               default=['https://dl.bintray.com/pantsbuild/bin/build-support'],
+               default=['https://s3.amazonaws.com/binaries.pantsbuild.org'],
                help='List of urls from which binary tools are downloaded.  Urls are searched in '
                     'order until the requested path is found.')
       register('--fetch-timeout-secs', type=int, default=30, advanced=True,


### PR DESCRIPTION
### Problem

bintray had already been performing spottily, and recently began rate limiting us.

### Solution

Now that all artifacts have been migrated to s3 (and all repositories that used to push to bintray have been updated) switch the default baseurls to s3.

### Result

@jsirois did a ton of other work to fix this, but as far as I can tell, this finalizes the switch. Fixes #4800.