### PR TITLE
Downgrade to vanilla requests.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -20,7 +20,7 @@ pystache==0.5.3
 pytest-cov>=2.4,<2.5
 pytest>=3.0.7,<4.0
 pywatchman==1.3.0
-requests[security]>=2.5.0,<2.19
+requests==2.5.0,<2.19
 scandir==1.2
 setproctitle==1.1.10
 setuptools==30.0.0


### PR DESCRIPTION
requests[security] has a dependency on pyopenssl, which is currently
triggering a depreaction due to an OpenSSL.rand call.

pyopenssl has fixed this issue in code, but is waiting for a maintainer
to return from vacation and cut a release.

In the meantime, the release cannot be completed with the current
dep due to the non-zero it raises.
```
      site-packages/urllib3/contrib/pyopenssl.py:46: DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead
  import OpenSSL.SSL
      **** Failed to install cryptography-2.0.3 (caused by: NonZeroExit("received exit code 1 during execution of
```

The redent upgrade to `requests[security]` was a CI-fix for ssl handshaking, and since the CI is currently having its own issues, I figured we could unlock the release while we wait.

If this commit lands, it should be short-term and be undone once the
pyopenssl can be released.

References: #4856
