### PR TITLE
Exclude target directories from rustfmt

### DIFF
--- a/build-support/bin/check_rust_formatting.sh
+++ b/build-support/bin/check_rust_formatting.sh
@@ -5,7 +5,7 @@ source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
 
 ensure_native_build_prerequisites
 
-files=( $(find "${NATIVE_ROOT}" -name '*.rs' -not -wholename '*/bazel_protos/*') )
+files=( $(find "${NATIVE_ROOT}" -name '*.rs' -not -wholename '*/bazel_protos/*' -not -wholename '*/target/*') )
 cmd=( "${CARGO_HOME}/bin/rustfmt" --config-path="${NATIVE_ROOT}/rustfmt.toml" )
 
 bad_files=( $(${cmd[*]} ${files[*]} --write-mode=diff 2>/dev/null | awk '$0 ~ /^Diff in/ {print $3}' | sort -u ; exit ${PIPESTATUS[0]}) )


### PR DESCRIPTION
It turns out sometimes there are generated files in there which aren't formattable.