### PR TITLE
Remove scheduler lock

### DIFF
--- a/pants.daemon.ini
+++ b/pants.daemon.ini
@@ -26,3 +26,4 @@
 
 [GLOBAL]
 enable_pantsd: True
+level: debug

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -93,10 +93,9 @@ class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'symbol_ta
     logger.debug('target_roots are: %r', target_roots)
     graph = LegacyBuildGraph.create(self.scheduler, self.symbol_table)
     logger.debug('build_graph is: %s', graph)
-    with self.scheduler.lock:
-      # Ensure the entire generator is unrolled.
-      for _ in graph.inject_specs_closure(target_roots.as_specs()):
-        pass
+    # Ensure the entire generator is unrolled.
+    for _ in graph.inject_specs_closure(target_roots.as_specs()):
+      pass
 
     address_mapper = LegacyAddressMapper(self.scheduler, build_root or get_buildroot())
     logger.debug('address_mapper is: %s', address_mapper)

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -106,11 +106,7 @@ typedef RunnableComplete (*extern_ptr_invoke_runnable)(ExternContext*, Value*, V
 
 typedef void Tasks;
 typedef void Scheduler;
-
-typedef struct {
-  uint64_t runnable_count;
-  uint64_t scheduling_iterations;
-} ExecutionStat;
+typedef void ExecutionRequest;
 
 typedef struct {
   Key             subject;
@@ -186,15 +182,17 @@ Scheduler* scheduler_create(Tasks*,
 void scheduler_pre_fork(Scheduler*);
 void scheduler_destroy(Scheduler*);
 
+
+ExecutionRequest* execution_request_create(void);
+void execution_request_destroy(ExecutionRequest*);
+
 uint64_t graph_len(Scheduler*);
 uint64_t graph_invalidate(Scheduler*, BufferBuffer);
-void graph_visualize(Scheduler*, char*);
-void graph_trace(Scheduler*, char*);
+void graph_visualize(Scheduler*, ExecutionRequest*, char*);
+void graph_trace(Scheduler*, ExecutionRequest*, char*);
 
-void execution_reset(Scheduler*);
-void execution_add_root_select(Scheduler*, Key, TypeConstraint);
-ExecutionStat execution_execute(Scheduler*);
-RawNodes* execution_roots(Scheduler*);
+void execution_add_root_select(Scheduler*, ExecutionRequest*, Key, TypeConstraint);
+RawNodes* execution_execute(Scheduler*, ExecutionRequest*);
 
 Value validator_run(Scheduler*);
 
@@ -660,6 +658,9 @@ class Native(object):
 
   def new_tasks(self):
     return self.gc(self.lib.tasks_create(), self.lib.tasks_destroy)
+
+  def new_execution_request(self):
+    return self.gc(self.lib.execution_request_create(), self.lib.execution_request_destroy)
 
   def new_scheduler(self,
                     tasks,

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -267,6 +267,15 @@ class WrappedNativeScheduler(object):
                                                self._to_key(subject),
                                                self._to_constraint(product))
 
+  def visualize_to_dir(self):
+    return self._native.visualize_to_dir
+
+  def to_keys(self, subjects):
+    return list(self._to_key(subject) for subject in subjects)
+
+  def pre_fork(self):
+    self._native.lib.scheduler_pre_fork(self._scheduler)
+
   def run_and_return_roots(self, execution_request):
     raw_roots = self._native.lib.execution_execute(self._scheduler, execution_request.native)
     try:
@@ -285,15 +294,6 @@ class WrappedNativeScheduler(object):
     finally:
       self._native.lib.nodes_destroy(raw_roots)
     return roots
-
-  def visualize_to_dir(self):
-    return self._native.visualize_to_dir
-
-  def to_keys(self, subjects):
-    return list(self._to_key(subject) for subject in subjects)
-
-  def pre_fork(self):
-    self._native.lib.scheduler_pre_fork(self._scheduler)
 
 
 class LocalScheduler(object):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import os
-import threading
 import time
 from collections import defaultdict
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -410,7 +410,7 @@ class LocalScheduler(object):
     filenames = set(direct_filenames)
     filenames.update(os.path.dirname(f) for f in direct_filenames)
     invalidated = self._scheduler.invalidate(filenames)
-    logger.debug('invalidated %d nodes for: %s', invalidated, filenames)
+    logger.info('invalidated %d nodes for: %s', invalidated, filenames)
     return invalidated
 
   def node_count(self):

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -97,7 +97,6 @@ class PantsDaemon(FingerprintedProcessManager):
         build_root,
         bootstrap_options_values.pants_workdir,
         bootstrap_options_values.level.upper(),
-        legacy_graph_helper.scheduler.lock,
         services,
         port_map,
         bootstrap_options_values.pants_subprocessdir,
@@ -143,7 +142,7 @@ class PantsDaemon(FingerprintedProcessManager):
         dict(pailgun=pailgun_service.pailgun_port)
       )
 
-  def __init__(self, native, build_root, work_dir, log_level, lock, services, socket_map,
+  def __init__(self, native, build_root, work_dir, log_level, services, socket_map,
                metadata_base_dir, bootstrap_options=None):
     """
     :param Native native: A `Native` instance.
@@ -158,13 +157,14 @@ class PantsDaemon(FingerprintedProcessManager):
     self._build_root = build_root
     self._work_dir = work_dir
     self._log_level = log_level
-    self._lock = lock
     self._services = services
     self._socket_map = socket_map
     self._bootstrap_options = bootstrap_options
 
     self._log_dir = os.path.join(work_dir, self.name)
     self._logger = logging.getLogger(__name__)
+    # A lock to guard the service thread lifecycles.
+    self._lock = threading.RLock()
     # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
     self._kill_switch = threading.Event()
     self._exiter = Exiter()

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -182,3 +182,13 @@ impl fmt::Debug for Noop {
     })
   }
 }
+
+pub fn throw(msg: &str) -> Failure {
+  Failure::Throw(
+    externs::create_exception(msg),
+    format!(
+      "Traceback (no traceback):\n  <pants native internals>\nException: {}",
+      msg
+    ).to_string(),
+  )
+}

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -160,7 +160,12 @@ impl fmt::Debug for Value {
 
 #[derive(Debug, Clone)]
 pub enum Failure {
+  /// A Node failed because a filesystem change invalidated it or its inputs.
+  /// A root requestor should usually immediately retry their request.
+  Invalidated,
+  /// There was no valid combination of rules to satisfy a request.
   Noop(Noop),
+  /// A rule raised an exception.
   Throw(Value, String),
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -394,7 +394,7 @@ pub extern "C" fn graph_len(scheduler_ptr: *mut Scheduler) -> u64 {
 pub extern "C" fn graph_visualize(
   scheduler_ptr: *mut Scheduler,
   execution_request_ptr: *mut ExecutionRequest,
-  path_ptr: *const raw::c_char
+  path_ptr: *const raw::c_char,
 ) {
   with_scheduler(scheduler_ptr, |scheduler| {
     with_execution_request(execution_request_ptr, |execution_request| {
@@ -402,9 +402,11 @@ pub extern "C" fn graph_visualize(
       let path = PathBuf::from(path_str);
       // TODO: This should likely return an error condition to python.
       //   see https://github.com/pantsbuild/pants/issues/4025
-      scheduler.visualize(execution_request, path.as_path()).unwrap_or_else(|e| {
-        println!("Failed to visualize to {}: {:?}", path.display(), e);
-      });
+      scheduler
+        .visualize(execution_request, path.as_path())
+        .unwrap_or_else(|e| {
+          println!("Failed to visualize to {}: {:?}", path.display(), e);
+        });
     })
   })
 }
@@ -413,15 +415,17 @@ pub extern "C" fn graph_visualize(
 pub extern "C" fn graph_trace(
   scheduler_ptr: *mut Scheduler,
   execution_request_ptr: *mut ExecutionRequest,
-  path_ptr: *const raw::c_char
+  path_ptr: *const raw::c_char,
 ) {
   let path_str = unsafe { CStr::from_ptr(path_ptr).to_string_lossy().into_owned() };
   let path = PathBuf::from(path_str);
   with_scheduler(scheduler_ptr, |scheduler| {
     with_execution_request(execution_request_ptr, |execution_request| {
-      scheduler.trace(execution_request, path.as_path()).unwrap_or_else(|e| {
-        println!("Failed to write trace to {}: {:?}", path.display(), e);
-      });
+      scheduler
+        .trace(execution_request, path.as_path())
+        .unwrap_or_else(|e| {
+          println!("Failed to write trace to {}: {:?}", path.display(), e);
+        });
     });
   });
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -50,6 +50,7 @@ enum RawStateTag {
   Return = 1,
   Throw = 2,
   Noop = 3,
+  Invalidated = 4,
 }
 
 #[repr(C)]
@@ -73,6 +74,10 @@ impl RawNode {
       Some(Err(Failure::Noop(noop))) => (
         RawStateTag::Noop as u8,
         externs::create_exception(&format!("{:?}", noop)),
+      ),
+      Some(Err(Failure::Invalidated)) => (
+        RawStateTag::Invalidated as u8,
+        externs::create_exception("Node was Invalidated"),
       ),
     };
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -72,7 +72,9 @@ impl RawNode {
       ),
       Err(Failure::Invalidated) => (
         RawStateTag::Invalidated as u8,
-        externs::create_exception("Node was Invalidated"),
+        externs::create_exception(
+          "Exhausted retries due to changed files.",
+        ),
       ),
     };
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -40,13 +40,12 @@ use externs::{Buffer, BufferBuffer, CloneValExtern, DropHandlesExtern, CreateExc
               SatisfiedByTypeExtern, StoreListExtern, StoreBytesExtern, TypeIdBuffer,
               ValForExtern, ValToStrExtern};
 use rule_graph::{GraphMaker, RuleGraph};
-use scheduler::{RootResult, Scheduler, ExecutionStat};
+use scheduler::{ExecutionRequest, RootResult, Scheduler};
 use tasks::Tasks;
 use types::Types;
 
 #[repr(C)]
 enum RawStateTag {
-  Empty = 0,
   Return = 1,
   Throw = 2,
   Noop = 3,
@@ -63,19 +62,15 @@ pub struct RawNode {
 }
 
 impl RawNode {
-  fn create(subject: &Key, product: &TypeConstraint, state: Option<RootResult>) -> RawNode {
+  fn create(subject: &Key, product: &TypeConstraint, state: RootResult) -> RawNode {
     let (state_tag, state_value) = match state {
-      None => (
-        RawStateTag::Empty as u8,
-        externs::create_exception("No value"),
-      ),
-      Some(Ok(v)) => (RawStateTag::Return as u8, v),
-      Some(Err(Failure::Throw(exc, _))) => (RawStateTag::Throw as u8, exc),
-      Some(Err(Failure::Noop(noop))) => (
+      Ok(v) => (RawStateTag::Return as u8, v),
+      Err(Failure::Throw(exc, _)) => (RawStateTag::Throw as u8, exc),
+      Err(Failure::Noop(noop)) => (
         RawStateTag::Noop as u8,
         externs::create_exception(&format!("{:?}", noop)),
       ),
-      Some(Err(Failure::Invalidated)) => (
+      Err(Failure::Invalidated) => (
         RawStateTag::Invalidated as u8,
         externs::create_exception("Node was Invalidated"),
       ),
@@ -98,7 +93,7 @@ pub struct RawNodes {
 }
 
 impl RawNodes {
-  fn create(node_states: Vec<(&Key, &TypeConstraint, Option<RootResult>)>) -> Box<RawNodes> {
+  fn create(node_states: Vec<(&Key, &TypeConstraint, RootResult)>) -> Box<RawNodes> {
     let nodes = node_states
       .into_iter()
       .map(|(subject, product, state)| {
@@ -110,7 +105,7 @@ impl RawNodes {
       nodes_len: 0,
       nodes: nodes,
     });
-    // NB: Unsafe! See comment on similar pattern in RawExecution::new().
+    // Creates a pointer into the struct itself, which is not possible to do in safe rust.
     raw_nodes.nodes_ptr = raw_nodes.nodes.as_ptr();
     raw_nodes.nodes_len = raw_nodes.nodes.len() as u64;
     raw_nodes
@@ -244,30 +239,28 @@ pub extern "C" fn scheduler_destroy(scheduler_ptr: *mut Scheduler) {
 }
 
 #[no_mangle]
-pub extern "C" fn execution_reset(scheduler_ptr: *mut Scheduler) {
-  with_scheduler(scheduler_ptr, |scheduler| { scheduler.reset(); })
-}
-
-#[no_mangle]
 pub extern "C" fn execution_add_root_select(
   scheduler_ptr: *mut Scheduler,
+  execution_request_ptr: *mut ExecutionRequest,
   subject: Key,
   product: TypeConstraint,
 ) {
   with_scheduler(scheduler_ptr, |scheduler| {
-    scheduler.add_root_select(subject, product);
+    with_execution_request(execution_request_ptr, |execution_request| {
+      scheduler.add_root_select(execution_request, subject, product);
+    })
   })
 }
 
 #[no_mangle]
-pub extern "C" fn execution_execute(scheduler_ptr: *mut Scheduler) -> ExecutionStat {
-  with_scheduler(scheduler_ptr, |scheduler| scheduler.execute())
-}
-
-#[no_mangle]
-pub extern "C" fn execution_roots(scheduler_ptr: *mut Scheduler) -> *const RawNodes {
+pub extern "C" fn execution_execute(
+  scheduler_ptr: *mut Scheduler,
+  execution_request_ptr: *mut ExecutionRequest,
+) -> *const RawNodes {
   with_scheduler(scheduler_ptr, |scheduler| {
-    Box::into_raw(RawNodes::create(scheduler.root_states()))
+    with_execution_request(execution_request_ptr, |execution_request| {
+      Box::into_raw(RawNodes::create(scheduler.execute(execution_request)))
+    })
   })
 }
 
@@ -377,8 +370,6 @@ pub extern "C" fn tasks_task_end(tasks_ptr: *mut Tasks) {
 
 #[no_mangle]
 pub extern "C" fn tasks_destroy(tasks_ptr: *mut Tasks) {
-  // convert the raw pointer back to a Box (without `forget`ing it) in order to cause it
-  // to be destroyed at the end of this function.
   let _ = unsafe { Box::from_raw(tasks_ptr) };
 }
 
@@ -400,34 +391,54 @@ pub extern "C" fn graph_len(scheduler_ptr: *mut Scheduler) -> u64 {
 }
 
 #[no_mangle]
-pub extern "C" fn graph_visualize(scheduler_ptr: *mut Scheduler, path_ptr: *const raw::c_char) {
+pub extern "C" fn graph_visualize(
+  scheduler_ptr: *mut Scheduler,
+  execution_request_ptr: *mut ExecutionRequest,
+  path_ptr: *const raw::c_char
+) {
   with_scheduler(scheduler_ptr, |scheduler| {
-    let path_str = unsafe { CStr::from_ptr(path_ptr).to_string_lossy().into_owned() };
-    let path = PathBuf::from(path_str);
-    // TODO: This should likely return an error condition to python.
-    //   see https://github.com/pantsbuild/pants/issues/4025
-    scheduler.visualize(path.as_path()).unwrap_or_else(|e| {
-      println!("Failed to visualize to {}: {:?}", path.display(), e);
-    });
+    with_execution_request(execution_request_ptr, |execution_request| {
+      let path_str = unsafe { CStr::from_ptr(path_ptr).to_string_lossy().into_owned() };
+      let path = PathBuf::from(path_str);
+      // TODO: This should likely return an error condition to python.
+      //   see https://github.com/pantsbuild/pants/issues/4025
+      scheduler.visualize(execution_request, path.as_path()).unwrap_or_else(|e| {
+        println!("Failed to visualize to {}: {:?}", path.display(), e);
+      });
+    })
   })
 }
 
 #[no_mangle]
-pub extern "C" fn graph_trace(scheduler_ptr: *mut Scheduler, path_ptr: *const raw::c_char) {
+pub extern "C" fn graph_trace(
+  scheduler_ptr: *mut Scheduler,
+  execution_request_ptr: *mut ExecutionRequest,
+  path_ptr: *const raw::c_char
+) {
   let path_str = unsafe { CStr::from_ptr(path_ptr).to_string_lossy().into_owned() };
   let path = PathBuf::from(path_str);
   with_scheduler(scheduler_ptr, |scheduler| {
-    scheduler.trace(path.as_path()).unwrap_or_else(|e| {
-      println!("Failed to write trace to {}: {:?}", path.display(), e);
+    with_execution_request(execution_request_ptr, |execution_request| {
+      scheduler.trace(execution_request, path.as_path()).unwrap_or_else(|e| {
+        println!("Failed to write trace to {}: {:?}", path.display(), e);
+      });
     });
   });
 }
 
 #[no_mangle]
 pub extern "C" fn nodes_destroy(raw_nodes_ptr: *mut RawNodes) {
-  // convert the raw pointer back to a Box (without `forget`ing it) in order to cause it
-  // to be destroyed at the end of this function.
   let _ = unsafe { Box::from_raw(raw_nodes_ptr) };
+}
+
+#[no_mangle]
+pub extern "C" fn execution_request_create() -> *const ExecutionRequest {
+  Box::into_raw(Box::new(ExecutionRequest::new()))
+}
+
+#[no_mangle]
+pub extern "C" fn execution_request_destroy(ptr: *mut ExecutionRequest) {
+  let _ = unsafe { Box::from_raw(ptr) };
 }
 
 #[no_mangle]
@@ -523,6 +534,16 @@ where
   let mut scheduler = unsafe { Box::from_raw(scheduler_ptr) };
   let t = f(&mut scheduler);
   mem::forget(scheduler);
+  t
+}
+
+fn with_execution_request<F, T>(execution_request_ptr: *mut ExecutionRequest, f: F) -> T
+where
+  F: FnOnce(&mut ExecutionRequest) -> T,
+{
+  let mut execution_request = unsafe { Box::from_raw(execution_request_ptr) };
+  let t = f(&mut execution_request);
+  mem::forget(execution_request);
   t
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -210,6 +210,7 @@ impl Select {
               }
               continue;
             }
+            i @ Failure::Invalidated => return Err(i),
             f @ Failure::Throw(..) => return Err(f),
           }
         }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -12,7 +12,7 @@ use ordermap::OrderMap;
 
 use boxfuture::{Boxable, BoxFuture};
 use context::Context;
-use core::{Failure, Key, Noop, TypeConstraint, Value, Variants};
+use core::{Failure, Key, Noop, TypeConstraint, Value, Variants, throw};
 use externs;
 use fs::{self, Dir, File, FileContent, Link, PathGlobs, PathStat, VFS};
 use rule_graph;
@@ -28,16 +28,6 @@ fn ok<O: Send + 'static>(value: O) -> NodeFuture<O> {
 
 fn err<O: Send + 'static>(failure: Failure) -> NodeFuture<O> {
   future::err(failure).to_boxed()
-}
-
-fn throw(msg: &str) -> Failure {
-  Failure::Throw(
-    externs::create_exception(msg),
-    format!(
-      "Traceback (no traceback):\n  <pants native internals>\nException: {}",
-      msg
-    ).to_string(),
-  )
 }
 
 ///

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -44,9 +44,7 @@ pub struct Scheduler {
 
 impl Scheduler {
   pub fn new(core: Core) -> Scheduler {
-    Scheduler {
-      core: Arc::new(core),
-    }
+    Scheduler { core: Arc::new(core) }
   }
 
   pub fn visualize(&self, request: &ExecutionRequest, path: &Path) -> io::Result<()> {
@@ -60,7 +58,12 @@ impl Scheduler {
     Ok(())
   }
 
-  pub fn add_root_select(&self, request: &mut ExecutionRequest, subject: Key, product: TypeConstraint) {
+  pub fn add_root_select(
+    &self,
+    request: &mut ExecutionRequest,
+    subject: Key,
+    product: TypeConstraint,
+  ) {
     let edges = self.find_root_edges_or_update_rule_graph(
       subject.type_id().clone(),
       selectors::Selector::Select(selectors::Select::without_variant(product)),
@@ -115,7 +118,7 @@ impl Scheduler {
         .create(root.clone(), &core)
         .or_else(move |e| match e {
           Failure::Invalidated => Scheduler::create(core, root, count - 1),
-          x => future::err(x).to_boxed()
+          x => future::err(x).to_boxed(),
         })
         .to_boxed()
     }
@@ -124,7 +127,10 @@ impl Scheduler {
   ///
   /// Compute the results for roots in the given request.
   ///
-  pub fn execute<'e>(&mut self, request: &'e ExecutionRequest) -> Vec<(&'e Key, &'e TypeConstraint, RootResult)> {
+  pub fn execute<'e>(
+    &mut self,
+    request: &'e ExecutionRequest,
+  ) -> Vec<(&'e Key, &'e TypeConstraint, RootResult)> {
     // Bootstrap tasks for the roots, and then wait for all of them.
     externs::log(
       LogLevel::Debug,
@@ -155,13 +161,7 @@ impl Scheduler {
       .roots
       .iter()
       .zip(results.into_iter())
-      .map(|(s, r)| {
-        (
-          &s.subject,
-          &s.selector.product,
-          r,
-        )
-      })
+      .map(|(s, r)| (&s.subject, &s.selector.product, r))
       .collect()
   }
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -15,69 +15,56 @@ use nodes::{NodeKey, Select};
 use rule_graph;
 use selectors;
 
+pub struct ExecutionRequest {
+  // Set of roots for an execution, in the order they were declared.
+  pub roots: Vec<Root>,
+}
+
+impl ExecutionRequest {
+  pub fn new() -> ExecutionRequest {
+    ExecutionRequest { roots: Vec::new() }
+  }
+
+  ///
+  /// Roots are limited to `Select`, which is known to produce a Value. This method
+  /// exists to satisfy Graph APIs which need instances of the NodeKey enum.
+  ///
+  fn root_nodes(&self) -> Vec<NodeKey> {
+    self.roots.iter().map(|r| r.clone().into()).collect()
+  }
+}
+
 ///
 /// Represents the state of an execution of (a subgraph of) a Graph.
 ///
 pub struct Scheduler {
   pub core: Arc<Core>,
-  // Initial set of roots for the execution, in the order they were declared.
-  roots: Vec<Root>,
 }
 
 impl Scheduler {
-  ///
-  /// Roots are limited to `Select`, which are known to produce Values. But this method exists
-  /// to satisfy Graph APIs which only need instances of the NodeKey enum.
-  ///
-  fn root_nodes(&self) -> Vec<NodeKey> {
-    self.roots.iter().map(|r| r.clone().into()).collect()
-  }
-
-  ///
-  /// Creates a Scheduler with an initially empty set of roots.
-  ///
   pub fn new(core: Core) -> Scheduler {
     Scheduler {
       core: Arc::new(core),
-      roots: Vec::new(),
     }
   }
 
-  pub fn visualize(&self, path: &Path) -> io::Result<()> {
-    self.core.graph.visualize(&self.root_nodes(), path)
+  pub fn visualize(&self, request: &ExecutionRequest, path: &Path) -> io::Result<()> {
+    self.core.graph.visualize(&request.root_nodes(), path)
   }
 
-  pub fn trace(&self, path: &Path) -> io::Result<()> {
-    for root in self.root_nodes() {
+  pub fn trace(&self, request: &ExecutionRequest, path: &Path) -> io::Result<()> {
+    for root in request.root_nodes() {
       self.core.graph.trace(&root, path)?;
     }
     Ok(())
   }
 
-  pub fn reset(&mut self) {
-    self.roots.clear();
-  }
-
-  pub fn root_states(&self) -> Vec<(&Key, &TypeConstraint, Option<RootResult>)> {
-    self
-      .roots
-      .iter()
-      .map(|s| {
-        (
-          &s.subject,
-          &s.selector.product,
-          self.core.graph.peek(s.clone()),
-        )
-      })
-      .collect()
-  }
-
-  pub fn add_root_select(&mut self, subject: Key, product: TypeConstraint) {
+  pub fn add_root_select(&self, request: &mut ExecutionRequest, subject: Key, product: TypeConstraint) {
     let edges = self.find_root_edges_or_update_rule_graph(
       subject.type_id().clone(),
       selectors::Selector::Select(selectors::Select::without_variant(product)),
     );
-    self.roots.push(Select::new(
+    request.roots.push(Select::new(
       product,
       subject,
       Default::default(),
@@ -114,44 +101,48 @@ impl Scheduler {
   ///
   /// Starting from existing roots, execute a graph to completion.
   ///
-  pub fn execute(&mut self) -> ExecutionStat {
-    // TODO: Restore counts.
-    let runnable_count = 0;
-    let scheduling_iterations = 0;
-
+  pub fn execute<'e>(&mut self, request: &'e ExecutionRequest) -> Vec<(&'e Key, &'e TypeConstraint, RootResult)> {
     // Bootstrap tasks for the roots, and then wait for all of them.
     externs::log(
       LogLevel::Debug,
-      &format!("Launching {} roots.", self.roots.len()),
+      &format!("Launching {} roots.", request.roots.len()),
     );
     let roots_res = future::join_all(
-      self
-        .root_nodes()
-        .into_iter()
+      request
+        .roots
+        .iter()
         .map(|root| {
           self
             .core
             .graph
             .create(root.clone(), &self.core)
-            .then::<_, Result<(), ()>>(move |_| {
+            .then::<_, Result<Result<Value, Failure>, ()>>(move |r| {
               externs::log(
                 LogLevel::Debug,
-                &format!("Root {} completed.", root.format()),
+                &format!("Root {} completed.", NodeKey::Select(root.clone()).format()),
               );
-              Ok(())
+              Ok(r)
             })
         })
         .collect::<Vec<_>>(),
     );
 
     // Wait for all roots to complete. Failure here should be impossible, because each
-    // individual Future in the join was mapped into success regardless of its result.
-    roots_res.wait().expect("Execution failed.");
+    // individual Future in the join was mapped into success.
+    let results = roots_res.wait().expect("Execution failed.");
 
-    ExecutionStat {
-      runnable_count: runnable_count,
-      scheduling_iterations: scheduling_iterations,
-    }
+    request
+      .roots
+      .iter()
+      .zip(results.into_iter())
+      .map(|(s, r)| {
+        (
+          &s.subject,
+          &s.selector.product,
+          r,
+        )
+      })
+      .collect()
   }
 }
 
@@ -166,10 +157,4 @@ impl ContextFactory for Arc<Core> {
   fn create(&self, entry_id: EntryId) -> Context {
     Context::new(entry_id, self.clone())
   }
-}
-
-#[repr(C)]
-pub struct ExecutionStat {
-  runnable_count: u64,
-  scheduling_iterations: u64,
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -36,7 +36,7 @@ impl ExecutionRequest {
 }
 
 ///
-/// Represents the state of an execution of (a subgraph of) a Graph.
+/// Represents the state of an execution of a Graph.
 ///
 pub struct Scheduler {
   pub core: Arc<Core>,
@@ -122,7 +122,7 @@ impl Scheduler {
   }
 
   ///
-  /// Starting from existing roots, execute a graph to completion.
+  /// Compute the results for roots in the given request.
   ///
   pub fn execute<'e>(&mut self, request: &'e ExecutionRequest) -> Vec<(&'e Key, &'e TypeConstraint, RootResult)> {
     // Bootstrap tasks for the roots, and then wait for all of them.

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -493,5 +493,4 @@ def setup_json_scheduler(build_root, native):
                         goals,
                         tasks,
                         project_tree,
-                        native,
-                        graph_lock=None)
+                        native)

--- a/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_pants_engine_integration.py
@@ -14,7 +14,7 @@ class PantsEngineIntegrationTest(PantsRunIntegrationTest):
     self.assert_success(pants_run)
     self.assertRegexpMatches(pants_run.stderr_data, 'build_graph is: .*LegacyBuildGraph')
     self.assertRegexpMatches(pants_run.stderr_data,
-                             'ran \d+ scheduling iterations and \d+ runnables in')
+                             'computed \d+ nodes in')
     self.assertNotRegexpMatches(pants_run.stderr_data, 'pantsd is running at pid \d+')
 
   def test_engine_binary(self):

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -109,20 +109,15 @@ class GraphTestBase(unittest.TestCase, SchedulerTestBase):
     request = scheduler.execution_request([TestTable().constraint()], [address])
     root_entries = scheduler.execute(request).root_products
     self.assertEquals(1, len(root_entries))
-    return root_entries[0]
-
-  def walk(self, scheduler, address):
-    """Return a list of all (Node, State) tuples reachable from the given Address."""
-    root, _ = self._populate(scheduler, address)
-    return list(e for e in scheduler.product_graph.walk([root], predicate=lambda n, s: True))
+    return request, root_entries[0][1]
 
   def resolve_failure(self, scheduler, address):
-    root, state = self._populate(scheduler, address)
+    _, state = self._populate(scheduler, address)
     self.assertEquals(type(state), Throw, '{} is not a Throw.'.format(state))
     return state.exc
 
   def resolve(self, scheduler, address):
-    root, state = self._populate(scheduler, address)
+    _, state = self._populate(scheduler, address)
     self.assertEquals(type(state), Return, '{} is not a Return.'.format(state))
     return state.value
 
@@ -190,9 +185,9 @@ class InlinedGraphTest(GraphTestBase):
 
   def do_test_trace_message(self, scheduler, parsed_address, expected_string=None):
     # Confirm that the root failed, and that a cycle occurred deeper in the graph.
-    root, state = self._populate(scheduler, parsed_address)
+    request, state = self._populate(scheduler, parsed_address)
     self.assertEqual(type(state), Throw)
-    trace_message = '\n'.join(scheduler.trace())
+    trace_message = '\n'.join(scheduler.trace(request))
 
     self.assert_throws_are_leaves(trace_message, Throw.__name__)
     if expected_string:

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -34,8 +34,9 @@ class EngineTest(unittest.TestCase):
                                         subjects=addresses)
 
   def test_serial_execution_simple(self):
-    result = self.scheduler.execute(self.request(['compile'], self.java))
-    self.scheduler.visualize_graph_to_file('blah/run.0.dot')
+    request = self.request(['compile'], self.java)
+    result = self.scheduler.execute(request)
+    self.scheduler.visualize_graph_to_file(request, 'blah/run.0.dot')
     self.assertEqual(Return(Classpath(creator='javac')), result.root_products[0][1])
     self.assertIsNone(result.error)
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -258,7 +258,7 @@ class SchedulerTraceTest(unittest.TestCase):
     request = scheduler._native.new_execution_request()
     subject = B()
     scheduler.add_root_selection(request, subject, A)
-    _ = scheduler.run_and_return_roots(request)
+    scheduler.run_and_return_roots(request)
 
     trace = '\n'.join(scheduler.graph_trace(request))
     # NB removing location info to make trace repeatable

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -56,7 +56,7 @@ class SchedulerTest(unittest.TestCase):
     """Execute the given request and return roots as a list of ((subject, product), value) tuples."""
     result = self.scheduler.execute(build_request)
     self.assertIsNone(result.error)
-    return self.scheduler.root_entries(build_request)
+    return result.root_products
 
   def request(self, goals, *subjects):
     return self.scheduler.build_request(goals=goals, subjects=subjects)
@@ -221,7 +221,7 @@ class SchedulerTest(unittest.TestCase):
 
     with temporary_dir() as td:
       output_path = os.path.join(td, 'output.dot')
-      self.scheduler.visualize_graph_to_file(output_path)
+      self.scheduler.visualize_graph_to_file(build_request, output_path)
       with open(output_path, 'rb') as fh:
         graphviz_output = fh.read().strip()
 
@@ -255,11 +255,12 @@ class SchedulerTraceTest(unittest.TestCase):
     ]
 
     scheduler = create_native_scheduler(rules)
+    request = scheduler._native.new_execution_request()
     subject = B()
-    scheduler.add_root_selection(subject, A)
-    scheduler.run_and_return_stat()
+    scheduler.add_root_selection(request, subject, A)
+    _ = scheduler.run_and_return_roots(request)
 
-    trace = '\n'.join(scheduler.graph_trace())
+    trace = '\n'.join(scheduler.graph_trace(request))
     # NB removing location info to make trace repeatable
     trace = remove_locations_from_traceback(trace)
 

--- a/tests/python/pants_test/pantsd/test_pants_daemon.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-import threading
 
 import mock
 
@@ -45,14 +44,12 @@ class LoggerStreamTest(BaseTest):
 class PantsDaemonTest(BaseTest):
   def setUp(self):
     super(PantsDaemonTest, self).setUp()
-    lock = threading.RLock()
     mock_options = mock.Mock()
     mock_options.pants_subprocessdir = 'non_existent_dir'
     self.pantsd = PantsDaemon(None,
                               'test_buildroot',
                               'test_work_dir',
                               logging.INFO,
-                              lock,
                               [],
                               {},
                               '/tmp/pants_test_metadata_dir',


### PR DESCRIPTION
### Problem

The scheduler lock existed for a few reasons:
1. To prevent `Nodes` from being invalidated out of the `Graph` while they were being consumed by other `Nodes`. Because `Context` holds an `EntryId` for the running `Node`, the `Node` would fail (...panic, actually) at the next attempt to resolve a dependency.
2. To protect access to the `roots` field of the Scheduler, which was mutated in order to statefully build up the set of roots via the `add_root_select` method, and then capture results later.
3. We used to walk the graph from the python side (but no longer), which meant that `Node`s needed their lifecycle to be tightly controlled. The API no longer allows for walking inner `Node`s, so only roots are relevant now.

### Solution

Introduce a new `Failure::Invalidated` type to act as a signal that a `Node`'s `Context`/`EntryId` was invalidated while it was running (due to a file change on disk). The `Scheduler` will retry creating a `Node` a few times to allow execution to recover in the common case of minor file edits.

Move the `roots` field off of `Scheduler` and onto a disposable `ExecutionRequest` struct, and have all relevant native functions take a reference to the `ExecutionRequest`.

### Result

The scheduler lock is removed. This doesn't address #5169, but it should clear up the python-side locking situation to assist in debugging it.