### PR TITLE
Installing a duplicate task into a goal should not throw error if replace=True

### DIFF
--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -140,8 +140,15 @@ class _Goal(object):
     if [bool(place) for place in [first, replace, before, after]].count(True) > 1:
       raise GoalError('Can only specify one of first, replace, before or after')
 
+    otn = self._ordered_task_names
+    if replace:
+      for tt in self.task_types():
+        tt.options_scope = None
+      del otn[:]
+      self._task_type_by_name = {}
+
     task_name = task_registrar.name
-    if not replace and task_name in self._task_type_by_name:
+    if task_name in self._task_type_by_name:
       raise GoalError(
         'Can only specify a task name once per goal, saw multiple values for {} in goal {}'.format(
           task_name,
@@ -166,12 +173,6 @@ class _Goal(object):
       '_stable_name': superclass.stable_name()
     })
 
-    otn = self._ordered_task_names
-    if replace:
-      for tt in self.task_types():
-        tt.options_scope = None
-      del otn[:]
-      self._task_type_by_name = {}
     if first:
       otn.insert(0, task_name)
     elif before in otn:

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -141,7 +141,7 @@ class _Goal(object):
       raise GoalError('Can only specify one of first, replace, before or after')
 
     task_name = task_registrar.name
-    if task_name in self._task_type_by_name:
+    if not replace and task_name in self._task_type_by_name:
       raise GoalError(
         'Can only specify a task name once per goal, saw multiple values for {} in goal {}'.format(
           task_name,

--- a/tests/python/pants_test/core_tasks/test_list_goals.py
+++ b/tests/python/pants_test/core_tasks/test_list_goals.py
@@ -103,6 +103,25 @@ class ListGoalsTest(ConsoleTaskTestBase):
     self.assertIn('foo', ctx.exception.message)
     self.assertIn(self._LIST_GOALS_NAME, ctx.exception.message)
 
+  def test_register_duplicate_task_name_is_not_error_when_replacing(self):
+    Goal.clear()
+
+    class NoopTask(Task):
+      def execute(self):
+        pass
+
+    class OtherNoopTask(Task):
+      def execute(self):
+        pass
+
+    goal = Goal.register(self._LIST_GOALS_NAME, self._LIST_GOALS_DESC)
+    task_name = 'foo'
+    goal.install(TaskRegistrar(task_name, NoopTask))
+    goal.install(TaskRegistrar(task_name, OtherNoopTask), replace=True)
+
+    self.assertIsInstance(OtherNoopTask, goal.task_type_by_name(task_name))
+
+
   # TODO(John Sirois): Re-enable when fixing up ListGoals `--graph` in
   # https://github.com/pantsbuild/pants/issues/918
   @expectedFailure

--- a/tests/python/pants_test/core_tasks/test_list_goals.py
+++ b/tests/python/pants_test/core_tasks/test_list_goals.py
@@ -119,7 +119,7 @@ class ListGoalsTest(ConsoleTaskTestBase):
     goal.install(TaskRegistrar(task_name, NoopTask))
     goal.install(TaskRegistrar(task_name, OtherNoopTask), replace=True)
 
-    self.assertIsInstance(OtherNoopTask, goal.task_type_by_name(task_name))
+    self.assertTrue(issubclass(goal.task_type_by_name(task_name), OtherNoopTask))
 
 
   # TODO(John Sirois): Re-enable when fixing up ListGoals `--graph` in

--- a/tests/python/pants_test/core_tasks/test_list_goals.py
+++ b/tests/python/pants_test/core_tasks/test_list_goals.py
@@ -121,7 +121,6 @@ class ListGoalsTest(ConsoleTaskTestBase):
 
     self.assertTrue(issubclass(goal.task_type_by_name(task_name), OtherNoopTask))
 
-
   # TODO(John Sirois): Re-enable when fixing up ListGoals `--graph` in
   # https://github.com/pantsbuild/pants/issues/918
   @expectedFailure


### PR DESCRIPTION
The change from PR #4863 seems to break the "replace" functionality by throwing an error because the task name is already in the goal even if replace is True.

Added a check for the replace flag before throwing the error.