### PR TITLE
add safe extract for archivers

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -100,7 +100,7 @@ class NodeDistribution(object):
       supportdir=supportdir, version=version, name=filename)
     logger.debug('Tarball for %s(%s): %s', supportdir, version, tarball_filepath)
     work_dir = os.path.dirname(tarball_filepath)
-    TGZ.extract(tarball_filepath, work_dir)
+    TGZ.extract(tarball_filepath, work_dir, safe=True)
     return work_dir
 
   @memoized_method

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -100,7 +100,7 @@ class NodeDistribution(object):
       supportdir=supportdir, version=version, name=filename)
     logger.debug('Tarball for %s(%s): %s', supportdir, version, tarball_filepath)
     work_dir = os.path.dirname(tarball_filepath)
-    TGZ.extract(tarball_filepath, work_dir, safe=True)
+    TGZ.extract(tarball_filepath, work_dir, concurrency_safe=True)
     return work_dir
 
   @memoized_method

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -100,7 +100,7 @@ class NodeDistribution(object):
       supportdir=supportdir, version=version, name=filename)
     logger.debug('Tarball for %s(%s): %s', supportdir, version, tarball_filepath)
     work_dir = os.path.dirname(tarball_filepath)
-    TGZ.extract(tarball_filepath, work_dir, safe=True)
+    TGZ.extract(tarball_filepath, work_dir)
     return work_dir
 
   @memoized_method

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -22,7 +22,7 @@ from pants.util.strutil import ensure_text
 class Archiver(AbstractClass):
 
   @classmethod
-  def extract(cls, path, outdir, filter_func=None, safe=False):
+  def extract(cls, path, outdir, filter_func=None, concurrency_safe=False):
     """Extracts an archive's contents to the specified outdir with an optional filter.
 
     :API: public
@@ -31,15 +31,17 @@ class Archiver(AbstractClass):
     :param string outdir: directory to extract files into
     :param function filter_func: optional filter with the filename as the parameter.  Returns True
       if the file should be extracted.  Note that filter_func is ignored for non-zip archives.
-    :param bool safe: True if use safe extraction.  Safe extraction ignores errors if destination
-      already exists and thus is safe to use in different threads / concurrent processes.
+    :param bool concurrency_safe: True to use concurrency safe method.  Concurrency safe extraction
+      will be performed on a temporary directory and the extacted directory will then be renamed
+      atomically to the outdir.  As a side effect, concurrency safe extraction will not allow
+      overlay of extracted contents onto an existing outdir.
     """
-    if safe:
+    if concurrency_safe:
       with temporary_dir() as temp_dir:
         cls._extract(path, temp_dir)
         safe_concurrent_rename(temp_dir, outdir)
     else:
-      # Leave the existing default behavior unchanged.
+      # Leave the existing default behavior unchanged and allows overlay of contents.
       cls._extract(path, outdir, filter_func=filter_func)
 
   @classmethod

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -22,7 +22,7 @@ from pants.util.strutil import ensure_text
 class Archiver(AbstractClass):
 
   @classmethod
-  def extract(cls, path, outdir, filter_func=None, safe=False):
+  def extract(cls, path, outdir, filter_func=None):
     """Extracts an archive's contents to the specified outdir with an optional filter.
 
     :API: public
@@ -31,16 +31,11 @@ class Archiver(AbstractClass):
     :param string outdir: directory to extract files into
     :param function filter_func: optional filter with the filename as the parameter.  Returns True
       if the file should be extracted.  Note that filter_func is ignored for non-zip archives.
-    :param bool safe: True if use safe extraction.  Safe extraction ignores errors if destination
-      already exists and thus is safe to use in different threads / concurrent processes.
     """
-    if safe:
-      with temporary_dir() as temp_dir:
-        cls._extract(path, temp_dir)
-        safe_concurrent_rename(temp_dir, outdir)
-    else:
-      # Leave the existing default behavior unchanged.
-      cls._extract(path, outdir, filter_func=filter_func)
+    # TODO(unrememberme): consider safe_concurrent_creation after it is made UNICODE safe.
+    with temporary_dir() as temp_dir:
+      cls._extract(path, temp_dir, filter_func=filter_func)
+      safe_concurrent_rename(temp_dir, outdir)
 
   @classmethod
   def _extract(cls, path, outdir):

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -22,7 +22,7 @@ from pants.util.strutil import ensure_text
 class Archiver(AbstractClass):
 
   @classmethod
-  def extract(cls, path, outdir, filter_func=None):
+  def extract(cls, path, outdir, filter_func=None, safe=False):
     """Extracts an archive's contents to the specified outdir with an optional filter.
 
     :API: public
@@ -31,11 +31,16 @@ class Archiver(AbstractClass):
     :param string outdir: directory to extract files into
     :param function filter_func: optional filter with the filename as the parameter.  Returns True
       if the file should be extracted.  Note that filter_func is ignored for non-zip archives.
+    :param bool safe: True if use safe extraction.  Safe extraction ignores errors if destination
+      already exists and thus is safe to use in different threads / concurrent processes.
     """
-    # TODO(unrememberme): consider safe_concurrent_creation after it is made UNICODE safe.
-    with temporary_dir() as temp_dir:
-      cls._extract(path, temp_dir, filter_func=filter_func)
-      safe_concurrent_rename(temp_dir, outdir)
+    if safe:
+      with temporary_dir() as temp_dir:
+        cls._extract(path, temp_dir)
+        safe_concurrent_rename(temp_dir, outdir)
+    else:
+      # Leave the existing default behavior unchanged.
+      cls._extract(path, outdir, filter_func=filter_func)
 
   @classmethod
   def _extract(cls, path, outdir):

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -32,8 +32,7 @@ class Archiver(AbstractClass):
     :param function filter_func: optional filter with the filename as the parameter.  Returns True
       if the file should be extracted.  Note that filter_func is ignored for non-zip archives.
     :param bool safe: True if use safe extraction.  Safe extraction ignores errors if destination
-      already exists and thus is safe to extract same archive in different threads / concurrent
-      processes.
+      already exists and thus is safe to use in different threads / concurrent processes.
     """
     if safe:
       with temporary_dir() as temp_dir:

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -24,7 +24,7 @@ class ArchiveTest(unittest.TestCase):
     return listing
 
   def round_trip(self, archiver, expected_ext, empty_dirs):
-    def test_round_trip(prefix=None):
+    def test_round_trip(prefix=None, safe=False):
       with temporary_dir() as fromdir:
         safe_mkdir(os.path.join(fromdir, 'a/b/c'))
         touch(os.path.join(fromdir, 'a/b/d/e.txt'))
@@ -40,7 +40,7 @@ class ArchiveTest(unittest.TestCase):
                   archive, expected_ext))
 
           with temporary_dir() as todir:
-            archiver.extract(archive, todir)
+            archiver.extract(archive, todir, safe=safe)
             fromlisting = self._listtree(fromdir, empty_dirs)
             if prefix:
               fromlisting = set(os.path.join(prefix, x) for x in fromlisting)
@@ -50,6 +50,7 @@ class ArchiveTest(unittest.TestCase):
 
     test_round_trip()
     test_round_trip(prefix='jake')
+    test_round_trip(safe=True)
 
   def test_tar(self):
     self.round_trip(archiver('tar'), expected_ext='tar', empty_dirs=True)
@@ -97,22 +98,3 @@ class ArchiveTest(unittest.TestCase):
     check_archive_with_flags('tgz', True)
     check_archive_with_flags('tbz2', False)
     check_archive_with_flags('tbz2', True)
-
-  def test_extract_to_exist_dir_with_no_error(self):
-
-    def test_extract_helper(archiver):
-      with temporary_dir() as fromdir:
-        safe_mkdir(os.path.join(fromdir, 'a/b/c'))
-        touch(os.path.join(fromdir, 'a/b/d/e.txt'))
-
-        with temporary_dir() as archivedir:
-          archive = archiver.create(fromdir, archivedir, 'archive')
-
-          with temporary_dir() as todir:
-            safe_mkdir(os.path.join(todir, 'e'))
-            touch(os.path.join(todir, 'e/f.txt'))
-            # Extract to existing dir gives no error
-            archiver.extract(archive, todir)
-
-    test_extract_helper(archiver('tar'))
-    test_extract_helper(archiver('zip'))

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -24,7 +24,7 @@ class ArchiveTest(unittest.TestCase):
     return listing
 
   def round_trip(self, archiver, expected_ext, empty_dirs):
-    def test_round_trip(prefix=None, safe=False):
+    def test_round_trip(prefix=None, concurrency_safe=False):
       with temporary_dir() as fromdir:
         safe_mkdir(os.path.join(fromdir, 'a/b/c'))
         touch(os.path.join(fromdir, 'a/b/d/e.txt'))
@@ -40,7 +40,7 @@ class ArchiveTest(unittest.TestCase):
                   archive, expected_ext))
 
           with temporary_dir() as todir:
-            archiver.extract(archive, todir, safe=safe)
+            archiver.extract(archive, todir, concurrency_safe=concurrency_safe)
             fromlisting = self._listtree(fromdir, empty_dirs)
             if prefix:
               fromlisting = set(os.path.join(prefix, x) for x in fromlisting)
@@ -50,7 +50,7 @@ class ArchiveTest(unittest.TestCase):
 
     test_round_trip()
     test_round_trip(prefix='jake')
-    test_round_trip(safe=True)
+    test_round_trip(concurrency_safe=True)
 
   def test_tar(self):
     self.round_trip(archiver('tar'), expected_ext='tar', empty_dirs=True)

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -24,7 +24,7 @@ class ArchiveTest(unittest.TestCase):
     return listing
 
   def round_trip(self, archiver, expected_ext, empty_dirs):
-    def test_round_trip(prefix=None, safe=False):
+    def test_round_trip(prefix=None):
       with temporary_dir() as fromdir:
         safe_mkdir(os.path.join(fromdir, 'a/b/c'))
         touch(os.path.join(fromdir, 'a/b/d/e.txt'))
@@ -40,7 +40,7 @@ class ArchiveTest(unittest.TestCase):
                   archive, expected_ext))
 
           with temporary_dir() as todir:
-            archiver.extract(archive, todir, safe=safe)
+            archiver.extract(archive, todir)
             fromlisting = self._listtree(fromdir, empty_dirs)
             if prefix:
               fromlisting = set(os.path.join(prefix, x) for x in fromlisting)
@@ -50,7 +50,6 @@ class ArchiveTest(unittest.TestCase):
 
     test_round_trip()
     test_round_trip(prefix='jake')
-    test_round_trip(safe=True)
 
   def test_tar(self):
     self.round_trip(archiver('tar'), expected_ext='tar', empty_dirs=True)
@@ -98,3 +97,22 @@ class ArchiveTest(unittest.TestCase):
     check_archive_with_flags('tgz', True)
     check_archive_with_flags('tbz2', False)
     check_archive_with_flags('tbz2', True)
+
+  def test_extract_to_exist_dir_with_no_error(self):
+
+    def test_extract_helper(archiver):
+      with temporary_dir() as fromdir:
+        safe_mkdir(os.path.join(fromdir, 'a/b/c'))
+        touch(os.path.join(fromdir, 'a/b/d/e.txt'))
+
+        with temporary_dir() as archivedir:
+          archive = archiver.create(fromdir, archivedir, 'archive')
+
+          with temporary_dir() as todir:
+            safe_mkdir(os.path.join(todir, 'e'))
+            touch(os.path.join(todir, 'e/f.txt'))
+            # Extract to existing dir gives no error
+            archiver.extract(archive, todir)
+
+    test_extract_helper(archiver('tar'))
+    test_extract_helper(archiver('zip'))

--- a/tests/python/pants_test/fs/test_archive.py
+++ b/tests/python/pants_test/fs/test_archive.py
@@ -24,7 +24,7 @@ class ArchiveTest(unittest.TestCase):
     return listing
 
   def round_trip(self, archiver, expected_ext, empty_dirs):
-    def test_round_trip(prefix=None):
+    def test_round_trip(prefix=None, safe=False):
       with temporary_dir() as fromdir:
         safe_mkdir(os.path.join(fromdir, 'a/b/c'))
         touch(os.path.join(fromdir, 'a/b/d/e.txt'))
@@ -40,7 +40,7 @@ class ArchiveTest(unittest.TestCase):
                   archive, expected_ext))
 
           with temporary_dir() as todir:
-            archiver.extract(archive, todir)
+            archiver.extract(archive, todir, safe=safe)
             fromlisting = self._listtree(fromdir, empty_dirs)
             if prefix:
               fromlisting = set(os.path.join(prefix, x) for x in fromlisting)
@@ -50,6 +50,7 @@ class ArchiveTest(unittest.TestCase):
 
     test_round_trip()
     test_round_trip(prefix='jake')
+    test_round_trip(safe=True)
 
   def test_tar(self):
     self.round_trip(archiver('tar'), expected_ext='tar', empty_dirs=True)


### PR DESCRIPTION
### Problem
When Archivers (TGZ, ZIP etc) used to extract an archive, if there are multiple versions of Pants running on the same machine, Pants might try to override the destination when the destination is being used, as seenion #4763 .  This causes occasional issues that are hard to reproduce, especially for subsystems download runtime supports. 

### Solution
Add a safe mode for Archive, which extract archived content into a temporary directory then use atomic rename to move the temporary directory to the final destination.  If final destination exists before the rename, the errors will be ignored.

### Result
