### PR TITLE
Fixup erroneous `exc` attribute access.

### DIFF
--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -240,7 +240,7 @@ class LegacyBuildGraph(BuildGraph):
                                                          subjects)
     except ResolveError as e:
       # NB: ResolveError means that a target was not found, which is a common user facing error.
-      raise AddressLookupError(str(e.exc))
+      raise AddressLookupError(str(e))
     except Exception as e:
       raise AddressLookupError(
         'Build graph construction failed: {} {}'.format(type(e).__name__, str(e))


### PR DESCRIPTION
By inspection, a `ResolveError` has no `exc`, only a `Throw` does. This
looks like it was a simple engine refactor ~typo/copypasta miss in
edd039bf.

Fixes #4812