### PR TITLE
Use the service deps if the target declares an exception.

### DIFF
--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -13,6 +13,7 @@ from collections import defaultdict, namedtuple
 from pants.backend.codegen.thrift.java.java_thrift_library import JavaThriftLibrary
 from pants.backend.codegen.thrift.java.thrift_defaults import ThriftDefaults
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException, TaskError
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
@@ -211,17 +212,22 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     if 0 != returncode:
       raise TaskError('Scrooge compiler exited non-zero for {} ({})'.format(target, returncode))
 
-  EXCEPTION_PARSER = re.compile(r'^\s*exception\s+(?:[^\s{]+)')
-  SERVICE_PARSER = re.compile(r'^\s*service\s+(?:[^\s{]+)')
+  @staticmethod
+  def _declares_exception(source):
+    # ideally we'd use more sophisticated parsing
+    exception_parser = re.compile(r'^\s*exception\s+(?:[^\s{]+)')
+    return ScroogeGen._has_declaration(source, exception_parser)
 
-  def _declares_exception(self, source):
-    return self._has_declaration(source, self.EXCEPTION_PARSER)
+  @staticmethod
+  def _declares_service(source):
+    # ideally we'd use more sophisticated parsing
+    service_parser = re.compile(r'^\s*service\s+(?:[^\s{]+)')
+    return ScroogeGen._has_declaration(source, service_parser)
 
-  def _declares_service(self, source):
-    return self._has_declaration(source, self.SERVICE_PARSER)
-
-  def _has_declaration(self, source, regex):
-    with open(source) as thrift:
+  @staticmethod
+  def _has_declaration(source, regex):
+    source_path = os.path.join(get_buildroot(), source)
+    with open(source_path) as thrift:
       return any(line for line in thrift if regex.search(line))
 
   def parse_gen_file_map(self, gen_file_map_path, outdir):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/scrooge_gen.py
@@ -211,11 +211,18 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
     if 0 != returncode:
       raise TaskError('Scrooge compiler exited non-zero for {} ({})'.format(target, returncode))
 
+  EXCEPTION_PARSER = re.compile(r'^\s*exception\s+(?:[^\s{]+)')
   SERVICE_PARSER = re.compile(r'^\s*service\s+(?:[^\s{]+)')
 
+  def _declares_exception(self, source):
+    return self._has_declaration(source, self.EXCEPTION_PARSER)
+
   def _declares_service(self, source):
+    return self._has_declaration(source, self.SERVICE_PARSER)
+
+  def _has_declaration(self, source, regex):
     with open(source) as thrift:
-      return any(line for line in thrift if self.SERVICE_PARSER.search(line))
+      return any(line for line in thrift if regex.search(line))
 
   def parse_gen_file_map(self, gen_file_map_path, outdir):
     d = defaultdict(set)
@@ -282,11 +289,11 @@ class ScroogeGen(SimpleCodegenTask, NailgunTask):
 
   def _thrift_dependencies_for_target(self, target):
     dep_info = self._resolved_dep_info
-    target_declares_service = any(self._declares_service(source)
-                                  for source in target.sources_relative_to_buildroot())
+    target_declares_service_or_exception = any(self._declares_service(source) or self._declares_exception(source)
+                                               for source in target.sources_relative_to_buildroot())
     language = self._thrift_defaults.language(target)
 
-    if target_declares_service:
+    if target_declares_service_or_exception:
       return dep_info.service[language]
     else:
       return dep_info.structs[language]

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -148,6 +148,7 @@ class ScroogeGenTest(NailgunTaskTestBase):
     context = self.context(target_roots=[target])
     task = self.prepare_execute(context)
 
+    task._declares_exception = lambda source: False
     task._declares_service = lambda source: False
 
     task.gen = MagicMock()

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_scrooge_gen.py
@@ -42,7 +42,9 @@ class ScroogeGenTest(NailgunTaskTestBase):
     self.set_options_for_scope('thrift-defaults',
                                compiler='unchecked',
                                language='uniform',
-                               rpc_style='async')
+                               rpc_style='async',
+                               service_deps='service_deps',
+                               structs_deps='structs_deps')
 
     self.add_to_build_file('test_validate', dedent('''
       java_thrift_library(name='one',
@@ -148,9 +150,6 @@ class ScroogeGenTest(NailgunTaskTestBase):
     context = self.context(target_roots=[target])
     task = self.prepare_execute(context)
 
-    task._declares_exception = lambda source: False
-    task._declares_service = lambda source: False
-
     task.gen = MagicMock()
     task.gen.return_value = {'test_smoke/a.thrift': sources}
 
@@ -177,3 +176,36 @@ class ScroogeGenTest(NailgunTaskTestBase):
 
     finally:
       Context.add_new_target = saved_add_new_target
+
+  def test_basic_deps(self):
+    contents = dedent('''#@namespace android org.pantsbuild.android_example
+      namespace java org.pantsbuild.example
+      struct Example {
+      1: optional i64 number
+      }
+    ''')
+    self._test_dependencies_help(contents, False, False)
+
+  def test_service_deps(self):
+    contents = dedent('''#@namespace android org.pantsbuild.android_example
+      namespace java org.pantsbuild.example
+      service MultiplicationService
+      {
+        int multiply(1:int n1, 2:int n2),
+      }''')
+    self._test_dependencies_help(contents, True, False)
+
+  def test_exception_deps(self):
+    contents = dedent('''#@namespace android org.pantsbuild.android_example
+      namespace java org.pantsbuild.example
+      exception InvalidOperation {
+        1: i32 what,
+        2: string why
+      }''')
+    self._test_dependencies_help(contents, False, True)
+
+  def _test_dependencies_help(self, contents, declares_service, declares_exception):
+    source = 'test_smoke/a.thrift'
+    self.create_file(relpath=source, contents=contents)
+    self.assertEquals(ScroogeGen._declares_service(source), declares_service)
+    self.assertEquals(ScroogeGen._declares_exception(source), declares_exception)


### PR DESCRIPTION
### Problem

Thrift exceptions require the same dependencies declared by services (namely they require com.twitter.finagle.SourcedException, which comes in from finagle), but are frequently used by callers similarly to structs.

scrooge and pants provide different sets of dependencies to structs-only targets than they do to targets which contain services. To resolve this, we would either need to split the classification again, into: "declares structs", "declares exceptions", and "declares services", or do a union based on which symbols are found in the file.

For now, the workaround is to add an empty service to a target that needs to use exceptions, or to move the exceptions to a target that defines a service instead.

### Solution

For sources that declare services OR exceptions, we now use the service deps.

### Result

Users will no longer need to use empty services or move the exceptions to targets that declare services.