### PR TITLE
Use the script verified identity when signing.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -559,8 +559,8 @@ function publish_packages() {
   activate_twine
   trap deactivate RETURN
 
-  twine upload --sign-with=get_pgp_keyid "${DEPLOY_WHEEL_DIR}"/*.whl
-  twine upload --sign-with=get_pgp_keyid "${DEPLOY_SDIST_DIR}"/*.tar.gz
+  twine upload --sign --identity=$(get_pgp_keyid) "${DEPLOY_WHEEL_DIR}"/*.whl
+  twine upload --sign --identity=$(get_pgp_keyid) "${DEPLOY_SDIST_DIR}"/*.tar.gz
 
   end_travis_section
 }


### PR DESCRIPTION
Previously, we ran roughly:
`python setup.py sdist upload --sign --identity=$(get_pgp_keyid)` in
order to honor the pgp key id the user signed off on earlier in the
script execution. This ports the same behavior to the `twine` invocation
which now replaces `python setup.py upload`.