### PR TITLE
Expose `jax_ws_library` target in `jax_ws` plugin.

### DIFF
--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/BUILD
@@ -11,5 +11,6 @@ contrib_plugin(
   ],
   distribution_name='pantsbuild.pants.contrib.jax_ws',
   description='JAX-WS Pants plugin',
+  build_file_aliases=True,
   register_goals=True,
 )

--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/register.py
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/register.py
@@ -5,8 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.goal.task_registrar import TaskRegistrar as task
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.jax_ws.targets.jax_ws_library import JaxWsLibrary
 from pants.contrib.jax_ws.tasks.jax_ws_gen import JaxWsGen

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -138,9 +138,13 @@ PKG_JAXWS=(
   "pkg_jax_ws_install_test"
 )
 function pkg_jax_ws_install_test() {
+  # Ensure our goal and target are installed and exposed.
   execute_packaged_pants_with_internal_backends \
       --plugins="['pantsbuild.pants.contrib.jax_ws==$(local_version)']" \
       --explain gen | grep "jax-ws" &> /dev/null
+  execute_packaged_pants_with_internal_backends \
+      --plugins="['pantsbuild.pants.contrib.jax_ws==$(local_version)']" \
+      targets | grep "jax_ws_library" &> /dev/null
 }
 
 # Once individual (new) package is declared above, insert it into the array below)


### PR DESCRIPTION
Previously just the `jax-ws` goal was exposed, not the `jax_ws_library`
target needed in BUILD files to use the goal.

Fixes #5121