### PR TITLE
Improve performance of simple codegen.

### DIFF
--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -195,12 +195,7 @@ class SimpleCodegenTask(Task):
               self._handle_duplicate_sources(vt.target, vt.results_dir)
             vt.update()
           # And inject a synthetic target to represent it.
-          self._inject_synthetic_target(
-            vt.target,
-            vt.results_dir,
-            vt.cache_key,
-            mark_transitive_invalidation_hash_dirty=False,
-          )
+          self._inject_synthetic_target(vt.target, vt.results_dir, vt.cache_key)
         self._mark_transitive_invalidation_hashes_dirty(
           vt.target.address for vt in invalidation_check.all_vts
         )
@@ -247,7 +242,6 @@ class SimpleCodegenTask(Task):
     target,
     target_workdir,
     fingerprint,
-    mark_transitive_invalidation_hash_dirty=True,
   ):
     """Create, inject, and return a synthetic target for the given target and workdir.
 
@@ -293,9 +287,6 @@ class SimpleCodegenTask(Task):
         dependent=synthetic_target.address,
         dependency=concrete_dependency_address,
       )
-
-    if mark_transitive_invalidation_hash_dirty:
-      self._mark_transitive_invalidation_hashes_dirty([target.address])
 
     if target in self.context.target_roots:
       self.context.target_roots.append(synthetic_target)


### PR DESCRIPTION
### Problem

When injecting synthetic targets the simple codegen task walks the build graph for each new target to mark its dependees dirty. Walking the build graph is expensive, and often the dependees of the synthetic targets being injected overlap, so we mark already invalid dependees invalid again.

### Solution

There are two related issues fixed here. 

1) The major perf win is to batch the invalidation of dependees of injected synthetic targets. This reduces the number of times we need to walk the build graph. ~~The default behavior of _inject_synthetic_target has not changed,~~ but for anyone not overriding the execute method of simple codegen, the synthetic target dependees will all be marked invalid in a single walk of the build graph. 

[Edit: The second commit removes the flag that makes this possible. _inject_synthetic_targets is not public api, so changing the default behavior is allowed. Thanks stuhood for this tip!]

2) Mark the dependees of the synthetic target dirty, rather than the dependees of the dependencies of the synthetic target, which reduces the number of targets that are invalidated. This is the change from walking the transitive dependee graph of `build_graph.dependencies_of(target.address)` to walking the transitive dependee graph of `target.address` The perf gain here is pretty minimal, but I believe this to have been a long standing minor error. 

### Result

tl;dr: This commit provides a 3.4x speedup to Codegen, and we walk the build graph only 300,000 times instead of 30,000,000.

My test here was to run `./pants buildgen` on the foursquare codebase twice on the commit immediately prior to this change (the first time to ensure a full cache hit, the second time to run analysis) and twice on the commit that makes the perf fix.

Note: These tests were run on the foursquare codebase with a patch (fast_simple_codegen) that overrode the execute and _inject_synthetic_target blocks of simple codegen. This commit makes the same change to simple_codegen_task directly.

Prior to this commit, the `[gen]` phase took 55 seconds:

```sh
13:15:50 00:24   [gen]
13:15:50 00:24     [thrift]
13:15:50 00:24     [protoc]
13:15:50 00:24     [antlr]
13:15:50 00:24     [ragel]
13:15:51 00:25     [jaxb]
13:15:51 00:25     [wire]
13:15:51 00:25     [go-thrift]
13:15:52 00:26     [validate-graph]
13:15:52 00:26     [spindle]
13:16:31 01:05     [thrift-python]
13:16:32 01:06     [soy]
13:16:43 01:17     [js]
13:16:43 01:17     [lesscss]
13:16:45 01:19   [webpack]
```
![without_perf_fix profile](https://user-images.githubusercontent.com/3494066/30933207-ea553958-a397-11e7-8077-0d7865f7ec6e.png)

You can see the hotspots in the perf profile above. We're hitting walk_rec thirty million times and 30% of the total run time is spent in walk_transitive_dependee_graph.

With this change in place, the `[gen]` phase took 16 seconds:
```sh
12:45:54 00:25   [gen]
12:45:54 00:25     [thrift]
12:45:54 00:25     [protoc]
12:45:54 00:25     [antlr]
12:45:55 00:26     [ragel]
12:45:55 00:26     [jaxb]
12:45:55 00:26     [wire]
12:45:56 00:27     [go-thrift]
12:45:56 00:27     [validate-graph]
12:45:56 00:27     [spindle]
12:46:03 00:34     [thrift-python]
12:46:04 00:35     [soy]
12:46:08 00:39     [js]
12:46:09 00:40     [lesscss]
12:46:10 00:41   [webpack]
```
![with_perf_fix profile](https://user-images.githubusercontent.com/3494066/30933291-25f65a96-a398-11e7-85bd-fb9ad0ddcb85.png)

Here the time spent in walk_transitive_dependee_graph has dropped from 30% of the total run time to 8%, and that the number of times we've called walk_rec has dropped from more than 30 million to 305,764. 