### PR TITLE
Fix JarCreate invalidation in the presence of changing resources.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_create.py
+++ b/src/python/pants/backend/jvm/tasks/jar_create.py
@@ -62,7 +62,14 @@ class JarCreate(JarBuilderTask):
     return True
 
   def execute(self):
-    with self.invalidated(self.context.targets(is_jvm_library)) as invalidation_check:
+    # NB: Invalidating dependents transitively is more than is strictly necessary, but
+    # we know that JarBuilderTask touches (at least) the direct dependencies of targets (in
+    # the case of resources). One of these tasks could implement an FingerprintStrategy that
+    # would attempt to hash the relevant dependencies, but that is really error prone, and
+    # this task is more than fast enough to re-run (JarTool "copies" pre-zipped data from input
+    # zip/jar files).
+    with self.invalidated(self.context.targets(is_jvm_library),
+                          invalidate_dependents=True) as invalidation_check:
       with self.context.new_workunit(name='jar-create', labels=[WorkUnitLabel.MULTITOOL]):
         jar_mapping = self.context.products.get('jars')
 

--- a/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/publish/hello/greet/BUILD
@@ -2,7 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-  dependencies=[],
+  dependencies=[
+    ':readme',
+  ],
   provides=artifact(
     org='org.pantsbuild.testproject.publish',
     name='hello-greet',
@@ -47,4 +49,9 @@ java_library(
       )
     )
  ),
+)
+
+resources(
+  name='readme',
+  sources=globs('*.txt'),
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_jar_publish_integration.py
@@ -9,7 +9,7 @@ import os
 import re
 
 from pants.base.build_environment import get_buildroot
-from pants.util.contextutil import temporary_dir
+from pants.util.contextutil import open_zip, temporary_dir
 from pants.util.dirutil import safe_rmtree
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
@@ -216,6 +216,40 @@ class JarPublishIntegrationTest(PantsRunIntegrationTest):
       pushdb_files=[],
       extra_options=['--override={}=1.2.3'.format(target)],
       assert_publish_config_contents=True)
+
+  def test_invalidate_resources(self):
+    """Tests that resource changes invalidate publishes."""
+    source_root = 'testprojects/src/java'
+    target_relative_to_sourceroot = 'org/pantsbuild/testproject/publish/hello/greet'
+    target = os.path.join(source_root, target_relative_to_sourceroot)
+    resource_relative_to_sourceroot = os.path.join(target_relative_to_sourceroot, 'TEMP.txt')
+    resource = os.path.join(source_root, resource_relative_to_sourceroot)
+
+    with self.temporary_workdir() as workdir:
+      def publish(resource_content):
+        with temporary_dir() as publish_dir:
+          with self.temporary_file_content(resource, resource_content):
+            # Validate that the target depends on the relevant resource.
+            self.assertIn(resource, self.run_pants(['filedeps', target]).stdout_data)
+
+            pants_run = self.run_pants_with_workdir(['publish.jar',
+                                                     '--local={}'.format(publish_dir),
+                                                     '--named-snapshot=X',
+                                                     '--no-dryrun',
+                                                     target
+                                                    ],
+                                                    workdir=workdir)
+            self.assert_success(pants_run)
+          # Validate that the content in the resulting jar matches.
+          jar = os.path.join(publish_dir,
+                             'org/pantsbuild/testproject/publish/hello-greet/X/hello-greet-X.jar')
+          with open_zip(jar, mode='r') as j:
+            with j.open(resource_relative_to_sourceroot) as jar_entry:
+              self.assertEquals(resource_content, jar_entry.read())
+
+      # Publish the same target twice with different resource content.
+      publish('one')
+      publish('two')
 
   def publish_test(self, target, artifacts, pushdb_files, extra_options=None, extra_config=None,
                    extra_env=None, success_expected=True, assert_publish_config_contents=False):


### PR DESCRIPTION
### Problem

As described in #4595, `JarCreate` caches jar contents too aggressively. The root cause is that the `JarTask` superclass looks at "some of the dependencies of a target" (in the case of that particular ticket: resources), but the target invalidation in `JarCreate` is configured to only invalidate for changes directly in the target.

This is another case of the "whitelist based cache key" issue, and is one of the primary motivators for moving to isolated-process-executions as cache entries.

### Solution

As described in the change: rather than attempting to whitelist exactly what `JarTask` touches, turning on `invalidate_dependents` is more durable in the face of further code changes. We do that here.

### Result

Fixes #4595.