### PR TITLE
Async Store

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -7,6 +7,8 @@ mod snapshot;
 pub use snapshot::Snapshot;
 mod store;
 pub use store::{Digest, Store};
+mod pool;
+pub use pool::ResettablePool;
 
 extern crate bazel_protos;
 extern crate boxfuture;
@@ -28,13 +30,13 @@ extern crate tempdir;
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::{fmt, fs};
 use std::io::{self, Read};
 use std::cmp::min;
 
-use futures::future::{self, IntoFuture, Future};
-use futures_cpupool::{CpuFuture, CpuPool};
+use futures::future::{self, Future};
+use futures_cpupool::CpuFuture;
 use glob::Pattern;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ordermap::OrderMap;
@@ -355,69 +357,6 @@ fn is_ignored(ignore: &Gitignore, stat: &Stat) -> bool {
     ignore::Match::None |
     ignore::Match::Whitelist(_) => false,
     ignore::Match::Ignore(_) => true,
-  }
-}
-
-///
-/// A wrapper around a CpuPool, to add the ability to drop the pool before forking,
-/// and then lazily re-initialize it in a new process.
-///
-/// When a process forks, the kernel clones only the thread that called fork: all other
-/// threads are effectively destroyed. If a CpuPool has live threads during a fork, it
-/// will not be able to perform any work or be dropped cleanly (it will hang instead).
-/// It's thus necessary to drop the pool before forking, and to re-create it after forking.
-///
-pub struct ResettablePool {
-  name_prefix: String,
-  pool: RwLock<Option<CpuPool>>,
-}
-
-impl ResettablePool {
-  pub fn new(name_prefix: String) -> ResettablePool {
-    ResettablePool {
-      name_prefix: name_prefix,
-      pool: RwLock::new(None),
-    }
-  }
-
-  ///
-  /// Delegates to `CpuPool::spawn_fn`, and shares its signature.
-  /// http://alexcrichton.com/futures-rs/futures_cpupool/struct.CpuPool.html#method.spawn_fn
-  ///
-  pub fn spawn_fn<F, R>(&self, f: F) -> CpuFuture<R::Item, R::Error>
-  where
-    F: FnOnce() -> R + Send + 'static,
-    R: IntoFuture + 'static,
-    R::Future: Send + 'static,
-    R::Item: Send + 'static,
-    R::Error: Send + 'static,
-  {
-    {
-      // The happy path: pool is already initialized.
-      let pool_opt = self.pool.read().unwrap();
-      if let Some(ref pool) = *pool_opt {
-        return pool.spawn_fn(f);
-      }
-    }
-    {
-      // Initialize the pool, but then release the write lock.
-      let mut pool_opt = self.pool.write().unwrap();
-      pool_opt.get_or_insert_with(|| self.new_pool());
-    }
-
-    // Recurse to run the function under the read lock.
-    self.spawn_fn(f)
-  }
-
-  pub fn reset(&self) {
-    let mut pool = self.pool.write().unwrap();
-    *pool = None;
-  }
-
-  fn new_pool(&self) -> CpuPool {
-    futures_cpupool::Builder::new()
-      .name_prefix(self.name_prefix.clone())
-      .create()
   }
 }
 

--- a/src/rust/engine/fs/src/pool.rs
+++ b/src/rust/engine/fs/src/pool.rs
@@ -1,0 +1,70 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::sync::RwLock;
+
+use futures_cpupool::{self, CpuFuture, CpuPool};
+use futures::future::IntoFuture;
+
+///
+/// A wrapper around a CpuPool, to add the ability to drop the pool before forking,
+/// and then lazily re-initialize it in a new process.
+///
+/// When a process forks, the kernel clones only the thread that called fork: all other
+/// threads are effectively destroyed. If a CpuPool has live threads during a fork, it
+/// will not be able to perform any work or be dropped cleanly (it will hang instead).
+/// It's thus necessary to drop the pool before forking, and to re-create it after forking.
+///
+pub struct ResettablePool {
+  name_prefix: String,
+  pool: RwLock<Option<CpuPool>>,
+}
+
+impl ResettablePool {
+  pub fn new(name_prefix: String) -> ResettablePool {
+    ResettablePool {
+      name_prefix: name_prefix,
+      pool: RwLock::new(None),
+    }
+  }
+
+  ///
+  /// Delegates to `CpuPool::spawn_fn`, and shares its signature.
+  /// http://alexcrichton.com/futures-rs/futures_cpupool/struct.CpuPool.html#method.spawn_fn
+  ///
+  pub fn spawn_fn<F, R>(&self, f: F) -> CpuFuture<R::Item, R::Error>
+  where
+    F: FnOnce() -> R + Send + 'static,
+    R: IntoFuture + 'static,
+    R::Future: Send + 'static,
+    R::Item: Send + 'static,
+    R::Error: Send + 'static,
+  {
+    {
+      // The happy path: pool is already initialized.
+      let pool_opt = self.pool.read().unwrap();
+      if let Some(ref pool) = *pool_opt {
+        return pool.spawn_fn(f);
+      }
+    }
+    {
+      // Initialize the pool, but then release the write lock.
+      let mut pool_opt = self.pool.write().unwrap();
+      pool_opt.get_or_insert_with(|| self.new_pool());
+    }
+
+    // Recurse to run the function under the read lock.
+    self.spawn_fn(f)
+  }
+
+  pub fn reset(&self) {
+    let mut pool = self.pool.write().unwrap();
+    *pool = None;
+  }
+
+  fn new_pool(&self) -> CpuPool {
+    futures_cpupool::Builder::new()
+      .name_prefix(self.name_prefix.clone())
+      .create()
+  }
+}

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -1,3 +1,6 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 use PathStat;
 use hash::Fingerprint;
 use std::fmt;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -796,7 +796,7 @@ impl Node for DigestFile {
         ))
       })
       .and_then(move |c| {
-        context.core.store.store_file_bytes(&c.content).map_err(
+        context.core.store.store_file_bytes(c.content).map_err(
           |e| throw(&e),
         )
       })


### PR DESCRIPTION
### Problem

`Store` executes IO, but was doing so synchronously on the main thread, which might block other operations.

### Solution

Give `Store` a reference to a `ResettablePool`, and execute all database operations on the pool.

It was also necessary to apply the "`Arc<Inner*>` pattern" (maybe it has a name?) to allow the `Store` to be cloned into the pool... this pattern seems much cleaner than the "`impl Trait for Arc<Struct>` pattern" that we've used with the `VFS` implementations... should consider switching those over at some point.

Finally, I added `Store::load_bytes_with` to support copying directly from LMDB buffers into a destination to avoid copying, and execute the copy on the IO pool.

### Result

`save_directory` and `materialize_directory` in `fs_util`, and `DigestFile` in `nodes` will execute concurrently. Helps to unblock #5105 and #5106.