### PR TITLE
Repair `BinaryNotFound` due to `sslv3 alert handshake failure`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -123,7 +123,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -151,7 +151,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -179,7 +179,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -207,7 +207,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -235,7 +235,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -263,7 +263,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -291,7 +291,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -319,7 +319,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -347,7 +347,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -375,7 +375,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -403,7 +403,7 @@ matrix:
             - gcc-multilib
             - python-dev
             - openssl
-            - openssl-dev
+            - libssl-dev
       language: python
       python: "2.7.13"
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       # Docker runs will write files as root, so avoid caching for this shard.
       cache: false
@@ -86,7 +85,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -96,6 +94,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -113,7 +113,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -123,6 +122,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -140,7 +141,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -150,6 +150,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -167,7 +169,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -177,6 +178,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -194,7 +197,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -204,6 +206,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -221,7 +225,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -231,6 +234,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -248,7 +253,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -258,6 +262,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -275,7 +281,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -285,6 +290,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -302,7 +309,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -312,6 +318,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -329,7 +337,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -339,6 +346,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -356,7 +365,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -366,6 +374,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:
@@ -383,7 +393,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -393,6 +402,8 @@ matrix:
             - lib32z1-dev
             - gcc-multilib
             - python-dev
+            - openssl
+            - openssl-dev
       language: python
       python: "2.7.13"
       before_install:

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -20,7 +20,7 @@ pystache==0.5.3
 pytest-cov>=2.4,<2.5
 pytest>=3.0.7,<4.0
 pywatchman==1.3.0
-requests>=2.5.0,<2.6
+requests[security]>=2.5.0,<2.19
 scandir==1.2
 setproctitle==1.1.10
 setuptools==30.0.0

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,6 +1,6 @@
 ansicolors==1.0.2
 beautifulsoup4>=4.3.2,<4.4
-cffi==1.7.0
+cffi==1.10.0
 coverage>=4.3.4,<4.4
 docutils>=0.12,<0.13
 fasteners==0.14.1


### PR DESCRIPTION
### Problem

The build recently started failing with SSL errors like:

```
BinaryNotFound: Failed to fetch binary scripts/cloc/1.66/cloc from any source: (Failed to fetch binary from https://binaries.pantsbuild.org/scripts/cloc/1.66/cloc: Problem GETing data from https://binaries.pantsbuild.org/scripts/cloc/1.66/cloc: [Errno 1] _ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure)
```

when retrieving artifacts via `BinaryUtil`.

### Solution

- Bump the `requests` version range to permit the latest version (noting no apparent mention of `API Changes` between current minimal to pypi current based on the changelog [here](https://github.com/requests/requests/blob/master/HISTORY.rst)).
- Use the `requests[security]` extra to include a superior/modernized set of underlying SSL libraries (see [here](https://github.com/requests/requests/issues/2022) for more info).
- Bump the `cffi` version to include a fix for a cryptography build/cffi issue seen [here](https://travis-ci.org/pantsbuild/pants/jobs/273118313#L5304).
- Add `openssl` and `libssl-dev` to Travis shards to support SSL related builds.
- Drop our reliance on the (now 2 versions) old Travis CI image based on observations in #4852, which presumably nets us a transitively better OpenSSL version via apt.

### Result

Closes #4852