### PR TITLE
Point binary URLs off to CNAMES we own.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -448,7 +448,7 @@ EOM
 # + bootstrap_native_code: Builds target-specific native engine binaries.
 source ${ROOT}/build-support/bin/native/bootstrap.sh
 
-readonly BINARY_BASE_URL=https://s3.amazonaws.com/binaries.pantsbuild.org
+readonly BINARY_BASE_URL=https://binaries.pantsbuild.org
 readonly NATIVE_ENGINE_BASE_URL=${BINARY_BASE_URL}/bin/native-engine
 
 function check_native_engine() {

--- a/contrib/node/examples/src/node/preinstalled-project/BUILD
+++ b/contrib/node/examples/src/node/preinstalled-project/BUILD
@@ -4,7 +4,7 @@
 node_preinstalled_module(
   sources=globs('package.json', 'src/*.js', 'test/*.js'),
   dependencies_archive_url=
-    'https://s3.amazonaws.com/node-preinstalled-modules.pantsbuild.org/node_modules.tar.gz'
+    'https://node-preinstalled-modules.pantsbuild.org/node_modules.tar.gz'
 )
 
 node_test(

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -55,7 +55,7 @@ class BinaryUtil(object):
     @classmethod
     def register_options(cls, register):
       register('--baseurls', type=list, advanced=True,
-               default=['https://s3.amazonaws.com/binaries.pantsbuild.org'],
+               default=['https://binaries.pantsbuild.org'],
                help='List of urls from which binary tools are downloaded.  Urls are searched in '
                     'order until the requested path is found.')
       register('--fetch-timeout-secs', type=int, default=30, advanced=True,


### PR DESCRIPTION
Cloudfare DNS allows us to get away with this now!