### PR TITLE
Preserve soft excludes bug while removing duplicates

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -875,7 +875,13 @@ class JvmCompile(NailgunTaskBase):
       if not hit_cache:
         # Compute the compile classpath for this target.
         cp_entries = [ctx.classes_dir]
-        cp_entries.extend(ClasspathUtil.compute_classpath(ctx.dependencies(self._dep_context),
+        # TODO: We convert to an iterator here in order to _preserve_ a bug that will be fixed
+        # in https://github.com/pantsbuild/pants/issues/4874: `ClasspathUtil.compute_classpath`
+        # expects to receive a list, but had been receiving an iterator. In the context of an
+        # iterator, `excludes` are not applied
+        # in ClasspathProducts.get_product_target_mappings_for_targets.
+        dependencies_iter = iter(ctx.dependencies(self._dep_context))
+        cp_entries.extend(ClasspathUtil.compute_classpath(dependencies_iter,
                                                           classpath_products,
                                                           extra_compile_time_classpath,
                                                           self._confs))

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -794,12 +794,13 @@ class Target(AbstractTarget):
     """
     strict_deps = self._cached_strict_dependencies_map.get(dep_context, None)
     if strict_deps is None:
-      strict_deps = []
+      strict_deps = OrderedSet()
       for declared in _resolve_strict_dependencies(self, dep_context):
         if isinstance(declared, dep_context.compiler_plugin_types):
-          strict_deps.extend(declared.closure(bfs=True, **dep_context.target_closure_kwargs))
+          strict_deps.update(declared.closure(bfs=True, **dep_context.target_closure_kwargs))
         else:
-          strict_deps.append(declared)
+          strict_deps.add(declared)
+      strict_deps = list(strict_deps)
       self._cached_strict_dependencies_map[dep_context] = strict_deps
     return strict_deps
 

--- a/testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep/BUILD
+++ b/testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep/BUILD
@@ -1,0 +1,8 @@
+scala_library(
+  dependencies=[
+    '3rdparty:guava',
+  ],
+  excludes=[
+    exclude(org='com.google.guava'),
+  ],
+)

--- a/testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep/Example.scala
+++ b/testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep/Example.scala
@@ -1,0 +1,9 @@
+package org.pantsbuild.testproject.exclude_direct_dep
+
+import com.google.common.base.Preconditions
+
+object Example {
+  def main(args: Array[String]) {
+    Preconditions.checkNotNull("This is not null.")
+  }
+}

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import unittest
 import xml.etree.ElementTree as ET
 
 from pants.util.contextutil import open_zip
@@ -166,6 +167,14 @@ class BaseZincCompileIntegrationTest(object):
       extra_args=['--compile-zinc-fatal-warnings-enabled-args=[\'-C-Werror\']'])
     test_combination('fatal', default_fatal_warnings=False, expect_success=False,
       extra_args=['--compile-zinc-fatal-warnings-disabled-args=[\'-S-Xfatal-warnings\']'])
+
+  @unittest.expectedFailure
+  def test_soft_excludes_at_compiletime(self):
+    with self.do_test_compile('testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep',
+                              extra_args=['--resolve-ivy-soft-excludes'],
+                              expect_failure=True) as found:
+      # TODO See #4874. Should have failed to compile because its only dependency is excluded.
+      pass
 
   def test_pool_created_for_fresh_compile_but_not_for_valid_compile(self):
     with self.temporary_cachedir() as cachedir, self.temporary_workdir() as workdir:

--- a/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
+++ b/tests/python/pants_test/backend/jvm/tasks/jvm_compile/zinc/zinc_compile_integration_base.py
@@ -172,7 +172,7 @@ class BaseZincCompileIntegrationTest(object):
   def test_soft_excludes_at_compiletime(self):
     with self.do_test_compile('testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep',
                               extra_args=['--resolve-ivy-soft-excludes'],
-                              expect_failure=True) as found:
+                              expect_failure=True):
       # TODO See #4874. Should have failed to compile because its only dependency is excluded.
       pass
 

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -59,6 +59,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/tests/java/org/pantsbuild/testproject/fail256:fail256',
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C',
+      'testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep',
       # These don't pass without special config.
       'testprojects/tests/java/org/pantsbuild/testproject/depman:new-tests',
       'testprojects/tests/java/org/pantsbuild/testproject/depman:old-tests',


### PR DESCRIPTION
### Problem

`soft_excludes` have been broken at compile time for a while: see #4874 and the comments here.

### Solution

This pull exposes the reason for #4874, and adds an xfailed test. Unfortunately, actually fixing this issue is going to require some fundamental API changes: we no longer walk the `BuildGraph` while computing the classpath: instead we walk it externally. And `excludes` are graph position specific. 

### Result

#4874 is marked, and the current behaviour is preserved, for now.