### PR TITLE
ByteStore impl for reading from the gRPC ContentAddressableStorage service

### DIFF
--- a/3rdparty/protobuf/googleapis/google/bytestream/bytestream.proto
+++ b/3rdparty/protobuf/googleapis/google/bytestream/bytestream.proto
@@ -1,0 +1,181 @@
+// Copyright 2016 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.bytestream;
+
+import "google/api/annotations.proto";
+import "google/protobuf/wrappers.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/bytestream;bytestream";
+option java_outer_classname = "ByteStreamProto";
+option java_package = "com.google.bytestream";
+
+
+// #### Introduction
+//
+// The Byte Stream API enables a client to read and write a stream of bytes to
+// and from a resource. Resources have names, and these names are supplied in
+// the API calls below to identify the resource that is being read from or
+// written to.
+//
+// All implementations of the Byte Stream API export the interface defined here:
+//
+// * `Read()`: Reads the contents of a resource.
+//
+// * `Write()`: Writes the contents of a resource. The client can call `Write()`
+//   multiple times with the same resource and can check the status of the write
+//   by calling `QueryWriteStatus()`.
+//
+// #### Service parameters and metadata
+//
+// The ByteStream API provides no direct way to access/modify any metadata
+// associated with the resource.
+//
+// #### Errors
+//
+// The errors returned by the service are in the Google canonical error space.
+service ByteStream {
+  // `Read()` is used to retrieve the contents of a resource as a sequence
+  // of bytes. The bytes are returned in a sequence of responses, and the
+  // responses are delivered as the results of a server-side streaming RPC.
+  rpc Read(ReadRequest) returns (stream ReadResponse);
+
+  // `Write()` is used to send the contents of a resource as a sequence of
+  // bytes. The bytes are sent in a sequence of request protos of a client-side
+  // streaming RPC.
+  //
+  // A `Write()` action is resumable. If there is an error or the connection is
+  // broken during the `Write()`, the client should check the status of the
+  // `Write()` by calling `QueryWriteStatus()` and continue writing from the
+  // returned `committed_size`. This may be less than the amount of data the
+  // client previously sent.
+  //
+  // Calling `Write()` on a resource name that was previously written and
+  // finalized could cause an error, depending on whether the underlying service
+  // allows over-writing of previously written resources.
+  //
+  // When the client closes the request channel, the service will respond with
+  // a `WriteResponse`. The service will not view the resource as `complete`
+  // until the client has sent a `WriteRequest` with `finish_write` set to
+  // `true`. Sending any requests on a stream after sending a request with
+  // `finish_write` set to `true` will cause an error. The client **should**
+  // check the `WriteResponse` it receives to determine how much data the
+  // service was able to commit and whether the service views the resource as
+  // `complete` or not.
+  rpc Write(stream WriteRequest) returns (WriteResponse);
+
+  // `QueryWriteStatus()` is used to find the `committed_size` for a resource
+  // that is being written, which can then be used as the `write_offset` for
+  // the next `Write()` call.
+  //
+  // If the resource does not exist (i.e., the resource has been deleted, or the
+  // first `Write()` has not yet reached the service), this method returns the
+  // error `NOT_FOUND`.
+  //
+  // The client **may** call `QueryWriteStatus()` at any time to determine how
+  // much data has been processed for this resource. This is useful if the
+  // client is buffering data and needs to know which data can be safely
+  // evicted. For any sequence of `QueryWriteStatus()` calls for a given
+  // resource name, the sequence of returned `committed_size` values will be
+  // non-decreasing.
+  rpc QueryWriteStatus(QueryWriteStatusRequest) returns (QueryWriteStatusResponse);
+}
+
+// Request object for ByteStream.Read.
+message ReadRequest {
+  // The name of the resource to read.
+  string resource_name = 1;
+
+  // The offset for the first byte to return in the read, relative to the start
+  // of the resource.
+  //
+  // A `read_offset` that is negative or greater than the size of the resource
+  // will cause an `OUT_OF_RANGE` error.
+  int64 read_offset = 2;
+
+  // The maximum number of `data` bytes the server is allowed to return in the
+  // sum of all `ReadResponse` messages. A `read_limit` of zero indicates that
+  // there is no limit, and a negative `read_limit` will cause an error.
+  //
+  // If the stream returns fewer bytes than allowed by the `read_limit` and no
+  // error occurred, the stream includes all data from the `read_offset` to the
+  // end of the resource.
+  int64 read_limit = 3;
+}
+
+// Response object for ByteStream.Read.
+message ReadResponse {
+  // A portion of the data for the resource. The service **may** leave `data`
+  // empty for any given `ReadResponse`. This enables the service to inform the
+  // client that the request is still live while it is running an operation to
+  // generate more data.
+  bytes data = 10;
+}
+
+// Request object for ByteStream.Write.
+message WriteRequest {
+  // The name of the resource to write. This **must** be set on the first
+  // `WriteRequest` of each `Write()` action. If it is set on subsequent calls,
+  // it **must** match the value of the first request.
+  string resource_name = 1;
+
+  // The offset from the beginning of the resource at which the data should be
+  // written. It is required on all `WriteRequest`s.
+  //
+  // In the first `WriteRequest` of a `Write()` action, it indicates
+  // the initial offset for the `Write()` call. The value **must** be equal to
+  // the `committed_size` that a call to `QueryWriteStatus()` would return.
+  //
+  // On subsequent calls, this value **must** be set and **must** be equal to
+  // the sum of the first `write_offset` and the sizes of all `data` bundles
+  // sent previously on this stream.
+  //
+  // An incorrect value will cause an error.
+  int64 write_offset = 2;
+
+  // If `true`, this indicates that the write is complete. Sending any
+  // `WriteRequest`s subsequent to one in which `finish_write` is `true` will
+  // cause an error.
+  bool finish_write = 3;
+
+  // A portion of the data for the resource. The client **may** leave `data`
+  // empty for any given `WriteRequest`. This enables the client to inform the
+  // service that the request is still live while it is running an operation to
+  // generate more data.
+  bytes data = 10;
+}
+
+// Response object for ByteStream.Write.
+message WriteResponse {
+  // The number of bytes that have been processed for the given resource.
+  int64 committed_size = 1;
+}
+
+// Request object for ByteStream.QueryWriteStatus.
+message QueryWriteStatusRequest {
+  // The name of the resource whose write status is being requested.
+  string resource_name = 1;
+}
+
+// Response object for ByteStream.QueryWriteStatus.
+message QueryWriteStatusResponse {
+  // The number of bytes that have been processed for the given resource.
+  int64 committed_size = 1;
+
+  // `complete` is `true` only if the client has sent a `WriteRequest` with
+  // `finish_write` set to true, and the server has processed that request.
+  bool complete = 2;
+}

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -10,6 +10,9 @@ pub use store::{Digest, Store};
 mod pool;
 pub use pool::ResettablePool;
 
+#[cfg(test)]
+pub mod test_cas;
+
 extern crate bazel_protos;
 extern crate boxfuture;
 extern crate digest;

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1,5 +1,6 @@
 use bazel_protos;
-use boxfuture::BoxFuture;
+use boxfuture::{BoxFuture, Boxable};
+use futures::{Future, future};
 use protobuf::core::Message;
 use std::path::Path;
 use std::sync::Arc;
@@ -37,13 +38,17 @@ pub struct Store {
   local: local::ByteStore,
 }
 
+// Note that Store doesn't implement ByteStore because it operates at a higher level of abstraction,
+// considering Directories as a standalone concept, rather than a buffer of bytes.
+// This has the nice property that Directories can be trusted to be valid and canonical.
+// We may want to re-visit this if we end up wanting to handle local/remote/merged interchangably.
 impl Store {
   pub fn new<P: AsRef<Path>>(path: P, pool: Arc<ResettablePool>) -> Result<Store, String> {
     Ok(Store { local: local::ByteStore::new(path, pool)? })
   }
 
   pub fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
-    self.local.store_file_bytes(bytes)
+    self.local.store_bytes(EntryType::File, bytes)
   }
 
   pub fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
@@ -51,7 +56,8 @@ impl Store {
     fingerprint: Fingerprint,
     f: F,
   ) -> BoxFuture<Option<T>, String> {
-    self.local.load_file_bytes_with(
+    self.local.load_bytes_with(
+      EntryType::File,
       fingerprint.clone(),
       Arc::new(f),
     )
@@ -61,14 +67,19 @@ impl Store {
     &self,
     directory: &bazel_protos::remote_execution::Directory,
   ) -> BoxFuture<Digest, String> {
-    self.local.record_directory(directory)
+    let local = self.local.clone();
+    future::result(directory.write_to_bytes().map_err(|e| {
+      format!("Error serializing directory proto {:?}: {:?}", directory, e)
+    })).and_then(move |bytes| local.store_bytes(EntryType::Directory, bytes))
+      .to_boxed()
   }
 
   pub fn load_directory(
     &self,
     fingerprint: Fingerprint,
   ) -> BoxFuture<Option<bazel_protos::remote_execution::Directory>, String> {
-    self.local.load_directory_proto_bytes_with(
+    self.local.load_bytes_with(
+      EntryType::Directory,
       fingerprint,
       Arc::new(|bytes: &[u8]| {
         let mut directory = bazel_protos::remote_execution::Directory::new();
@@ -81,46 +92,35 @@ impl Store {
   }
 }
 
+pub enum EntryType {
+  Directory,
+  File,
+}
+
 ///
 /// ByteStore allows read and write access to byte-buffers of two types:
 /// 1. File contents (arbitrary blobs with no particular assumed structure).
 /// 2. Directory protos, serialized using the standard protobuf binary serialization.
 ///
 pub trait ByteStore {
-  fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String>;
+  fn store_bytes(&self, entry_type: EntryType, bytes: Vec<u8>) -> BoxFuture<Digest, String>;
 
-  fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+  fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
     &self,
-    fingerprint: Fingerprint,
-    f: Arc<F>,
-  ) -> BoxFuture<Option<T>, String>;
-
-  fn record_directory(
-    &self,
-    directory: &bazel_protos::remote_execution::Directory,
-  ) -> BoxFuture<Digest, String>;
-
-  ///
-  /// Load a Directory proto's bytes. This function will only return canonical Directory protos.
-  ///
-  fn load_directory_proto_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
-    &self,
+    entry_type: EntryType,
     fingerprint: Fingerprint,
     f: Arc<F>,
   ) -> BoxFuture<Option<T>, String>;
 }
 
 mod local {
-  use super::Digest;
+  use super::{Digest, EntryType};
 
-  use bazel_protos;
   use boxfuture::{Boxable, BoxFuture};
   use digest::{Digest as DigestTrait, FixedOutput};
-  use futures::{future, Future};
-  use futures_cpupool::CpuFuture;
+  use futures::Future;
   use lmdb::{Database, DatabaseFlags, Environment, NO_OVERWRITE, Transaction};
   use lmdb::Error::{KeyExist, NotFound};
-  use protobuf::core::Message;
   use sha2::Sha256;
   use std::error::Error;
   use std::path::Path;
@@ -174,117 +174,79 @@ mod local {
         }),
       })
     }
-
-    fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
-      &self,
-      fingerprint: Fingerprint,
-      db: Database,
-      f: Arc<F>,
-    ) -> CpuFuture<Option<T>, String> {
-      let store = self.inner.clone();
-      self.inner.pool.spawn_fn(move || {
-        let ro_txn = store.env.begin_ro_txn().map_err(|err| {
-          format!(
-            "Failed to begin read transaction: {}",
-            err.description().to_string()
-          )
-        });
-        ro_txn.and_then(|txn| match txn.get(db, &fingerprint) {
-          Ok(bytes) => Ok(Some(f(bytes))),
-          Err(NotFound) => Ok(None),
-          Err(err) => Err(format!(
-            "Error loading fingerprint {}: {}",
-            fingerprint,
-            err.description().to_string()
-          )),
-        })
-      })
-    }
-
-    fn store_bytes(&self, bytes: Vec<u8>, db: Database) -> CpuFuture<Fingerprint, String> {
-      let store = self.clone();
-      self.inner.pool.spawn_fn(move || {
-        let fingerprint = {
-          let mut hasher = Sha256::default();
-          hasher.input(&bytes);
-          Fingerprint::from_bytes_unsafe(hasher.fixed_result().as_slice())
-        };
-
-        let put_res = store.inner.env.begin_rw_txn().and_then(|mut txn| {
-          txn.put(db, &fingerprint, &bytes, NO_OVERWRITE).and_then(
-            |()| txn.commit(),
-          )
-        });
-
-        match put_res {
-          Ok(()) => Ok(fingerprint),
-          Err(KeyExist) => Ok(fingerprint),
-          Err(err) => Err(format!(
-            "Error storing fingerprint {}: {}",
-            fingerprint,
-            err.description()
-          )),
-        }
-      })
-    }
   }
 
   impl super::ByteStore for ByteStore {
-    fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
+    fn store_bytes(&self, entry_type: EntryType, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
       let len = bytes.len();
+      let db = match entry_type {
+        EntryType::Directory => self.inner.directory_store,
+        EntryType::File => self.inner.file_store,
+      }.clone();
+
+      let inner = self.inner.clone();
       self
-        .store_bytes(bytes, self.inner.file_store.clone())
+        .inner
+        .pool
+        .spawn_fn(move || {
+          let fingerprint = {
+            let mut hasher = Sha256::default();
+            hasher.input(&bytes);
+            Fingerprint::from_bytes_unsafe(hasher.fixed_result().as_slice())
+          };
+
+          let put_res = inner.env.begin_rw_txn().and_then(|mut txn| {
+            txn.put(db, &fingerprint, &bytes, NO_OVERWRITE).and_then(
+            |()| txn.commit(),
+          )
+          });
+
+          match put_res {
+            Ok(()) => Ok(fingerprint),
+            Err(KeyExist) => Ok(fingerprint),
+            Err(err) => Err(format!(
+              "Error storing fingerprint {}: {}",
+              fingerprint,
+              err.description()
+            )),
+          }
+        })
         .map(move |fingerprint| Digest(fingerprint, len))
         .to_boxed()
     }
 
-    fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+    fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
       &self,
+      entry_type: EntryType,
       fingerprint: Fingerprint,
       f: Arc<F>,
     ) -> BoxFuture<Option<T>, String> {
+      let db = match entry_type {
+        EntryType::Directory => self.inner.directory_store,
+        EntryType::File => self.inner.file_store,
+      }.clone();
+
+      let store = self.inner.clone();
       self
-        .load_bytes_with(fingerprint, self.inner.file_store, f)
-        .to_boxed()
-    }
-
-    ///
-    /// Store the Directory proto. Does not do anything about the files or directories claimed to be
-    /// contained therein.
-    ///
-    /// Assumes that the directory has been properly canonicalized.
-    ///
-    fn record_directory(
-      &self,
-      directory: &bazel_protos::remote_execution::Directory,
-    ) -> BoxFuture<Digest, String> {
-      let store = self.clone();
-      future::result(directory.write_to_bytes().map_err(|e| {
-        format!(
-          "Error serializing directory proto {:?}: {}",
-          directory,
-          e.description()
-        )
-      })).and_then(move |bytes| {
-        let len = bytes.len();
-
-        store
-          .store_bytes(bytes, store.inner.directory_store.clone())
-          .map(move |fingerprint| Digest(fingerprint, len))
-      })
-        .to_boxed()
-    }
-
-    fn load_directory_proto_bytes_with<
-      T: Send + 'static,
-      F: Fn(&[u8]) -> T + Send + Sync + 'static,
-    >(
-      &self,
-      fingerprint: Fingerprint,
-      f: Arc<F>,
-    ) -> BoxFuture<Option<T>, String> {
-      self
-        .load_bytes_with(fingerprint.clone(), self.inner.directory_store, f)
+        .inner
+        .pool
+        .spawn_fn(move || {
+          let ro_txn = store.env.begin_ro_txn().map_err(|err| {
+            format!(
+              "Failed to begin read transaction: {}",
+              err.description().to_string()
+            )
+          });
+          ro_txn.and_then(|txn| match txn.get(db, &fingerprint) {
+            Ok(bytes) => Ok(Some(f(bytes))),
+            Err(NotFound) => Ok(None),
+            Err(err) => Err(format!(
+              "Error loading fingerprint {}: {}",
+              fingerprint,
+              err.description().to_string()
+            )),
+          })
+        })
         .to_boxed()
     }
   }
@@ -294,7 +256,7 @@ mod local {
     extern crate tempdir;
 
     use futures::Future;
-    use super::{ByteStore, Fingerprint, ResettablePool};
+    use super::{ByteStore, EntryType, Fingerprint, ResettablePool};
     use super::super::ByteStore as _ByteStore;
     use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
     use protobuf::Message;
@@ -303,14 +265,16 @@ mod local {
     use tempdir::TempDir;
 
     use super::super::tests::{DIRECTORY_HASH, HASH, digest, directory, directory_fingerprint,
-                              fingerprint, str_bytes};
+                              fingerprint, load_directory_proto_bytes, load_file_bytes, str_bytes};
 
     #[test]
     fn save_file() {
       let dir = TempDir::new("store").unwrap();
 
       assert_eq!(
-        new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
+        new_store(dir.path())
+          .store_bytes(EntryType::File, str_bytes())
+          .wait(),
         Ok(digest())
       );
     }
@@ -320,11 +284,13 @@ mod local {
       let dir = TempDir::new("store").unwrap();
 
       new_store(dir.path())
-        .store_file_bytes(str_bytes())
+        .store_bytes(EntryType::File, str_bytes())
         .wait()
         .unwrap();
       assert_eq!(
-        new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
+        new_store(dir.path())
+          .store_bytes(EntryType::File, str_bytes())
+          .wait(),
         Ok(digest())
       );
     }
@@ -352,7 +318,9 @@ mod local {
       );
 
       assert_eq!(
-        new_store(dir.path()).store_file_bytes(str_bytes()).wait(),
+        new_store(dir.path())
+          .store_bytes(EntryType::File, str_bytes())
+          .wait(),
         Ok(digest())
       );
 
@@ -368,7 +336,10 @@ mod local {
       let dir = TempDir::new("store").unwrap();
 
       let store = new_store(dir.path());
-      let hash = store.store_file_bytes(data.clone()).wait().unwrap();
+      let hash = store
+        .store_bytes(EntryType::File, data.clone())
+        .wait()
+        .unwrap();
       assert_eq!(load_file_bytes(&store, hash.0), Ok(Some(data)));
     }
 
@@ -387,7 +358,7 @@ mod local {
 
       assert_eq!(
         &new_store(dir.path())
-          .record_directory(&directory())
+          .store_bytes(EntryType::Directory, directory().write_to_bytes().unwrap())
           .wait()
           .unwrap()
           .0
@@ -416,7 +387,7 @@ mod local {
       let dir = TempDir::new("store").unwrap();
 
       new_store(dir.path())
-        .store_file_bytes(str_bytes())
+        .store_bytes(EntryType::File, str_bytes())
         .wait()
         .unwrap();
 
@@ -429,31 +400,18 @@ mod local {
     fn new_store<P: AsRef<Path>>(dir: P) -> ByteStore {
       ByteStore::new(dir, Arc::new(ResettablePool::new("test-pool-".to_string()))).unwrap()
     }
-
-    fn load_file_bytes(
-      store: &ByteStore,
-      fingerprint: Fingerprint,
-    ) -> Result<Option<Vec<u8>>, String> {
-      store
-        .load_file_bytes_with(fingerprint, Arc::new(|bytes: &[u8]| bytes.to_vec()))
-        .wait()
-    }
-
-    fn load_directory_proto_bytes(
-      store: &ByteStore,
-      fingerprint: Fingerprint,
-    ) -> Result<Option<Vec<u8>>, String> {
-      store
-        .load_directory_proto_bytes_with(fingerprint, Arc::new(|bytes: &[u8]| bytes.to_vec()))
-        .wait()
-    }
   }
 }
 
 #[cfg(test)]
 mod tests {
+  use super::{ByteStore, Digest, EntryType, Fingerprint};
+  use super::super::test_cas::StubCAS;
+
   use bazel_protos;
-  use super::{Digest, Fingerprint};
+  use futures::Future;
+  use protobuf::Message;
+  use std::sync::Arc;
 
   pub const STR: &str = "European Burmese";
   pub const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
@@ -491,6 +449,46 @@ c0033144c785a94d3ebd82baa931cd16";
 
   pub fn directory_fingerprint() -> Fingerprint {
     Fingerprint::from_hex_string(DIRECTORY_HASH).unwrap()
+  }
+
+  pub fn load_file_bytes<B: ByteStore>(
+    store: &B,
+    fingerprint: Fingerprint,
+  ) -> Result<Option<Vec<u8>>, String> {
+    store
+      .load_bytes_with(
+        EntryType::File,
+        fingerprint,
+        Arc::new(|bytes: &[u8]| bytes.to_vec()),
+      )
+      .wait()
+  }
+
+  pub fn load_directory_proto_bytes<B: ByteStore>(
+    store: &B,
+    fingerprint: Fingerprint,
+  ) -> Result<Option<Vec<u8>>, String> {
+    store
+      .load_bytes_with(
+        EntryType::Directory,
+        fingerprint,
+        Arc::new(|bytes: &[u8]| bytes.to_vec()),
+      )
+      .wait()
+  }
+
+  pub fn new_cas(chunk_size_bytes: usize) -> StubCAS {
+    StubCAS::new(
+      chunk_size_bytes as i64,
+      vec![
+        (fingerprint(), str_bytes()),
+        (
+          directory_fingerprint(),
+          directory().write_to_bytes().unwrap()
+        ),
+      ].into_iter()
+        .collect(),
+    )
   }
 
   #[test]

--- a/src/rust/engine/fs/src/test_cas.rs
+++ b/src/rust/engine/fs/src/test_cas.rs
@@ -1,0 +1,179 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bazel_protos;
+use futures;
+use grpcio;
+
+use futures::Future;
+use Fingerprint;
+
+///
+/// Implements the ContentAddressableStorage gRPC API, answering read requests with either known
+/// content, NotFound for valid but unknown content, or InvalidArguments for bad arguments.
+///
+pub struct StubCAS {
+  server_transport: grpcio::Server,
+}
+
+impl StubCAS {
+  ///
+  /// # Arguments
+  /// * `chunk_size_bytes` - The maximum number of bytes of content to include per streamed message.
+  ///                        Messages will saturate until the last one, which may be smaller than
+  ///                        this value.
+  ///                        If a negative value is given, all requests will receive an error.
+  /// * `blobs`            - Known Fingerprints and their content responses. These are not checked
+  ///                        for correctness.
+  pub fn new(chunk_size_bytes: i64, blobs: HashMap<Fingerprint, Vec<u8>>) -> StubCAS {
+    let env = Arc::new(grpcio::Environment::new(1));
+    let responder = StubCASResponder {
+      chunk_size_bytes,
+      blobs,
+    };
+    let mut server_transport = grpcio::ServerBuilder::new(env)
+      .register_service(bazel_protos::bytestream_grpc::create_byte_stream(
+        responder.clone(),
+      ))
+      .bind("localhost", 0)
+      .build()
+      .unwrap();
+    server_transport.start();
+
+    let cas = StubCAS { server_transport };
+    cas
+  }
+
+  pub fn empty() -> StubCAS {
+    StubCAS::new(1024, HashMap::new())
+  }
+
+  pub fn always_errors() -> StubCAS {
+    StubCAS::new(-1, HashMap::new())
+  }
+
+  ///
+  /// The address on which this server is listening over insecure HTTP transport.
+  ///
+  pub fn address(&self) -> String {
+    let bind_addr = self.server_transport.bind_addrs().first().unwrap();
+    format!("{}:{}", bind_addr.0, bind_addr.1)
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct StubCASResponder {
+  chunk_size_bytes: i64,
+  blobs: HashMap<Fingerprint, Vec<u8>>,
+}
+
+impl StubCASResponder {
+  fn read_internal(
+    &self,
+    req: bazel_protos::bytestream::ReadRequest,
+  ) -> Result<Vec<bazel_protos::bytestream::ReadResponse>, grpcio::RpcStatus> {
+    let parts: Vec<_> = req.get_resource_name().splitn(4, "/").collect();
+    if parts.len() != 4 || parts.get(0) != Some(&"") || parts.get(1) != Some(&"blobs") {
+      return Err(grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::InvalidArgument,
+        Some(format!(
+          "Bad resource name format {} - want /blobs/some-sha256/size",
+          req.get_resource_name()
+        )),
+      ));
+    }
+    let digest = parts.get(2).unwrap();
+    let fingerprint = Fingerprint::from_hex_string(digest).map_err(|e| {
+      grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::InvalidArgument,
+        Some(format!("Bad digest {}: {}", digest, e)),
+      )
+    })?;
+    if self.chunk_size_bytes < 0 {
+      return Err(grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::Internal,
+        Some("StubCAS is configured to always fail".to_owned()),
+      ));
+    }
+    let maybe_bytes = self.blobs.get(&fingerprint);
+    match maybe_bytes {
+      Some(bytes) => Ok(
+        bytes
+          .chunks(self.chunk_size_bytes as usize)
+          .map(|b| {
+            let mut resp = bazel_protos::bytestream::ReadResponse::new();
+            resp.set_data(b.to_vec());
+            resp
+          })
+          .collect(),
+      ),
+      None => Err(grpcio::RpcStatus::new(
+        grpcio::RpcStatusCode::NotFound,
+        Some(format!("Did not find digest {}", fingerprint)),
+      )),
+    }
+  }
+
+  ///
+  /// Sends a stream of responses down a sink, in ctx's threadpool.
+  ///
+  fn send<Item, S>(
+    &self,
+    ctx: grpcio::RpcContext,
+    sink: grpcio::ServerStreamingSink<Item>,
+    stream: S,
+  ) where
+    Item: Send + 'static,
+    S: futures::Stream<Item = (Item, grpcio::WriteFlags), Error = grpcio::Error> + Send + 'static,
+  {
+    ctx.spawn(stream.forward(sink).map(|_| ()).map_err(|_| ()));
+  }
+}
+
+impl bazel_protos::bytestream_grpc::ByteStream for StubCASResponder {
+  fn read(
+    &self,
+    ctx: grpcio::RpcContext,
+    req: bazel_protos::bytestream::ReadRequest,
+    sink: grpcio::ServerStreamingSink<bazel_protos::bytestream::ReadResponse>,
+  ) {
+    match self.read_internal(req) {
+      Ok(response) => {
+        self.send(
+          ctx,
+          sink,
+          futures::stream::iter_ok(response.into_iter().map(|chunk| {
+            (chunk, grpcio::WriteFlags::default())
+          })),
+        )
+      }
+      Err(err) => {
+        sink.fail(err);
+      }
+    }
+  }
+
+  fn write(
+    &self,
+    _ctx: grpcio::RpcContext,
+    _stream: grpcio::RequestStream<bazel_protos::bytestream::WriteRequest>,
+    sink: grpcio::ClientStreamingSink<bazel_protos::bytestream::WriteResponse>,
+  ) {
+    sink.fail(grpcio::RpcStatus::new(
+      grpcio::RpcStatusCode::Unimplemented,
+      None,
+    ));
+  }
+
+  fn query_write_status(
+    &self,
+    _ctx: grpcio::RpcContext,
+    _req: bazel_protos::bytestream::QueryWriteStatusRequest,
+    sink: grpcio::UnarySink<bazel_protos::bytestream::QueryWriteStatusResponse>,
+  ) {
+    sink.fail(grpcio::RpcStatus::new(
+      grpcio::RpcStatusCode::Unimplemented,
+      None,
+    ));
+  }
+}

--- a/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
+++ b/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
@@ -12,4 +12,4 @@ googleapis="${thirdpartyprotobuf}/googleapis"
 outdir="${here}/src"
 mkdir -p "${outdir}"
 
-"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust/cargo/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"
+"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust/cargo/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/bytestream/bytestream.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"

--- a/src/rust/engine/process_execution/bazel_protos/src/lib.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/lib.rs
@@ -2,6 +2,8 @@ extern crate futures;
 extern crate grpcio;
 extern crate protobuf;
 
+pub mod bytestream;
+pub mod bytestream_grpc;
 pub mod code;
 pub mod empty;
 pub mod operations;


### PR DESCRIPTION
As specified in https://github.com/googleapis/googleapis/blob/master/google/devtools/remoteexecution/v1test/remote_execution.proto
    
Isn't actually used by the Store yet, that will be the next PR.
