### PR TITLE
[pantsd] Scrub PANTS_ENTRYPOINT env var upon use.

### DIFF
--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -18,6 +18,12 @@ def test():
   print(TEST_STR)
 
 
+def test_env():
+  """An alternate test entrypoint for exercising scrubbing."""
+  import os
+  print(os.environ.get('PANTS_ENTRYPOINT'))
+
+
 def main():
   exiter = Exiter()
   exiter.set_except_hook()

--- a/src/python/pants/bin/pants_exe.py
+++ b/src/python/pants/bin/pants_exe.py
@@ -21,7 +21,7 @@ def test():
 def test_env():
   """An alternate test entrypoint for exercising scrubbing."""
   import os
-  print(os.environ.get('PANTS_ENTRYPOINT'))
+  print('PANTS_ENTRYPOINT={}'.format(os.environ.get('PANTS_ENTRYPOINT')))
 
 
 def main():

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -46,7 +46,7 @@ class PantsLoader(object):
 
   @staticmethod
   def determine_entrypoint(env_var, default):
-    return os.environ.pop(env_var, default) or default
+    return os.environ.pop(env_var, default)
 
   @staticmethod
   def load_and_execute(entrypoint):

--- a/src/python/pants/bin/pants_loader.py
+++ b/src/python/pants/bin/pants_loader.py
@@ -46,7 +46,7 @@ class PantsLoader(object):
 
   @staticmethod
   def determine_entrypoint(env_var, default):
-    return os.environ.get(env_var) or default
+    return os.environ.pop(env_var, default) or default
 
   @staticmethod
   def load_and_execute(entrypoint):

--- a/tests/python/pants_test/bin/test_loader_integration.py
+++ b/tests/python/pants_test/bin/test_loader_integration.py
@@ -43,4 +43,4 @@ class LoaderIntegrationTest(PantsRunIntegrationTest):
       extra_env={'PANTS_ENTRYPOINT': 'pants.bin.pants_exe:test_env'}
     )
     self.assert_success(pants_run)
-    self.assertIn('None', pants_run.stdout_data)
+    self.assertIn('PANTS_ENTRYPOINT=None', pants_run.stdout_data)

--- a/tests/python/pants_test/bin/test_loader_integration.py
+++ b/tests/python/pants_test/bin/test_loader_integration.py
@@ -36,3 +36,11 @@ class LoaderIntegrationTest(PantsRunIntegrationTest):
     self.assert_failure(pants_run)
     self.assertIn('TEST_STR', pants_run.stderr_data)
     self.assertIn('not callable', pants_run.stderr_data)
+
+  def test_alternate_entrypoint_scrubbing(self):
+    pants_run = self.run_pants(
+      command=['help'],
+      extra_env={'PANTS_ENTRYPOINT': 'pants.bin.pants_exe:test_env'}
+    )
+    self.assert_success(pants_run)
+    self.assertIn('None', pants_run.stdout_data)


### PR DESCRIPTION
### Problem

Currently, if a daemon-enabled `pants` ends up executing itself, the `PANTS_ENTRYPOINT` env var can leak into the subprocess execution environment causing unexpected/undesired results.

### Solution

Scrub `PANTS_ENTRYPOINT` via `os.environ.pop`.

### Result

Less leakage.  