### PR TITLE
Fix PythonRun in the presence of the daemon.

### DIFF
--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 import signal
+import sys
 
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.tasks2.python_execution_task_base import PythonExecutionTaskBase
@@ -44,7 +45,12 @@ class PythonRun(PythonExecutionTaskBase):
       with self.context.new_workunit(name='run',
                                      cmd=pex.cmdline(args),
                                      labels=[WorkUnitLabel.TOOL, WorkUnitLabel.RUN]):
-        po = pex.run(blocking=False, args=args, env=os.environ.copy())
+        po = pex.run(blocking=False,
+                     args=args,
+                     env=os.environ.copy(),
+                     stdin=sys.stdin,
+                     stdout=sys.stdout,
+                     stderr=sys.stderr)
         try:
           result = po.wait()
           if result != 0:

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -6,15 +6,17 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.util.contextutil import temporary_dir
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 
 
 class PythonRunIntegrationTest(PantsRunIntegrationTest):
   testproject = 'testprojects/src/python/interpreter_selection'
 
+  @ensure_daemon
   def test_run_3(self):
     self._maybe_run_version('3')
 
+  @ensure_daemon
   def test_run_27(self):
     self._maybe_run_version('2.7')
 


### PR DESCRIPTION
### Problem

As described in #5040, if `stdin` and `stdout` are not explicitly passed to a forked subprocess, the `subprocess` module triggers additional logic that causes the current values of `sys.stdout` and `sys.stderr` to be ignored in favor of forking with the parent processes' values of [stdin, stdout, and stderr as 0, 1, and 2, respectively](http://man7.org/linux/man-pages/man3/stdin.3.html). In the case of pantsd-runner, this results in writing directly to the nailgun socket (which has one of those numerical `fds` in the forked process), and rendering an error like the one shown in #5221.

### Solution

Explicitly pass stdin/stdout/stderr.

### Result

Fixes #5221.