### PR TITLE
Add a VFS impl for PosixFS.

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -24,7 +24,7 @@ extern crate tempdir;
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Mutex, RwLock, RwLockReadGuard};
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard};
 use std::{fmt, fs};
 use std::io::{self, Read};
 use std::cmp::min;
@@ -542,6 +542,24 @@ impl PosixFS {
       .expect("Uninitialized CpuPool!")
       .spawn_fn(move || PosixFS::scandir_sync(root, dir))
       .to_boxed()
+  }
+}
+
+impl VFS<io::Error> for Arc<PosixFS> {
+  fn read_link(&self, link: Link) -> BoxFuture<PathBuf, io::Error> {
+    PosixFS::read_link(self, &link)
+  }
+
+  fn scandir(&self, dir: Dir) -> BoxFuture<Vec<Stat>, io::Error> {
+    PosixFS::scandir(self, &dir)
+  }
+
+  fn ignore<P: AsRef<Path>>(&self, path: P, is_dir: bool) -> bool {
+    PosixFS::ignore(self, path, is_dir)
+  }
+
+  fn mk_error(msg: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, msg)
   }
 }
 


### PR DESCRIPTION
### Problem

`PosixFS` cannot be used directly to expand `PathGlobs` into `PathStats`, but that would be very useful for synchronous/non-incremental snapshot capture.

### Solution

Add a `VFS` impl for `PosixFS`. Given further tweaks to align the parameters types and the self type (not worthwhile now?) the implementations of the methods could likely move into the VFS impl, rather than staying in `impl PosixFS` and needing to be proxied to.