### PR TITLE
Migrate BinaryUtil options to bootstrap options.

### DIFF
--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -50,6 +50,9 @@ class BinaryUtil(object):
     """
     :API: public
     """
+    # N.B. `BinaryUtil` sources all of its options from bootstrap options, so that
+    # `BinaryUtil` instances can be created prior to `Subsystem` bootstrapping. So
+    # this options scope is unused, but required to remain a `Subsystem`.
     options_scope = 'binaries'
 
     @classmethod

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -53,27 +53,18 @@ class BinaryUtil(object):
     options_scope = 'binaries'
 
     @classmethod
-    def register_options(cls, register):
-      register('--baseurls', type=list, advanced=True,
-               default=['https://binaries.pantsbuild.org'],
-               help='List of urls from which binary tools are downloaded.  Urls are searched in '
-                    'order until the requested path is found.')
-      register('--fetch-timeout-secs', type=int, default=30, advanced=True,
-               help='Timeout in seconds for url reads when fetching binary tools from the '
-                    'repos specified by --baseurls')
-      register('--path-by-id', type=dict, advanced=True,
-               help='Maps output of uname for a machine to a binary search path.  e.g. '
-               '{ ("darwin", "15"): ["mac", "10.11"]), ("linux", "arm32"): ["linux", "arm32"] }')
-
-    @classmethod
     def create(cls):
       """
       :API: public
       """
       # NB: create is a class method to ~force binary fetch location to be global.
       options = cls.global_instance().get_options()
-      return BinaryUtil(options.baseurls, options.fetch_timeout_secs, options.pants_bootstrapdir,
-                        options.path_by_id)
+      return BinaryUtil(
+        options.binaries_baseurls,
+        options.binaries_fetch_timeout_secs,
+        options.pants_bootstrapdir,
+        options.binaries_path_by_id
+      )
 
   class MissingMachineInfo(TaskError):
     """Indicates that pants was unable to map this machine's OS to a binary path prefix."""

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -145,6 +145,18 @@ class GlobalOptionsRegistrar(Optionable):
              help='A directory to write execution and rule graphs to as `dot` files. The contents '
                   'of the directory will be overwritten if any filenames collide.')
 
+    # BinaryUtil options.
+    register('--binaries-baseurls', type=list, advanced=True,
+             default=['https://binaries.pantsbuild.org'],
+             help='List of URLs from which binary tools are downloaded. URLs are searched in '
+                  'order until the requested path is found.')
+    register('--binaries-fetch-timeout-secs', type=int, default=30, advanced=True,
+             help='Timeout in seconds for URL reads when fetching binary tools from the '
+                  'repos specified by --baseurls.')
+    register('--binaries-path-by-id', type=dict, advanced=True,
+             help=('Maps output of uname for a machine to a binary search path. e.g. '
+             '{("darwin", "15"): ["mac", "10.11"]), ("linux", "arm32"): ["linux", "arm32"]}'))
+
   @classmethod
   def register_options(cls, register):
     """Register options not tied to any particular task or subsystem."""


### PR DESCRIPTION
### Problem

In order to fully externalize pantsd lifecycle, we need to untangle pantsd's reliance on `Subsystem` dependencies and their options. This is an initial step in that direction.

### Solution

Migrate `BinaryUtil` options to bootstrap options.

### Result

Able to leverage `BinaryUtil` before subsystems are setup by directly calling `BinaryUtil.__init__` with global options.