### PR TITLE
Use more generic portion of `requests` exception message in tests

### DIFF
--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -76,7 +76,7 @@ class TestArtifactCache(unittest.TestCase):
                                               local)
         with self.assertRaises(NonfatalArtifactCacheError) as ex:
           self.do_test_artifact_cache(artifact_cache)
-        self.assertIn('Connection aborted', str(ex.exception))
+        self.assertIn('Failed to HEAD', str(ex.exception))
 
         self.do_test_artifact_cache(artifact_cache)
 


### PR DESCRIPTION
### Problem

It appears that newer versions of `requests` (`2.18.4` vs `???`: argh, floating) result in slightly different error messages on linux. While we really shouldn't be floating that widely, it seems like it might be necessary to in order to allow pants to be built in contexts where other versions of requests are necessary.

An example failure: https://travis-ci.org/pantsbuild/pants/jobs/288657800

### Solution

Continue to float as begun with #4916, but use a more stable portion of the error message for comparison.

### Result

OSX and Linux both pass.