### PR TITLE
Reduce time/package requirements on binary-builder shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
         - ./pants --version && ./build-support/bin/release.sh -nc
 
     - os: linux
+      language: generic
       services:
         - docker
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
         - SHARD="OSX Native Engine Binary Builder"
         - PREPARE_DEPLOY=1
       script:
-        - ./pants --version && ./build-support/bin/release.sh -n
+        - ./pants --version && ./build-support/bin/release.sh -nc
 
     - os: linux
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
           -v "${HOME}:/travis/home"
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
-          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -n"
+          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -nc"
 
     - os: linux
       dist: trusty

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -83,9 +83,12 @@ function pkg_pants_testinfra_install_test() {
 }
 
 # Once an individual (new) package is declared above, insert it into the array below)
-RELEASE_PACKAGES=(
+CORE_PACKAGES=(
   PKG_PANTS
   PKG_PANTS_TESTINFRA
+)
+RELEASE_PACKAGES=(
+  ${CORE_PACKAGES[*]}
   ${CONTRIB_PACKAGES[*]}
 )
 #
@@ -196,6 +199,8 @@ EOM
 }
 
 function install_and_test_packages() {
+  CORE_ONLY=$0
+  shift 1
   PIP_ARGS=(
     "$@"
     --quiet
@@ -210,7 +215,14 @@ function install_and_test_packages() {
   export PANTS_PLUGIN_CACHE_DIR=$(mktemp -d -t plugins_cache.XXXXX)
   trap "rm -rf ${PANTS_PLUGIN_CACHE_DIR}" EXIT
 
-  for PACKAGE in "${RELEASE_PACKAGES[@]}"
+  if [[ "${CORE_ONLY}" == "true" ]]
+  then
+    PACKAGES=$CORE_PACKAGES
+  else
+    PACKAGES=$RELEASE_PACKAGES
+  fi
+
+  for PACKAGE in "${PACKAGES[@]}"
   do
     NAME=$(pkg_name $PACKAGE)
     INSTALL_TEST_FUNC=$(pkg_install_test_func $PACKAGE)
@@ -226,8 +238,9 @@ function install_and_test_packages() {
 }
 
 function dry_run_install() {
+  CORE_ONLY=$0
   build_packages && \
-  install_and_test_packages --find-links="${DEPLOY_WHEEL_DIR}"
+  install_and_test_packages $CORE_ONLY --find-links="${DEPLOY_WHEEL_DIR}"
 }
 
 ALLOWED_ORIGIN_URLS=(
@@ -556,7 +569,7 @@ function usage() {
   echo "PyPi.  Credentials are needed for this as described in the"
   echo "release docs: http://pantsbuild.org/release.html"
   echo
-  echo "Usage: $0 [-d] (-h|-n|-t|-l|-o|-e)"
+  echo "Usage: $0 [-d] [-c] (-h|-n|-t|-l|-o|-e)"
   echo " -d  Enables debug mode (verbose output, script pauses after venv creation)"
   echo " -h  Prints out this help message."
   echo " -n  Performs a release dry run."
@@ -566,11 +579,13 @@ function usage() {
   echo " -t  Tests a live release."
   echo "       Ensures the latest packages have been propagated to PyPi"
   echo "       and can be installed in an ephemeral virtualenv."
+  echo " -c  Skips contrib during a dry or test run."
+  echo "       It is still necessary to pass -n or -t to trigger the test/dry run."
   echo " -l  Lists all pantsbuild packages that this script releases."
   echo " -o  Lists all pantsbuild package owners."
   echo " -e  Check that wheels are prebuilt for this release."
   echo
-  echo "All options (except for '-d') are mutually exclusive."
+  echo "All options (except for '-d' and '-c') are mutually exclusive."
 
   if (( $# > 0 )); then
     die "$@"
@@ -579,12 +594,13 @@ function usage() {
   fi
 }
 
-while getopts "hdntloe" opt; do
+while getopts "hdntcloe" opt; do
   case ${opt} in
     h) usage ;;
     d) debug="true" ;;
     n) dry_run="true" ;;
     t) test_release="true" ;;
+    c) core_only="true" ;;
     l) list_packages && exit 0 ;;
     o) list_owners && exit 0 ;;
     e) check_prebuilt_wheels && exit 0 ;;
@@ -602,13 +618,13 @@ if [[ "${dry_run}" == "true" && "${test_release}" == "true" ]]; then
 elif [[ "${dry_run}" == "true" ]]; then
   banner "Performing a dry run release" && \
   (
-    dry_run_install && \
+    dry_run_install $core_only && \
     banner "Dry run release succeeded"
   ) || die "Dry run release failed."
 elif [[ "${test_release}" == "true" ]]; then
   banner "Installing and testing the latest released packages" && \
   (
-    install_and_test_packages && \
+    install_and_test_packages $core_only && \
     banner "Successfully installed and tested the latest released packages"
   ) || die "Failed to install and test the latest released packages."
 else

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -8,19 +8,6 @@ FROM python:2.7.13-wheezy
 # Ensure Pants runs under the 2.7.13 interpreter.
 ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
 
-# Install various things Pants requires.
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" > \
-      /etc/apt/sources.list.d/java-8-debian.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> \
-      /etc/apt/sources.list.d/java-8-debian.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && \
-    echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-    echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      cmake \
-      oracle-java8-installer
-
 # Setup mount points for the travis ci user & workdir.
 VOLUME /travis/home
 VOLUME /travis/workdir

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -8,6 +8,10 @@ FROM python:2.7.13-wheezy
 # Ensure Pants runs under the 2.7.13 interpreter.
 ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
 
+# Install various things Pants requires.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk
+
 # Setup mount points for the travis ci user & workdir.
 VOLUME /travis/home
 VOLUME /travis/workdir


### PR DESCRIPTION
### Problem

The binary-builder shards currently run dry-run releases (using `-n`), which additionally runs the tests for contrib packages. But OSX time in travis continues to be a relatively scarce resource, and running the contrib tests can take up to 30 minutes in some cases. Additionally, running the contrib tests increases the number of tools required, all of which need to be installed in our (wheezy) docker image (see #4995).

### Solution

Add support to both test (`-t`) and dry-run (`-n`) releases for a "core only" `-c` flag, which skips testing contrib modules. Pass `-c` for both binary-builder shards.

Contrib continues to be tested on the dedicated contrib shards.

### Result

Both shards should run more quickly, and with fewer requirements.

Anecdotally, the difference with `-nc` on my laptop:
```
[=== 03:53 Dry run release succeeded ===]
```
vs a recent run of master in the OSX travis shard with `-n`:
```
[=== 32:48 Dry run release succeeded ===]
```