### PR TITLE
refactor optionable fingerprinting [WIP]

### DIFF
--- a/src/docs/dev_tasks.md
+++ b/src/docs/dev_tasks.md
@@ -109,15 +109,19 @@ required a product type:
 Task Implementation Versioning
 ------------------------------
 
-Tasks may optionally specify an implementation version.  This is useful to be sure that cached
-objects from previous runs of pants using an older version are not used.  If you change a task
-class in a way that will impact its outputs you should update the version.  Implementation
-versions are set with the class method implementation_version.
+Any
+[`Optionable`](https://github.com/pantsbuild/pants/blob/master/src/python/pants/option/optionable.py),
+including any `Task`, may optionally specify an implementation version. This is
+useful to be sure that cached objects from previous runs of pants using an older
+version are not used.  If you change a task class in a way that will impact its
+outputs you should update the version.  Implementation versions are set with the
+class method `implementation_version()`:
 
     :::python
     Class FooTask(Task):
       @classmethod
       def implementation_version(cls):
+        # NB: make sure to always append to the super class's implementation_version()!
         return super(FooTask, cls).implementation_version() + [('FooTask', 1)]
 
 We store both a version number and the name of the class in order to disambiguate changes in

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -92,7 +92,7 @@ class OptionsInitializer(object):
       set(Goal.get_optionables())
     )
     for ss in subsystems:
-      known_scope_infos |= set(ss.known_scope_infos())
+      known_scope_infos.update(ss.known_scope_infos())
 
     # Add scopes for all tasks in all goals.
     for goal in Goal.all():

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -88,7 +88,12 @@ class Optionable(OptionableFactory, AbstractClass):
   deprecated_options_scope = None
   deprecated_options_scope_removal_version = None
 
-  implementation_versions = []
+  @classmethod
+  def implementation_versions(cls):
+    """
+    :API: public
+    """
+    return []
 
   class CycleException(Exception):
     """Thrown when a circular dependency is detected."""
@@ -101,7 +106,7 @@ class Optionable(OptionableFactory, AbstractClass):
   @classmethod
   @memoized_method
   def implementation_version_str(cls):
-    return '.'.join(['_'.join(map(str, x)) for x in cls.implementation_versions])
+    return '.'.join(['_'.join(map(str, x)) for x in cls.implementation_versions()])
 
   @classmethod
   @memoized_method

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -59,18 +59,16 @@ class OptionableFactory(AbstractClass):
       )
 
 
-class SubsystemDependency(namedtuple('_SubsystemDependency', ('subsystem_cls', 'scope'))):
+class SubsystemDependency(datatype('_SubsystemDependency', ('subsystem_cls', 'scope'))):
   def subsystem_dependency_joined_scope(self):
     return self.subsystem_cls.subscope(self.scope)
 
 
 class SubsystemClientError(Exception): pass
 
-
-class Register(namedtuple('_Register', ('options', 'optionable', 'bootstrap', 'scope'))):
+class Register(datatype('_Register', ('options', 'optionable', 'bootstrap', 'scope'))):
   def __call__(self, *args, **kwargs):
     kwargs['registering_class'] = self.optionable
-    # print('args: {}, kwargs: {}'.format(args, kwargs))
     self.options.register(self.scope, *args, **kwargs)
 
 
@@ -88,8 +86,9 @@ class Optionable(OptionableFactory, AbstractClass):
   deprecated_options_scope = None
   deprecated_options_scope_removal_version = None
 
+  # TODO: rename to `implementation_versions` and make into a `classproperty`!
   @classmethod
-  def implementation_versions(cls):
+  def implementation_version(cls):
     """
     :API: public
     """
@@ -106,7 +105,7 @@ class Optionable(OptionableFactory, AbstractClass):
   @classmethod
   @memoized_method
   def implementation_version_str(cls):
-    return '.'.join(['_'.join(map(str, x)) for x in cls.implementation_versions()])
+    return '.'.join(['_'.join(map(str, x)) for x in cls.implementation_versions])
 
   @classmethod
   @memoized_method
@@ -241,7 +240,7 @@ class Optionable(OptionableFactory, AbstractClass):
 
     while len(q) > 0:
       (sdep, ss_path) = q.pop()
-      (ss, _) = sdep
+      ss = sdep.subsystem_cls
       if ss in ss_path:
         cycle = list(ss_path) + [ss]
         raise cls.CycleException(cycle)

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -89,7 +89,7 @@ class Options(object):
 
     Also adds any deprecated scopes.
     """
-    ret = {GlobalOptionsRegistrar.get_scope_info()}
+    ret = set(GlobalOptionsRegistrar.known_scope_infos())
     original_scopes = set()
     for si in scope_infos:
       ret.add(si)
@@ -283,20 +283,6 @@ class Options(object):
     deprecated_scope = self.known_scope_to_info[scope].deprecated_scope
     if deprecated_scope:
       self.get_parser(deprecated_scope).register(*args, **kwargs)
-
-  def registration_function_for_optionable(self, optionable_class):
-    """Returns a function for registering options on the given scope."""
-    self._assert_not_frozen()
-    # TODO(benjy): Make this an instance of a class that implements __call__, so we can
-    # docstring it, and so it's less weird than attatching properties to a function.
-    def register(*args, **kwargs):
-      kwargs['registering_class'] = optionable_class
-      self.register(optionable_class.options_scope, *args, **kwargs)
-    # Clients can access the bootstrap option values as register.bootstrap.
-    register.bootstrap = self.bootstrap_option_values()
-    # Clients can access the scope as register.scope.
-    register.scope = optionable_class.options_scope
-    return register
 
   def get_parser(self, scope):
     """Returns the parser for the given scope, so code can register on it directly."""

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -45,6 +45,12 @@ class Subsystem(Optionable):
         'Subsystem "{}" not initialized for scope "{}". '
         'Is subsystem missing from subsystem_dependencies() in a task? '.format(class_name, scope))
 
+  class NoMappingForKey(Exception):
+    """Thrown when a mapping doesn't exist for a given injectables key."""
+
+  class TooManySpecsForKey(Exception):
+    """Thrown when a mapping contains multiple specs when a singular spec is expected."""
+
   @classmethod
   def is_subsystem_type(cls, obj):
     return inspect.isclass(obj) and issubclass(obj, cls)

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -39,7 +39,9 @@ class Subsystem(Optionable):
   """
   options_scope_category = ScopeInfo.SUBSYSTEM
 
-  implementation_versions = [('Subsystem', 0)]
+  @classmethod
+  def implementation_versions(cls):
+    return super(Subsystem, cls).implementation_versions() + [('Subsystem', 0)]
 
   class UninitializedSubsystemError(SubsystemError):
     def __init__(self, class_name, scope):

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -6,16 +6,16 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import inspect
 
-from pants.option.optionable import Optionable
+from pants.build_graph.address import Address
+from pants.option.optionable import Optionable, SubsystemDependency
 from pants.option.scope import ScopeInfo
-from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin, SubsystemDependency
 
 
 class SubsystemError(Exception):
   """An error in a subsystem."""
 
 
-class Subsystem(SubsystemClientMixin, Optionable):
+class Subsystem(Optionable):
   """A separable piece of functionality that may be reused across multiple tasks or other code.
 
   Subsystems encapsulate the configuration and initialization of things like JVMs,

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -40,8 +40,8 @@ class Subsystem(Optionable):
   options_scope_category = ScopeInfo.SUBSYSTEM
 
   @classmethod
-  def implementation_versions(cls):
-    return super(Subsystem, cls).implementation_versions() + [('Subsystem', 0)]
+  def implementation_version(cls):
+    return super(Subsystem, cls).implementation_version() + [('Subsystem', 0)]
 
   class UninitializedSubsystemError(SubsystemError):
     def __init__(self, class_name, scope):

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -39,6 +39,8 @@ class Subsystem(Optionable):
   """
   options_scope_category = ScopeInfo.SUBSYSTEM
 
+  implementation_versions = [('Subsystem', 0)]
+
   class UninitializedSubsystemError(SubsystemError):
     def __init__(self, class_name, scope):
       super(Subsystem.UninitializedSubsystemError, self).__init__(

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -58,7 +58,9 @@ class TaskBase(Optionable, AbstractClass):
   """
   options_scope_category = ScopeInfo.TASK
 
-  implementation_versions = [('TaskBase', 2)]
+  @classmethod
+  def implementation_versions(cls):
+    return super(TaskBase, cls).implementation_versions() + [('TaskBase', 2)]
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -141,6 +141,7 @@ class TaskBase(Optionable, AbstractClass):
     self._cache_factory = CacheSetup.create_cache_factory_for_task(self)
     self._force_invalidated = False
 
+  # TODO: which fingerprint to use????
   @memoized_property
   def _build_invalidator(self):
     return BuildInvalidator.Factory.create(build_task=self.fingerprint)

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -272,16 +272,12 @@ class TaskBase(Optionable, AbstractClass):
   # TODO: move some stuff back to Task, and move some of the new subsystem dependency stuff to
   # Optionable!
   def _options_fingerprint(self, scope):
-    options_hasher = sha1()
-    options_hasher.update(scope.encode('utf-8'))
-    options_fp = OptionsFingerprinter.combined_options_fingerprint_for_scope(
+    return OptionsFingerprinter.combined_options_fingerprint_for_scope(
       scope,
       self.context.options,
       build_graph=self.context.build_graph,
       include_passthru=self.supports_passthru_args(),
     )
-    options_hasher.update(options_fp.encode('utf-8'))
-    return options_hasher.hexdigest() if PY3 else options_hasher.hexdigest().decode('utf-8')
 
   @memoized_property
   def fingerprint(self):

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -143,11 +143,13 @@ class TaskBase(Optionable, AbstractClass):
   def _build_invalidator(self):
     return BuildInvalidator.Factory.create(build_task=self.fingerprint)
 
-  def _fingerprint(self):
+  @memoized_property
+  def fingerprint(self):
     hasher = sha1()
-    for scope_info in self.known_scope_infos():
+    hasher.update(super(TaskBase, self).fingerprint)
+    for scope_info in self.closure_scope_info_strs():
       pairs = self.context.options.get_fingerprintable_for_scope(
-        scope_info.scope,
+        scope_info,
         include_passthru=self.supports_passthru_args())
       for (option_type, option_val) in pairs:
         fp = self._options_fingerprinter.fingerprint(option_type, option_val)

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -59,8 +59,8 @@ class TaskBase(Optionable, AbstractClass):
   options_scope_category = ScopeInfo.TASK
 
   @classmethod
-  def implementation_versions(cls):
-    return super(TaskBase, cls).implementation_versions() + [('TaskBase', 2)]
+  def implementation_version(cls):
+    return super(TaskBase, cls).implementation_version() + [('TaskBase', 2)]
 
   @classmethod
   def subsystem_dependencies(cls):

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -120,7 +120,8 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
     def scope_to_flags(self):
       return {}
 
-    def get_fingerprintable_for_scope(self, bottom_scope, include_passthru=False):
+    def get_fingerprintable_for_scope(self, bottom_scope, include_passthru=False,
+                                      fingerprint_key=None, invert=False):
       """Returns a list of fingerprintable (option type, option value) pairs for
       the given scope.
 
@@ -131,6 +132,10 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
       :param bool include_passthru: Whether to include passthru args captured by `bottom_scope` in the
                                     fingerprintable options.
       """
+      if fingerprint_key is not None:
+        raise Exception('fingerprint key not none: {}'.format(fingerprint_key))
+      if invert is True:
+        raise Exception('invert is true')
       pairs = []
       if include_passthru:
         pu_args = self.passthru_args_for_scope(bottom_scope)

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -222,7 +222,7 @@ class SubsystemTest(unittest.TestCase):
       def subsystem_dependencies(cls):
         return (DummySubsystem.scoped(cls), SubsystemB)
 
-    dep_scopes = {dep.options_scope for dep in SubsystemA.subsystem_dependencies_iter()}
+    dep_scopes = set(dep.subsystem_dependency_joined_scope() for dep in SubsystemA.subsystem_dependencies_iter())
     self.assertEqual({'b', 'dummy.a'}, dep_scopes)
 
   def test_subsystem_closure_iter(self):


### PR DESCRIPTION
### Problem

This started off as a one-line fix for #4966, but while researching that I found #2739 and thought it would make sense to move fingerprinting logic into `Optionable`, so made changes for that as well.

This PR should be considered a WIP -- it still needs updated docstrings, and has no added tests.

### Solution

- Merge `SubsystemClientMixin` into `Optionable`, along with the fingerprinting logic from `TaskBase`. `TaskBase` now has a specialized `fingerprint` property, and `Subsystem` now gets a fingerprint property from `Optionable`.
- Add `stable_name` to the `fingerprint` for `Optionable`.
- Simplify option registration logic by introducing `Register` and removing `registration_function_for_optionable` from `Optionable`.

### Result

- Any `Optionable` now has a `fingerprint` property (including `Subsystem`). This fingerprint now includes `stable_name` and `implementation_versions`, and recurses into subsystem dependencies.
- Any class deriving from `TaskBase` adds fingerprints for all the key-value pairs of all options specified, also recursing into subsystem dependencies. This fingerprint may be possible to move into `Optionable`, but I'm not sure how to obtain an `OptionFingerprinter`.