### PR TITLE
Fix thrift handling in the new python pipeline.

### DIFF
--- a/examples/src/thrift/org/pantsbuild/example/distance/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/distance/BUILD
@@ -18,3 +18,7 @@ python_thrift_library(name='distance-python',
     version='0.0.1',
   )
 )
+
+python_thrift_library(name='unexported-distance-python',
+  sources=['distance.thrift'],
+)

--- a/examples/src/thrift/org/pantsbuild/example/precipitation/BUILD
+++ b/examples/src/thrift/org/pantsbuild/example/precipitation/BUILD
@@ -18,4 +18,19 @@ python_thrift_library(name='precipitation-python',
   dependencies=[
     'examples/src/thrift/org/pantsbuild/example/distance:distance-python',
   ],
+  provides=setup_py(
+    name='pantsbuild.pants.precipitation-thrift-python',
+    version='0.0.1',
+  )
+)
+
+python_thrift_library(name='monolithic-precipitation-python',
+  sources=['precipitation.thrift'],
+  dependencies=[
+    'examples/src/thrift/org/pantsbuild/example/distance:unexported-distance-python',
+  ],
+  provides=setup_py(
+    name='pantsbuild.pants.monolithic-precipitation-thrift-python',
+    version='0.0.1',
+  )
 )

--- a/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
+++ b/src/python/pants/backend/codegen/thrift/python/apache_thrift_py_gen.py
@@ -10,7 +10,7 @@ import os
 from pants.backend.codegen.thrift.lib.apache_thrift_gen_base import ApacheThriftGenBase
 from pants.backend.codegen.thrift.python.python_thrift_library import PythonThriftLibrary
 from pants.backend.python.targets.python_library import PythonLibrary
-from pants.util.dirutil import safe_delete
+from pants.util.dirutil import safe_delete, safe_walk
 
 
 class ApacheThriftPyGen(ApacheThriftGenBase):
@@ -26,9 +26,28 @@ class ApacheThriftPyGen(ApacheThriftGenBase):
 
   def execute_codegen(self, target, target_workdir):
     super(ApacheThriftPyGen, self).execute_codegen(target, target_workdir)
-    # Thrift puts an __init__.py file at the root, and we don't want one there
-    # (it's not needed, and it confuses some import mechanisms).
-    safe_delete(os.path.join(target_workdir, '__init__.py'))
+
+    # Thrift generates code with all parent namespaces with empty __init__.py's. Since pants allows
+    # splitting a thrift namespace hierarchy across multiple packages, we explicitly insert
+    # namespace packages to allow for consumption of 2 or more of these packages in the same
+    # PYTHONPATH.
+    for root, _, files in safe_walk(target_workdir):
+      if '__init__.py' not in files:  # skip non-packages
+        continue
+
+      init_py_abspath = os.path.join(root, '__init__.py')
+
+      # Thrift puts an __init__.py file at the root, and we don't want one there (it's not needed,
+      # and it confuses some import mechanisms).
+      if root == target_workdir:
+        safe_delete(init_py_abspath)
+      elif os.path.getsize(init_py_abspath) == 0:  # empty __init__, translate to namespace package
+        with open(init_py_abspath, 'wb') as f:
+          f.write(b"__import__('pkg_resources').declare_namespace(__name__)")
+      else:
+        # A non-empty __init__, this is a leaf package, usually with ttypes and constants; so we
+        # leave as-is.
+        pass
 
   def ignore_dup(self, tgt1, tgt2, rel_src):
     # Thrift generates all the intermediate __init__.py files, and they shouldn't

--- a/tests/python/pants_test/backend/codegen/thrift/python/BUILD
+++ b/tests/python/pants_test/backend/codegen/thrift/python/BUILD
@@ -3,6 +3,7 @@
 
 python_tests(
   dependencies=[
+    '3rdparty/python:six',
     'src/python/pants/backend/codegen/thrift/python',
     'src/python/pants/backend/python/targets:python',
     'tests/python/pants_test/tasks:task_test_base',

--- a/tests/python/pants_test/backend/python/tasks2/test_setup_py_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_setup_py_integration.py
@@ -13,47 +13,122 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class SetupPyIntegrationTest(PantsRunIntegrationTest):
 
-  def test_setup_py_with_codegen(self):
-    self.maxDiff = None
+  def assert_sdist(self, pants_run, key, files):
+    sdist_path = 'dist/{}-0.0.1.tar.gz'.format(key)
+    self.assertTrue(re.search(r'Writing .*/{}'.format(sdist_path), pants_run.stdout_data))
 
-    sdist_path = 'dist/pantsbuild.pants.distance-thrift-python-0.0.1.tar.gz'
+    src_entries = ['src/{}'.format(f) for f in files]
+
+    egg_info_entries = [
+      'src/{}.egg-info/{}'.format(key.replace('-', '_'), relpath) for relpath in [
+        '',
+        'dependency_links.txt',
+        'PKG-INFO',
+        'requires.txt',
+        'SOURCES.txt',
+        'namespace_packages.txt',
+        'top_level.txt',
+      ]
+    ]
+
+    expected_entries = [
+      '{}-0.0.1/{}'.format(key, relpath) for relpath in [
+        '',
+        'MANIFEST.in',
+        'PKG-INFO',
+        'setup.cfg',
+        'setup.py',
+        'src/',
+      ] + src_entries + egg_info_entries
+    ]
+
+    with tarfile.open(sdist_path, 'r') as sdist:
+      infos = sdist.getmembers()
+      entries = [(info.name.rstrip('/') + '/' if info.isdir() else info.name) for info in infos]
+      self.assertEquals(sorted(expected_entries), sorted(entries),
+                        '\nExpected entries:\n{}\n\nActual entries:\n{}'.format(
+                          '\n'.join(sorted(expected_entries)),
+                          '\n'.join(sorted(entries))))
+
+  def test_setup_py_with_codegen_simple(self):
+    self.maxDiff = None
 
     command = ['setup-py',
                'examples/src/thrift/org/pantsbuild/example/distance:distance-python']
     pants_run = self.run_pants(command=command)
     self.assert_success(pants_run)
-    self.assertTrue(re.search(r'Writing .*/{}'.format(sdist_path), pants_run.stdout_data))
-    with tarfile.open(sdist_path, 'r') as sdist:
-      entries = sdist.getnames()
-    print(entries)
-    expected_prefix = 'pantsbuild.pants.distance-thrift-python-0.0.1'
-    expected_entries = [
-        expected_prefix + relpath for relpath in [
-        '',
-        '/MANIFEST.in',
-        '/PKG-INFO',
-        '/setup.cfg',
-        '/setup.py',
-        '/src',
-        '/src/org',
-        '/src/org/__init__.py',
-        '/src/org/pantsbuild',
-        '/src/org/pantsbuild/__init__.py',
-        '/src/org/pantsbuild/example',
-        '/src/org/pantsbuild/example/__init__.py',
-        '/src/org/pantsbuild/example/distance',
-        '/src/org/pantsbuild/example/distance/__init__.py',
-        '/src/org/pantsbuild/example/distance/constants.py',
-        '/src/org/pantsbuild/example/distance/ttypes.py',
-        '/src/pantsbuild.pants.distance_thrift_python.egg-info',
-        '/src/pantsbuild.pants.distance_thrift_python.egg-info/dependency_links.txt',
-        '/src/pantsbuild.pants.distance_thrift_python.egg-info/PKG-INFO',
-        '/src/pantsbuild.pants.distance_thrift_python.egg-info/requires.txt',
-        '/src/pantsbuild.pants.distance_thrift_python.egg-info/SOURCES.txt',
-        '/src/pantsbuild.pants.distance_thrift_python.egg-info/top_level.txt'
-      ]
+
+    self.assert_sdist(pants_run,
+                      'pantsbuild.pants.distance-thrift-python',
+                      ['org/',
+                       'org/__init__.py',
+                       'org/pantsbuild/',
+                       'org/pantsbuild/__init__.py',
+                       'org/pantsbuild/example/',
+                       'org/pantsbuild/example/__init__.py',
+                       'org/pantsbuild/example/distance/',
+                       'org/pantsbuild/example/distance/__init__.py',
+                       'org/pantsbuild/example/distance/constants.py',
+                       'org/pantsbuild/example/distance/ttypes.py'])
+
+  def test_setup_py_with_codegen_exported_deps(self):
+    self.maxDiff = None
+
+    command = ['setup-py',
+               '--recursive',
+               'examples/src/thrift/org/pantsbuild/example/precipitation:precipitation-python']
+    pants_run = self.run_pants(command=command)
+    self.assert_success(pants_run)
+
+    self.assert_sdist(pants_run,
+                      'pantsbuild.pants.precipitation-thrift-python',
+                      ['org/',
+                       'org/__init__.py',
+                       'org/pantsbuild/',
+                       'org/pantsbuild/__init__.py',
+                       'org/pantsbuild/example/',
+                       'org/pantsbuild/example/__init__.py',
+                       'org/pantsbuild/example/precipitation/',
+                       'org/pantsbuild/example/precipitation/__init__.py',
+                       'org/pantsbuild/example/precipitation/constants.py',
+                       'org/pantsbuild/example/precipitation/ttypes.py'])
+
+    self.assert_sdist(pants_run,
+                      'pantsbuild.pants.distance-thrift-python',
+                      ['org/',
+                       'org/__init__.py',
+                       'org/pantsbuild/',
+                       'org/pantsbuild/__init__.py',
+                       'org/pantsbuild/example/',
+                       'org/pantsbuild/example/__init__.py',
+                       'org/pantsbuild/example/distance/',
+                       'org/pantsbuild/example/distance/__init__.py',
+                       'org/pantsbuild/example/distance/constants.py',
+                       'org/pantsbuild/example/distance/ttypes.py'])
+
+  def test_setup_py_with_codegen_unexported_deps(self):
+    self.maxDiff = None
+
+    command = [
+      'setup-py',
+      'examples/src/thrift/org/pantsbuild/example/precipitation:monolithic-precipitation-python'
     ]
-    self.assertEquals(
-      sorted(expected_entries),
-      sorted(entries)
-    )
+    pants_run = self.run_pants(command=command)
+    self.assert_success(pants_run)
+
+    self.assert_sdist(pants_run,
+                      'pantsbuild.pants.monolithic-precipitation-thrift-python',
+                      ['org/',
+                       'org/__init__.py',
+                       'org/pantsbuild/',
+                       'org/pantsbuild/__init__.py',
+                       'org/pantsbuild/example/',
+                       'org/pantsbuild/example/__init__.py',
+                       'org/pantsbuild/example/distance/',
+                       'org/pantsbuild/example/distance/__init__.py',
+                       'org/pantsbuild/example/distance/constants.py',
+                       'org/pantsbuild/example/distance/ttypes.py',
+                       'org/pantsbuild/example/precipitation/',
+                       'org/pantsbuild/example/precipitation/__init__.py',
+                       'org/pantsbuild/example/precipitation/constants.py',
+                       'org/pantsbuild/example/precipitation/ttypes.py'])


### PR DESCRIPTION
The old pipeline supported breaking up a thrift graph into multiple
packages by inserting namespace packages in the generated code but this
support had not been ported to the new pipeline. This is now supported
in the new pipeline with test coverage.

Additionally, `setup-py` did not handle thrift graphs, rejecting them
during the target ownership check phase. Fix this phase to only check
original targets and delay generated source file replacment until target
write time.

Fixes #5153