### PR TITLE
add "lines" parameter for `!inc[]` markdown directive

### DIFF
--- a/examples/src/java/org/pantsbuild/example/page.md
+++ b/examples/src/java/org/pantsbuild/example/page.md
@@ -107,6 +107,13 @@ end-at=*substring*<br>
 When excerpting the file to include, stop at a line containing
 *substring*.
 
+lines=*start-line*-*end-line*<br>
+When excerpting the file to include, start at *start-line* and end at
+*end-line*. *start-line* and *end-line* should both be positive integers
+(nonzero) with a hyphen between them, and *end-line* should not be less than *start-line* (e.g
+`lines=1-12`). If the `lines` parameter is provided, no other parameter can be
+used.
+
 ReStructedText Syntax
 ---------------------
 

--- a/examples/src/python/example/3rdparty_py.md
+++ b/examples/src/python/example/3rdparty_py.md
@@ -33,7 +33,7 @@ E.g, your `3rdparty/python/BUILD` file might look like:
 
 ...with `3rdparty/python/requirements.txt` like:
 
-!inc[end-before=pathspec](../../../../3rdparty/python/requirements.txt)
+!inc[lines=1-12](../../../../3rdparty/python/requirements.txt)
 
 `python_requirements` defines a named target for each line in the
 `requirements.txt` line. For example, a line like `ansicolors==1.0.2` in

--- a/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
+++ b/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
@@ -57,8 +57,8 @@ class WikilinksExtension(markdown.Extension):
 # !inc[start-at=void main&end-before=private HelloMain](HelloMain.java)
 INCLUDE_PATTERN = r'!inc(\[(?P<params>[^]]*)\])?\((?P<path>[^' + '\n' + r']*)\)'
 
-INCLUDE_RECOGNIZED_PARAMS = frozenset(
-  'start-before', 'start-at', 'end-before', 'end-at', 'lines')
+INCLUDE_RECOGNIZED_PARAMS = frozenset([
+  'start-after', 'start-at', 'end-before', 'end-at', 'lines'])
 
 LINES_PATTERN = re.compile(r'\A([1-9][0-9]*)-([1-9][0-9]*)\Z')
 
@@ -99,10 +99,11 @@ def choose_include_text(s, params, source_path):
 
 def include_by_line_range(source_lines, line_range_arg, params_dict):
   # 'lines' should be the only parameter specified
-  conflicts = ('"{0}={1}"'.format(p, v) for p, v in params_dict if p != 'lines')
+  conflicts = [(p, v) for p, v in params_dict.iteritems() if p != 'lines']
   if len(conflicts) > 0:
+    error_msgs = ', '.join(['"{0}={1}"'.format(p, v) for (p, v) in conflicts])
     raise TaskError('"lines" directive conflicts with other directives: [{0}]'
-                    .format(', '.join(conflicts)))
+                    .format(error_msgs))
 
   # validate the line range
   lines_match = LINES_PATTERN.match(line_range_arg)

--- a/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
+++ b/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
@@ -87,9 +87,9 @@ def choose_include_text(s, params):
     if not param: continue
     if param not in INCLUDE_RECOGNIZED_PARAMS:
       valid_params = ["'{0}'".format(p) for p in INCLUDE_RECOGNIZED_PARAMS]
-      raise IncludeParamParseError('Invalid !inc parameter name "{0}"'
-                                   ': valid parameters are: [{1}].'
-                                   .format(param, ', '.join(valid_params)))
+      raise IncludeParamParseError(
+        'Invalid parameter name "{0}": valid parameters are: [{1}].'
+        .format(param, ', '.join(valid_params)))
     params_dict[param] = value
 
   chosen_lines = []
@@ -116,15 +116,15 @@ def choose_include_text(s, params):
     # LINES_PATTERN does not allow 0 or negative numbers
     if line_end < line_start:
       raise IncludeParamParseError(
-        'Invalid end line "{0}" in parameter "lines={1}":'
-        ' should be >= {2}, the start line'
+        'Invalid end line "{0}" in argument "{1}" for parameter "lines"'
+        ': should be >= {2}, the start line'
         .format(line_end, line_range_arg, line_start))
     nlines = len(source_lines)
     if line_end > nlines:
-      raise IncludeParamParseError('Invalid end line "{0}"'
-                      ' (should be <= {1}, the number of lines in the source)'
-                      ' from "{2}" for "lines"'
-                      .format(line_end, nlines, line_range_arg))
+      raise IncludeParamParseError(
+        'Invalid end line "{0}" in argument "{1}" for parameter "lines"'
+        ': should be <= {1}, the number of lines in the source text'
+        .format(line_end, line_range_arg, nlines))
     # line range arguments start at 1
     chosen_lines = source_lines[(line_start - 1):line_end]
 

--- a/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
+++ b/src/python/pants/backend/docgen/tasks/markdown_to_html_utils.py
@@ -62,6 +62,7 @@ INCLUDE_RECOGNIZED_PARAMS = frozenset([
 
 LINES_PATTERN = re.compile(r'\A([1-9][0-9]*)-([1-9][0-9]*)\Z')
 
+
 def choose_include_text(s, params, source_path):
   """Given the contents of a file and !inc[these params], return matching lines
 
@@ -97,9 +98,10 @@ def choose_include_text(s, params, source_path):
                     .format(include_error, params, source_path))
   return '\n'.join(chosen_lines)
 
+
 def include_by_line_range(source_lines, line_range_arg, params_dict):
   # 'lines' should be the only parameter specified
-  conflicts = [(p, v) for p, v in params_dict.iteritems() if p != 'lines']
+  conflicts = [(p, params_dict[p]) for p in params_dict if p != 'lines']
   if len(conflicts) > 0:
     error_msgs = ', '.join(['"{0}={1}"'.format(p, v) for (p, v) in conflicts])
     raise TaskError('"lines" directive conflicts with other directives: [{0}]'
@@ -125,6 +127,7 @@ def include_by_line_range(source_lines, line_range_arg, params_dict):
 
   # line range arguments start at 1
   return source_lines[(line_start - 1):line_end]
+
 
 def include_by_text_match(source_lines, params_dict):
   chosen_lines = []

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -30,6 +30,23 @@ class ChooseLinesTest(unittest.TestCase):
         markdown_to_html_utils.choose_include_text(ABC, '', 'fake.md'),
         '\n'.join(['able', 'baker', 'charlie']))
 
+  def test_include_bad_params(self):
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param', 'fake-md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param=3', 'fake-md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'start-at=AAA&bad-param=3', 'fake-md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param=3&start-at=AAA', 'fake-md'))
+
   def test_include_start_at(self):
     self.assertEquals(
         markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl', 'fake.md'),

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -27,151 +27,151 @@ charlie"""
 class ChooseLinesTest(unittest.TestCase):
   def test_include_no_params(self):
     self.assertEquals(
-        markdown_to_html_utils.choose_include_text(ABC, '', 'fake.md'),
+        markdown_to_html_utils.choose_include_text(ABC, ''),
         '\n'.join(['able', 'baker', 'charlie']))
 
   def test_include_bad_params(self):
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param', 'fake-md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param=3', 'fake-md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param=3'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'start-at=AAA&bad-param=3', 'fake-md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'start-at=AAA&bad-param=3'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param=3&start-at=AAA', 'fake-md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'bad-param=3&start-at=AAA'))
 
   def test_include_start_at(self):
     self.assertEquals(
-        markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl', 'fake.md'),
+        markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl'),
         '\n'.join(['able', 'baker', 'charlie']))
 
     self.assertEquals(
-        markdown_to_html_utils.choose_include_text(ABC, 'start-at=bak', 'fake.md'),
+        markdown_to_html_utils.choose_include_text(ABC, 'start-at=bak'),
         '\n'.join(['baker', 'charlie']))
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-at=xxx', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-at=xxx'),
       '')
 
   def test_include_start_after(self):
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-after=bak', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-after=bak'),
       'charlie')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-after=cha', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-after=cha'),
       '')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-after=xxx', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-after=xxx'),
       '')
 
   def test_include_end_at(self):
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'end-at=abl', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'end-at=abl'),
       'able')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'end-at=bak', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'end-at=bak'),
       '\n'.join(['able', 'baker']))
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'end-at=xxx', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'end-at=xxx'),
       '')
 
   def test_include_end_before(self):
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'end-before=abl', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'end-before=abl'),
       '')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'end-before=xxx', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'end-before=xxx'),
       '')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'end-before=bak', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'end-before=bak'),
       'able')
 
   def test_include_start_at_end_at(self):
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl&end-at=abl', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl&end-at=abl'),
       'able')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-at=cha&end-at=cha', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-at=cha&end-at=cha'),
       'charlie')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl&end-at=bak', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-at=abl&end-at=bak'),
       '\n'.join(['able', 'baker']))
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'start-at=bak&end-at=abl', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'start-at=bak&end-at=abl'),
       '')
 
   def test_include_lines(self):
     # valid line ranges
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2'),
       '\n'.join(['able', 'baker']))
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'lines=1-1', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'lines=1-1'),
       'able')
 
     self.assertEquals(
-      markdown_to_html_utils.choose_include_text(ABC, 'lines=2-3', 'fake.md'),
+      markdown_to_html_utils.choose_include_text(ABC, 'lines=2-3'),
       '\n'.join(['baker', 'charlie']))
 
     # mixing lines directives with conflicting ones
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2&start-at=AAA', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2&start-at=AAA'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'start-at=AAA&lines=1-2', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'start-at=AAA&lines=1-2'))
 
     # should throw regardless of relative positions of "lines" and other directives
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2&start-before=AAA', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2&start-before=AAA'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'end-at=AAA&lines=1-2', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'end-at=AAA&lines=1-2'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'end-before=AAA&lines=1-2', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'end-before=AAA&lines=1-2'))
 
     # invalid line ranges
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=AAA', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=AAA'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=0-2', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=0-2'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=-1-2', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=-1-2'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=3-2', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=3-2'))
 
     self.assertRaises(
-      markdown_to_html_utils.TaskError,
-      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-4', 'fake.md'))
+      markdown_to_html_utils.IncludeParamParseError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-4'))
 
 
 class MarkdownToHtmlTest(TaskTestBase):

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -100,6 +100,7 @@ class ChooseLinesTest(unittest.TestCase):
       '')
 
   def test_include_lines(self):
+    # valid line ranges
     self.assertEquals(
       markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2', 'fake.md'),
       '\n'.join(['able', 'baker']))
@@ -112,10 +113,29 @@ class ChooseLinesTest(unittest.TestCase):
       markdown_to_html_utils.choose_include_text(ABC, 'lines=2-3', 'fake.md'),
       '\n'.join(['baker', 'charlie']))
 
+    # mixing lines directives with conflicting ones
     self.assertRaises(
       markdown_to_html_utils.TaskError,
       lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2&start-at=AAA', 'fake.md'))
 
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'start-at=AAA&lines=1-2', 'fake.md'))
+
+    # should throw regardless of relative positions of "lines" and other directives
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2&start-before=AAA', 'fake.md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'end-at=AAA&lines=1-2', 'fake.md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'end-before=AAA&lines=1-2', 'fake.md'))
+
+    # invalid line ranges
     self.assertRaises(
       markdown_to_html_utils.TaskError,
       lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=AAA', 'fake.md'))

--- a/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
+++ b/tests/python/pants_test/backend/docgen/tasks/test_markdown_to_html.py
@@ -99,6 +99,43 @@ class ChooseLinesTest(unittest.TestCase):
       markdown_to_html_utils.choose_include_text(ABC, 'start-at=bak&end-at=abl', 'fake.md'),
       '')
 
+  def test_include_lines(self):
+    self.assertEquals(
+      markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2', 'fake.md'),
+      '\n'.join(['able', 'baker']))
+
+    self.assertEquals(
+      markdown_to_html_utils.choose_include_text(ABC, 'lines=1-1', 'fake.md'),
+      'able')
+
+    self.assertEquals(
+      markdown_to_html_utils.choose_include_text(ABC, 'lines=2-3', 'fake.md'),
+      '\n'.join(['baker', 'charlie']))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-2&start-at=AAA', 'fake.md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=AAA', 'fake.md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=0-2', 'fake.md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=-1-2', 'fake.md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=3-2', 'fake.md'))
+
+    self.assertRaises(
+      markdown_to_html_utils.TaskError,
+      lambda: markdown_to_html_utils.choose_include_text(ABC, 'lines=1-4', 'fake.md'))
+
 
 class MarkdownToHtmlTest(TaskTestBase):
   @classmethod


### PR DESCRIPTION
### Problem

There are many instances of inline code added to the documentation. This creates snippets that need to be updated when pants changes. One way to make this easier is to allow selecting numeric line ranges from files which can have their content change over time (e.g. `requirements.txt`). See #4982 for more description.

### Solution

- add "lines" parameter to custom `!inc` markdown directive in docgen
- add tests and docs for the new feature
- include a line range from `requirements.txt` to demonstrate usage