### PR TITLE
Bump pyopenssl==17.3.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,7 +16,7 @@ pex==1.2.11
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4
-pyopenssl==17.1.0
+pyopenssl==17.3.0
 pystache==0.5.3
 pytest-cov>=2.4,<2.5
 pytest>=3.0.7,<4.0


### PR DESCRIPTION
### Problem

In #4865 we transitively pinned PyOpenSSL to `17.1.0` to avoid a release-breaking deprecation warning present in `17.2.0` that was being triggered even tho the deprecated codepath wasn't being used. This was fixed in upstream master, but had not yet been released - until today.

### Solution

Bump PyOpenSSL back to latest.

### Result

Back on the latest/greatest version, sans spurious deprecation warnings.