### PR TITLE
Make SelectTransitive a Node in the graph again. 

### DIFF
--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -588,9 +588,7 @@ struct TransitiveExpansion {
   outputs: OrderMap<Key, Value>,
 }
 
-impl Node for SelectTransitive {
-  type Output = Value;
-
+impl SelectTransitive {
   fn run(self, context: Context) -> NodeFuture<Value> {
     // Select the product holding the dependency list.
     Select {
@@ -655,12 +653,6 @@ impl Node for SelectTransitive {
         }
       })
       .to_boxed()
-  }
-}
-
-impl From<SelectTransitive> for NodeKey {
-  fn from(n: SelectTransitive) -> Self {
-    NodeKey::SelectTransitive(n)
   }
 }
 
@@ -1069,7 +1061,6 @@ pub enum NodeKey {
   Scandir(Scandir),
   Stat(Stat),
   Select(Select),
-  SelectTransitive(SelectTransitive),
   Snapshot(Snapshot),
   Task(Task),
 }
@@ -1093,13 +1084,6 @@ impl NodeKey {
           typstr(&s.selector.product)
         )
       }
-      &NodeKey::SelectTransitive(ref s) => {
-        format!(
-          "TransitiveDependencies( {}, {})",
-          typstr(&s.selector.product),
-          typstr(&s.selector.dep_product)
-        )
-      }
       &NodeKey::Task(ref s) => {
         format!(
           "Task({}, {}, {})",
@@ -1118,7 +1102,6 @@ impl NodeKey {
     }
     match self {
       &NodeKey::Select(ref s) => typstr(&s.selector.product),
-      &NodeKey::SelectTransitive(ref s) => typstr(&s.selector.product),
       &NodeKey::Task(ref s) => typstr(&s.product),
       &NodeKey::Snapshot(..) => "Snapshot".to_string(),
       &NodeKey::ReadLink(..) => "LinkDest".to_string(),
@@ -1149,7 +1132,6 @@ impl Node for NodeKey {
       NodeKey::Stat(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Scandir(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Select(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::SelectTransitive(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Snapshot(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Task(n) => n.run(context).map(|v| v.into()).to_boxed(),
     }


### PR DESCRIPTION


### Problem

SelectTransitive was removed from graph in #5095 accidentally. And it wasnt clear why Select was left as a Node.

### Solution

Make SelectTransitive a Node in the graph again. 
Clarify why Select was left as a Node and TODO (since its used as the root in the Graph)

### Result

`$ time ./pants list :: | wc -l`
   ```
 1544
real	0m5.474s
user	0m4.821s
sys	0m1.830s
===
    1544
real	0m5.246s
user	0m4.672s
sys	0m1.728s
```