### PR TITLE
Make --idea-plugin-open-with a regular option rather than advanced.

### DIFF
--- a/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
+++ b/src/python/pants/backend/project_info/tasks/idea_plugin_gen.py
@@ -65,7 +65,7 @@ class IdeaPluginGen(ConsoleTask):
              help='Attempts to open the generated project in IDEA.')
     register('--java-encoding', default='UTF-8',
              help='Sets the file encoding for java files in this project.')
-    register('--open-with', advanced=True, default=None, recursive=True,
+    register('--open-with', type=str, default=None, recursive=True,
              help='Program used to open the generated IntelliJ project.')
     register('--debug_port', type=int, default=5005,
              help='Port to use for launching tasks under the debugger.')


### PR DESCRIPTION
### Problem

User often wants to use it but it does not show up in the regular `help` because it is only `help-advanced`