### PR TITLE
Prepare the notes for 1.3.1rc0

### DIFF
--- a/src/python/pants/notes/1.3.x.rst
+++ b/src/python/pants/notes/1.3.x.rst
@@ -3,6 +3,62 @@
 
 This document describes releases leading up to the ``1.3.x`` ``stable`` series.
 
+1.3.1rc0 (11/03/2017)
+---------------------
+
+The first release candidate for the ``1.3.1`` stable release.
+
+API Changes
+~~~~~~~~~~~
+
+* Allow users to tell pants where to look for python interpreters (#4930)
+  `PR #4930 <https://github.com/pantsbuild/pants/pull/4930>`_
+
+* Add classname to target data reported by pytest (#4675)
+  `PR #4675 <https://github.com/pantsbuild/pants/pull/4675>`_
+
+Bugfixes
+~~~~~~~~
+
+* Switch default binary-baseurls to s3 (#4806)
+  `PR #4806 <https://github.com/pantsbuild/pants/pull/4806>`_
+
+* Fix JarCreate invalidation in the presence of changing resources. (#5030)
+  `PR #5030 <https://github.com/pantsbuild/pants/pull/5030>`_
+
+* Allow in-repo scalac plugins to have in-repo deps. (#4987)
+  `PR #4987 <https://github.com/pantsbuild/pants/pull/4987>`_
+
+* Add default routing for OSX High Sierra binaries. (#4894)
+  `PR #4894 <https://github.com/pantsbuild/pants/pull/4894>`_
+
+* Fingerprint a bunch of go options. (#4743)
+  `PR #4743 <https://github.com/pantsbuild/pants/pull/4743>`_
+
+* Improve transitive resolve package checking in tests. (#4738)
+  `PR #4738 <https://github.com/pantsbuild/pants/pull/4738>`_
+
+* Ensure that target root order is preserved (#4708)
+  `PR #4708 <https://github.com/pantsbuild/pants/pull/4708>`_
+
+* Fix new `PytestRun` task deselection handling. (#4648)
+  `PR #4648 <https://github.com/pantsbuild/pants/pull/4648>`_
+
+Refactoring, Improvements, and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Bump petgraph to 0.4.5 (#4836)
+  `PR #4836 <https://github.com/pantsbuild/pants/pull/4836>`_
+
+* Partition and pass JVM options to scalafmt (#4774)
+  `PR #4774 <https://github.com/pantsbuild/pants/pull/4774>`_
+
+* Use ElementTree to parse JUnit XML files because it is much faster than minidom (#4693)
+  `PR #4693 <https://github.com/pantsbuild/pants/pull/4693>`_
+
+* Improve safe_concurrent_creation contextmanager. (#4690)
+  `PR #4690 <https://github.com/pantsbuild/pants/pull/4690>`_
+
 1.3.0 (06/06/2017)
 ------------------
 


### PR DESCRIPTION
Prepare the notes for 1.3.1rc0 as specified in https://www.pantsbuild.org/release.html#preparation-for-the-release-from-the-stable-branch. There are two tests failing on the branch, but I'm going to cut the release candidate now and debug them over the weekend.