### PR TITLE
Factoring out cobertura specific code from junit_run.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coverage/base.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/base.py
@@ -106,14 +106,13 @@ class BaseCoverage(CoverageInterface):
 
   @classmethod
   def register_options(cls, register, register_jvm_tool):
+    pass
+
+  @classmethod
+  def register_generic_coverage_options(cls, register, register_jvm_tool):
     register('--coverage', type=bool, fingerprint=True, help='Collect code coverage data.')
 
-    # TODO(John Sirois): Fold this base class up into `Cobertura` once `--coverage-processor` is
-    # killed.
-    register('--coverage-processor', advanced=True, default='cobertura', choices=['cobertura'],
-             removal_version='1.6.0.dev0',
-             removal_hint='Only cobertura is supported for code coverage so this option can be '
-                          'omitted.',
+    register('--coverage-processor', advanced=True, default='cobertura', choices=['cobertura', 'jacoco'],
              help='Which coverage subsystem to use.')
 
     register('--coverage-jvm-options', advanced=True, type=list, fingerprint=True,

--- a/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
@@ -28,6 +28,8 @@ class Cobertura(BaseCoverage):
 
   @classmethod
   def register_options(cls, register, register_jvm_tool):
+    super(Cobertura, cls).register_options(register, register_jvm_tool)
+
     slf4j_jar = JarDependency(org='org.slf4j', name='slf4j-simple', rev='1.7.5')
     slf4j_api_jar = JarDependency(org='org.slf4j', name='slf4j-api', rev='1.7.5')
 

--- a/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/cobertura.py
@@ -28,8 +28,6 @@ class Cobertura(BaseCoverage):
 
   @classmethod
   def register_options(cls, register, register_jvm_tool):
-    super(Cobertura, cls).register_options(register, register_jvm_tool)
-
     slf4j_jar = JarDependency(org='org.slf4j', name='slf4j-simple', rev='1.7.5')
     slf4j_api_jar = JarDependency(org='org.slf4j', name='slf4j-api', rev='1.7.5')
 

--- a/src/python/pants/backend/jvm/tasks/coverage/factory.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/factory.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 from pants.backend.jvm.tasks.coverage.base import BaseCoverage, NoCoverage
 from pants.backend.jvm.tasks.coverage.cobertura import Cobertura, CoberturaTaskSettings
+from pants.backend.jvm.tasks.coverage.jacoco import Jacoco, JacocoTaskSettings
 
 
 class CoverageFactory(object):
@@ -15,15 +16,20 @@ class CoverageFactory(object):
   @staticmethod
   def from_task(task, output_dir, all_targets, execute_java):
     coverage = NoCoverage()
+    options = task.get_options()
 
-    if task.get_options().coverage or task.get_options().is_flagged('coverage_open'):
-      # currently only cobertura is supported, and is ensured by parameter definition
-      settings = CoberturaTaskSettings.from_task(task, workdir=output_dir)
-      coverage = Cobertura(settings, all_targets, execute_java)
+    if options.coverage or options.coverage_processor or options.is_flagged('coverage_open'):
+      if options.coverage_processor == 'cobertura':
+        settings = CoberturaTaskSettings.from_task(task, workdir=output_dir)
+        coverage = Cobertura(settings, all_targets, execute_java)
+    elif options.coverage-processor == 'jacoco':
+        settings = JacocoTaskSettings.from_task(task, workdir=output_dir)
+        coverage = Jacoco(settings, all_targets, execute_java)
 
     return coverage
 
   @staticmethod
   def register_options(register, register_jvm_tool):
-    BaseCoverage.register_options(register, register_jvm_tool)
+    BaseCoverage.register_generic_coverage_options(register, register_jvm_tool)
     Cobertura.register_options(register, register_jvm_tool)
+    Jacoco.register_options(register, register_jvm_tool)

--- a/src/python/pants/backend/jvm/tasks/coverage/factory.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/factory.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.jvm.tasks.coverage.base import BaseCoverage, NoCoverage
+from pants.backend.jvm.tasks.coverage.cobertura import Cobertura, CoberturaTaskSettings
+
+
+class CoverageFactory(object):
+  """A factory for creating code coverage classes and registering their options."""
+
+  @staticmethod
+  def from_task(task, output_dir, all_targets, execute_java):
+    coverage = NoCoverage()
+
+    if task.get_options().coverage or task.get_options().is_flagged('coverage_open'):
+      # currently only cobertura is supported, and is ensured by parameter definition
+      settings = CoberturaTaskSettings.from_task(task, workdir=output_dir)
+      coverage = Cobertura(settings, all_targets, execute_java)
+
+    return coverage
+
+  @staticmethod
+  def register_options(register, register_jvm_tool):
+    BaseCoverage.register_options(register, register_jvm_tool)
+    Cobertura.register_options(register, register_jvm_tool)

--- a/src/python/pants/backend/jvm/tasks/coverage/jacoco.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/jacoco.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import functools
+import os
+from collections import defaultdict
+
+from twitter.common.collections import OrderedSet
+
+from pants.backend.jvm.tasks.coverage.base import BaseCoverage, CoverageTaskSettings
+from pants.base.exceptions import TaskError
+from pants.java.jar.jar_dependency import JarDependency
+from pants.util import desktop
+from pants.util.contextutil import temporary_file
+from pants.util.dirutil import relativize_paths, safe_delete, safe_mkdir, touch
+
+
+class JacocoTaskSettings(CoverageTaskSettings):
+  """A class that holds task settings for jacoco coverage."""
+
+
+class Jacoco(BaseCoverage):
+  """Class to run coverage tests with Jacoco."""
+
+  @classmethod
+  def register_options(cls, register, register_jvm_tool):
+    super(Jacoco, cls).register_options(register, register_jvm_tool)
+
+  def __init__(self, settings, targets, execute_java_for_targets):
+    """
+    :param settings: The options for a `Jacoco` coverage run.
+    :type settings: :class:`JacocoTaskSettings`
+    :param list targets: A list of targets to instrument and record code coverage for.
+    :param execute_java_for_targets: A function that accepts a list of targets whose JVM platform
+                                     constraints are used to pick a JVM `Distribution`. The function
+                                     should also accept `*args` and `**kwargs` compatible with the
+                                     remaining parameters accepted by
+                                     `pants.java.util.execute_java`.
+    """
+    super(Jacoco, self).__init__(settings)
+
+  def instrument(self):
+    # jacoco does runtime instrumentation, so this is a noop
+    return
+
+  @property
+  def classpath_append(self):
+    return ()
+
+  @property
+  def classpath_prepend(self):
+    return ()
+
+  @property
+  def extra_jvm_options(self):
+    # TODO(jtrobec): implement code coverage using jacoco
+    return []
+
+  def report(self, execution_failed_exception=None):
+    # TODO(jtrobec): implement code coverage using jacoco
+    return
+
+  def maybe_open_report(self):
+    # TODO(jtrobec): implement code coverage using jacoco
+    return

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -21,8 +21,7 @@ from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.targets.junit_tests import JUnitTests
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
-from pants.backend.jvm.tasks.coverage.base import NoCoverage
-from pants.backend.jvm.tasks.coverage.cobertura import Cobertura, CoberturaTaskSettings
+from pants.backend.jvm.tasks.coverage.factory import CoverageFactory
 from pants.backend.jvm.tasks.jvm_task import JvmTask
 from pants.backend.jvm.tasks.jvm_tool_task_mixin import JvmToolTaskMixin
 from pants.backend.jvm.tasks.reports.junit_html_report import JUnitHtmlReport, NoJunitHtmlReport
@@ -188,7 +187,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
              help='Attempt to open the html summary report in a browser (implies --html-report)')
 
     # TODO(John Sirois): Remove direct register when coverage steps are moved to their own tasks.
-    Cobertura.register_options(register, cls.register_jvm_tool)
+    CoverageFactory.register_options(register, cls.register_jvm_tool)
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -632,11 +631,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     else:
       junit_html_report = NoJunitHtmlReport()
 
-    if self.get_options().coverage or self.get_options().is_flagged('coverage_open'):
-      settings = CoberturaTaskSettings.from_task(self, workdir=output_dir)
-      coverage = Cobertura(settings, all_targets, self.execute_java_for_coverage)
-    else:
-      coverage = NoCoverage()
+    coverage = CoverageFactory.from_task(self, output_dir, all_targets, self.execute_java_for_coverage)
 
     reports = self.Reports(junit_html_report, coverage)
 


### PR DESCRIPTION
### Problem

junit_run currently has some direct references to the Cobertura coverage classes. I want to add support for a new coverage library (jacoco) and the coupling here will make this awkward.

### Solution

Creation of the coverage engine and registration of its parameters have been moved out to a factory class.

### Result

junit_run is now agnostic of what specific coverage library is being used.