### PR TITLE
Relocate stable_json_sha1 to hash_utils.

### DIFF
--- a/contrib/confluence/src/python/pants/contrib/confluence/targets/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/targets/BUILD
@@ -5,6 +5,7 @@
 
 python_library(
   dependencies = [
+    'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',

--- a/contrib/confluence/src/python/pants/contrib/confluence/targets/doc_page.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/targets/doc_page.py
@@ -5,8 +5,9 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.base.hash_utils import stable_json_hash
 from pants.base.payload import Payload
-from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes, stable_json_sha1
+from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes
 from pants.build_graph.target import Target
 
 
@@ -32,7 +33,7 @@ class WikiArtifact(object):
     self.config = kwargs
 
   def fingerprint(self):
-    return combine_hashes([self.wiki.fingerprint(), stable_json_sha1(self.config)])
+    return combine_hashes([self.wiki.fingerprint(), stable_json_hash(self.config)])
 
 
 class Wiki(object):
@@ -47,7 +48,7 @@ class Wiki(object):
 
   def fingerprint(self):
     # TODO: url_builder is not a part of fingerprint.
-    return stable_json_sha1(self.name)
+    return stable_json_hash(self.name)
 
 
 class Page(Target):

--- a/src/python/pants/backend/docgen/targets/BUILD
+++ b/src/python/pants/backend/docgen/targets/BUILD
@@ -5,6 +5,7 @@
 python_library(
   dependencies = [
     'src/python/pants/base:deprecated',
+    'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',

--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -6,8 +6,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.base.deprecated import deprecated
+from pants.base.hash_utils import stable_json_hash
 from pants.base.payload import Payload
-from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes, stable_json_sha1
+from pants.base.payload_field import PayloadField, PrimitiveField, combine_hashes
 from pants.build_graph.target import Target
 
 
@@ -17,7 +18,7 @@ class WikiArtifact(object):
   This object allows you to specify which wiki a page should be published to, along with additional
   wiki-specific parameters, such as the title, parent page, etc.
   """
-  
+
   @deprecated('1.6.0.dev0',
               'Use contrib.confluence.targets.doc_page.wiki_artifact(...) instead',
               'wiki_artifact(...) target object')
@@ -35,7 +36,7 @@ class WikiArtifact(object):
     self.config = kwargs
 
   def fingerprint(self):
-    return combine_hashes([self.wiki.fingerprint(), stable_json_sha1(self.config)])
+    return combine_hashes([self.wiki.fingerprint(), stable_json_hash(self.config)])
 
 
 class Wiki(object):
@@ -51,7 +52,7 @@ class Wiki(object):
 
   def fingerprint(self):
     # TODO: url_builder is not a part of fingerprint.
-    return stable_json_sha1(self.name)
+    return stable_json_hash(self.name)
 
 
 class Page(Target):

--- a/src/python/pants/backend/jvm/BUILD
+++ b/src/python/pants/backend/jvm/BUILD
@@ -16,6 +16,7 @@ python_library(
   dependencies=[
     '3rdparty/python:six',
     ':repository',
+    'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload_field',
   ],
 )

--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -8,7 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from six import string_types
 
 from pants.backend.jvm.repository import Repository
-from pants.base.payload_field import PayloadField, stable_json_sha1
+from pants.base.hash_utils import stable_json_hash
+from pants.base.payload_field import PayloadField
 
 
 class PublicationMetadata(PayloadField):
@@ -75,7 +76,7 @@ class Artifact(PayloadField):
       fingerprint = self.publication_metadata.fingerprint()
       if fingerprint:
         data += (fingerprint,)
-    return stable_json_sha1(data)
+    return stable_json_hash(data)
 
   def __ne__(self, other):
     return not self.__eq__(other)

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -577,6 +577,7 @@ python_library(
     ':resources_task',
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:fingerprint_strategy',
+    'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload_field',
     'src/python/pants/util:dirutil',
   ],

--- a/src/python/pants/backend/jvm/tasks/prepare_services.py
+++ b/src/python/pants/backend/jvm/tasks/prepare_services.py
@@ -10,7 +10,7 @@ import os
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.resources_task import ResourcesTask
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
-from pants.base.payload_field import stable_json_sha1
+from pants.base.hash_utils import stable_json_hash
 from pants.util.dirutil import safe_open
 
 
@@ -18,7 +18,7 @@ class JvmServiceFingerprintStrategy(DefaultFingerprintStrategy):
   """Fingerprints a JvmTarget for its service provider configuration."""
 
   def compute_fingerprint(self, target):
-    return stable_json_sha1(target.services)
+    return stable_json_hash(target.services)
 
 
 class PrepareServices(ResourcesTask):

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -120,6 +120,8 @@ python_library(
   sources = ['payload_field.py'],
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    ':deprecated',
+    ':hash_utils',
     'src/python/pants/util:meta',
   ]
 )

--- a/src/python/pants/base/hash_utils.py
+++ b/src/python/pants/base/hash_utils.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import hashlib
+import json
 
 
 def hash_all(strs, digest=None):
@@ -31,6 +32,22 @@ def hash_file(path, digest=None):
       digest.update(s)
       s = fd.read(8192)
   return digest.hexdigest()
+
+
+def stable_json_hash(obj, digest=None, encoder=None):
+  """Hashes `obj` stably; ie repeated calls with the same inputs will produce the same hash.
+
+  :param obj: An object that can be rendered to json using the given `encoder`.
+  :param digest: An optional `hashlib` compatible message digest. Defaults to `hashlib.sha1`.
+  :param encoder: An optional custom json encoder.
+  :type encoder: :class:`json.JSONEncoder`
+  :returns: A stable hash of the given `obj`.
+  :rtype: str
+
+  :API: public
+  """
+  json_str = json.dumps(obj, ensure_ascii=True, allow_nan=False, sort_keys=True, cls=encoder)
+  return hash_all(json_str, digest=digest)
 
 
 class Sharder(object):

--- a/src/python/pants/base/payload_field.py
+++ b/src/python/pants/base/payload_field.py
@@ -5,24 +5,23 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import json
 from abc import abstractmethod
 from hashlib import sha1
 
 from twitter.common.collections import OrderedSet
 
+from pants.base.deprecated import deprecated
+from pants.base.hash_utils import stable_json_hash
 from pants.util.meta import AbstractClass
 
 
-def stable_json_dumps(obj):
-  return json.dumps(obj, ensure_ascii=True, allow_nan=False, sort_keys=True)
-
-
+@deprecated(removal_version='1.6.0.dev0',
+            hint_message='Use pants.base.hash_utils.stable_json_hash instead.')
 def stable_json_sha1(obj):
   """
   :API: public
   """
-  return sha1(stable_json_dumps(obj)).hexdigest()
+  return stable_json_hash(obj)
 
 
 def combine_hashes(hashes):
@@ -127,7 +126,7 @@ class PythonRequirementsField(frozenset, PayloadField):
           req._use_2to3,
           req.compatibility,
         )
-        yield stable_json_sha1(hash_items)
+        yield stable_json_hash(hash_items)
     return combine_hashes(fingerprint_iter())
 
 
@@ -140,7 +139,7 @@ class ExcludesField(OrderedSet, PayloadField):
   """
 
   def _compute_fingerprint(self):
-    return stable_json_sha1(tuple(repr(exclude) for exclude in self))
+    return stable_json_hash(tuple(repr(exclude) for exclude in self))
 
 
 class JarsField(tuple, PayloadField):
@@ -152,7 +151,7 @@ class JarsField(tuple, PayloadField):
   """
 
   def _compute_fingerprint(self):
-    return stable_json_sha1(tuple(jar.cache_key() for jar in self))
+    return stable_json_hash(tuple(jar.cache_key() for jar in self))
 
 
 class PrimitiveField(PayloadField):
@@ -171,7 +170,7 @@ class PrimitiveField(PayloadField):
     return self._underlying
 
   def _compute_fingerprint(self):
-    return stable_json_sha1(self._underlying)
+    return stable_json_hash(self._underlying)
 
 
 class SetOfPrimitivesField(PayloadField):
@@ -191,4 +190,4 @@ class SetOfPrimitivesField(PayloadField):
     return self._underlying
 
   def _compute_fingerprint(self):
-    return stable_json_sha1(self._underlying)
+    return stable_json_hash(self._underlying)

--- a/src/python/pants/java/jar/BUILD
+++ b/src/python/pants/java/jar/BUILD
@@ -5,6 +5,7 @@ python_library(
   dependencies = [
     '3rdparty/python:six',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload_field',
     'src/python/pants/base:validation',
     'src/python/pants/build_graph',

--- a/src/python/pants/java/jar/jar_dependency.py
+++ b/src/python/pants/java/jar/jar_dependency.py
@@ -9,7 +9,7 @@ import os
 import urlparse
 
 from pants.base.build_environment import get_buildroot
-from pants.base.payload_field import stable_json_sha1
+from pants.base.hash_utils import stable_json_hash
 from pants.base.validation import assert_list
 from pants.java.jar.exclude import Exclude
 from pants.java.jar.jar_dependency_utils import M2Coordinate
@@ -157,7 +157,7 @@ class JarDependency(datatype('JarDependency', [
 
   def cache_key(self):
     excludes = [(e.org, e.name) for e in self.excludes]
-    return stable_json_sha1(dict(org=self.org,
+    return stable_json_hash(dict(org=self.org,
                                  name=self.name,
                                  rev=self.rev,
                                  force=self.force,
@@ -166,4 +166,4 @@ class JarDependency(datatype('JarDependency', [
                                  classifier=self.classifier,
                                  transitive=self.transitive,
                                  mutable=self.mutable,
-                                 excludes=excludes,))
+                                 excludes=excludes))

--- a/src/python/pants/option/BUILD
+++ b/src/python/pants/option/BUILD
@@ -9,6 +9,7 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
+    'src/python/pants/base:hash_utils',
     'src/python/pants/util:eval',
     'src/python/pants/util:memo',
     'src/python/pants/util:meta',

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import functools
 import json
 import os
 from hashlib import sha1
@@ -12,6 +13,7 @@ from hashlib import sha1
 import six
 
 from pants.base.build_environment import get_buildroot
+from pants.base.hash_utils import stable_json_hash
 from pants.option.custom_types import UnsetBool, dict_with_files_option, file_option, target_option
 
 
@@ -22,12 +24,7 @@ class Encoder(json.JSONEncoder):
     return super(Encoder, self).default(o)
 
 
-def stable_json_dumps(obj):
-  return json.dumps(obj, ensure_ascii=True, allow_nan=False, sort_keys=True, cls=Encoder)
-
-
-def stable_json_sha1(obj):
-  return sha1(stable_json_dumps(obj)).hexdigest()
+stable_json_sha1 = functools.partial(stable_json_hash, encoder=Encoder)
 
 
 class OptionsFingerprinter(object):

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -604,6 +604,7 @@ python_tests(
     'src/python/pants/backend/jvm/tasks:classpath_products',
     'src/python/pants/backend/jvm/tasks:resources_task',
     'src/python/pants/base:fingerprint_strategy',
+    'src/python/pants/base:hash_utils',
     'src/python/pants/base:payload',
     'src/python/pants/base:payload_field',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_resources_task.py
@@ -10,8 +10,9 @@ import os
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.resources_task import ResourcesTask
 from pants.base.fingerprint_strategy import DefaultFingerprintStrategy
+from pants.base.hash_utils import stable_json_hash
 from pants.base.payload import Payload
-from pants.base.payload_field import PrimitiveField, stable_json_sha1
+from pants.base.payload_field import PrimitiveField
 from pants.build_graph.target import Target
 from pants.util.dirutil import touch
 from pants_test.tasks.task_test_base import TaskTestBase
@@ -157,7 +158,7 @@ class MinimalImplResourcesTaskTest(ResourcesTaskTestBase):
 class CustomInvalidationStrategtResourcesTaskTest(ResourcesTaskTestBase):
   class TagsInvalidationStrategy(DefaultFingerprintStrategy):
     def compute_fingerprint(self, target):
-      return stable_json_sha1(sorted(target.tags))
+      return stable_json_hash(sorted(target.tags))
 
   class CustomInvalidationStrategyResourcesTask(ResourcesTaskTestBase.MinimalImplResourcesTask):
     def create_invalidation_strategy(self):


### PR DESCRIPTION
The function is used more widely than in payload fingerprinting.