### PR TITLE
Test only: update node version to 8.9.0 and yarn version to 1.3.2

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -36,14 +36,14 @@ class NodeDistribution(object):
       register('--supportdir', advanced=True, default='bin/node',
                help='Find the Node distributions under this dir.  Used as part of the path to '
                     'lookup the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-      register('--version', advanced=True, default='6.9.1',
+      register('--version', advanced=True, default='8.9.0',
                help='Node distribution version.  Used as part of the path to lookup the '
                     'distribution with --binary-util-baseurls and --pants-bootstrapdir')
       register('--package-manager', advanced=True, default='npm', fingerprint=True,
                choices=NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys(),
                help='Default package manager config for repo. Should be one of {}'.format(
                  NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys()))
-      register('--yarnpkg-version', advanced=True, default='v0.19.1', fingerprint=True,
+      register('--yarnpkg-version', advanced=True, default='v1.3.2', fingerprint=True,
                help='Yarnpkg version. Used for binary utils')
 
     def create(self):


### PR DESCRIPTION
### Problem
Not intended to merge.
Test node 8.9.0 LTS and newest yarn 1.3.2 with Pants

### Solution

### Result
