### PR TITLE
Introduce a Digest type

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 pub mod hash;
+mod snapshot;
+pub use snapshot::Snapshot;
 pub mod store;
 
 extern crate bazel_protos;
@@ -808,23 +810,6 @@ impl fmt::Debug for FileContent {
       self.content.len(),
       describer,
       &self.content[..len]
-    )
-  }
-}
-
-#[derive(Clone)]
-pub struct Snapshot {
-  pub fingerprint: Fingerprint,
-  pub path_stats: Vec<PathStat>,
-}
-
-impl fmt::Debug for Snapshot {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(
-      f,
-      "Snapshot({}, entries={})",
-      self.fingerprint.to_hex(),
-      self.path_stats.len()
     )
   }
 }

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -1,0 +1,20 @@
+use PathStat;
+use hash::Fingerprint;
+use std::fmt;
+
+#[derive(Clone)]
+pub struct Snapshot {
+  pub fingerprint: Fingerprint,
+  pub path_stats: Vec<PathStat>,
+}
+
+impl fmt::Debug for Snapshot {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(
+      f,
+      "Snapshot({}, entries={})",
+      self.fingerprint.to_hex(),
+      self.path_stats.len()
+    )
+  }
+}


### PR DESCRIPTION
This is equivalent to the Bazel Remote Execution Digest protobuf, but
without the overhead and awkward API of a protobuf.

Passing around these tuples of Fingerprint and size is a little
annoying.

Also, give it an Into implementation for Digest, because that's a thing
we do a lot with them.

This is also going to be a product type in the graph, so having a type
for it is useful.