### PR TITLE
Give travis just the AWS permissions it needs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -423,9 +423,9 @@ matrix:
 deploy:
   # See: https://docs.travis-ci.com/user/deployment/s3/
   provider: s3
-  access_key_id: AKIAIQHTQI5E42SQBSNA
+  access_key_id: AKIAIWOKBXVU3JLY6EGQ
   secret_access_key:
-    secure: RQVzsNfZL8AgsXdjZ67j2tWs5Tjl/FKpmE1fyVgldMbua/xhW8dzdFrtOeWjTPX4/+sJZ4U7/tZectBtWejmrXUJiZQKJwJBnsyYxysENTWOV80BEYyoz2RPr8HSVbMZ1ZHtUafzO3OqV1x+Pvgpg8FUeUfsy3TGUk0JREO90Q0=
+    secure: UBVbpdYJ81OsDGKlPRBw6FlPJGlxosnFQ4A1xBbU5GwEBfv90GoKc6J0UwF+I4CDwytj/BlAks1XbW0zYX0oeIlXDnl1Vfikm1k4hfIr6VCLHKppiU69FlEs+ph0Dktz8+aUWhrvJzICZs6Gu08kTBQ5++3ulDWDeTHqjr713YM=
   bucket: binaries.pantsbuild.org
   local_dir: dist/deploy
   # Otherwise travis will stash dist/deploy and the deploy will fail.


### PR DESCRIPTION
Previously it acted on behalf of an admin user.
Now it acts on behalf of a 'TravisCI' role user with just
the necessary permissions (writing to the binaries S3 bucket,
and exemption from MFA requirements).
