### PR TITLE
Add wheezy docker image for use not from travis

### DIFF
--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -3,7 +3,7 @@
 
 # Use the standard python-2.7 docker Debian Wheezy image for binary compatibility with old linux
 # distros.
-FROM pantsbuild:wheezy
+FROM pantsbuild/wheezy:latest
 
 # Setup mount points for the travis ci user & workdir.
 VOLUME /travis/home

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -3,14 +3,7 @@
 
 # Use the standard python-2.7 docker Debian Wheezy image for binary compatibility with old linux
 # distros.
-FROM python:2.7.13-wheezy
-
-# Ensure Pants runs under the 2.7.13 interpreter.
-ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
-
-# Install various things Pants requires.
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk
+FROM pantsbuild:wheezy
 
 # Setup mount points for the travis ci user & workdir.
 VOLUME /travis/home

--- a/build-support/docker/wheezy/Dockerfile
+++ b/build-support/docker/wheezy/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Use the standard python-2.7 docker Debian Wheezy image for binary compatibility with old linux
+# distros.
+FROM python:2.7.13-wheezy
+
+# Ensure Pants runs under the 2.7.13 interpreter.
+ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
+
+# Install various things Pants requires.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk


### PR DESCRIPTION
This helps to build binaries supporting older operating systems without
requiring the use of travis.