### PR TITLE
Invalidate parent directories

### DIFF
--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -126,10 +126,7 @@ class GraphInvalidationTest(GraphTestBase):
 
       # Invalidate the '3rdparty/python' DirectoryListing, the `3rdparty` DirectoryListing,
       # and then the root DirectoryListing by "touching" files/dirs.
-      # NB: Invalidation of entries in the root directory is special: because Watchman will
-      # never trigger an event for the root itself, we treat changes to files in the root
-      # directory as events for the root.
-      for filename in ('3rdparty/python/BUILD', '3rdparty/python', 'non_existing_file'):
+      for filename in ('3rdparty/python/BUILD', '3rdparty/jvm', 'non_existing_file'):
         invalidated_count = scheduler.invalidate_files([filename])
         self.assertGreater(invalidated_count,
                            0,


### PR DESCRIPTION
### Problem

Watchman `4.9.0` does not send events for a parent when a child is created or deleted, which causes issues like #4662.

### Solution

Revert to explicitly invalidating the parent directory when a child has changed. More precision is possible here, but it's possible that re-gaining the precision by using the `notify` crate would be preferable (see #4999).

### Result

Fixes #4662.