### PR TITLE
Kill noisy NodeModule.__init__() debug logging.

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/targets/node_module.py
+++ b/contrib/node/src/python/pants/contrib/node/targets/node_module.py
@@ -53,5 +53,4 @@ class NodeModule(NodePackage):
       'output_dir': PrimitiveField(output_dir),
       'dev_dependency': PrimitiveField(dev_dependency),
     })
-    logger.debug('NodeModule payload: %s', payload.fields)
     super(NodeModule, self).__init__(address=address, payload=payload, **kwargs)


### PR DESCRIPTION
This reduces debug output during a `./pants list ::` in repos containing many `NodeModule` targets.