### PR TITLE
Relativize the classpaths that are recorded during a JVM compile

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -554,7 +554,8 @@ class JvmCompile(NailgunTaskBase):
       raise TaskError("Compilation failure: {}".format(e))
 
   def _record_compile_classpath(self, classpath, targets, outdir):
-    text = '\n'.join(classpath)
+    relative_classpaths = [os.path.relpath(path) for path in classpath]
+    text = '\n'.join(relative_classpaths)
     for target in targets:
       path = os.path.join(outdir, 'compile_classpath', '{}.txt'.format(target.id))
       safe_mkdir(os.path.dirname(path), clean=False)

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -554,7 +554,7 @@ class JvmCompile(NailgunTaskBase):
       raise TaskError("Compilation failure: {}".format(e))
 
   def _record_compile_classpath(self, classpath, targets, outdir):
-    relative_classpaths = [os.path.relpath(path) for path in classpath]
+    relative_classpaths = [fast_relpath(path, self.get_options().pants_workdir) for path in classpath]
     text = '\n'.join(relative_classpaths)
     for target in targets:
       path = os.path.join(outdir, 'compile_classpath', '{}.txt'.format(target.id))


### PR DESCRIPTION
### Problem

Currently, when we record classpaths during JVM compiles, we are recording the absolute paths. This is violating the idea that all builds are relatively homogenous. Additionally, if there is additional caching of jars, the absolute classpaths could cause unnecessary misses. 

### Solution

The solution is to relativize the classpaths. 

### Result

Instead of 
```
/var/lib/mesos/slaves/a3942c64-03ad-4d95-80d7-767c6ba796c5-S7111/hashed-run/workspace/pants/.pants.d/compile/zinc/27609ddd7aa2/target/current/classes
/var/lib/mesos/slaves/a3942c64-03ad-4d95-80d7-767c6ba796c5-S7111/hashed-run/workspace/pants/.pants.d/ivy/jars/org.apache.thrift/libthrift/jars/libthrift-0.5.0-5.jar
```
The file contains relative classpaths to the pants global workdir (ie .pants.d). For instance
```
compile/zinc/27609ddd7aa2/target/current/classes
ivy/jars/org.apache.thrift/libthrift/jars/libthrift-0.5.0-5.jar
```