### PR TITLE
Fixup sdist release.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -549,6 +549,12 @@ function activate_twine() {
 }
 
 function publish_packages() {
+  # TODO(John Sirois): Remove sdist generation and twine upload when
+  # https://github.com/pantsbuild/pants/issues/4956 is resolved.
+  # NB: We need this step to generate sdists. It also generates wheels locally, but we nuke them
+  # and replace with pre-tested binary wheels we download from s3.
+  build_packages
+
   rm -rf "${DEPLOY_WHEEL_DIR}"
   mkdir -p "${DEPLOY_WHEEL_DIR}"
 


### PR DESCRIPTION
Previously the publishing step assumed sdists had been generated but
there was no step actually doing this. Have `publish_packages` call
`build_packages` to ensure this.

Fixes #5027 