### PR TITLE
Add a centos6 Dockerfile

### DIFF
--- a/build-support/docker/centos6/Dockerfile
+++ b/build-support/docker/centos6/Dockerfile
@@ -4,13 +4,6 @@
 # Use centos6 for compatibility with glibc 2.12.
 FROM centos:6
 
-# Ensure Pants runs under the 2.7.13 interpreter.
-ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
-
-# TODO: Not https? Now we're really doing some science!
-RUN curl -o /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo
-RUN rpm --import http://linuxsoft.cern.ch/cern/slc6X/x86_64/RPM-GPG-KEY-cern
-
 # Install python 2.7.13, (more) modern gcc, and a JDK.
 RUN yum -y update
 RUN yum install -y centos-release-scl

--- a/build-support/docker/centos6/Dockerfile
+++ b/build-support/docker/centos6/Dockerfile
@@ -21,21 +21,5 @@ RUN yum install -y \
   java-1.8.0-openjdk-devel \
   python27
 
-# Setup mount points for the travis ci user & workdir.
-VOLUME /travis/home
-VOLUME /travis/workdir
-
-# Setup a non-root user to execute the build under (avoids problems with npm install).
-ARG TRAVIS_USER=travis_ci
-ARG TRAVIS_UID=1000
-ARG TRAVIS_GROUP=root
-ARG TRAVIS_GID=0
-
-RUN groupadd --gid ${TRAVIS_GID} ${TRAVIS_GROUP}
-RUN useradd -d /travis/home -g ${TRAVIS_GROUP} --uid ${TRAVIS_UID} ${TRAVIS_USER}
-USER ${TRAVIS_USER}:${TRAVIS_GROUP}
-
-WORKDIR /travis/workdir
-
 # By default, execute in an environment with python27 enabled.
 ENTRYPOINT ["/usr/bin/scl", "enable", "python27", "devtoolset-7",  "--"]

--- a/build-support/docker/centos6/Dockerfile
+++ b/build-support/docker/centos6/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Use centos6 for compatibility with glibc 2.12.
+FROM centos:6
+
+# Ensure Pants runs under the 2.7.13 interpreter.
+ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
+
+# TODO: Not https? Now we're really doing some science!
+RUN curl -o /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo
+RUN rpm --import http://linuxsoft.cern.ch/cern/slc6X/x86_64/RPM-GPG-KEY-cern
+
+# Install python 2.7.13, (more) modern gcc, and a JDK.
+RUN yum -y update
+RUN yum install -y centos-release-scl
+RUN yum install -y \
+  devtoolset-7-gcc \
+  devtoolset-7-gcc-c++ \
+  git \
+  java-1.8.0-openjdk-devel \
+  python27
+
+# Setup mount points for the travis ci user & workdir.
+VOLUME /travis/home
+VOLUME /travis/workdir
+
+# Setup a non-root user to execute the build under (avoids problems with npm install).
+ARG TRAVIS_USER=travis_ci
+ARG TRAVIS_UID=1000
+ARG TRAVIS_GROUP=root
+ARG TRAVIS_GID=0
+
+RUN groupadd --gid ${TRAVIS_GID} ${TRAVIS_GROUP}
+RUN useradd -d /travis/home -g ${TRAVIS_GROUP} --uid ${TRAVIS_UID} ${TRAVIS_USER}
+USER ${TRAVIS_USER}:${TRAVIS_GROUP}
+
+WORKDIR /travis/workdir
+
+# By default, execute in an environment with python27 enabled.
+ENTRYPOINT ["/usr/bin/scl", "enable", "python27", "devtoolset-7",  "--"]

--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -19,4 +19,7 @@ RUN groupadd --gid ${TRAVIS_GID} ${TRAVIS_GROUP}
 RUN useradd -d /travis/home -g ${TRAVIS_GROUP} --uid ${TRAVIS_UID} ${TRAVIS_USER}
 USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 
+# Ensure Pants runs under the 2.7.13 interpreter.
+ENV PANTS_PYTHON_SETUP_INTERPRETER_CONSTRAINTS="['CPython==2.7.13']"
+
 WORKDIR /travis/workdir


### PR DESCRIPTION
### Problem

The wheels built in #5118 and consumed in #5159 are built in debian wheezy, meaning that they have a glibc 2.13 dependency... centos6 (still consumed in various places at Twitter) uses glibc 2.12.

More generally, it is beneficial to have binary releases of pants be compatible with as many linux distributions as possible (those that are in active use, at least).

### Solution

Add a centos6 docker image, which was previously confirmed here to be capable of building pants.

### Result

In a future change (once this image is published to https://hub.docker.com/r/pantsbuild/), we will switch the linux binary builder shard (`build-support/docker/travis_ci/Dockerfile`) to this image.