### PR TITLE
Extract resettable pool logic for reuse

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -128,7 +128,12 @@ class DaemonPantsRunner(ProcessManager):
     self.daemonize(write_pid=False)
 
   def pre_fork(self):
-    """Pre-fork callback executed via ProcessManager.daemonize()."""
+    """Pre-fork callback executed via ProcessManager.daemonize().
+
+    The scheduler has thread pools which need to be re-initialized after a fork: this ensures that
+    when the pantsd-runner forks from pantsd, there is a working pool for any work that happens
+    in that child process.
+    """
     if self._graph_helper:
       self._graph_helper.scheduler.pre_fork()
 

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -10,7 +10,7 @@ use boxfuture::{Boxable, BoxFuture};
 use clap::{App, Arg, SubCommand};
 use fs::hash::Fingerprint;
 use fs::store::{Digest, Store};
-use fs::VFS;
+use fs::{VFS, ResettablePool};
 use futures::future::{Future, join_all};
 use itertools::Itertools;
 use std::error::Error;
@@ -272,7 +272,11 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
 }
 
 fn make_posix_fs<P: AsRef<Path>>(root: P) -> fs::PosixFS {
-  fs::PosixFS::new(&root, vec![]).unwrap()
+  fs::PosixFS::new(
+    &root,
+    Arc::new(ResettablePool::new("test-pool-".to_string())),
+    vec![],
+  ).unwrap()
 }
 
 fn save_file(

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -274,7 +274,7 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
 fn make_posix_fs<P: AsRef<Path>>(root: P) -> fs::PosixFS {
   fs::PosixFS::new(
     &root,
-    Arc::new(ResettablePool::new("test-pool-".to_string())),
+    Arc::new(ResettablePool::new("fsutil-pool-".to_string())),
     vec![],
   ).unwrap()
 }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use core::TypeId;
 use externs;
-use fs::{PosixFS, Snapshots};
+use fs::{PosixFS, Snapshots, ResettablePool};
 use graph::{EntryId, Graph};
 use rule_graph::RuleGraph;
 use tasks::Tasks;
@@ -22,6 +22,7 @@ pub struct Core {
   pub tasks: Tasks,
   pub rule_graph: RuleGraph,
   pub types: Types,
+  pub pool: Arc<ResettablePool>,
   pub snapshots: Snapshots,
   pub vfs: PosixFS,
 }
@@ -53,23 +54,25 @@ impl Core {
       types.snapshots.clone(),
     );
     let rule_graph = RuleGraph::new(&tasks, root_subject_types);
+    let pool = Arc::new(ResettablePool::new("io-".to_string()));
 
     Core {
       graph: Graph::new(),
       tasks: tasks,
-      types: types,
       rule_graph: rule_graph,
+      types: types,
+      pool: pool.clone(),
       snapshots: snapshots,
       // FIXME: Errors in initialization should definitely be exposed as python
       // exceptions, rather than as panics.
-      vfs: PosixFS::new(build_root, ignore_patterns).unwrap_or_else(|e| {
+      vfs: PosixFS::new(build_root, pool, ignore_patterns).unwrap_or_else(|e| {
         panic!("Could not initialize VFS: {:?}", e);
       }),
     }
   }
 
   pub fn pre_fork(&self) {
-    self.vfs.pre_fork();
+    self.pool.reset();
   }
 }
 


### PR DESCRIPTION
### Problem

The resettable `CpuPool` in `PosixFS` should be consumed by `Store` in order to parallelize requests to `LMDB`, but currently it is tightly coupled to its parent struct.

### Solution

Extract `ResettablePool`, and prepare for `Core` to pass it to both `PosixFS` and `Store`. Also, take this opportunity to improve the API for accessing the pool.

### Result

Fixes #5108.