### PR TITLE
Prune travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,10 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
+      before_script:
+        # The lint shard attempts to ivy resolve against the Android SDK due to
+        # references in `build-support/ivy/ivysettings.xml`.
+        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Various pants self checks and lint"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ before_cache:
   # The stats cache contains timestamped reports unused by CI but that
   # thrash the cache.  Skip caching these.
   - rm -rf ${HOME}/.cache/pants/stats
+  # While the bin directory is relatively large, it's also very quick to restore from S3:
+  # prune it to keep the total cache size down.
+  #   see https://docs.travis-ci.com/user/caching/#Things-not-to-cache
+  - rm -rf ${HOME}/.cache/pants/bin
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,13 @@ before_cache:
   # The stats cache contains timestamped reports unused by CI but that
   # thrash the cache.  Skip caching these.
   - rm -rf ${HOME}/.cache/pants/stats
-  # While the bin directory is relatively large, it's also very quick to restore from S3:
-  # prune it to keep the total cache size down.
+  # While the bin directory and rust toolchains are relatively large, they're also very quick to
+  # restore/install: prune them to keep the total cache size down.
   #   see https://docs.travis-ci.com/user/caching/#Things-not-to-cache
+  # NB: We do _not_ prune the cargo cache, since that holds compiled tools and outputs, and
+  # individually resolved artifacts.
   - rm -rf ${HOME}/.cache/pants/bin
+  - rm -rf ${HOME}/.cache/pants/rust/rustup
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_cache:
   - rm -rf ${HOME}/.cache/pants/rust/rustup
   # Render a summary of what is left in the home directory, to assist with further pruning of
   # the cache.
-  - du -d2 ${HOME} | sort -r
+  - du -d2 ${HOME} | sort -r -n
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_cache:
   - rm -rf ${HOME}/.cache/pants/rust/rustup
   # Render a summary of what is left in the home directory, to assist with further pruning of
   # the cache.
-  - du -d2 -h ${HOME} | sort -h -r
+  - du -d2 ${HOME} | sort -r
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ env:
     - ANDROID_HOME="$ANDROID_SDK_INSTALL_LOCATION/android-sdk-linux"
 
 before_cache:
-  - echo "Pre-prune du:"
-  - du -d2 -h ${HOME}/.cache/pants ${HOME}/.ivy2/pants ${HOME}/.npm ${HOME}/.android ${ANDROID_SDK_INSTALL_LOCATION}
   # Ensure permissions to do the below removals, which happen with or without caching enabled.
   - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
   # Kill all python bytecode in our cached venvs.  Some files appear to
@@ -35,8 +33,9 @@ before_cache:
   # individually resolved artifacts.
   - rm -rf ${HOME}/.cache/pants/bin
   - rm -rf ${HOME}/.cache/pants/rust/rustup
-  - echo "Post-prune du:"
-  - du -d2 -h ${HOME}/.cache/pants ${HOME}/.ivy2/pants ${HOME}/.npm ${HOME}/.android ${ANDROID_SDK_INSTALL_LOCATION}
+  # Render a summary of what is left in the home directory, to assist with further pruning of
+  # the cache.
+  - du -d2 -h ${HOME} | sort -h -r
 
 cache:
   directories:
@@ -46,8 +45,6 @@ cache:
     # using its own isolated cache:
     #   https://github.com/pantsbuild/pants/issues/2485
     - ${HOME}/.npm
-    - ${HOME}/.android
-    - ${ANDROID_SDK_INSTALL_LOCATION}
     - build-support/isort.venv
     - build-support/pants_dev_deps.venv
 
@@ -108,8 +105,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Various pants self checks and lint"
       script:
@@ -136,8 +131,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Unit tests for pants and pants-plugins - shard 1"
       script:
@@ -164,8 +157,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Unit tests for pants and pants-plugins - shard 2"
       script:
@@ -193,6 +184,7 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
       before_script:
+        # Contrib tests need Android.
         - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python contrib tests - shard 1"
@@ -221,6 +213,7 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
       before_script:
+        # Contrib tests need Android.
         - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python contrib tests - shard 2"
@@ -248,8 +241,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python integration tests for pants - shard 1"
       script:
@@ -276,8 +267,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python integration tests for pants - shard 2"
       script:
@@ -304,8 +293,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python integration tests for pants - shard 3"
       script:
@@ -332,8 +319,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python integration tests for pants - shard 4"
       script:
@@ -360,8 +345,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python integration tests for pants - shard 5"
       script:
@@ -388,8 +371,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python integration tests for pants - shard 6"
       script:
@@ -416,8 +397,6 @@ matrix:
         - sudo rm -rf /usr/lib/jvm/java-1.6.0-openjdk-amd64
         - sudo rm -rf /usr/lib/jvm/java-6-openjdk-amd64
         - jdk_switcher use oraclejdk8
-      before_script:
-        - ./build-support/bin/install-android-sdk.sh
       env:
         - SHARD="Python integration tests for pants - shard 7"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ env:
     - ANDROID_HOME="$ANDROID_SDK_INSTALL_LOCATION/android-sdk-linux"
 
 before_cache:
+  - echo "Pre-prune du:"
+  - du -d2 -h ${HOME}/.cache/pants ${HOME}/.ivy2/pants ${HOME}/.npm ${HOME}/.android ${ANDROID_SDK_INSTALL_LOCATION}
   # Ensure permissions to do the below removals, which happen with or without caching enabled.
   - sudo chown -R travis:travis "${HOME}" "${TRAVIS_BUILD_DIR}"
   # Kill all python bytecode in our cached venvs.  Some files appear to
@@ -33,6 +35,8 @@ before_cache:
   # individually resolved artifacts.
   - rm -rf ${HOME}/.cache/pants/bin
   - rm -rf ${HOME}/.cache/pants/rust/rustup
+  - echo "Post-prune du:"
+  - du -d2 -h ${HOME}/.cache/pants ${HOME}/.ivy2/pants ${HOME}/.npm ${HOME}/.android ${ANDROID_SDK_INSTALL_LOCATION}
 
 cache:
   directories:

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -69,12 +69,14 @@ function _ensure_cffi_sources() {
 function ensure_native_build_prerequisites() {
   # Control a pants-specific rust toolchain.
 
-  export CARGO_HOME=${CACHE_ROOT}/rust-toolchain
-  export RUSTUP_HOME=${CARGO_HOME}
+  local rust_toolchain_root="${CACHE_ROOT}/rust"
+  export CARGO_HOME="${rust_toolchain_root}/cargo"
+  export RUSTUP_HOME="${rust_toolchain_root}/rustup"
 
   local rust_toolchain="1.20.0"
 
-  if [[ ! -x "${RUSTUP_HOME}/bin/rustup" ]]
+  # NB: rustup installs itself into CARGO_HOME, but fetches toolchains into RUSTUP_HOME.
+  if [[ ! -x "${CARGO_HOME}/bin/rustup" ]]
   then
     log "A pants owned rustup installation could not be found, installing via the instructions at" \
         "https://www.rustup.rs ..."

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -199,7 +199,7 @@ EOM
 }
 
 function install_and_test_packages() {
-  CORE_ONLY=$0
+  CORE_ONLY=$1
   shift 1
   PIP_ARGS=(
     "$@"
@@ -217,9 +217,9 @@ function install_and_test_packages() {
 
   if [[ "${CORE_ONLY}" == "true" ]]
   then
-    PACKAGES=$CORE_PACKAGES
+    PACKAGES=("${CORE_PACKAGES[@]}")
   else
-    PACKAGES=$RELEASE_PACKAGES
+    PACKAGES=("${RELEASE_PACKAGES[@]}")
   fi
 
   for PACKAGE in "${PACKAGES[@]}"
@@ -238,9 +238,9 @@ function install_and_test_packages() {
 }
 
 function dry_run_install() {
-  CORE_ONLY=$0
+  CORE_ONLY=$1
   build_packages && \
-  install_and_test_packages $CORE_ONLY --find-links="${DEPLOY_WHEEL_DIR}"
+  install_and_test_packages "${CORE_ONLY}" --find-links="${DEPLOY_WHEEL_DIR}"
 }
 
 ALLOWED_ORIGIN_URLS=(
@@ -618,13 +618,13 @@ if [[ "${dry_run}" == "true" && "${test_release}" == "true" ]]; then
 elif [[ "${dry_run}" == "true" ]]; then
   banner "Performing a dry run release" && \
   (
-    dry_run_install $core_only && \
+    dry_run_install "${core_only}" && \
     banner "Dry run release succeeded"
   ) || die "Dry run release failed."
 elif [[ "${test_release}" == "true" ]]; then
   banner "Installing and testing the latest released packages" && \
   (
-    install_and_test_packages $core_only && \
+    install_and_test_packages "${core_only}" && \
     banner "Successfully installed and tested the latest released packages"
   ) || die "Failed to install and test the latest released packages."
 else

--- a/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
+++ b/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
@@ -12,4 +12,4 @@ googleapis="${thirdpartyprotobuf}/googleapis"
 outdir="${here}/src"
 mkdir -p "${outdir}"
 
-"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust-toolchain/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"
+"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust/cargo/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"


### PR DESCRIPTION
### Problem

Recent travis runs have been failing to upload the cache due to timeouts with messages like:
```
running `casher push` took longer than 180 seconds and has been aborted
```
This is due to the total filesize of cached items.

### Solution

* Only install the android distribution on shards that need it, and don't cache it on shards that do install it. It can be installed in 60-70 seconds, and occupies 2.1GB in the cache (see #4996).
* Split `CARGO_HOME` from `RUSTUP_HOME`, and remove the latter from the travis cache.
* Remove the `~/.cache/pants/bin` directory from the travis cache, as it is trivially restored from S3.
* Fix the utter brokenness of #4992. Despite getting master green, it was riddled with bad bashisms.

### Result

The cache is significantly smaller, and typically uploads in under 90 seconds (half of the timeout).

Fixes #4996.