### PR TITLE
Stop dual-publishing the docsite.

### DIFF
--- a/build-support/bin/publish_docs.sh
+++ b/build-support/bin/publish_docs.sh
@@ -86,18 +86,21 @@ continue."
   (
     ${REPO_ROOT}/src/docs/publish_via_git.sh \
       https://github.com/pantsbuild/pantsbuild.github.io.git \
-      ${publish_path} && \
-      ${REPO_ROOT}/src/docs/publish_via_git.sh \
-      https://github.com/benjyw/benjyw.github.io.git \
-      ${publish_path} && \
+      ${publish_path}
     do_open ${url}/index.html
   ) || die "Publish to ${url} failed."
 fi
 
-# Note that we push the docs to two repos: pantsbuild.github.io and benjyw.github.io.
-# The latter is where we redirect www.pantsbuild.org to via CNAME. We can't redirect
-# to the former because then HTTPS won't work (the cert is for pantsbuild.github.io).
-# This way we have working https URLs when needed, but also an http-only version at the
-# more respectable domain of pantsbuild.org.
-# This is a stopgap workaround until we can host the docsite ourselves, under our own
-# SSL cert.
+# Note that we use Cloudflare to enforce:
+#
+# - Flattening the apex domain pantsbuild.org to www.pantsbuild.org
+# - Requiring HTTPS
+# - Directing www.pantsbuild.org traffic via CNAME to pantsbuild.github.io.
+# - Caching www.pantsbuild.org content.
+# - Directing binaries.pantsbuild.org and node-preinstalled-modules.pantsbuild.org
+#   to the appropriate S3 buckets via CNAME.
+
+# Google domains is still our registrar, but we use it only to point to Cloudflare's nameservers.
+
+# See the DNS and Page Rules tabs in our Cloudflare acct, and also the GitHub Pages
+# custom domain setup here:  https://github.com/pantsbuild/pantsbuild.github.io/settings


### PR DESCRIPTION
Document how we now host it, while supporting HTTPS.
