### PR TITLE
Log and increase pantsd startup timeout

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -319,8 +319,8 @@ class PantsDaemon(FingerprintedProcessManager):
         self.terminate(include_watchman=False)
         self._logger.debug('launching pantsd')
         self.daemon_spawn()
-        # Wait up to 10 seconds for pantsd to write its pidfile so we can display the pid to the user.
-        self.await_pid(10)
+        # Wait up to 60 seconds for pantsd to write its pidfile.
+        self.await_pid(60)
       listening_port = self.read_named_socket('pailgun', int)
       pantsd_pid = self.pid
     self._logger.debug('released lock: {}'.format(self.process_lock))

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -118,8 +118,8 @@ class ProcessMetadataManager(object):
                           seconds. N.B. this is timing based, so won't be exact if the runtime of
                           the closure exceeds the timeout.
     :param float wait_interval: the amount of time to sleep between closure invocations.
-    :param float info_interval: the amount of time to wait before and between info logging that
-                                we're still waiting for the `action_msg`.
+    :param float info_interval: the amount of time to wait before and between reports via info
+                                logging that we're still waiting for the closure to succeed.
     :raises: :class:`ProcessManager.Timeout` on execution timeout.
     """
     now = time.time()

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -74,7 +74,8 @@ class ProcessMetadataManager(object):
   class MetadataError(Exception): pass
   class Timeout(Exception): pass
 
-  FILE_WAIT_SEC = 10
+  FAIL_WAIT_SEC = 10
+  INFO_INTERVAL_SEC = 5
   WAIT_INTERVAL_SEC = .1
 
   def __init__(self, metadata_base_dir=None):
@@ -105,7 +106,8 @@ class ProcessMetadataManager(object):
       return item
 
   @classmethod
-  def _deadline_until(cls, closure, timeout, wait_interval=WAIT_INTERVAL_SEC):
+  def _deadline_until(cls, closure, action_msg, timeout=FAIL_WAIT_SEC,
+                      wait_interval=WAIT_INTERVAL_SEC, info_interval=INFO_INTERVAL_SEC):
     """Execute a function/closure repeatedly until a True condition or timeout is met.
 
     :param func closure: the function/closure to execute (should not block for long periods of time
@@ -113,30 +115,38 @@ class ProcessMetadataManager(object):
     :param float timeout: the maximum amount of time to wait for a true result from the closure in
                           seconds. N.B. this is timing based, so won't be exact if the runtime of
                           the closure exceeds the timeout.
+    :param str action_msg: a description of the action that is being executed, to be rendered as
+                           info while we wait, and as part of any rendered exception.
     :param float wait_interval: the amount of time to sleep between closure invocations.
+    :param float info_interval: the amount of time to wait before and between info logging that
+                                we're still waiting for the `action_msg`.
     :raises: :class:`ProcessManager.Timeout` on execution timeout.
     """
-    deadline = time.time() + timeout
+    now = time.time()
+    deadline = now + timeout
+    info_deadline = now + info_interval
     while 1:
       if closure():
         return True
-      elif time.time() > deadline:
-        raise cls.Timeout('exceeded timeout of {} seconds for {}'.format(timeout, closure))
+
+      now = time.time()
+      if now > deadline:
+        raise cls.Timeout('exceeded timeout of {} seconds while waiting for {}'.format(timeout, action_msg))
+
+      if now > info_deadline:
+        logger.info('waiting for {}...'.format(action_msg))
+        info_deadline = now + info_interval
       elif wait_interval:
         time.sleep(wait_interval)
 
   @classmethod
-  def _wait_for_file(cls, filename, timeout=FILE_WAIT_SEC, want_content=True):
+  def _wait_for_file(cls, filename, timeout=FAIL_WAIT_SEC, want_content=True):
     """Wait up to timeout seconds for filename to appear with a non-zero size or raise Timeout()."""
     def file_waiter():
       return os.path.exists(filename) and (not want_content or os.path.getsize(filename))
 
-    try:
-      return cls._deadline_until(file_waiter, timeout)
-    except cls.Timeout:
-      # Re-raise with a more helpful exception message.
-      raise cls.Timeout('exceeded timeout of {} seconds while waiting for file {} to appear'
-                         .format(timeout, filename))
+    action_msg = 'file {} to appear'.format(filename)
+    return cls._deadline_until(file_waiter, action_msg, timeout=timeout)
 
   def _get_metadata_dir_by_name(self, name):
     """Retrieve the metadata dir by name.
@@ -407,7 +417,7 @@ class ProcessManager(ProcessMetadataManager):
 
         # Wait up to kill_wait seconds to terminate or move onto the next signal.
         try:
-          if self._deadline_until(self.is_dead, kill_wait):
+          if self._deadline_until(self.is_dead, 'daemon to exit', timeout=kill_wait):
             alive = False
             logger.debug('successfully terminated pid {}'.format(pid))
             break

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -112,11 +112,11 @@ class ProcessMetadataManager(object):
 
     :param func closure: the function/closure to execute (should not block for long periods of time
                          and must return True on success).
+    :param str action_msg: a description of the action that is being executed, to be rendered as
+                           info while we wait, and as part of any rendered exception.
     :param float timeout: the maximum amount of time to wait for a true result from the closure in
                           seconds. N.B. this is timing based, so won't be exact if the runtime of
                           the closure exceeds the timeout.
-    :param str action_msg: a description of the action that is being executed, to be rendered as
-                           info while we wait, and as part of any rendered exception.
     :param float wait_interval: the amount of time to sleep between closure invocations.
     :param float info_interval: the amount of time to wait before and between info logging that
                                 we're still waiting for the `action_msg`.
@@ -135,7 +135,7 @@ class ProcessMetadataManager(object):
 
       if now > info_deadline:
         logger.info('waiting for {}...'.format(action_msg))
-        info_deadline = now + info_interval
+        info_deadline = info_deadline + info_interval
       elif wait_interval:
         time.sleep(wait_interval)
 

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -141,7 +141,10 @@ class TestProcessMetadataManager(BaseTest):
 
   def test_deadline_until(self):
     with self.assertRaises(self.pmm.Timeout):
-      self.pmm._deadline_until(lambda: False, timeout=.1)
+      with self.captured_logging() as captured:
+        self.pmm._deadline_until(lambda: False, 'the impossible', timeout=.5, info_interval=.1)
+    self.assertTrue(4 <= len(captured.infos()) <= 6,
+                    'Expected between 4 and 6 infos, got: {}'.format(captured.infos()))
 
   def test_wait_for_file(self):
     with temporary_dir() as td:

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -109,6 +109,7 @@ python_tests(
   sources = ['test_osutil.py'],
   dependencies = [
     'src/python/pants/util:osutil',
+    'tests/python/pants_test:base_test',
   ]
 )
 


### PR DESCRIPTION
### Problem

As described on #5227, the 10 second startup time for the daemon is occasionally too short on a busy machine.

### Solution

Since the startup time of the daemon itself should not be proportional to the size of the repo, but just how busy the machine is, set the timeout much higher rather than making it configurable. Additionally, log why we are waiting (if we do end up waiting) in order to explain the potentially much longer delay.

### Result

Busy machines should not see spurious failures to start the daemon. Fixes #5227.