### PR TITLE
Fixup `./build-support/bin/release.sh -t`.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -63,7 +63,7 @@ PKG_PANTS=(
 )
 function pkg_pants_install_test() {
   PIP_ARGS="$@"
-  pip install ${PIP_ARGS} "$(find_pkg pantsbuild.pants)" || \
+  pip install ${PIP_ARGS} "pantsbuild.pants==$(local_version)" || \
     die "pip install of pantsbuild.pants failed!"
   execute_packaged_pants_with_internal_backends list src:: || \
     die "'pants list src::' failed in venv!"
@@ -78,7 +78,7 @@ PKG_PANTS_TESTINFRA=(
 )
 function pkg_pants_testinfra_install_test() {
   PIP_ARGS="$@"
-  pip install ${PIP_ARGS} "$(find_pkg pantsbuild.pants.testinfra)" && \
+  pip install ${PIP_ARGS} "pantsbuild.pants.testinfra==$(local_version)" && \
   python -c "import pants_test"
 }
 


### PR DESCRIPTION
Previously the install and test function for `pantsbuild.pants` and
`pantsbuild.pants.testinfra` pip-installed a local wheel instead of
letting the pip enviornment determine whether to find a local wheel or
try to fetch a distribution. Fix this so that these two packages are
asked for by version requirement only just like all the other (contrib)
packages.