### PR TITLE
Content-addressable {file,directory} store and utility

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -36,6 +36,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "block-buffer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,7 +130,7 @@ dependencies = [
  "hex 0.2.0 (git+https://github.com/illicitonion/rust-hex?rev=42e3c1ee5b90ec854eda00fd8e968fb6266d84df)",
  "ignore 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lmdb-rs 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "gcc"
-version = "0.3.54"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -257,23 +262,23 @@ version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "liblmdb-sys"
-version = "0.2.2"
+name = "lmdb"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "lmdb-rs"
-version = "0.7.6"
+name = "lmdb-sys"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -483,6 +488,7 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4019bdb99c0c1ddd56c12c2f507c174d729c6915eca6bd9d27c42f3d93b0f4"
@@ -498,7 +504,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
 "checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90d069fe6beb9be359ef505650b3f73228c5591a3c4b1f32be2f4f44459ffa3a"
@@ -509,8 +515,8 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
-"checksum liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "feed38a3a580f60bf61aaa067b0ff4123395966839adeaf67258a9e50c4d2e49"
-"checksum lmdb-rs 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4aefe7b433f795629ce42f35ccf7a620c38bd457238bfaa2489dafc7e36167e7"
+"checksum lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "44ac7bf1552c1386b70e77ff9d801971f19641bf2dc08b981cd2397bf812c65d"
+"checksum lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3db58e1767416fc1e9e3265635d3bb7bf3677a0dc8d4e8d6ee14850ec5c11ae9"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum nodrop 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4b44ef57f346558881a49986cf1bfa716275c7ad99ab143ac8dd47be2abf77"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -116,6 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "fs"
 version = "0.0.1"
 dependencies = [
+ "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -124,7 +125,9 @@ dependencies = [
  "hex 0.2.0 (git+https://github.com/illicitonion/rust-hex?rev=42e3c1ee5b90ec854eda00fd8e968fb6266d84df)",
  "ignore 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-rs 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,6 +162,11 @@ dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "generic-array"
@@ -247,6 +255,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "liblmdb-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lmdb-rs"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -470,6 +498,7 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
 "checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum globset 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90d069fe6beb9be359ef505650b3f73228c5591a3c4b1f32be2f4f44459ffa3a"
@@ -480,6 +509,8 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
+"checksum liblmdb-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "feed38a3a580f60bf61aaa067b0ff4123395966839adeaf67258a9e50c4d2e49"
+"checksum lmdb-rs 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4aefe7b433f795629ce42f35ccf7a620c38bd457238bfaa2489dafc7e36167e7"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum nodrop 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4b44ef57f346558881a49986cf1bfa716275c7ad99ab143ac8dd47be2abf77"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -14,7 +14,7 @@ glob = "0.2.11"
 hex = { git = "https://github.com/illicitonion/rust-hex", rev = "42e3c1ee5b90ec854eda00fd8e968fb6266d84df" }
 ignore = "0.1.8"
 lazy_static = "0.2.2"
-lmdb-rs = "0.7.6"
+lmdb = "0.7.2"
 ordermap = "0.2.8"
 protobuf = "1.4.1"
 sha2 = "0.6.0"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -4,6 +4,7 @@ name = "fs"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
+bazel_protos = { path = "../process_execution/bazel_protos" }
 boxfuture = { path = "../boxfuture" }
 digest = "0.6.2"
 futures = "0.1.16"
@@ -13,7 +14,9 @@ glob = "0.2.11"
 hex = { git = "https://github.com/illicitonion/rust-hex", rev = "42e3c1ee5b90ec854eda00fd8e968fb6266d84df" }
 ignore = "0.1.8"
 lazy_static = "0.2.2"
+lmdb-rs = "0.7.6"
 ordermap = "0.2.8"
+protobuf = "1.4.1"
 sha2 = "0.6.0"
 tar = "0.4.13"
 tempdir = "0.3.5"

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "fs_util"
+version = "0.0.1"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+
+[dependencies]
+bazel_protos = { path = "../../process_execution/bazel_protos" }
+clap = "2"
+fs = { path = ".." }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -103,13 +103,12 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), String> {
 }
 
 fn save_file(store: &Store, path: &Path) -> Result<(Fingerprint, usize), String> {
-  let mut file = File::open(path).map_err(|e| {
-    format!("Error opening file {:?}: {}", path, e.description())
-  })?;
   let mut buf = Vec::new();
-  file.read_to_end(&mut buf).map_err(|e| {
-    format!("Error reading file {:?}: {}", path, e.description())
-  })?;
+  File::open(path)
+    .and_then(|mut f| f.read_to_end(&mut buf))
+    .map_err(|e| {
+      format!("Error reading file {:?}: {}", path, e.description())
+    })?;
   Ok((store.store_file_bytes(&buf)?, buf.len()))
 }
 

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -1,0 +1,189 @@
+extern crate bazel_protos;
+extern crate clap;
+extern crate fs;
+
+use clap::{App, Arg, SubCommand};
+use fs::hash::Fingerprint;
+use fs::store::Store;
+use std::error::Error;
+use std::fs::{DirEntry, File, read_dir};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::exit;
+
+fn main() {
+  let top_match = App::new("fs_util")
+    .subcommand(
+      SubCommand::with_name("file")
+        .subcommand(
+          SubCommand::with_name("cat")
+            .about("Output the contents of a file by fingerprint.")
+            .arg(Arg::with_name("fingerprint").required(true).takes_value(
+              true,
+            )),
+        )
+        .subcommand(
+          SubCommand::with_name("save")
+            .about(
+              "Ingest a file by path, which allows it to be used in Directories/Snapshots. \
+Outputs a fingerprint of its contents.",
+            )
+            .arg(Arg::with_name("path").required(true).takes_value(true)),
+        ),
+    )
+    .subcommand(
+      SubCommand::with_name("directory").subcommand(
+        SubCommand::with_name("save")
+          .about(
+            "Ingest a directory recursively. Saves all files found therein and saves Directory \
+protos for each directory found. Outputs a fingerprint of the canonical top-level Directory proto.",
+          )
+          .arg(Arg::with_name("source").required(true).takes_value(true)),
+      ),
+    )
+    .arg(
+      Arg::with_name("store_dir")
+        .takes_value(true)
+          // TODO: Default this to wherever pants actually stores this.
+        .default_value("/tmp/lmdb"),
+    )
+    .get_matches();
+
+  let store = Store::new(top_match.value_of("store_dir").unwrap()).unwrap();
+
+  match top_match.subcommand() {
+    ("file", Some(sub_match)) => {
+      match sub_match.subcommand() {
+        ("cat", Some(args)) => {
+          let fingerprint = fingerprint_or_die(args.value_of("fingerprint").unwrap());
+          match store.load_bytes(&fingerprint).unwrap() {
+            Some(bytes) => {
+              io::stdout().write(&bytes).unwrap();
+            }
+            None => {
+              die(format!("File with fingerprint {} not found", fingerprint));
+            }
+          }
+        }
+        ("save", Some(args)) => {
+          match save_file(&store, &PathBuf::from(args.value_of("path").unwrap())) {
+            Ok((fingerprint, _)) => println!("{}", fingerprint),
+            Err(err) => die(err),
+          };
+        }
+        (_, _) => unimplemented!(),
+      }
+    }
+    ("directory", Some(sub_match)) => {
+      match sub_match.subcommand() {
+        ("save", Some(args)) => {
+          match save_directory(&store, &PathBuf::from(args.value_of("source").unwrap())) {
+            Ok((fingerprint, _)) => println!("{}", fingerprint),
+            Err(err) => die(err),
+          }
+        }
+        (_, _) => unimplemented!(),
+      }
+    }
+    (_, _) => unimplemented!(),
+  }
+}
+
+fn save_file(store: &Store, path: &Path) -> Result<(Fingerprint, usize), String> {
+  let mut file = File::open(path).map_err(|e| {
+    format!("Error opening file {:?}: {}", path, e.description())
+  })?;
+  let mut buf = Vec::new();
+  file.read_to_end(&mut buf).map_err(|e| {
+    format!("Error reading file {:?}: {}", path, e.description())
+  })?;
+  Ok((store.store_file_bytes(&buf)?, buf.len()))
+}
+
+fn save_directory(store: &Store, root: &Path) -> Result<(Fingerprint, usize), String> {
+  let mut directory = bazel_protos::remote_execution::Directory::new();
+  for maybe_entry in read_dir(root).map_err(|e| {
+    format!("Error reading dir {:?}: {}", root, e.description())
+  })?
+  {
+    let entry = maybe_entry.map_err(|e| {
+      format!(
+        "Error reading dir entry within {:?}: {}",
+        root,
+        e.description()
+      )
+    })?;
+    let metadata = entry.metadata().map_err(|e| {
+      format!(
+        "Error stating file {:?}: {}",
+        entry.path(),
+        e.description().to_string()
+      )
+    })?;
+    if metadata.is_dir() {
+      let (fingerprint, proto_size_bytes) = save_directory(store, &entry.path())?;
+      directory.mut_directories().push({
+        let mut dir_node = bazel_protos::remote_execution::DirectoryNode::new();
+        dir_node.set_name(path_to_utf8(&entry, DirEntry::file_name)?);
+        dir_node.set_digest(fingerprint_to_digest(&fingerprint, proto_size_bytes as i64));
+        dir_node
+      })
+    } else if metadata.is_file() {
+      let (fingerprint, size_bytes) = save_file(store, &entry.path())?;
+      directory.mut_files().push({
+        let mut file_node = bazel_protos::remote_execution::FileNode::new();
+        file_node.set_name(path_to_utf8(&entry, DirEntry::file_name)?);
+        file_node.set_digest(fingerprint_to_digest(&fingerprint, size_bytes as i64));
+        file_node.set_is_executable(metadata.permissions().mode() & 1 == 1);
+        file_node
+      });
+    }
+  }
+  directory.mut_directories().sort_by_key(
+    |f| f.get_name().to_string(),
+  );
+  directory.mut_files().sort_by_key(
+    |f| f.get_name().to_string(),
+  );
+  store.record_directory(&directory)
+}
+
+pub fn fingerprint_to_digest(
+  fingerprint: &Fingerprint,
+  size_bytes: i64,
+) -> bazel_protos::remote_execution::Digest {
+  let mut digest = bazel_protos::remote_execution::Digest::new();
+  digest.set_hash(fingerprint.to_hex());
+  digest.set_size_bytes(size_bytes);
+  digest
+}
+
+fn path_to_utf8<F, P>(dir: &DirEntry, f: F) -> Result<String, String>
+where
+  F: Fn(&DirEntry) -> P,
+  P: AsRef<Path>,
+{
+  match f(dir).as_ref().to_str() {
+    Some(dir) => Ok(dir.to_string()),
+    None => Err(format!(
+      "Error convering file path to UTF8: {:?}",
+      dir.path()
+    )),
+  }
+}
+
+fn fingerprint_or_die(s: &str) -> Fingerprint {
+  match Fingerprint::from_hex_string(s) {
+    Ok(f) => f,
+    Err(err) => {
+      die(err);
+      panic!()
+    }
+  }
+}
+
+fn die(error: String) {
+  eprintln!("{}", error);
+  exit(1);
+}

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -45,9 +45,8 @@ protos for each directory found. Outputs a fingerprint of the canonical top-leve
       )
       .arg(
         Arg::with_name("local_store_path")
-            .takes_value(true)
-            // TODO: Default this to wherever pants actually stores this.
-            .default_value("/tmp/lmdb"),
+          .takes_value(true)
+          .required(true),
       )
       .get_matches(),
   ) {
@@ -148,7 +147,9 @@ fn save_directory(store: &Store, root: &Path) -> Result<(Fingerprint, usize), St
           file_node
         });
       }
-      fs::Stat::Link(_) => unimplemented!(),
+      fs::Stat::Link(fs::Link(path)) => {
+        return Err(format!("Don't yet know how to handle symlinks: {:?}", path))
+      }
     }
   }
   store.record_directory(&directory)

--- a/src/rust/engine/fs/src/hash.rs
+++ b/src/rust/engine/fs/src/hash.rs
@@ -60,6 +60,12 @@ impl fmt::Debug for Fingerprint {
   }
 }
 
+impl AsRef<[u8]> for Fingerprint {
+  fn as_ref(&self) -> &[u8] {
+    &self.0[..]
+  }
+}
+
 ///
 /// A Write instance that fingerprints all data that passes through it.
 ///

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -368,7 +368,7 @@ impl PosixFS {
     ignore_builder.build()
   }
 
-  fn scandir_sync(dir: Dir, dir_abs: PathBuf) -> Result<Vec<Stat>, io::Error> {
+  pub fn scandir_sync(dir: Dir, dir_abs: &Path) -> Result<Vec<Stat>, io::Error> {
     let mut stats = Vec::new();
     for dir_entry_res in dir_abs.read_dir()? {
       let dir_entry = dir_entry_res?;
@@ -453,7 +453,7 @@ impl PosixFS {
     pool
       .as_ref()
       .expect("Uninitialized CpuPool!")
-      .spawn_fn(move || PosixFS::scandir_sync(dir, dir_abs))
+      .spawn_fn(move || PosixFS::scandir_sync(dir, &dir_abs))
       .to_boxed()
   }
 }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-mod hash;
+pub mod hash;
+pub mod store;
 
+extern crate bazel_protos;
 extern crate boxfuture;
 extern crate digest;
 extern crate futures;
@@ -12,7 +14,9 @@ extern crate hex;
 extern crate ignore;
 #[macro_use]
 extern crate lazy_static;
+extern crate lmdb_rs;
 extern crate ordermap;
+extern crate protobuf;
 extern crate sha2;
 extern crate tar;
 extern crate tempdir;

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -14,7 +14,7 @@ extern crate hex;
 extern crate ignore;
 #[macro_use]
 extern crate lazy_static;
-extern crate lmdb_rs;
+extern crate lmdb;
 extern crate ordermap;
 extern crate protobuf;
 extern crate sha2;

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1,0 +1,238 @@
+use bazel_protos;
+use digest::{Digest, FixedOutput};
+use lmdb_rs::{DbFlags, DbHandle, EnvBuilder, Environment, MdbError, MdbValue, ToMdbValue};
+use protobuf::core::Message;
+use sha2::Sha256;
+use std::error::Error;
+use std::mem::transmute;
+use std::path::Path;
+
+use hash::Fingerprint;
+
+///
+/// A content-addressed store of file contents, and Directories.
+///
+/// Currently, Store only stores things locally on disk, but in the future it will gain the ability
+/// to fetch files from remote content-addressable storage too.
+///
+pub struct Store {
+  env: Environment,
+  file_store: DbHandle,
+
+  // Store directories separately from files because:
+  //  1. They may have different lifetimes.
+  //  2. It's nice to know whether we should be able to parse something as a proto.
+  directory_store: DbHandle,
+}
+
+impl Store {
+  pub fn new<P: AsRef<Path>>(path: P) -> Result<Store, String> {
+    // 2 DBs; one for file contents, one for directories.
+    let env = EnvBuilder::new().max_dbs(2).open(path, 0o600).map_err(
+      |e| {
+        format!("Error making env: {}", e.description())
+      },
+    )?;
+    let file_db_handle = env.create_db("files", DbFlags::empty()).map_err(|e| {
+      format!("Error creating/opening files database: {}", e.description())
+    })?;
+    let directory_db_handle = env.create_db("directories", DbFlags::empty()).map_err(
+      |e| {
+        format!(
+          "Error creating/opening directories database: {}",
+          e.description()
+        )
+      },
+    )?;
+    Ok(Store {
+      env: env,
+      file_store: file_db_handle,
+      directory_store: directory_db_handle,
+    })
+  }
+
+  pub fn store_file_bytes(&self, bytes: &[u8]) -> Result<Fingerprint, String> {
+    self.store_bytes(bytes, &self.file_store)
+  }
+
+  fn store_bytes(&self, bytes: &[u8], db: &DbHandle) -> Result<Fingerprint, String> {
+    let mut hasher = Sha256::default();
+    hasher.input(&bytes);
+    let fingerprint = Fingerprint::from_bytes_unsafe(hasher.fixed_result().as_slice());
+
+    let txn = self.env.new_transaction().map_err(|e| {
+      format!(
+        "Error making new transaction to store fingerprint {}: {}",
+        fingerprint,
+        e.description()
+      )
+    })?;
+    {
+      let db = txn.bind(db);
+      match db.insert(&fingerprint, &bytes) {
+        Ok(_) => {}
+        Err(MdbError::KeyExists) => return Ok(fingerprint),
+        Err(err) => {
+          return Err(format!(
+            "Error storing fingerprint {}: {}",
+            fingerprint,
+            err.description()
+          ))
+        }
+      };
+    }
+    match txn.commit() {
+      Ok(_) => Ok(fingerprint),
+      Err(MdbError::KeyExists) => Ok(fingerprint),
+      Err(err) => Err(format!(
+        "Error committing transaction for fingerprint {}: {}",
+        fingerprint,
+        err.description()
+      )),
+    }
+  }
+
+  pub fn load_bytes(&self, fingerprint: &Fingerprint) -> Result<Option<Vec<u8>>, String> {
+    let reader = self.env.get_reader().map_err(|e| {
+      format!(
+        "Error getting reader for fingerprint {}: {}",
+        fingerprint,
+        e.description()
+      )
+    })?;
+    let db = reader.bind(&self.file_store);
+    match db.get(&fingerprint.as_bytes().as_ref()) {
+      Ok(v) => Ok(Some(v)),
+      Err(MdbError::NotFound) => Ok(None),
+      Err(err) => Err(format!(
+        "Error getting fingerprint {}: {}",
+        fingerprint,
+        err.description().to_string()
+      )),
+    }
+  }
+
+  ///
+  /// Store the Directory proto. Does not do anything about the files or directories claimed to be
+  /// contained therein.
+  ///
+  /// Assumes that the directory has been properly canonicalized.
+  ///
+  pub fn record_directory(
+    &self,
+    directory: &bazel_protos::remote_execution::Directory,
+  ) -> Result<(Fingerprint, usize), String> {
+    let bytes = directory.write_to_bytes().map_err(|e| {
+      format!(
+        "Error serializing directory proto {:?}: {}",
+        directory,
+        e.description()
+      )
+    })?;
+
+    Ok((
+      self.store_bytes(&bytes, &self.directory_store)?,
+      bytes.len(),
+    ))
+  }
+}
+
+impl ToMdbValue for Fingerprint {
+  fn to_mdb_value<'a>(&'a self) -> MdbValue<'a> {
+    unsafe { MdbValue::new(transmute(self.as_bytes().as_ptr()), self.as_bytes().len()) }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use bazel_protos;
+  use super::{Fingerprint, Store};
+  extern crate tempdir;
+  use tempdir::TempDir;
+
+  const STR: &str = "European Burmese";
+  const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
+
+  #[test]
+  fn save_file() {
+    let dir = TempDir::new("store").unwrap();
+
+    assert_eq!(
+      &Store::new(dir.path())
+        .unwrap()
+        .store_file_bytes(STR.as_bytes())
+        .unwrap()
+        .to_hex(),
+      HASH
+    );
+  }
+
+  #[test]
+  fn save_file_is_idempotent() {
+    let dir = TempDir::new("store").unwrap();
+
+    &Store::new(dir.path())
+      .unwrap()
+      .store_file_bytes(STR.as_bytes())
+      .unwrap();
+    assert_eq!(
+      &Store::new(dir.path())
+        .unwrap()
+        .store_file_bytes(STR.as_bytes())
+        .unwrap()
+        .to_hex(),
+      HASH
+    );
+  }
+
+  #[test]
+  fn roundtrip_file() {
+    let data = Vec::from(STR.as_bytes());
+    let dir = TempDir::new("store").unwrap();
+
+    let store = Store::new(dir.path()).unwrap();
+    let hash = store.store_file_bytes(&data).unwrap();
+    assert_eq!(store.load_bytes(&hash).unwrap().unwrap(), data);
+  }
+
+  #[test]
+  fn missing_file() {
+    let dir = TempDir::new("store").unwrap();
+    assert_eq!(
+      Store::new(dir.path())
+        .unwrap()
+        .load_bytes(&Fingerprint::from_hex_string(HASH).unwrap())
+        .unwrap(),
+      None
+    );
+  }
+
+  #[test]
+  fn record_directory_proto() {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_files().push({
+      let mut file = bazel_protos::remote_execution::FileNode::new();
+      file.set_name("roland".to_string());
+      file.set_digest({
+        let mut digest = bazel_protos::remote_execution::Digest::new();
+        digest.set_hash(HASH.to_string());
+        digest.set_size_bytes(STR.len() as i64);
+        digest
+      });
+      file.set_is_executable(false);
+      file
+    });
+
+    let dir = TempDir::new("store").unwrap();
+
+    assert_eq!(
+      &Store::new(dir.path())
+        .unwrap()
+        .record_directory(&directory)
+        .unwrap()
+        .0
+        .to_hex(),
+      "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"
+    );
+  }
+}


### PR DESCRIPTION
Stores files by fingerprint, and Directory protos.
    
Command line utility allows you to:
 * fs_util file cat [digest]
 * fs_util file save [path]
 * fs_util directory save [path]
    
In the near future, the command line utility will also allow you to:
 * fs_util directory materialize [digest] [path]
And the library will allow delegating to a remote
ContentAddressableStore for fetches, and allow files and directories to
be pushed to remote ContentAddressableStores.