### PR TITLE
Add default routing for OSX High Sierra binaries.

### DIFF
--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -34,6 +34,7 @@ _DEFAULT_PATH_BY_ID = {
   ('darwin', '14'): ('mac', '10.10'),
   ('darwin', '15'): ('mac', '10.11'),
   ('darwin', '16'): ('mac', '10.12'),
+  ('darwin', '17'): ('mac', '10.13'),
 }
 
 


### PR DESCRIPTION
These are now uploaded to https://binaries.pantsbuild.org.

Fixes #4893