### PR TITLE
Allow customized coverage.py configuration

### DIFF
--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -169,7 +169,10 @@ class PytestRun(TestRunnerTaskMixin, Task):
     register('--coverage-output-dir', metavar='<DIR>', default=None,
              help='Directory to emit coverage reports to. '
              'If not specified, a default within dist is used.')
-    register('--coverage-config-file', metavar='<FILE>', default=None,
+    register('--coverage-config-file',
+             metavar='<FILE>',
+             default=None,
+             fingerprint=True,
              help='Absolute path to a file containing configuration for the '
                   'coverage.py module. If not specified, pantsbuild default '
                   'configuration is used. See http://coverage.readthedocs.io/en/latest/config.html '


### PR DESCRIPTION
This PR adds a command-line flag to the tests.pytest goal.

### Problem

At this time, pants uses a default `.coveragerc` file, which omits certain standard options and disallows any customization of the behavior of python test coverage reporting. It would be highly desirable to be able to configure Python test coverage by allowing developers to use their own `.coveragerc` files. They are already comfortable with the syntax of these files, and understand them.  Many will already have files that fit with their projects.  Allowing the direct use of these files would enhance the "Pythonic" quality of working with pants as a build system for Python projects, encouraging adoption by the wider Python community.

A cursory search of issues open for "coverage" did not reveal many related issues (except perhaps #1105), but I'd be happy to open an issue if it needs to be so.

### Solution

I have added a new configuration option "--coverage-config-file" to the `PytestRun` test runner task in `tasks2` in the Python backend.  This file allows passing a path (absolute, or relative to the current working directory when running pants) to a `.coveragerc` file at command-line invocation of the pytest runner.

In the `_generate_coverage_config` method of the pytest test runner, this configuration option is used to read the coverage file, and the contents are used instead of the hard-coded default configuration.  If the configuration option is not passed on the command line, the default configuration is used as a fallback.

### Result

With this change, it is possible to pass a customized coverage configuration file at run time.  This allows developers to control the behavior of coverage.py for each pytest test target they have.  Or they can have a single file that applies to all targets under a given project.

As a side effect, with this change it is no longer necessary to specify files to be covered at the command line.  The cofiguration options for coverage.py allow for include/omit and provide a far more flexible and complete control over what to cover and what to omit than is available with the current command-line options.

