### PR TITLE
Fix git scm test suite due to changed git cmd line

### DIFF
--- a/tests/python/pants_test/scm/test_git.py
+++ b/tests/python/pants_test/scm/test_git.py
@@ -67,7 +67,7 @@ class GitTest(unittest.TestCase):
       self.initial_rev = subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip()
       subprocess.check_call(['git', 'tag', 'first'])
       subprocess.check_call(['git', 'push', '--tags', 'depot', 'master'])
-      subprocess.check_call(['git', 'branch', '--set-upstream', 'master', 'depot/master'])
+      subprocess.check_call(['git', 'branch', '--set-upstream-to', 'depot/master'])
 
       with safe_open(self.readme_file, 'w') as readme:
         readme.write('Hello World.\u2764'.encode('utf-8'))


### PR DESCRIPTION
### Problem

The test suite for Git integration present in test_git.py failed on me reproducible due to a change in Git command line behavior. 

git branch --set-upstream master depot/master fails due to command deprecation. The suggested replacement based on the manual is
git branch --set-upstream-to depot/master

This is what this change proposes. All Git related tests went from mostly red to full green afterwards.
The version of Git present here is 2.15.0

### Solution

See above.

### Result

Green tests.