### PR TITLE
Target Rename Goal

### DIFF
--- a/src/python/pants/build_graph/meta_rename.py
+++ b/src/python/pants/build_graph/meta_rename.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import defaultdict
+
+from pants.backend.jvm.targets.scala_library import ScalaLibrary
+from pants.base.specs import DescendantAddresses
+from pants.build_graph.address import Address
+from pants.task.task import Task
+
+class MetaRename(Task):
+  """Rename a target for its dependants
+
+  Provides a mechanism for renaming the target's name within its local BUILD file.
+  Also renames the target for its addresses wherever it's specified as a dependency.
+  """
+
+  @classmethod
+  def register_options(cls, register):
+    super(MetaRename, cls).register_options(register)
+
+    register('--from', type=str, advanced=True, default=None, help='The old dependency name to change')
+    register('--to', type=str, advanced=True, default=None, help='The new name for the dependency')
+
+  def __init__(self, *args, **kwargs):
+    super(MetaRename, self).__init__(*args, **kwargs)
+
+    self._from = self.get_options()['from']
+    self._to = self.get_options().to
+
+  def execute(self):
+    self.update_target_builds()
+
+  def update_target_builds(self):
+    from_address = Address.parse(self._from)
+    to_address = Address.parse(self._to)
+    
+    self.replace_in_file(from_address.spec_path + '/BUILD', from_address.target_name, to_address.target_name)
+
+    from_target = ScalaLibrary(name=from_address.target_name, address=from_address, build_graph=[], **{})
+    dependency_graph = self.dependency_graph()
+    dependant_addresses = dependency_graph[from_target]
+    
+    for address in dependant_addresses:
+      self.replace_in_file(address.spec_path + '/BUILD', from_address.target_name, to_address.target_name)
+
+  def dependency_graph(self, scope=''):
+    dependency_graph = defaultdict(set)
+
+    for address in self.context.build_graph.inject_specs_closure([DescendantAddresses(scope)]):
+      target = self.context.build_graph.get_target(address)
+
+      for dependency in target.dependencies:
+        dependency_graph[dependency].add(address)
+
+    return dependency_graph
+
+  def replace_in_file(self, _file, old_name, new_name):
+    with open(_file, 'r') as f:
+      source = f.read()
+
+    new_source = source.replace(old_name, new_name)
+
+    with open(_file, 'w') as new_file:
+      new_file.write(new_source)

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -24,6 +24,7 @@ from pants.core_tasks.targets_help import TargetsHelp
 from pants.core_tasks.what_changed import WhatChanged
 from pants.goal.goal import Goal
 from pants.goal.task_registrar import TaskRegistrar as task
+from pants.build_graph.meta_rename import MetaRename
 
 
 def register_goals():
@@ -98,3 +99,5 @@ def register_goals():
   # Processing aliased targets has to occur very early.
   task(name='substitute-aliased-targets', action=SubstituteAliasedTargets).install('bootstrap',
                                                                                    first=True)
+  # Register a task to rename a target.
+  task(name='meta-rename', action=MetaRename).install()

--- a/tests/python/pants_test/build_graph/BUILD
+++ b/tests/python/pants_test/build_graph/BUILD
@@ -138,3 +138,15 @@ python_tests(
     'tests/python/pants_test:base_test',
   ]
 )
+
+python_tests(
+  name = 'meta-rename',
+  sources = ['test_meta_rename.py'],
+  dependencies = [
+    'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/build_graph',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test:base_test',
+    'tests/python/pants_test/tasks:task_test_base',
+  ]
+)

--- a/tests/python/pants_test/build_graph/test_meta_rename.py
+++ b/tests/python/pants_test/build_graph/test_meta_rename.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import defaultdict
+
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.base.specs import DescendantAddresses
+from pants.build_graph.address import Address
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.build_graph.meta_rename import MetaRename
+from pants_test.base_test import BaseTest
+from pants_test.tasks.task_test_base import TaskTestBase
+from pants.util.dirutil import safe_delete
+
+class MetaRenameTest(TaskTestBase):
+  """Test renaming in MetaRename"""
+
+  @classmethod
+  def task_type(cls):
+    return MetaRename
+
+  @property
+  def alias_groups(self):
+    return BuildFileAliases(targets={ 'java_library': JavaLibrary })
+
+  def setUp(self):
+    super(MetaRenameTest, self).setUp()
+
+    self.set_options(**{ 'from': '', 'to': '' })
+
+    targets = self._prepare_dependencies()
+
+    self.meta_rename = self.create_task(self.context(target_roots=targets))
+    self.full_graph = self.meta_rename.dependency_graph()
+
+  def test_dependency_graph(self):
+    self.assertEqual(
+      self.full_graph.__str__(),
+      "defaultdict(<type 'set'>, {JavaLibrary(BuildFileAddress(a/BUILD, a)): set([BuildFileAddress(b/BUILD, b)])})"
+    )
+
+  def test_replace_in_file(self):
+    _file = 'foo.txt'
+
+    with open(_file, 'w') as new_file:
+      new_file.write('bar foo')
+
+    self.meta_rename.replace_in_file(_file, 'foo', 'goo')
+
+    with open(_file, 'r') as f:
+      source = f.read()
+
+    safe_delete(_file)
+
+    self.assertEqual(source, 'bar goo')
+
+  def _prepare_dependencies(self):
+    targets = {}
+
+    targets['a'] = self.create_library('a', 'java_library', 'a', ['A.java'])
+    targets['b'] = self.create_library('b', 'java_library', 'b', ['B.java'], dependencies=['a'])
+
+    return targets.values()


### PR DESCRIPTION
### Problem

What if an owner of a popular library wants to change the Pants target name for that library? Well, they would have to update multiple BUILD files to ensure that all of the library's dependants use the new name.

### Solution
The solution provides a pants goal called 'meta-rename' that allows the library manager to update the name of a target through `--from` and `--to` options. The solution itself builds a dependency graph of the entire project. With the specified target from the `--from` argument, the `meta-rename` goal will locate the proper BUILD files to update by looking through the built dependency graph.

### To Verify

Try running the following (make sure there are no newlines on the command line):
 ```
./pants meta-rename --from=src/scala/org/pantsbuild/zinc/analysis:analysis 
--to=src/scala/org/pantsbuild/zinc/analysis:new_analysis
```

* Observe the changed BUILD files that update name of zinc/analysis as well as its address name for the BUILD files of its dependents.

Also run the test:
`./pants test tests/python/pants_test/build_graph:meta-rename`

### Follow-Up

* To improve this goal, one could add a scope option that limits the parsing of the entire project to build the dependency graph.
* Support all the targets beyond Scala, like Python, Java, and more.

-----

@wisechengyi @ity 

Sources: 
* https://github.com/pantsbuild/pants/issues/4845