### PR TITLE
[pantsd] Repair daemon lifecycle options fingerprinting.

### DIFF
--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -329,6 +329,7 @@ class Options(object):
     :API: public
     """
     fingerprint_key = fingerprint_key or 'fingerprint'
+    fingerprint_default = bool(invert)
     pairs = []
 
     if include_passthru:
@@ -346,7 +347,7 @@ class Options(object):
       for (_, kwargs) in sorted(parser.option_registrations_iter()):
         if kwargs.get('recursive', False) and not kwargs.get('recursive_root', False):
           continue  # We only need to fprint recursive options once.
-        if bool(invert) == bool(kwargs.get(fingerprint_key, False)):
+        if kwargs.get(fingerprint_key, fingerprint_default) is not True:
           continue
         # Note that we read the value from scope, even if the registration was on an enclosing
         # scope, to get the right value for recursive options (and because this mirrors what

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -244,6 +244,22 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         pantsd_run(cmd[1:], {'GLOBAL': {'level': cmd[0]}})
         checker.assert_running()
 
+  def test_pantsd_lifecycle_non_invalidation(self):
+    with self.pantsd_successful_run_context() as (pantsd_run, checker, _):
+      variants = (
+        ['-q', 'help'],
+        ['--no-colors', 'help'],
+        ['help']
+      )
+      last_pid = None
+      for cmd in itertools.chain(*itertools.repeat(variants, 3)):
+        # Run with a CLI flag.
+        pantsd_run(cmd)
+        next_pid = checker.await_pantsd()
+        if last_pid is not None:
+          self.assertEqual(last_pid, next_pid)
+        last_pid = next_pid
+
   def test_pantsd_stray_runners(self):
     # Allow env var overrides for local stress testing.
     attempts = int(os.environ.get('PANTS_TEST_PANTSD_STRESS_ATTEMPTS', 20))


### PR DESCRIPTION
### Problem

Currently, changing any option in the global scope will result in the daemon restarting itself. It should only do this for options marked `daemon=False`.

### Solution

Repair `Options.get_fingerprintable_for_scope()` for the `inverted=True` case and add tests.

### Result

Fixes #5222