### PR TITLE
Deprecate legacy junit "public" workdir reports.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -313,6 +313,7 @@ timeout_default: 60
 chroot: true
 timeouts: true
 timeout_default: 60
+legacy_report_layout: False
 
 
 [buildgen.go]

--- a/src/python/pants/backend/jvm/tasks/BUILD
+++ b/src/python/pants/backend/jvm/tasks/BUILD
@@ -397,6 +397,7 @@ python_library(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/backend/jvm:argfile',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/build_graph',

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -429,7 +429,9 @@ python_tests(
   name = 'junit_run_integration',
   sources = ['test_junit_run_integration.py'],
   dependencies = [
+    '3rdparty/python:parameterized',
     ':missing_jvm_check',
+    'src/python/pants/base:build_environment',
     'src/python/pants/util:process_handler',
     'tests/python/pants_test:int-test',
   ],
@@ -441,6 +443,8 @@ python_tests(
   name = 'junit_tests_integration',
   sources = ['test_junit_tests_integration.py'],
   dependencies = [
+    '3rdparty/python:parameterized',
+    'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -10,8 +10,15 @@ import os
 import time
 from unittest import skipIf
 
+from parameterized import parameterized
+
+from pants.base.build_environment import get_buildroot
 from pants_test.backend.jvm.tasks.missing_jvm_check import is_missing_jvm
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+OUTPUT_MODES = [('legacy_layout', ['--legacy-report-layout'], True),
+                ('nominal_layout', ['--no-legacy-report-layout'], False)]
 
 
 class JunitRunIntegrationTest(PantsRunIntegrationTest):
@@ -35,36 +42,41 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
                                 'testprojects/tests/java/org/pantsbuild/testproject/matcher'])
     self.assert_success(pants_run)
 
-  def test_junit_run_with_cobertura_coverage_succeeds(self):
-    with self.pants_results(['clean-all',
-                             'test.junit',
-                             'testprojects/tests/java/org/pantsbuild/testproject/unicode::',
+  def report_file_path(self, results, relpath, legacy=False):
+    return os.path.join(results.workdir if legacy else os.path.join(get_buildroot(), 'dist'),
+                        relpath)
+
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_run_with_cobertura_coverage_succeeds(self, unused_test_name, extra_args, legacy):
+    with self.pants_results(['clean-all', 'test.junit'] + extra_args +
+                            ['testprojects/tests/java/org/pantsbuild/testproject/unicode::',
                              '--test-junit-coverage-processor=cobertura',
                              '--test-junit-coverage']) as results:
       self.assert_success(results)
       # validate that the expected coverage file exists, and it reflects 100% line rate coverage
-      coverage_xml = os.path.join(results.workdir, 'test/junit/coverage/xml/coverage.xml')
+      coverage_xml = self.report_file_path(results, 'test/junit/coverage/xml/coverage.xml', legacy)
       self.assertTrue(os.path.isfile(coverage_xml))
       with codecs.open(coverage_xml, 'r', encoding='utf8') as xml:
         self.assertIn('line-rate="1.0"', xml.read())
       # validate that the html report was able to find sources for annotation
-      cucumber_src_html = os.path.join(
-          results.workdir,
+      cucumber_src_html = self.report_file_path(
+          results,
           'test/junit/coverage/html/'
-          'org.pantsbuild.testproject.unicode.cucumber.CucumberAnnotatedExample.html')
+          'org.pantsbuild.testproject.unicode.cucumber.CucumberAnnotatedExample.html',
+          legacy)
       self.assertTrue(os.path.isfile(cucumber_src_html))
       with codecs.open(cucumber_src_html, 'r', encoding='utf8') as src:
         self.assertIn('String pleasantry()', src.read())
 
-  def test_junit_run_with_jacoco_coverage_succeeds(self):
-    with self.pants_results(['clean-all',
-                             'test.junit',
-                             'testprojects/tests/java/org/pantsbuild/testproject/unicode::',
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_run_with_jacoco_coverage_succeeds(self, unused_test_name, extra_args, legacy):
+    with self.pants_results(['clean-all', 'test.junit'] + extra_args +
+                            ['testprojects/tests/java/org/pantsbuild/testproject/unicode::',
                              '--test-junit-coverage-processor=jacoco',
                              '--test-junit-coverage']) as results:
       self.assert_success(results)
       # validate that the expected coverage file exists, and it reflects 100% line rate coverage
-      coverage_xml = os.path.join(results.workdir, 'test/junit/coverage/reports/xml')
+      coverage_xml = self.report_file_path(results, 'test/junit/coverage/reports/xml', legacy)
       self.assertTrue(os.path.isfile(coverage_xml))
       with codecs.open(coverage_xml, 'r', encoding='utf8') as xml:
         self.assertIn(
@@ -72,10 +84,11 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
           '<method name="&lt;init&gt;" desc="()V" line="13">'
           '<counter type="INSTRUCTION" missed="0" covered="3"/>', xml.read())
       # validate that the html report was able to find sources for annotation
-      cucumber_src_html = os.path.join(
-          results.workdir,
+      cucumber_src_html = self.report_file_path(
+          results,
           'test/junit/coverage/reports/html/'
-          'org.pantsbuild.testproject.unicode.cucumber/CucumberAnnotatedExample.html')
+          'org.pantsbuild.testproject.unicode.cucumber/CucumberAnnotatedExample.html',
+          legacy)
       self.assertTrue(os.path.isfile(cucumber_src_html))
       with codecs.open(cucumber_src_html, 'r', encoding='utf8') as src:
         self.assertIn('class="el_method">pleasantry()</a>', src.read())
@@ -134,17 +147,16 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
                              synthetic_jar_target]).stdout_data
     self.assertIn('Synthetic jar run is not detected', output)
 
-  def do_test_junit_run_with_html_report(self, tests=(), args=()):
+  def do_test_junit_run_with_html_report(self, tests=(), args=(), legacy=False):
     def html_report_test(test):
       return '--test=org.pantsbuild.testproject.htmlreport.HtmlReportTest#{}'.format(test)
 
-    with self.pants_results(['clean-all', 'test.junit'] +
+    with self.pants_results(['clean-all', 'test.junit'] + list(args) +
                             [html_report_test(name) for name in tests] +
                             ['testprojects/tests/java/org/pantsbuild/testproject/htmlreport::',
-                             '--test-junit-html-report'] +
-                            list(args)) as results:
+                             '--test-junit-html-report']) as results:
       self.assert_failure(results)
-      report_html = os.path.join(results.workdir, 'test/junit/reports/junit-report.html')
+      report_html = self.report_file_path(results, 'test/junit/reports/junit-report.html', legacy)
       self.assertTrue(os.path.isfile(report_html))
       with codecs.open(report_html, 'r', encoding='utf8') as src:
         html = src.read()
@@ -153,12 +165,15 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
         self.assertIn('testErrors', html)
         self.assertIn('testSkipped', html)
 
-  def test_junit_run_with_html_report(self):
-    self.do_test_junit_run_with_html_report()
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_run_with_html_report(self, unused_test_name, extra_args, legacy):
+    self.do_test_junit_run_with_html_report(args=extra_args, legacy=legacy)
 
-  def test_junit_run_with_html_report_merged(self):
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_run_with_html_report_merged(self, unused_test_name, extra_args, legacy):
     self.do_test_junit_run_with_html_report(tests=['testPasses',
                                                    'testFails',
                                                    'testErrors',
                                                    'testSkipped'],
-                                            args=['--test-junit-batch-size=3'])
+                                            args=['--batch-size=3'] + extra_args,
+                                            legacy=legacy)

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -7,31 +7,52 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
+from parameterized import parameterized
+
+from pants.base.build_environment import get_buildroot
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+OUTPUT_MODES = [('legacy_layout', ['--legacy-report-layout'], True),
+                ('nominal_layout', ['--no-legacy-report-layout'], False)]
 
 
 class JunitTestsIntegrationTest(PantsRunIntegrationTest):
 
-  def _assert_output_for_class(self, workdir, classname):
-    out_dir = os.path.join(workdir, 'test', 'junit')
-    self.assertTrue(os.path.exists(os.path.join(out_dir, '{}.out.txt'.format(classname))))
-    self.assertTrue(os.path.exists(os.path.join(out_dir, '{}.err.txt'.format(classname))))
+  def _assert_output_for_class(self, workdir, classname, expect_legacy=True):
+    def get_outdir(basedir):
+      return os.path.join(basedir, 'test', 'junit')
 
-  def _assert_junit_output(self, workdir):
-    self._assert_output_for_class(workdir, 'org.pantsbuild.example.hello.greet.GreetingTest')
-    self._assert_output_for_class(workdir, 'org.pantsbuild.example.hello.welcome.WelSpec')
+    def get_stdout_file(basedir):
+      return os.path.join(basedir, '{}.out.txt'.format(classname))
 
-  def test_junit_test_custom_interpreter(self):
+    def get_stderr_file(basedir):
+      return os.path.join(basedir, '{}.err.txt'.format(classname))
+
+    outdir = get_outdir(os.path.join(get_buildroot(), 'dist'))
+    self.assertTrue(os.path.exists(get_stdout_file(outdir)))
+    self.assertTrue(os.path.exists(get_stderr_file(outdir)))
+
+    legacy_outdir = get_outdir(workdir)
+    self.assertEqual(expect_legacy, os.path.exists(get_stdout_file(legacy_outdir)))
+    self.assertEqual(expect_legacy, os.path.exists(get_stderr_file(legacy_outdir)))
+
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_test_custom_interpreter(self, unused_test_name, extra_args, expect_legacy):
     with self.temporary_workdir() as workdir:
-      pants_run = self.run_pants_with_workdir([
-          'test',
-          'examples/tests/java/org/pantsbuild/example/hello/greet',
-          'examples/tests/scala/org/pantsbuild/example/hello/welcome',
-          '--python-setup-interpreter-constraints=CPython>=2.7,<3',
-          '--python-setup-interpreter-constraints=CPython>=3.3'],
+      pants_run = self.run_pants_with_workdir(
+          ['test.junit'] + extra_args +
+          ['examples/tests/java/org/pantsbuild/example/hello/greet',
+           'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
           workdir)
       self.assert_success(pants_run)
-      self._assert_junit_output(workdir)
+
+      self._assert_output_for_class(workdir=workdir,
+                                    classname='org.pantsbuild.example.hello.greet.GreetingTest',
+                                    expect_legacy=expect_legacy)
+      self._assert_output_for_class(workdir=workdir,
+                                    classname='org.pantsbuild.example.hello.welcome.WelSpec',
+                                    expect_legacy=expect_legacy)
 
   def test_junit_test(self):
     with self.temporary_workdir() as workdir:
@@ -41,38 +62,56 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
           workdir)
       self.assert_failure(pants_run)
 
-  def test_junit_test_with_test_option_with_relpath(self):
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_test_with_test_option_with_relpath(self,
+                                                    unused_test_name,
+                                                    extra_args,
+                                                    expect_legacy):
     with self.temporary_workdir() as workdir:
-      pants_run = self.run_pants_with_workdir([
-          'test.junit',
-          '--test=examples/tests/java/org/pantsbuild/example/hello/greet/GreetingTest.java',
-          'examples/tests/java/org/pantsbuild/example/hello/greet',
-          'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
+      pants_run = self.run_pants_with_workdir(
+          ['test.junit'] + extra_args +
+          ['--test=examples/tests/java/org/pantsbuild/example/hello/greet/GreetingTest.java',
+           'examples/tests/java/org/pantsbuild/example/hello/greet',
+           'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
           workdir)
       self.assert_success(pants_run)
-      self._assert_output_for_class(workdir, 'org.pantsbuild.example.hello.greet.GreetingTest')
+      self._assert_output_for_class(workdir=workdir,
+                                    classname='org.pantsbuild.example.hello.greet.GreetingTest',
+                                    expect_legacy=expect_legacy)
 
-  def test_junit_test_with_test_option_with_dot_slash_relpath(self):
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_test_with_test_option_with_dot_slash_relpath(self,
+                                                              unused_test_name,
+                                                              extra_args,
+                                                              expect_legacy):
     with self.temporary_workdir() as workdir:
-      pants_run = self.run_pants_with_workdir([
-          'test.junit',
-          '--test=./examples/tests/java/org/pantsbuild/example/hello/greet/GreetingTest.java',
-          'examples/tests/java/org/pantsbuild/example/hello/greet',
-          'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
+      pants_run = self.run_pants_with_workdir(
+          ['test.junit'] + extra_args +
+          ['--test=./examples/tests/java/org/pantsbuild/example/hello/greet/GreetingTest.java',
+           'examples/tests/java/org/pantsbuild/example/hello/greet',
+           'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
           workdir)
       self.assert_success(pants_run)
-      self._assert_output_for_class(workdir, 'org.pantsbuild.example.hello.greet.GreetingTest')
+      self._assert_output_for_class(workdir=workdir,
+                                    classname='org.pantsbuild.example.hello.greet.GreetingTest',
+                                    expect_legacy=expect_legacy)
 
-  def test_junit_test_with_test_option_with_classname(self):
+  @parameterized.expand(OUTPUT_MODES)
+  def test_junit_test_with_test_option_with_classname(self,
+                                                      unused_test_name,
+                                                      extra_args,
+                                                      expect_legacy):
     with self.temporary_workdir() as workdir:
-      pants_run = self.run_pants_with_workdir([
-          'test.junit',
-          '--test=org.pantsbuild.example.hello.greet.GreetingTest',
-          'examples/tests/java/org/pantsbuild/example/hello/greet',
-          'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
+      pants_run = self.run_pants_with_workdir(
+          ['test.junit'] + extra_args +
+          ['--test=org.pantsbuild.example.hello.greet.GreetingTest',
+           'examples/tests/java/org/pantsbuild/example/hello/greet',
+           'examples/tests/scala/org/pantsbuild/example/hello/welcome'],
           workdir)
       self.assert_success(pants_run)
-      self._assert_output_for_class(workdir, 'org.pantsbuild.example.hello.greet.GreetingTest')
+      self._assert_output_for_class(workdir=workdir,
+                                    classname='org.pantsbuild.example.hello.greet.GreetingTest',
+                                    expect_legacy=expect_legacy)
 
   def test_junit_test_requiring_cwd_fails_without_option_specified(self):
     pants_run = self.run_pants([

--- a/tests/python/pants_test/tasks/test_changed_target_integration.py
+++ b/tests/python/pants_test/tasks/test_changed_target_integration.py
@@ -122,7 +122,8 @@ class ChangedTargetGoalsIntegrationTest(PantsRunIntegrationTest):
   def test_test_changed(self):
     with self.known_commits(), self.temporary_workdir() as workdir:
       cmd = ['test-changed', '--diffspec=HEAD~2..HEAD~1']
-      junit_out = os.path.join(workdir, 'test', 'junit', 'org.pantsbuild.ClassTest.out.txt')
+      junit_out = os.path.join(get_buildroot(), 'dist', 'test', 'junit',
+                               'org.pantsbuild.ClassTest.out.txt')
 
       self.assertFalse(os.path.exists(junit_out))
 


### PR DESCRIPTION
Some Pants users expect junit report files to be deposited at the top
level of the `JUnitRun` workdir, ie in `.pants.d/test/junit/`. This is
undesirable since `.pants.d` is a "private" directory for Pants internal
use and since user visible output files are traditionally placed under
the `dist/` dir. Have `JUnitRun` always output report files under
`dist/` and only also output under `.pants.d/test/junit/` under a
deprecated option to provide a migration path.

Fixes #3879