### PR TITLE
Improve `--cache-ignore` performance.

### DIFF
--- a/src/python/pants/invalidation/BUILD
+++ b/src/python/pants/invalidation/BUILD
@@ -11,6 +11,5 @@ python_library(
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',
-    'src/python/pants/util:objects',
   ],
 )

--- a/src/python/pants/invalidation/BUILD
+++ b/src/python/pants/invalidation/BUILD
@@ -10,5 +10,7 @@ python_library(
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
+    'src/python/pants/util:objects',
   ],
 )

--- a/src/python/pants/invalidation/build_invalidator.py
+++ b/src/python/pants/invalidation/build_invalidator.py
@@ -5,10 +5,12 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+
 import errno
 import hashlib
 import os
 from abc import abstractmethod
+from collections import namedtuple
 
 from pants.base.hash_utils import hash_all
 from pants.build_graph.target import Target
@@ -16,7 +18,6 @@ from pants.fs.fs import safe_filename
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import safe_mkdir
 from pants.util.meta import AbstractClass
-from pants.util.objects import datatype
 
 
 # Bump this to invalidate all existing keys in artifact caches across all pants deployments in the
@@ -25,7 +26,7 @@ from pants.util.objects import datatype
 GLOBAL_CACHE_KEY_GEN_VERSION = '7'
 
 
-class CacheKey(datatype('CacheKey', ['id', 'hash'])):
+class CacheKey(namedtuple('CacheKey', ['id', 'hash'])):
   """A CacheKey represents some version of a set of targets.
 
   - id identifies the set of targets.

--- a/src/python/pants/invalidation/build_invalidator.py
+++ b/src/python/pants/invalidation/build_invalidator.py
@@ -8,21 +8,15 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import errno
 import hashlib
 import os
-from collections import namedtuple
+from abc import abstractmethod
 
 from pants.base.hash_utils import hash_all
 from pants.build_graph.target import Target
 from pants.fs.fs import safe_filename
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import safe_mkdir
-
-
-# A CacheKey represents some version of a set of targets.
-#  - id identifies the set of targets.
-#  - hash is a fingerprint of all invalidating inputs to the build step, i.e., it uniquely
-#    determines a given version of the artifacts created when building the target set.
-
-CacheKey = namedtuple('CacheKey', ['id', 'hash'])
+from pants.util.meta import AbstractClass
+from pants.util.objects import datatype
 
 
 # Bump this to invalidate all existing keys in artifact caches across all pants deployments in the
@@ -31,11 +25,23 @@ CacheKey = namedtuple('CacheKey', ['id', 'hash'])
 GLOBAL_CACHE_KEY_GEN_VERSION = '7'
 
 
-class CacheKeyGenerator(object):
-  """Generates cache keys for versions of target sets."""
+class CacheKey(datatype('CacheKey', ['id', 'hash'])):
+  """A CacheKey represents some version of a set of targets.
 
-  @staticmethod
-  def combine_cache_keys(cache_keys):
+  - id identifies the set of targets.
+  - hash is a fingerprint of all invalidating inputs to the build step, i.e., it uniquely
+    determines a given version of the artifacts created when building the target set.
+  """
+
+  _UNCACHEABLE_HASH = '__UNCACHEABLE_HASH__'
+
+  @classmethod
+  def uncacheable(cls, id):
+    """Creates a cache key this is never `cacheable`."""
+    return cls(id=id, hash=cls._UNCACHEABLE_HASH)
+
+  @classmethod
+  def combine_cache_keys(cls, cache_keys):
     """Returns a cache key for a list of target sets that already have cache keys.
 
     This operation is 'idempotent' in the sense that if cache_keys contains a single key
@@ -50,8 +56,36 @@ class CacheKeyGenerator(object):
     else:
       combined_id = Target.maybe_readable_combine_ids(cache_key.id for cache_key in cache_keys)
       combined_hash = hash_all(sorted(cache_key.hash for cache_key in cache_keys))
-      return CacheKey(combined_id, combined_hash)
+      return cls(combined_id, combined_hash)
 
+  @property
+  def cacheable(self):
+    """Indicates whether artifacts associated with this cache key should be cached.
+
+    :return: `True` if this cache key represents a cacheable set of target artifacts.
+    :rtype: bool
+    """
+    return self.hash != self._UNCACHEABLE_HASH
+
+
+class CacheKeyGeneratorInterface(AbstractClass):
+  """Generates cache keys for versions of target sets."""
+
+  @abstractmethod
+  def key_for_target(self, target, transitive=False, fingerprint_strategy=None):
+    """Get a key representing the given target and its sources.
+
+    A key for a set of targets can be created by calling CacheKey.combine_cache_keys()
+    on the target's individual cache keys.
+
+    :target: The target to create a CacheKey for.
+    :transitive: Whether or not to include a fingerprint of all of :target:'s dependencies.
+    :fingerprint_strategy: A FingerprintStrategy instance, which can do per task, finer grained
+      fingerprinting of a given Target.
+    """
+
+
+class CacheKeyGenerator(CacheKeyGeneratorInterface):
   def __init__(self, *base_fingerprint_inputs):
     """
     :base_fingerprint_inputs: Information to be included in the fingerprint for all cache keys
@@ -64,17 +98,6 @@ class CacheKeyGenerator(object):
     self._base_hasher = hasher
 
   def key_for_target(self, target, transitive=False, fingerprint_strategy=None):
-    """Get a key representing the given target and its sources.
-
-    A key for a set of targets can be created by calling combine_cache_keys()
-    on the target's individual cache keys.
-
-    :target: The target to create a CacheKey for.
-    :transitive: Whether or not to include a fingerprint of all of :target:'s dependencies.
-    :fingerprint_strategy: A FingerprintStrategy instance, which can do per task, finer grained
-      fingerprinting of a given Target.
-    """
-
     hasher = self._base_hasher.copy()
     key_suffix = hasher.hexdigest()[:12]
     if transitive:
@@ -86,6 +109,13 @@ class CacheKeyGenerator(object):
       return CacheKey(target.id, full_key)
     else:
       return None
+
+
+class UncacheableCacheKeyGenerator(CacheKeyGeneratorInterface):
+  """A cache key generator that always returns uncacheable cache keys."""
+
+  def key_for_target(self, target, transitive=False, fingerprint_strategy=None):
+    return CacheKey.uncacheable(target.id)
 
 
 # A persistent map from target set to cache key, which is a fingerprint of all
@@ -108,6 +138,15 @@ class BuildInvalidator(object):
       root = os.path.join(cls.global_instance().get_options().pants_workdir, 'build_invalidator')
       return BuildInvalidator(root, scope=build_task)
 
+  @staticmethod
+  def cacheable(cache_key):
+    """Indicates whether artifacts associated with the given `cache_key` should be cached.
+
+    :return: `True` if the `cache_key` represents a cacheable set of target artifacts.
+    :rtype: bool
+    """
+    return cache_key.cacheable
+
   def __init__(self, root, scope=None):
     """Create a build invalidator using the given root fingerprint database directory.
 
@@ -126,6 +165,10 @@ class BuildInvalidator(object):
     :param cache_key: A CacheKey object (as returned by CacheKeyGenerator.key_for().
     :returns: The previous cache_key, or None if there was not a previous build.
     """
+    if not self.cacheable(cache_key):
+      # We should never successfully cache an uncacheable CacheKey.
+      return None
+
     previous_hash = self._read_sha(cache_key)
     if not previous_hash:
       return None
@@ -137,6 +180,10 @@ class BuildInvalidator(object):
     :param cache_key: A CacheKey object (as returned by CacheKeyGenerator.key_for().
     :returns: True if the cached version of the item is out of date.
     """
+    if not self.cacheable(cache_key):
+      # An uncacheable CacheKey is always out of date.
+      return True
+
     return self._read_sha(cache_key) != cache_key.hash
 
   def update(self, cache_key):
@@ -144,7 +191,8 @@ class BuildInvalidator(object):
 
     :param cache_key: A CacheKey object (typically returned by CacheKeyGenerator.key_for()).
     """
-    self._write_sha(cache_key)
+    if self.cacheable(cache_key):
+      self._write_sha(cache_key)
 
   def force_invalidate_all(self):
     """Force-invalidates all cached items."""
@@ -153,7 +201,8 @@ class BuildInvalidator(object):
   def force_invalidate(self, cache_key):
     """Force-invalidate the cached item."""
     try:
-      os.unlink(self._sha_file(cache_key))
+      if self.cacheable(cache_key):
+        os.unlink(self._sha_file(cache_key))
     except OSError as e:
       if e.errno != errno.ENOENT:
         raise

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -12,7 +12,7 @@ from hashlib import sha1
 
 from pants.build_graph.build_graph import sort_targets
 from pants.build_graph.target import Target
-from pants.invalidation.build_invalidator import CacheKeyGenerator
+from pants.invalidation.build_invalidator import CacheKey
 from pants.util.dirutil import relative_symlink, safe_delete, safe_mkdir, safe_rmtree
 from pants.util.memo import memoized_method
 
@@ -54,15 +54,17 @@ class VersionedTargetSet(object):
     self.targets = [vt.target for vt in versioned_targets]
 
     # The following line is a no-op if cache_key was set in the VersionedTarget __init__ method.
-    self.cache_key = CacheKeyGenerator.combine_cache_keys([vt.cache_key
-                                                           for vt in versioned_targets])
+    self.cache_key = CacheKey.combine_cache_keys([vt.cache_key for vt in versioned_targets])
     # NB: previous_cache_key may be None on the first build of a target.
     self.previous_cache_key = cache_manager.previous_key(self.cache_key)
     self.valid = self.previous_cache_key == self.cache_key
 
     if cache_manager.invalidation_report:
-      cache_manager.invalidation_report.add_vts(cache_manager, self.targets, self.cache_key,
-                                                self.valid, phase='init')
+      cache_manager.invalidation_report.add_vts(cache_manager.task_name,
+                                                self.targets,
+                                                self.cache_key,
+                                                self.valid,
+                                                phase='init')
 
     self._results_dir = None
     self._current_results_dir = None
@@ -70,6 +72,15 @@ class VersionedTargetSet(object):
     # True if the results_dir for this VT was created incrementally via clone of the
     # previous results_dir.
     self.is_incremental = False
+
+  @property
+  def cacheable(self):
+    """Indicates whether artifacts associated with this target set should be cached.
+
+    :return: `True` if this target set's associated artifacts can be cached.
+    :rtype: bool
+    """
+    return self._cache_manager.cacheable(self.cache_key)
 
   def update(self):
     self._cache_manager.update(self)
@@ -173,6 +184,15 @@ class VersionedTarget(VersionedTargetSet):
     # Must come after the assignments above, as they are used in the parent's __init__.
     super(VersionedTarget, self).__init__(cache_manager, [self])
     self.id = target.id
+
+  @property
+  def cacheable(self):
+    """Indicates whether artifacts associated with this target should be cached.
+
+    :return: `True` if this target's associated artifacts can be cached.
+    :rtype: bool
+    """
+    return super(VersionedTarget, self).cacheable and not self.target.has_label('no_cache')
 
   def create_results_dir(self):
     """Ensure that the empty results directory and a stable symlink exist for these versioned targets."""
@@ -348,6 +368,14 @@ class InvalidationCacheManager(object):
         if target_key is not None:
           yield VersionedTarget(self, target, target_key)
     return list(vt_iter())
+
+  def cacheable(self, cache_key):
+    """Indicates whether artifacts associated with the given `cache_key` should be cached.
+
+    :return: `True` if the `cache_key` represents a cacheable set of target artifacts.
+    :rtype: bool
+    """
+    return self._invalidator.cacheable(cache_key)
 
   def previous_key(self, cache_key):
     return self._invalidator.previous_key(cache_key)

--- a/src/python/pants/reporting/invalidation_report.py
+++ b/src/python/pants/reporting/invalidation_report.py
@@ -25,15 +25,12 @@ class InvalidationReport(object):
       :param valid: True if the cache_key is valid
       """
 
-    def __init__(self, task_name, cache_manager, invocation_id):
+    def __init__(self, task_name, invocation_id):
       self._task_name = task_name
-      self.cache_manager = cache_manager
       self._invocation_id = invocation_id
       self._entries = []
 
-    def add(self, targets, cache_key, valid, phase=None):
-      if not phase:
-        raise ValueError('Must specify a descriptive phase= value (e.g. "init", "pre-check", ...')
+    def add(self, targets, cache_key, valid, phase):
       # Manufacture an id from a hash of the target ids
       targets_hash = Target.identify(targets)
       self._entries.append(self.TaskEntry(targets_hash=targets_hash,
@@ -69,22 +66,22 @@ class InvalidationReport(object):
   def set_filename(self, filename):
     self._filename = filename
 
-  def add_task(self, cache_manager):
+  def add_task(self, task_name):
     self._invocation_id += 1
-    task_report = self.TaskReport(cache_manager.task_name, cache_manager, self._invocation_id)
-    self._task_reports[id(cache_manager)] = task_report
+    task_report = self.TaskReport(task_name, self._invocation_id)
+    self._task_reports[task_name] = task_report
     return task_report
 
-  def add_vts(self, cache_manager, targets, cache_key, valid, phase):
+  def add_vts(self, task_name, targets, cache_key, valid, phase):
     """ Add a single VersionedTargetSet entry to the report.
     :param InvalidationCacheManager cache_manager:
     :param CacheKey cache_key:
     :param bool valid:
     :param string phase:
     """
-    if id(cache_manager) not in self._task_reports:
-      self.add_task(cache_manager)
-    self._task_reports[id(cache_manager)].add(targets, cache_key, valid, phase)
+    if task_name not in self._task_reports:
+      self.add_task(task_name)
+    self._task_reports[task_name].add(targets, cache_key, valid, phase)
 
   def report(self, filename=None):
     """ Write details of each versioned target to file

--- a/tests/python/pants_test/task/BUILD
+++ b/tests/python/pants_test/task/BUILD
@@ -49,7 +49,6 @@ python_tests(
   dependencies=[
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
-    'src/python/pants/base:payload',
     'src/python/pants/build_graph',
     'src/python/pants/cache:cache',
     'src/python/pants/task',


### PR DESCRIPTION
Now `--cache-ignore` avoids fingerprinting targets altogether.
Previously fingerprints would be caclculated but then ignored.

Fixes #4890
