### PR TITLE
Reset swappable streams in JUnit runner before closing the TeeOutputStreams to the log files

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -173,15 +173,15 @@ public class ConsoleRunnerImpl {
       }
     }
 
-    byte[] readOut() throws IOException {
+    byte[] readOut() {
       return read(outstream);
     }
 
-    byte[] readErr() throws IOException {
+    byte[] readErr() {
       return read(errstream);
     }
 
-    private byte[] read(ByteArrayOutputStream stream) throws IOException {
+    private byte[] read(ByteArrayOutputStream stream) {
       Preconditions.checkState(closed, "Capture must be closed by all users before it can be read");
       return stream.toByteArray();
     }
@@ -237,6 +237,8 @@ public class ConsoleRunnerImpl {
 
     @Override
     public void testRunFinished(Result result) throws Exception {
+      swappableOut.swap(swappableOut.getOriginal());
+      swappableErr.swap(swappableErr.getOriginal());
       for (StreamCapture capture : suiteCaptures.values()) {
         capture.close();
       }

--- a/src/python/pants/backend/jvm/argfile.py
+++ b/src/python/pants/backend/jvm/argfile.py
@@ -5,12 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 from contextlib import contextmanager
 
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import safe_open
 
+logger = logging.getLogger(__name__)
 
 @contextmanager
 def safe_args(args,
@@ -37,6 +39,7 @@ def safe_args(args,
   max_args = max_args or options.max_subprocess_args
   if len(args) > max_args:
     def create_argfile(f):
+      logger.debug('Creating argfile {} with contents {}'.format(f.name, ' '.join(args)))
       f.write(delimiter.join(args))
       f.close()
       return [quoter(f.name) if quoter else '@{}'.format(f.name)]


### PR DESCRIPTION
### Problem

When trying to use the junit-runner with changes from https://github.com/pantsbuild/pants/pull/5173 I started getting `java.io.FileNotFoundException: (Too many open files in system)`

Also add a debugging line that was useful for debugging large test runs.

### Solution

Reset the swappable streams before you try to close the TeeOutputStreams that use them.

### Result

Using the junit-runner with these changes I no longer see `Too many open files in system` error.