### PR TITLE
Remove python 2.6 support completely.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       # Docker runs will write files as root, so avoid caching for this shard.
       cache: false
@@ -86,7 +85,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -115,7 +113,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -144,7 +141,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -173,7 +169,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -202,7 +197,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -231,7 +225,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -260,7 +253,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -289,7 +281,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -318,7 +309,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -347,7 +337,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -376,7 +365,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:
@@ -405,7 +393,6 @@ matrix:
 
     - os: linux
       dist: trusty
-      group: deprecated-2017Q2
       sudo: required
       addons:
         apt:

--- a/examples/src/python/example/README.md
+++ b/examples/src/python/example/README.md
@@ -135,14 +135,17 @@ Use `test` to run the tests. This uses `pytest`:
     13:29:29 00:01     [pytest]
     13:29:29 00:01       [run]
                          ============== test session starts ===============
-                         platform darwin -- Python 2.6.8 -- py-1.4.20 -- pytest-2.5.2
-                         plugins: cov, timeout
+                         platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
+                         rootdir: /home/jsirois, inifile:
+                         plugins: cov-2.4.0, timeout-1.2.0
                          collected 2 items
 
-                         examples/tests/python/example_test/hello/greet/test_greet.py ..
+                         .pants.d/pyprep/sources/48bd113ee4f5fa26f55357fbd9bb6d31382241fa/example_test/hello/greet/test_greet.py ..
 
-                         ============ 1 passed in 0.02 seconds ============
+                          generated xml file: /home/jsirois/dev/pantsbuild/jsirois-pants2/.pants.d/test/pytest/examples.tests.python.example_test.hello.greet.greet/junitxml/TEST-examples.tests.python.example_test.hello.greet.greet.xml 
+                         ============ 2 passed in 0.01 seconds ============
 
+                       examples.tests.python.example_test.hello.greet.greet                            .....   SUCCESS
     13:30:18 00:50     [junit]
     13:30:18 00:50     [specs]
                    SUCCESS
@@ -279,16 +282,19 @@ Pants runs Python tests with `pytest`. You can pass CLI options to `pytest` with
 you could run:
 
     :::bash
-    $ ./pants test.pytest --options='-k req' examples/tests/python/example_test/hello/greet
+    $ ./pants test.pytest --options='-k foo' examples/tests/python/example_test/hello/greet
     ...
                      ============== test session starts ===============
-                     platform darwin -- Python 2.6.8 -- py-1.4.20 -- pytest-2.5.2
-                     plugins: cov, timeout
+                     platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
+                     rootdir: /home/jsirois, inifile:
+                     plugins: cov-2.4.0, timeout-1.2.0
                      collected 2 items
 
-                     ========= 2 tests deselected by '-kfoo' ==========
+                      generated xml file: /home/jsirois/dev/pantsbuild/jsirois-pants2/.pants.d/test/pytest/examples.tests.python.example_test.hello.greet.greet/junitxml/TEST-examples.tests.python.example_test.hello.greet.greet.xml 
+                     =============== 2 tests deselected ===============
                      ========== 2 deselected in 0.01 seconds ==========
 
+                   examples.tests.python.example_test.hello.greet.greet                            .....   SUCCESS
     13:34:28 00:02     [junit]
     13:34:28 00:02     [specs]
                SUCCESS
@@ -305,16 +311,19 @@ parameters:
     10:43:04 00:01       [prep_command]
     10:43:04 00:01     [pytest]
     10:43:04 00:01       [run]
-                         ============== test session starts ===============
-                         platform darwin -- Python 2.7.5 -- py-1.4.26 -- pytest-2.6.4
-                         plugins: cov, timeout
-                         collected 2 items
+                     ============== test session starts ===============
+                     platform linux2 -- Python 2.7.12, pytest-3.0.7, py-1.4.32, pluggy-0.4.0
+                     rootdir: /home/jsirois, inifile:
+                     plugins: cov-2.4.0, timeout-1.2.0
+                     collected 2 items
 
-                         examples/tests/python/example_test/hello/greet/test_greet.py .
+                     .pants.d/pyprep/sources/48bd113ee4f5fa26f55357fbd9bb6d31382241fa/example_test/hello/greet/test_greet.py .
 
-                         ========= 1 tests deselected by '-kreq' ==========
-                         ===== 1 passed, 1 deselected in 0.05 seconds =====
+                      generated xml file: /home/jsirois/dev/pantsbuild/jsirois-pants2/.pants.d/test/pytest/examples.tests.python.example_test.hello.greet.greet/junitxml/TEST-examples.tests.python.example_test.hello.greet.greet.xml 
+                     =============== 1 tests deselected ===============
+                     ===== 1 passed, 1 deselected in 0.01 seconds =====
 
+                   examples.tests.python.example_test.hello.greet.greet                            .....   SUCCESS
     10:43:05 00:02     [junit]
     10:43:05 00:02     [specs]
                    SUCCESS

--- a/src/python/pants/backend/project_info/tasks/templates/eclipse/pydevproject-3.7.mustache
+++ b/src/python/pants/backend/project_info/tasks/templates/eclipse/pydevproject-3.7.mustache
@@ -10,7 +10,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 <pydev_project>
   {{! TODO(John Sirois): support python project setups with interpreter of choice.}}
   <pydev_property name="org.python.pydev.PYTHON_PROJECT_INTERPRETER">Default</pydev_property>
-  <pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.6</pydev_property>
+  <pydev_property name="org.python.pydev.PYTHON_PROJECT_VERSION">python 2.7</pydev_property>
   <pydev_pathproperty name="org.python.pydev.PROJECT_SOURCE_PATH">
     {{#project.pythonpaths}}
       {{#includes?}}

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -34,7 +34,7 @@ class PythonSetup(Subsystem):
     register('--interpreter-constraints', advanced=True, default=[], type=list,
              metavar='<requirement>',
              help="Constrain the selected Python interpreter.  Specify with requirement syntax, "
-                  "e.g. 'CPython>=2.6,<3' or 'PyPy'. Multiple constraints will be ORed together. "
+                  "e.g. 'CPython>=2.7,<3' or 'PyPy'. Multiple constraints will be ORed together. "
                   "These constraints are applied in addition to any compatibilities required by "
                   "the relevant targets.")
     register('--setuptools-version', advanced=True, default='30.0.0',

--- a/src/python/pants/backend/python/tasks/setup_py.py
+++ b/src/python/pants/backend/python/tasks/setup_py.py
@@ -551,9 +551,9 @@ class SetupPy(PythonTask):
     # pprint.pformat embeds u's in the string itself during conversion.
     # For that reason we convert each unicode string independently.
     #
-    # hoth:~ travis$ python
-    # Python 2.6.8 (unknown, Aug 25 2013, 00:04:29)
-    # [GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)] on darwin
+    # jsirois@gill ~ $ python2
+    # Python 2.7.13 (default, Jul 21 2017, 03:24:34)
+    # [GCC 7.1.1 20170630] on linux2
     # Type "help", "copyright", "credits" or "license" for more information.
     # >>> import pprint
     # >>> data = {u'entry_points': {u'console_scripts': [u'pants = pants.bin.pants_exe:main']}}

--- a/src/python/pants/backend/python/tasks2/setup_py.py
+++ b/src/python/pants/backend/python/tasks2/setup_py.py
@@ -544,9 +544,9 @@ class SetupPy(Task):
     # pprint.pformat embeds u's in the string itself during conversion.
     # For that reason we convert each unicode string independently.
     #
-    # hoth:~ travis$ python
-    # Python 2.6.8 (unknown, Aug 25 2013, 00:04:29)
-    # [GCC 4.2.1 Compatible Apple LLVM 5.0 (clang-500.0.68)] on darwin
+    # jsirois@gill ~ $ python2
+    # Python 2.7.13 (default, Jul 21 2017, 03:24:34)
+    # [GCC 7.1.1 20170630] on linux2
     # Type "help", "copyright", "credits" or "license" for more information.
     # >>> import pprint
     # >>> data = {u'entry_points': {u'console_scripts': [u'pants = pants.bin.pants_exe:main']}}

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -90,13 +90,8 @@ class ZipArchiver(Archiver):
         # While we're at it, we also perform this safety test.
         if name.startswith(b'/') or name.startswith(b'..'):
           raise ValueError('Zip file contains unsafe path: {}'.format(name))
-        # Ignore directories. extract() will create parent dirs as needed.
-        # OS X's python 2.6.1 has a bug in zipfile that makes it unzip directories as regular files.
-        # This method should work on for python 2.6-3.x.
-        # TODO(Eric Ayers) Pants no longer builds with python 2.6. Can this be removed?
-        if not name.endswith(b'/'):
-          if (not filter_func or filter_func(name)):
-            archive_file.extract(name, outdir)
+        if (not filter_func or filter_func(name)):
+          archive_file.extract(name, outdir)
 
   def __init__(self, compression, extension):
     """

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -184,7 +184,7 @@ class GlobalOptionsRegistrar(Optionable):
              removal_version='1.5.0.dev0',
              removal_hint='Use --interpreter-constraints in scope python-setup instead.',
              help="Constrain what Python interpreters to use.  Uses Requirement format from "
-                  "pkg_resources, e.g. 'CPython>=2.6,<3' or 'PyPy'. By default, no constraints "
+                  "pkg_resources, e.g. 'CPython>=2.7,<3' or 'PyPy'. By default, no constraints "
                   "are used.  Multiple constraints may be added.  They will be ORed together.")
     register('--exclude-target-regexp', advanced=True, type=list, default=[],
              metavar='<regexp>',

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -31,7 +31,7 @@ def environment_as(**kwargs):
   """Update the environment to the supplied values, for example:
 
   with environment_as(PYTHONPATH='foo:bar:baz',
-                      PYTHON='/usr/bin/python2.6'):
+                      PYTHON='/usr/bin/python2.7'):
     subprocess.Popen(foo).wait()
   """
   new_environment = kwargs

--- a/testprojects/src/python/interpreter_selection/BUILD
+++ b/testprojects/src/python/interpreter_selection/BUILD
@@ -9,16 +9,16 @@ python_library(
   sources = ['echo_interpreter_version.py'],
   dependencies = [],
   # Play with this to test interpreter selection in the pex machinery.
-  compatibility = ['CPython>=2.6,<3']
+  compatibility = ['CPython>=2.7,<3', 'CPython>=3.3']
 )
 
 python_binary(
-  name = 'echo_interpreter_version_2.6',
+  name = 'echo_interpreter_version_3',
   dependencies = [
     ':echo_interpreter_version_lib',
   ],
   entry_point = 'interpreter_selection.echo_interpreter_version',
-  compatibility = ['CPython>=2.6,<2.7']
+  compatibility = ['CPython>=3.3']
 )
 
 python_binary(
@@ -46,14 +46,14 @@ python_binary(
     ':echo_interpreter_version_lib',
   ],
   entry_point = 'interpreter_selection.echo_interpreter_version',
-  compatibility = ['CPython<2.6']
+  compatibility = ['CPython<2.7']
 )
 
 python_library(
   name = 'die_lib',
   sources = ['die.py'],
   dependencies = [],
-  compatibility = ['CPython>=2.6,<3']
+  compatibility = ['CPython>=2.7,<3']
 )
 
 python_binary(

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -27,7 +27,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           'test',
           'examples/tests/java/org/pantsbuild/example/hello/greet',
           'examples/tests/scala/org/pantsbuild/example/hello/welcome',
-          '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+          '--python-setup-interpreter-constraints=CPython>=2.7,<3',
           '--python-setup-interpreter-constraints=CPython>=3.3'],
           workdir)
       self.assert_success(pants_run)
@@ -78,7 +78,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
-        '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+        '--python-setup-interpreter-constraints=CPython>=2.7,<3',
         '--python-setup-interpreter-constraints=CPython>=3.3',
         '--jvm-test-junit-options=-Dcwd.test.enabled=true'])
     self.assert_failure(pants_run)
@@ -87,7 +87,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
-        '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+        '--python-setup-interpreter-constraints=CPython>=2.7,<3',
         '--python-setup-interpreter-constraints=CPython>=3.3',
         '--jvm-test-junit-options=-Dcwd.test.enabled=true',
         '--no-test-junit-chroot',
@@ -98,7 +98,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants([
         'test',
         'testprojects/tests/java/org/pantsbuild/testproject/cwdexample',
-        '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+        '--python-setup-interpreter-constraints=CPython>=2.7,<3',
         '--python-setup-interpreter-constraints=CPython>=3.3',
         '--jvm-test-junit-options=-Dcwd.test.enabled=true'])
     self.assert_failure(pants_run)

--- a/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jvm_run_integration.py
@@ -19,7 +19,7 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
     # Avoid some known-to-choke-on interpreters.
     command = ['run',
                target,
-               '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+               '--python-setup-interpreter-constraints=CPython>=2.7,<3',
                '--python-setup-interpreter-constraints=CPython>=3.3'] + list(args)
     pants_run = self.run_pants(command)
     self.assert_success(pants_run)
@@ -44,7 +44,7 @@ class JvmRunIntegrationTest(PantsRunIntegrationTest):
     # Make sure the test fails if you don't specify a directory
     pants_run = self.run_pants(['run',
                                 'testprojects/src/java/org/pantsbuild/testproject/cwdexample',
-                                '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+                                '--python-setup-interpreter-constraints=CPython>=2.7,<3',
                                 '--python-setup-interpreter-constraints=CPython>=3.3'])
     self.assert_failure(pants_run)
     self.assertIn('Neither ExampleCwd.java nor readme.txt found.', pants_run.stderr_data)

--- a/tests/python/pants_test/backend/python/tasks2/test_python_repl_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_repl_integration.py
@@ -14,7 +14,7 @@ class PythonReplIntegrationTest(PantsRunIntegrationTest):
     # Run a repl on a library target. Avoid some known-to-choke-on interpreters.
     command = ['repl',
                'testprojects/src/python/interpreter_selection:echo_interpreter_version_lib',
-               '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+               '--python-setup-interpreter-constraints=CPython>=2.7,<3',
                '--python-setup-interpreter-constraints=CPython>=3.3',
                '--quiet']
     program = 'from interpreter_selection.echo_interpreter_version import say_hello; say_hello()'

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -12,13 +12,13 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class PythonRunIntegrationTest(PantsRunIntegrationTest):
   testproject = 'testprojects/src/python/interpreter_selection'
 
-  def test_run_26(self):
-    self._maybe_run_version('2.6')
+  def test_run_3(self):
+    self._maybe_run_version('3')
 
   def test_run_27(self):
     self._maybe_run_version('2.7')
 
-  def test_run_27_and_then_26(self):
+  def test_run_27_and_then_3(self):
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
       pants_run_27 = self.run_pants(
@@ -26,18 +26,18 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
         config=pants_ini_config
       )
       self.assert_success(pants_run_27)
-      pants_run_26 = self.run_pants(
-        command=['run', '{}:echo_interpreter_version_2.6'.format(self.testproject),
-                 '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+      pants_run_3 = self.run_pants(
+        command=['run', '{}:echo_interpreter_version_3'.format(self.testproject),
+                 '--python-setup-interpreter-constraints=CPython>=2.7,<3',
                  '--python-setup-interpreter-constraints=CPython>=3.3'],
         config=pants_ini_config
       )
-      self.assert_success(pants_run_26)
+      self.assert_success(pants_run_3)
 
   def test_die(self):
     command = ['run',
                '{}:die'.format(self.testproject),
-               '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+               '--python-setup-interpreter-constraints=CPython>=2.7,<3',
                '--python-setup-interpreter-constraints=CPython>=3.3',
                '--quiet']
     pants_run = self.run_pants(command=command)
@@ -59,9 +59,10 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     if self.has_python_version(version):
       print('Found python {}. Testing running on it.'.format(version))
       echo = self._run_echo_version(version)
-      v = echo.split('.')  # E.g., 2.6.8.
+      v = echo.split('.')  # E.g., 2.7.13.
       self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
-      self.assertEquals(version, '{}.{}'.format(v[0], v[1]))
+      expected_components = version.split('.')
+      self.assertEquals(expected_components, v[:len(expected_components,)])
     else:
       print('No python {} found. Skipping.'.format(version))
       self.skipTest('No python {} on system'.format(version))
@@ -73,7 +74,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     # Avoid some known-to-choke-on interpreters.
     command = ['run',
                binary_target,
-               '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+               '--python-setup-interpreter-constraints=CPython>=2.7,<3',
                '--python-setup-interpreter-constraints=CPython>=3.3',
                '--quiet']
     pants_run = self.run_pants(command=command)

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -97,7 +97,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
   def has_python_version(cls, version):
     """Returns true if the current system has the specified version of python.
 
-    :param version: A python version string, such as 2.6, 3.
+    :param version: A python version string, such as 2.7, 3.
     """
     try:
       subprocess.call(['python%s' % version, '-V'])

--- a/tests/python/pants_test/python/test_interpreter_selection_integration.py
+++ b/tests/python/pants_test/python/test_interpreter_selection_integration.py
@@ -21,8 +21,8 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
     self.assert_failure(pants_run,
                         'Unexpected successful build of {binary}.'.format(binary=binary_target))
 
-  def test_select_26(self):
-    self._maybe_test_version('2.6')
+  def test_select_3(self):
+    self._maybe_test_version('3')
 
   def test_select_27(self):
     self._maybe_test_version('2.7')
@@ -31,9 +31,10 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
     if self.has_python_version(version):
       print('Found python {}. Testing interpreter selection against it.'.format(version))
       echo = self._echo_version(version)
-      v = echo.split('.')  # E.g., 2.6.8 .
+      v = echo.split('.')  # E.g., 2.7.13.
       self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
-      self.assertEquals(version, '{}.{}'.format(v[0], v[1]))
+      expected_components = version.split('.')
+      self.assertEquals(expected_components, v[:len(expected_components)])
     else:
       print('No python {} found. Skipping.'.format(version))
       self.skipTest('No python {} on system'.format(version))
@@ -60,6 +61,6 @@ class InterpreterSelectionIntegrationTest(PantsRunIntegrationTest):
     # Avoid some known-to-choke-on interpreters.
     command = ['binary',
                binary_target,
-               '--python-setup-interpreter-constraints=CPython>=2.6,<3',
+               '--python-setup-interpreter-constraints=CPython>=2.7,<3',
                '--python-setup-interpreter-constraints=CPython>=3.3']
     return self.run_pants(command=command, config=config)


### PR DESCRIPTION
Pants itself has required 2.7 to run for a while now and the latest pex
upgrade drops support for 2.6 in our python backend execution
infrastructure so it's now safe to drop 2.6 support completely.