### PR TITLE
[pantsd] Catch ESRCH on os.kill of pantsd-runner.

### DIFF
--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -150,7 +150,7 @@ class NailgunClient(object):
     if self._session and self._session.remote_pid is not None:
       try:
         os.kill(self._session.remote_pid, signal.SIGINT)
-      except Exception as e:
+      except (OSError, IOError) as e:
         # Ignore "No such process" errors.
         if e.errno != errno.ESRCH:
           raise

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -148,7 +148,12 @@ class NailgunClient(object):
   def send_control_c(self):
     """Sends SIGINT to a nailgun server using pid information from the active session."""
     if self._session and self._session.remote_pid is not None:
-      os.kill(self._session.remote_pid, signal.SIGINT)
+      try:
+        os.kill(self._session.remote_pid, signal.SIGINT)
+      except Exception as e:
+        # Ignore "No such process" errors.
+        if e.errno != errno.ESRCH:
+          raise
 
   def execute(self, main_class, cwd=None, *args, **environment):
     """Executes the given main_class with any supplied args in the given environment.


### PR DESCRIPTION
### Problem

Sending control-C currently fires `os.kill`, which can fail if the process doesn't exist.

### Solution

Mask `errno.ESRCH` ("No such process...").

### Result

Fixes #5212