### PR TITLE
[python-repl] pass env through to repl

### DIFF
--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
+
 from pex.pex_info import PexInfo
 
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
@@ -49,5 +51,6 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
 
   # NB: **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):
-    po = pex.run(blocking=False, **pex_run_kwargs)
+    env = pex_run_kwargs.pop('env', os.environ).copy()
+    po = pex.run(blocking=False, env=env, **pex_run_kwargs)
     po.wait()

--- a/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
@@ -19,7 +19,7 @@ from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.task.repl_task_mixin import ReplTaskMixin
-from pants.util.contextutil import temporary_dir
+from pants.util.contextutil import environment_as, temporary_dir
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
 
@@ -176,6 +176,13 @@ class PythonReplTest(PythonTaskTestBase):
     self.do_test_repl(code=['import java.lang.unreachable'],
                       expected=[''],
                       targets=[self.non_python_target])
+
+  def test_access_to_env(self):
+    with environment_as(SOME_ENV_VAR='twelve'):
+      self.do_test_repl(code=['import os',
+                               'print(os.environ.get("SOME_ENV_VAR"))'],
+                        expected=['twelve'],
+                        targets=[self.library])
 
   def test_ipython(self):
     # IPython supports shelling out with a leading !, so indirectly test its presence by reading


### PR DESCRIPTION
### Problem

The python repl zeros out the environment variables. See https://github.com/pantsbuild/pants/issues/4795

### Solution

Pass a copy of the current environment to the repl pex when it is run.

### Result

The environment is accessible from the repl