### PR TITLE
Fix the S3 upload in the travis deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -419,6 +419,8 @@ matrix:
 
 deploy:
   # See: https://docs.travis-ci.com/user/deployment/bintray/
+  # TODO: Do we still need to deploy to bintray?  If not we can remove this and also
+  # the code that generates ./native-engine.bintray.json.
   - provider: bintray
     # NB: This is generated in after_success in each shard above.
     file: ./native-engine.bintray.json
@@ -441,16 +443,18 @@ deploy:
     secret_access_key:
       secure: RQVzsNfZL8AgsXdjZ67j2tWs5Tjl/FKpmE1fyVgldMbua/xhW8dzdFrtOeWjTPX4/+sJZ4U7/tZectBtWejmrXUJiZQKJwJBnsyYxysENTWOV80BEYyoz2RPr8HSVbMZ1ZHtUafzO3OqV1x+Pvgpg8FUeUfsy3TGUk0JREO90Q0=
     bucket: binaries.pantsbuild.org
-    local-dir: build-support/bin/native/s3-upload
+    local_dir: build-support/bin/native/s3-upload
+    skip_cleanup: true  # Otherwise travis will stash build-support/bin/native/s3-upload and the deploy will fail.
     acl: public_read
     on:
+      # TODO: Do we need this condition? If so, document why, as it superficially appears to be irrelevant.
       condition: -f ./native-engine.bintray.json
       # NB: Deploys are always tagged as part of the deploy process encoded in
       # `build-support/bin/release.sh`, so this ensures we release an appropriate native engine binary
       # for all releases. Unfortunately, CI only runs after the release tag hits origin and so there
       # will be a lag of roughly 30 minutes until a pypi release has its paired native engine version
-      # available on bintray for OSX and linux. This trade-off (vs releasing for all branch builds),
-      # helps us use bintray in a friendly way.
+      # available on s3 for OSX and linux. This trade-off (vs releasing for all branch builds),
+      # helps us use s3 in a friendly way.
       tags: true
       repo: pantsbuild/pants
 


### PR DESCRIPTION
- Without the `skip_cleanup: true` stanza travis does a
  `git stash --all` before deploying, which removes the
  `build-support/bin/native/s3-upload` dir.
- Also fixed spelling of `local-dir` to `local_dir`. Travis
  apparently normalizes both to the latter, but we may as
  well match what appears in the travis documentation, to
  reduce confusion among future readers.
- Also added some comments/TODOs, for things that weren't
  clear to me as a first-time reader of this code.

Addresses https://github.com/pantsbuild/pants/issues/4811.