### PR TITLE
Fix memory leak in `./pants changed`

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/java.py
+++ b/src/python/pants/backend/jvm/subsystems/java.py
@@ -21,6 +21,9 @@ class Java(JvmToolMixin, ZincLanguageMixin, Subsystem):
   """
   options_scope = 'java'
 
+  _javac_tool_name = 'javac'
+  _default_javac_spec = '//:{}'.format(_javac_tool_name)
+
   @classmethod
   def register_options(cls, register):
     super(Java, cls).register_options(register)
@@ -31,7 +34,7 @@ class Java(JvmToolMixin, ZincLanguageMixin, Subsystem):
     # Javac plugins can access basically all of the compiler internals, so we don't shade anything.
     # Hence the unspecified main= argument. This tool is optional, hence the empty classpath list.
     cls.register_jvm_tool(register,
-                          'javac',
+                          cls._javac_tool_name,
                           classpath=[],
                           help='Java compiler to use.  If unspecified, we use the compiler '
                                'embedded in the Java distribution we run on.')
@@ -42,20 +45,17 @@ class Java(JvmToolMixin, ZincLanguageMixin, Subsystem):
              fingerprint=True)
 
   def injectables(self, build_graph):
-    toolsjar_spec = self._tools_jar_spec
-    if toolsjar_spec:
-      synthetic_address = Address.parse(toolsjar_spec)
-      if not build_graph.contains_address(synthetic_address):
-        build_graph.inject_synthetic_target(synthetic_address, ToolsJar)
+    # If a javac target has been defined on disk, use it: otherwise, inject a ToolsJar
+    # target to provide the dependency.
+    javac_address = Address.parse(self._javac_spec)
+    if not build_graph.contains_address(javac_address):
+      build_graph.inject_synthetic_target(javac_address, ToolsJar)
 
   @property
   def injectables_spec_mapping(self):
     return {
       'plugin': self._plugin_dependency_specs,
-      # If no javac library is specified, this maps to None. The caller must handle
-      # this case by defaulting to the JDK's tools.jar.
       'javac': [self._javac_spec],
-      'tools.jar': [self._tools_jar_spec]
     }
 
   @classmethod
@@ -73,11 +73,10 @@ class Java(JvmToolMixin, ZincLanguageMixin, Subsystem):
     opts = self.get_options()
     # TODO: These checks are a continuation of the hack that allows tests to pass without
     # caring about this subsystem.
-    self._javac_spec = getattr(opts, 'javac', None)
+    self._javac_spec = getattr(opts, 'javac', self._default_javac_spec)
     self._plugin_dependency_specs = [
       Address.parse(spec).spec for spec in getattr(opts, 'compiler_plugin_deps', [])
     ]
-    self._tools_jar_spec = '//:tools-jar-synthetic'
 
   def javac_classpath(self, products):
     return self.tool_classpath_from_products(products, 'javac', self.options_scope)

--- a/src/python/pants/backend/jvm/targets/javac_plugin.py
+++ b/src/python/pants/backend/jvm/targets/javac_plugin.py
@@ -34,7 +34,4 @@ class JavacPlugin(JavaLibrary):
     for spec in super(JavacPlugin, cls).compute_dependency_specs(kwargs, payload):
       yield spec
 
-    yield (
-      Java.global_instance().injectables_spec_for_key('javac') or
-      Java.global_instance().injectables_spec_for_key('tools.jar')
-    )
+    yield Java.global_instance().injectables_spec_for_key('javac')

--- a/src/python/pants/engine/legacy/change_calculator.py
+++ b/src/python/pants/engine/legacy/change_calculator.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from pants.base.specs import DescendantAddresses
 from pants.build_graph.address import Address
 from pants.engine.legacy.graph import HydratedTargets, target_types_from_symbol_table
-from pants.engine.legacy.source_mapper import EngineSourceMapper, resolve_and_parse_specs
+from pants.engine.legacy.source_mapper import EngineSourceMapper
 from pants.scm.change_calculator import ChangeCalculator
 
 

--- a/src/python/pants/engine/legacy/change_calculator.py
+++ b/src/python/pants/engine/legacy/change_calculator.py
@@ -72,7 +72,7 @@ class _HydratedTargetDependentGraph(object):
     target_cls = self._target_types[hydrated_target.adaptor.type_alias]
 
     declared_deps = hydrated_target.dependencies
-    implicit_deps = target_cls.compute_dependency_specs(kwargs=hydrated_target.adaptor.kwargs())
+    implicit_deps = (Address.parse(s) for s in target_cls.compute_dependency_specs(kwargs=hydrated_target.adaptor.kwargs()))
     resources_deps = self._resources_addresses(hydrated_target)
 
     for dep in itertools.chain(declared_deps, implicit_deps, resources_deps):

--- a/testprojects/src/python/sources/BUILD
+++ b/testprojects/src/python/sources/BUILD
@@ -2,8 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  # TODO: Some tests in tests/python/pants_test/engine/legacy:changed_integration
-  # (e.g., test_changed_coverage_direct_src_python_sources_sources_py) fail if this
-  # target doesn't have an explicit sources= stanza.  Figure out why, and fix.
+  dependencies=[
+    ':text',
+  ],
   sources=globs('*.py'),
+)
+
+resources(
+  name='text',
+  sources=globs('*.txt'),
 )

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -410,14 +410,22 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
       self.assertEqual(pants_run.stdout_data.strip(), '')
 
   @ensure_engine
-  def test_changed_with_deleted_file(self):
-    deleted_file = 'src/python/sources/sources.py'
-
+  def test_changed_with_deleted_source(self):
     with create_isolated_git_repo() as worktree:
-      safe_delete(os.path.join(worktree, deleted_file))
+      safe_delete(os.path.join(worktree, 'src/python/sources/sources.py'))
       pants_run = self.run_pants(['changed'])
       self.assert_success(pants_run)
       self.assertEqual(pants_run.stdout_data.strip(), 'src/python/sources:sources')
+
+  def test_changed_with_deleted_resource(self):
+    # NB: This test cannot be executed via the TEST_MAPPING because the v1 engine claims that python
+    # targets own their Resources targets (meaning that `--include-dependees=none` lies to you),
+    # while the v2 engine does what you would expect.
+    with create_isolated_git_repo() as worktree:
+      safe_delete(os.path.join(worktree, 'src/python/sources/sources.txt'))
+      pants_run = self.run_pants(['list', '--changed-parent=HEAD'])
+      self.assert_success(pants_run)
+      self.assertEqual(pants_run.stdout_data.strip(), 'src/python/sources:text')
 
   def test_list_changed(self):
     deleted_file = 'src/python/sources/sources.py'
@@ -428,19 +436,15 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
       self.assert_success(pants_run)
       self.assertEqual(pants_run.stdout_data.strip(), 'src/python/sources:sources')
 
-  # Following 4 tests do not run in isolated repo because they don't mutate working copy.
   def test_changed(self):
     self.assert_changed_new_equals_old([])
 
-  @unittest.skip("Pending fix for https://github.com/pantsbuild/pants/issues/4010")
   def test_changed_with_changes_since(self):
     self.assert_changed_new_equals_old(['--changes-since=HEAD^^'])
 
-  @unittest.skip("Pending fix for https://github.com/pantsbuild/pants/issues/4010")
   def test_changed_with_changes_since_direct(self):
     self.assert_changed_new_equals_old(['--changes-since=HEAD^^', '--include-dependees=direct'])
 
-  @unittest.skip("Pending fix for https://github.com/pantsbuild/pants/issues/4010")
   def test_changed_with_changes_since_transitive(self):
     self.assert_changed_new_equals_old(['--changes-since=HEAD^^', '--include-dependees=transitive'])
 

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import shutil
-import unittest
 from contextlib import contextmanager
 from textwrap import dedent
 


### PR DESCRIPTION
### Problem

Before @kwlzn fixed #4508 by introducing `compute_dependency_specs`, there was no way to get the "implicit" dependencies of a Target without constructing it. So #4424 switched to using a full `BuildGraph` to compute the dependents in changed. While that fixed the bug, it also introduced a memory leak, because instantiating a Target causes a cycle with the BuildGraph that owns it. 

### Solution

Now that #4508 is fixed, restore the codepaths that were replaced in #4424, and use `compute_dependency_specs` to compute the "implicit" dependencies of Targets in the graph. Additionally, cleans up the `tool.jar`/`javac` split in the Java subsystem to remove the requirement that `def injectables` has been called before requesting injectable specs.

### Result

Fixes #4494.