### PR TITLE
Reduce BUILD file parse pollution

### DIFF
--- a/src/python/pants/engine/legacy/parser.py
+++ b/src/python/pants/engine/legacy/parser.py
@@ -120,6 +120,10 @@ class LegacyPythonCallbacksParser(Parser):
     python = filecontent
 
     # Mutate the parse context for the new path, then exec, and copy the resulting objects.
+    # We execute with a (shallow) clone of the symbols as a defense against accidental
+    # pollution of the namespace via imports or variable definitions. Defending against
+    # _intentional_ mutation would require a deep clone, which doesn't seem worth the cost at
+    # this juncture.
     self._parse_context._storage.clear(os.path.dirname(filepath))
-    six.exec_(python, self._symbols)
+    six.exec_(python, dict(self._symbols))
     return list(self._parse_context._storage.objects)

--- a/src/python/pants/engine/parser.py
+++ b/src/python/pants/engine/parser.py
@@ -29,6 +29,11 @@ class SymbolTable(AbstractClass):
     return Exactly(*symbol_table_types, description='symbol table types')
 
 
+class EmptyTable(SymbolTable):
+  def table(self):
+    return {}
+
+
 class Parser(AbstractClass):
 
   @abstractmethod

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -134,6 +134,16 @@ python_tests(
 )
 
 python_tests(
+  name = 'parser',
+  sources = ['test_parser.py'],
+  dependencies = [
+    'src/python/pants/build_graph',
+    'src/python/pants/engine/legacy:parser',
+    'src/python/pants/engine:parser',
+  ]
+)
+
+python_tests(
   name = 'structs',
   sources = ['test_structs.py'],
   dependencies = [

--- a/tests/python/pants_test/engine/legacy/test_parser.py
+++ b/tests/python/pants_test/engine/legacy/test_parser.py
@@ -19,6 +19,6 @@ class LegacyPythonCallbacksParserTest(unittest.TestCase):
     parser = LegacyPythonCallbacksParser(EmptyTable(), BuildFileAliases())
     # Call to import a module should succeed.
     parser.parse('/dev/null', '''import os; os.path.join('x', 'y')''')
-    # But the imported module not be visible as a symbol in further parses.
+    # But the imported module should not be visible as a symbol in further parses.
     with self.assertRaises(NameError):
       parser.parse('/dev/null', '''os.path.join('x', 'y')''')

--- a/tests/python/pants_test/engine/legacy/test_parser.py
+++ b/tests/python/pants_test/engine/legacy/test_parser.py
@@ -1,0 +1,24 @@
+# coding=utf-8
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import unittest
+
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.engine.legacy.parser import LegacyPythonCallbacksParser
+from pants.engine.parser import EmptyTable
+
+
+class LegacyPythonCallbacksParserTest(unittest.TestCase):
+
+  def test_no_import_sideeffects(self):
+    # A parser with no symbols registered.
+    parser = LegacyPythonCallbacksParser(EmptyTable(), BuildFileAliases())
+    # Call to import a module should succeed.
+    parser.parse('/dev/null', '''import os; os.path.join('x', 'y')''')
+    # But the imported module not be visible as a symbol in further parses.
+    with self.assertRaises(NameError):
+      parser.parse('/dev/null', '''os.path.join('x', 'y')''')

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -10,7 +10,6 @@ import shutil
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.nodes import Return
-from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import LocalScheduler
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -17,12 +17,6 @@ from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants_test.engine.util import init_native
 
 
-class EmptyTable(SymbolTable):
-  @classmethod
-  def table(cls):
-    return {}
-
-
 class SchedulerTestBase(object):
   """A mixin for classes (tests, presumably) which need to create temporary schedulers.
 

--- a/tests/python/pants_test/engine/test_parsers.py
+++ b/tests/python/pants_test/engine/test_parsers.py
@@ -29,12 +29,6 @@ class Bob(object):
     return isinstance(other, Bob) and self._key() == other._key()
 
 
-class EmptyTable(parser.SymbolTable):
-  @classmethod
-  def table(cls):
-    return {}
-
-
 class TestTable(parser.SymbolTable):
   @classmethod
   def table(cls):
@@ -53,7 +47,7 @@ def parse(parser, document, **args):
 
 class JsonParserTest(unittest.TestCase):
   def parse(self, document, symbol_table=None, **kwargs):
-    symbol_table = symbol_table or EmptyTable()
+    symbol_table = symbol_table or parser.EmptyTable()
     return parse(parsers.JsonParser(symbol_table), document, **kwargs)
 
   def round_trip(self, obj, symbol_table=None):
@@ -229,7 +223,7 @@ class JsonParserTest(unittest.TestCase):
     """).strip()
     filepath = '/dev/null'
     with self.assertRaises(parser.ParseError) as exc:
-      parsers.JsonParser(EmptyTable()).parse(filepath, document)
+      parsers.JsonParser(parser.EmptyTable()).parse(filepath, document)
 
     # Strip trailing whitespace from the message since our expected literal below will have
     # trailing ws stripped via editors and code reviews calling for it.
@@ -327,7 +321,7 @@ class PythonAssignmentsParserTest(unittest.TestCase):
       hobbies=[1, 2, 3]
     )
     """)
-    results = parse(parsers.PythonAssignmentsParser(EmptyTable()), document)
+    results = parse(parsers.PythonAssignmentsParser(parser.EmptyTable()), document)
     self.assertEqual([Bob(name='nancy', hobbies=[1, 2, 3])], results)
 
     # No symbol table was used so no `type_alias` plumbing can be expected.


### PR DESCRIPTION
### Problem

As described on #4880, the parser used in the v2 engine was re-using a symbol table across parses, which (in the presence of non-deterministic execution orders due to engine concurrency) could cause non-deterministic successful parses of otherwise invalid code.

### Solution

Shallow clone the symbol table for each use, which should defend against 95% of errors in this area. The remaining 5% would require deep cloning (or recreating) the symbol table for each file parse, which doesn't seem worth the benefit.

### Result

A failing test that imports in parsed files now succeeds, and non-determinism due to imports should be eliminated. Fixes #4880