### PR TITLE
Fix `BundleIntegrationTest`.

### DIFF
--- a/tests/python/pants_test/engine/legacy/test_bundle_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_bundle_integration.py
@@ -78,4 +78,4 @@ class BundleIntegrationTest(PantsRunIntegrationTest):
        'testprojects/src/java/org/pantsbuild/testproject/bundle:bundle-resource-ordering']
     )
     self.assert_success(pants_run)
-    self.assertEquals(pants_run.stdout_data, 'Hello world from Foo\n\n')
+    self.assertEquals(pants_run.stdout_data.strip(), 'Hello world from Foo')


### PR DESCRIPTION
The `test_bundle_resource_ordering` test was failing, finding one
newline instead of two in the `./pants run` output. Remove sensitivity
to `./pants run` output handling and focus on the contents of the
resource read/output.