### PR TITLE
Fix the `--color` flag for zinc

### DIFF
--- a/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
+++ b/src/scala/org/pantsbuild/zinc/compiler/InputUtils.scala
@@ -66,15 +66,13 @@ object InputUtils {
         .withOrder(compileOrder)
     val reporter =
       ReporterUtil.getDefault(
-        ReporterConfig.create(
-          "",
-          Int.MaxValue,
-          true,
-          settings.consoleLog.msgPredicates.toArray,
-          settings.consoleLog.filePredicates.toArray,
-          settings.consoleLog.javaLogLevel,
-          positionMapper
-        )
+        ReporterUtil.getDefaultReporterConfig()
+          .withMaximumErrors(Int.MaxValue)
+          .withUseColor(settings.consoleLog.color)
+          .withMsgFilters(settings.consoleLog.msgPredicates.toArray)
+          .withFileFilters(settings.consoleLog.filePredicates.toArray)
+          .withLogLevel(settings.consoleLog.javaLogLevel)
+          .withPositionMapper(positionMapper)
       )
     val setup =
       Setup.create(


### PR DESCRIPTION
### Problem

The color flag is currently being respected for console logging, but not for compiler/reporter logging.

### Solution

Pass `--color` through to the `ReporterConfig` using the builder API.

### Result

#4729 is unblocked, and:
```
./pants compile --no-colors testprojects/src/java/org/pantsbuild/testproject/dummies:compilation_failure_target
```
results in no color, as expected.