### PR TITLE
Refer to Buildozer 0.6.0.dce8b3c287652cbcaf43c8dd076b3f48c92ab44c

### DIFF
--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
@@ -42,7 +42,7 @@ class Buildozer(Task):
 
   @classmethod
   def register_options(cls, register):
-    register('--version', default='0.6.1', help='Version of buildozer.')
+    register('--version', default='0.6.0.dce8b3c287652cbcaf43c8dd076b3f48c92ab44c', help='Version of buildozer.')
     register('--add-dependencies', type=str, help='The dependency or dependencies to add')
     register('--remove-dependencies', type=str, help='The dependency or dependencies to remove')
     register('--command', type=str, help='A custom buildozer command to execute')
@@ -72,7 +72,7 @@ class Buildozer(Task):
       Buildozer.execute_binary(command, address.spec, binary=self._executable)
 
   @classmethod
-  def execute_binary(cls, command, spec, binary=None, version='0.6.1'):
+  def execute_binary(cls, command, spec, binary=None, version='0.6.0.dce8b3c287652cbcaf43c8dd076b3f48c92ab44c'):
     binary = binary if binary else BinaryUtil.Factory.create().select_binary('scripts/buildozer', version, 'buildozer')
 
     Buildozer._execute_buildozer_command([binary, command, spec])

--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer.py
@@ -42,7 +42,7 @@ class Buildozer(Task):
 
   @classmethod
   def register_options(cls, register):
-    register('--version', default='0.4.5', help='Version of buildozer.')
+    register('--version', default='0.6.1', help='Version of buildozer.')
     register('--add-dependencies', type=str, help='The dependency or dependencies to add')
     register('--remove-dependencies', type=str, help='The dependency or dependencies to remove')
     register('--command', type=str, help='A custom buildozer command to execute')
@@ -72,7 +72,7 @@ class Buildozer(Task):
       Buildozer.execute_binary(command, address.spec, binary=self._executable)
 
   @classmethod
-  def execute_binary(cls, command, spec, binary=None, version='0.4.5'):
+  def execute_binary(cls, command, spec, binary=None, version='0.6.1'):
     binary = binary if binary else BinaryUtil.Factory.create().select_binary('scripts/buildozer', version, 'buildozer')
 
     Buildozer._execute_buildozer_command([binary, command, spec])

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/buildozer_util.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/buildozer_util.py
@@ -12,8 +12,7 @@ def prepare_dependencies(self):
   self.add_to_build_file('c', 'java_library(name="c", dependencies=["a:a"])')
   self.add_to_build_file('d', 'java_library(name="d", dependencies=["a:a", "b"])')
 
-  targets = {}
-  targets['a'] = self.make_target('a')
+  targets = { 'a': self.make_target('a') }
   targets['b'] = self.make_target('b', dependencies=[targets['a']])
   targets['c'] = self.make_target('c', dependencies=[targets['a'], targets['b']])
   targets['d'] = self.make_target('d', dependencies=[targets['a'], targets['b']])

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_buildozer.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_buildozer.py
@@ -75,8 +75,7 @@ class BuildozerTest(TaskTestBase):
   def test_implicit_name(self):
     self.add_to_build_file('e', 'java_library()')
 
-    targets={}
-    targets['e'] = self.make_target('e')
+    targets = { 'e': self.make_target('e') }
     roots = ['e']
     dependency_to_add = '/o/p/q'
 
@@ -87,10 +86,7 @@ class BuildozerTest(TaskTestBase):
     self.add_to_build_file('g', 'java_library(name="g")')
     self.add_to_build_file('h', 'java_library()')
 
-    targets={}
-    targets['e'] = self.make_target('e')
-    targets['g'] = self.make_target('g')
-    targets['h'] = self.make_target('h')
+    targets = { 'e': self.make_target('e'), 'g': self.make_target('g'), 'h': self.make_target('h') }
     roots = ['h']
     dependency_to_add = '/r/s/t'
 

--- a/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_meta_rename.py
+++ b/contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor/test_meta_rename.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
+
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.binaries.binary_util import BinaryUtil
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -38,7 +40,7 @@ class MetaRenameTest(TaskTestBase):
     init_subsystem(BinaryUtil.Factory)
 
     self.meta_rename.execute()
-    self.assertInFile(self.new_name, '{}/{}/BUILD'.format(self.build_root, self.spec_path))
+    self.assertInFile(self.new_name, os.path.join(self.build_root, self.spec_path, 'BUILD'))
 
   def test_update_dependee_references(self):
     init_subsystem(BinaryUtil.Factory)
@@ -46,4 +48,4 @@ class MetaRenameTest(TaskTestBase):
     self.meta_rename.execute()
 
     for target in ['a', 'b', 'c']:
-      self.assertInFile(self.new_name, '{}/{}/BUILD'.format(self.build_root, target))
+      self.assertInFile(self.new_name, os.path.join(self.build_root, target, 'BUILD'))


### PR DESCRIPTION
[With the `UseImplicitName` function merged into buildozer](https://github.com/bazelbuild/buildtools/pull/154), we can now use an updated set of binaries to have a smoother integration of buildozer into pants.

This changes the binary reference from version 0.4.5 to 0.6.0.dce8b3c287652cbcaf43c8dd076b3f48c92ab44c in Buildozer