### PR TITLE
Add configurable message when missing-deps-suggest doesn't have suggestions

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -188,12 +188,11 @@ class JvmCompile(NailgunTaskBase):
              help='Suggest missing dependencies on a best-effort basis from target\'s transitive'
                   'deps for compilation failures that are due to class not found.')
     
-    register('--missing-deps-not-found-msg', type=str,
-             help='The string that should be printed when missing-deps-suggest can\'t find any '
-                  'targets for the classes not found during compilation. This should likely '
-                  'include a link to documentation about dependency management.',
-             default='Missing-deps-suggest could not find the dependencies needed to compile '
-                     'your target. Please see https://www.pantsbuild.org/3rdparty_jvm.html for '
+    register('--missing-deps-not-found-msg', advanced=True, type=str,
+             help='The string that should be printed when pants can\'t find any suggestions for '
+                  'targets containing the classes not found during compilation. This should '
+                  'likely include a link to documentation about dependency management.',
+             default='Please see https://www.pantsbuild.org/3rdparty_jvm.html for '
                      'more information.')
 
     register('--class-not-found-error-patterns', advanced=True, type=list,
@@ -807,11 +806,11 @@ class JvmCompile(NailgunTaskBase):
         self.context.log.info(suggestion_msg)
 
       if no_suggestions:
-        self.context.log.error('Unable to find any deps from target\'s transitive '
+        self.context.log.warn('Unable to find any deps from target\'s transitive '
                                'dependencies that provide the following missing classes:')
         no_suggestion_msg = '\n   '.join(sorted(list(no_suggestions)))
-        self.context.log.error('  {}'.format(no_suggestion_msg))
-        self.context.log.error(self.get_options().missing_deps_not_found_msg)
+        self.context.log.warn('  {}'.format(no_suggestion_msg))
+        self.context.log.warn(self.get_options().missing_deps_not_found_msg)
 
   def _upstream_analysis(self, compile_contexts, classpath_entries):
     """Returns tuples of classes_dir->analysis_file for the closure of the target."""

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -193,7 +193,8 @@ class JvmCompile(NailgunTaskBase):
                   'targets for the classes not found during compilation. This should likely '
                   'include a link to documentation about dependency management.',
              default='Missing-deps-suggest could not find the dependencies needed to compile '
-                     'your target. Please see <> for more information.')
+                     'your target. Please see https://www.pantsbuild.org/3rdparty_jvm.html for '
+                     'more information.')
 
     register('--class-not-found-error-patterns', advanced=True, type=list,
              default=CLASS_NOT_FOUND_ERROR_PATTERNS,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -189,11 +189,11 @@ class JvmCompile(NailgunTaskBase):
                   'deps for compilation failures that are due to class not found.')
     
     register('--missing-deps-not-found-msg', advanced=True, type=str,
-             help='The string that should be printed when pants can\'t find any suggestions for '
-                  'targets containing the classes not found during compilation. This should '
+             help='The message to print when pants can\'t find any suggestions for targets '
+                  'containing the classes not found during compilation. This should '
                   'likely include a link to documentation about dependency management.',
-             default='Please see https://www.pantsbuild.org/3rdparty_jvm.html for '
-                     'more information.')
+             default='Please see https://www.pantsbuild.org/3rdparty_jvm.html#strict-dependencies '
+                     'for more information.')
 
     register('--class-not-found-error-patterns', advanced=True, type=list,
              default=CLASS_NOT_FOUND_ERROR_PATTERNS,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -187,6 +187,13 @@ class JvmCompile(NailgunTaskBase):
     register('--suggest-missing-deps', type=bool,
              help='Suggest missing dependencies on a best-effort basis from target\'s transitive'
                   'deps for compilation failures that are due to class not found.')
+    
+    register('--missing-deps-not-found-msg', type=str,
+             help='The string that should be printed when missing-deps-suggest can\'t find any '
+                  'targets for the classes not found during compilation. This should likely '
+                  'include a link to documentation about dependency management.',
+             default='Missing-deps-suggest could not find the dependencies needed to compile '
+                     'your target. Please see <> for more information.')
 
     register('--class-not-found-error-patterns', advanced=True, type=list,
              default=CLASS_NOT_FOUND_ERROR_PATTERNS,
@@ -799,10 +806,11 @@ class JvmCompile(NailgunTaskBase):
         self.context.log.info(suggestion_msg)
 
       if no_suggestions:
-        self.context.log.debug('Unable to find any deps from target\'s transitive '
+        self.context.log.error('Unable to find any deps from target\'s transitive '
                                'dependencies that provide the following missing classes:')
         no_suggestion_msg = '\n   '.join(sorted(list(no_suggestions)))
-        self.context.log.debug('  {}'.format(no_suggestion_msg))
+        self.context.log.error('  {}'.format(no_suggestion_msg))
+        self.context.log.error(self.get_options().missing_deps_not_found_msg)
 
   def _upstream_analysis(self, compile_contexts, classpath_entries):
     """Returns tuples of classes_dir->analysis_file for the closure of the target."""


### PR DESCRIPTION
### Problem
It would be good to have a configurable message that will be printed when missing-deps-suggest cannot find any targets. The goal of this message is to point people to some documentation that might help solve their dependency problems. 

### Solution
Add an option that takes a string and logs it as an error when missing-deps-suggest matches a class not found error but doesn't have any suggestions. Please not that I upgraded the existing logs from debug to error because I thought it was useful to see the exact classes that couldn't be matched. 