### PR TITLE
Post suffixed-wheel release fixups

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -702,10 +702,6 @@ function usage() {
   echo " -e  Check that wheels are prebuilt for this release."
   echo
   echo "All options (except for '-d' and '-c') are mutually exclusive."
-  echo
-  echo "There is one environment variable that significantly affects behaviour: setting"
-  echo "SUFFIXED_VERSION to a non-empty value will cause all commands to operate on a"
-  echo "git HEAD-SHA suffixed version of pants."
 
   if (( $# > 0 )); then
     die "$@"

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -163,7 +163,8 @@ is not required.
 3. Publish to PyPi
 ------------------
 
-Now that we've smoke-tested this release, we can publish to PyPi:
+Once the first two travis shards (the "binary builder" shards) have completed for your
+release commit, you can publish to PyPi:
 
     :::bash
     $ ./build-support/bin/release.sh

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -72,9 +72,6 @@ script fail:
         username: <fill me in>
         password: <fill me in>
         EOF
-        
-  - The release script requires Bash 4.  If you're on MacOS you may have to run `brew install bash`,
-    as the Bash that ships with MacOS is ancient.
     
   - Note that the release script expects your pantsbuild/pants git remote to be named `origin`.
     If you have another name for it, you should `git remote rename othername origin` before running


### PR DESCRIPTION
### Problem

In order to complete the `1.4.0.dev22` release, a few additional edits to the `release.sh` script were necessary.

### Solution

1. Update `find_pkg` to locate wheels by version.
2. Use a more portable implementation of case insensitive username matching.
3. URL-escape S3 keys (since `+` has special meaning in URLs).
4. Validate that if a whl is not cross-platform, we have it for exactly two platforms.