### PR TITLE
Error if the wrong subprocess is imported

### DIFF
--- a/build-support/bin/check_banned_imports.sh
+++ b/build-support/bin/check_banned_imports.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -u
+
+bad_files="$(find src tests pants-plugins examples contrib -name '*.py' | xargs grep -l "^import subprocess")"
+if [ -n "${bad_files}" ]; then
+    echo >&2 "Found forbidden imports. Instead of \`import subprocess\` you should \`from pants.util.process_handler import subprocess\`. Bad files:"
+    echo >&2 "${bad_files}"
+    exit 1
+fi

--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -13,6 +13,7 @@ fi
 echo -n "* Checking native_engine_version: " && ./build-support/bin/check_native_engine_version.sh || exit 1
 echo "* Checking packages" && ./build-support/bin/check_packages.sh || exit 1
 echo "* Checking headers" && ./build-support/bin/check_header.sh || exit 1
+echo "* Checking for banned imports" && ./build-support/bin/check_banned_imports.sh || exit 1
 
 $(git rev-parse --verify master > /dev/null 2>&1)
 if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
@kwlzn flagged this as an error in
https://github.com/pantsbuild/pants/pull/4921 - rather than relying on
manual review to catch the problem in the future, give a pre-commit
error with a suggested replacement.

Example error on failure:

```
$ git commit -a
* Checking native_engine_version: verified: 5d5266579286db1f1fa254f383571b3c5031b97b
* Checking packages
* Checking headers
* Checking for banned imports
Found forbidden imports. Instead of `import subprocess` you should `from pants.util.process_handler import subprocess`. Bad files:
src/python/pants/backend/codegen/protobuf/java/protobuf_gen.py
```