### PR TITLE
Add integration test for forking during file invalidation

### DIFF
--- a/tests/python/pants_test/pantsd/BUILD
+++ b/tests/python/pants_test/pantsd/BUILD
@@ -66,6 +66,7 @@ python_tests(
   name = 'pantsd_integration',
   sources = ['test_pantsd_integration.py'],
   dependencies = [
+    '3rdparty/python:futures',
     'src/python/pants/pantsd:process_manager',
     'src/python/pants/util:collections',
     'tests/python/pants_test:int-test',


### PR DESCRIPTION
### Problem

#5169 describes a deadlock that occurs when any native-engine lock is acquired by a non-main thread during a fork. Pre #4931 the `context_lock` was acquired for the entire length of a request, but during that change that lock acquisition was removed.

Kris fixed this as part of #5156, but there is not yet a test confirming that the issue is fixed.

### Solution

Add a test to cover #5169.

### Result

Covers #5169 with an integration test.