### PR TITLE
add `typing` module to Pants venv

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -29,4 +29,5 @@ setuptools==30.0.0
 subprocess32==3.2.7
 six>=1.9.0,<2
 thrift>=0.9.1
+typing==3.6.2
 wheel==0.29.0


### PR DESCRIPTION
The `typing` module is a backport of the Python 3.x `typing` module. It enables use of [PEP 484](https://www.python.org/dev/peps/pep-0484/)-compatible type hints. This is essential for any reasonable use of `mypy` to check Pants code.