### PR TITLE
Store can backfill from a CAS

### DIFF
--- a/3rdparty/protobuf/googleapis/google/bytestream/bytestream.proto
+++ b/3rdparty/protobuf/googleapis/google/bytestream/bytestream.proto
@@ -1,0 +1,181 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.bytestream;
+
+import "google/api/annotations.proto";
+import "google/protobuf/wrappers.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/bytestream;bytestream";
+option java_outer_classname = "ByteStreamProto";
+option java_package = "com.google.bytestream";
+
+
+// #### Introduction
+//
+// The Byte Stream API enables a client to read and write a stream of bytes to
+// and from a resource. Resources have names, and these names are supplied in
+// the API calls below to identify the resource that is being read from or
+// written to.
+//
+// All implementations of the Byte Stream API export the interface defined here:
+//
+// * `Read()`: Reads the contents of a resource.
+//
+// * `Write()`: Writes the contents of a resource. The client can call `Write()`
+//   multiple times with the same resource and can check the status of the write
+//   by calling `QueryWriteStatus()`.
+//
+// #### Service parameters and metadata
+//
+// The ByteStream API provides no direct way to access/modify any metadata
+// associated with the resource.
+//
+// #### Errors
+//
+// The errors returned by the service are in the Google canonical error space.
+service ByteStream {
+  // `Read()` is used to retrieve the contents of a resource as a sequence
+  // of bytes. The bytes are returned in a sequence of responses, and the
+  // responses are delivered as the results of a server-side streaming RPC.
+  rpc Read(ReadRequest) returns (stream ReadResponse);
+
+  // `Write()` is used to send the contents of a resource as a sequence of
+  // bytes. The bytes are sent in a sequence of request protos of a client-side
+  // streaming RPC.
+  //
+  // A `Write()` action is resumable. If there is an error or the connection is
+  // broken during the `Write()`, the client should check the status of the
+  // `Write()` by calling `QueryWriteStatus()` and continue writing from the
+  // returned `committed_size`. This may be less than the amount of data the
+  // client previously sent.
+  //
+  // Calling `Write()` on a resource name that was previously written and
+  // finalized could cause an error, depending on whether the underlying service
+  // allows over-writing of previously written resources.
+  //
+  // When the client closes the request channel, the service will respond with
+  // a `WriteResponse`. The service will not view the resource as `complete`
+  // until the client has sent a `WriteRequest` with `finish_write` set to
+  // `true`. Sending any requests on a stream after sending a request with
+  // `finish_write` set to `true` will cause an error. The client **should**
+  // check the `WriteResponse` it receives to determine how much data the
+  // service was able to commit and whether the service views the resource as
+  // `complete` or not.
+  rpc Write(stream WriteRequest) returns (WriteResponse);
+
+  // `QueryWriteStatus()` is used to find the `committed_size` for a resource
+  // that is being written, which can then be used as the `write_offset` for
+  // the next `Write()` call.
+  //
+  // If the resource does not exist (i.e., the resource has been deleted, or the
+  // first `Write()` has not yet reached the service), this method returns the
+  // error `NOT_FOUND`.
+  //
+  // The client **may** call `QueryWriteStatus()` at any time to determine how
+  // much data has been processed for this resource. This is useful if the
+  // client is buffering data and needs to know which data can be safely
+  // evicted. For any sequence of `QueryWriteStatus()` calls for a given
+  // resource name, the sequence of returned `committed_size` values will be
+  // non-decreasing.
+  rpc QueryWriteStatus(QueryWriteStatusRequest) returns (QueryWriteStatusResponse);
+}
+
+// Request object for ByteStream.Read.
+message ReadRequest {
+  // The name of the resource to read.
+  string resource_name = 1;
+
+  // The offset for the first byte to return in the read, relative to the start
+  // of the resource.
+  //
+  // A `read_offset` that is negative or greater than the size of the resource
+  // will cause an `OUT_OF_RANGE` error.
+  int64 read_offset = 2;
+
+  // The maximum number of `data` bytes the server is allowed to return in the
+  // sum of all `ReadResponse` messages. A `read_limit` of zero indicates that
+  // there is no limit, and a negative `read_limit` will cause an error.
+  //
+  // If the stream returns fewer bytes than allowed by the `read_limit` and no
+  // error occurred, the stream includes all data from the `read_offset` to the
+  // end of the resource.
+  int64 read_limit = 3;
+}
+
+// Response object for ByteStream.Read.
+message ReadResponse {
+  // A portion of the data for the resource. The service **may** leave `data`
+  // empty for any given `ReadResponse`. This enables the service to inform the
+  // client that the request is still live while it is running an operation to
+  // generate more data.
+  bytes data = 10;
+}
+
+// Request object for ByteStream.Write.
+message WriteRequest {
+  // The name of the resource to write. This **must** be set on the first
+  // `WriteRequest` of each `Write()` action. If it is set on subsequent calls,
+  // it **must** match the value of the first request.
+  string resource_name = 1;
+
+  // The offset from the beginning of the resource at which the data should be
+  // written. It is required on all `WriteRequest`s.
+  //
+  // In the first `WriteRequest` of a `Write()` action, it indicates
+  // the initial offset for the `Write()` call. The value **must** be equal to
+  // the `committed_size` that a call to `QueryWriteStatus()` would return.
+  //
+  // On subsequent calls, this value **must** be set and **must** be equal to
+  // the sum of the first `write_offset` and the sizes of all `data` bundles
+  // sent previously on this stream.
+  //
+  // An incorrect value will cause an error.
+  int64 write_offset = 2;
+
+  // If `true`, this indicates that the write is complete. Sending any
+  // `WriteRequest`s subsequent to one in which `finish_write` is `true` will
+  // cause an error.
+  bool finish_write = 3;
+
+  // A portion of the data for the resource. The client **may** leave `data`
+  // empty for any given `WriteRequest`. This enables the client to inform the
+  // service that the request is still live while it is running an operation to
+  // generate more data.
+  bytes data = 10;
+}
+
+// Response object for ByteStream.Write.
+message WriteResponse {
+  // The number of bytes that have been processed for the given resource.
+  int64 committed_size = 1;
+}
+
+// Request object for ByteStream.QueryWriteStatus.
+message QueryWriteStatusRequest {
+  // The name of the resource whose write status is being requested.
+  string resource_name = 1;
+}
+
+// Response object for ByteStream.QueryWriteStatus.
+message QueryWriteStatusResponse {
+  // The number of bytes that have been processed for the given resource.
+  int64 committed_size = 1;
+
+  // `complete` is `true` only if the client has sent a `WriteRequest` with
+  // `finish_write` set to true, and the server has processed that request.
+  bool complete = 2;
+}

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -3,11 +3,11 @@ name = "engine"
 version = "0.0.1"
 dependencies = [
  "boxfuture 0.0.1",
- "cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
@@ -25,7 +25,7 @@ dependencies = [
 name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)",
  "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -53,7 +53,7 @@ dependencies = [
 name = "boxfuture"
 version = "0.0.1"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -76,7 +76,7 @@ name = "cmake"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -108,8 +108,8 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fnv"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -129,18 +129,19 @@ dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -162,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -170,7 +171,7 @@ name = "futures-cpupool"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -184,7 +185,7 @@ name = "generic-array"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nodrop 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -199,7 +200,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,9 +211,9 @@ name = "grpcio"
 version = "0.1.2"
 source = "git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4#eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4"
 dependencies = [
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-sys 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -222,9 +223,9 @@ name = "grpcio-sys"
 version = "0.1.2"
 source = "git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4#eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4"
 dependencies = [
- "cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -240,7 +241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -251,10 +252,10 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -268,12 +269,12 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -282,7 +283,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -292,7 +293,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -306,7 +307,7 @@ name = "memchr"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -314,29 +315,21 @@ name = "memchr"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nodrop"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num_cpus"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "odds"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ordermap"
@@ -345,7 +338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ordermap"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -354,7 +347,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -380,16 +373,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -432,11 +425,12 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -445,7 +439,7 @@ name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -453,7 +447,7 @@ name = "thread_local"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -503,7 +497,7 @@ name = "xattr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
@@ -512,19 +506,19 @@ dependencies = [
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4019bdb99c0c1ddd56c12c2f507c174d729c6915eca6bd9d27c42f3d93b0f4"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e14cd15a7cbc2c6a905677e54b831ee91af2ff43b352010f6133236463b65cac"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
-"checksum either 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e311a7479512fbdf858fb54d91ec59f3b9f85bc0113659f46bba12b199d273ce"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "aa75ec8f7927063335a9583e7fa87b0110bb888cf766dc01b54c0ff70d760c8e"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
-"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 "checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
-"checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
+"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
 "checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
@@ -534,30 +528,29 @@ dependencies = [
 "checksum grpcio-sys 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)" = "<none>"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
 "checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"
-"checksum itertools 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2c52051d3fd3b505796a0ee90f2e5ec43213808585e8adc4d0182492cf62751a"
+"checksum itertools 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f3f75d7cf195a7eedb0611efe8684b55c6c7264afe3d8bc00b704f061c0fdf"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
-"checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "44ac7bf1552c1386b70e77ff9d801971f19641bf2dc08b981cd2397bf812c65d"
 "checksum lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3db58e1767416fc1e9e3265635d3bb7bf3677a0dc8d4e8d6ee14850ec5c11ae9"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e01e64d9017d18e7fc09d8e4fe0e28ff6931019e979fb8019319db7ca827f8a6"
-"checksum nodrop 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4b44ef57f346558881a49986cf1bfa716275c7ad99ab143ac8dd47be2abf77"
+"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
-"checksum odds 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "c3df9b730298cea3a1c3faa90b7e2f9df3a9c400d0936d6015e6165734eefcba"
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
-"checksum ordermap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c7790b1bc9bf27776cd5cdeaae1263758c2c597d4ae02b58aa63c320f94d778"
+"checksum ordermap 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "40cd62c688b4d8078c3f0eef70d7762f17c08bf52b225799ddcb4cf275dd1f19"
 "checksum petgraph 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "28d0872a49ce3ee71b345f4fa675afe394d9e0d077f8eeeb3d04081724065d67"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "99c7a6694a7896f7c039bc20a6947b83781b019d7d40df77ae069cd2a432e4a7"
-"checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
-"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
+"checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
+"checksum redox_syscall 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "ab105df655884ede59d45b7070c8a65002d921461ee813a024558ca16030eea0"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum same-file 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70a18720d745fb9ca6a041b37cb36d0b21066006b6cff8b5b360142d4b81fb60"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
-"checksum tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "281285b717926caa919ad905ef89c63d75805c7d89437fb873100925a53f2b1b"
+"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -22,7 +22,7 @@ cc = "1.0"
 boxfuture = { path = "boxfuture" }
 fnv = "1.0.5"
 fs = { path = "fs" }
-futures = "0.1.16"
+futures = "0.1.17"
 lazy_static = "0.2.2"
 ordermap = "0.2.8"
 petgraph = "0.4.5"

--- a/src/rust/engine/boxfuture/Cargo.toml
+++ b/src/rust/engine/boxfuture/Cargo.toml
@@ -4,4 +4,4 @@ name = "boxfuture"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
-futures = "0.1.16"
+futures = "0.1.17"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -7,10 +7,11 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 bazel_protos = { path = "../process_execution/bazel_protos" }
 boxfuture = { path = "../boxfuture" }
 digest = "0.6.2"
-futures = "0.1.16"
+futures = "0.1.17"
 futures-cpupool = "0.1.6"
 glob = "0.2.11"
 hex = "0.3.1"
+grpcio = { git = "https://github.com/illicitonion/grpc-rs", rev = "eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4" }
 ignore = "0.3.1"
 itertools = "0.7.2"
 lazy_static = "0.2.2"

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -8,5 +8,5 @@ bazel_protos = { path = "../../process_execution/bazel_protos" }
 boxfuture = { path = "../../boxfuture" }
 clap = "2"
 fs = { path = ".." }
-futures = "0.1.16"
+futures = "0.1.17"
 protobuf = "1.4.1"

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -121,6 +121,12 @@ to this directory.",
           .long("local-store-path")
           .required(true),
       )
+        .arg(
+          Arg::with_name("server-address")
+              .takes_value(true)
+              .long("server-address")
+              .required(false)
+        )
       .get_matches(),
   ) {
     Ok(_) => {}
@@ -133,14 +139,16 @@ to this directory.",
 
 fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
   let store_dir = top_match.value_of("local-store-path").unwrap();
+  let maybe_server_address = top_match.value_of("server-address").map(|s| s.to_owned());
   let pool = Arc::new(ResettablePool::new("fsutil-pool-".to_string()));
-  let store = Arc::new(Store::new(store_dir, pool.clone()).map_err(|e| {
-    format!(
-      "Failed to open/create store for directory {}: {}",
-      store_dir,
-      e
-    )
-  })?);
+  let store = Arc::new(Store::new(store_dir, pool.clone(), maybe_server_address)
+    .map_err(|e| {
+      format!(
+        "Failed to open/create store for directory {}: {}",
+        store_dir,
+        e
+      )
+    })?);
 
   match top_match.subcommand() {
     ("file", Some(sub_match)) => {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -10,12 +10,16 @@ pub use store::{Digest, Store};
 mod pool;
 pub use pool::ResettablePool;
 
+#[cfg(test)]
+mod test_cas;
+
 extern crate bazel_protos;
 extern crate boxfuture;
 extern crate digest;
 extern crate futures;
 extern crate futures_cpupool;
 extern crate glob;
+extern crate grpcio;
 extern crate hex;
 extern crate ignore;
 extern crate itertools;

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -187,7 +187,7 @@ mod tests {
   fn setup() -> (Arc<Store>, TempDir, Arc<PosixFS>, Arc<FileSaver>) {
     let pool = Arc::new(ResettablePool::new("test-pool-".to_string()));
     let store = Arc::new(
-      Store::new(TempDir::new("lmdb_store").unwrap(), pool.clone()).unwrap(),
+      Store::new(TempDir::new("lmdb_store").unwrap(), pool.clone(), None).unwrap(),
     );
     let dir = TempDir::new("root").unwrap();
     let posix_fs = Arc::new(PosixFS::new(dir.path(), pool, vec![]).unwrap());

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -190,13 +190,13 @@ impl Store {
     self
       .load_bytes_local_with(fingerprint, db, f.clone())
       .and_then(move |maybe_bytes| match maybe_bytes {
-        Some(value) => future::ok(Some(value)).to_boxed() as BoxFuture<_, _>,
+        Some(value) => future::ok(Some(value)).to_boxed(),
         None => {
           match grpc_env {
             Some(GrpcEnvironment { address, env }) => {
               store.load_bytes_remote_with(fingerprint, db, f, &address, env)
             }
-            None => future::ok(None).to_boxed() as BoxFuture<_, _>,
+            None => future::ok(None).to_boxed(),
           }
         }
       })

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -274,8 +274,9 @@ impl Store {
               _ => {}
             }
           }
+          let result = Some(f(&bytes));
           store_copy
-                  .store_bytes(bytes.clone(), db)
+                  .store_bytes(bytes, db)
                   .and_then(move |retrieved_fingerprint| {
                     if retrieved_fingerprint == fingerprint {
                       Ok(())
@@ -287,9 +288,7 @@ impl Store {
                           fingerprint,
                           retrieved_fingerprint))
                     }
-                  }).map(move |()| {
-                Some(f(&bytes))
-              }).to_boxed()
+                  }).map(move |()| result).to_boxed()
         }
         None => future::ok(None).to_boxed() as BoxFuture<_, _>,
       })

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -189,7 +189,7 @@ impl Store {
     let f = Arc::new(f);
     self
       .load_bytes_local_with(fingerprint, db, f.clone())
-      .map(move |maybe_bytes| match maybe_bytes {
+      .and_then(move |maybe_bytes| match maybe_bytes {
         Some(value) => future::ok(Some(value)).to_boxed() as BoxFuture<_, _>,
         None => {
           match grpc_env {
@@ -200,8 +200,6 @@ impl Store {
           }
         }
       })
-      .to_boxed()
-      .flatten()
       .to_boxed()
   }
 

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -370,7 +370,6 @@ mod tests {
   use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
   use protobuf::Message;
   use sha2::Sha256;
-  use std::collections::HashMap;
   use std::path::Path;
   use std::sync::Arc;
   use tempdir::TempDir;
@@ -557,7 +556,7 @@ mod tests {
   fn missing_file_local_and_remote() {
     let dir = TempDir::new("store").unwrap();
 
-    let cas = new_empty_cas();
+    let cas = StubCAS::empty();
 
     assert_eq!(
       new_store(dir.path(), Some(cas.address()))
@@ -708,7 +707,7 @@ mod tests {
   fn missing_directory_local_and_remote() {
     let dir = TempDir::new("store").unwrap();
 
-    let cas = new_empty_cas();
+    let cas = StubCAS::empty();
 
     assert_eq!(
       new_store(dir.path(), Some(cas.address()))
@@ -722,7 +721,7 @@ mod tests {
   fn load_file_grpc_error() {
     let dir = TempDir::new("store").unwrap();
 
-    let cas = StubCAS::new(-1, HashMap::new());
+    let cas = StubCAS::always_errors();
 
     let error = new_store(dir.path(), Some(cas.address()))
       .load_file_bytes(fingerprint())
@@ -738,7 +737,7 @@ mod tests {
   fn load_directory_grpc_error() {
     let dir = TempDir::new("store").unwrap();
 
-    let cas = StubCAS::new(-1, HashMap::new());
+    let cas = StubCAS::always_errors();
 
     let error = new_store(dir.path(), Some(cas.address()))
       .load_directory_proto(directory_fingerprint())
@@ -852,9 +851,5 @@ mod tests {
       chunk_size_bytes as i64,
       vec![(fingerprint(), str_bytes())].into_iter().collect(),
     )
-  }
-
-  fn new_empty_cas() -> StubCAS {
-    StubCAS::new(10, HashMap::new())
   }
 }

--- a/src/rust/engine/fs/src/test_cas.rs
+++ b/src/rust/engine/fs/src/test_cas.rs
@@ -44,6 +44,14 @@ impl StubCAS {
     cas
   }
 
+  pub fn empty() -> StubCAS {
+    StubCAS::new(1024, HashMap::new())
+  }
+
+  pub fn always_errors() -> StubCAS {
+    StubCAS::new(-1, HashMap::new())
+  }
+
   ///
   /// The address on which this server is listening over insecure HTTP transport.
   ///

--- a/src/rust/engine/fs/src/test_cas.rs
+++ b/src/rust/engine/fs/src/test_cas.rs
@@ -1,0 +1,171 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bazel_protos;
+use futures;
+use grpcio;
+
+use futures::Future;
+use Fingerprint;
+
+///
+/// Implements the ContentAddressableStorage gRPC API, answering read requests with either known
+/// content, NotFound for valid but unknown content, or InvalidArguments for bad arguments.
+///
+pub struct StubCAS {
+  server_transport: grpcio::Server,
+}
+
+impl StubCAS {
+  ///
+  /// # Arguments
+  /// * `chunk_size_bytes` - The maximum number of bytes of content to include per streamed message.
+  ///                        Messages will saturate until the last one, which may be smaller than
+  ///                        this value.
+  ///                        If a negative value is given, all requests will receive an error.
+  /// * `blobs`            - Known Fingerprints and their content responses. These are not checked
+  ///                        for correctness.
+  pub fn new(chunk_size_bytes: i64, blobs: HashMap<Fingerprint, Vec<u8>>) -> StubCAS {
+    let env = Arc::new(grpcio::Environment::new(1));
+    let responder = StubCASResponder {
+      chunk_size_bytes,
+      blobs,
+    };
+    let mut server_transport = grpcio::ServerBuilder::new(env)
+      .register_service(bazel_protos::bytestream_grpc::create_byte_stream(
+        responder.clone(),
+      ))
+      .bind("localhost", 0)
+      .build()
+      .unwrap();
+    server_transport.start();
+
+    let cas = StubCAS { server_transport };
+    cas
+  }
+
+  ///
+  /// The address on which this server is listening over insecure HTTP transport.
+  ///
+  pub fn address(&self) -> String {
+    let bind_addr = self.server_transport.bind_addrs().first().unwrap();
+    format!("{}:{}", bind_addr.0, bind_addr.1)
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct StubCASResponder {
+  chunk_size_bytes: i64,
+  blobs: HashMap<Fingerprint, Vec<u8>>,
+}
+
+impl StubCASResponder {
+  fn read_internal(
+    &self,
+    req: bazel_protos::bytestream::ReadRequest,
+  ) -> Result<Vec<bazel_protos::bytestream::ReadResponse>, grpcio::RpcStatus> {
+    let parts: Vec<_> = req.get_resource_name().splitn(4, "/").collect();
+    if parts.len() != 4 || parts.get(0) != Some(&"") || parts.get(1) != Some(&"blobs") {
+      return Err(grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::InvalidArgument,
+        Some(format!(
+          "Bad resource name format {} - want /blobs/some-sha256/size",
+          req.get_resource_name()
+        )),
+      ));
+    }
+    let digest = parts.get(2).unwrap();
+    let fingerprint = Fingerprint::from_hex_string(digest).map_err(|e| {
+      grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::InvalidArgument,
+        Some(format!("Bad digest {}: {}", digest, e)),
+      )
+    })?;
+    if self.chunk_size_bytes < 0 {
+      return Err(grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::Internal,
+        Some("StubCAS is configured to always fail".to_owned()),
+      ));
+    }
+    let maybe_bytes = self.blobs.get(&fingerprint);
+    match maybe_bytes {
+      Some(bytes) => Ok(
+        bytes
+          .chunks(self.chunk_size_bytes as usize)
+          .map(|b| {
+            let mut resp = bazel_protos::bytestream::ReadResponse::new();
+            resp.set_data(b.to_vec());
+            resp
+          })
+          .collect(),
+      ),
+      None => Err(grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::NotFound,
+        Some(format!("Did not find digest {}", fingerprint)),
+      )),
+    }
+  }
+
+  ///
+  /// Sends a stream of responses down a sink, in ctx's threadpool.
+  ///
+  fn send<Item, S>(
+    &self,
+    ctx: grpcio::RpcContext,
+    sink: grpcio::ServerStreamingSink<Item>,
+    stream: S,
+  ) where
+    Item: Send + 'static,
+    S: futures::Stream<Item = (Item, grpcio::WriteFlags), Error = grpcio::Error> + Send + 'static,
+  {
+    ctx.spawn(stream.forward(sink).map(|_| ()).map_err(|_| ()));
+  }
+}
+
+impl bazel_protos::bytestream_grpc::ByteStream for StubCASResponder {
+  fn read(
+    &self,
+    ctx: grpcio::RpcContext,
+    req: bazel_protos::bytestream::ReadRequest,
+    sink: grpcio::ServerStreamingSink<bazel_protos::bytestream::ReadResponse>,
+  ) {
+    match self.read_internal(req) {
+      Ok(response) => {
+        self.send(
+          ctx,
+          sink,
+          futures::stream::iter_ok(response.into_iter().map(|chunk| {
+            (chunk, grpcio::WriteFlags::default())
+          })),
+        )
+      }
+      Err(err) => {
+        sink.fail(err);
+      }
+    }
+  }
+
+  fn write(
+    &self,
+    _ctx: grpcio::RpcContext,
+    _stream: grpcio::RequestStream<bazel_protos::bytestream::WriteRequest>,
+    sink: grpcio::ClientStreamingSink<bazel_protos::bytestream::WriteResponse>,
+  ) {
+    sink.fail(grpcio::RpcStatus::new(
+      grpcio::RpcStatusCode::Unimplemented,
+      None,
+    ));
+  }
+
+  fn query_write_status(
+    &self,
+    _ctx: grpcio::RpcContext,
+    _req: bazel_protos::bytestream::QueryWriteStatusRequest,
+    sink: grpcio::UnarySink<bazel_protos::bytestream::QueryWriteStatusResponse>,
+  ) {
+    sink.fail(grpcio::RpcStatus::new(
+      grpcio::RpcStatusCode::Unimplemented,
+      None,
+    ));
+  }
+}

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -4,6 +4,6 @@ name = "bazel_protos"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
-futures = "0.1.16"
+futures = "0.1.17"
 grpcio = { git = "https://github.com/illicitonion/grpc-rs", rev = "eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4", features = ["secure"] }
 protobuf = "1.4.1"

--- a/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
+++ b/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
@@ -12,4 +12,4 @@ googleapis="${thirdpartyprotobuf}/googleapis"
 outdir="${here}/src"
 mkdir -p "${outdir}"
 
-"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust/cargo/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"
+"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust/cargo/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/bytestream/bytestream.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"

--- a/src/rust/engine/process_execution/bazel_protos/src/lib.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/lib.rs
@@ -2,6 +2,8 @@ extern crate futures;
 extern crate grpcio;
 extern crate protobuf;
 
+pub mod bytestream;
+pub mod bytestream_grpc;
 pub mod code;
 pub mod empty;
 pub mod operations;

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -52,7 +52,8 @@ impl Core {
 
     let store = safe_create_dir_all_ioerror(&store_path)
         .map_err(|e| format!("{:?}", e))
-        .and_then(|()| Store::new(store_path, pool.clone()))
+        // TODO: Pass in a CAS address
+        .and_then(|()| Store::new(store_path, pool.clone(), None))
         .unwrap_or_else(
       |e| {
         panic!("Could not initialize Store directory {:?}", e)


### PR DESCRIPTION
This uses the ContentAddressableStorageService protocol specified in
https://github.com/googleapis/googleapis/blob/master/google/devtools/remoteexecution/v1test/remote_execution.proto

There are a few of problems with this implementation:
1. It has one unnecessary synchronisation point inside
   load_bytes_remote_with - I'm going to work this out before merging.
2. It doesn't currently pass around the sizes of Digests. I have an
   ongoing discussion with both the Bazel API specifiers, and the scoot
   team, about what we should do here. Passing around a size, or a size
   hint, is easy to do, but I don't want to commit to how it's going to
   be done until we know whether it needs to be.
3. It is hard-coded to run with a one-thread threadpool. I'm not sure
   whether we should be configuring this statically (like we do for the
   IO pool), or through from a pants config. If the latter, I haven't
   worked out how to do that yet.
4. Context doesn't currently accept a CAS address (specified by pants
   config). I will wire this up in a subsequent PR.