### PR TITLE
Add custom commands to the `buildozer` goal

### DIFF
--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
@@ -48,24 +48,16 @@ class Buildozer(Task):
 
   def execute(self):
     if self.options.command:
-      if self.options.add_dependencies or self.remove_dependencies():
-        raise TaskError('Use the command option only')
-      self.execute_custom_command()
+      if self.options.add_dependencies or self.options.remove_dependencies:
+        raise TaskError('Buildozer custom command cannot be used together with ' +
+                        '--add-dependencies or --remove-dependencies.')
+      self._execute_buildozer_script(self.options.command)
 
     if self.options.add_dependencies:
-      self.add_dependencies()
+      self._execute_buildozer_script('add dependencies {}'.format(self.options.add_dependencies))
 
     if self.options.remove_dependencies:
-      self.remove_dependencies()
-
-  def add_dependencies(self):
-    self._execute_buildozer_script('add dependencies {}'.format(self.options.add_dependencies))
-
-  def remove_dependencies(self):
-    self._execute_buildozer_script('remove dependencies {}'.format(self.options.remove_dependencies))
-
-  def execute_custom_command(self):
-    self._execute_buildozer_script(self.options.command)
+      self._execute_buildozer_script('remove dependencies {}'.format(self.options.remove_dependencies))
 
   def _execute_buildozer_script(self, command):
     for root in self.context.target_roots:

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
@@ -47,14 +47,16 @@ class Buildozer(Task):
     self._executable = BinaryUtil.Factory.create().select_binary('scripts/buildozer', self.options.version, 'buildozer')
 
   def execute(self):
+    if self.options.command:
+      if self.options.add_dependencies or self.remove_dependencies():
+        raise TaskError('Use the command option only')
+      self.execute_custom_command()
+
     if self.options.add_dependencies:
       self.add_dependencies()
 
     if self.options.remove_dependencies:
       self.remove_dependencies()
-
-    if self.options.command:
-      self.execute_custom_command()
 
   def add_dependencies(self):
     self._execute_buildozer_script('add dependencies {}'.format(self.options.add_dependencies))

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
@@ -38,6 +38,7 @@ class Buildozer(Task):
     register('--version', default='0.4.5', help='Version of buildozer.')
     register('--add-dependencies', type=str, help='The dependency or dependencies to add')
     register('--remove-dependencies', type=str, help='The dependency or dependencies to remove')
+    register('--command', type=str, help='A custom buildozer command to execute')
 
   def __init__(self, *args, **kwargs):
     super(Buildozer, self).__init__(*args, **kwargs)
@@ -52,11 +53,17 @@ class Buildozer(Task):
     if self.options.remove_dependencies:
       self.remove_dependencies()
 
+    if self.options.command:
+      self.execute_custom_command()
+
   def add_dependencies(self):
     self._execute_buildozer_script('add dependencies {}'.format(self.options.add_dependencies))
 
   def remove_dependencies(self):
     self._execute_buildozer_script('remove dependencies {}'.format(self.options.remove_dependencies))
+
+  def execute_custom_command(self):
+    self._execute_buildozer_script(self.options.command)
 
   def _execute_buildozer_script(self, command):
     for root in self.context.target_roots:

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_buildozer.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_buildozer.py
@@ -42,6 +42,18 @@ class BuildozerTest(TaskTestBase):
   def test_remove_multiple_dependencies(self):
     self._test_remove_dependencies('d', 'a b')
 
+  def test_custom_command(self):
+    build_file = self.build_root + '/b/BUILD'
+    new_build_name = 'b_2'
+
+    self._clean_build_file(build_file)
+    self._test_buildozer_execution({ 'command': 'set name {}'.format(new_build_name) })
+
+    with open(build_file) as f:
+      build_source = f.read()
+
+    self.assertIn(new_build_name, build_source)
+
   def _test_add_dependencies(self, spec_path, dependencies_to_add):
     build_file = self.build_root + '/{}/BUILD'.format(spec_path)
 

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_buildozer.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_buildozer.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import re
 
 from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants_test.tasks.task_test_base import TaskTestBase
 
@@ -53,6 +54,10 @@ class BuildozerTest(TaskTestBase):
       build_source = f.read()
 
     self.assertIn(new_build_name, build_source)
+
+  def test_custom_command_error(self):
+    with self.assertRaises(TaskError):
+      self._test_buildozer_execution({ 'command': 'foo', 'add-dependencies': 'boo' })
 
   def _test_add_dependencies(self, spec_path, dependencies_to_add):
     build_file = self.build_root + '/{}/BUILD'.format(spec_path)


### PR DESCRIPTION
### Problem and Solution

We should take full advantage of the buildozer binary. This code change adds support for a `--command` option to the buildozer goal. This will be particularly helpful for executing features beyond adding and removing dependencies. For example, setting the name of an attribute, replacing an attribute name, and printing attributes within a BUILD file are all custom
commands that can be executed now with --command.
@wisechengyi

Example to rename the name attribute to new_name in //tmp:tmp:

`./pants buildozer --command='set name new_name' //tmp:tmp`

This follows up on:
* https://github.com/pantsbuild/pants/pull/4921

This will also help out:
* https://github.com/pantsbuild/pants/pull/4882

### To verify:
- Create tmp/BUILD and run the example: 
`./pants buildozer --command='set name new_name' //tmp:tmp`
- Run the test:
`/pants test contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor:buildozer`
- Execute any of the custom buildozer commands listed in: https://github.com/bazelbuild/buildtools/tree/master/buildozer