### PR TITLE
Fix `PythonInterpreterCache`.

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
@@ -23,7 +23,7 @@ from pants.base.generator import Generator, TemplateData
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.python.python_repos import PythonRepos
 from pants.util.dirutil import safe_concurrent_creation, safe_mkdir
-from pants.util.memo import memoized_method
+from pants.util.memo import memoized_property
 from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.pex_info import PexInfo
@@ -42,6 +42,10 @@ class PythonEval(ResolveRequirementsTaskBase):
 
   _EXEC_NAME = '__pants_executable__'
   _EVAL_TEMPLATE_PATH = os.path.join('templates', 'python_eval', 'eval.py.mustache')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(PythonEval, cls).subsystem_dependencies() + (PythonRepos, PythonSetup)
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -77,18 +81,11 @@ class PythonEval(ResolveRequirementsTaskBase):
       compiled = self._compile_targets(invalidation_check.invalid_vts)
       return compiled  # Collected and returned for tests
 
-  @memoized_method
+  @memoized_property
   def _interpreter_cache(self):
-    interpreter_cache = PythonInterpreterCache(PythonSetup.global_instance(),
-                                               PythonRepos.global_instance(),
-                                               logger=self.context.log.debug)
-    # Cache setup's requirement fetching can hang if run concurrently by another pants proc.
-    self.context.acquire_lock()
-    try:
-      interpreter_cache.setup()
-    finally:
-      self.context.release_lock()
-    return interpreter_cache
+    return PythonInterpreterCache(PythonSetup.global_instance(),
+                                  PythonRepos.global_instance(),
+                                  logger=self.context.log.debug)
 
   def _compile_targets(self, invalid_vts):
     with self.context.new_workunit(name='eval-targets', labels=[WorkUnitLabel.MULTITOOL]):
@@ -221,7 +218,7 @@ class PythonEval(ResolveRequirementsTaskBase):
 
   def _get_interpreter_for_target_closure(self, target):
     targets = [t for t in target.closure() if isinstance(t, PythonTarget)]
-    return self._interpreter_cache().select_interpreter_for_targets(targets)
+    return self._interpreter_cache.select_interpreter_for_targets(targets)
 
   def _resolve_requirements_for_versioned_target_closure(self, interpreter, vt):
     reqs_pex_path = os.path.realpath(os.path.join(self.workdir, str(interpreter.identity),

--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -69,10 +69,11 @@ python_library(
   sources = ['interpreter_cache.py'],
   dependencies = [
     '3rdparty/python:pex',
-    '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/util:dirutil',
-    'src/python/pants/base:exceptions',
     'src/python/pants/backend/python/targets',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/process',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
   ]
 )
 

--- a/src/python/pants/backend/python/interpreter_cache.py
+++ b/src/python/pants/backend/python/interpreter_cache.py
@@ -11,11 +11,12 @@ import shutil
 from pex.interpreter import PythonIdentity, PythonInterpreter
 from pex.package import EggPackage, Package, SourcePackage
 from pex.resolver import resolve
-from twitter.common.collections import OrderedSet
 
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.base.exceptions import TaskError
+from pants.process.lock import OwnerPrintingInterProcessFileLock
 from pants.util.dirutil import safe_concurrent_creation, safe_mkdir
+from pants.util.memo import memoized_property
 
 
 # TODO(wickman) Create a safer version of this and add to twitter.common.dirutil
@@ -41,27 +42,29 @@ class PythonInterpreterCache(object):
   def __init__(self, python_setup, python_repos, logger=None):
     self._python_setup = python_setup
     self._python_repos = python_repos
-    self._cache_dir = python_setup.interpreter_cache_dir
-    safe_mkdir(self._cache_dir)
-    self._interpreters = set()
     self._logger = logger or (lambda msg: True)
 
-  @property
-  def interpreters(self):
-    """Returns the set of cached interpreters."""
-    return self._interpreters
+  @memoized_property
+  def _cache_dir(self):
+    cache_dir = self._python_setup.interpreter_cache_dir
+    safe_mkdir(cache_dir)
+    return cache_dir
 
   def select_interpreter_for_targets(self, targets):
     """Pick an interpreter compatible with all the specified targets."""
-    allowed_interpreters = OrderedSet(self.interpreters)
-    tgts_with_compatibilities = []  # Used only for error messages.
-
-    # Constrain allowed_interpreters based on each target's compatibility requirements.
+    tgts_with_compatibilities = []
+    filters = set()
     for target in targets:
       if isinstance(target, PythonTarget) and target.compatibility:
         tgts_with_compatibilities.append(target)
-        compatible_with_target = list(self.matched_interpreters(target.compatibility))
-        allowed_interpreters &= compatible_with_target
+        filters.update(target.compatibility)
+
+    allowed_interpreters = set(self.setup(filters=filters))
+
+    # Constrain allowed_interpreters based on each target's compatibility requirements.
+    for target in tgts_with_compatibilities:
+      compatible_with_target = set(self._matching(allowed_interpreters, target.compatibility))
+      allowed_interpreters &= compatible_with_target
 
     if not allowed_interpreters:
       # Create a helpful error message.
@@ -95,11 +98,12 @@ class PythonInterpreterCache(object):
   def _setup_cached(self, filters):
     """Find all currently-cached interpreters."""
     for interpreter_dir in os.listdir(self._cache_dir):
-      path = os.path.join(self._cache_dir, interpreter_dir)
-      pi = self._interpreter_from_path(path, filters)
-      if pi:
-        self._logger('Detected interpreter {}: {}'.format(pi.binary, str(pi.identity)))
-        self._interpreters.add(pi)
+      if os.path.isdir(interpreter_dir):
+        path = os.path.join(self._cache_dir, interpreter_dir)
+        pi = self._interpreter_from_path(path, filters)
+        if pi:
+          self._logger('Detected interpreter {}: {}'.format(pi.binary, str(pi.identity)))
+          yield pi
 
   def _setup_paths(self, paths, filters):
     """Find interpreters under paths, and cache them."""
@@ -110,46 +114,43 @@ class PythonInterpreterCache(object):
       if pi is None:
         self._setup_interpreter(interpreter, cache_path)
         pi = self._interpreter_from_path(cache_path, filters)
-        if pi is None:
-          continue
-      self._interpreters.add(pi)
+      if pi:
+        yield pi
 
-  def matched_interpreters(self, filters):
-    """Given some filters, yield any interpreter that matches at least one of them.
-
-    :param filters: A sequence of strings that constrain the interpreter compatibility for this
-      cache, using the Requirement-style format, e.g. ``'CPython>=3', or just ['>=2.7','<3']``
-      for requirements agnostic to interpreter class.
-    """
-    for match in self._matching(self.interpreters, filters):
-      yield match
-
-  def setup(self, paths=(), force=False, filters=(b'',)):
+  def setup(self, paths=(), filters=(b'',)):
     """Sets up a cache of python interpreters.
 
-    NB: Must be called prior to accessing the ``interpreters`` property or the ``matches`` method.
-
     :param paths: The paths to search for a python interpreter; the system ``PATH`` by default.
-    :param bool force: When ``True`` the interpreter cache is always re-built.
     :param filters: A sequence of strings that constrain the interpreter compatibility for this
       cache, using the Requirement-style format, e.g. ``'CPython>=3', or just ['>=2.7','<3']``
       for requirements agnostic to interpreter class.
+    :returns: A list of cached interpreters
+    :rtype: list of :class:`pex.interpreter.PythonInterpreter`
     """
     # We filter the interpreter cache itself (and not just the interpreters we pull from it)
     # because setting up some python versions (e.g., 3<=python<3.3) crashes, and this gives us
     # an escape hatch.
-    filters = self._python_setup.interpreter_constraints if not any(filters) else filters
-    setup_paths = paths or os.getenv('PATH').split(os.pathsep)
-    self._setup_cached(filters)
-    def unsatisfied_filters():
-      return filter(lambda f: len(list(self._matching(self.interpreters, [f]))) == 0, filters)
-    if force or len(unsatisfied_filters()) > 0:
-      self._setup_paths(setup_paths, filters)
-    for filt in unsatisfied_filters():
+    filters = filters if any(filters) else self._python_setup.interpreter_constraints
+    setup_paths = (paths
+                   or self._python_setup.interpreter_search_paths
+                   or os.getenv('PATH').split(os.pathsep))
+
+    def unsatisfied_filters(interpreters):
+      return filter(lambda f: len(list(self._matching(interpreters, [f]))) == 0, filters)
+
+    interpreters = []
+    with OwnerPrintingInterProcessFileLock(path=os.path.join(self._cache_dir, '.file_lock')):
+      interpreters.extend(self._setup_cached(filters))
+      if unsatisfied_filters(interpreters):
+        interpreters.extend(self._setup_paths(setup_paths, filters))
+
+    for filt in unsatisfied_filters(interpreters):
       self._logger('No valid interpreters found for {}!'.format(filt))
-    matches = list(self.matched_interpreters(filters))
+
+    matches = list(self._matching(interpreters, filters))
     if len(matches) == 0:
       self._logger('Found no valid interpreters!')
+
     return matches
 
   def _resolve(self, interpreter, interpreter_dir=None):

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -62,7 +62,8 @@ class PythonSetup(Subsystem):
     register('--artifact-cache-dir', advanced=True, default=None, metavar='<dir>',
              help='The parent directory for the python artifact cache. '
                   'If unspecified, a standard path under the workdir is used.')
-    register('--interpreter-search-paths', advanced=True, type=list, default=[], metavar='<binary-paths>',
+    register('--interpreter-search-paths', advanced=True, type=list, default=[],
+             metavar='<binary-paths>',
              help='A list of paths to search for python interpreters.')
 
   @property

--- a/src/python/pants/backend/python/tasks/python_task.py
+++ b/src/python/pants/backend/python/tasks/python_task.py
@@ -40,27 +40,13 @@ class PythonTask(Task):
 
   def __init__(self, *args, **kwargs):
     super(PythonTask, self).__init__(*args, **kwargs)
-    self._interpreter_cache = None
-    self._interpreter = None
-
-  @property
-  def interpreter_cache(self):
-    if self._interpreter_cache is None:
-      self._interpreter_cache = PythonInterpreterCache(PythonSetup.global_instance(),
-                                                       PythonRepos.global_instance(),
-                                                       logger=self.context.log.debug)
-
-      # Cache setup's requirement fetching can hang if run concurrently by another pants proc.
-      self.context.acquire_lock()
-      try:
-        self._interpreter_cache.setup()
-      finally:
-        self.context.release_lock()
-    return self._interpreter_cache
+    self._interpreter_cache = PythonInterpreterCache(PythonSetup.global_instance(),
+                                                     PythonRepos.global_instance(),
+                                                     logger=self.context.log.debug)
 
   def select_interpreter_for_targets(self, targets):
     """Pick an interpreter compatible with all the specified targets."""
-    return self.interpreter_cache.select_interpreter_for_targets(targets)
+    return self._interpreter_cache.select_interpreter_for_targets(targets)
 
   @property
   def chroot_cache_dir(self):

--- a/tests/python/pants_test/backend/python/test_interpreter_cache.py
+++ b/tests/python/pants_test/backend/python/test_interpreter_cache.py
@@ -40,12 +40,8 @@ class TestInterpreterCache(BaseTest):
     with temporary_dir() as path:
       mock_setup.interpreter_cache_dir = path
       cache = PythonInterpreterCache(mock_setup, mock.MagicMock())
-
-      def set_interpreters(_):
-        cache._interpreters.add(self._interpreter)
-
-      cache._setup_cached = mock.Mock(side_effect=set_interpreters)
-      cache._setup_paths = mock.Mock()
+      cache._setup_cached = mock.Mock(return_value=[self._interpreter])
+      cache._setup_paths = mock.Mock(return_value=[])
       yield cache, path
 
   def _do_test(self, constraints, filters, expected):

--- a/tests/python/pants_test/backend/python/test_python_chroot.py
+++ b/tests/python/pants_test/backend/python/test_python_chroot.py
@@ -59,11 +59,8 @@ class PythonChrootTest(BaseTest):
     thrift_binary_factory = ThriftBinary.Factory.global_instance().create
 
     interpreter_cache = PythonInterpreterCache(self.python_setup, python_repos)
-    interpreter_cache.setup()
-    interpreters = list(interpreter_cache.matched_interpreters(
-      self.python_setup.interpreter_constraints))
-    self.assertGreater(len(interpreters), 0)
-    interpreter = interpreters[0]
+    interpreter = interpreter_cache.select_interpreter_for_targets(targets)
+    self.assertIsNotNone(interpreter)
 
     with temporary_dir() as chroot:
       pex_builder = PEXBuilder(path=chroot, interpreter=interpreter)


### PR DESCRIPTION
Previously, `PythonInterpreterCache` was broken in several ways:
    
1. Use was delicate: `setup` had to be called before
`select_interpreter_for_targets` and an appropriate set of filters
derived from the targets passed to `select_interpreter_for_targets`
needed to be passed to `setup` to ensure a compatible
`PythonInterpreter` was selected when one was available.
2. Locking was left to the caller.

In practice, Pants code did not pass filters to `setup` and so was
broken by 1 (see: #5081) and the locking done was via a Pants workspace
file lock, which was broken for `PythonSetup`s that used a global
`--resolver-cache-dir` (which was the case with the Pants repo itself).

Fix `PythonInterpreterCache` by removing the requirement to call `setup`
first: `select_interpreter_for_targets` now derives the correct filter
set from the targets it's given and calls setup with these. Also move the
locking responsibility into `PythonInterpreterCache`, ensuring safe
concurrent usage regardless of context.

Fixes #5081