### PR TITLE
Fix setting of PEX_PATH in ./pants run (v2 backend) 

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -13,7 +13,7 @@ packaging==16.8
 pathspec==0.5.0
 parameterized==0.6.1
 pep8==1.6.2
-pex==1.2.11
+pex==1.2.13
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
@@ -166,12 +166,14 @@ class PythonEval(ResolveRequirementsTaskBase):
           # executable_file_content does what the user intends (including, probably, calling that
           # underlying entry point).
           pex_info.entry_point = self._EXEC_NAME
+          extra_pex_paths = [pex.path() for pex in filter(None, [reqs_pex, srcs_pex])]
+          if extra_pex_paths:
+            pex_info.merge_pex_path(':'.join(extra_pex_paths))
           builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
           builder.freeze()
 
       exec_pex = PEX(exec_pex_path, interpreter)
-      extra_pex_paths = [pex.path() for pex in filter(None, [reqs_pex, srcs_pex])]
-      pex = WrappedPEX(exec_pex, extra_pex_paths, interpreter)
+      pex = WrappedPEX(exec_pex, interpreter)
 
       with self.context.new_workunit(name='eval',
                                      labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.RUN,

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
@@ -166,14 +166,12 @@ class PythonEval(ResolveRequirementsTaskBase):
           # executable_file_content does what the user intends (including, probably, calling that
           # underlying entry point).
           pex_info.entry_point = self._EXEC_NAME
-          extra_pex_paths = [pex.path() for pex in filter(None, [reqs_pex, srcs_pex])]
-          if extra_pex_paths:
-            pex_info.merge_pex_path(':'.join(extra_pex_paths))
           builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
           builder.freeze()
 
       exec_pex = PEX(exec_pex_path, interpreter)
-      pex = WrappedPEX(exec_pex, interpreter)
+      extra_pex_paths = [pex.path() for pex in filter(None, [reqs_pex, srcs_pex])]
+      pex = WrappedPEX(exec_pex, interpreter, extra_pex_paths)
 
       with self.context.new_workunit(name='eval',
                                      labels=[WorkUnitLabel.COMPILER, WorkUnitLabel.RUN,

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-from copy import copy
 
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -53,9 +53,9 @@ class WrappedPEX(object):
     cmdline = ' '.join(self._pex.cmdline(args))
     pex_path = self._pex_path()
     if pex_path:
-     return '{env_var_name}={pex_path} {cmdline}'.format(env_var_name=self._PEX_PATH_ENV_VAR_NAME,
-                                                         pex_path=pex_path,
-                                                         cmdline=cmdline)
+      return '{env_var_name}={pex_path} {cmdline}'.format(env_var_name=self._PEX_PATH_ENV_VAR_NAME,
+                                                          pex_path=pex_path,
+                                                          cmdline=cmdline)
     else:
       return cmdline
 

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -116,7 +116,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           # Add the extra requirements first, so they take precedence over any colliding version
           # in the target set's dependency closure.
           pexes = [self.resolve_requirements([self.context.build_graph.get_target(addr)])] + pexes
-        
+
         extra_pex_paths = [pex.path() for pex in pexes if pex]
 
         if extra_pex_paths:

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -53,10 +53,7 @@ class WrappedPEX(object):
     return ' '.join(self._pex.cmdline(args))
 
   def run(self, *args, **kwargs):
-    kwargs_copy = copy(kwargs)
-    env = copy(kwargs_copy.get('env')) if 'env' in kwargs_copy else {}
-    kwargs_copy['env'] = env
-    return self._pex.run(*args, **kwargs_copy)
+    return self._pex.run(*args, **kwargs)
 
 
 class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
@@ -120,7 +117,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
         extra_pex_paths = [pex.path() for pex in pexes if pex]
 
         if extra_pex_paths:
-          pex_info.pex_path = ':'.join(extra_pex_paths)
+          pex_info.merge_pex_path(':'.join(extra_pex_paths))
 
         with safe_concurrent_creation(path) as safe_path:
           builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -31,14 +31,13 @@ class WrappedPEX(object):
 
   _PEX_PATH_ENV_VAR_NAME = 'PEX_PATH'
 
-  def __init__(self, pex, extra_pex_paths, interpreter):
+  def __init__(self, pex, interpreter):
     """
     :param pex: The main pex we wrap.
     :param extra_pex_paths: Other pexes, to "merge" in via the PEX_PATH mechanism.
     :param interpreter: The interpreter the main pex will run on.
     """
     self._pex = pex
-    self._extra_pex_paths = extra_pex_paths
     self._interpreter = interpreter
 
   @property
@@ -122,12 +121,4 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           builder = PEXBuilder(safe_path, interpreter, pex_info=pex_info)
           builder.freeze()
 
-        with open(extra_pex_paths_file_path, 'w') as outfile:
-          for epp in extra_pex_paths:
-            outfile.write(epp)
-            outfile.write(b'\n')
-
-    if extra_pex_paths is None:
-      with open(extra_pex_paths_file_path, 'r') as infile:
-        extra_pex_paths = [p.strip() for p in infile.readlines()]
-    return WrappedPEX(PEX(os.path.realpath(path), interpreter), extra_pex_paths, interpreter)
+    return WrappedPEX(PEX(os.path.realpath(path), interpreter), interpreter)

--- a/src/python/pants/backend/python/tasks2/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks2/python_execution_task_base.py
@@ -92,7 +92,6 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
 
       interpreter = self.context.products.get_data(PythonInterpreter)
       path = os.path.join(self.workdir, str(interpreter.identity), target_set_id)
-      extra_pex_paths_file_path = path + '.extra_pex_paths'
       extra_pex_paths = None
 
       # Note that we check for the existence of the directory, instead of for invalid_vts,


### PR DESCRIPTION
### Problem

App servers that need to re-execute (apps watching for file systems changes, jupyter notebooks, etc.) throw an ImportError when being ran with `./pants run` because the pants runner pex is losing context of where to find the requirements pex, the sources pex, and any other pexes to merge into the runtime environment. This context is encapsulated in a search path called `PEX_PATH`, which is being loaded into the `PEX_PATH` environment variable and is consequently scrubbed out of the environment upon re-exec by pex internal logic. 

### Solution

Completely remove any setting of `PEX_PATH` in the environment upon construction of the pants runner pex and instead pass this extra pex path information to the `pex_info` metadata that is used by the `PEXBuilder` object to construct the pants runner pex. 

### Result

Applications that need to re-execute will now be able to locate the sources module and entry point because the search path to resolve them (`PEX_PATH`) will be persisted in the pants runner pex's PEX-INFO metadata. 