### PR TITLE
[pantsd] Improve service locking.

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -337,6 +337,9 @@ class LocalScheduler(object):
 
     self._scheduler.assert_ruleset_valid()
 
+  def graph_len(self):
+    return self._scheduler.graph_len()
+
   def trace(self, execution_request):
     """Yields a stringified 'stacktrace' starting from the scheduler's roots."""
     for line in self._scheduler.graph_trace(execution_request.native):

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -90,13 +90,18 @@ class PailgunHandler(PailgunHandlerBase):
 class PailgunServer(TCPServer):
   """A (forking) pants nailgun server."""
 
-  def __init__(self, server_address, runner_factory, handler_class=None, bind_and_activate=True):
+  def __init__(self, server_address, runner_factory, lifecycle_lock,
+               handler_class=None, bind_and_activate=True):
     """Override of TCPServer.__init__().
 
     N.B. the majority of this function is copied verbatim from TCPServer.__init__().
 
     :param tuple server_address: An address tuple of (hostname, port) for socket.bind().
     :param class runner_factory: A factory function for creating a DaemonPantsRunner for each run.
+    :param threading.RLock lifecycle_lock: A lock used to guard against abrupt teardown of the servers
+                                           execution thread during handling. All pailgun request handling
+                                           will take place under care of this lock, which would be shared with
+                                           a `PailgunServer`-external lifecycle manager to guard teardown.
     :param class handler_class: The request handler class to use for each request. (Optional)
     :param bool bind_and_activate: If True, binds and activates networking at __init__ time.
                                    (Optional)
@@ -105,6 +110,7 @@ class PailgunServer(TCPServer):
     BaseServer.__init__(self, server_address, handler_class or PailgunHandler)
     self.socket = RecvBufferedSocket(socket.socket(self.address_family, self.socket_type))
     self.runner_factory = runner_factory
+    self.lifecycle_lock = lifecycle_lock
     self.allow_reuse_address = True           # Allow quick reuse of TCP_WAIT sockets.
     self.server_port = None                   # Set during server_bind() once the port is bound.
 
@@ -121,12 +127,18 @@ class PailgunServer(TCPServer):
     TCPServer.server_bind(self)
     _, self.server_port = self.socket.getsockname()[:2]
 
+  def handle_request(self):
+    """Override of TCPServer.handle_request() that guards handling with a lock."""
+    # Handle the underlying accept and request under care of the lifecycle lock, which will
+    # help ensure no client protocol errors from unexpected teardown from accept to close.
+    with self.lifecycle_lock():
+      TCPServer.handle_request(self)
+
   def process_request(self, request, client_address):
     """Override of TCPServer.process_request() that provides for forking request handlers and
     delegates error handling to the request handler."""
     # Instantiate the request handler.
     handler = self.RequestHandlerClass(request, client_address, self)
-
     try:
       # Attempt to handle a request with the handler.
       handler.handle_request()

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-import select
 import socket
 import traceback
 

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -40,8 +40,8 @@ class FSEventService(PantsService):
     self._executor = None
     self._handlers = {}
 
-  def setup(self, lock, executor=None):
-    super(FSEventService, self).setup(lock)
+  def setup(self, lifecycle_lock, fork_lock, executor=None):
+    super(FSEventService, self).setup(lifecycle_lock, fork_lock)
     self._executor = executor or ThreadPoolExecutor(max_workers=self._worker_count)
 
   def terminate(self):

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -31,12 +31,19 @@ class PantsService(AbstractClass):
     """
     return self._kill_switch.is_set()
 
-  def setup(self, lock):
+  def setup(self, lifecycle_lock, fork_lock):
     """Called before `run` to allow for service->service or other side-effecting setup.
 
-    :param threading.Lock lock: A global service<->service lock for guarding critical work.
+    :param threading.RLock lifecycle_lock: A lock to guard the service thread lifecycles. This
+                                           can be used by individual services to safeguard
+                                           daemon-synchronous sections that should be protected
+                                           from abrupt teardown.
+    :param threading.RLock fork_lock: A lock to guard pantsd->runner forks. This can be used by
+                                      services to safeguard resources held by threads at fork
+                                      time, so that we can fork without deadlocking.
     """
-    self.lock = lock
+    self.lifecycle_lock = lifecycle_lock
+    self.fork_lock = fork_lock
 
   @abstractmethod
   def run(self):

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import Queue
-import threading
 
 from pants.pantsd.service.pants_service import PantsService
 
@@ -20,6 +19,8 @@ class SchedulerService(PantsService):
   in memory.
   """
 
+  QUEUE_SIZE = 64
+
   def __init__(self, fs_event_service, legacy_graph_helper):
     """
     :param FSEventService fs_event_service: An unstarted FSEventService instance for setting up
@@ -30,20 +31,19 @@ class SchedulerService(PantsService):
     super(SchedulerService, self).__init__()
     self._fs_event_service = fs_event_service
     self._graph_helper = legacy_graph_helper
-    self._scheduler = legacy_graph_helper.scheduler
 
+    self._scheduler = legacy_graph_helper.scheduler
     self._logger = logging.getLogger(__name__)
-    self._event_queue = Queue.Queue(maxsize=64)
-    self._ready = threading.Event()
+    self._event_queue = Queue.Queue(maxsize=self.QUEUE_SIZE)
 
   @property
   def change_calculator(self):
     """Surfaces the change calculator."""
     return self._graph_helper.change_calculator
 
-  def setup(self, lock):
+  def setup(self, lifecycle_lock, fork_lock):
     """Service setup."""
-    super(SchedulerService, self).setup(lock)
+    super(SchedulerService, self).setup(lifecycle_lock, fork_lock)
     # Register filesystem event handlers on an FSEventService instance.
     self._fs_event_service.register_all_files_handler(self._enqueue_fs_event)
 
@@ -55,7 +55,7 @@ class SchedulerService(PantsService):
 
   def _handle_batch_event(self, files):
     self._logger.debug('handling change event for: %s', files)
-    with self.lock:
+    with self.fork_lock:
       self._scheduler.invalidate_files(files)
 
   def _process_event_queue(self):
@@ -65,23 +65,21 @@ class SchedulerService(PantsService):
     except Queue.Empty:
       return
 
-    with self.lock:
-      try:
-        subscription, is_initial_event, files = (event['subscription'],
-                                                 event['is_fresh_instance'],
-                                                 [f.decode('utf-8') for f in event['files']])
-      except (KeyError, UnicodeDecodeError) as e:
-        self._logger.warn('%r raised by invalid watchman event: %s', e, event)
-        return
+    try:
+      subscription, is_initial_event, files = (event['subscription'],
+                                               event['is_fresh_instance'],
+                                               [f.decode('utf-8') for f in event['files']])
+    except (KeyError, UnicodeDecodeError) as e:
+      self._logger.warn('%r raised by invalid watchman event: %s', e, event)
+      return
 
-      self._logger.debug('processing {} files for subscription {} (first_event={})'
-                         .format(len(files), subscription, is_initial_event))
+    self._logger.debug('processing {} files for subscription {} (first_event={})'
+                       .format(len(files), subscription, is_initial_event))
 
-      # The first watchman event is a listing of all files - ignore it.
-      if not is_initial_event:
-        self._handle_batch_event(files)
+    # The first watchman event is a listing of all files - ignore it.
+    if not is_initial_event:
+      self._handle_batch_event(files)
 
-    if not self._ready.is_set(): self._ready.set()
     self._event_queue.task_done()
 
   def warm_product_graph(self, spec_roots):
@@ -89,10 +87,7 @@ class SchedulerService(PantsService):
 
     :returns: A `LegacyGraphHelper` instance for graph construction.
     """
-    # Block warming until the initial watchman filesystem event is seen.
-    self._ready.wait()
-
-    with self.lock:
+    with self.fork_lock:
       self._graph_helper.warm_product_graph(spec_roots)
       return self._graph_helper
 

--- a/src/python/pants/util/socket.py
+++ b/src/python/pants/util/socket.py
@@ -29,7 +29,7 @@ def safe_select(*args, **kwargs):
   while 1:
     try:
       return select.select(*args, **kwargs)
-    except select.error as e:
+    except (OSError, select.error) as e:
       if e[0] != errno.EINTR:
         raise
 

--- a/tests/python/pants_test/pantsd/service/test_fs_event_service.py
+++ b/tests/python/pants_test/pantsd/service/test_fs_event_service.py
@@ -37,7 +37,7 @@ class TestFSEventService(BaseTest):
     BaseTest.setUp(self)
     self.mock_watchman = mock.create_autospec(Watchman, spec_set=True)
     self.service = FSEventService(self.mock_watchman, self.BUILD_ROOT, self.WORKER_COUNT)
-    self.service.setup(None, executor=TestExecutor())
+    self.service.setup(None, None, executor=TestExecutor())
     self.service.register_all_files_handler(lambda x: True, name='test')
     self.service.register_all_files_handler(lambda x: False, name='test2')
 

--- a/tests/python/pants_test/pantsd/test_pailgun_server.py
+++ b/tests/python/pants_test/pantsd/test_pailgun_server.py
@@ -6,7 +6,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import socket
+import threading
 import unittest
+from contextlib import contextmanager
 from SocketServer import TCPServer
 
 import mock
@@ -23,13 +25,20 @@ class TestPailgunServer(unittest.TestCase):
     self.mock_handler_inst = mock.Mock()
     self.mock_runner_factory = mock.Mock(side_effect=Exception('this should never be called'))
     self.mock_handler_class = mock.Mock(return_value=self.mock_handler_inst)
-    self.scheduler_lock = mock.Mock()
+    self.lock = threading.RLock()
+
+    @contextmanager
+    def lock():
+      with self.lock:
+        yield
+
     with mock.patch.object(PailgunServer, 'server_bind'), \
          mock.patch.object(PailgunServer, 'server_activate'):
       self.server = PailgunServer(
         server_address=('0.0.0.0', 0),
         runner_factory=self.mock_runner_factory,
-        handler_class=self.mock_handler_class
+        handler_class=self.mock_handler_class,
+        lifecycle_lock=lock
       )
 
   @mock.patch.object(TCPServer, 'server_bind', **PATCH_OPTS)


### PR DESCRIPTION
### Problem

Currently, `PantsDaemon` and all resident `PantsService` instances use a singular global `threading.RLock` to guard critical sections. This prevents us from locking an entire Pailgun run against unexpected daemon teardown.

### Solution

Split and plumb two different locks to services: a lifecycle lock and a fork lock. The lifecycle lock will be used to guard unexpected service thread teardowns and the fork lock will be used to acquire locks before forking `pantsd-runner` processes to ensure no threads have locks acquired during the fork (which can result in post-fork deadlocks).

### Result

Fixes #5194