### PR TITLE
download_binary.sh takes hostname as a parameter

### DIFF
--- a/build-support/bin/download_binary.sh
+++ b/build-support/bin/download_binary.sh
@@ -1,31 +1,31 @@
 #!/bin/bash -eu
 
-# Downloads the specified binary at the specified version from binaries.pantsbuild.org if it's not already present.
+# Downloads the specified binary at the specified version from the specified binary host if it's not already present.
 # Uses a reimplementation of the BinaryUtils mechanism.
 # Outputs an absolute path to the binary, whether fetched or already present, to stdout.
 
 # If the file ends in ".tar.gz", untars the file and outputs the directory to which the files were untar'd.
 # Otherwise, makes the file executable.
 
-if [[ $# -ne 2 && $# -ne 3 ]]; then
-  echo >&2 "Usage: $0 util_name version [filename]"
-  echo >&2 "Example: $0 go 1.7.3 go.tar.gz"
+if [[ $# -ne 3 && $# -ne 4 ]]; then
+  echo >&2 "Usage: $0 host util_name version [filename]"
+  echo >&2 "Example: $0 binaries.pantsbuild.org go 1.7.3 go.tar.gz"
   exit 1
 fi
-util_name="$1"
-version="$2"
-filename="${3:-${util_name}}"
+host="$1"
+util_name="$2"
+version="$3"
+filename="${4:-${util_name}}"
 
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd "../.." && pwd)"
-source "${REPO_ROOT}/build-support/common.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-path="bin/${util_name}/$(get_os)/${version}/${filename}"
+path="bin/${util_name}/$("${SCRIPT_DIR}/get_os.sh")/${version}/${filename}"
 cache_path="${HOME}/.cache/pants/${path}"
 
 if [[ ! -f "${cache_path}" ]]; then
   mkdir -p "$(dirname "${cache_path}")"
-  curl --fail "https://binaries.pantsbuild.org/${path}" > "${cache_path}".tmp
+  curl --fail "https://${host}/${path}" > "${cache_path}".tmp
   mv "${cache_path}"{.tmp,}
   if [[ "${filename}" == *tar.gz ]]; then
     tar -C "$(dirname "${cache_path}")" -xzf "${cache_path}"

--- a/build-support/bin/get_os.sh
+++ b/build-support/bin/get_os.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+# Outputs the current operating system and variant, as used by BinaryUtils.
+# Example output: mac/10.13
+# Example output: linux/x86_64
+
+case "$(uname)" in
+  "Darwin")
+    os="mac"
+    base="$(uname -r)"
+    os_version="10.$(( ${base%%.*} - 4))"
+    ;;
+  "Linux")
+    os="linux"
+    os_version="$(uname -m)"
+    ;;
+  *)
+    echo >&2 "Unknown platform"
+    exit 1
+    ;;
+esac
+
+echo "${os}/${os_version}"

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -114,8 +114,8 @@ function ensure_native_build_prerequisites() {
   fi
 
   local download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
-  local readonly cmakeroot="$("${download_binary}" "cmake" "3.9.5" "cmake.tar.gz")" || die "Failed to fetch cmake"
-  local readonly goroot="$("${download_binary}" "go" "1.7.3" "go.tar.gz")/go" || die "Failed to fetch go"
+  local readonly cmakeroot="$("${download_binary}" "binaries.pantsbuild.org" "cmake" "3.9.5" "cmake.tar.gz")" || die "Failed to fetch cmake"
+  local readonly goroot="$("${download_binary}" "binaries.pantsbuild.org" "go" "1.7.3" "go.tar.gz")/go" || die "Failed to fetch go"
 
   export GOROOT="${goroot}"
   export EXTRA_PATH_FOR_CARGO="${cmakeroot}/bin:${goroot}/bin"

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -229,7 +229,7 @@ function build_pants_packages() {
   (
     set -e
     RUST_BACKTRACE=1 PANTS_SRCPATH="${ROOT}/src/python" run_cargo build --release --manifest-path="${ROOT}/src/rust/engine/fs/fs_util/Cargo.toml"
-    dst_dir="${DEPLOY_DIR}/bin/fs_util/$(get_os)/${version}"
+    dst_dir="${DEPLOY_DIR}/bin/fs_util/$("${ROOT}/build-support/bin/get_os.sh")/${version}"
     mkdir -p "${dst_dir}"
     cp "${ROOT}/src/rust/engine/fs/fs_util/target/release/fs_util" "${dst_dir}/"
   ) || die "Failed to build fs_util"

--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -82,23 +82,3 @@ function set_archflags() {
   fi
 }
 set_archflags
-
-function get_os() {
-  case "$(uname)" in
-    "Darwin")
-      os="mac"
-      base="$(uname -r)"
-      os_version="10.$(( ${base%%.*} - 4))"
-      ;;
-    "Linux")
-      os="linux"
-      os_version="$(uname -m)"
-      ;;
-    *)
-      echo >&2 "Unknown platform"
-      exit 1
-      ;;
-  esac
-
-  echo "${os}/${os_version}"
-}

--- a/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
+++ b/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
@@ -5,7 +5,7 @@
 here="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 REPO_ROOT="$(dirname "$(dirname "$(dirname "$(dirname "$(dirname "${here}")")")")")"
 
-protoc="$("${REPO_ROOT}/build-support/bin/download_binary.sh" "protobuf" "3.4.1" "protoc")"
+protoc="$("${REPO_ROOT}/build-support/bin/download_binary.sh" "binaries.pantsbuild.org" "protobuf" "3.4.1" "protoc")"
 
 thirdpartyprotobuf="../../../../../3rdparty/protobuf"
 googleapis="${thirdpartyprotobuf}/googleapis"


### PR DESCRIPTION
This allows it to be re-used in contexts where an alternative binary
host is used.