### PR TITLE
Avoid os.fork() prior to stats upload.

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -326,12 +326,7 @@ class RunTracker(Subsystem):
     # Upload to remote stats db.
     stats_url = self.get_options().stats_upload_url
     if stats_url:
-      pid = os.fork()
-      if pid == 0:
-        try:
-          self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
-        finally:
-          os._exit(0)
+      self.post_stats(stats_url, stats, timeout=self.get_options().stats_upload_timeout)
 
     # Write stats to local json file.
     stats_json_file_name = self.get_options().stats_local_json_file


### PR DESCRIPTION
### Problem

Presently, we do an `os.fork()` just before posting build stats in order to reduce the time-until-timeout for users who aren't connected to the VPN (and thus can't reach the stats server).

For users on OSX 10.11 (and potentially others), this seems to have been causing a silent segmentation fault in the forked process due to https://bugs.python.org/issue13829 .

With the addition of `faulthandler` support to pants, we now see a full traceback to stderr when this segmentation fault happens in the forked process due to retaining handles to the original processes stdio descriptors. At first this appeared to be a new issue encountered during release handling, but after investigating it seems like it's just `faulthandler`'s improved logging revealing a long-standing masked segfault.

### Solution

Remove the `os.fork()` call prior to stats upload and revisit.

### Result

Can no longer reproduce the segmentation fault.