### PR TITLE
[pantsd] Repair stdio truncation.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -1,6 +1,7 @@
 ansicolors==1.0.2
 beautifulsoup4>=4.3.2,<4.4
 cffi==1.11.1
+contextlib2==0.5.5
 coverage>=4.3.4,<4.4
 docutils>=0.12,<0.13
 fasteners==0.14.1

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import datetime
 import os
 import signal
-import socket
 import sys
 from contextlib import contextmanager
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -119,8 +119,7 @@ class DaemonPantsRunner(ProcessManager):
       # N.B. This will be passed to and called by the `DaemonExiter` prior to sending an
       # exit chunk, to avoid any socket shutdown vs write races.
       def finalizer():
-        # HACK: Sleep 1ms from the main thread to free the GIL.
-        time.sleep(.001)
+        time.sleep(.001)  # HACK: Sleep 1ms in the main thread to free the GIL.
         writer.stop()
         writer.join()
       yield finalizer

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -119,9 +119,13 @@ class DaemonPantsRunner(ProcessManager):
       # N.B. This will be passed to and called by the `DaemonExiter` prior to sending an
       # exit chunk, to avoid any socket shutdown vs write races.
       def finalizer():
-        time.sleep(.001)  # HACK: Sleep 1ms in the main thread to free the GIL.
-        writer.stop()
-        writer.join()
+        try:
+          stdout.flush()
+          stderr.flush()
+        finally:
+          time.sleep(.001)  # HACK: Sleep 1ms in the main thread to free the GIL.
+          writer.stop()
+          writer.join()
       yield finalizer
 
   def _setup_sigint_handler(self):

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -80,7 +80,7 @@ class RemotePantsRunner(object):
     log_level = logging.getLevelName(self._bootstrap_options.for_global_scope().level.upper())
 
     formatter = logging.Formatter('%(levelname)s] %(message)s')
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stderr)
     handler.setLevel(log_level)
     handler.setFormatter(formatter)
 

--- a/src/python/pants/java/BUILD
+++ b/src/python/pants/java/BUILD
@@ -29,6 +29,7 @@ python_library(
   name = 'nailgun_io',
   sources = ['nailgun_io.py'],
   dependencies = [
+    '3rdparty/python:contextlib2',
     ':nailgun_protocol'
   ]
 )

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -25,11 +25,14 @@ class NailgunClientSession(NailgunProtocol):
 
   def __init__(self, sock, in_fd, out_fd, err_fd, exit_on_broken_pipe=False):
     self._sock = sock
+    self._input_writer = None
     if in_fd:
-      self._input_writer = NailgunStreamWriter(in_fd, self._sock,
-                                               ChunkType.STDIN, ChunkType.STDIN_EOF)
-    else:
-      self._input_writer = None
+      self._input_writer = NailgunStreamWriter(
+        (in_fd,),
+        self._sock,
+        (ChunkType.STDIN,),
+        ChunkType.STDIN_EOF
+      )
     self._stdout = out_fd
     self._stderr = err_fd
     self._exit_on_broken_pipe = exit_on_broken_pipe
@@ -42,6 +45,7 @@ class NailgunClientSession(NailgunProtocol):
   def _maybe_stop_input_writer(self):
     if self._input_writer:
       self._input_writer.stop()
+      self._input_writer.join()
 
   def _write_flush(self, fd, payload=None):
     """Write a payload to a given fd (if provided) and flush the fd."""

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -43,7 +43,7 @@ class NailgunClientSession(NailgunProtocol):
       self._input_writer.start()
 
   def _maybe_stop_input_writer(self):
-    if self._input_writer:
+    if self._input_writer and self._input_writer.is_alive():
       self._input_writer.stop()
       self._input_writer.join()
 

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import io
 import os
 import select
-import socket
 import threading
 from contextlib import contextmanager
 
@@ -21,7 +20,6 @@ def _pipe(isatty):
   r_fd, w_fd = os.openpty() if isatty else os.pipe()
   with os.fdopen(r_fd, 'r') as r, os.fdopen(w_fd, 'w') as w:
     yield (r, w)
-
 
 
 class _StoppableDaemonThread(threading.Thread):

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -94,6 +94,7 @@ class NailgunStreamStdinReader(_StoppableDaemonThread):
           self._write_handle.write(payload)
           self._write_handle.flush()
         elif chunk_type == ChunkType.STDIN_EOF:
+          self._write_handle.close()
           return
         else:
           raise NailgunProtocol.ProtocolError(
@@ -179,7 +180,10 @@ class NailgunStreamWriter(_StoppableDaemonThread):
               if self._chunk_eof_type is not None:
                 NailgunProtocol.write_chunk(self._socket, self._chunk_eof_type)
             finally:
-              self._in_files.remove(fh)
+              try:
+                os.close(fileno)
+              finally:
+                self._in_files.remove(fh)
           else:
             NailgunProtocol.write_chunk(
               self._socket,

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -94,7 +94,6 @@ class NailgunStreamStdinReader(_StoppableDaemonThread):
           self._write_handle.write(payload)
           self._write_handle.flush()
         elif chunk_type == ChunkType.STDIN_EOF:
-          self._write_handle.close()
           return
         else:
           raise NailgunProtocol.ProtocolError(

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -13,16 +13,41 @@ import threading
 from contextlib import contextmanager
 
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
+from pants.util.socket import teardown_socket
 
 
 @contextmanager
 def _pipe(isatty):
   r_fd, w_fd = os.openpty() if isatty else os.pipe()
-  try:
-    yield os.fdopen(r_fd, 'r'), os.fdopen(w_fd, 'w')
-  finally:
-    os.close(r_fd)
-    os.close(w_fd)
+  with os.fdopen(r_fd, 'r') as r, os.fdopen(w_fd, 'w') as w:
+    yield (r, w)
+
+
+
+class _StoppableDaemonThread(threading.Thread):
+  def __init__(self):
+    super(_StoppableDaemonThread, self).__init__()
+    self.daemon = True
+    # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
+    self._stopped = threading.Event()
+
+  @property
+  def is_stopped(self):
+    """Indicates whether or not the instance is stopped."""
+    return self._stopped.is_set()
+
+  def stop(self):
+    """Stops the instance."""
+    self._stopped.set()
+
+  @contextmanager
+  def running(self):
+    self.start()
+    try:
+      yield
+    finally:
+      self.stop()
+      self.join()
 
 
 class NailgunStreamStdinReader(threading.Thread):
@@ -73,17 +98,18 @@ class NailgunStreamStdinReader(threading.Thread):
       else:
         self._try_close()
         raise NailgunProtocol.ProtocolError(
-            'received unexpected chunk {} -> {}: closing.'.format(chunk_type, payload))
+          'received unexpected chunk {} -> {}: closing.'.format(chunk_type, payload)
+        )
 
 
-class NailgunStreamWriter(threading.Thread):
+class NailgunStreamWriter(_StoppableDaemonThread):
   """Reads input from an input fd and writes Nailgun chunks on a socket.
 
   Should generally be managed with the `open` classmethod contextmanager, which will create
   a pipe and provide its writing end to the caller.
   """
 
-  SELECT_TIMEOUT = 1
+  SELECT_TIMEOUT = .25
 
   def __init__(self, in_file, sock, chunk_type, chunk_eof_type, buf_size=None, select_timeout=None):
     """
@@ -96,24 +122,12 @@ class NailgunStreamWriter(threading.Thread):
     :param int select_timeout: the timeout (in seconds) for select.select() calls against the fd.
     """
     super(NailgunStreamWriter, self).__init__()
-    self.daemon = True
     self._in_file = in_file
     self._socket = sock
     self._buf_size = buf_size or io.DEFAULT_BUFFER_SIZE
     self._chunk_type = chunk_type
     self._chunk_eof_type = chunk_eof_type
     self._select_timeout = select_timeout or self.SELECT_TIMEOUT
-    # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
-    self._stopped = threading.Event()
-
-  @property
-  def is_stopped(self):
-    """Indicates whether or not the instance is stopped."""
-    return self._stopped.is_set()
-
-  def stop(self):
-    """Stops the instance."""
-    self._stopped.set()
 
   @classmethod
   @contextmanager
@@ -121,17 +135,9 @@ class NailgunStreamWriter(threading.Thread):
     """Yields the write side of a pipe that will copy appropriately chunked values to the socket."""
     with _pipe(isatty) as (read_handle, write_handle):
       writer = NailgunStreamWriter(read_handle, sock, chunk_type, chunk_eof_type,
-                                  buf_size=buf_size, select_timeout=select_timeout)
+                                   buf_size=buf_size, select_timeout=select_timeout)
       with writer.running():
-        yield write_handle
-
-  @contextmanager
-  def running(self):
-    self.start()
-    try:
-      yield
-    finally:
-      self.stop()
+        yield write_handle, writer
 
   def run(self):
     while not self.is_stopped:
@@ -141,18 +147,18 @@ class NailgunStreamWriter(threading.Thread):
         self.stop()
         return
 
-      if not self.is_stopped and self._in_file in readable:
+      if self._in_file in readable:
         data = os.read(self._in_file.fileno(), self._buf_size)
-
-        if not self.is_stopped:
-          if data:
-            NailgunProtocol.write_chunk(self._socket, self._chunk_type, data)
-          else:
+        if data:
+          NailgunProtocol.write_chunk(self._socket, self._chunk_type, data)
+        else:
+          # We've reached EOF.
+          try:
             try:
               if self._chunk_eof_type is not None:
                 NailgunProtocol.write_chunk(self._socket, self._chunk_eof_type)
-                self._socket.shutdown(socket.SHUT_WR)  # Shutdown socket sends.
-            except socket.error:  # Can happen if response is quick.
-              pass
             finally:
-              self.stop()
+              teardown_socket(self._socket)
+          finally:
+            self.stop()
+            return

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -224,6 +224,11 @@ class NailgunProtocol(object):
     cls.write_chunk(sock, ChunkType.EXIT, payload)
 
   @classmethod
+  def send_pid(cls, sock, pid):
+    """Send the PID chunk over the specified socket."""
+    cls.write_chunk(sock, ChunkType.PID, pid)
+
+  @classmethod
   def isatty_to_env(cls, stdin, stdout, stderr):
     """Generate nailgun tty capability environment variables based on checking a set of fds.
 

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -90,15 +90,13 @@ class PailgunHandler(PailgunHandlerBase):
 class PailgunServer(TCPServer):
   """A (forking) pants nailgun server."""
 
-  def __init__(self, server_address, runner_factory, context_lock,
-               handler_class=None, bind_and_activate=True):
+  def __init__(self, server_address, runner_factory, handler_class=None, bind_and_activate=True):
     """Override of TCPServer.__init__().
 
     N.B. the majority of this function is copied verbatim from TCPServer.__init__().
 
     :param tuple server_address: An address tuple of (hostname, port) for socket.bind().
     :param class runner_factory: A factory function for creating a DaemonPantsRunner for each run.
-    :param func context_lock: A contextmgr that will be used as a lock during request handling/forking.
     :param class handler_class: The request handler class to use for each request. (Optional)
     :param bool bind_and_activate: If True, binds and activates networking at __init__ time.
                                    (Optional)
@@ -109,7 +107,6 @@ class PailgunServer(TCPServer):
     self.runner_factory = runner_factory
     self.allow_reuse_address = True           # Allow quick reuse of TCP_WAIT sockets.
     self.server_port = None                   # Set during server_bind() once the port is bound.
-    self._context_lock = context_lock
 
     if bind_and_activate:
       try:
@@ -131,7 +128,7 @@ class PailgunServer(TCPServer):
     handler = self.RequestHandlerClass(request, client_address, self)
 
     try:
-      # Attempt to handle a request with the handler under the context_lock.
+      # Attempt to handle a request with the handler.
       handler.handle_request()
     except Exception as e:
       # If that fails, (synchronously) handle the error with the error handler sans-fork.

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -11,7 +11,7 @@ import traceback
 
 from six.moves.socketserver import BaseRequestHandler, BaseServer, TCPServer
 
-from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
+from pants.java.nailgun_protocol import NailgunProtocol
 from pants.util.contextutil import maybe_profiled
 from pants.util.socket import RecvBufferedSocket
 
@@ -83,8 +83,8 @@ class PailgunHandler(PailgunHandlerBase):
   def handle_error(self, exc=None):
     """Error handler for failed calls to handle()."""
     if exc:
-      NailgunProtocol.write_chunk(self.request, ChunkType.STDERR, traceback.format_exc())
-    NailgunProtocol.write_chunk(self.request, ChunkType.EXIT, '1')
+      NailgunProtocol.send_stderr(self.request, traceback.format_exc())
+    NailgunProtocol.send_exit(self.request, '1')
 
 
 class PailgunServer(TCPServer):

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -9,7 +9,6 @@ import logging
 import select
 import sys
 import traceback
-from contextlib import contextmanager
 
 from pants.pantsd.pailgun_server import PailgunServer
 from pants.pantsd.service.pants_service import PantsService

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -75,14 +75,17 @@ class PailgunService(PantsService):
             ''.join(traceback.format_exception(*deferred_exc))
           )
 
-      return self._runner_class(sock, exiter, arguments, environment, graph_helper, deferred_exc)
+      return self._runner_class(
+        sock,
+        exiter,
+        arguments,
+        environment,
+        graph_helper,
+        self.lock,
+        deferred_exc
+      )
 
-    @contextmanager
-    def context_lock():
-      with self.lock:
-        yield
-
-    return PailgunServer(self._bind_addr, runner_factory, context_lock)
+    return PailgunServer(self._bind_addr, runner_factory)
 
   def run(self):
     """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -55,7 +55,8 @@ class SchedulerService(PantsService):
 
   def _handle_batch_event(self, files):
     self._logger.debug('handling change event for: %s', files)
-    self._scheduler.invalidate_files(files)
+    with self.lock:
+      self._scheduler.invalidate_files(files)
 
   def _process_event_queue(self):
     """File event notification queue processor."""

--- a/src/python/pants/util/socket.py
+++ b/src/python/pants/util/socket.py
@@ -8,6 +8,17 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import errno
 import io
 import select
+import socket
+
+
+def teardown_socket(socket):
+  """Shuts down and closes a socket."""
+  try:
+    socket.shutdown(socket.SHUT_WR)
+  except socket.error:
+    pass
+  finally:
+    socket.close()
 
 
 def safe_select(*args, **kwargs):

--- a/src/python/pants/util/socket.py
+++ b/src/python/pants/util/socket.py
@@ -11,14 +11,14 @@ import select
 import socket
 
 
-def teardown_socket(socket):
+def teardown_socket(s):
   """Shuts down and closes a socket."""
   try:
-    socket.shutdown(socket.SHUT_WR)
+    s.shutdown(socket.SHUT_WR)
   except socket.error:
     pass
   finally:
-    socket.close()
+    s.close()
 
 
 def safe_select(*args, **kwargs):
@@ -37,14 +37,14 @@ def safe_select(*args, **kwargs):
 class RecvBufferedSocket(object):
   """A socket wrapper that simplifies recv() buffering."""
 
-  def __init__(self, socket, chunk_size=io.DEFAULT_BUFFER_SIZE, select_timeout=None):
+  def __init__(self, sock, chunk_size=io.DEFAULT_BUFFER_SIZE, select_timeout=None):
     """
-    :param socket socket: The socket.socket object to wrap.
+    :param socket sock: The socket.socket object to wrap.
     :param int chunk_size: The smallest max read size for calls to recv() in bytes.
     :param float select_timeout: The select timeout for a socket read in seconds. An integer value
                                  effectively makes self.recv non-blocking (default: None, blocking).
     """
-    self._socket = socket
+    self._socket = sock
     self._chunk_size = chunk_size
     self._select_timeout = select_timeout
     self._buffer = b''

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -58,7 +58,7 @@ class TestNailgunStreamWriter(unittest.TestCase):
   def test_run_stop_on_error(self, mock_select):
     mock_select.return_value = ([], [], [self.in_file])
     self.writer.run()
-    self.assertTrue(self.writer.is_stopped)
+    self.assertFalse(self.writer.is_alive())
     self.assertEquals(mock_select.call_count, 1)
 
   @mock.patch('os.read')
@@ -77,18 +77,16 @@ class TestNailgunStreamWriter(unittest.TestCase):
     # Exercise NailgunStreamWriter.running() and .run() simultaneously.
     inc = 0
     with self.writer.running():
-      while not self.writer.is_stopped:
+      while self.writer.is_alive():
         time.sleep(0.01)
         inc += 1
         if inc >= 1000:
           raise Exception('waited too long.')
 
-    self.assertTrue(self.writer.is_stopped)
+    self.assertFalse(self.writer.is_alive())
 
     mock_read.assert_called_with(-1, io.DEFAULT_BUFFER_SIZE)
     self.assertEquals(mock_read.call_count, 2)
-
-    self.mock_socket.shutdown.assert_called_once_with(socket.SHUT_WR)
 
     mock_writer.assert_has_calls([
       mock.call(mock.ANY, ChunkType.STDIN, b'A' * 300),

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import inspect
 import io
-import socket
 import time
 import unittest
 

--- a/tests/python/pants_test/java/test_nailgun_io.py
+++ b/tests/python/pants_test/java/test_nailgun_io.py
@@ -38,8 +38,12 @@ class TestNailgunStreamWriter(unittest.TestCase):
   def setUp(self):
     self.in_file = FakeFile()
     self.mock_socket = mock.Mock()
-    self.writer = NailgunStreamWriter(self.in_file, self.mock_socket,
-                                      ChunkType.STDIN, ChunkType.STDIN_EOF)
+    self.writer = NailgunStreamWriter(
+      (self.in_file,),
+      self.mock_socket,
+      (ChunkType.STDIN,),
+      ChunkType.STDIN_EOF
+    )
 
   def test_stop(self):
     self.assertFalse(self.writer.is_stopped)

--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -69,10 +69,11 @@ python_tests(
     'src/python/pants/pantsd:process_manager',
     'src/python/pants/util:collections',
     'tests/python/pants_test:int-test',
-    'tests/python/pants_test/testutils:process_test_util'
+    'tests/python/pants_test/testutils:process_test_util',
+    '3rdparty/python:ansicolors'
   ],
   tags = {'integration'},
-  timeout = 600
+  timeout = 900
 )
 
 python_tests(

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import socket
 import unittest
-from contextlib import contextmanager
 from SocketServer import TCPServer
 
 import mock
@@ -19,23 +18,17 @@ from pants.pantsd.pailgun_server import PailgunHandler, PailgunServer
 PATCH_OPTS = dict(autospec=True, spec_set=True)
 
 
-@contextmanager
-def mock_context_lock():
-  yield
-
-
 class TestPailgunServer(unittest.TestCase):
   def setUp(self):
     self.mock_handler_inst = mock.Mock()
     self.mock_runner_factory = mock.Mock(side_effect=Exception('this should never be called'))
     self.mock_handler_class = mock.Mock(return_value=self.mock_handler_inst)
-    self.scheduler_lock = mock_context_lock
+    self.scheduler_lock = mock.Mock()
     with mock.patch.object(PailgunServer, 'server_bind'), \
          mock.patch.object(PailgunServer, 'server_activate'):
       self.server = PailgunServer(
         server_address=('0.0.0.0', 0),
         runner_factory=self.mock_runner_factory,
-        context_lock=self.scheduler_lock,
         handler_class=self.mock_handler_class
       )
 

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -77,7 +77,7 @@ class PantsDaemonTest(BaseTest):
 
     self.mock_service.terminate.assert_called_once_with()
     self.assertTrue(self.pantsd.is_killed)
-    mock_thread.join.assert_called_once_with()
+    mock_thread.join.assert_called_once_with(PantsDaemon.JOIN_TIMEOUT_SECONDS)
 
   def test_run_services_no_services(self):
     self.pantsd._run_services([])

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -17,13 +17,17 @@ from pants.util.collections import combined_dict
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.process_test_util import assert_no_process_exists_by_command
 
+from colors import bold, cyan, magenta
+
 
 class PantsDaemonMonitor(ProcessManager):
   def __init__(self, metadata_base_dir=None):
     super(PantsDaemonMonitor, self).__init__(name='pantsd', metadata_base_dir=metadata_base_dir)
 
   def _log(self):
-    print('PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
+    print(magenta(
+      'PantsDaemonMonitor: pid is {} is_alive={}'.format(self._pid, self.is_alive()))
+    )
 
   def await_pantsd(self, timeout=3):
     self._process = None
@@ -44,9 +48,9 @@ class PantsDaemonMonitor(ProcessManager):
 
 
 def banner(s):
-  print('=' * 63)
-  print('- {} {}'.format(s, '-' * (60 - len(s))))
-  print('=' * 63)
+  print(cyan('=' * 63))
+  print(cyan('- {} {}'.format(s, '-' * (60 - len(s)))))
+  print(cyan('=' * 63))
 
 
 def read_pantsd_log(workdir):
@@ -101,13 +105,18 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
 
   def assert_success_runner(self, workdir, config, cmd, extra_config={}):
     combined_config = combined_dict(config, extra_config)
-    print('\nrunning: ./pants {} (config={})'.format(' '.join(cmd), combined_config))
+    print(bold(cyan('\nrunning: ./pants {} (config={})'
+                    .format(' '.join(cmd), combined_config))))
+    start_time = time.time()
     run = self.run_pants_with_workdir(
       cmd,
       workdir,
       combined_config,
       tee_output=True
     )
+    elapsed = time.time() - start_time
+    print(bold(cyan('\ncompleted in {} seconds'.format(elapsed))))
+
     self.assert_success(run)
     return run
 

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -112,7 +112,8 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
       cmd,
       workdir,
       combined_config,
-      tee_output=True
+      # TODO: With this uncommented, `test_pantsd_run` fails.
+      # tee_output=True
     )
     elapsed = time.time() - start_time
     print(bold(cyan('\ncompleted in {} seconds'.format(elapsed))))

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -12,12 +12,12 @@ import signal
 import time
 from contextlib import contextmanager
 
+from colors import bold, cyan, magenta
+
 from pants.pantsd.process_manager import ProcessManager
 from pants.util.collections import combined_dict
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.process_test_util import assert_no_process_exists_by_command
-
-from colors import bold, cyan, magenta
 
 
 class PantsDaemonMonitor(ProcessManager):

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -207,7 +207,7 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         pantsd_run(cmd[1:], {'GLOBAL': {'level': cmd[0]}})
         checker.assert_running()
 
-  def test_pantsd_runner_strays(self):
+  def test_pantsd_stray_runners(self):
     # Allow env var overrides for local stress testing.
     attempts = int(os.environ.get('PANTS_TEST_PANTSD_STRESS_ATTEMPTS', 20))
     cmd = os.environ.get('PANTS_TEST_PANTSD_STRESS_CMD', 'help').split()

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -197,7 +197,7 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
     with self.pantsd_successful_run_context('debug') as (pantsd_run, checker, _):
       pantsd_run(['help'])
       checker.await_pantsd()
-      for _ in xrange(attempts):
+      for _ in range(attempts):
         pantsd_run(['help'])
         checker.assert_running()
         assert_no_process_exists_by_command('pantsd-runner')

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -200,8 +200,8 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
 
   def test_pantsd_runner_strays(self):
     # Allow env var overrides for local stress testing.
-    attempts = int(os.environ.get('PANTS_TEST_PANTSD_ATTEMPTS', 20))
-    cmd = os.environ.get('PANTS_TEST_PANTSD_ATTEMPTS', 'help').split()
+    attempts = int(os.environ.get('PANTS_TEST_PANTSD_STRESS_ATTEMPTS', 20))
+    cmd = os.environ.get('PANTS_TEST_PANTSD_STRESS_CMD', 'help').split()
     with self.pantsd_successful_run_context('debug') as (pantsd_run, checker, _):
       pantsd_run(cmd)
       checker.await_pantsd()

--- a/tests/python/pants_test/testutils/process_test_util.py
+++ b/tests/python/pants_test/testutils/process_test_util.py
@@ -8,11 +8,18 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import psutil
 
 
-def check_process_exists_by_command(name):
+class ProcessStillRunning(AssertionError):
+  """Raised when a process shouldn't be running but is."""
+
+
+def assert_no_process_exists_by_command(name):
+  """Asserts that no process exists for a given command with a helpful error."""
   for proc in psutil.process_iter():
     try:
-      if name in ''.join(proc.cmdline()):
-        return True
+      cmdline = proc.cmdline()
+      if name in ''.join(cmdline):
+        raise ProcessStillRunning(
+          'a {} process was detected at PID {} (cmdline={})'.format(name, proc.pid(), cmdline)
+        )
     except (psutil.NoSuchProcess, psutil.AccessDenied):
       pass
-  return False

--- a/tests/python/pants_test/testutils/process_test_util.py
+++ b/tests/python/pants_test/testutils/process_test_util.py
@@ -19,7 +19,7 @@ def assert_no_process_exists_by_command(name):
       cmdline = proc.cmdline()
       if name in ''.join(cmdline):
         raise ProcessStillRunning(
-          'a {} process was detected at PID {} (cmdline={})'.format(name, proc.pid(), cmdline)
+          'a {} process was detected at PID {} (cmdline={})'.format(name, proc.pid, cmdline)
         )
     except (psutil.NoSuchProcess, psutil.AccessDenied):
       pass


### PR DESCRIPTION
### Problem

The introduction of `os.pipe()` usage for daemon stdio streams introduced 3 new threads (stdin, stdout, stderr) involved in every pantsd-runner run. Because the writers are running in python threads, it's possible (and likely, on my machine) for the main thread to write an `EXIT` chunk before the `NailgunStreamWriter` threads are able to wake up and write their payloads to the socket.

### Solution

Construct a finalizing function and pass this to the `DaemonExiter` to invoke before sending any exit chunks. This finalizer will stop and join the writer threads giving the writers a chance to emit any remaining output before termination.

### Result

Output truncation is no longer reproducible.