### PR TITLE
Bump to jarjar 1.6.5 to improve JDK9 support

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/shader.py
+++ b/src/python/pants/backend/jvm/subsystems/shader.py
@@ -237,7 +237,7 @@ class Shader(object):
       cls.register_jvm_tool(register,
                             'jarjar',
                             classpath=[
-                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.6.4')
+                              JarDependency(org='org.pantsbuild', name='jarjar', rev='1.6.5')
                             ])
 
     @classmethod


### PR DESCRIPTION
### Problem

As described on https://github.com/pantsbuild/jarjar/pull/30, the version of ASM in use in jarjar did not support JDK9 modules.

### Solution

Update to a version of jarjar that includes https://github.com/pantsbuild/jarjar/pull/30