### PR TITLE
Repair requests range pin to include higher versions.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -22,7 +22,7 @@ pystache==0.5.3
 pytest-cov>=2.4,<2.5
 pytest>=3.0.7,<4.0
 pywatchman==1.4.1
-requests[security]==2.5.0,<2.19
+requests[security]>=2.5.0,<2.19
 scandir==1.2
 setproctitle==1.1.10
 setuptools==30.0.0


### PR DESCRIPTION
### Problem

Currently, the version pinning for `requests` is malformed and implicitly pinned to `2.5.0`.

### Solution

Use `>=` vs `==` to permit usage of later `requests` versions.

### Result

Before:

```
[omerta pants (d89eb359)]$ ./pants 2>&1 | grep requests
Collecting requests[security]<2.19,==2.5.0 (from -r /Users/kwilson/dev/pants/3rdparty/python/requirements.txt (line 25))
  Using cached requests-2.5.0-py2.py3-none-any.whl
...
```

After:

```
[omerta pants (kwlzn/requests_pin)]$ ./pants 2>&1 | grep requests
Collecting requests[security]<2.19,>=2.5.0 (from -r /Users/kwilson/dev/pants/3rdparty/python/requirements.txt (line 25))
  Using cached requests-2.18.4-py2.py3-none-any.whl
...
```