### PR TITLE
Use @files for javadoc so it runs with a longer command line

### DIFF
--- a/src/java/org/pantsbuild/tools/jar/JarBuilder.java
+++ b/src/java/org/pantsbuild/tools/jar/JarBuilder.java
@@ -103,14 +103,14 @@ public class JarBuilder implements Closeable {
     }
 
     /**
-     * Returns the duplicate path.
+     * @return the duplicate path.
      */
     public String getPath() {
       return entry.getJarPath();
     }
 
     /**
-     * Returns the contents of the duplicate entry.
+     * @return the contents of duplicate entry
      */
     public ByteSource getSource() {
       return entry.contents;
@@ -182,7 +182,7 @@ public class JarBuilder implements Closeable {
     }
 
     /**
-     * Returns the action that should be applied when a duplicate entry falls under this policy's
+     * @return The action that should be applied when a duplicate entry falls under this policy's
      * jurisdiction.
      */
     public DuplicateAction getAction() {
@@ -212,6 +212,7 @@ public class JarBuilder implements Closeable {
      * Creates a handler that always applies the given {@code action}.
      *
      * @param action The action to perform on all duplicate entries encountered.
+     * @return a handler
      */
     public static DuplicateHandler always(DuplicateAction action) {
       Preconditions.checkNotNull(action);
@@ -224,6 +225,8 @@ public class JarBuilder implements Closeable {
      * <p>
      * Merged resources include META-INF/services/ files.
      * </p>
+     *
+     * @return a handler
      */
     public static DuplicateHandler skipDuplicatesConcatWellKnownMetadata() {
       DuplicatePolicy concatServices =
@@ -238,6 +241,9 @@ public class JarBuilder implements Closeable {
     /**
      * A convenience constructor equivalent to calling:
      * {@code DuplicateHandler(defaultAction, Arrays.asList(policies))}
+     *
+     * @param defaultAction The default action to apply when no policy matches.
+     * @param policies The policies to apply in preference order.
      */
     public DuplicateHandler(DuplicateAction defaultAction, DuplicatePolicy... policies) {
       this(defaultAction, ImmutableList.copyOf(policies));
@@ -272,12 +278,15 @@ public class JarBuilder implements Closeable {
   public interface Source {
 
     /**
-     * Returns a name for this source.
+     * @return a name for this source.
      */
     String name();
 
     /**
      * Identifies a member of this source.
+     *
+     * @param name The name of the source
+     * @return identity
      */
     String identify(String name);
   }
@@ -437,17 +446,17 @@ public class JarBuilder implements Closeable {
    */
   public interface Entry {
     /**
-     * Returns the source that contains the entry.
+     * @return the source that contains the entry.
      */
     Source getSource();
 
     /**
-     * Returns the name of the entry within its source.
+     * @return the name of the entry within its source.
      */
     String getName();
 
     /**
-     * Returns the path this entry will be added into the jar at.
+     * @return the path this entry will be added into the jar at.
      */
     String getJarPath();
   }
@@ -668,6 +677,7 @@ public class JarBuilder implements Closeable {
    * If the {@code target} does not exist a new jar will be created at its path.
    *
    * @param target The target jar file to write.
+   * @param listener A progress listener
    */
   public JarBuilder(File target, Listener listener) {
     this.target = Preconditions.checkNotNull(target);

--- a/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
+++ b/src/python/pants/backend/jvm/tasks/jvmdoc_gen.py
@@ -9,12 +9,14 @@ import collections
 import contextlib
 import multiprocessing
 import os
+import re
 import subprocess
 
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.base.exceptions import TaskError
 from pants.util import desktop
 from pants.util.dirutil import safe_mkdir, safe_walk
+from pants.util.memo import memoized_property
 
 
 Jvmdoc = collections.namedtuple('Jvmdoc', ['tool_name', 'product_type'])
@@ -54,6 +56,9 @@ class JvmdocGen(JvmTask):
              fingerprint=True,
              help='Do not consider {0} errors to be build errors.'.format(tool_name))
 
+    register('--exclude-patterns', type=list, default=[], fingerprint=True,
+             help='Patterns for targets to be excluded from doc generation.')
+
     # TODO(John Sirois): This supports the JarPublish task and is an abstraction leak.
     # It allows folks doing a local-publish to skip an expensive and un-needed step.
     # Remove this flag and instead support conditional requirements being registered against
@@ -78,6 +83,10 @@ class JvmdocGen(JvmTask):
     self.ignore_failure = options.ignore_failure
     self.skip = options.skip
 
+  @memoized_property
+  def _exclude_patterns(self):
+    return [re.compile(x) for x in set(self.get_options().exclude_patterns or [])]
+
   def generate_doc(self, language_predicate, create_jvmdoc_command):
     """
     Generate an execute method given a language predicate and command to create documentation
@@ -95,8 +104,19 @@ class JvmdocGen(JvmTask):
       raise TaskError(
           'Cannot provide {} target mappings for combined output'.format(self.jvmdoc().product_type))
 
-    def docable(tgt):
-      return language_predicate(tgt) and (self._include_codegen or not tgt.is_synthetic)
+    def docable(target):
+      if not language_predicate(target):
+        self.context.log.debug('Skipping [{}] because it is does not pass the language predicate'.format(target.address.spec))
+        return False
+      if not self._include_codegen and target.is_synthetic:
+        self.context.log.debug('Skipping [{}] because it is a synthetic target'.format(target.address.spec))
+        return False
+      for pattern in self._exclude_patterns:
+        if pattern.search(target.address.spec):
+          self.context.log.debug(
+            "Skipping [{}] because it matches exclude pattern '{}'".format(target.address.spec, pattern.pattern))
+          return False
+      return True
 
     targets = self.context.targets(predicate=docable)
     if not targets:
@@ -185,9 +205,9 @@ class JvmdocGen(JvmTask):
 
   def _handle_create_jvmdoc_result(self, targets, result, command):
     if result != 0:
-      targetlist = ", ".join(map(str, targets))
+      targetlist = ", ".join(map(lambda target: target.address.spec, targets))
       message = 'Failed to process {} for {} [{}]: {}'.format(
-                self.jvmdoc().tool_name, targetlist, result, command)
+                self.jvmdoc().tool_name, targetlist, result, " ".join(command))
       if self.ignore_failure:
         self.context.log.warn(message)
       else:


### PR DESCRIPTION

### Problem

With very large runs of javadoc it would fail when the classpath or argument list was too long.  There was also no way to exclude specific targets from doc generation

### Solution

Use @files for the javadoc classpath and argument list and add an exclude patterns option

### Result

You should now be able to run javadoc against larger file sets and exclude targets on an individual basis.