### PR TITLE
travis_ci Dockerfile actually works not on travis

### DIFF
--- a/build-support/docker/travis_ci/Dockerfile
+++ b/build-support/docker/travis_ci/Dockerfile
@@ -14,7 +14,7 @@ ARG TRAVIS_UID=1000
 ARG TRAVIS_GROUP=root
 ARG TRAVIS_GID=0
 
-RUN groupadd --gid ${TRAVIS_GID} ${TRAVIS_GROUP}
+RUN groupadd --gid ${TRAVIS_GID} ${TRAVIS_GROUP} || true
 RUN useradd -d /travis/home -g ${TRAVIS_GROUP} --uid ${TRAVIS_UID} ${TRAVIS_USER}
 USER ${TRAVIS_USER}:${TRAVIS_GROUP}
 


### PR DESCRIPTION
Running without the TRAVIS_* env vars set currently fails because root
is a group which already exists.