### PR TITLE
Close suiteCaptures after all tests are finished instead of after each test

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -72,10 +72,8 @@ public class ConsoleRunnerImpl {
       this.original = out;
     }
 
-    OutputStream swap(OutputStream out) {
-      OutputStream old = this.out;
+    void swap(OutputStream out) {
       this.out = out;
-      return old;
     }
 
     /**
@@ -96,16 +94,11 @@ public class ConsoleRunnerImpl {
     private final File err;
     private OutputStream errstream;
 
-    private int useCount;
     private boolean closed;
 
-    StreamCapture(File out, File err) throws IOException {
+    StreamCapture(File out, File err) {
       this.out = out;
       this.err = err;
-    }
-
-    void incrementUseCount() {
-      this.useCount++;
     }
 
     OutputStream getOutputStream() throws FileNotFoundException {
@@ -123,7 +116,7 @@ public class ConsoleRunnerImpl {
     }
 
     void close() throws IOException {
-      if (--useCount <= 0 && !closed) {
+      if (!closed) {
         if (outstream != null) {
           Closeables.close(outstream, /* swallowIOException */ true);
         }
@@ -132,11 +125,6 @@ public class ConsoleRunnerImpl {
         }
         closed = true;
       }
-    }
-
-    void dispose() throws IOException {
-      useCount = 0;
-      close();
     }
 
     byte[] readOut() throws IOException {
@@ -243,7 +231,6 @@ public class ConsoleRunnerImpl {
             suiteCapture = new StreamCapture(out, err);
             suiteCaptures.put(test.getTestClass(), suiteCapture);
           }
-          suiteCapture.incrementUseCount();
         }
       }
     }
@@ -251,7 +238,7 @@ public class ConsoleRunnerImpl {
     @Override
     public void testRunFinished(Result result) throws Exception {
       for (StreamCapture capture : suiteCaptures.values()) {
-        capture.dispose();
+        capture.close();
       }
       caseCaptures.clear();
       super.testRunFinished(result);
@@ -295,7 +282,8 @@ public class ConsoleRunnerImpl {
           swappableErr.getOriginal().append(new String(capture.readErr(), UTF_8));
         } else {
           // Do nothing.
-          // In case of exception in @BeforeClass method testFailure executes without testStarted.
+          // When there is an exception in a @BeforeClass method the testStarted callback is not
+          // called before the testFailure callback so there will be no caseCapture for the test.
         }
       }
       super.testFailure(failure);
@@ -303,9 +291,6 @@ public class ConsoleRunnerImpl {
 
     @Override
     public void testFinished(Description description) throws Exception {
-      swappableOut.swap(swappableOut.getOriginal());
-      swappableErr.swap(swappableErr.getOriginal());
-      suiteCaptures.get(description.getTestClass()).close();
       if (caseCaptures.containsKey(description)) {
         caseCaptures.remove(description).close();
       }

--- a/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImplTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImplTest.java
@@ -10,6 +10,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -31,7 +33,7 @@ import static org.junit.Assert.fail;
 
 /**
  * These tests are similar to the tests in ConsoleRunnerTest but they create a ConosoleRunnerImpl
- * directory so they can capture the output more easily and test assertions based on the output.
+ * directory so they can capture and make assertions on the output.
  */
 public class ConsoleRunnerImplTest {
 
@@ -82,7 +84,7 @@ public class ConsoleRunnerImplTest {
   }
 
   private String runTest(Class testClass) {
-    return runTests(Lists.newArrayList(testClass.getCanonicalName()), false);
+    return runTest(testClass, false);
   }
 
   private String runTest(Class testClass, boolean shouldFail) {
@@ -92,6 +94,13 @@ public class ConsoleRunnerImplTest {
   private String runTests(List<String> tests, boolean shouldFail) {
     ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     PrintStream outputStream = new PrintStream(outContent);
+
+    // Clean log files
+    for (File file : outdir.listFiles()) {
+      if (file.getName().endsWith("txt")) {
+        file.delete();
+      }
+    }
 
     ConsoleRunnerImpl runner = new ConsoleRunnerImpl(
         failFast,
@@ -189,6 +198,8 @@ public class ConsoleRunnerImplTest {
     assertThat(output, containsString("testFails(org.pantsbuild.tools.junit.lib.OutputModeTest)"));
     assertThat(output, containsString("testErrors(org.pantsbuild.tools.junit.lib.OutputModeTest)"));
     assertThat(output, containsString("Tests run: 3,  Failures: 2"));
+    String testLogContents = getTestLogContents(OutputModeTest.class, ".out.txt");
+    assertThat(testLogContents, containsString("Output from passing test"));
 
     outputMode = ConsoleRunnerImpl.OutputMode.FAILURE_ONLY;
     output = runTest(OutputModeTest.class, true);
@@ -200,6 +211,8 @@ public class ConsoleRunnerImplTest {
     assertThat(output, containsString("testFails(org.pantsbuild.tools.junit.lib.OutputModeTest)"));
     assertThat(output, containsString("testErrors(org.pantsbuild.tools.junit.lib.OutputModeTest)"));
     assertThat(output, containsString("Tests run: 3,  Failures: 2"));
+    testLogContents = getTestLogContents(OutputModeTest.class, ".out.txt");
+    assertThat(testLogContents, containsString("Output from passing test"));
 
     outputMode = ConsoleRunnerImpl.OutputMode.NONE;
     output = runTest(OutputModeTest.class, true);
@@ -211,6 +224,8 @@ public class ConsoleRunnerImplTest {
     assertThat(output, containsString("testFails(org.pantsbuild.tools.junit.lib.OutputModeTest)"));
     assertThat(output, containsString("testErrors(org.pantsbuild.tools.junit.lib.OutputModeTest)"));
     assertThat(output, containsString("Tests run: 3,  Failures: 2"));
+    testLogContents = getTestLogContents(OutputModeTest.class, ".out.txt");
+    assertThat(testLogContents, containsString("Output from passing test"));
   }
 
   @Test
@@ -259,6 +274,32 @@ public class ConsoleRunnerImplTest {
     outputMode = ConsoleRunnerImpl.OutputMode.ALL;
     String output = runTest(LogOutputInTeardownTest.class);
     assertThat(output, containsString("Output in tearDown"));
-    assertThat(output, containsString("OK (1 test)"));
+    assertThat(output, containsString("OK (3 tests)"));
+    String testLogContents = getTestLogContents(LogOutputInTeardownTest.class, ".out.txt");
+    assertThat(testLogContents, containsString("Output in tearDown"));
+
+    outputMode = ConsoleRunnerImpl.OutputMode.FAILURE_ONLY;
+    output = runTest(LogOutputInTeardownTest.class);
+    assertThat(output, not(containsString("Output in tearDown")));
+    assertThat(output, containsString("OK (3 tests)"));
+    testLogContents = getTestLogContents(LogOutputInTeardownTest.class, ".out.txt");
+    assertThat(testLogContents, containsString("Output in tearDown"));
+
+    outputMode = ConsoleRunnerImpl.OutputMode.NONE;
+    output = runTest(LogOutputInTeardownTest.class);
+    assertThat(output, not(containsString("Output in tearDown")));
+    assertThat(output, containsString("OK (3 tests)"));
+    testLogContents = getTestLogContents(LogOutputInTeardownTest.class, ".out.txt");
+    assertThat(testLogContents, containsString("Output in tearDown"));
+  }
+
+  private String getTestLogContents(Class testClass, String extension) {
+    try {
+      return new String(
+          Files.readAllBytes(Paths.get(outdir.getPath(), testClass.getCanonicalName() + extension)),
+          Charsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/tests/java/org/pantsbuild/tools/junit/lib/LogOutputInTeardownTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/LogOutputInTeardownTest.java
@@ -15,7 +15,17 @@ public class LogOutputInTeardownTest {
   }
 
   @Test
-  public void test() {
+  public void testOne() {
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testTwo() {
+    Assert.assertTrue(true);
+  }
+
+  @Test
+  public void testThree() {
     Assert.assertTrue(true);
   }
 }


### PR DESCRIPTION
### Problem

Output in tearDown may get sent to stdout even when you are using OutputMode.NONE.  Based on @baroquebobcat's feedback in https://github.com/pantsbuild/pants/pull/5165.  Also some minor cleanup of other methods.

### Solution

Close the suiteCapture at the very end of the test run instead of after each test is finished so we can write to it during test tearDown

### Result

Should not get any extra output with OutputMode.NONE when there is output in tearDown.