### PR TITLE
Have twine use the previously established pgp key during release.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -558,8 +558,9 @@ function publish_packages() {
 
   activate_twine
   trap deactivate RETURN
-  twine upload --sign "${DEPLOY_WHEEL_DIR}"/*.whl
-  twine upload --sign "${DEPLOY_SDIST_DIR}"/*.tar.gz
+
+  twine upload --sign-with=get_pgp_keyid "${DEPLOY_WHEEL_DIR}"/*.whl
+  twine upload --sign-with=get_pgp_keyid "${DEPLOY_SDIST_DIR}"/*.tar.gz
 
   end_travis_section
 }


### PR DESCRIPTION
### Problem

Twine was using the default key of the box, not the key the release
script gleaned from the git config.

### Solution
Explicitly ask twine to use the key from git.

### Result

Correct key used.

NOTE: Pushing this TBR since it was required for me to complete release.