### PR TITLE
Update confluence deprecation warning

### DIFF
--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
@@ -16,6 +16,7 @@ from pants.util.dirutil import safe_open
 from pants.contrib.confluence.targets.doc_page import Page
 from pants.contrib.confluence.util.confluence_util import Confluence, ConfluenceError
 
+
 # Copied from `pants.backend.docgen.tasks.confluence_publish`
 # TODO: Rethink this. We shouldn't require subclassing this. Instead, the wiki identity should come
 # from options. However if we decide against that, we should rename this ConfluencePublishBase.

--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
@@ -16,7 +16,6 @@ from pants.util.dirutil import safe_open
 from pants.contrib.confluence.targets.doc_page import Page
 from pants.contrib.confluence.util.confluence_util import Confluence, ConfluenceError
 
-
 # Copied from `pants.backend.docgen.tasks.confluence_publish`
 # TODO: Rethink this. We shouldn't require subclassing this. Instead, the wiki identity should come
 # from options. However if we decide against that, we should rename this ConfluencePublishBase.

--- a/src/python/pants/backend/docgen/tasks/confluence_publish.py
+++ b/src/python/pants/backend/docgen/tasks/confluence_publish.py
@@ -11,14 +11,12 @@ import textwrap
 from twitter.common.confluence import Confluence, ConfluenceError
 
 from pants.backend.docgen.targets.doc import Page
-from pants.base.deprecated import deprecated_module
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.task.task import Task
 from pants.util import desktop
 from pants.util.dirutil import safe_open
 
-
-deprecated_module('1.6.0.dev0', 'Use contrib.confluence.tasks.confluence_publish.py instead')
 
 # TODO: Rethink this. We shouldn't require subclassing this. Instead, the wiki identity should come
 # from options. However if we decide against that, we should rename this ConfluencePublishBase.
@@ -63,6 +61,12 @@ class ConfluencePublish(Task):
     return 'confluence1'
 
   def execute(self):
+    deprecated_conditional(
+      lambda: True,
+      '1.6.0.dev0',
+      'pants.backend.docgen.tasks.confluence_publish.py is deprecated',
+      'Use contrib.confluence.tasks.confluence_publish.py instead'
+    )
     pages = []
     targets = self.context.targets()
     for target in targets:

--- a/src/python/pants/backend/docgen/tasks/confluence_publish.py
+++ b/src/python/pants/backend/docgen/tasks/confluence_publish.py
@@ -17,9 +17,9 @@ from pants.task.task import Task
 from pants.util import desktop
 from pants.util.dirutil import safe_open
 
+
 # TODO: Rethink this. We shouldn't require subclassing this. Instead, the wiki identity should come
 # from options. However if we decide against that, we should rename this ConfluencePublishBase.
-
 class ConfluencePublish(Task):
   """A task to publish Page targets to Confluence wikis."""
 

--- a/src/python/pants/backend/docgen/tasks/confluence_publish.py
+++ b/src/python/pants/backend/docgen/tasks/confluence_publish.py
@@ -17,7 +17,6 @@ from pants.task.task import Task
 from pants.util import desktop
 from pants.util.dirutil import safe_open
 
-
 # TODO: Rethink this. We shouldn't require subclassing this. Instead, the wiki identity should come
 # from options. However if we decide against that, we should rename this ConfluencePublishBase.
 
@@ -64,7 +63,7 @@ class ConfluencePublish(Task):
     deprecated_conditional(
       lambda: True,
       '1.6.0.dev0',
-      'pants.backend.docgen.tasks.confluence_publish.py is deprecated',
+      'pants.backend.docgen.tasks.confluence_publish.py',
       'Use contrib.confluence.tasks.confluence_publish.py instead'
     )
     pages = []


### PR DESCRIPTION
### Problem
The confluence deprecation warning was printed whenever the module was loaded but it should only warn when it is used.

### Solution
Moved it to the execute function so it only warns when it executes. 

### Result
I can now run pants goals without seeing the warning.
Before:
```
$ ./pants goals
WARN] /Users/workspace/pants/src/python/pants/backend/docgen/tasks/confluence_publish.py:21: DeprecationWarning: DEPRECATED: module will be removed in version 1.6.0.dev0.
  Use contrib.confluence.tasks.confluence_publish.py instead
  deprecated_module('1.6.0.dev0', 'Use contrib.confluence.tasks.confluence_publish.py instead')

Installed goals:
                    apk: Build an android bundle with compiled code and assets.
        bash-completion: Generate a Bash shell script that teaches Bash how to autocomplete pants command lines.
                  bench: Run benchmarks.
                 binary: Create a runnable binary.
              bootstrap: Bootstrap tools needed by subsequent build steps.
               buildgen: Automatically generate BUILD files.
              buildozer: Manipulate BUILD files.
                 bundle: Create a deployable application bundle.
                changed: Emits the targets that have been modified since a given commit.
   check-published-deps: Find references to outdated JVM artifacts.
               classmap: Print a mapping from class name to the owning target from target's runtime classpath.
              clean-all: Delete all build products, creating a clean workspace.
                   cloc: Print counts of lines of code.
                compile: Compile source code.
        compile-changed: Find and compile changed targets.
       deferred-sources: Map DeferredSourcesFields to files that produce the product 'unpacked_archives'.
              dep-usage: Collect target dependency usage data.
              dependees: List all targets that depend on any of the input targets.
           dependencies: Print the target's dependencies.
                 depmap: Depict the target's dependencies.
      detect-duplicates: Detect JVM classes and resources with the same qualified name on the classpath.
                    doc: Generate documentation.
                eclipse: Create an Eclipse project from the given targets.
                 ensime: Create an Ensime project from the given targets.
                 export: Export project information in JSON format.
       export-classpath: Create stable symlinks for runtime classpath entries for JVM targets.
               filedeps: List all source and BUILD files a target transitively depends on.
                filemap: Print a mapping from source file to the target that owns the source file.
                 filter: Filter the input targets based on various criteria.
                    fmt: Autoformat source code.
                    gen: Generate code.
                     go: Runs an arbitrary go command against zero or more go targets.
                 go-env: Runs an arbitrary command in a go workspace defined by zero or more go targets.
                  goals: List available goals.
                   idea: Create an IntelliJ IDEA project from the given targets.
            idea-plugin: Invoke IntelliJ Pants plugin (installation required) to create a project.
                imports: Resolve external source dependencies.
             invalidate: Invalidate the entire build.
   jvm-platform-explain: Console task which provides helpful analysis about jvm platform dependencies.
  jvm-platform-validate: Validation step that runs well in advance of jvm compile.
            kill-pantsd: Terminate the pants daemon.
             killserver: Kill the reporting server.
                   lint: Find formatting errors in source code.
                   list: Lists all targets matching the target specs.
            list-owners: Print targets that own a source file.
               markdown: Generate HTML from Markdown docs.
            meta-rename: Rename a target and update its dependees' dependencies with the new target name
               minimize: Print a minimal covering set of targets.
             ng-killall: Kill running nailgun servers.
                options: Display meta-information about options.
                   path: Find a dependency path from one target to another.
               pathdeps: List all paths containing BUILD files the target depends on.
                  paths: List all dependency paths from one target to another.
                publish: Publish a build artifact.
              reference: Generate Pants reference documentation.
                   repl: Run a REPL.
             repl-dirty: Run a REPL, skipping compilation.
                resolve: Resolve external binary dependencies.
              resources: Prepare resources.
                  roots: List the repo's registered source roots.
                    run: Invoke a binary.
              run-dirty: Invoke a binary, skipping compilation.
                 server: Run the reporting server.
               setup-py: Generate setup.py-based Python projects.
                   sign: Sign Android packages with keystores using the jarsigner tool.
                sitegen: Generate the Pants static web site.
                   sort: Topologically sort the targets.
                targets: List available target types.
                   test: Run tests.
           test-changed: Find and test changed targets.
          thrift-linter: Print linter warnings for thrift files.
            unpack-jars: Unpack artifacts specified by unpacked_jars() targets.
```
After:
```
$ ./pants goals
Installed goals:
                    apk: Build an android bundle with compiled code and assets.
        bash-completion: Generate a Bash shell script that teaches Bash how to autocomplete pants command lines.
                  bench: Run benchmarks.
                 binary: Create a runnable binary.
              bootstrap: Bootstrap tools needed by subsequent build steps.
               buildgen: Automatically generate BUILD files.
              buildozer: Manipulate BUILD files.
                 bundle: Create a deployable application bundle.
                changed: Emits the targets that have been modified since a given commit.
   check-published-deps: Find references to outdated JVM artifacts.
               classmap: Print a mapping from class name to the owning target from target's runtime classpath.
              clean-all: Delete all build products, creating a clean workspace.
                   cloc: Print counts of lines of code.
                compile: Compile source code.
        compile-changed: Find and compile changed targets.
       deferred-sources: Map DeferredSourcesFields to files that produce the product 'unpacked_archives'.
              dep-usage: Collect target dependency usage data.
              dependees: List all targets that depend on any of the input targets.
           dependencies: Print the target's dependencies.
                 depmap: Depict the target's dependencies.
      detect-duplicates: Detect JVM classes and resources with the same qualified name on the classpath.
                    doc: Generate documentation.
                eclipse: Create an Eclipse project from the given targets.
                 ensime: Create an Ensime project from the given targets.
                 export: Export project information in JSON format.
       export-classpath: Create stable symlinks for runtime classpath entries for JVM targets.
               filedeps: List all source and BUILD files a target transitively depends on.
                filemap: Print a mapping from source file to the target that owns the source file.
                 filter: Filter the input targets based on various criteria.
                    fmt: Autoformat source code.
                    gen: Generate code.
                     go: Runs an arbitrary go command against zero or more go targets.
                 go-env: Runs an arbitrary command in a go workspace defined by zero or more go targets.
                  goals: List available goals.
                   idea: Create an IntelliJ IDEA project from the given targets.
            idea-plugin: Invoke IntelliJ Pants plugin (installation required) to create a project.
                imports: Resolve external source dependencies.
             invalidate: Invalidate the entire build.
   jvm-platform-explain: Console task which provides helpful analysis about jvm platform dependencies.
  jvm-platform-validate: Validation step that runs well in advance of jvm compile.
            kill-pantsd: Terminate the pants daemon.
             killserver: Kill the reporting server.
                   lint: Find formatting errors in source code.
                   list: Lists all targets matching the target specs.
            list-owners: Print targets that own a source file.
               markdown: Generate HTML from Markdown docs.
            meta-rename: Rename a target and update its dependees' dependencies with the new target name
               minimize: Print a minimal covering set of targets.
             ng-killall: Kill running nailgun servers.
                options: Display meta-information about options.
                   path: Find a dependency path from one target to another.
               pathdeps: List all paths containing BUILD files the target depends on.
                  paths: List all dependency paths from one target to another.
                publish: Publish a build artifact.
              reference: Generate Pants reference documentation.
                   repl: Run a REPL.
             repl-dirty: Run a REPL, skipping compilation.
                resolve: Resolve external binary dependencies.
              resources: Prepare resources.
                  roots: List the repo's registered source roots.
                    run: Invoke a binary.
              run-dirty: Invoke a binary, skipping compilation.
                 server: Run the reporting server.
               setup-py: Generate setup.py-based Python projects.
                   sign: Sign Android packages with keystores using the jarsigner tool.
                sitegen: Generate the Pants static web site.
                   sort: Topologically sort the targets.
                targets: List available target types.
                   test: Run tests.
           test-changed: Find and test changed targets.
          thrift-linter: Print linter warnings for thrift files.
            unpack-jars: Unpack artifacts specified by unpacked_jars() targets.
```

Example:
```
11:45:53 00:00 [main]
               (To run a reporting server: ./pants server)
11:45:53 00:00   [setup]
11:45:53 00:00     [parse]
               Executing tasks in goals: markdown -> confluence
11:45:54 00:01   [markdown]
11:45:54 00:01     [markdown]
                   Emitted /User/workspace/dist/markdown/css/codehighlight.css
11:45:54 00:01   [confluence]
11:45:54 00:01     [confluence]WARN] /User/workspace/pants/src/python/pants/engine/round_engine.py:47: DeprecationWarning: DEPRECATED: pants.backend.docgen.tasks.confluence_publish.py will be removed in version 1.6.0.dev0.
  Use contrib.confluence.tasks.confluence_publish.py instead
  task.execute()


11:45:54 00:01   [complete]
               SUCCESS
```