### PR TITLE
Prepare the 1.3.1rc1 release

### DIFF
--- a/src/python/pants/notes/1.3.x.rst
+++ b/src/python/pants/notes/1.3.x.rst
@@ -3,6 +3,20 @@
 
 This document describes releases leading up to the ``1.3.x`` ``stable`` series.
 
+1.3.1rc1 (11/09/2017)
+---------------------
+
+The second release candidate for the ``1.3.1`` stable release.
+
+Bugfixes
+~~~~~~~~
+
+* Include bintray as a backup binary baseurl. (#5068)
+  `PR #5068 <https://github.com/pantsbuild/pants/pull/5068>`_
+
+* Ensure setuptools version when running setup.py. (#4753)
+  `PR #4753 <https://github.com/pantsbuild/pants/pull/4753>`_
+
 1.3.1rc0 (11/03/2017)
 ---------------------
 


### PR DESCRIPTION
As described in https://www.pantsbuild.org/release.html#preparation-for-the-release-from-the-stable-branch