### PR TITLE
Re-add requests[security] and pin pyOpenSSL==17.1.0 to avoid deprecat…

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,11 +16,12 @@ pex==1.2.11
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4
+pyopenssl==17.1.0
 pystache==0.5.3
 pytest-cov>=2.4,<2.5
 pytest>=3.0.7,<4.0
 pywatchman==1.3.0
-requests==2.5.0,<2.19
+requests[security]==2.5.0,<2.19
 scandir==1.2
 setproctitle==1.1.10
 setuptools==30.0.0

--- a/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies=[
     '3rdparty/python:requests',
+    '3rdparty/python:pyopenssl',
     '3rdparty/python:six',
     'contrib/go/src/python/pants/contrib/go/targets',
     'src/python/pants/base:workunit',

--- a/src/python/pants/cache/BUILD
+++ b/src/python/pants/cache/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies = [
     '3rdparty/python:requests',
+    '3rdparty/python:pyopenssl',
     '3rdparty/python:six',
     'src/python/pants/base:deprecated',
     'src/python/pants/base:validation',

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -77,6 +77,7 @@ python_library(
     ':aggregated_timings',
     ':artifact_cache_stats',
     '3rdparty/python:requests',
+    '3rdparty/python:pyopenssl',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:run_info',
     'src/python/pants/base:worker_pool',

--- a/src/python/pants/net/BUILD
+++ b/src/python/pants/net/BUILD
@@ -5,6 +5,7 @@ python_library(
   sources = rglobs('*.py'),
   dependencies = [
     '3rdparty/python:requests',
+    '3rdparty/python:pyopenssl',
     '3rdparty/python:six',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:meta',

--- a/tests/python/pants_test/net/http/BUILD
+++ b/tests/python/pants_test/net/http/BUILD
@@ -5,6 +5,7 @@ python_tests(
   dependencies = [
     '3rdparty/python:mock',
     '3rdparty/python:requests',
+    '3rdparty/python:pyopenssl',
     '3rdparty/python:six',
     'src/python/pants/net',
     'src/python/pants/util:contextutil',


### PR DESCRIPTION
…ion warning.

### Problem

Master is currently broken with SSLv3 issues on binary fetches - fixed once in #4853, then reverted in #4858. #4858 passed CI with a populated cache, but once cleared and re-run revealed the breakage was still there.

### Solution

Re-apply `requests[security]` and pin `pyOpenSSL` to an older version that doesn't throw the deprecation warning.

### Result

No deprecation warnings locally.