### PR TITLE
go fetching handles multiple meta tags

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
@@ -37,13 +37,10 @@ class GoImportMetaTagReader(Subsystem):
       >""", flags=re.VERBOSE)
 
   @classmethod
-  def find_meta_tag(cls, page_html):
+  def find_meta_tags(cls, page_html):
     """Returns the content of the meta tag if found inside of the provided HTML."""
 
-    matched = cls._META_IMPORT_REGEX.search(page_html)
-    if matched:
-      return matched.groups()
-    return None, None, None
+    return cls._META_IMPORT_REGEX.findall(page_html)
 
   @memoized_method
   def get_imported_repo(self, import_path):
@@ -65,13 +62,13 @@ class GoImportMetaTagReader(Subsystem):
     if not page_data:
       return None
 
-    root, vcs, url = self.find_meta_tag(page_data.text)
-    if root and vcs and url:
-      # Check to make sure returned root is an exact match to the provided import path. If it is
-      # not then run a recursive check on the returned and return the values provided by that call.
-      if root == import_path:
-        return ImportedRepo(root, vcs, url)
-      elif import_path.startswith(root):
-        return self.get_imported_repo(root)
+    for (root, vcs, url) in self.find_meta_tags(page_data.text):
+      if root and vcs and url:
+        # Check to make sure returned root is an exact match to the provided import path. If it is
+        # not then run a recursive check on the returned and return the values provided by that call.
+        if root == import_path:
+          return ImportedRepo(root, vcs, url)
+        elif import_path.startswith(root):
+          return self.get_imported_repo(root)
 
     return None

--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_import_meta_tag_reader.py
@@ -62,6 +62,8 @@ class GoImportMetaTagReader(Subsystem):
     if not page_data:
       return None
 
+    # Return the first match, rather than doing some kind of longest prefix search.
+    # Hopefully no one returns multiple valid go-import meta tags.
     for (root, vcs, url) in self.find_meta_tags(page_data.text):
       if root and vcs and url:
         # Check to make sure returned root is an exact match to the provided import path. If it is

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_import_meta_tag_reader.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_go_import_meta_tag_reader.py
@@ -14,10 +14,10 @@ class FetchersTest(unittest.TestCase):
   def test_find_meta_tag_all_one_line(self):
     test_html = '<!DOCTYPE html><html><head><meta name="go-import" content="google.golang.org/api git https://code.googlesource.com/google-api-go-client"></head><body> Nothing to see here.</body></html>'
 
-    meta_tag_content = GoImportMetaTagReader.find_meta_tag(test_html)
+    meta_tag_content = GoImportMetaTagReader.find_meta_tags(test_html)
     self.assertEqual(meta_tag_content,
-                     ('google.golang.org/api', 'git',
-                      'https://code.googlesource.com/google-api-go-client'))
+                     [('google.golang.org/api', 'git',
+                      'https://code.googlesource.com/google-api-go-client')])
 
   def test_find_meta_tag_typical(self):
     test_html = """
@@ -35,10 +35,10 @@ class FetchersTest(unittest.TestCase):
     </html>
     """
 
-    meta_tag_content = GoImportMetaTagReader.find_meta_tag(test_html)
+    meta_tag_content = GoImportMetaTagReader.find_meta_tags(test_html)
     self.assertEqual(meta_tag_content,
-                     ('google.golang.org/api', 'git',
-                      'https://code.googlesource.com/google-api-go-client'))
+                     [('google.golang.org/api', 'git',
+                      'https://code.googlesource.com/google-api-go-client')])
 
   def test_find_multiline_meta_tag(self):
     test_html = """
@@ -58,13 +58,50 @@ class FetchersTest(unittest.TestCase):
     </html>
     """
 
-    meta_tag_content = GoImportMetaTagReader.find_meta_tag(test_html)
+    meta_tag_content = GoImportMetaTagReader.find_meta_tags(test_html)
     self.assertEqual(meta_tag_content,
-                     ('google.golang.org/api', 'git',
-                      'https://code.googlesource.com/google-api-go-client'))
+                     [('google.golang.org/api', 'git',
+                      'https://code.googlesource.com/google-api-go-client')])
+
+  def test_find_multiple_go_import_meta_tag(self):
+    test_html = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <meta name="go-import"
+          content="google.golang.org/notapi
+                   git
+                   https://code.googlesource.com/google-notapi-go-client">
+    <meta name="go-import"
+          content="google.golang.org/api
+                   git
+                   https://code.googlesource.com/google-api-go-client">
+    <meta name="go-import"
+          content="google.golang.org/otherapi
+                   git
+                   https://code.googlesource.com/google-otherapi-go-client">
+    <meta http-equiv="refresh" content="0; url=https://godoc.org/google.golang.org/api/googleapi">
+    </head>
+    <body>
+    Nothing to see here.
+    Please <a href="https://godoc.org/google.golang.org/api/googleapi">move along</a>.
+    </body>
+    </html>
+    """
+
+    meta_tag_content = GoImportMetaTagReader.find_meta_tags(test_html)
+    self.assertEqual(meta_tag_content,
+      [
+        ('google.golang.org/notapi', 'git',
+         'https://code.googlesource.com/google-notapi-go-client'),
+        ('google.golang.org/api', 'git',
+         'https://code.googlesource.com/google-api-go-client'),
+        ('google.golang.org/otherapi', 'git',
+        'https://code.googlesource.com/google-otherapi-go-client'),
+      ])
 
   def test_no_meta_tag(self):
     test_html = "<!DOCTYPE html><html><head></head><body>Nothing to see here.</body></html>"
 
-    meta_tag_content = GoImportMetaTagReader.find_meta_tag(test_html)
-    self.assertEqual(meta_tag_content, (None, None, None))
+    meta_tag_content = GoImportMetaTagReader.find_meta_tags(test_html)
+    self.assertEqual(meta_tag_content, [])


### PR DESCRIPTION
It's valid for a site to serve multiple go-import meta tags for distinct
import-prefixes. Right now if the first one doesn't match, we fail.

https://bazil.org/fuse/ is an example of a package/site which does this.

I'm not implementing finding the longest prefix of multiple, because
hopefully no one does that.