### PR TITLE
Mention name of binary we can't find

### DIFF
--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -103,8 +103,8 @@ class BinaryUtil(object):
     try:
       middle_path = self._path_by_id[os_id]
     except KeyError:
-      raise self.MissingMachineInfo(('Unable to find binary {name} version {version}. ' +
-                                    'Update --binaries-path-by-id to find binaries for {os_id!r}')
+      raise self.MissingMachineInfo('Unable to find binary {name} version {version}. '
+                                    'Update --binaries-path-by-id to find binaries for {os_id!r}'
                                     .format(name=name, version=version, os_id=os_id))
     return os.path.join(supportdir, *(middle_path + (version, name)))
 

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -103,8 +103,9 @@ class BinaryUtil(object):
     try:
       middle_path = self._path_by_id[os_id]
     except KeyError:
-      raise self.MissingMachineInfo('Update --binaries-path-by-id to find binaries for {!r}'
-                                    .format(os_id))
+      raise self.MissingMachineInfo(('Unable to find binary {name} version {version}. ' +
+                                    'Update --binaries-path-by-id to find binaries for {os_id!r}')
+                                    .format(name=name, version=version, os_id=os_id))
     return os.path.join(supportdir, *(middle_path + (version, name)))
 
   def __init__(self, baseurls, timeout_secs, bootstrapdir, path_by_id=None):

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -165,7 +165,7 @@ class BinaryUtilTest(BaseTest):
 
     with self.assertRaisesRegexp(BinaryUtil.MissingMachineInfo,
                                  r'Pants has no binaries for vms'):
-      binary_util._select_binary_base_path("supportdir", "name", "version", uname_func=uname_func)
+      binary_util._select_binary_base_path("supportdir", "version", "name", uname_func=uname_func)
 
   def test_select_binary_base_path_missing_version(self):
     binary_util = BinaryUtil([], 0, '/tmp')
@@ -175,9 +175,9 @@ class BinaryUtilTest(BaseTest):
 
     os_id = ('darwin', '999')
     with self.assertRaisesRegexp(BinaryUtil.MissingMachineInfo,
-                                 r'Update --binaries-path-by-id to find binaries for '
+                                 r'myname.*Update --binaries-path-by-id to find binaries for '
                                  r'{}'.format(re.escape(repr(os_id)))):
-      binary_util._select_binary_base_path("supportdir", "name", "version", uname_func=uname_func)
+      binary_util._select_binary_base_path("supportdir", "myversion", "myname", uname_func=uname_func)
 
   def test_select_binary_base_path_override(self):
     binary_util = BinaryUtil([], 0, '/tmp',

--- a/tests/python/pants_test/binaries/test_binary_util.py
+++ b/tests/python/pants_test/binaries/test_binary_util.py
@@ -143,8 +143,8 @@ class BinaryUtilTest(BaseTest):
     def uname_func():
       return "linux", "dontcare1", "dontcare2", "dontcare3", "amd64"
 
-    self.assertEquals("supportdir/linux/x86_64/name/version",
-                      binary_util._select_binary_base_path("supportdir", "name", "version",
+    self.assertEquals("supportdir/linux/x86_64/version/name",
+                      binary_util._select_binary_base_path("supportdir", "version", "name",
                                                            uname_func=uname_func))
 
   def test_select_binary_base_path_darwin(self):
@@ -153,8 +153,8 @@ class BinaryUtilTest(BaseTest):
     def uname_func():
       return "darwin", "dontcare1", "14.9", "dontcare2", "dontcare3",
 
-    self.assertEquals("supportdir/mac/10.10/name/version",
-                      binary_util._select_binary_base_path("supportdir", "name", "version",
+    self.assertEquals("supportdir/mac/10.10/version/name",
+                      binary_util._select_binary_base_path("supportdir", "version", "name",
                                                            uname_func=uname_func))
 
   def test_select_binary_base_path_missing_os(self):
@@ -186,6 +186,6 @@ class BinaryUtilTest(BaseTest):
     def uname_func():
       return "darwin", "dontcare1", "100.99", "dontcare2", "t1000"
 
-    self.assertEquals("supportdir/skynet/42/name/version",
-                      binary_util._select_binary_base_path("supportdir", "name", "version",
+    self.assertEquals("supportdir/skynet/42/version/name",
+                      binary_util._select_binary_base_path("supportdir", "version", "name",
                                                            uname_func=uname_func))


### PR DESCRIPTION
This gives better debugging information for what went wrong.