### PR TITLE
Fix showing test output that happens after the tests are finished

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -303,6 +303,8 @@ public class ConsoleRunnerImpl {
 
     @Override
     public void testFinished(Description description) throws Exception {
+      swappableOut.swap(swappableOut.getOriginal());
+      swappableErr.swap(swappableErr.getOriginal());
       suiteCaptures.get(description.getTestClass()).close();
       if (caseCaptures.containsKey(description)) {
         caseCaptures.remove(description).close();

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImplTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImplTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.notification.RunListener;
 import org.pantsbuild.tools.junit.lib.AllFailingTest;
 import org.pantsbuild.tools.junit.lib.AllPassingTest;
 import org.pantsbuild.tools.junit.lib.ExceptionInSetupTest;
+import org.pantsbuild.tools.junit.lib.LogOutputInTeardownTest;
 import org.pantsbuild.tools.junit.lib.OutputModeTest;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -251,5 +252,13 @@ public class ConsoleRunnerImplTest {
     String output = runTest(AllPassingTest.class, true);
     assertThat(output, containsString("OK (4 tests)"));
     assertThat(output, containsString("java.io.IOException: Bogus IOException"));
+  }
+
+  @Test
+  public void testOutputAfterTestFinished() {
+    outputMode = ConsoleRunnerImpl.OutputMode.ALL;
+    String output = runTest(LogOutputInTeardownTest.class);
+    assertThat(output, containsString("Output in tearDown"));
+    assertThat(output, containsString("OK (1 test)"));
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/lib/LogOutputInTeardownTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/LogOutputInTeardownTest.java
@@ -1,0 +1,21 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogOutputInTeardownTest {
+  @AfterClass
+  public static void tearDown() {
+    System.out.println("Output in tearDown");
+  }
+
+  @Test
+  public void test() {
+    Assert.assertTrue(true);
+  }
+}


### PR DESCRIPTION
### Problem

If a test prints output after all of the test are finished the test runner will only print the first character of the output. 

### Solution

In the ConsoleTestRunner the swappableOut and swappableErr streams are directed at a TeeOutputStream that prints to both stdout and a log file.  When a test is finished the log file is closed but the swappableOut and swappableErr were still pointed at the TeeOutputStreem which uses the logfile for output.  When you try to write to one of the swappable streams the first character to stdout prints but then throws and exception when it tries to print to the closed log file.  The fix is to swap the swappable streams back to their original streams before closing the log file streams.

### Result

Instead of only getting the first character of each line of output you now get all of the output after the tests are finished.