### PR TITLE
Send timing/cache report to stderr

### DIFF
--- a/src/python/pants/reporting/quiet_reporter.py
+++ b/src/python/pants/reporting/quiet_reporter.py
@@ -51,7 +51,7 @@ class QuietReporter(PlainTextReporterBase):
     pass
 
   def _emit(self, s):
-    sys.stdout.write(s)
+    sys.stderr.write(s)
 
   def level_for_workunit(self, workunit, default_level):
     """Force the reporter to consider every workunit to be logging for level Report.ERROR"""

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -11,8 +11,8 @@ from pants.reporting.report import Report
 
 
 class ReporterDestination(object):
-  OUT = 'out'
-  ERR = 'err'
+  OUT = 0
+  ERR = 1
 
 
 class Reporter(object):

--- a/src/python/pants/reporting/reporter.py
+++ b/src/python/pants/reporting/reporter.py
@@ -10,6 +10,11 @@ from collections import namedtuple
 from pants.reporting.report import Report
 
 
+class ReporterDestination(object):
+  OUT = 'out'
+  ERR = 'err'
+
+
 class Reporter(object):
   """Formats and emits reports.
 

--- a/src/python/pants/reporting/reporting.py
+++ b/src/python/pants/reporting/reporting.py
@@ -16,6 +16,7 @@ from pants.reporting.invalidation_report import InvalidationReport
 from pants.reporting.plaintext_reporter import LabelFormat, PlainTextReporter, ToolOutputFormat
 from pants.reporting.quiet_reporter import QuietReporter
 from pants.reporting.report import Report, ReportingError
+from pants.reporting.reporter import ReporterDestination
 from pants.reporting.reporting_server import ReportingServerManager
 from pants.subsystem.subsystem import Subsystem
 from pants.util.dirutil import relative_symlink, safe_mkdir, safe_rmtree
@@ -68,8 +69,9 @@ class Reporting(Subsystem):
     # Capture initial console reporting into a buffer. We'll do something with it once
     # we know what the cmd-line flag settings are.
     outfile = StringIO()
+    errfile = StringIO()
     capturing_reporter_settings = PlainTextReporter.Settings(
-      outfile=outfile, log_level=Report.INFO,
+      outfile=outfile, errfile=errfile, log_level=Report.INFO,
       color=False, indent=True, timing=False,
       cache_stats=False,
       label_format=self.get_options().console_label_format,
@@ -95,14 +97,20 @@ class Reporting(Subsystem):
   def _get_invalidation_report(self):
     return InvalidationReport() if self.get_options().invalidation_report else None
 
+  @staticmethod
+  def _consume_stringio(f):
+    f.flush()
+    buffered_output = f.getvalue()
+    f.close()
+    return buffered_output
+
   def update_reporting(self, global_options, is_quiet_task, run_tracker):
     """Updates reporting config once we've parsed cmd-line flags."""
 
     # Get any output silently buffered in the old console reporter, and remove it.
-    old_outfile = run_tracker.report.remove_reporter('capturing').settings.outfile
-    old_outfile.flush()
-    buffered_output = old_outfile.getvalue()
-    old_outfile.close()
+    removed_reporter = run_tracker.report.remove_reporter('capturing')
+    buffered_out = self._consume_stringio(removed_reporter.settings.outfile)
+    buffered_err = self._consume_stringio(removed_reporter.settings.errfile)
 
     log_level = Report.log_level_from_string(global_options.level or 'info')
     # Ideally, we'd use terminfo or somesuch to discover whether a
@@ -117,12 +125,13 @@ class Reporting(Subsystem):
                                                               timing=timing, cache_stats=cache_stats))
     else:
       # Set up the new console reporter.
-      settings = PlainTextReporter.Settings(log_level=log_level, outfile=sys.stdout, color=color,
-                                            indent=True, timing=timing, cache_stats=cache_stats,
+      settings = PlainTextReporter.Settings(log_level=log_level, outfile=sys.stdout, errfile=sys.stderr,
+                                            color=color, indent=True, timing=timing, cache_stats=cache_stats,
                                             label_format=self.get_options().console_label_format,
                                             tool_output_format=self.get_options().console_tool_output_format)
       console_reporter = PlainTextReporter(run_tracker, settings)
-      console_reporter.emit(buffered_output)
+      console_reporter.emit(buffered_out, dest=ReporterDestination.OUT)
+      console_reporter.emit(buffered_err, dest=ReporterDestination.ERR)
       console_reporter.flush()
     run_tracker.report.add_reporter('console', console_reporter)
 
@@ -131,12 +140,14 @@ class Reporting(Subsystem):
       safe_mkdir(global_options.logdir)
       run_id = run_tracker.run_info.get_info('id')
       outfile = open(os.path.join(global_options.logdir, '{}.log'.format(run_id)), 'w')
-      settings = PlainTextReporter.Settings(log_level=log_level, outfile=outfile, color=False,
-                                            indent=True, timing=True, cache_stats=True,
+      errfile = open(os.path.join(global_options.logdir, '{}.err.log'.format(run_id)), 'w')
+      settings = PlainTextReporter.Settings(log_level=log_level, outfile=outfile, errfile=errfile,
+                                            color=False, indent=True, timing=True, cache_stats=True,
                                             label_format=self.get_options().console_label_format,
                                             tool_output_format=self.get_options().console_tool_output_format)
       logfile_reporter = PlainTextReporter(run_tracker, settings)
-      logfile_reporter.emit(buffered_output)
+      logfile_reporter.emit(buffered_out, dest=ReporterDestination.OUT)
+      logfile_reporter.emit(buffered_err, dest=ReporterDestination.ERR)
       logfile_reporter.flush()
       run_tracker.report.add_reporter('logfile', logfile_reporter)
 

--- a/tests/python/pants_test/reporting/BUILD
+++ b/tests/python/pants_test/reporting/BUILD
@@ -5,16 +5,18 @@ python_tests(
   sources = ['test_linkify.py'],
   dependencies = [
     'src/python/pants/reporting',
-  ]
+  ],
+  timeout = 10,
 )
 
 python_tests(
   name = 'reporting_integration',
   sources = ['test_reporting_integration.py'],
   dependencies = [
+    '3rdparty/python:parameterized',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test'
   ],
   tags = {'integration'},
-  timeout = 120,
+  timeout = 240,
 )

--- a/tests/python/pants_test/reporting/test_reporting_integration.py
+++ b/tests/python/pants_test/reporting/test_reporting_integration.py
@@ -9,6 +9,8 @@ import os.path
 import re
 import unittest
 
+from parameterized import parameterized
+
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -144,3 +146,11 @@ class TestReportingIntegrationTest(PantsRunIntegrationTest, unittest.TestCase):
     self.assertIn('*** Got invalid key BAZ for --reporting-console-tool-output-format. Expected one of [', pants_run.stdout_data)
     self.assertIn('*** Got invalid value QUX for --reporting-console-tool-output-format. Expected one of [', pants_run.stdout_data)
     self.assertIn('', pants_run.stdout_data)
+
+  @parameterized.expand(['--quiet', '--no-quiet'])
+  def test_epilog_to_stderr(self, quiet_flag):
+    command = ['--time', quiet_flag, 'bootstrap', 'examples/src/java/org/pantsbuild/example/hello::']
+    pants_run = self.run_pants(command)
+    self.assert_success(pants_run)
+    self.assertIn('Cumulative Timings', pants_run.stderr_data)
+    self.assertNotIn('Cumulative Timings', pants_run.stdout_data)


### PR DESCRIPTION
### Problem

`--time` is very useful to have enabled by default in automated environments, but currently renders to `stdout`.

### Solution

Add `errfile` to `PlainTextReporter`, and render the timing and cache hit report ("epilog") to it.

### Result

`--time` can safely be used in more cases.