### PR TITLE
Reset swappable streams in JUnit runner before closing the TeeOutputStreams to the log files and close XML Files after use

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConsoleRunnerImpl.java
@@ -173,15 +173,15 @@ public class ConsoleRunnerImpl {
       }
     }
 
-    byte[] readOut() throws IOException {
+    byte[] readOut() {
       return read(outstream);
     }
 
-    byte[] readErr() throws IOException {
+    byte[] readErr() {
       return read(errstream);
     }
 
-    private byte[] read(ByteArrayOutputStream stream) throws IOException {
+    private byte[] read(ByteArrayOutputStream stream) {
       Preconditions.checkState(closed, "Capture must be closed by all users before it can be read");
       return stream.toByteArray();
     }
@@ -237,6 +237,8 @@ public class ConsoleRunnerImpl {
 
     @Override
     public void testRunFinished(Result result) throws Exception {
+      swappableOut.swap(swappableOut.getOriginal());
+      swappableErr.swap(swappableErr.getOriginal());
       for (StreamCapture capture : suiteCaptures.values()) {
         capture.close();
       }
@@ -246,6 +248,9 @@ public class ConsoleRunnerImpl {
 
     @Override
     public void testStarted(Description description) throws Exception {
+      if (!Util.isRunnable(description)) {
+        return;
+      }
       StreamCapture suiteCapture = suiteCaptures.get(description.getTestClass());
       OutputStream suiteOut = suiteCapture.getOutputStream();
       OutputStream suiteErr = suiteCapture.getErrorStream();
@@ -291,6 +296,9 @@ public class ConsoleRunnerImpl {
 
     @Override
     public void testFinished(Description description) throws Exception {
+      if (!Util.isRunnable(description)) {
+        return;
+      }
       if (caseCaptures.containsKey(description)) {
         caseCaptures.remove(description).close();
       }

--- a/src/python/pants/backend/jvm/argfile.py
+++ b/src/python/pants/backend/jvm/argfile.py
@@ -5,11 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 from contextlib import contextmanager
 
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import safe_open
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -37,6 +40,7 @@ def safe_args(args,
   max_args = max_args or options.max_subprocess_args
   if len(args) > max_args:
     def create_argfile(f):
+      logger.debug('Creating argfile {} with contents {}'.format(f.name, ' '.join(args)))
       f.write(delimiter.join(args))
       f.close()
       return [quoter(f.name) if quoter else '@{}'.format(f.name)]

--- a/tests/java/org/pantsbuild/tools/junit/lib/AllIgnoredTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/AllIgnoredTest.java
@@ -1,0 +1,36 @@
+// Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.tools.junit.lib;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * This test is intentionally under a java_library() BUILD target so it will not be run
+ * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
+ */
+public class AllIgnoredTest {
+  @Test @Ignore
+  public void testIgnoreOne() {
+    System.out.println("testIgnoreOne");
+    Assert.assertTrue(true);
+  }
+
+  @Test @Ignore
+  public void testIgnoreTwo() {
+    System.out.println("testIgnoreTwo");
+    Assert.assertTrue(true);
+  }
+
+  @Test @Ignore
+  public void testIgnoreThree() {
+    Assert.assertTrue(true);
+  }
+
+  @Test @Ignore
+  public void testIgnoreFour() {
+    Assert.assertTrue(true);
+  }
+}

--- a/tests/java/org/pantsbuild/tools/junit/lib/OutputModeTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/OutputModeTest.java
@@ -3,7 +3,11 @@
 
 package org.pantsbuild.tools.junit.lib;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -12,6 +16,26 @@ import org.junit.Test;
  * on its own. It is run by the ConsoleRunnerTest suite to test ConsoleRunnerImpl.
  */
 public class OutputModeTest {
+  @BeforeClass
+  public static void classSetUp() {
+    System.out.println("Output in classSetUp");
+  }
+
+  @Before
+  public void setUp() {
+    System.out.println("Output in setUp");
+  }
+
+  @After
+  public void tearDown() {
+    System.out.println("Output in tearDown");
+  }
+
+  @AfterClass
+  public static void classTearDown() {
+    System.out.println("Output in classTearDown");
+  }
+
   @Test
   public void testPasses() {
     System.out.println("Output from passing test");

--- a/tests/java/org/pantsbuild/tools/junit/lib/XmlReportMockitoStubbingTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/lib/XmlReportMockitoStubbingTest.java
@@ -8,7 +8,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
### Problem

With the old test runner we were seeing `java.io.FileNotFoundException: (Too many open files in system)` mentioned in https://github.com/pantsbuild/pants/pull/5184 for large test runs.  We were also seeing cases where the log would only print the first character of the log line when there was logging after the test had finished.

### Solution

To fix `(Too many open files in system)` close the XML files after they are written.  To fix the single character log lines reset the swappable streams to their original streams before closing the TeeOutputStream they write to.

Also add a debug log line that is helpful when testing large test suites.

### Result

We can run our entire test suite and we get all of the logging we expect.