### PR TITLE
Don't render cancelled nodes in trace

### DIFF
--- a/src/rust/engine/src/graph.rs
+++ b/src/rust/engine/src/graph.rs
@@ -388,7 +388,7 @@ impl InnerGraph {
           // because a dependent failed. In either case, it's not useful to render
           // them, as we don't know whether they would have succeeded or failed.
           true
-        },
+        }
       }
     };
 

--- a/src/rust/engine/src/graph.rs
+++ b/src/rust/engine/src/graph.rs
@@ -379,11 +379,16 @@ impl InnerGraph {
 
     let is_bottom = |eid: EntryId| -> bool {
       match self.unsafe_entry_for_id(eid).peek::<NodeKey>() {
-        None |
         Some(Err(Failure::Invalidated)) => false,
         Some(Err(Failure::Noop(..))) => true,
         Some(Err(Failure::Throw(..))) => false,
         Some(Ok(_)) => true,
+        None => {
+          // A Node with no state is either still running, or effectively cancelled
+          // because a dependent failed. In either case, it's not useful to render
+          // them, as we don't know whether they would have succeeded or failed.
+          true
+        },
       }
     };
 


### PR DESCRIPTION
### Problem

#3695 initially described a solution to a problem experienced in the original "slow-failing" implementation of the engine: if there were multiple paths between a root and a failure, we would render all of them, which was hugely redundant.

But since that ticket was opened, we switched to a fast-failing implementation via the switch to Futures. When one dependency of a Node fails, the rest are effectively cancelled, since Futures are pull based. This (should) have the effect of rendering exactly one failure path per root: the first failure that is encountered while computing that root.

But it was still the case that we were printing redundant/useless information: cancelled dependencies were being rendered, which in the case of things like `./pants list ::` resulted in a lot of noise.

### Solution

Since a cancelled node is never the source of a failure, don't render them.

### Result

The added test no longer renders a `<None>` entry, like:
```
Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
  Computing Task(<class 'pants_test.engine.test_engine.A'>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
    Computing Task(<class 'pants_test.engine.test_engine.D'>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =D)
      <None>
    Computing Task(<function nested_raise at 0xEEEEEEEEE>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C)
      Throw(An exception for B)
        Traceback (most recent call last):
          File LOCATION-INFO, in extern_invoke_runnable
            val = runnable(*args)
          File LOCATION-INFO, in nested_raise
            fn_raises(x)
          File LOCATION-INFO, in fn_raises
            raise Exception('An exception for {}'.format(type(x).__name__))
        Exception: An exception for B
```

Fixes #3695.