### PR TITLE
[pantsd] Bump watchman to v4.9.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -20,7 +20,7 @@ pyopenssl==17.1.0
 pystache==0.5.3
 pytest-cov>=2.4,<2.5
 pytest>=3.0.7,<4.0
-pywatchman==1.3.0
+pywatchman==1.4.1
 requests[security]==2.5.0,<2.19
 scandir==1.2
 setproctitle==1.1.10

--- a/src/python/pants/pantsd/subsystem/watchman_launcher.py
+++ b/src/python/pants/pantsd/subsystem/watchman_launcher.py
@@ -26,7 +26,7 @@ class WatchmanLauncher(object):
 
     @classmethod
     def register_options(cls, register):
-      register('--version', advanced=True, default='4.5.0',
+      register('--version', advanced=True, default='4.9.0',
                help='Watchman version.')
       register('--supportdir', advanced=True, default='bin/watchman',
                help='Find watchman binaries under this dir. Used as part of the path to lookup '


### PR DESCRIPTION
### Problem

The watchman version we're using is outdated.

### Solution

Upgrade to the latest watchman version!

### Result

Realize a handful of bugfixes, performance improvements and memory utilization fixes (e.g. a purported 40% memory reduction in 4.7.0) per the watchman release notes [here](https://facebook.github.io/watchman/docs/release-notes.html).