### PR TITLE
Use a stable URL to restore kythe binary fetching

### DIFF
--- a/build-support/ivy/ivysettings.xml
+++ b/build-support/ivy/ivysettings.xml
@@ -70,7 +70,7 @@ Licensed under the Apache License, Version 2.0 (see LICENSE).
 
       <!-- Custom repo for Kythe jars, as Google don't currently publish them anywhere. -->
       <url name="benjyw/binhost">
-        <artifact pattern="https://github.com/benjyw/binhost/raw/master/[organisation]/${kythe.artifact}" />
+        <artifact pattern="https://github.com/benjyw/binhost/raw/99702052db865e0229998afbf19b5503d11225d3/[organisation]/${kythe.artifact}" />
       </url>
 
       <!-- for retrieving jacoco snapshot, remove when a version containing cli is released -->


### PR DESCRIPTION
### Problem

The repository URL we were using to fetch kythe was not stable, and a recent commit broke the old URLs.

### Solution

Switch to fetching using a stable github URL.

### Result

CI should be fixed.