### PR TITLE
Error on task name reuse for a particular goal

### DIFF
--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -141,6 +141,11 @@ class _Goal(object):
       raise GoalError('Can only specify one of first, replace, before or after')
 
     task_name = task_registrar.name
+    if task_name in self._task_type_by_name:
+      raise GoalError(
+        'Can only specify a task name once per goal, saw multiple values for {} in goal {}'.format(
+          task_name,
+          self.name))
     Optionable.validate_scope_name_component(task_name)
     options_scope = Goal.scope(self.name, task_name)
 


### PR DESCRIPTION
We use name as a unique key in the engine, so if you register the same
name more than once only one of the tasks will actually be called, and
the others silently ignored.