### PR TITLE
WIP: Perform exclude_target_regexp filtering only when constructing TargetRoots

### DIFF
--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -105,6 +105,7 @@ class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'symbol_ta
 class EngineInitializer(object):
   """Constructs the components necessary to run the v2 engine with v1 BuildGraph compatibility."""
 
+  # TODO(dwh): Ununsed exclude_target_regexps
   @staticmethod
   def setup_legacy_graph(pants_ignore_patterns,
                          workdir,
@@ -112,6 +113,7 @@ class EngineInitializer(object):
                          native=None,
                          build_file_aliases=None,
                          build_ignore_patterns=None,
+                         exclude_target_regexps=None,
                          subproject_roots=None,
                          include_trace_on_error=True):
     """Construct and return the components necessary for LegacyBuildGraph construction.

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -112,7 +112,6 @@ class EngineInitializer(object):
                          native=None,
                          build_file_aliases=None,
                          build_ignore_patterns=None,
-                         exclude_target_regexps=None,
                          subproject_roots=None,
                          include_trace_on_error=True):
     """Construct and return the components necessary for LegacyBuildGraph construction.
@@ -126,7 +125,6 @@ class EngineInitializer(object):
     :type build_file_aliases: :class:`pants.build_graph.build_file_aliases.BuildFileAliases`
     :param list build_ignore_patterns: A list of paths ignore patterns used when searching for BUILD
                                        files, usually taken from the '--build-ignore' global option.
-    :param list exclude_target_regexps: A list of regular expressions for excluding targets.
     :param list subproject_roots: Paths that correspond with embedded build roots
                                   under the current build root.
     :param bool include_trace_on_error: If True, when an error occurs, the error message will
@@ -148,7 +146,6 @@ class EngineInitializer(object):
     parser = LegacyPythonCallbacksParser(symbol_table, build_file_aliases)
     address_mapper = AddressMapper(parser=parser,
                                    build_ignore_patterns=build_ignore_patterns,
-                                   exclude_target_regexps=exclude_target_regexps,
                                    subproject_roots=subproject_roots)
 
     # Load the native backend.

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -104,7 +104,6 @@ class GoalRunnerFactory(object):
           native=native,
           build_file_aliases=self._build_config.registered_aliases(),
           build_ignore_patterns=build_ignore_patterns,
-          exclude_target_regexps=exclude_target_regexps,
           subproject_roots=subproject_build_roots,
           include_trace_on_error=self._options.for_global_scope().print_exception_stacktrace
         )

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 import os
-import re
 import traceback
 from collections import defaultdict
 
@@ -47,7 +46,8 @@ class BuildFileAddressMapper(AddressMapper):
   # patterns, because the asterisks in its name make it an invalid regexp.
   _UNMATCHED_KEY = '** unmatched **'
 
-  def __init__(self, build_file_parser, project_tree, build_ignore_patterns=None,
+  # TODO(dwh): Ununsed exclude_target_regexps
+  def __init__(self, build_file_parser, project_tree, build_ignore_patterns=None, exclude_target_regexps=None,
                subproject_roots=None):
     """Create a BuildFileAddressMapper.
 

--- a/src/python/pants/build_graph/build_file_address_mapper.py
+++ b/src/python/pants/build_graph/build_file_address_mapper.py
@@ -47,7 +47,7 @@ class BuildFileAddressMapper(AddressMapper):
   # patterns, because the asterisks in its name make it an invalid regexp.
   _UNMATCHED_KEY = '** unmatched **'
 
-  def __init__(self, build_file_parser, project_tree, build_ignore_patterns=None, exclude_target_regexps=None,
+  def __init__(self, build_file_parser, project_tree, build_ignore_patterns=None,
                subproject_roots=None):
     """Create a BuildFileAddressMapper.
 
@@ -59,8 +59,6 @@ class BuildFileAddressMapper(AddressMapper):
     self._project_tree = project_tree
     self._build_ignore_patterns = PathSpec.from_lines(GitWildMatchPattern, build_ignore_patterns or [])
 
-    self._exclude_target_regexps = exclude_target_regexps or []
-    self._exclude_patterns = [re.compile(pattern) for pattern in self._exclude_target_regexps]
     self.subproject_roots = subproject_roots or []
 
   @property
@@ -170,23 +168,11 @@ class BuildFileAddressMapper(AddressMapper):
     """Execute a collection of `specs.Spec` objects and return a set of Addresses."""
     excluded_target_map = defaultdict(set)  # pattern -> targets (for debugging)
 
-    def exclude_spec(spec):
-      for pattern in self._exclude_patterns:
-        if pattern.search(spec) is not None:
-          excluded_target_map[pattern.pattern].add(spec)
-          return True
-      excluded_target_map[self._UNMATCHED_KEY].add(spec)
-      return False
-
-    def exclude_address(address):
-      return exclude_spec(address.spec)
-
     #TODO: Investigate why using set will break ci. May help migration to v2 engine.
     addresses = OrderedSet()
     for spec in specs:
       for address in self._scan_spec(spec, fail_fast):
-        if not exclude_address(address):
-          addresses.add(address)
+        addresses.add(address)
 
     # Print debug information about the excluded targets
     if logger.getEffectiveLevel() <= logging.DEBUG and excluded_target_map:

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -244,17 +244,10 @@ def addresses_from_address_families(address_mapper, address_families, spec):
     if not address_families:
       raise ResolveError('Path "{}" contains no BUILD files.'.format(spec.directory))
 
-  def exclude_address(address):
-    if address_mapper.exclude_patterns:
-      address_str = address.spec
-      return any(p.search(address_str) is not None for p in address_mapper.exclude_patterns)
-    return False
-
   def all_included_addresses():
     return (a
             for af in address_families
-            for a in af.addressables.keys()
-            if not exclude_address(a))
+            for a in af.addressables.keys())
 
   if type(spec) in (DescendantAddresses, SiblingAddresses):
     raise_if_empty_address_families()

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -169,7 +169,6 @@ class AddressMapper(object):
                parser,
                build_patterns=None,
                build_ignore_patterns=None,
-               exclude_target_regexps=None,
                subproject_roots=None):
     """Create an AddressMapper.
 
@@ -181,13 +180,10 @@ class AddressMapper(object):
     :param tuple build_patterns: A tuple of fnmatch-compatible patterns for identifying BUILD files
                                  used to resolve addresses.
     :param list build_ignore_patterns: A list of path ignore patterns used when searching for BUILD files.
-    :param list exclude_target_regexps: A list of regular expressions for excluding targets.
     """
     self.parser = parser
     self.build_patterns = build_patterns or (b'BUILD', b'BUILD.*')
     self.build_ignore_patterns = PathSpec.from_lines(GitWildMatchPattern, build_ignore_patterns or [])
-    self._exclude_target_regexps = exclude_target_regexps or []
-    self.exclude_patterns = [re.compile(pattern) for pattern in self._exclude_target_regexps]
     self.subproject_roots = subproject_roots or []
 
   def __eq__(self, other):

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import re
 from collections import OrderedDict
 
 from pathspec import PathSpec
@@ -165,10 +164,12 @@ class ResolveError(MappingError):
 class AddressMapper(object):
   """Configuration to parse build files matching a filename pattern."""
 
+  # TODO(dwh): Ignored exclude_target_regexps
   def __init__(self,
                parser,
                build_patterns=None,
                build_ignore_patterns=None,
+               exclude_target_regexps=None,
                subproject_roots=None):
     """Create an AddressMapper.
 

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -115,7 +115,6 @@ class PantsDaemon(FingerprintedProcessManager):
         bootstrap_options.pants_workdir,
         native=native,
         build_ignore_patterns=bootstrap_options.build_ignore,
-        exclude_target_regexps=bootstrap_options.exclude_target_regexp,
         subproject_roots=bootstrap_options.subproject_roots,
       )
 


### PR DESCRIPTION
This is a bit messy, inefficient, and untested, but I'll fix that up if
CI is happy.

I'm consciously leaving the whole change_calculator branch of this as it
currently is, rather than trying to share the logic there too, because
it's slated to be deleted in 1.5.0.