### PR TITLE
Update junit-runner to 1.0.21

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -20,7 +20,7 @@ class JUnit(JvmToolMixin, Subsystem):
   RUNNER_MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   LIBRARY_JAR = JarDependency(org='junit', name='junit', rev=LIBRARY_REV)
-  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.17')
+  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.21')
 
   @classmethod
   def register_options(cls, register):

--- a/tests/java/org/pantsbuild/tools/junit/README
+++ b/tests/java/org/pantsbuild/tools/junit/README
@@ -41,5 +41,7 @@ III.) The operation below should be done on MASTER. Publish a jar with:
 3) looks ok? do it:
 yes | ./pants publish.jar --no-dryrun src/java/org/pantsbuild/tools/junit
 
+4) Follow the steps at https://www.pantsbuild.org/release_jvm.html to promote the jar to Maven Central.
+
 IV.) Switch back to a dev branch. Make a change that bumps the revision number in BUILD.tools and
 un-@Ignores any tests temporarily ignored in step I.


### PR DESCRIPTION
### Problem

Truncated logging output in test tearDown. https://github.com/pantsbuild/pants/pull/5165

### Solution

Update junit-runner to pick up https://github.com/pantsbuild/pants/pull/5165
