### PR TITLE
[pantsd] Daemon lifecycle for options changes.

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -31,9 +31,9 @@ class PantsRunner(object):
 
   def run(self):
     options_bootstrapper = OptionsBootstrapper(env=self._env, args=self._args)
-    bootstrap_options = options_bootstrapper.get_bootstrap_options().for_global_scope()
+    bootstrap_options = options_bootstrapper.get_bootstrap_options()
 
-    if bootstrap_options.enable_pantsd:
+    if bootstrap_options.for_global_scope().enable_pantsd:
       try:
         return RemotePantsRunner(self._exiter, self._args, self._env, bootstrap_options).run()
       except RemotePantsRunner.Fallback as e:

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -69,7 +69,7 @@ class RemotePantsRunner(object):
 
   def _setup_logging(self):
     """Sets up basic stdio logging for the thin client."""
-    log_level = logging.getLevelName(self._bootstrap_options.level.upper())
+    log_level = logging.getLevelName(self._bootstrap_options.for_global_scope().level.upper())
 
     formatter = logging.Formatter('%(levelname)s] %(message)s')
     handler = logging.StreamHandler(sys.stdout)

--- a/src/python/pants/core_tasks/pantsd_kill.py
+++ b/src/python/pants/core_tasks/pantsd_kill.py
@@ -16,6 +16,6 @@ class PantsDaemonKill(Task):
 
   def execute(self):
     try:
-      PantsDaemon.Factory.create(self.get_options()).terminate()
+      PantsDaemon.Factory.create(self.context.options).terminate()
     except ProcessManager.NonResponsiveProcess as e:
       raise TaskError('failure while terminating pantsd: {}'.format(e))

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -40,6 +40,7 @@ FrozenRegistration = mk_registration_error('Cannot register an option on a scope
                                            'on any of its inner scopes.')
 ImplicitValIsNone = mk_registration_error('Implicit value cannot be None.')
 InvalidKwarg = mk_registration_error('Invalid registration kwarg {kwarg}.')
+InvalidKwargNonGlobalScope = mk_registration_error('Invalid registration kwarg {kwarg} on non-global scope.')
 InvalidMemberType = mk_registration_error('member_type {member_type} not allowed.')
 MemberTypeNotAllowed = mk_registration_error('member_type not allowed on option with type {type_}. '
                                              'It may only be specified if type=list.')

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -50,7 +50,7 @@ class GlobalOptionsRegistrar(Optionable):
     # setup a 'WARN' logging level name that maps to 'WARNING'.
     logging.addLevelName(logging.WARNING, 'WARN')
     register('-l', '--level', choices=['debug', 'info', 'warn'], default='info', recursive=True,
-             help='Set the logging level.')
+             daemon=True, help='Set the logging level.')
     register('-q', '--quiet', type=bool, recursive=True,
              help='Squelches most console output. NOTE: Some tasks default to behaving quietly: '
                   'inverting this option supports making them noisier than they would be otherwise.')
@@ -63,15 +63,15 @@ class GlobalOptionsRegistrar(Optionable):
     # setup scripts, runner scripts, IDE plugins, etc., may grep this out of pants.ini
     # and use it to select the right version.
     # Note that to print the version of the pants instance you're running, use -v, -V or --version.
-    register('--pants-version', advanced=True, default=pants_version(),
+    register('--pants-version', advanced=True, default=pants_version(), daemon=True,
              help='Use this pants version.')
 
-    register('--plugins', advanced=True, type=list, help='Load these plugins.')
-    register('--plugin-cache-dir', advanced=True,
+    register('--plugins', advanced=True, type=list, daemon=True, help='Load these plugins.')
+    register('--plugin-cache-dir', advanced=True, daemon=True,
              default=os.path.join(get_pants_cachedir(), 'plugins'),
              help='Cache resolved plugin requirements here.')
 
-    register('--backend-packages', advanced=True, type=list,
+    register('--backend-packages', advanced=True, type=list, daemon=True,
              default=['pants.backend.graph_info',
                       'pants.backend.python',
                       'pants.backend.jvm',
@@ -88,51 +88,52 @@ class GlobalOptionsRegistrar(Optionable):
                   'Add contrib and custom backends to this list.')
 
     register('--pants-bootstrapdir', advanced=True, metavar='<dir>', default=get_pants_cachedir(),
-             help='Use this dir for global cache.')
+             daemon=True, help='Use this dir for global cache.')
     register('--pants-configdir', advanced=True, metavar='<dir>', default=get_pants_configdir(),
-             help='Use this dir for global config files.')
-    register('--pants-workdir', advanced=True, metavar='<dir>',
+             daemon=True, help='Use this dir for global config files.')
+    register('--pants-workdir', advanced=True, metavar='<dir>', daemon=True,
              default=os.path.join(buildroot, '.pants.d'),
              help='Write intermediate output files to this dir.')
-    register('--pants-supportdir', advanced=True, metavar='<dir>',
+    register('--pants-supportdir', advanced=True, metavar='<dir>', daemon=True,
              default=os.path.join(buildroot, 'build-support'),
              help='Use support files from this dir.')
-    register('--pants-distdir', advanced=True, metavar='<dir>',
+    register('--pants-distdir', advanced=True, metavar='<dir>', daemon=True,
              default=default_distdir,
              help='Write end-product artifacts to this dir. If you modify this path, you '
                   'should also update --build-ignore and --pants-ignore to include the '
                   'custom dist dir path as well.')
     register('--pants-subprocessdir', advanced=True, default=os.path.join(buildroot, '.pids'),
+             daemon=True,
              help='The directory to use for tracking subprocess metadata, if any. This should '
                   'live outside of the dir used by `--pants-workdir` to allow for tracking '
                   'subprocesses that outlive the workdir data (e.g. `./pants server`).')
-    register('--pants-config-files', advanced=True, type=list,
+    register('--pants-config-files', advanced=True, type=list, daemon=True,
              default=[get_default_pants_config_file()], help='Paths to Pants config files.')
     # TODO: Deprecate the --pantsrc/--pantsrc-files options?  This would require being able
     # to set extra config file locations in an initial bootstrap config file.
-    register('--config-override', advanced=True, type=list, metavar='<path>',
+    register('--config-override', advanced=True, type=list, metavar='<path>', daemon=True,
              removal_version='1.6.0.dev0',
              removal_hint='Use --pants-config-files=<second config file path> instead.',
              help='A second config file, to override pants.ini.')
-    register('--pantsrc', advanced=True, type=bool, default=True,
+    register('--pantsrc', advanced=True, type=bool, default=True, daemon=True,
              help='Use pantsrc files.')
-    register('--pantsrc-files', advanced=True, type=list, metavar='<path>',
+    register('--pantsrc-files', advanced=True, type=list, metavar='<path>', daemon=True,
              default=['/etc/pantsrc', '~/.pants.rc'],
              help='Override config with values from these files. '
                   'Later files override earlier ones.')
-    register('--pythonpath', advanced=True, type=list,
+    register('--pythonpath', advanced=True, type=list, daemon=True,
              help='Add these directories to PYTHONPATH to search for plugins.')
     register('--target-spec-file', type=list, dest='target_spec_files',
              help='Read additional specs from this file, one per line')
     register('--verify-config', type=bool, default=True,
              help='Verify that all config file values correspond to known options.')
-    register('--build-ignore', advanced=True, type=list, fromfile=True,
+    register('--build-ignore', advanced=True, type=list, fromfile=True, daemon=True,
              default=['.*/', default_rel_distdir, 'bower_components/',
                       'node_modules/', '*.egg-info/'],
              help='Paths to ignore when identifying BUILD files. '
                   'This does not affect any other filesystem operations. '
                   'Patterns use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')
-    register('--pants-ignore', advanced=True, type=list, fromfile=True,
+    register('--pants-ignore', advanced=True, type=list, fromfile=True, daemon=True,
              default=['.*/', default_rel_distdir],
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
@@ -140,34 +141,34 @@ class GlobalOptionsRegistrar(Optionable):
                   'This currently only affects the v2 engine. '
                   'To experiment with v2 engine, try --enable-v2-engine option.')
     register('--exclude-target-regexp', advanced=True, type=list, default=[],
-             metavar='<regexp>',
-             help='Exclude target roots that match these regexes.')
+             metavar='<regexp>', help='Exclude target roots that match these regexes.')
     register('--subproject-roots', type=list, advanced=True, fromfile=True, default=[],
+             daemon=True,
              help='Paths that correspond with build roots for any subproject that this '
                   'project depends on.')
 
     # These logging options are registered in the bootstrap phase so that plugins can log during
     # registration and not so that their values can be interpolated in configs.
-    register('-d', '--logdir', advanced=True, metavar='<dir>',
+    register('-d', '--logdir', advanced=True, metavar='<dir>', daemon=True,
              help='Write logs to files under this directory.')
 
     # This facilitates bootstrap-time configuration of pantsd usage such that we can
     # determine whether or not to use the Pailgun client to invoke a given pants run
     # without resorting to heavier options parsing.
-    register('--enable-pantsd', advanced=True, type=bool, default=False,
+    register('--enable-pantsd', advanced=True, type=bool, default=False, daemon=True,
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
 
     # This facilitates use of the v2 engine, sans daemon.
     # TODO: Add removal_version='1.5.0.dev0' before 1.4 lands.
-    register('--enable-v2-engine', advanced=True, type=bool, default=True,
+    register('--enable-v2-engine', advanced=True, type=bool, default=True, daemon=True,
              help='Enables use of the v2 engine.')
 
     # These facilitate configuring the native engine.
-    register('--native-engine-version', advanced=True, default='DEPRECATED',
+    register('--native-engine-version', advanced=True, default='DEPRECATED', daemon=True,
              removal_version='1.6.0.dev0',
              removal_hint='Unused, the native engine is now embedded in the pantsbuild.pants wheel',
              help='Native engine version.')
-    register('--native-engine-supportdir', advanced=True, default='DEPRECATED',
+    register('--native-engine-supportdir', advanced=True, default='DEPRECATED', daemon=True,
              removal_version='1.6.0.dev0',
              removal_hint='Unused, the native engine is now embedded in the pantsbuild.pants wheel',
              help='Find native engine binaries under this dir. Used as part of the path to '
@@ -177,43 +178,46 @@ class GlobalOptionsRegistrar(Optionable):
                   'of the directory will be overwritten if any filenames collide.')
 
     # BinaryUtil options.
-    register('--binaries-baseurls', type=list, advanced=True,
+    register('--binaries-baseurls', type=list, advanced=True, daemon=True,
              default=['https://binaries.pantsbuild.org'],
              help='List of URLs from which binary tools are downloaded. URLs are '
                   'searched in order until the requested path is found.')
     register('--binaries-fetch-timeout-secs', type=int, default=30, advanced=True,
+             daemon=True,
              help='Timeout in seconds for URL reads when fetching binary tools from the '
                   'repos specified by --baseurls.')
-    register('--binaries-path-by-id', type=dict, advanced=True,
+    register('--binaries-path-by-id', type=dict, advanced=True, daemon=True,
              help=('Maps output of uname for a machine to a binary search path. e.g. '
                    '{("darwin", "15"): ["mac", "10.11"]), ("linux", "arm32"): ["linux"'
                    ', "arm32"]}'))
 
     # Pants Daemon options.
-    register('--pantsd-pailgun-host', advanced=True, default='127.0.0.1',
+    register('--pantsd-pailgun-host', advanced=True, default='127.0.0.1', daemon=True,
              help='The host to bind the pants nailgun server to.')
-    register('--pantsd-pailgun-port', advanced=True, type=int, default=0,
+    register('--pantsd-pailgun-port', advanced=True, type=int, default=0, daemon=True,
              help='The port to bind the pants nailgun server to. Defaults to a random port.')
-    register('--pantsd-log-dir', advanced=True, default=None,
+    register('--pantsd-log-dir', advanced=True, default=None, daemon=True,
              help='The directory to log pantsd output to.')
-    register('--pantsd-fs-event-detection', advanced=True, type=bool,
+    register('--pantsd-fs-event-detection', advanced=True, type=bool, daemon=True,
              removal_version='1.5.0.dev0',
              removal_hint='This option is now implied by `--enable-pantsd`.',
              help='Whether or not to use filesystem event detection.')
-    register('--pantsd-fs-event-workers', advanced=True, type=int, default=4,
+    register('--pantsd-fs-event-workers', advanced=True, type=int, default=4, daemon=True,
              help='The number of workers to use for the filesystem event service executor pool.')
 
     # Watchman options.
-    register('--watchman-version', advanced=True, default='4.5.0', help='Watchman version.')
-    register('--watchman-supportdir', advanced=True, default='bin/watchman',
+    register('--watchman-version', advanced=True, default='4.5.0', daemon=True,
+             help='Watchman version.')
+    register('--watchman-supportdir', advanced=True, default='bin/watchman', daemon=True,
              help='Find watchman binaries under this dir. Used as part of the path to lookup '
                   'the binary with --binary-util-baseurls and --pants-bootstrapdir.')
     register('--watchman-startup-timeout', type=float, advanced=True, default=30.0,
+             daemon=True,
              help='The watchman socket timeout (in seconds) for the initial `watch-project` command. '
                   'This may need to be set higher for larger repos due to watchman startup cost.')
-    register('--watchman-socket-timeout', type=float, advanced=True, default=5.0,
+    register('--watchman-socket-timeout', type=float, advanced=True, default=5.0, daemon=True,
              help='The watchman client socket timeout in seconds.')
-    register('--watchman-socket-path', type=str, advanced=True, default=None,
+    register('--watchman-socket-path', type=str, advanced=True, default=None, daemon=True,
              help='The path to the watchman UNIX socket. This can be overridden if the default '
                   'absolute path length exceeds the maximum allowed by the OS.')
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -50,28 +50,28 @@ class GlobalOptionsRegistrar(Optionable):
     # setup a 'WARN' logging level name that maps to 'WARNING'.
     logging.addLevelName(logging.WARNING, 'WARN')
     register('-l', '--level', choices=['debug', 'info', 'warn'], default='info', recursive=True,
-             daemon=True, help='Set the logging level.')
-    register('-q', '--quiet', type=bool, recursive=True,
+             help='Set the logging level.')
+    register('-q', '--quiet', type=bool, recursive=True, daemon=False,
              help='Squelches most console output. NOTE: Some tasks default to behaving quietly: '
                   'inverting this option supports making them noisier than they would be otherwise.')
     # Not really needed in bootstrap options, but putting it here means it displays right
     # after -l and -q in help output, which is conveniently contextual.
-    register('--colors', type=bool, default=sys.stdout.isatty(), recursive=True,
+    register('--colors', type=bool, default=sys.stdout.isatty(), recursive=True, daemon=False,
              help='Set whether log messages are displayed in color.')
 
     # Pants code uses this only to verify that we are of the requested version. However
     # setup scripts, runner scripts, IDE plugins, etc., may grep this out of pants.ini
     # and use it to select the right version.
     # Note that to print the version of the pants instance you're running, use -v, -V or --version.
-    register('--pants-version', advanced=True, default=pants_version(), daemon=True,
+    register('--pants-version', advanced=True, default=pants_version(),
              help='Use this pants version.')
 
-    register('--plugins', advanced=True, type=list, daemon=True, help='Load these plugins.')
-    register('--plugin-cache-dir', advanced=True, daemon=True,
+    register('--plugins', advanced=True, type=list, help='Load these plugins.')
+    register('--plugin-cache-dir', advanced=True,
              default=os.path.join(get_pants_cachedir(), 'plugins'),
              help='Cache resolved plugin requirements here.')
 
-    register('--backend-packages', advanced=True, type=list, daemon=True,
+    register('--backend-packages', advanced=True, type=list,
              default=['pants.backend.graph_info',
                       'pants.backend.python',
                       'pants.backend.jvm',
@@ -88,136 +88,131 @@ class GlobalOptionsRegistrar(Optionable):
                   'Add contrib and custom backends to this list.')
 
     register('--pants-bootstrapdir', advanced=True, metavar='<dir>', default=get_pants_cachedir(),
-             daemon=True, help='Use this dir for global cache.')
+             help='Use this dir for global cache.')
     register('--pants-configdir', advanced=True, metavar='<dir>', default=get_pants_configdir(),
-             daemon=True, help='Use this dir for global config files.')
-    register('--pants-workdir', advanced=True, metavar='<dir>', daemon=True,
+             help='Use this dir for global config files.')
+    register('--pants-workdir', advanced=True, metavar='<dir>',
              default=os.path.join(buildroot, '.pants.d'),
              help='Write intermediate output files to this dir.')
-    register('--pants-supportdir', advanced=True, metavar='<dir>', daemon=True,
+    register('--pants-supportdir', advanced=True, metavar='<dir>',
              default=os.path.join(buildroot, 'build-support'),
              help='Use support files from this dir.')
-    register('--pants-distdir', advanced=True, metavar='<dir>', daemon=True,
+    register('--pants-distdir', advanced=True, metavar='<dir>',
              default=default_distdir,
              help='Write end-product artifacts to this dir. If you modify this path, you '
                   'should also update --build-ignore and --pants-ignore to include the '
                   'custom dist dir path as well.')
     register('--pants-subprocessdir', advanced=True, default=os.path.join(buildroot, '.pids'),
-             daemon=True,
              help='The directory to use for tracking subprocess metadata, if any. This should '
                   'live outside of the dir used by `--pants-workdir` to allow for tracking '
                   'subprocesses that outlive the workdir data (e.g. `./pants server`).')
-    register('--pants-config-files', advanced=True, type=list, daemon=True,
+    register('--pants-config-files', advanced=True, type=list,
              default=[get_default_pants_config_file()], help='Paths to Pants config files.')
     # TODO: Deprecate the --pantsrc/--pantsrc-files options?  This would require being able
     # to set extra config file locations in an initial bootstrap config file.
-    register('--config-override', advanced=True, type=list, metavar='<path>', daemon=True,
+    register('--config-override', advanced=True, type=list, metavar='<path>',
              removal_version='1.6.0.dev0',
              removal_hint='Use --pants-config-files=<second config file path> instead.',
              help='A second config file, to override pants.ini.')
-    register('--pantsrc', advanced=True, type=bool, default=True, daemon=True,
+    register('--pantsrc', advanced=True, type=bool, default=True,
              help='Use pantsrc files.')
-    register('--pantsrc-files', advanced=True, type=list, metavar='<path>', daemon=True,
+    register('--pantsrc-files', advanced=True, type=list, metavar='<path>',
              default=['/etc/pantsrc', '~/.pants.rc'],
              help='Override config with values from these files. '
                   'Later files override earlier ones.')
-    register('--pythonpath', advanced=True, type=list, daemon=True,
+    register('--pythonpath', advanced=True, type=list,
              help='Add these directories to PYTHONPATH to search for plugins.')
-    register('--target-spec-file', type=list, dest='target_spec_files',
+    register('--target-spec-file', type=list, dest='target_spec_files', daemon=False,
              help='Read additional specs from this file, one per line')
-    register('--verify-config', type=bool, default=True,
+    register('--verify-config', type=bool, default=True, daemon=False,
              help='Verify that all config file values correspond to known options.')
-    register('--build-ignore', advanced=True, type=list, fromfile=True, daemon=True,
+    register('--build-ignore', advanced=True, type=list, fromfile=True,
              default=['.*/', default_rel_distdir, 'bower_components/',
                       'node_modules/', '*.egg-info/'],
              help='Paths to ignore when identifying BUILD files. '
                   'This does not affect any other filesystem operations. '
                   'Patterns use the gitignore pattern syntax (https://git-scm.com/docs/gitignore).')
-    register('--pants-ignore', advanced=True, type=list, fromfile=True, daemon=True,
+    register('--pants-ignore', advanced=True, type=list, fromfile=True,
              default=['.*/', default_rel_distdir],
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore). '
                   'This currently only affects the v2 engine. '
                   'To experiment with v2 engine, try --enable-v2-engine option.')
-    register('--exclude-target-regexp', advanced=True, type=list, default=[],
+    register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,
              metavar='<regexp>', help='Exclude target roots that match these regexes.')
     register('--subproject-roots', type=list, advanced=True, fromfile=True, default=[],
-             daemon=True,
              help='Paths that correspond with build roots for any subproject that this '
                   'project depends on.')
 
     # These logging options are registered in the bootstrap phase so that plugins can log during
     # registration and not so that their values can be interpolated in configs.
-    register('-d', '--logdir', advanced=True, metavar='<dir>', daemon=True,
+    register('-d', '--logdir', advanced=True, metavar='<dir>',
              help='Write logs to files under this directory.')
 
     # This facilitates bootstrap-time configuration of pantsd usage such that we can
     # determine whether or not to use the Pailgun client to invoke a given pants run
     # without resorting to heavier options parsing.
-    register('--enable-pantsd', advanced=True, type=bool, default=False, daemon=True,
+    register('--enable-pantsd', advanced=True, type=bool, default=False,
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
 
     # This facilitates use of the v2 engine, sans daemon.
     # TODO: Add removal_version='1.5.0.dev0' before 1.4 lands.
-    register('--enable-v2-engine', advanced=True, type=bool, default=True, daemon=True,
+    register('--enable-v2-engine', advanced=True, type=bool, default=True,
              help='Enables use of the v2 engine.')
 
     # These facilitate configuring the native engine.
-    register('--native-engine-version', advanced=True, default='DEPRECATED', daemon=True,
+    register('--native-engine-version', advanced=True, default='DEPRECATED',
              removal_version='1.6.0.dev0',
              removal_hint='Unused, the native engine is now embedded in the pantsbuild.pants wheel',
              help='Native engine version.')
-    register('--native-engine-supportdir', advanced=True, default='DEPRECATED', daemon=True,
+    register('--native-engine-supportdir', advanced=True, default='DEPRECATED',
              removal_version='1.6.0.dev0',
              removal_hint='Unused, the native engine is now embedded in the pantsbuild.pants wheel',
              help='Find native engine binaries under this dir. Used as part of the path to '
                   'lookup the binary with --binary-util-baseurls and --pants-bootstrapdir.')
-    register('--native-engine-visualize-to', advanced=True, default=None, type=dir_option,
+    register('--native-engine-visualize-to', advanced=True, default=None, type=dir_option, daemon=False,
              help='A directory to write execution and rule graphs to as `dot` files. The contents '
                   'of the directory will be overwritten if any filenames collide.')
 
     # BinaryUtil options.
-    register('--binaries-baseurls', type=list, advanced=True, daemon=True,
+    register('--binaries-baseurls', type=list, advanced=True,
              default=['https://binaries.pantsbuild.org'],
              help='List of URLs from which binary tools are downloaded. URLs are '
                   'searched in order until the requested path is found.')
-    register('--binaries-fetch-timeout-secs', type=int, default=30, advanced=True,
-             daemon=True,
+    register('--binaries-fetch-timeout-secs', type=int, default=30, advanced=True, daemon=False,
              help='Timeout in seconds for URL reads when fetching binary tools from the '
                   'repos specified by --baseurls.')
-    register('--binaries-path-by-id', type=dict, advanced=True, daemon=True,
+    register('--binaries-path-by-id', type=dict, advanced=True,
              help=('Maps output of uname for a machine to a binary search path. e.g. '
                    '{("darwin", "15"): ["mac", "10.11"]), ("linux", "arm32"): ["linux"'
                    ', "arm32"]}'))
 
     # Pants Daemon options.
-    register('--pantsd-pailgun-host', advanced=True, default='127.0.0.1', daemon=True,
+    register('--pantsd-pailgun-host', advanced=True, default='127.0.0.1',
              help='The host to bind the pants nailgun server to.')
-    register('--pantsd-pailgun-port', advanced=True, type=int, default=0, daemon=True,
+    register('--pantsd-pailgun-port', advanced=True, type=int, default=0,
              help='The port to bind the pants nailgun server to. Defaults to a random port.')
-    register('--pantsd-log-dir', advanced=True, default=None, daemon=True,
+    register('--pantsd-log-dir', advanced=True, default=None,
              help='The directory to log pantsd output to.')
-    register('--pantsd-fs-event-detection', advanced=True, type=bool, daemon=True,
+    register('--pantsd-fs-event-detection', advanced=True, type=bool,
              removal_version='1.5.0.dev0',
              removal_hint='This option is now implied by `--enable-pantsd`.',
              help='Whether or not to use filesystem event detection.')
-    register('--pantsd-fs-event-workers', advanced=True, type=int, default=4, daemon=True,
+    register('--pantsd-fs-event-workers', advanced=True, type=int, default=4,
              help='The number of workers to use for the filesystem event service executor pool.')
 
     # Watchman options.
-    register('--watchman-version', advanced=True, default='4.5.0', daemon=True,
-             help='Watchman version.')
-    register('--watchman-supportdir', advanced=True, default='bin/watchman', daemon=True,
+    register('--watchman-version', advanced=True, default='4.5.0', help='Watchman version.')
+    register('--watchman-supportdir', advanced=True, default='bin/watchman',
              help='Find watchman binaries under this dir. Used as part of the path to lookup '
                   'the binary with --binary-util-baseurls and --pants-bootstrapdir.')
     register('--watchman-startup-timeout', type=float, advanced=True, default=30.0,
-             daemon=True,
              help='The watchman socket timeout (in seconds) for the initial `watch-project` command. '
                   'This may need to be set higher for larger repos due to watchman startup cost.')
-    register('--watchman-socket-timeout', type=float, advanced=True, default=5.0, daemon=True,
+    register('--watchman-socket-timeout', type=float, advanced=True, default=5.0,
              help='The watchman client socket timeout in seconds.')
-    register('--watchman-socket-path', type=str, advanced=True, default=None, daemon=True,
+    register('--watchman-socket-path', type=str, advanced=True, default=None,
              help='The path to the watchman UNIX socket. This can be overridden if the default '
                   'absolute path length exceeds the maximum allowed by the OS.')
 

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -6,9 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import copy
-import hashlib
-
-import six
 
 from pants.option.ranked_value import RankedValue
 
@@ -146,22 +143,3 @@ class OptionValueContainer(object):
     ret = type(self)()
     ret._value_map = copy.copy(self._value_map)
     return ret
-
-  def sha1(self, exclude_keys=None):
-    """Computes and returns the current sha1 fingerprint for this `OptionValueContainer`.
-
-    :param list exclude_keys: A list of keys to exclude from fingerprint computation.
-    """
-    exclude_keys = set(exclude_keys or [])
-    acceptable_types = set((bytes, str, list, tuple, dict, int, float, bool, type(None)))
-    hasher = hashlib.sha1()
-    # N.B. This is pre-`sorted()` in `__iter__` above for determinism.
-    for k in self:
-      if k in exclude_keys: continue
-      hasher.update(k)
-      v = self.get(k)
-      assert type(v) in acceptable_types, 'unhashable option type: {}'.format(type(v))
-      # N.B. This relies on implicit string conversion to do the right thing for
-      # primitive types (e.g. `str([1, 2, 3])` -> "[1, 2, 3]").
-      hasher.update(six.binary_type(v))
-    return hasher.hexdigest()

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -312,7 +312,8 @@ class Options(object):
 
     return values
 
-  def get_fingerprintable_for_scope(self, scope, include_passthru=False, fingerprint_key=None):
+  def get_fingerprintable_for_scope(self, scope, include_passthru=False, fingerprint_key=None,
+                                    invert=False):
     """Returns a list of fingerprintable (option type, option value) pairs for the given scope.
 
     Fingerprintable options are options registered via a "fingerprint=True" kwarg. This flag
@@ -322,10 +323,12 @@ class Options(object):
     :param bool include_passthru: Whether to include passthru args captured by `scope` in the
                                   fingerprintable options.
     :param string fingerprint_key: The option kwarg to match against (defaults to 'fingerprint').
+    :param bool invert: Whether or not to invert the boolean check for the fingerprint_key value.
 
     :API: public
     """
     fingerprint_key = fingerprint_key or 'fingerprint'
+    fingerprint_default = False if invert else None
     pairs = []
 
     if include_passthru:
@@ -344,7 +347,7 @@ class Options(object):
       for (_, kwargs) in sorted(parser.option_registrations_iter()):
         if kwargs.get('recursive') and not kwargs.get('recursive_root'):
           continue  # We only need to fprint recursive options once.
-        if kwargs.get(fingerprint_key) is not True:
+        if kwargs.get(fingerprint_key, fingerprint_default) is not (False if invert else True):
           continue
         # Note that we read the value from scope, even if the registration was on an enclosing
         # scope, to get the right value for recursive options (and because this mirrors what

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -312,17 +312,20 @@ class Options(object):
 
     return values
 
-  def get_fingerprintable_for_scope(self, scope, include_passthru=False):
+  def get_fingerprintable_for_scope(self, scope, include_passthru=False, fingerprint_key=None):
     """Returns a list of fingerprintable (option type, option value) pairs for the given scope.
 
-    Fingerprintable options are options registered via a "fingerprint=True" kwarg.
+    Fingerprintable options are options registered via a "fingerprint=True" kwarg. This flag
+    can be parameterized with `fingerprint_key` for special cases.
 
     :param str scope: The scope to gather fingerprintable options for.
     :param bool include_passthru: Whether to include passthru args captured by `scope` in the
                                   fingerprintable options.
+    :param string fingerprint_key: The option kwarg to match against (defaults to 'fingerprint').
 
     :API: public
     """
+    fingerprint_key = fingerprint_key or 'fingerprint'
     pairs = []
 
     if include_passthru:
@@ -341,7 +344,7 @@ class Options(object):
       for (_, kwargs) in sorted(parser.option_registrations_iter()):
         if kwargs.get('recursive') and not kwargs.get('recursive_root'):
           continue  # We only need to fprint recursive options once.
-        if kwargs.get('fingerprint') is not True:
+        if kwargs.get(fingerprint_key) is not True:
           continue
         # Note that we read the value from scope, even if the registration was on an enclosing
         # scope, to get the right value for recursive options (and because this mirrors what

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -9,6 +9,8 @@ import json
 import os
 from hashlib import sha1
 
+import six
+
 from pants.base.build_environment import get_buildroot
 from pants.option.custom_types import UnsetBool, dict_with_files_option, file_option, target_option
 
@@ -34,7 +36,32 @@ class OptionsFingerprinter(object):
   :API: public
   """
 
-  def __init__(self, build_graph):
+  @classmethod
+  def combined_options_fingerprint_for_scope(cls, scope, options, fingerprint_key=None,
+                                             build_graph=None):
+    """Given options and a scope, compute a combined fingerprint for the scope.
+
+    :param string scope: The scope to fingerprint.
+    :param Options options: The `Options` object to fingerprint.
+    :param string fingerprint_key: The options kwarg to filter against.
+    :param BuildGraph build_graph: A `BuildGraph` instance, only needed if fingerprinting
+                                   target options.
+    """
+    fingerprinter = cls(build_graph)
+    hasher = sha1()
+    for (
+      option_type, option_value
+    ) in options.get_fingerprintable_for_scope(scope, fingerprint_key=fingerprint_key):
+      hasher.update(
+        # N.B. `OptionsFingerprinter.fingerprint()` can return `None`,
+        # so we always cast to bytes here.
+        six.binary_type(
+          fingerprinter.fingerprint(option_type, option_value)
+        )
+      )
+    return hasher.hexdigest()
+
+  def __init__(self, build_graph=None):
     self._build_graph = build_graph
 
   def fingerprint(self, option_type, option_val):
@@ -63,6 +90,9 @@ class OptionsFingerprinter(object):
 
   def _fingerprint_target_specs(self, specs):
     """Returns a fingerprint of the targets resolved from given target specs."""
+    assert self._build_graph is not None, (
+      'cannot fingerprint specs `{}` without a `BuildGraph`'.format(specs)
+    )
     hasher = sha1()
     for spec in sorted(specs):
       for target in sorted(self._build_graph.resolve(spec)):

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -38,20 +38,23 @@ class OptionsFingerprinter(object):
 
   @classmethod
   def combined_options_fingerprint_for_scope(cls, scope, options, fingerprint_key=None,
-                                             build_graph=None):
+                                             invert=None, build_graph=None):
     """Given options and a scope, compute a combined fingerprint for the scope.
 
     :param string scope: The scope to fingerprint.
     :param Options options: The `Options` object to fingerprint.
     :param string fingerprint_key: The options kwarg to filter against.
+    :param bool invert: Whether or not to invert the boolean check for the fingerprint_key value.
     :param BuildGraph build_graph: A `BuildGraph` instance, only needed if fingerprinting
                                    target options.
     """
     fingerprinter = cls(build_graph)
     hasher = sha1()
-    for (
-      option_type, option_value
-    ) in options.get_fingerprintable_for_scope(scope, fingerprint_key=fingerprint_key):
+    for (option_type, option_value) in options.get_fingerprintable_for_scope(
+      scope,
+      fingerprint_key=fingerprint_key,
+      invert=invert
+    ):
       hasher.update(
         # N.B. `OptionsFingerprinter.fingerprint()` can return `None`,
         # so we always cast to bytes here.

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -20,10 +20,10 @@ from pants.option.custom_types import (DictValueComponent, ListValueComponent, U
                                        dict_option, dir_option, file_option, list_option,
                                        target_option)
 from pants.option.errors import (BooleanOptionNameWithNo, FrozenRegistration, ImplicitValIsNone,
-                                 InvalidKwarg, InvalidMemberType, MemberTypeNotAllowed,
-                                 NoOptionNames, OptionAlreadyRegistered, OptionNameDash,
-                                 OptionNameDoubleDash, ParseError, RecursiveSubsystemOption,
-                                 Shadowing)
+                                 InvalidKwarg, InvalidKwargNonGlobalScope, InvalidMemberType,
+                                 MemberTypeNotAllowed, NoOptionNames, OptionAlreadyRegistered,
+                                 OptionNameDash, OptionNameDoubleDash, ParseError,
+                                 RecursiveSubsystemOption, Shadowing)
 from pants.option.option_util import is_dict_option, is_list_option
 from pants.option.ranked_value import RankedValue
 from pants.option.scope import ScopeInfo
@@ -381,6 +381,10 @@ class Parser(object):
     for kwarg in kwargs:
       if kwarg not in self._allowed_registration_kwargs:
         error(InvalidKwarg, kwarg=kwarg)
+
+      # Ensure `daemon=True` can't be passed on non-global scopes (except for `recursive=True`).
+      if (kwarg == 'daemon' and self._scope != GLOBAL_SCOPE and kwargs.get('recursive') is False):
+        error(InvalidKwargNonGlobalScope, kwarg=kwarg)
 
     removal_version = kwargs.get('removal_version')
     if removal_version is not None:

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -340,7 +340,8 @@ class Parser(object):
   _allowed_registration_kwargs = {
     'type', 'member_type', 'choices', 'dest', 'default', 'implicit_value', 'metavar',
     'help', 'advanced', 'recursive', 'recursive_root', 'registering_class',
-    'fingerprint', 'removal_version', 'removal_hint', 'fromfile', 'mutually_exclusive_group'
+    'fingerprint', 'removal_version', 'removal_hint', 'fromfile', 'mutually_exclusive_group',
+    'daemon'
   }
 
   # TODO: Remove dict_option from here after deprecation is complete.

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -182,7 +182,8 @@ class PantsDaemon(FingerprintedProcessManager):
     return OptionsFingerprinter.combined_options_fingerprint_for_scope(
       GLOBAL_SCOPE,
       self._bootstrap_options,
-      fingerprint_key='daemon'
+      fingerprint_key='daemon',
+      invert=True
     )
 
   def shutdown(self, service_thread_map):

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -535,7 +535,7 @@ class FingerprintedProcessManager(ProcessManager):
       sep = sep or self.FINGERPRINT_CMD_SEP
       cmdline = cmdline or []
       for cmd_part in cmdline:
-        if cmd_part.startswith('{}='.format(key, sep)):
+        if cmd_part.startswith('{}{}'.format(key, sep)):
           return cmd_part.split(sep)[1]
 
   def has_current_fingerprint(self, fingerprint):

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -512,6 +512,9 @@ class FingerprintedProcessManager(ProcessManager):
   def fingerprint(self):
     """The fingerprint of the current process.
 
+    This can either read the current fingerprint from the running process's psutil.Process.cmdline
+    (if the managed process supports that) or from the `ProcessManager` metadata.
+
     :returns: The fingerprint of the running process as read from the process table, ProcessManager
               metadata or `None`.
     :rtype: string

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -499,3 +499,57 @@ class ProcessManager(ProcessMetadataManager):
 
   def post_fork_parent(self):
     """Post-fork parent callback for subclasses."""
+
+
+class FingerprintedProcessManager(ProcessManager):
+  """A `ProcessManager` subclass that provides a general strategy for process fingerprinting."""
+
+  FINGERPRINT_KEY = 'fingerprint'
+  FINGERPRINT_CMD_KEY = None
+  FINGERPRINT_CMD_SEP = '='
+
+  @property
+  def fingerprint(self):
+    """The fingerprint of the current process.
+
+    :returns: The fingerprint of the running process as read from the process table, ProcessManager
+              metadata or `None`.
+    :rtype: string
+    """
+    return (
+      self.parse_fingerprint(self.cmdline) or
+      self.read_metadata_by_name(self.name, self.FINGERPRINT_KEY)
+    )
+
+  def parse_fingerprint(self, cmdline, key=None, sep=None):
+    """Given a psutil.Process.cmdline, parse and return a fingerprint.
+
+    :param list cmdline: The psutil.Process.cmdline of the current process.
+    :param string key: The key for fingerprint discovery.
+    :param string sep: The key/value separator for fingerprint discovery.
+    :returns: The parsed fingerprint or `None`.
+    :rtype: string or `None`
+    """
+    key = key or self.FINGERPRINT_CMD_KEY
+    if key:
+      sep = sep or self.FINGERPRINT_CMD_SEP
+      cmdline = cmdline or []
+      for cmd_part in cmdline:
+        if cmd_part.startswith('{}='.format(key, sep)):
+          return cmd_part.split(sep)[1]
+
+  def has_current_fingerprint(self, fingerprint):
+    """Determines if a new fingerprint is the current fingerprint of the running process.
+
+    :param string fingerprint: The new fingerprint to compare to.
+    :rtype: bool
+    """
+    return fingerprint == self.fingerprint
+
+  def needs_restart(self, fingerprint):
+    """Determines if the current ProcessManager needs to be started or restarted.
+
+    :param string fingerprint: The new fingerprint to compare to.
+    :rtype: bool
+    """
+    return self.is_dead() or not self.has_current_fingerprint(fingerprint)

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -67,6 +67,7 @@ python_tests(
   sources = ['test_pantsd_integration.py'],
   dependencies = [
     'src/python/pants/pantsd:process_manager',
+    'src/python/pants/util:collections',
     'tests/python/pants_test:int-test',
     'tests/python/pants_test/testutils:process_test_util'
   ],

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -71,7 +71,7 @@ python_tests(
     'tests/python/pants_test/testutils:process_test_util'
   ],
   tags = {'integration'},
-  timeout = 300
+  timeout = 600
 )
 
 python_tests(

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -48,6 +48,7 @@ class PantsDaemonTest(BaseTest):
     lock = threading.RLock()
     mock_options = mock.Mock()
     mock_options.pants_subprocessdir = 'non_existent_dir'
+    mock_options.sha1.return_value = 'some_sha'
     self.pantsd = PantsDaemon(None,
                               'test_buildroot',
                               'test_work_dir',

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -48,7 +48,6 @@ class PantsDaemonTest(BaseTest):
     lock = threading.RLock()
     mock_options = mock.Mock()
     mock_options.pants_subprocessdir = 'non_existent_dir'
-    mock_options.sha1.return_value = 'some_sha'
     self.pantsd = PantsDaemon(None,
                               'test_buildroot',
                               'test_work_dir',
@@ -98,9 +97,12 @@ class PantsDaemonTest(BaseTest):
 
   @mock.patch('threading.Thread', **PATCH_OPTS)
   @mock.patch.object(PantsDaemon, 'shutdown', spec_set=True)
-  def test_run_services_runtimefailure(self, mock_shutdown, mock_thread):
+  @mock.patch.object(PantsDaemon, 'options_fingerprint', spec_set=True,
+                     new_callable=mock.PropertyMock)
+  def test_run_services_runtimefailure(self, mock_fp, mock_shutdown, mock_thread):
     self.mock_killswitch.is_set.side_effect = [False, False, True]
     mock_thread.return_value.is_alive.side_effect = [True, False]
+    mock_fp.return_value = 'some_sha'
 
     with self.assertRaises(PantsDaemon.RuntimeFailure):
       self.pantsd._run_services([self.mock_service])

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import functools
+import itertools
 import os
 import signal
 import time
@@ -19,15 +21,30 @@ class PantsDaemonMonitor(ProcessManager):
   def __init__(self, metadata_base_dir=None):
     super(PantsDaemonMonitor, self).__init__(name='pantsd', metadata_base_dir=metadata_base_dir)
 
-  def await_pantsd(self, timeout=10):
+  def _log(self):
+    print('PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
+
+  def await_pantsd(self, timeout=3):
+    self._process = None
     self._pid = self.await_pid(timeout)
     self.assert_running()
+    return self._pid
 
   def assert_running(self):
+    self._log()
     assert self._pid is not None and self.is_alive(), 'pantsd should be running!'
+    return self._pid
 
   def assert_stopped(self):
+    self._log()
     assert self._pid is not None and self.is_dead(), 'pantsd should be stopped!'
+    return self._pid
+
+
+def banner(s):
+  print('=' * 63)
+  print('- {} {}'.format(s, '-' * (60 - len(s))))
+  print('=' * 63)
 
 
 def read_pantsd_log(workdir):
@@ -43,6 +60,7 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
     with self.temporary_workdir() as workdir_base:
       pid_dir = os.path.join(workdir_base, '.pids')
       workdir = os.path.join(workdir_base, '.workdir.pants.d')
+      print('\npantsd log is {}/pantsd/pantsd.log'.format(workdir))
       pantsd_config = {
         'GLOBAL': {
           'enable_pantsd': True,
@@ -54,79 +72,56 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         }
       }
       checker = PantsDaemonMonitor(pid_dir)
-      yield workdir, pantsd_config, checker
+      self.assert_success_runner(workdir, pantsd_config, ['kill-pantsd'])
+      try:
+        yield workdir, pantsd_config, checker
+      finally:
+        banner('BEGIN pantsd.log')
+        for line in read_pantsd_log(workdir):
+          print(line)
+        banner('END pantsd.log')
+        self.assert_success_runner(workdir, pantsd_config, ['kill-pantsd'])
+        checker.assert_stopped()
+
+  @contextmanager
+  def pantsd_successful_run_context(self, log_level='info'):
+    with self.pantsd_test_context(log_level) as (workdir, pantsd_config, checker):
+      yield (
+        functools.partial(
+          self.assert_success_runner,
+          workdir,
+          pantsd_config
+        ),
+        checker,
+        workdir
+      )
+
+  def assert_success_runner(self, workdir, config, cmd):
+    print('running: ./pants {}'.format(' '.join(cmd)))
+    return self.assert_success(
+      self.run_pants_with_workdir(cmd, workdir, config)
+    )
 
   def test_pantsd_compile(self):
-    with self.pantsd_test_context('debug') as (workdir, pantsd_config, checker):
-      # Explicitly kill any running pantsd instances for the current buildroot.
-      self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-      try:
-        # Start pantsd implicitly via a throwaway invocation.
-        self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
-        checker.await_pantsd()
-
-        # This tests a deeper pantsd-based run by actually invoking a full compile.
-        self.assert_success(
-          self.run_pants_with_workdir(
-            ['compile', 'examples/src/scala/org/pantsbuild/example/hello/welcome'],
-            workdir,
-            pantsd_config)
-        )
-        checker.assert_running()
-      finally:
-        try:
-          for line in read_pantsd_log(workdir):
-            print(line)
-        finally:
-          # Explicitly kill pantsd (from a pantsd-launched runner).
-          self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-          checker.assert_stopped()
+    with self.pantsd_successful_run_context('debug') as (pantsd_run, checker, workdir):
+      # This tests a deeper pantsd-based run by actually invoking a full compile.
+      pantsd_run(['compile', 'examples/src/scala/org/pantsbuild/example/hello/welcome'])
+      checker.await_pantsd()
 
   def test_pantsd_run(self):
-    with self.pantsd_test_context('debug') as (workdir, pantsd_config, checker):
-      print('log: {}/pantsd/pantsd.log'.format(workdir))
-      # Explicitly kill any running pantsd instances for the current buildroot.
-      print('\nkill-pantsd')
-      self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-      try:
-        # Start pantsd implicitly via a throwaway invocation.
-        print('help')
-        self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
-        checker.await_pantsd()
+    with self.pantsd_successful_run_context('debug') as (pantsd_run, checker, workdir):
+      pantsd_run(['list', '3rdparty:'])
+      checker.await_pantsd()
 
-        print('list 3rdparty:')
-        self.assert_success(self.run_pants_with_workdir(['list', '3rdparty:'],
-                                                        workdir,
-                                                        pantsd_config))
-        checker.assert_running()
+      pantsd_run(['list', ':'])
+      checker.assert_running()
 
-        print('list :')
-        self.assert_success(self.run_pants_with_workdir(['list', ':'],
-                                                        workdir,
-                                                        pantsd_config))
-        checker.assert_running()
+      pantsd_run(['list', '::'])
+      checker.assert_running()
 
-        print('list ::')
-        self.assert_success(self.run_pants_with_workdir(['list', '::'],
-                                                        workdir,
-                                                        pantsd_config))
-        checker.assert_running()
-
-        # And again using the cached BuildGraph.
-        print('list ::')
-        self.assert_success(self.run_pants_with_workdir(['list', '::'],
-                                                        workdir,
-                                                        pantsd_config))
-        checker.assert_running()
-      finally:
-        try:
-          for line in read_pantsd_log(workdir):
-            print(line)
-        finally:
-          # Explicitly kill pantsd (from a pantsd-launched runner).
-          print('kill-pantsd')
-          self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-          checker.assert_stopped()
+      # And again using the cached BuildGraph.
+      pantsd_run(['list', '::'])
+      checker.assert_running()
 
       # Assert there were no warnings or errors thrown in the pantsd log.
       for line in read_pantsd_log(workdir):
@@ -138,66 +133,56 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
 
   def test_pantsd_broken_pipe(self):
     with self.pantsd_test_context() as (workdir, pantsd_config, checker):
-      # Explicitly kill any running pantsd instances for the current buildroot.
-      self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-      try:
-        # Start pantsd implicitly via a throwaway invocation.
-        self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
-        checker.await_pantsd()
-
-        run = self.run_pants_with_workdir('help | head -1', workdir, pantsd_config, shell=True)
-        self.assertNotIn('broken pipe', run.stderr_data.lower())
-        checker.assert_running()
-      finally:
-        # Explicitly kill pantsd (from a pantsd-launched runner).
-        self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-        checker.assert_stopped()
+      run = self.run_pants_with_workdir('help | head -1', workdir, pantsd_config, shell=True)
+      self.assertNotIn('broken pipe', run.stderr_data.lower())
+      checker.await_pantsd()
 
   def test_pantsd_stacktrace_dump(self):
+    with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir):
+      pantsd_run(['help'])
+      checker.await_pantsd()
+
+      os.kill(checker.pid, signal.SIGUSR2)
+
+      # Wait for log flush.
+      time.sleep(2)
+
+      self.assertIn('Current thread 0x', '\n'.join(read_pantsd_log(workdir)))
+
+  def test_pantsd_pantsd_runner_doesnt_die_after_failed_run(self):
     with self.pantsd_test_context() as (workdir, pantsd_config, checker):
-      print('log: {}/pantsd/pantsd.log'.format(workdir))
-      # Explicitly kill any running pantsd instances for the current buildroot.
-      self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-      try:
-        # Start pantsd implicitly via a throwaway invocation.
-        self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
-        checker.await_pantsd()
+      # Run target that throws an exception in pants.
+      self.assert_failure(
+        self.run_pants_with_workdir(
+          ['bundle', 'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-files'],
+          workdir,
+          pantsd_config)
+      )
+      checker.await_pantsd()
 
-        os.kill(checker.pid, signal.SIGUSR2)
+      # Check for no stray pantsd-runner prcesses.
+      self.assertFalse(check_process_exists_by_command('pantsd-runner'))
 
-        # Wait for log flush.
-        time.sleep(2)
+      # Assert pantsd is in a good functional state.
+      self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
+      checker.assert_running()
 
-        self.assertIn('Current thread 0x', '\n'.join(read_pantsd_log(workdir)))
-      finally:
-        # Explicitly kill pantsd (from a pantsd-launched runner).
-        self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-        checker.assert_stopped()
+  def test_pantsd_lifecycle_invalidation(self):
+    """Runs pants commands with pantsd enabled, in a loop, alternating between options that
+    should invalidate pantsd and incur a restart and then asserts for pid consistency.
+    """
+    with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir):
+      variants = (
+        ['-ldebug', 'help'],
+        ['-linfo', 'help']
+      )
+      last_pid = None
+      for cmd in itertools.chain(*itertools.repeat(variants, 3)):
+        pantsd_run(cmd)
+        next_pid = checker.await_pantsd()
+        if last_pid:
+          self.assertNotEqual(last_pid, next_pid)
+        last_pid = next_pid
 
-  def test_pantsd_runner_doesnt_die_after_failed_run(self):
-    with self.pantsd_test_context() as (workdir, pantsd_config, checker):
-      self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-      try:
-        # Start pantsd implicitly via a throwaway invocation.
-        self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
-        checker.await_pantsd()
-
-        # Run target that throws an exception in pants.
-        self.assert_failure(
-          self.run_pants_with_workdir(
-            ['bundle', 'testprojects/src/java/org/pantsbuild/testproject/bundle:missing-files'],
-            workdir,
-            pantsd_config)
-        )
+        pantsd_run(cmd)
         checker.assert_running()
-
-        # Check for no stray pantsd-runner prcesses.
-        self.assertFalse(check_process_exists_by_command('pantsd-runner'))
-
-        # Assert pantsd is in a good functional state.
-        self.assert_success(self.run_pants_with_workdir(['help'], workdir, pantsd_config))
-        checker.assert_running()
-      finally:
-        # Explicitly kill pantsd (from a pantsd-launched runner).
-        self.assert_success(self.run_pants_with_workdir(['kill-pantsd'], workdir, pantsd_config))
-        checker.assert_stopped()

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -13,9 +13,9 @@ import time
 from contextlib import contextmanager
 
 from pants.pantsd.process_manager import ProcessManager
+from pants.util.collections import combined_dict
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.process_test_util import check_process_exists_by_command
-from pants.util.collections import combined_dict
 
 
 class PantsDaemonMonitor(ProcessManager):


### PR DESCRIPTION
### Problem

Currently, if options (from cli args, pants.ini, env vars, rc files et al) affecting the daemon change between runs the daemon does not detect this and will happily run with trapped, stale state.

### Solution

Fingerprint the relevant subset of bootstrap options at startup time in the thin client and compare that fingerprint to the one used at launch time for the current pantsd process to determine if the daemon needs to be restarted in advance of the run. This piggy-backs on top of the daemon externalization work.

### Result

Fixes #3941.