### PR TITLE
Call wsimport script instead of using tools.jar so jax-ws will work on java 9

### DIFF
--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/tasks/jax_ws_gen.py
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/tasks/jax_ws_gen.py
@@ -11,8 +11,10 @@ import os
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.tasks.nailgun_task import NailgunTask
 from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.java.distribution.distribution import DistributionLocator
 from pants.task.simple_codegen_task import SimpleCodegenTask
+from pants.util.process_handler import subprocess
 
 from pants.contrib.jax_ws.targets.jax_ws_library import JaxWsLibrary
 
@@ -46,47 +48,42 @@ class JaxWsGen(SimpleCodegenTask, NailgunTask):
     return [cls.IsolatedCodegenStrategy]
 
   def execute_codegen(self, target, target_workdir):
-    distribution = DistributionLocator.cached(jdk=True)
-    # Note, using tools.jar will only work with Java 8 and lower.  The tools.jar does not exist
-    # in JDK 9 and this will have to be revisted when Java 9 is released.
-    # See http://openjdk.java.net/jeps/220 for more information
-    classpath = distribution.find_libs(['tools.jar'])
-
     wsdl_directory = target.payload.sources.rel_path
     for source in target.payload.sources.source_paths:
       url = os.path.join(wsdl_directory, source)
+      wsimport_cmd = self._build_wsimport_cmd(target, target_workdir, url)
+      with self.context.new_workunit(name='wsimport',
+                                     cmd=' '.join(wsimport_cmd),
+                                     labels=[WorkUnitLabel.TOOL]) as workunit:
+        self.context.log.debug('Executing {}'.format(' '.join(wsimport_cmd)))
+        return_code = subprocess.Popen(wsimport_cmd,
+                                       stdout=workunit.output('stdout'),
+                                       stderr=workunit.output('stderr')).wait()
+        workunit.set_outcome(WorkUnit.FAILURE if return_code else WorkUnit.SUCCESS)
+        if return_code:
+          raise TaskError('wsimport exited non-zero {rc}'.format(rc=return_code))
 
-      args = self._format_args_for_relative_path(target, target_workdir, url)
-
-      result = self.runjava(
-        classpath=classpath,
-        main='com.sun.tools.internal.ws.WsImport',
-        jvm_options=self.get_options().jvm_options,
-        args=args,
-        workunit_name='wsimport')
-      if result != 0:
-        raise TaskError('JAX-WS compiler exited non-zero ({0})'.format(result))
-
-  def _format_args_for_relative_path(self, target, target_workdir, url):
+  def _build_wsimport_cmd(self, target, target_workdir, url):
+    distribution = DistributionLocator.cached(jdk=True)
     # Ported and trimmed down from:
     # https://java.net/projects/jax-ws-commons/sources/svn/content/trunk/
     # jaxws-maven-plugin/src/main/java/org/jvnet/jax_ws_commons/jaxws/WsImportMojo.java?rev=1191
-    args = []
+    cmd = ['{}/bin/wsimport'.format(distribution.real_home)]
     if self.get_options().ws_verbose:
-      args.append('-verbose')
+      cmd.append('-verbose')
     if self.get_options().ws_quiet:
-      args.append('-quiet')
-    args.append('-Xnocompile') # Always let pants do the compiling work.
-    args.extend(['-keep', '-s', os.path.abspath(target_workdir)])
-    args.extend(['-d', os.path.abspath(target_workdir)])
+      cmd.append('-quiet')
+    cmd.append('-Xnocompile') # Always let pants do the compiling work.
+    cmd.extend(['-keep', '-s', os.path.abspath(target_workdir)])
+    cmd.extend(['-d', os.path.abspath(target_workdir)])
     if target.payload.xjc_args:
-      args.extend(('-B{}'.format(a) if a.startswith('-') else a) for a in target.payload.xjc_args)
-    args.append('-B-no-header') # Don't let xjc write out a timestamp, because it'll break caching.
-    args.extend(target.payload.extra_args)
-    args.append(url)
+      cmd.extend(('-B{}'.format(a) if a.startswith('-') else a) for a in target.payload.xjc_args)
+    cmd.append('-B-no-header') # Don't let xjc write out a timestamp, because it'll break caching.
+    cmd.extend(target.payload.extra_args)
+    cmd.append(url)
     if self.get_options().level == 'debug':
-      args.append('-Xdebug')
-    return args
+      cmd.append('-Xdebug')
+    return cmd
 
   @property
   def _copy_target_attributes(self):


### PR DESCRIPTION
### Problem

The original implementation of jax-ws used tools.jar to use the `com.sun.tools.internal.ws.WsImport` class with java.  This meant the plugin could not be used with java 9 because tools.jar is not in the java 9 jdk.

### Solution

Use JAVA_HOME/bin/wsimport instead which is a script that will call WsImport in all JDKs that support wsimport.

### Result

You can now use java-ws on java9