### PR TITLE
Upgrade pex to latest.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -12,7 +12,7 @@ mock==2.0.0
 packaging==16.8
 pathspec==0.5.0
 pep8==1.6.2
-pex==1.2.8
+pex==1.2.11
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4


### PR DESCRIPTION
This brings in support for using subprocess32 when available which
Pants will leverage to provide robust test timeouts for one.