### PR TITLE
Make the ivy resolution confs participate in the fingerprint.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -49,7 +49,7 @@ class IvyResolve(IvyTaskMixin, NailgunTask):
     register('--args', type=list,
              fingerprint=True,
              help='Pass these extra args to ivy.')
-    register('--confs', type=list, default=['default'],
+    register('--confs', type=list, default=['default'], fingerprint=True,
              help='Pass a configuration to ivy in addition to the default ones.')
     register('--mutable-pattern',
              fingerprint=True,


### PR DESCRIPTION
Changing confs should definitely invalidate the resolution.
