### PR TITLE
TargetRoots always requires options

### DIFF
--- a/src/python/pants/init/target_roots.py
+++ b/src/python/pants/init/target_roots.py
@@ -12,8 +12,6 @@ from twitter.common.collections import OrderedSet
 from pants.base.build_environment import get_buildroot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.specs import SingleAddress
-from pants.init.options_initializer import OptionsInitializer
-from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.scm.subsystems.changed import ChangedRequest
 
 
@@ -40,16 +38,12 @@ class TargetRoots(object):
     return OrderedSet(spec_parser.parse_spec(spec_str) for spec_str in target_specs)
 
   @classmethod
-  def create(cls, options=None, args=None, build_root=None, change_calculator=None):
+  def create(cls, options, build_root=None, change_calculator=None):
     """
-    :param Options options: An `Options` instance to use, if available.
-    :param string args: Raw cli args to use for parsing if an `Options` instance isn't available.
+    :param Options options: An `Options` instance to use.
     :param string build_root: The build root.
     :param ChangeCalculator change_calculator: A `ChangeCalculator` for calculating changes.
     """
-    if not options:
-      assert args is not None, 'must pass `args` if not passing `options`'
-      options, _ = OptionsInitializer(OptionsBootstrapper(args=args)).setup(init_logging=False)
 
     # Determine the literal target roots.
     spec_roots = cls.parse_specs(options.target_specs, build_root)
@@ -59,7 +53,7 @@ class TargetRoots(object):
     changed_options = options.for_scope('changed')
     changed_request = ChangedRequest.from_options(changed_options)
 
-    logger.debug('args are: %s', args)
+
     logger.debug('spec_roots are: %s', spec_roots)
     logger.debug('changed_request is: %s', changed_request)
 

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -11,6 +11,8 @@ import sys
 import traceback
 from contextlib import contextmanager
 
+from pants.init.options_initializer import OptionsInitializer
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.pantsd.pailgun_server import PailgunServer
 from pants.pantsd.service.pants_service import PantsService
 
@@ -57,10 +59,10 @@ class PailgunService(PantsService):
 
       self._logger.debug('execution commandline: %s', arguments)
       if self._scheduler_service:
-        # N.B. This parses sys.argv by way of OptionsInitializer/OptionsBootstrapper prior to
-        # the main pants run to derive target roots for caching in the underlying product graph.
+        self._logger.debug('args are: %s', arguments)
+        options, _ = OptionsInitializer(OptionsBootstrapper(args=arguments)).setup(init_logging=False)
         target_roots = self._target_roots_class.create(
-          args=arguments,
+          options,
           change_calculator=self._scheduler_service.change_calculator
         )
         try:

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -65,7 +65,7 @@ class GraphTestBase(unittest.TestCase):
     return graph, target_roots
 
   def create_target_roots(self, specs):
-    return TargetRoots.create(options=self._make_setup_args(specs))
+    return TargetRoots.create(self._make_setup_args(specs))
 
 
 class GraphTargetScanFailureTests(GraphTestBase):


### PR DESCRIPTION
There are a surprising number of places where options parsing will
implicitly be done if you omit an optional argument.

This is one of a series of PRs which will push options parsing out to
happen where we actually have a reference to the arguments we're
parsing, rather than to implicitly happen wherever we may happen to need
options.