### PR TITLE
Only generate Android resource deps when needed.

### DIFF
--- a/contrib/android/src/python/pants/contrib/android/tasks/unpack_libraries.py
+++ b/contrib/android/src/python/pants/contrib/android/tasks/unpack_libraries.py
@@ -155,7 +155,7 @@ class UnpackLibraries(Task):
 
     # Depending on the contents of the unpacked aar file, create the dependencies.
     deps = []
-    if os.path.isdir(resource_dir):
+    if os.path.isdir(resource_dir) and os.listdir(resource_dir):
       new_resource_target = self.create_resource_target(library, coordinate, manifest, resource_dir)
 
       # # The new libraries resources must be compiled both by themselves and along with the dependent library.

--- a/contrib/android/tests/python/pants_test/contrib/android/tasks/test_unpack_libraries.py
+++ b/contrib/android/tests/python/pants_test/contrib/android/tasks/test_unpack_libraries.py
@@ -39,8 +39,10 @@ class UnpackLibrariesTest(TestAndroidBase):
         fp.close()
     if classes_jar:
       self.create_jarfile(location, filenames=filenames)
+    resource_dir = os.path.join(location, 'res')
+    safe_mkdir(resource_dir)
     if resources:
-      safe_mkdir(os.path.join(location, 'res'))
+      touch(os.path.join(resource_dir, 'resource_file'))
     return location
 
   def create_aarfile(self, location, name, filenames=None):


### PR DESCRIPTION
Previously, `.aar` archives with empty `res/` dirs would trigger
creation of a bugus synthetic `AndroidResources` dependency in the
associated library. The existing tests are modified to exercise the
case of empty `res/` dirs.