### PR TITLE
revert log statement edits from #5170 that break console logging

### DIFF
--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -364,10 +364,13 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
         targets.extend(vt.targets)
 
       if len(targets):
-        msg, detail = items_to_report_element(
-          [t.address.reference() for t in targets],
-          'target')
-        self.context.log.info('Invalidated {}: {}.'.format(msg, detail))
+        target_address_references = [t.address.reference() for t in targets]
+        msg_elements = [
+          'Invalidated ',
+          items_to_report_element(target_address_references, 'target'),
+          '.',
+        ]
+        self.context.log.info(*msg_elements)
 
     self._update_invalidation_report(invalidation_check, 'pre-check')
 
@@ -581,11 +584,14 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
       return None
 
   def _report_targets(self, prefix, targets, suffix, logger=None):
+    target_address_references = [t.address.reference() for t in targets]
+    msg_elements = [
+      prefix,
+      items_to_report_element(target_address_references, 'target'),
+      suffix,
+    ]
     logger = logger or self.context.log.info
-    msg, detail = items_to_report_element(
-      [t.address.reference() for t in targets],
-      'target')
-    logger(prefix + '{}: {}'.format(msg, detail) + suffix)
+    logger(*msg_elements)
 
   def require_single_root_target(self):
     """If a single target was specified on the cmd line, returns that target.


### PR DESCRIPTION
Revert log statement edits from 0bbe913f1 (#5170) that cause tests and many
other tasks to spew out many many lines of code to the console.

### Problem

After #5170, due to edits to some log statements that crept in there by accident, there's now tons more console output than before during many common tasks. This could be up to hundreds of lines more depending upon which targets were just invalidated. See the redacted shell log below:

```
> ./pants --tag='-integration' test.pytest --chroot tests/python/pants_test/backend/jvm::
::

01:54:28 00:00 [main]
               (To run a reporting server: ./pants server)
01:54:28 00:00   [setup]
01:54:30 00:02     [parse]
               Executing tasks in goals: bootstrap -> imports -> unpack-jars -> deferred-sources -> jvm-platform-validate -> gen -> resolve -> resources -> compile -> pyprep -> test
01:54:30 00:02   [bootstrap]

...more execution phase logs...

01:54:31 00:03     [sources]
                   Invalidated 66 targets: tests/python/pants_test:test_infra
                   tests/python/pants_test/backend/jvm:jar_dependency_utils
                   tests/python/pants_test/backend/jvm/subsystems:custom_scala
                   tests/python/pants_test/backend/jvm/subsystems:jar_dependency_management
                   tests/python/pants_test/backend/jvm/subsystems:shader
...continued for 61 more lines...
```

### Solution

Revert the changes to logging in `task.py` and use explicit, consistent variable names when passing arguments to the log function.

I'm really not sure how I let this one slip through, or even why I thought to do it in the first place (I vaguely remember there being some exception raised by an invalid argument to the logger call in these methods that was visible in the pants debug log for a failing pytest run for #5170, but I can't reproduce this even after looking through shell input history). Thanks a lot to @wisechengyi for pointing out the out-of-place edits on the previous PR -- I was going to comment on that and then realized this a problem when I happened upon [the explicit warning about this exact issue in `src/python/pants/reporting/plaintext_reporter.py`](https://github.com/pantsbuild/pants/blob/0bbe913f1c67f298b3191ed51498b20144536888/src/python/pants/reporting/plaintext_reporter.py#L163).