### PR TITLE
Remove requirement for root build file in `changed`

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -239,8 +239,10 @@ def addresses_from_address_families(address_mapper, address_families, spec):
      - there were no matching AddressFamilies, or
      - the Spec matches no addresses for SingleAddresses.
   """
-  if not address_families:
-    raise ResolveError('Path "{}" contains no BUILD files.'.format(spec.directory))
+
+  def raise_if_empty_address_families():
+    if not address_families:
+      raise ResolveError('Path "{}" contains no BUILD files.'.format(spec.directory))
 
   def exclude_address(address):
     if address_mapper.exclude_patterns:
@@ -248,20 +250,22 @@ def addresses_from_address_families(address_mapper, address_families, spec):
       return any(p.search(address_str) is not None for p in address_mapper.exclude_patterns)
     return False
 
-  if type(spec) in (DescendantAddresses, SiblingAddresses, AscendantAddresses):
-    addresses = tuple(a
-                      for af in address_families
-                      for a in af.addressables.keys()
-                      if not exclude_address(a))
+  def all_included_addresses():
+    return (a
+            for af in address_families
+            for a in af.addressables.keys()
+            if not exclude_address(a))
+
+  if type(spec) in (DescendantAddresses, SiblingAddresses):
+    raise_if_empty_address_families()
+    addresses = tuple(all_included_addresses())
   elif type(spec) is SingleAddress:
-    # TODO Could assert len(address_families) == 1, as it should always be true in this case.
-    addresses = tuple(a
-                      for af in address_families
-                      for a in af.addressables.keys()
-                      if a.target_name == spec.name and not exclude_address(a))
-    if not addresses:
-      if len(address_families) == 1:
-        _raise_did_you_mean(address_families[0], spec.name)
+    raise_if_empty_address_families()
+    addresses = tuple(a for a in all_included_addresses() if a.target_name == spec.name)
+    if not addresses and len(address_families) == 1:
+      _raise_did_you_mean(address_families[0], spec.name)
+  elif type(spec) is AscendantAddresses:
+    addresses = tuple(all_included_addresses())
   else:
     raise ValueError('Unrecognized Spec type: {}'.format(spec))
 

--- a/tests/python/pants_test/engine/legacy/test_changed_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_changed_integration.py
@@ -26,6 +26,14 @@ def lines_to_set(str_or_list):
     return set(x for x in str(str_or_list).split('\n') if x)
 
 
+def create_file_in(worktree, path, content):
+  """Creates a file in the given worktree, and returns its path."""
+  write_path = os.path.join(worktree, path)
+  with safe_open(write_path, 'w') as f:
+    f.write(dedent(content))
+  return write_path
+
+
 @contextmanager
 def mutated_working_copy(files_to_mutate, to_append='\n '):
   """Given a list of files, append whitespace to each of them to trigger a git diff - then reset."""
@@ -79,10 +87,7 @@ def create_isolated_git_repo():
   with temporary_dir(root_dir=get_buildroot()) as worktree:
     def create_file(path, content):
       """Creates a file in the isolated git repo."""
-      write_path = os.path.join(worktree, path)
-      with safe_open(write_path, 'w') as f:
-        f.write(dedent(content))
-      return write_path
+      return create_file_in(worktree, path, content)
 
     def copy_into(path, to_path=None):
       """Copies a file from the real git repo into the isolated git repo."""
@@ -425,6 +430,13 @@ class ChangedIntegrationTest(PantsRunIntegrationTest, TestGenerator):
       pants_run = self.run_pants(['list', '--changed-parent=HEAD'])
       self.assert_success(pants_run)
       self.assertEqual(pants_run.stdout_data.strip(), 'src/python/sources:text')
+
+  def test_changed_in_directory_without_build_file(self):
+    with create_isolated_git_repo() as worktree:
+      create_file_in(worktree, 'new-project/README.txt', 'This is important.')
+      pants_run = self.run_pants(['list', '--changed-parent=HEAD'])
+      self.assert_success(pants_run)
+      self.assertEqual(pants_run.stdout_data.strip(), '')
 
   def test_list_changed(self):
     deleted_file = 'src/python/sources/sources.py'


### PR DESCRIPTION
### Problem

The `changed` options as implemented in the v2 engine use the `AscendantAddresses` spec type to find "all addresses above a directory". As described in #4833 and #4904, this currently introduces a requirement that at least one `BUILD` file exists between a changed file and the root of the repo.

### Solution

Remove the requirement for a non-empty set of `AddressFamily` instances when expanding `AscendantAddresses`, and add a covering integration test.

### Result

`AscendantAddress` instances that don't encounter `BUILD` files will not cause errors.

Fixes #4833 and #4904.