### PR TITLE
Prefactor Store wrapper

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -10,6 +10,7 @@ digest = "0.6.2"
 futures = "0.1.16"
 futures-cpupool = "0.1.6"
 glob = "0.2.11"
+grpcio = { git = "https://github.com/illicitonion/grpc-rs", rev = "eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4", features = ["secure"] }
 hex = "0.3.1"
 ignore = "0.3.1"
 itertools = "0.7.2"

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -16,6 +16,7 @@ extern crate digest;
 extern crate futures;
 extern crate futures_cpupool;
 extern crate glob;
+extern crate grpcio;
 extern crate hex;
 extern crate ignore;
 extern crate itertools;

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -49,11 +49,11 @@ impl Store {
   pub fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
     &self,
     fingerprint: Fingerprint,
-    f: Arc<F>,
+    f: F,
   ) -> BoxFuture<Option<T>, String> {
     self.local.load_file_bytes_with(
       fingerprint.clone(),
-      f.clone(),
+      Arc::new(f),
     )
   }
 

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1,207 +1,11 @@
 use bazel_protos;
-use boxfuture::{Boxable, BoxFuture};
-use digest::{Digest as DigestTrait, FixedOutput};
-use futures::{future, Future};
-use futures_cpupool::CpuFuture;
-use lmdb::{Database, DatabaseFlags, Environment, NO_OVERWRITE, Transaction};
-use lmdb::Error::{KeyExist, NotFound};
+use boxfuture::BoxFuture;
 use protobuf::core::Message;
-use sha2::Sha256;
-use std::error::Error;
 use std::path::Path;
 use std::sync::Arc;
 
 use hash::Fingerprint;
 use pool::ResettablePool;
-
-///
-/// A content-addressed store of file contents, and Directories.
-///
-/// Currently, Store only stores things locally on disk, but in the future it will gain the ability
-/// to fetch files from remote content-addressable storage too.
-///
-#[derive(Clone)]
-pub struct Store {
-  inner: Arc<InnerStore>,
-}
-
-struct InnerStore {
-  env: Environment,
-  pool: Arc<ResettablePool>,
-  file_store: Database,
-  // Store directories separately from files because:
-  //  1. They may have different lifetimes.
-  //  2. It's nice to know whether we should be able to parse something as a proto.
-  directory_store: Database,
-}
-
-impl Store {
-  pub fn new<P: AsRef<Path>>(path: P, pool: Arc<ResettablePool>) -> Result<Store, String> {
-    // 2 DBs; one for file contents, one for directories.
-    let env = Environment::new()
-      .set_max_dbs(2)
-      .set_map_size(16 * 1024 * 1024 * 1024)
-      .open(path.as_ref())
-      .map_err(|e| format!("Error making env: {}", e.description()))?;
-    let file_database = env
-      .create_db(Some("files"), DatabaseFlags::empty())
-      .map_err(|e| {
-        format!("Error creating/opening files database: {}", e.description())
-      })?;
-    let directory_database = env
-      .create_db(Some("directories"), DatabaseFlags::empty())
-      .map_err(|e| {
-        format!(
-          "Error creating/opening directories database: {}",
-          e.description()
-        )
-      })?;
-    Ok(Store {
-      inner: Arc::new(InnerStore {
-        env: env,
-        pool: pool,
-        file_store: file_database,
-        directory_store: directory_database,
-      }),
-    })
-  }
-
-  pub fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
-    let len = bytes.len();
-    self
-      .store_bytes(bytes, self.inner.file_store.clone())
-      .map(move |fingerprint| Digest(fingerprint, len))
-      .to_boxed()
-  }
-
-  fn store_bytes(&self, bytes: Vec<u8>, db: Database) -> CpuFuture<Fingerprint, String> {
-    let store = self.clone();
-    self.inner.pool.spawn_fn(move || {
-      let fingerprint = {
-        let mut hasher = Sha256::default();
-        hasher.input(&bytes);
-        Fingerprint::from_bytes_unsafe(hasher.fixed_result().as_slice())
-      };
-
-      let put_res = store.inner.env.begin_rw_txn().and_then(|mut txn| {
-        txn.put(db, &fingerprint, &bytes, NO_OVERWRITE).and_then(
-              |()| txn.commit(),
-          )
-      });
-
-      match put_res {
-        Ok(()) => Ok(fingerprint),
-        Err(KeyExist) => Ok(fingerprint),
-        Err(err) => Err(format!(
-          "Error storing fingerprint {}: {}",
-          fingerprint,
-          err.description()
-        )),
-      }
-    })
-  }
-
-  pub fn load_file_bytes(&self, fingerprint: Fingerprint) -> CpuFuture<Option<Vec<u8>>, String> {
-    self.load_bytes(fingerprint, self.inner.file_store.clone())
-  }
-
-  pub fn load_file_bytes_with<T: Send + 'static, F: FnOnce(&[u8]) -> T + Send + 'static>(
-    &self,
-    fingerprint: Fingerprint,
-    f: F,
-  ) -> CpuFuture<Option<T>, String> {
-    self.load_bytes_with(fingerprint, self.inner.file_store.clone(), f)
-  }
-
-  pub fn load_directory_proto_bytes(
-    &self,
-    fingerprint: Fingerprint,
-  ) -> CpuFuture<Option<Vec<u8>>, String> {
-    self.load_bytes(fingerprint, self.inner.directory_store.clone())
-  }
-
-  pub fn load_directory_proto(
-    &self,
-    fingerprint: Fingerprint,
-  ) -> BoxFuture<Option<bazel_protos::remote_execution::Directory>, String> {
-    self
-      .load_directory_proto_bytes(fingerprint)
-      .and_then(move |res| match res {
-        Some(bytes) => {
-          let mut proto = bazel_protos::remote_execution::Directory::new();
-          proto
-            .merge_from_bytes(&bytes)
-            .map_err(|e| {
-              format!("Error deserializing proto {}: {}", fingerprint, e)
-            })
-            .and(Ok(Some(proto)))
-        }
-        None => Ok(None),
-      })
-      .to_boxed()
-  }
-
-  fn load_bytes(
-    &self,
-    fingerprint: Fingerprint,
-    db: Database,
-  ) -> CpuFuture<Option<Vec<u8>>, String> {
-    self.load_bytes_with(fingerprint, db, |bytes| Vec::from(bytes))
-  }
-
-  fn load_bytes_with<T: Send + 'static, F: FnOnce(&[u8]) -> T + Send + 'static>(
-    &self,
-    fingerprint: Fingerprint,
-    db: Database,
-    f: F,
-  ) -> CpuFuture<Option<T>, String> {
-    let store = self.inner.clone();
-    self.inner.pool.spawn_fn(move || {
-      let ro_txn = store.env.begin_ro_txn().map_err(|err| {
-        format!(
-          "Failed to begin read transaction: {}",
-          err.description().to_string()
-        )
-      });
-      ro_txn.and_then(|txn| match txn.get(db, &fingerprint) {
-        Ok(bytes) => Ok(Some(f(bytes))),
-        Err(NotFound) => Ok(None),
-        Err(err) => Err(format!(
-          "Error loading fingerprint {}: {}",
-          fingerprint,
-          err.description().to_string()
-        )),
-      })
-    })
-  }
-
-  ///
-  /// Store the Directory proto. Does not do anything about the files or directories claimed to be
-  /// contained therein.
-  ///
-  /// Assumes that the directory has been properly canonicalized.
-  ///
-  pub fn record_directory(
-    &self,
-    directory: &bazel_protos::remote_execution::Directory,
-  ) -> BoxFuture<Digest, String> {
-    let store = self.clone();
-    future::result(directory.write_to_bytes().map_err(|e| {
-      format!(
-        "Error serializing directory proto {:?}: {}",
-        directory,
-        e.description()
-      )
-    })).and_then(move |bytes| {
-      let len = bytes.len();
-
-      store
-        .store_bytes(bytes, store.inner.directory_store.clone())
-        .map(move |fingerprint| Digest(fingerprint, len))
-    })
-      .to_boxed()
-  }
-}
 
 ///
 /// A Digest is a fingerprint, as well as the size in bytes of the plaintext for which that is the
@@ -222,111 +26,453 @@ impl Into<bazel_protos::remote_execution::Digest> for Digest {
   }
 }
 
-#[cfg(test)]
-mod tests {
-  extern crate tempdir;
+///
+/// A content-addressed store of file contents, and Directories.
+///
+/// Currently, Store only stores things locally on disk, but in the future it will gain the ability
+/// to fetch files from remote content-addressable storage too.
+///
+#[derive(Clone)]
+pub struct Store {
+  local: local::ByteStore,
+}
 
-  use bazel_protos;
-  use futures::Future;
-  use super::{Digest, Fingerprint, ResettablePool, Store};
-  use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
-  use protobuf::Message;
-  use std::path::Path;
-  use std::sync::Arc;
-  use tempdir::TempDir;
-
-
-  const STR: &str = "European Burmese";
-  const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
-
-  fn digest() -> Digest {
-    Digest(Fingerprint::from_hex_string(HASH).unwrap(), STR.len())
+impl Store {
+  pub fn new<P: AsRef<Path>>(path: P, pool: Arc<ResettablePool>) -> Result<Store, String> {
+    Ok(Store { local: local::ByteStore::new(path, pool)? })
   }
 
-  fn str_bytes() -> Vec<u8> {
+  pub fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
+    self.local.store_file_bytes(bytes)
+  }
+
+  pub fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+    &self,
+    fingerprint: Fingerprint,
+    f: Arc<F>,
+  ) -> BoxFuture<Option<T>, String> {
+    self.local.load_file_bytes_with(
+      fingerprint.clone(),
+      f.clone(),
+    )
+  }
+
+  pub fn record_directory(
+    &self,
+    directory: &bazel_protos::remote_execution::Directory,
+  ) -> BoxFuture<Digest, String> {
+    self.local.record_directory(directory)
+  }
+
+  pub fn load_directory(
+    &self,
+    fingerprint: Fingerprint,
+  ) -> BoxFuture<Option<bazel_protos::remote_execution::Directory>, String> {
+    self.local.load_directory_proto_bytes_with(
+      fingerprint,
+      Arc::new(|bytes: &[u8]| {
+        let mut directory = bazel_protos::remote_execution::Directory::new();
+        directory.merge_from_bytes(bytes).expect(
+          "LMDB corruption: Directory bytes were not valid",
+        );
+        directory
+      }),
+    )
+  }
+}
+
+///
+/// ByteStore allows read and write access to byte-buffers of two types:
+/// 1. File contents (arbitrary blobs with no particular assumed structure).
+/// 2. Directory protos, serialized using the standard protobuf binary serialization.
+///
+pub trait ByteStore {
+  fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String>;
+
+  fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+    &self,
+    fingerprint: Fingerprint,
+    f: Arc<F>,
+  ) -> BoxFuture<Option<T>, String>;
+
+  fn record_directory(
+    &self,
+    directory: &bazel_protos::remote_execution::Directory,
+  ) -> BoxFuture<Digest, String>;
+
+  ///
+  /// Load a Directory proto's bytes. This function will only return canonical Directory protos.
+  ///
+  fn load_directory_proto_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+    &self,
+    fingerprint: Fingerprint,
+    f: Arc<F>,
+  ) -> BoxFuture<Option<T>, String>;
+}
+
+mod local {
+  use super::Digest;
+
+  use bazel_protos;
+  use boxfuture::{Boxable, BoxFuture};
+  use digest::{Digest as DigestTrait, FixedOutput};
+  use futures::{future, Future};
+  use futures_cpupool::CpuFuture;
+  use lmdb::{Database, DatabaseFlags, Environment, NO_OVERWRITE, Transaction};
+  use lmdb::Error::{KeyExist, NotFound};
+  use protobuf::core::Message;
+  use sha2::Sha256;
+  use std::error::Error;
+  use std::path::Path;
+  use std::sync::Arc;
+
+  use hash::Fingerprint;
+  use pool::ResettablePool;
+
+  #[derive(Clone)]
+  pub struct ByteStore {
+    inner: Arc<InnerStore>,
+  }
+
+  struct InnerStore {
+    env: Environment,
+    pool: Arc<ResettablePool>,
+    file_store: Database,
+    // Store directories separately from files because:
+    //  1. They may have different lifetimes.
+    //  2. It's nice to know whether we should be able to parse something as a proto.
+    directory_store: Database,
+  }
+
+  impl ByteStore {
+    pub fn new<P: AsRef<Path>>(path: P, pool: Arc<ResettablePool>) -> Result<ByteStore, String> {
+      // 2 DBs; one for file contents, one for directories.
+      let env = Environment::new()
+        .set_max_dbs(2)
+        .set_map_size(16 * 1024 * 1024 * 1024)
+        .open(path.as_ref())
+        .map_err(|e| format!("Error making env: {}", e.description()))?;
+      let file_database = env
+        .create_db(Some("files"), DatabaseFlags::empty())
+        .map_err(|e| {
+          format!("Error creating/opening files database: {}", e.description())
+        })?;
+      let directory_database = env
+        .create_db(Some("directories"), DatabaseFlags::empty())
+        .map_err(|e| {
+          format!(
+            "Error creating/opening directories database: {}",
+            e.description()
+          )
+        })?;
+      Ok(ByteStore {
+        inner: Arc::new(InnerStore {
+          env: env,
+          pool: pool,
+          file_store: file_database,
+          directory_store: directory_database,
+        }),
+      })
+    }
+
+    fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+      &self,
+      fingerprint: Fingerprint,
+      db: Database,
+      f: Arc<F>,
+    ) -> CpuFuture<Option<T>, String> {
+      let store = self.inner.clone();
+      self.inner.pool.spawn_fn(move || {
+        let ro_txn = store.env.begin_ro_txn().map_err(|err| {
+          format!(
+            "Failed to begin read transaction: {}",
+            err.description().to_string()
+          )
+        });
+        ro_txn.and_then(|txn| match txn.get(db, &fingerprint) {
+          Ok(bytes) => Ok(Some(f(bytes))),
+          Err(NotFound) => Ok(None),
+          Err(err) => Err(format!(
+            "Error loading fingerprint {}: {}",
+            fingerprint,
+            err.description().to_string()
+          )),
+        })
+      })
+    }
+
+    fn store_bytes(&self, bytes: Vec<u8>, db: Database) -> CpuFuture<Fingerprint, String> {
+      let store = self.clone();
+      self.inner.pool.spawn_fn(move || {
+        let fingerprint = {
+          let mut hasher = Sha256::default();
+          hasher.input(&bytes);
+          Fingerprint::from_bytes_unsafe(hasher.fixed_result().as_slice())
+        };
+
+        let put_res = store.inner.env.begin_rw_txn().and_then(|mut txn| {
+          txn.put(db, &fingerprint, &bytes, NO_OVERWRITE).and_then(
+            |()| txn.commit(),
+          )
+        });
+
+        match put_res {
+          Ok(()) => Ok(fingerprint),
+          Err(KeyExist) => Ok(fingerprint),
+          Err(err) => Err(format!(
+            "Error storing fingerprint {}: {}",
+            fingerprint,
+            err.description()
+          )),
+        }
+      })
+    }
+  }
+
+  impl super::ByteStore for ByteStore {
+    fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
+      let len = bytes.len();
+      self
+        .store_bytes(bytes, self.inner.file_store.clone())
+        .map(move |fingerprint| Digest(fingerprint, len))
+        .to_boxed()
+    }
+
+    fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+      &self,
+      fingerprint: Fingerprint,
+      f: Arc<F>,
+    ) -> BoxFuture<Option<T>, String> {
+      self
+        .load_bytes_with(fingerprint, self.inner.file_store, f)
+        .to_boxed()
+    }
+
+    ///
+    /// Store the Directory proto. Does not do anything about the files or directories claimed to be
+    /// contained therein.
+    ///
+    /// Assumes that the directory has been properly canonicalized.
+    ///
+    fn record_directory(
+      &self,
+      directory: &bazel_protos::remote_execution::Directory,
+    ) -> BoxFuture<Digest, String> {
+      let store = self.clone();
+      future::result(directory.write_to_bytes().map_err(|e| {
+        format!(
+          "Error serializing directory proto {:?}: {}",
+          directory,
+          e.description()
+        )
+      })).and_then(move |bytes| {
+        let len = bytes.len();
+
+        store
+          .store_bytes(bytes, store.inner.directory_store.clone())
+          .map(move |fingerprint| Digest(fingerprint, len))
+      })
+        .to_boxed()
+    }
+
+    fn load_directory_proto_bytes_with<
+      T: Send + 'static,
+      F: Fn(&[u8]) -> T + Send + Sync + 'static,
+    >(
+      &self,
+      fingerprint: Fingerprint,
+      f: Arc<F>,
+    ) -> BoxFuture<Option<T>, String> {
+      self
+        .load_bytes_with(fingerprint.clone(), self.inner.directory_store, f)
+        .to_boxed()
+    }
+  }
+
+  #[cfg(test)]
+  mod tests {
+    extern crate tempdir;
+
+    use futures::Future;
+    use super::{ByteStore, Fingerprint, ResettablePool};
+    use super::super::ByteStore as _ByteStore;
+    use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
+    use protobuf::Message;
+    use std::path::Path;
+    use std::sync::Arc;
+    use tempdir::TempDir;
+
+    use super::super::tests::{DIRECTORY_HASH, HASH, digest, directory, directory_fingerprint,
+                              fingerprint, str_bytes};
+
+    #[test]
+    fn save_file() {
+      let dir = TempDir::new("store").unwrap();
+
+      assert_eq!(
+        new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
+        Ok(digest())
+      );
+    }
+
+    #[test]
+    fn save_file_is_idempotent() {
+      let dir = TempDir::new("store").unwrap();
+
+      new_store(dir.path())
+        .store_file_bytes(str_bytes())
+        .wait()
+        .unwrap();
+      assert_eq!(
+        new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
+        Ok(digest())
+      );
+    }
+
+    #[test]
+    fn save_file_collision_preserves_first() {
+      let dir = TempDir::new("store").unwrap();
+
+      let fingerprint = Fingerprint::from_hex_string(HASH).unwrap();
+      let bogus_value: Vec<u8> = vec![];
+
+      let env = Environment::new().set_max_dbs(1).open(dir.path()).unwrap();
+      let database = env.create_db(Some("files"), DatabaseFlags::empty());
+      env
+        .begin_rw_txn()
+        .and_then(|mut txn| {
+          txn.put(database.unwrap(), &fingerprint, &bogus_value, WriteFlags::empty())
+                .and_then(|()| txn.commit())
+        })
+        .unwrap();
+
+      assert_eq!(
+        load_file_bytes(&new_store(dir.path()), fingerprint),
+        Ok(Some(bogus_value.clone()))
+      );
+
+      assert_eq!(
+        new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
+        Ok(digest())
+      );
+
+      assert_eq!(
+        load_file_bytes(&new_store(dir.path()), fingerprint),
+        Ok(Some(bogus_value.clone()))
+      );
+    }
+
+    #[test]
+    fn roundtrip_file() {
+      let data = str_bytes();
+      let dir = TempDir::new("store").unwrap();
+
+      let store = new_store(dir.path());
+      let hash = store.store_file_bytes(data.clone()).wait().unwrap();
+      assert_eq!(load_file_bytes(&store, hash.0), Ok(Some(data)));
+    }
+
+    #[test]
+    fn missing_file() {
+      let dir = TempDir::new("store").unwrap();
+      assert_eq!(
+        load_file_bytes(&new_store(dir.path()), fingerprint()),
+        Ok(None)
+      );
+    }
+
+    #[test]
+    fn record_and_load_directory_proto() {
+      let dir = TempDir::new("store").unwrap();
+
+      assert_eq!(
+        &new_store(dir.path())
+          .record_directory(&directory())
+          .wait()
+          .unwrap()
+          .0
+          .to_hex(),
+        DIRECTORY_HASH
+      );
+
+      assert_eq!(
+        load_directory_proto_bytes(&new_store(dir.path()), directory_fingerprint()),
+        Ok(Some(directory().write_to_bytes().unwrap()))
+      );
+    }
+
+    #[test]
+    fn missing_directory() {
+      let dir = TempDir::new("store").unwrap();
+
+      assert_eq!(
+        load_directory_proto_bytes(&new_store(dir.path()), directory_fingerprint()),
+        Ok(None)
+      );
+    }
+
+    #[test]
+    fn file_is_not_directory_proto() {
+      let dir = TempDir::new("store").unwrap();
+
+      new_store(dir.path())
+        .store_file_bytes(str_bytes())
+        .wait()
+        .unwrap();
+
+      assert_eq!(
+        load_directory_proto_bytes(&new_store(dir.path()), fingerprint()),
+        Ok(None)
+      );
+    }
+
+    fn new_store<P: AsRef<Path>>(dir: P) -> ByteStore {
+      ByteStore::new(dir, Arc::new(ResettablePool::new("test-pool-".to_string()))).unwrap()
+    }
+
+    fn load_file_bytes(
+      store: &ByteStore,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      store
+        .load_file_bytes_with(fingerprint, Arc::new(|bytes: &[u8]| bytes.to_vec()))
+        .wait()
+    }
+
+    fn load_directory_proto_bytes(
+      store: &ByteStore,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      store
+        .load_directory_proto_bytes_with(fingerprint, Arc::new(|bytes: &[u8]| bytes.to_vec()))
+        .wait()
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use bazel_protos;
+  use super::{Digest, Fingerprint};
+
+  pub const STR: &str = "European Burmese";
+  pub const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
+  pub const DIRECTORY_HASH: &str = "63949aa823baf765eff07b946050d76e\
+c0033144c785a94d3ebd82baa931cd16";
+
+  pub fn fingerprint() -> Fingerprint {
+    Fingerprint::from_hex_string(HASH).unwrap()
+  }
+
+  pub fn digest() -> Digest {
+    Digest(fingerprint(), STR.len())
+  }
+
+  pub fn str_bytes() -> Vec<u8> {
     STR.as_bytes().to_owned()
   }
 
-  #[test]
-  fn save_file() {
-    let dir = TempDir::new("store").unwrap();
-
-    assert_eq!(
-      new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
-      Ok(digest())
-    );
-  }
-
-  #[test]
-  fn save_file_is_idempotent() {
-    let dir = TempDir::new("store").unwrap();
-
-    new_store(dir.path())
-      .store_file_bytes(str_bytes())
-      .wait()
-      .unwrap();
-    assert_eq!(
-      new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
-      Ok(digest())
-    );
-  }
-
-  #[test]
-  fn save_file_collision_preserves_first() {
-    let dir = TempDir::new("store").unwrap();
-
-    let fingerprint = Fingerprint::from_hex_string(HASH).unwrap();
-    let bogus_value: Vec<u8> = vec![];
-
-    let env = Environment::new().set_max_dbs(1).open(dir.path()).unwrap();
-    let database = env.create_db(Some("files"), DatabaseFlags::empty());
-    env
-      .begin_rw_txn()
-      .and_then(|mut txn| {
-        txn.put(database.unwrap(), &fingerprint, &bogus_value, WriteFlags::empty())
-            .and_then(|()| txn.commit())
-      })
-      .unwrap();
-
-    assert_eq!(
-      new_store(dir.path()).load_file_bytes(fingerprint).wait(),
-      Ok(Some(bogus_value.clone()))
-    );
-
-    assert_eq!(
-      new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
-      Ok(digest())
-    );
-
-    assert_eq!(
-      new_store(dir.path()).load_file_bytes(fingerprint).wait(),
-      Ok(Some(bogus_value))
-    );
-  }
-
-  #[test]
-  fn roundtrip_file() {
-    let data = str_bytes();
-    let dir = TempDir::new("store").unwrap();
-
-    let store = new_store(dir.path());
-    let hash = store.store_file_bytes(data.clone()).wait().unwrap();
-    assert_eq!(store.load_file_bytes(hash.0).wait(), Ok(Some(data)));
-  }
-
-  #[test]
-  fn missing_file() {
-    let dir = TempDir::new("store").unwrap();
-    assert_eq!(
-      new_store(dir.path())
-        .load_file_bytes(Fingerprint::from_hex_string(HASH).unwrap())
-        .wait(),
-      Ok(None)
-    );
-  }
-
-  #[test]
-  fn record_and_load_directory_proto() {
+  pub fn directory() -> bazel_protos::remote_execution::Directory {
     let mut directory = bazel_protos::remote_execution::Directory::new();
     directory.mut_files().push({
       let mut file = bazel_protos::remote_execution::FileNode::new();
@@ -340,58 +486,11 @@ mod tests {
       file.set_is_executable(false);
       file
     });
-
-    let dir = TempDir::new("store").unwrap();
-
-    let hash = "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16";
-
-    assert_eq!(
-      &new_store(dir.path())
-        .record_directory(&directory)
-        .wait()
-        .unwrap()
-        .0
-        .to_hex(),
-      hash
-    );
-
-    assert_eq!(
-      new_store(dir.path())
-        .load_directory_proto(Fingerprint::from_hex_string(hash).unwrap())
-        .wait(),
-      Ok(Some(directory.clone()))
-    );
-
-    assert_eq!(
-      new_store(dir.path())
-        .load_directory_proto_bytes(Fingerprint::from_hex_string(hash).unwrap())
-        .wait(),
-      Ok(Some(directory.write_to_bytes().unwrap()))
-    );
+    directory
   }
 
-  #[test]
-  fn file_is_not_directory_proto() {
-    let dir = TempDir::new("store").unwrap();
-
-    new_store(dir.path())
-      .store_file_bytes(str_bytes())
-      .wait()
-      .unwrap();
-
-    assert_eq!(
-      new_store(dir.path())
-        .load_directory_proto(Fingerprint::from_hex_string(HASH).unwrap())
-        .wait(),
-      Ok(None)
-    );
-
-    assert_eq!(
-      new_store(dir.path())
-        .load_directory_proto_bytes(Fingerprint::from_hex_string(HASH).unwrap())
-        .wait(),
-      Ok(None)
-    );
+  pub fn directory_fingerprint() -> Fingerprint {
+    Fingerprint::from_hex_string(DIRECTORY_HASH).unwrap()
   }
 
   #[test]
@@ -401,9 +500,5 @@ mod tests {
     bazel_digest.set_hash(HASH.to_string());
     bazel_digest.set_size_bytes(16);
     assert_eq!(bazel_digest, digest.into());
-  }
-
-  fn new_store<P: AsRef<Path>>(dir: P) -> Store {
-    Store::new(dir, Arc::new(ResettablePool::new("test-pool-".to_string()))).unwrap()
   }
 }

--- a/src/rust/engine/process_executor/Cargo.lock
+++ b/src/rust/engine/process_executor/Cargo.lock
@@ -27,7 +27,7 @@ name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.1.1 (git+https://github.com/illicitonion/grpc-rs?rev=2acabdbff71e77a14b95b0b30c6d7de516355df7)",
+ "grpcio 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)",
  "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -72,7 +72,7 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,11 +107,11 @@ dependencies = [
 
 [[package]]
 name = "grpcio"
-version = "0.1.1"
-source = "git+https://github.com/illicitonion/grpc-rs?rev=2acabdbff71e77a14b95b0b30c6d7de516355df7#2acabdbff71e77a14b95b0b30c6d7de516355df7"
+version = "0.1.2"
+source = "git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4#eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4"
 dependencies = [
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio-sys 0.1.1 (git+https://github.com/illicitonion/grpc-rs?rev=2acabdbff71e77a14b95b0b30c6d7de516355df7)",
+ "grpcio-sys 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)",
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -119,11 +119,11 @@ dependencies = [
 
 [[package]]
 name = "grpcio-sys"
-version = "0.1.1"
-source = "git+https://github.com/illicitonion/grpc-rs?rev=2acabdbff71e77a14b95b0b30c6d7de516355df7#2acabdbff71e77a14b95b0b30c6d7de516355df7"
+version = "0.1.2"
+source = "git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4#eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4"
 dependencies = [
  "cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -171,7 +171,7 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "grpcio 0.1.1 (git+https://github.com/illicitonion/grpc-rs?rev=2acabdbff71e77a14b95b0b30c6d7de516355df7)",
+ "grpcio 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)",
  "protobuf 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -273,13 +273,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c674f0870e3dbd4105184ea035acb1c32c8ae69939c9e228d2b11bbfe29efad"
 "checksum clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3451e409013178663435d6f15fdb212f14ee4424a3d74f979d081d0a66b6f1f2"
-"checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
+"checksum cmake 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e14cd15a7cbc2c6a905677e54b831ee91af2ff43b352010f6133236463b65cac"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
-"checksum grpcio 0.1.1 (git+https://github.com/illicitonion/grpc-rs?rev=2acabdbff71e77a14b95b0b30c6d7de516355df7)" = "<none>"
-"checksum grpcio-sys 0.1.1 (git+https://github.com/illicitonion/grpc-rs?rev=2acabdbff71e77a14b95b0b30c6d7de516355df7)" = "<none>"
+"checksum grpcio 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)" = "<none>"
+"checksum grpcio-sys 0.1.2 (git+https://github.com/illicitonion/grpc-rs?rev=eb0ca7eb50a19777e2e1d61b3b734a265d3d64e4)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"


### PR DESCRIPTION
Store will contain the logic to merge/fall-back between a local and
remote ByteStore. This is just moving the existing logic into the
ByteStore trait and an impl thereof, introducing a wrapper Store.