### PR TITLE
Include target addresses which trigger deprecation warnings

### DIFF
--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -94,8 +94,12 @@ class JvmTarget(Target, Jarable):
     :param scalac_plugins: names of compiler plugins to use when compiling this target with scalac.
     :param dict scalac_plugin_args: Map from scalac plugin name to list of arguments for that plugin.
     """
-    deprecated_conditional(lambda: resources is not None, '1.5.0.dev0',
-                           'The `resources=` JVM target argument', 'Use `dependencies=` instead.')
+    deprecated_conditional(
+      lambda: resources is not None,
+      '1.5.0.dev0',
+      'The `resources=` JVM target argument found on target {}'.format(address.to_address()),
+      'Use `dependencies=` instead.'
+    )
 
     self.address = address  # Set in case a TargetDefinitionException is thrown early
     payload = payload or Payload()

--- a/src/python/pants/backend/jvm/targets/jvm_target.py
+++ b/src/python/pants/backend/jvm/targets/jvm_target.py
@@ -97,7 +97,7 @@ class JvmTarget(Target, Jarable):
     deprecated_conditional(
       lambda: resources is not None,
       '1.5.0.dev0',
-      'The `resources=` JVM target argument found on target {}'.format(address.to_address()),
+      'The `resources=` JVM target argument found on target {}'.format(address.spec),
       'Use `dependencies=` instead.'
     )
 

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -37,7 +37,11 @@ class PythonTarget(Target):
       deprecated_conditional(
         lambda: True,
         '1.5.0.dev0',
-        'The `resources=` Python target argument', 'Depend on resources targets instead.'
+        'The `resources=` Python target argument found on target //{}:{}'.format(
+            parse_context.rel_path,
+            kwargs.get('name', 'unknown')
+        ),
+        'Depend on resources targets instead.'
       )
       resources_kwargs = dict(
         name=cls._suffix_for_synthetic_spec(kwargs.get('name', 'unknown')),
@@ -90,10 +94,20 @@ class PythonTarget(Target):
       format, e.g. ``'CPython>=3', or just ['>=2.7','<3']`` for requirements
       agnostic to interpreter class.
     """
-    deprecated_conditional(lambda: resources is not None, '1.5.0.dev0',
-                           'The `resources=` Python target argument', 'Depend on resources targets instead.')
-    deprecated_conditional(lambda: resource_targets is not None, '1.5.0.dev0',
-                           'The `resource_targets=` Python target argument', 'Use `dependencies=` instead.')
+    deprecated_conditional(
+      lambda: resources is not None,
+      '1.5.0.dev0',
+      'The `resources=` Python target argument found on target {}'.format(address.to_address()),
+      'Depend on resources targets instead.'
+    )
+    deprecated_conditional(
+      lambda: resource_targets is not None,
+      '1.5.0.dev0',
+      'The `resource_targets=` Python target argument found on target {}'.format(
+        address.to_address()
+      ),
+      'Use `dependencies=` instead.'
+    )
     self.address = address
     payload = payload or Payload()
     payload.add_fields({

--- a/src/python/pants/backend/python/targets/python_target.py
+++ b/src/python/pants/backend/python/targets/python_target.py
@@ -37,7 +37,7 @@ class PythonTarget(Target):
       deprecated_conditional(
         lambda: True,
         '1.5.0.dev0',
-        'The `resources=` Python target argument found on target //{}:{}'.format(
+        'The `resources=` Python target argument found on target {}:{}'.format(
             parse_context.rel_path,
             kwargs.get('name', 'unknown')
         ),
@@ -97,15 +97,13 @@ class PythonTarget(Target):
     deprecated_conditional(
       lambda: resources is not None,
       '1.5.0.dev0',
-      'The `resources=` Python target argument found on target {}'.format(address.to_address()),
+      'The `resources=` Python target argument found on target {}'.format(address.spec),
       'Depend on resources targets instead.'
     )
     deprecated_conditional(
       lambda: resource_targets is not None,
       '1.5.0.dev0',
-      'The `resource_targets=` Python target argument found on target {}'.format(
-        address.to_address()
-      ),
+      'The `resource_targets=` Python target argument found on target {}'.format(address.spec),
       'Use `dependencies=` instead.'
     )
     self.address = address


### PR DESCRIPTION
This makes it much easier to fix the problems raised by the warnings.