### PR TITLE
Utility to tee subprocess output to sys.std{out,err} and a buffer

### DIFF
--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -22,7 +22,7 @@ from pants.fs.archive import ZIP
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import environment_as, pushd, temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_mkdir_for, safe_open
-from pants.util.process_handler import subprocess
+from pants.util.process_handler import SubprocessProcessHandler, subprocess
 from pants_test.testutils.file_test_util import check_symlinks, contains_exact_files
 
 
@@ -158,7 +158,7 @@ class PantsRunIntegrationTest(unittest.TestCase):
       return ret
 
   def run_pants_with_workdir(self, command, workdir, config=None, stdin_data=None, extra_env=None,
-                             build_root=None, **kwargs):
+                             build_root=None, tee_output=False, **kwargs):
 
     args = [
       '--no-pantsrc',
@@ -222,7 +222,10 @@ class PantsRunIntegrationTest(unittest.TestCase):
 
     proc = subprocess.Popen(pants_command, env=env, stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
-    (stdout_data, stderr_data) = proc.communicate(stdin_data)
+    communicate_fn = proc.communicate
+    if tee_output:
+      communicate_fn = SubprocessProcessHandler(proc).communicate_teeing_stdout_and_stderr
+    (stdout_data, stderr_data) = communicate_fn(stdin_data)
 
     return PantsResult(pants_command, proc.returncode, stdout_data.decode("utf-8"),
                        stderr_data.decode("utf-8"), workdir)

--- a/tests/python/pants_test/util/test_process_handler.py
+++ b/tests/python/pants_test/util/test_process_handler.py
@@ -20,3 +20,31 @@ class TestSubprocessProcessHandler(unittest.TestCase):
     process = subprocess.Popen(["/bin/sh", "-c", "exit 0"])
     process_handler = SubprocessProcessHandler(process)
     self.assertEquals(process_handler.wait(), 0)
+
+  def test_communicate_teeing_retrieves_stdout_and_stderr(self):
+    process = subprocess.Popen(["/bin/bash", "-c",
+"""
+  echo "1out"
+  echo >&2 "1err"
+  sleep 0.05
+  echo >&2 "2err"
+  echo "2out"
+  sleep 0.05
+  echo "3out"
+  sleep 0.05
+  echo >&2 "3err"
+  sleep 0.05
+exit 1
+"""], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process_handler = SubprocessProcessHandler(process)
+    self.assertEquals(process_handler.communicate_teeing_stdout_and_stderr(), (
+"""1out
+2out
+3out
+""", """1err
+2err
+3err
+"""))
+    # Sadly, this test doesn't test that sys.std{out,err} also receive the output.
+    # You can see it when you run it, but any way we have of spying on sys.std{out,err}
+    # isn't picklable enough to write a test which works.


### PR DESCRIPTION
This is useful for debugging tests which invoke pants, where they
fail/flake because pants timed out or hanged. It allows us to fetch the
std{out,err} of the pants process, while also storing it so we can
assert against it in the test.