### PR TITLE
[pantsd] Improve locking.

### DIFF
--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -94,7 +94,7 @@ class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'symbol_ta
     logger.debug('target_roots are: %r', target_roots)
     graph = LegacyBuildGraph.create(self.scheduler, self.symbol_table_cls)
     logger.debug('build_graph is: %s', graph)
-    with self.scheduler.locked():
+    with self.scheduler.lock:
       # Ensure the entire generator is unrolled.
       for _ in graph.inject_specs_closure(target_roots.as_specs()):
         pass

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -10,7 +10,6 @@ import os
 import threading
 import time
 from collections import defaultdict
-from contextlib import contextmanager
 
 from pants.base.exceptions import TaskError
 from pants.base.project_tree import Dir, File, Link

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -86,30 +86,30 @@ class WrappedNativeScheduler(object):
     self._register_rules(rule_index)
 
     self._scheduler = native.new_scheduler(
-        self._tasks,
-        self._root_subject_types,
-        build_root,
-        work_dir,
-        ignore_patterns,
-        Snapshot,
-        _Snapshots,
-        FileContent,
-        FilesContent,
-        Path,
-        Dir,
-        File,
-        Link,
-        has_products_constraint,
-        constraint_for(Address),
-        constraint_for(Variants),
-        constraint_for(PathGlobs),
-        constraint_for(Snapshot),
-        constraint_for(_Snapshots),
-        constraint_for(FilesContent),
-        constraint_for(Dir),
-        constraint_for(File),
-        constraint_for(Link),
-      )
+      self._tasks,
+      self._root_subject_types,
+      build_root,
+      work_dir,
+      ignore_patterns,
+      Snapshot,
+      _Snapshots,
+      FileContent,
+      FilesContent,
+      Path,
+      Dir,
+      File,
+      Link,
+      has_products_constraint,
+      constraint_for(Address),
+      constraint_for(Variants),
+      constraint_for(PathGlobs),
+      constraint_for(Snapshot),
+      constraint_for(_Snapshots),
+      constraint_for(FilesContent),
+      constraint_for(Dir),
+      constraint_for(File),
+      constraint_for(Link),
+    )
 
   def _root_type_ids(self):
     return self._to_ids_buf(sorted(self._root_subject_types))
@@ -350,6 +350,10 @@ class LocalScheduler(object):
 
     self._scheduler.assert_ruleset_valid()
 
+  @property
+  def lock(self):
+    return self._product_graph_lock
+
   def trace(self):
     """Yields a stringified 'stacktrace' starting from the scheduler's roots."""
     with self._product_graph_lock:
@@ -399,11 +403,6 @@ class LocalScheduler(object):
     :returns: An ExecutionRequest for the given products and subjects.
     """
     return ExecutionRequest(tuple((s, p) for s in subjects for p in products))
-
-  @contextmanager
-  def locked(self):
-    with self._product_graph_lock:
-      yield
 
   def root_entries(self, execution_request):
     """Returns the roots for the given ExecutionRequest as a list of tuples of:

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -132,7 +132,7 @@ class PailgunServer(TCPServer):
 
     try:
       # Attempt to handle a request with the handler under the context_lock.
-      with self._context_lock():
+      with self._context_lock:
         handler.handle_request()
     except Exception as e:
       # If that fails, (synchronously) handle the error with the error handler sans-fork.

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -132,7 +132,7 @@ class PailgunServer(TCPServer):
 
     try:
       # Attempt to handle a request with the handler under the context_lock.
-      with self._context_lock:
+      with self._context_lock():
         handler.handle_request()
     except Exception as e:
       # If that fails, (synchronously) handle the error with the error handler sans-fork.

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -40,7 +40,8 @@ class FSEventService(PantsService):
     self._executor = None
     self._handlers = {}
 
-  def setup(self, executor=None):
+  def setup(self, lock, executor=None):
+    super(FSEventService, self).setup(lock)
     self._executor = executor or ThreadPoolExecutor(max_workers=self._worker_count)
 
   def terminate(self):

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -97,8 +97,7 @@ class FSEventService(PantsService):
 
   def fire_callback(self, handler_name, event_data):
     """Fire an event callback for a given handler."""
-    with self.lock:
-      return self._handlers[handler_name].callback(event_data)
+    return self._handlers[handler_name].callback(event_data)
 
   def run(self):
     """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -97,7 +97,8 @@ class FSEventService(PantsService):
 
   def fire_callback(self, handler_name, event_data):
     """Fire an event callback for a given handler."""
-    return self._handlers[handler_name].callback(event_data)
+    with self.lock:
+      return self._handlers[handler_name].callback(event_data)
 
   def run(self):
     """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -77,19 +77,7 @@ class PailgunService(PantsService):
 
       return self._runner_class(sock, exiter, arguments, environment, graph_helper, deferred_exc)
 
-    @contextmanager
-    def context_lock():
-      """This lock is used to safeguard Pailgun request handling against a fork() with the
-      scheduler lock held by another thread (e.g. the FSEventService thread), which can
-      lead to a pailgun deadlock.
-      """
-      if self._scheduler_service:
-        with self._scheduler_service.locked():
-          yield
-      else:
-        yield
-
-    return PailgunServer(self._bind_addr, runner_factory, context_lock)
+    return PailgunServer(self._bind_addr, runner_factory, self.locked)
 
   def run(self):
     """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -9,7 +9,6 @@ import logging
 import select
 import sys
 import traceback
-from contextlib import contextmanager
 
 from pants.pantsd.pailgun_server import PailgunServer
 from pants.pantsd.service.pants_service import PantsService

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import threading
 from abc import abstractmethod
-from contextlib import contextmanager
 
 from pants.util.meta import AbstractClass
 

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -21,7 +21,6 @@ class PantsService(AbstractClass):
     super(PantsService, self).__init__()
     self.name = self.__class__.__name__
     self._kill_switch = threading.Event()
-    self._lock = None
 
   @property
   def is_killed(self):
@@ -41,7 +40,7 @@ class PantsService(AbstractClass):
 
     :param threading.Lock lock: A global service<->service lock for guarding critical work.
     """
-    self._lock = lock
+    self.lock = lock
 
   @abstractmethod
   def run(self):
@@ -50,9 +49,3 @@ class PantsService(AbstractClass):
   def terminate(self):
     """Called upon service teardown."""
     self._kill_switch.set()
-
-  @contextmanager
-  def locked(self):
-    """A contextmanager for executing critical sections in the daemon."""
-    with self._lock:
-      yield

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -35,11 +35,6 @@ class SchedulerService(PantsService):
     self._event_queue = Queue.Queue(maxsize=64)
 
   @property
-  def locked(self):
-    """Surfaces the scheduler's `locked` method as part of the service's public API."""
-    return self._scheduler.locked
-
-  @property
   def change_calculator(self):
     """Surfaces the change calculator."""
     return self._graph_helper.change_calculator
@@ -48,8 +43,9 @@ class SchedulerService(PantsService):
     """Pre-fork controls."""
     self._scheduler.pre_fork()
 
-  def setup(self):
+  def setup(self, lock):
     """Service setup."""
+    super(SchedulerService, self).setup(lock)
     # Register filesystem event handlers on an FSEventService instance.
     self._fs_event_service.register_all_files_handler(self._enqueue_fs_event)
 

--- a/tests/python/pants_test/init/test_pants_daemon_launcher.py
+++ b/tests/python/pants_test/init/test_pants_daemon_launcher.py
@@ -15,7 +15,7 @@ from pants_test.subsystem.subsystem_util import global_subsystem_instance
 
 
 class PantsDaemonLauncherTest(BaseTest):
-  PDL_PATCH_OPTS = dict(autospec=True, spec_set=True, return_value=(None, None))
+  PDL_PATCH_OPTS = dict(autospec=True, spec_set=True, return_value=(None, None, None))
 
   def pants_daemon_launcher(self):
     factory = global_subsystem_instance(PantsDaemonLauncher.Factory)

--- a/tests/python/pants_test/pantsd/service/test_fs_event_service.py
+++ b/tests/python/pants_test/pantsd/service/test_fs_event_service.py
@@ -37,7 +37,7 @@ class TestFSEventService(BaseTest):
     BaseTest.setUp(self)
     self.mock_watchman = mock.create_autospec(Watchman, spec_set=True)
     self.service = FSEventService(self.mock_watchman, self.BUILD_ROOT, self.WORKER_COUNT)
-    self.service.setup(TestExecutor())
+    self.service.setup(None, executor=TestExecutor())
     self.service.register_all_files_handler(lambda x: True, name='test')
     self.service.register_all_files_handler(lambda x: False, name='test2')
 


### PR DESCRIPTION
### Problem

Currently, the daemon relies on a `locked` contextmanager threaded through via the scheduler service for guarding critical sections around pailgun forking. This does not make an affordance for e.g. locking around filesystem event processing or other scenarios.

### Solution

Thread a daemon-global lock and helper method to `PantsService` and it's progeny for easier intra-daemon locking scenarios. Wrap some critical sections with it.

### Result

Better locking with less race conditions.