### PR TITLE
Update engine lockfile to new Rust version

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1,18 +1,3 @@
-[root]
-name = "engine"
-version = "0.0.1"
-dependencies = [
- "boxfuture 0.0.1",
- "cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "fs 0.0.1",
- "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "process_execution 0.0.1",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -96,6 +81,21 @@ dependencies = [
 name = "either"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "engine"
+version = "0.0.1"
+dependencies = [
+ "boxfuture 0.0.1",
+ "cc 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "process_execution 0.0.1",
+]
 
 [[package]]
 name = "fake-simd"


### PR DESCRIPTION
1.22 removed [root]: https://github.com/rust-lang/cargo/pull/4571

The old file is compatible, cargo updates it when it runs, which means I can't
release because the workspace isn't clean.