### PR TITLE
Swap stdio file descriptors at the os level

### DIFF
--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import sys
 
 from pex.pex_info import PexInfo
 
@@ -53,10 +52,5 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
   # NB: **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):
     env = pex_run_kwargs.pop('env', os.environ).copy()
-    po = pex.run(blocking=False,
-                 env=env,
-                 stdin=sys.stdin,
-                 stdout=sys.stdout,
-                 stderr=sys.stderr,
-                 **pex_run_kwargs)
+    po = pex.run(blocking=False, env=env, **pex_run_kwargs)
     po.wait()

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -117,7 +117,7 @@ class DaemonPantsRunner(ProcessManager):
            (stdout_isatty, stderr_isatty)
          ) as ((stdout, stderr), writer),\
          NailgunStreamStdinReader.open(sock, stdin_isatty) as stdin,\
-         stdio_as(stdout=stdout, stderr=stderr, stdin=stdin):
+         stdio_as(stdout_fd=stdout.fileno(), stderr_fd=stderr.fileno(), stdin_fd=stdin.fileno()):
       # N.B. This will be passed to and called by the `DaemonExiter` prior to sending an
       # exit chunk, to avoid any socket shutdown vs write races.
       def finalizer():

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -115,11 +115,12 @@ class DaemonPantsRunner(ProcessManager):
            (ChunkType.STDOUT, ChunkType.STDERR),
            None,
            (stdout_isatty, stderr_isatty)
-         ) as ((stdout, stderr), writer),\
-         NailgunStreamStdinReader.open(sock, stdin_isatty) as stdin,\
-         stdio_as(stdout_fd=stdout.fileno(), stderr_fd=stderr.fileno(), stdin_fd=stdin.fileno()):
+         ) as ((stdout_fd, stderr_fd), writer),\
+         NailgunStreamStdinReader.open(sock, stdin_isatty) as stdin_fd,\
+         stdio_as(stdout_fd=stdout_fd, stderr_fd=stderr_fd, stdin_fd=stdin_fd):
       # N.B. This will be passed to and called by the `DaemonExiter` prior to sending an
       # exit chunk, to avoid any socket shutdown vs write races.
+      stdout, stderr = sys.stdout, sys.stderr
       def finalizer():
         try:
           stdout.flush()

--- a/src/python/pants/java/nailgun_client.py
+++ b/src/python/pants/java/nailgun_client.py
@@ -23,18 +23,18 @@ logger = logging.getLogger(__name__)
 class NailgunClientSession(NailgunProtocol):
   """Handles a single nailgun client session."""
 
-  def __init__(self, sock, in_fd, out_fd, err_fd, exit_on_broken_pipe=False):
+  def __init__(self, sock, in_file, out_file, err_file, exit_on_broken_pipe=False):
     self._sock = sock
     self._input_writer = None
-    if in_fd:
+    if in_file:
       self._input_writer = NailgunStreamWriter(
-        (in_fd,),
+        (in_file.fileno(),),
         self._sock,
         (ChunkType.STDIN,),
         ChunkType.STDIN_EOF
       )
-    self._stdout = out_fd
-    self._stderr = err_fd
+    self._stdout = out_file
+    self._stderr = err_file
     self._exit_on_broken_pipe = exit_on_broken_pipe
     self.remote_pid = None
 

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -117,7 +117,7 @@ class NailgunStreamWriter(_StoppableDaemonThread):
 
   def __init__(self, in_fds, sock, chunk_types, chunk_eof_type, buf_size=None, select_timeout=None):
     """
-    :param tuple in_files: A tuple of input file-likes to read from.
+    :param tuple in_fds: A tuple of input file descriptors to read from.
     :param socket sock: the socket to emit nailgun protocol chunks over.
     :param tuple chunk_types: A tuple of chunk types with a 1:1 positional association with in_files.
     :param int chunk_eof_type: The nailgun chunk type for EOF (applies only to stdin).
@@ -125,7 +125,8 @@ class NailgunStreamWriter(_StoppableDaemonThread):
     :param int select_timeout: the timeout (in seconds) for select.select() calls against the fd.
     """
     super(NailgunStreamWriter, self).__init__()
-    self._in_fds = list(in_fds[:])
+    # Validates that we've received file descriptor numbers.
+    self._in_fds = [int(f) for f in in_fds]
     self._socket = sock
     self._chunk_eof_type = chunk_eof_type
     self._buf_size = buf_size or io.DEFAULT_BUFFER_SIZE

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -19,8 +19,11 @@ from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 @contextmanager
 def _pipe(isatty):
   r_fd, w_fd = os.openpty() if isatty else os.pipe()
-  with os.fdopen(r_fd, 'r') as r, os.fdopen(w_fd, 'w') as w:
-    yield (r, w)
+  try:
+    yield (r_fd, w_fd)
+  finally:
+    os.close(r_fd)
+    os.close(w_fd)
 
 
 class _StoppableDaemonThread(threading.Thread):
@@ -79,10 +82,10 @@ class NailgunStreamStdinReader(_StoppableDaemonThread):
   @classmethod
   @contextmanager
   def open(cls, sock, isatty=False):
-    with _pipe(isatty) as (read_handle, write_handle):
-      reader = NailgunStreamStdinReader(sock, write_handle)
+    with _pipe(isatty) as (read_fd, write_fd):
+      reader = NailgunStreamStdinReader(sock, os.fdopen(write_fd, 'wb'))
       with reader.running():
-        yield read_handle
+        yield read_fd
 
   def run(self):
     try:
@@ -112,7 +115,7 @@ class NailgunStreamWriter(_StoppableDaemonThread):
 
   SELECT_TIMEOUT = .15
 
-  def __init__(self, in_files, sock, chunk_types, chunk_eof_type, buf_size=None, select_timeout=None):
+  def __init__(self, in_fds, sock, chunk_types, chunk_eof_type, buf_size=None, select_timeout=None):
     """
     :param tuple in_files: A tuple of input file-likes to read from.
     :param socket sock: the socket to emit nailgun protocol chunks over.
@@ -122,13 +125,13 @@ class NailgunStreamWriter(_StoppableDaemonThread):
     :param int select_timeout: the timeout (in seconds) for select.select() calls against the fd.
     """
     super(NailgunStreamWriter, self).__init__()
-    self._in_files = list(in_files[:])
+    self._in_fds = list(in_fds[:])
     self._socket = sock
     self._chunk_eof_type = chunk_eof_type
     self._buf_size = buf_size or io.DEFAULT_BUFFER_SIZE
     self._select_timeout = select_timeout or self.SELECT_TIMEOUT
-    self._assert_aligned(in_files, chunk_types)
-    self._fileno_chunk_type_map = {f.fileno(): t for f, t in zip(in_files, chunk_types)}
+    self._assert_aligned(in_fds, chunk_types)
+    self._fileno_chunk_type_map = {f: t for f, t in zip(in_fds, chunk_types)}
 
   @classmethod
   def _assert_aligned(self, *iterables):
@@ -149,12 +152,12 @@ class NailgunStreamWriter(_StoppableDaemonThread):
 
     # N.B. This is purely to permit safe handling of a dynamic number of contextmanagers.
     with ExitStack() as stack:
-      read_handles, write_handles = zip(
+      read_fds, write_fds = zip(
         # Allocate one pipe pair per chunk type provided.
         *(stack.enter_context(_pipe(isatty)) for isatty in isattys)
       )
       writer = NailgunStreamWriter(
-        read_handles,
+        read_fds,
         sock,
         chunk_types,
         chunk_eof_type,
@@ -162,15 +165,14 @@ class NailgunStreamWriter(_StoppableDaemonThread):
         select_timeout=select_timeout
       )
       with writer.running():
-        yield write_handles, writer
+        yield write_fds, writer
 
   def run(self):
-    while self._in_files and not self.is_stopped:
-      readable, _, errored = select.select(self._in_files, [], self._in_files, self._select_timeout)
+    while self._in_fds and not self.is_stopped:
+      readable, _, errored = select.select(self._in_fds, [], self._in_fds, self._select_timeout)
 
       if readable:
-        for fh in readable:
-          fileno = fh.fileno()
+        for fileno in readable:
           data = os.read(fileno, self._buf_size)
 
           if not data:
@@ -182,7 +184,7 @@ class NailgunStreamWriter(_StoppableDaemonThread):
               try:
                 os.close(fileno)
               finally:
-                self._in_files.remove(fh)
+                self._in_fds.remove(fileno)
           else:
             NailgunProtocol.write_chunk(
               self._socket,
@@ -191,5 +193,5 @@ class NailgunStreamWriter(_StoppableDaemonThread):
             )
 
       if errored:
-        for fh in errored:
-          self._in_files.remove(fh)
+        for fileno in errored:
+          self._in_fds.remove(fileno)

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -68,6 +68,8 @@ python_library(
     'src/python/pants/pantsd/service:fs_event_service',
     'src/python/pants/pantsd/service:pailgun_service',
     'src/python/pants/pantsd/service:scheduler_service',
+    'src/python/pants/util:collections',
+    'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',
     ':process_manager',
     ':watchman_launcher'

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 import threading
+from contextlib import contextmanager
 
 from setproctitle import setproctitle as set_process_title
 
@@ -28,6 +29,7 @@ from pants.pantsd.service.pailgun_service import PailgunService
 from pants.pantsd.service.scheduler_service import SchedulerService
 from pants.pantsd.watchman_launcher import WatchmanLauncher
 from pants.util.collections import combined_dict
+from pants.util.contextutil import stdio_as
 from pants.util.memo import memoized_property
 
 
@@ -202,7 +204,7 @@ class PantsDaemon(FingerprintedProcessManager):
       self._kill_switch.set()
 
   @staticmethod
-  def _close_fds():
+  def _close_stdio():
     """Close stdio streams to avoid output in the tty that launched pantsd."""
     for fd in (sys.stdin, sys.stdout, sys.stderr):
       file_no = fd.fileno()
@@ -210,21 +212,37 @@ class PantsDaemon(FingerprintedProcessManager):
       fd.close()
       os.close(file_no)
 
-  def _setup_logging(self, log_level):
-    """Initializes logging."""
-    # Reinitialize logging for the daemon context.
-    result = setup_logging(log_level, log_dir=self._log_dir, log_name=self.LOG_NAME)
+  @contextmanager
+  def _pantsd_logging(self):
+    """A context manager that runs with pantsd logging.
 
-    # Close out tty file descriptors.
-    self._close_fds()
+    Asserts that stdio (represented by file handles 0, 1, 2) is closed to ensure that
+    we can safely reuse those fd numbers.
+    """
 
-    # Redirect stdio to the root logger.
-    sys.stdout = _LoggerStream(logging.getLogger(), logging.INFO, result.log_stream)
-    sys.stderr = _LoggerStream(logging.getLogger(), logging.WARN, result.log_stream)
+    # Ensure that stdio is closed so that we can safely reuse those file descriptors.
+    for fd in (0, 1, 2):
+      try:
+        os.fdopen(fd)
+        raise AssertionError(
+            'pantsd logging cannot initialize while stdio is open: {}'.format(fd))
+      except OSError:
+        pass
 
-    self._logger.debug('logging initialized')
+    # Redirect stdio to /dev/null for the rest of the run, to reserve those file descriptors
+    # for further forks.
+    with stdio_as(stdin_fd=-1, stdout_fd=-1, stderr_fd=-1):
+      # Reinitialize logging for the daemon context.
+      result = setup_logging(self._log_level, log_dir=self._log_dir, log_name=self.LOG_NAME)
 
-    return result.log_stream
+      # Do a python-level redirect of stdout/stderr, which will not disturb `0,1,2`.
+      # TODO: Consider giving these pipes/actual fds, in order to make them "deep" replacements
+      # for `1,2`, and allow them to be used via `stdio_as`.
+      sys.stdout = _LoggerStream(logging.getLogger(), logging.INFO, result.log_stream)
+      sys.stderr = _LoggerStream(logging.getLogger(), logging.WARN, result.log_stream)
+
+      self._logger.debug('logging initialized')
+      yield result.log_stream
 
   def _setup_services(self, services):
     assert self._lifecycle_lock is not None, 'PantsDaemon lock has not been set!'
@@ -278,21 +296,22 @@ class PantsDaemon(FingerprintedProcessManager):
   def run_sync(self):
     """Synchronously run pantsd."""
     # Switch log output to the daemon's log stream from here forward.
-    log_stream = self._setup_logging(self._log_level)
-    self._exiter.set_except_hook(log_stream)
-    self._logger.info('pantsd starting, log level is {}'.format(self._log_level))
+    self._close_stdio()
+    with self._pantsd_logging() as log_stream:
+      self._exiter.set_except_hook(log_stream)
+      self._logger.info('pantsd starting, log level is {}'.format(self._log_level))
 
-    self._native.set_panic_handler()
+      self._native.set_panic_handler()
 
-    # Set the process name in ps output to 'pantsd' vs './pants compile src/etc:: -ldebug'.
-    set_process_title('pantsd [{}]'.format(self._build_root))
+      # Set the process name in ps output to 'pantsd' vs './pants compile src/etc:: -ldebug'.
+      set_process_title('pantsd [{}]'.format(self._build_root))
 
-    # Write service socket information to .pids.
-    self._write_named_sockets(self._socket_map)
+      # Write service socket information to .pids.
+      self._write_named_sockets(self._socket_map)
 
-    # Enter the main service runner loop.
-    self._setup_services(self._services)
-    self._run_services(self._services)
+      # Enter the main service runner loop.
+      self._setup_services(self._services)
+      self._run_services(self._services)
 
   def post_fork_child(self):
     """Post-fork() child callback for ProcessManager.daemon_spawn()."""

--- a/tests/python/pants_test/backend/python/tasks/test_python_isort_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_isort_integration.py
@@ -6,11 +6,12 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.backend.python.tasks.python_isort import IsortPythonTask
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 
 
 class PythonIsortTest(PantsRunIntegrationTest):
 
+  @ensure_daemon
   def test_isort_no_python_sources_should_noop(self):
     command = ['-ldebug',
                'fmt.isort',

--- a/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
@@ -19,7 +19,7 @@ from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants.task.repl_task_mixin import ReplTaskMixin
-from pants.util.contextutil import environment_as, temporary_dir
+from pants.util.contextutil import environment_as, stdio_as, temporary_dir
 from pants_test.backend.python.tasks.python_task_test_base import PythonTaskTestBase
 
 
@@ -70,20 +70,16 @@ class PythonReplTest(PythonTaskTestBase):
     ReplTaskMixin.reset_implementations()
 
   @contextmanager
-  def new_io(self, input):
-    orig_stdin, orig_stdout, orig_stderr = sys.stdin, sys.stdout, sys.stderr
+  def new_io(self, stdin_data):
     with temporary_dir() as iodir:
       stdin = os.path.join(iodir, 'stdin')
       stdout = os.path.join(iodir, 'stdout')
       stderr = os.path.join(iodir, 'stderr')
       with open(stdin, 'w') as fp:
-        fp.write(input)
+        fp.write(stdin_data)
       with open(stdin, 'rb') as inp, open(stdout, 'wb') as out, open(stderr, 'wb') as err:
-        sys.stdin, sys.stdout, sys.stderr = inp, out, err
-        try:
-          yield inp, out, err
-        finally:
-          sys.stdin, sys.stdout, sys.stderr = orig_stdin, orig_stdout, orig_stderr
+        with stdio_as(stdin_fd=inp.fileno(), stdout_fd=out.fileno(), stderr_fd=err.fileno()):
+          yield (stdin, stdout, stderr)
 
   def do_test_repl(self, code, expected, targets, options=None):
     if options:
@@ -123,7 +119,7 @@ class PythonReplTest(PythonTaskTestBase):
 
     with self.new_io('\n'.join(code)) as (inp, out, err):
       python_repl.execute()
-      with open(out.name) as fp:
+      with open(out) as fp:
         lines = fp.read()
         if not expected:
           self.assertEqual('', lines)

--- a/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_repl.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import sys
 from contextlib import contextmanager
 from textwrap import dedent
 

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -11,16 +11,18 @@ import sys
 from pex.pex_bootstrapper import get_pex_info
 
 from pants.util.contextutil import temporary_dir
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest, ensure_daemon
 from pants_test.testutils.pexrc_util import setup_pexrc_with_pex_python_path
 
 
 class PythonRunIntegrationTest(PantsRunIntegrationTest):
   testproject = 'testprojects/src/python/interpreter_selection'
 
+  @ensure_daemon
   def test_run_3(self):
     self._maybe_run_version('3')
 
+  @ensure_daemon
   def test_run_27(self):
     self._maybe_run_version('2.7')
 

--- a/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_python_run_integration.py
@@ -27,6 +27,9 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     self._maybe_run_version('2.7')
 
   def test_run_27_and_then_3(self):
+    if self.skip_if_no_python('2.7') or self.skip_if_no_python('3'):
+      return
+
     with temporary_dir() as interpreters_cache:
       pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
       pants_run_27 = self.run_pants(
@@ -66,54 +69,50 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
   def test_pants_run_interpreter_selection_with_pexrc(self):
     py27 = '2.7'
     py3 = '3'
-    if self.has_python_version(py27) and self.has_python_version(py3):
-      print('Found both python {} and python {}. Running test.'.format(py27, py3))
-      py27_path, py3_path = self.python_interpreter_path(py27), self.python_interpreter_path(py3)
-      with setup_pexrc_with_pex_python_path(os.path.join(os.path.dirname(sys.argv[0]), '.pexrc'), [py27_path, py3_path]):
-        with temporary_dir() as interpreters_cache:
-          pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
-          pants_run_27 = self.run_pants(
-            command=['run', '{}:main_py2'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
-            config=pants_ini_config
-          )
-          self.assert_success(pants_run_27)
-          # Interpreter selection for Python 2 is problematic in CI due to multiple virtualenvs in play.
-          if not os.getenv('CI'):
-            self.assertIn(py27_path.split(py27)[0], pants_run_27.stdout_data)
-          pants_run_3 = self.run_pants(
-            command=['run', '{}:main_py3'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
-            config=pants_ini_config
-          )
-          self.assert_success(pants_run_3)
-          # Protection for when the sys.executable path underlies a symlink pointing to 'python' without '3'
-          # at the end of the basename.
-          self.assertIn(py3_path.split(py3)[0], pants_run_3.stdout_data)
-    else:
-      print('Could not find both python {} and python {} on system. Skipping.'.format(py27, py3))
-      self.skipTest('Missing neccesary Python interpreters on system.')
+    if self.skip_if_no_python(py27) or self.skip_if_no_python(py3):
+      return
+
+    py27_path, py3_path = self.python_interpreter_path(py27), self.python_interpreter_path(py3)
+    with setup_pexrc_with_pex_python_path(os.path.join(os.path.dirname(sys.argv[0]), '.pexrc'), [py27_path, py3_path]):
+      with temporary_dir() as interpreters_cache:
+        pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
+        pants_run_27 = self.run_pants(
+          command=['run', '{}:main_py2'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
+          config=pants_ini_config
+        )
+        self.assert_success(pants_run_27)
+        # Interpreter selection for Python 2 is problematic in CI due to multiple virtualenvs in play.
+        if not os.getenv('CI'):
+          self.assertIn(py27_path.split(py27)[0], pants_run_27.stdout_data)
+        pants_run_3 = self.run_pants(
+          command=['run', '{}:main_py3'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
+          config=pants_ini_config
+        )
+        self.assert_success(pants_run_3)
+        # Protection for when the sys.executable path underlies a symlink pointing to 'python' without '3'
+        # at the end of the basename.
+        self.assertIn(py3_path.split(py3)[0], pants_run_3.stdout_data)
 
   def test_pants_binary_interpreter_selection_with_pexrc(self):
     py27 = '2.7'
     py3 = '3'
-    if self.has_python_version(py27) and self.has_python_version(py3):
-      print('Found both python {} and python {}. Running test.'.format(py27, py3))
-      py27_path, py3_path = self.python_interpreter_path(py27), self.python_interpreter_path(py3)
-      with setup_pexrc_with_pex_python_path(os.path.join(os.path.dirname(sys.argv[0]), '.pexrc')  , [py27_path, py3_path]):
-        with temporary_dir() as interpreters_cache:
-          pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
-          pants_run_27 = self.run_pants(
-            command=['binary', '{}:main_py2'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
-            config=pants_ini_config
-          )
-          self.assert_success(pants_run_27)
-          pants_run_3 = self.run_pants(
-            command=['binary', '{}:main_py3'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
-            config=pants_ini_config
-          )
-          self.assert_success(pants_run_3)
-    else:
-      print('Could not find both python {} and python {} on system. Skipping.'.format(py27, py3))
-      self.skipTest('Missing neccesary Python interpreters on system.')
+    if self.skip_if_no_python(py27) or self.skip_if_no_python(py3):
+      return
+
+    py27_path, py3_path = self.python_interpreter_path(py27), self.python_interpreter_path(py3)
+    with setup_pexrc_with_pex_python_path(os.path.join(os.path.dirname(sys.argv[0]), '.pexrc')  , [py27_path, py3_path]):
+      with temporary_dir() as interpreters_cache:
+        pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}
+        pants_run_27 = self.run_pants(
+          command=['binary', '{}:main_py2'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
+          config=pants_ini_config
+        )
+        self.assert_success(pants_run_27)
+        pants_run_3 = self.run_pants(
+          command=['binary', '{}:main_py3'.format(os.path.join(self.testproject, 'python_3_selection_testing'))],
+          config=pants_ini_config
+        )
+        self.assert_success(pants_run_3)
 
     # Ensure proper interpreter constraints were passed to built pexes.
     py2_pex = os.path.join(os.getcwd(), 'dist', 'main_py2.pex')
@@ -127,17 +126,23 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     os.remove(py2_pex)
     os.remove(py3_pex)
 
+  def skip_if_no_python(self, version):
+    if not self.has_python_version(version):
+      msg = 'No python {} found. Skipping.'.format(version)
+      print(msg)
+      self.skipTest(msg)
+      return True
+    return False
+
   def _maybe_run_version(self, version):
-    if self.has_python_version(version):
-      print('Found python {}. Testing running on it.'.format(version))
-      echo = self._run_echo_version(version)
-      v = echo.split('.')  # E.g., 2.7.13.
-      self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
-      expected_components = version.split('.')
-      self.assertEquals(expected_components, v[:len(expected_components,)])
-    else:
-      print('No python {} found. Skipping.'.format(version))
-      self.skipTest('No python {} on system'.format(version))
+    if self.skip_if_no_python(version):
+      return
+
+    echo = self._run_echo_version(version)
+    v = echo.split('.')  # E.g., 2.7.13.
+    self.assertTrue(len(v) > 2, 'Not a valid version string: {}'.format(v))
+    expected_components = version.split('.')
+    self.assertEquals(expected_components, v[:len(expected_components,)])
 
   def _run_echo_version(self, version):
     binary_name = 'echo_interpreter_version_{}'.format(version)

--- a/tests/python/pants_test/java/test_nailgun_client.py
+++ b/tests/python/pants_test/java/test_nailgun_client.py
@@ -49,9 +49,9 @@ class TestNailgunClientSession(unittest.TestCase):
 
     self.nailgun_client_session = NailgunClientSession(
       sock=self.client_sock,
-      in_fd=None,
-      out_fd=self.fake_stdout,
-      err_fd=self.fake_stderr
+      in_file=None,
+      out_file=self.fake_stdout,
+      err_file=self.fake_stderr
     )
 
     self.mock_stdin_reader = mock.create_autospec(NailgunStreamWriter, spec_set=True)

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -291,9 +291,9 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
       daemon_runs = [pantsd_run(cmd) for cmd in cmds]
       checker.await_pantsd()
 
-    for run in daemon_runs:
-      self.assertEqual(run.stderr_data.strip(), '')
-      self.assertNotEqual(run.stdout_data, '')
+    for cmd, run in zip(cmds, daemon_runs):
+      self.assertEqual(run.stderr_data.strip(), '', 'Non-empty stderr for {}'.format(cmd))
+      self.assertNotEqual(run.stdout_data, '', 'Empty stdout for {}'.format(cmd))
 
     for run_pairs in zip(non_daemon_runs, daemon_runs):
       self.assertEqual(*(run.stdout_data for run in run_pairs))


### PR DESCRIPTION
### Problem

As explained in comments on #5221, due to how we were replacing the file descriptors that backed `sys.{stdin,stdout,stderr}`, it was possible for `subprocess` calls to behave differently in the daemon vs outside the daemon. In short: `subprocess` contains assumptions that the file descriptors behind the stdio handles have file descriptors `0, 1, 2`. 

### Solution

Update `stdio_as` to make os-level replacements of file descriptors, in addition to the replacements of the python-level handles. As explained in the docstring there, it is impossible to tell whether the replaced file descriptors in `0, 1, 2` have been leaked/aliased for other usages, so the caller needs to be careful that the handles they are replacing are safe to replace.

This is accomplished in the context of the `pantsd` process by calling `stdio_as` immediately after we close the stdio file handles, guaranteeing that they are reusable. We replace them with open (but useless: pointed to `/dev/null`) handles to reserve the `0, 1, 2` file descriptors for usage in forked runners.

Finally, in the `pantsd-runner` process, the reserved `0, 1, 2` slots are replaced (again at the os fd level) with pipes that are copied to the nailgun socket.

### Result

#5221 is fixed, and further recurrences of that issue are prevented since `subprocess` calls act exactly as they would outside the context of the daemon.