### PR TITLE
Extend timeout for cargo fetching git repos

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -124,6 +124,13 @@ function run_cargo() {
 
 function _build_native_code() {
   # Builds the native code, and echos the path of the built binary.
+
+  # Sometimes fetching a large git repo dependency can take more than 10 minutes.
+  # This times out on travis, because nothing is printed to stdout/stderr in that time.
+  # Pre-fetch those git repos with an extended timeout.
+  if type -t travis_wait >/dev/null; then
+    travis_wait 30 run_cargo fetch --manifest-path ${NATIVE_ROOT}/Cargo.toml
+  fi
   run_cargo build ${MODE_FLAG} --manifest-path ${NATIVE_ROOT}/Cargo.toml || die
   echo "${NATIVE_ROOT}/target/${MODE}/libengine.${LIB_EXTENSION}"
 }


### PR DESCRIPTION
Hopefully this won't be necessary when we have no longer forked grpc because we should hit Travis caches more often.