### PR TITLE
Use Jessie not Weezy for docker image on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,7 @@ matrix:
       env:
         - SHARD="Linux Native Engine Binary Builder"
         - NATIVE_ENGINE_DEPLOY=1
-        # Use the standard python-2.7 docker Debian Wheezy image for binary compatibility with old
-        # linux distros.
-        - DOCKER_IMAGE="python:2.7.13-wheezy"
+        - DOCKER_IMAGE="python:2.7.13-jessie"
       before_install:
         # Remove any Ubuntu binary cruft before building.
         - git clean -fdx


### PR DESCRIPTION
The Weezy image uses a glibc which isn't compatible with the
binary_utils binaries we publish for Linux.