### PR TITLE
Kill custom binaries.baseurls.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -301,7 +301,3 @@ materialize: True
 remote: True
 fail_floating: True
 
-[binaries]
-# TODO(John Sirois): Consider making this the default.
-# See: https://github.com/pantsbuild/pants/issues/4800
-baseurls: ['https://s3.amazonaws.com/binaries.pantsbuild.org']


### PR DESCRIPTION
The same baseurls are now hardcoded as the default.