### PR TITLE
Fetch go and cmake as part of bootstrap

### DIFF
--- a/build-support/bin/check_rust_formatting.sh
+++ b/build-support/bin/check_rust_formatting.sh
@@ -3,7 +3,7 @@
 REPO_ROOT="$(cd $(dirname "${BASH_SOURCE[0]}") && cd ../.. && pwd -P)"
 source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
 
-ensure_native_build_prerequisites
+ensure_native_build_prerequisites >/dev/null
 
 files=( $(find "${NATIVE_ROOT}" -name '*.rs' -not -wholename '*/bazel_protos/*' -not -wholename '*/target/*') )
 cmd=( "${CARGO_HOME}/bin/rustfmt" --config-path="${NATIVE_ROOT}/rustfmt.toml" )

--- a/build-support/bin/download_binary.sh
+++ b/build-support/bin/download_binary.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -eu
+
+# Downloads the specified binary at the specified version from binaries.pantsbuild.org if it's not already present.
+# Uses a reimplementation of the BinaryUtils mechanism.
+# Outputs an absolute path to the binary, whether fetched or already present, to stdout.
+
+# If the file ends in ".tar.gz", untars the file and outputs the directory to which the files were untar'd.
+# Otherwise, makes the file executable.
+
+if [[ $# -ne 2 && $# -ne 3 ]]; then
+  echo >&2 "Usage: $0 util_name version [filename]"
+  echo >&2 "Example: $0 go 1.7.3 go.tar.gz"
+  exit 1
+fi
+util_name="$1"
+version="$2"
+filename="${3:-${util_name}}"
+
+case "$(uname)" in
+  "Darwin")
+    os="mac"
+    base="$(uname -r)"
+    os_version="10.$(( ${base%%.*} - 4))"
+    ;;
+  "Linux")
+    os="linux"
+    os_version="$(uname -m)"
+    ;;
+  *)
+    echo >&2 "Unknown platform when fetching binary"
+    exit 1
+    ;;
+esac
+
+path="bin/${util_name}/${os}/${os_version}/${version}/${filename}"
+cache_path="${HOME}/.cache/pants/${path}"
+
+if [[ ! -f "${cache_path}" ]]; then
+  mkdir -p "$(dirname "${cache_path}")"
+  curl "https://binaries.pantsbuild.org/${path}" > "${cache_path}"
+  if [[ "${filename}" == *tar.gz ]]; then
+    tar -C "$(dirname "${cache_path}")" -xzf "${cache_path}"
+  else
+    chmod 0755 "${cache_path}"
+  fi
+fi
+
+to_output="${cache_path}"
+if [[ "${filename}" == *tar.gz ]]; then
+  to_output="$(dirname "${to_output}")"
+fi
+echo "${to_output}"

--- a/build-support/bin/download_binary.sh
+++ b/build-support/bin/download_binary.sh
@@ -37,7 +37,8 @@ cache_path="${HOME}/.cache/pants/${path}"
 
 if [[ ! -f "${cache_path}" ]]; then
   mkdir -p "$(dirname "${cache_path}")"
-  curl "https://binaries.pantsbuild.org/${path}" > "${cache_path}"
+  curl --fail "https://binaries.pantsbuild.org/${path}" > "${cache_path}".tmp
+  mv "${cache_path}"{.tmp,}
   if [[ "${filename}" == *tar.gz ]]; then
     tar -C "$(dirname "${cache_path}")" -xzf "${cache_path}"
   else

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -102,7 +102,7 @@ function ensure_native_build_prerequisites() {
   cmake="$("${download_binary}" "cmake" "3.9.4" "cmake.tar.gz")/bin/cmake" || die "Failed to fetch cmake"
   go="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go/bin/go" || die "Failed to fetch go"
 
-  echo "$(dirname "${cmake}"):$(dirname "${go}")"
+  export EXTRA_PATH_FOR_CARGO="$(dirname "${cmake}"):$(dirname "${go}")"
 }
 
 # Echos directories to add to $PATH.
@@ -114,11 +114,11 @@ function prepare_to_build_native_code() {
 }
 
 function run_cargo() {
-  EXTRA_PATH="$(prepare_to_build_native_code)" || die
+  prepare_to_build_native_code || die
 
   local readonly cargo="${CARGO_HOME}/bin/cargo"
   # We change to the ${REPO_ROOT} because if we're not in a subdirectory of it, .cargo/config isn't picked up.
-  (cd "${REPO_ROOT}" && PATH="${EXTRA_PATH}:${PATH}" "${cargo}" "$@")
+  (cd "${REPO_ROOT}" && PATH="${EXTRA_PATH_FOR_CARGO}:${PATH}" "${cargo}" "$@")
 }
 
 function _build_native_code() {

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -99,10 +99,11 @@ function ensure_native_build_prerequisites() {
   fi
 
   local download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
-  cmake="$("${download_binary}" "cmake" "3.9.4" "cmake.tar.gz")/bin/cmake" || die "Failed to fetch cmake"
-  go="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go/bin/go" || die "Failed to fetch go"
+  local readonly cmakeroot="$("${download_binary}" "cmake" "3.9.4" "cmake.tar.gz")" || die "Failed to fetch cmake"
+  local readonly goroot="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go" || die "Failed to fetch go"
 
-  export EXTRA_PATH_FOR_CARGO="$(dirname "${cmake}"):$(dirname "${go}")"
+  export GOROOT="${goroot}"
+  export EXTRA_PATH_FOR_CARGO="${cmakeroot}/bin:${goroot}/bin"
 }
 
 # Echos directories to add to $PATH.

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -99,8 +99,8 @@ function ensure_native_build_prerequisites() {
   fi
 
   local download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
-  cmake="$("${download_binary}" "cmake" "3.9.4" "cmake.tar.gz")/bin/cmake"
-  go="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go/bin/go"
+  cmake="$("${download_binary}" "cmake" "3.9.4" "cmake.tar.gz")/bin/cmake" || die "Failed to fetch cmake"
+  go="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go/bin/go" || die "Failed to fetch go"
 
   echo "$(dirname "${cmake}"):$(dirname "${go}")"
 }
@@ -109,12 +109,12 @@ function ensure_native_build_prerequisites() {
 function prepare_to_build_native_code() {
   # Must happen in the pants venv and have PANTS_SRCPATH set.
 
-  ensure_native_build_prerequisites
-  _ensure_cffi_sources
+  ensure_native_build_prerequisites || die
+  _ensure_cffi_sources || die
 }
 
 function run_cargo() {
-  EXTRA_PATH="$(prepare_to_build_native_code)"
+  EXTRA_PATH="$(prepare_to_build_native_code)" || die
 
   local readonly cargo="${CARGO_HOME}/bin/cargo"
   # We change to the ${REPO_ROOT} because if we're not in a subdirectory of it, .cargo/config isn't picked up.

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -65,6 +65,7 @@ function _ensure_cffi_sources() {
   PYTHONPATH="${PANTS_SRCPATH}:${PYTHONPATH}" python "${CFFI_BOOTSTRAPPER}" "${NATIVE_ROOT}/src/cffi" >&2
 }
 
+# Echos directories to add to $PATH.
 function ensure_native_build_prerequisites() {
   # Control a pants-specific rust toolchain.
 
@@ -96,8 +97,15 @@ function ensure_native_build_prerequisites() {
   if [[ ! -x "${CARGO_HOME}/bin/rustfmt" ]]; then
     "${CARGO_HOME}/bin/cargo" install rustfmt >&2
   fi
+
+  local download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
+  cmake="$("${download_binary}" "cmake" "3.9.4" "cmake.tar.gz")/bin/cmake"
+  go="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go/bin/go"
+
+  echo "$(dirname "${cmake}"):$(dirname "${go}")"
 }
 
+# Echos directories to add to $PATH.
 function prepare_to_build_native_code() {
   # Must happen in the pants venv and have PANTS_SRCPATH set.
 
@@ -106,11 +114,11 @@ function prepare_to_build_native_code() {
 }
 
 function run_cargo() {
-  prepare_to_build_native_code
+  EXTRA_PATH="$(prepare_to_build_native_code)"
 
   local readonly cargo="${CARGO_HOME}/bin/cargo"
   # We change to the ${REPO_ROOT} because if we're not in a subdirectory of it, .cargo/config isn't picked up.
-  (cd "${REPO_ROOT}" && "${cargo}" "$@")
+  (cd "${REPO_ROOT}" && PATH="${EXTRA_PATH}:${PATH}" "${cargo}" "$@")
 }
 
 function _build_native_code() {

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -5,19 +5,6 @@
 # distros.
 FROM python:2.7.13-wheezy
 
-# The native engine has a dependency on gRPC which builds with cmake.
-RUN bash -c "pushd /tmp && \
- curl -O https://cmake.org/files/v3.8/cmake-3.8.0.tar.gz && \
- tar xzf cmake-3.8.0.tar.gz && cd cmake-3.8.0 && \
- ./configure && make && make install && \
- popd && \
- rm -rf /tmp/cmake-3.8.0 /tmp/cmake-3.8.0.tar.gz"
-
-# The native engine has a dependency on gRPC which requires go to build.
-RUN bash -c "tar -C /usr/local -xzf <(curl https://binaries.pantsbuild.org/bin/go/linux/x86_64/1.7.6/go.tar.gz)"
-
-ENV PATH="${PATH}:/usr/local/go/bin"
-
 # Ensure Pants runs under the 2.7.13 interpreter.
 ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
 

--- a/src/rust/engine/process_executor/bazel_protos/generate-grpc.sh
+++ b/src/rust/engine/process_executor/bazel_protos/generate-grpc.sh
@@ -1,38 +1,15 @@
 #!/bin/bash -eu
 
-# Fetches protoc 3.4.1 if it's missing in the same style as BinaryUtil.
-# Compile protos with that protoc, outputting into source repository.
+# Compile protos with protoc, outputting into source repository.
 
 here="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "${here}")")")")")"
 
-case "$(uname)" in
-  "Darwin")
-    os="mac"
-    base="$(uname -r)"
-    os_version="10.$(( ${base%%.*} - 4))"
-    ;;
-  "Linux")
-    os="linux"
-    os_version="$(uname -m)"
-    ;;
-  *)
-    echo >&2 "Unknown platform when fetching protoc"
-    exit 1
-    ;;
-esac
-
-path="bin/protobuf/${os}/${os_version}/3.4.1/protoc"
-cache_path="${HOME}/.cache/${path}"
-
-if [ ! -x "${cache_path}" ]; then
-  mkdir -p "$(dirname "${cache_path}")"
-  curl "https://binaries.pantsbuild.org/${path}" > "${cache_path}"
-  chmod 0755 "${cache_path}"
-fi
+protoc="$("${REPO_ROOT}/build-support/bin/download_binary.sh" "protobuf" "3.4.1" "protoc")"
 
 thirdpartyprotobuf="../../../../../3rdparty/protobuf"
 googleapis="${thirdpartyprotobuf}/googleapis"
 outdir="${here}/src"
 mkdir -p "${outdir}"
 
-"${cache_path}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust-toolchain/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/rpc/status.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"
+"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust-toolchain/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/rpc/status.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"


### PR DESCRIPTION
These are required to build grpc.

Fixes #4961.

Depends on https://github.com/pantsbuild/binaries/pull/45