### PR TITLE
Allow users to request a fixed python interpreter

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -62,11 +62,17 @@ class PythonSetup(Subsystem):
     register('--artifact-cache-dir', advanced=True, default=None, metavar='<dir>',
              help='The parent directory for the python artifact cache. '
                   'If unspecified, a standard path under the workdir is used.')
+    register('--interpreter-search-paths', advanced=True, type=list, default=[], metavar='<binary-paths>',
+             help='A list of paths to search for python interpreters.')
 
   @property
   def interpreter_constraints(self):
     return (self.get_options().interpreter_constraints or self.get_options().interpreter or
             [self.get_options().interpreter_requirement or b''])
+
+  @property
+  def interpreter_search_paths(self):
+    return self.get_options().interpreter_search_paths
 
   @property
   def setuptools_version(self):


### PR DESCRIPTION
### Problem

In some situations, the automatic python picker logic picks the wrong version of Python and we don't have much control over that beyond being able to specify version constraints (which sometimes aren't sufficient).

### Solution

I added an option to explicitly specify a list of paths to search.

### Result

Users can now pass in `--python-setup-interpreter-search-paths=<search-paths>` and have Pants search in the specified paths. You can even pass in the full path of the interpreter (e.g., `which python`) and it'll figure that out!