### PR TITLE
(wip) More packages for centos6 docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,7 @@ matrix:
           -v "${HOME}:/travis/home"
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
-          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -nc && \
-          ./pants clean-all setup-py --run='bdist_wheel --python-tag cp27 --plat-name linux_x86_64' --recursive tests/python/pants_test:test_infra"
+          sh -c "git clean -xfd && ./pants --version && ./pants clean-all setup-py --run='bdist_wheel --python-tag cp27 --plat-name linux_x86_64' --recursive tests/python/pants_test:test_infra"
 
     - os: linux
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,6 @@ matrix:
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
           sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -nc && \
-          # Sanity test for publishing
           ./pants clean-all setup-py --run='bdist_wheel --python-tag cp27 --plat-name linux_x86_64' --recursive tests/python/pants_test:test_infra"
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,9 @@ matrix:
           -v "${HOME}:/travis/home"
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
-          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -nc"
+          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -nc && \
+          # Sanity test for publishing
+          ./pants clean-all setup-py --run='bdist_wheel --python-tag cp27 --plat-name linux_x86_64' --recursive tests/python/pants_test:test_infra"
 
     - os: linux
       dist: trusty

--- a/build-support/docker/centos6/Dockerfile
+++ b/build-support/docker/centos6/Dockerfile
@@ -11,9 +11,6 @@ RUN yum install -y \
   devtoolset-7-gcc \
   devtoolset-7-gcc-c++ \
   git \
-  libffi \
-  libffi-devel \
-  openssl-devel \
   java-1.8.0-openjdk-devel \
   python27
 

--- a/build-support/docker/centos6/Dockerfile
+++ b/build-support/docker/centos6/Dockerfile
@@ -11,6 +11,9 @@ RUN yum install -y \
   devtoolset-7-gcc \
   devtoolset-7-gcc-c++ \
   git \
+  libffi \
+  libffi-devel \
+  openssl-devel \
   java-1.8.0-openjdk-devel \
   python27
 


### PR DESCRIPTION
  ### Problem

Currently doing `./pants setup-py ...` in centos6 image will result missing file error on `ffi` and `openssl`

```
02:43:31 00:35   [pyprep]
02:43:31 00:35     [interpreter]
02:43:36 00:40     [requirements]
                   Invalidated 24 targets.**** Failed to install cffi-1.11.1 (caused by: NonZeroExit("received exit code 1 during execution of `[u'/mnt/build-support/pants_dev_deps.venv/bin/python2.7', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpjTjacf']` while trying to execute `[u'/mnt/build-support/pants_dev_deps.venv/bin/python2.7', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpjTjacf']`",)
):
stdout:
running bdist_wheel
running build
running build_py
creating build
creating build/lib.linux-x86_64-2.7
creating build/lib.linux-x86_64-2.7/cffi
copying cffi/ffiplatform.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/__init__.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/model.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/backend_ctypes.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/lock.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/verifier.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/cparser.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/error.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/vengine_gen.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/api.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/recompiler.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/commontypes.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/setuptools_ext.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/cffi_opcode.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/vengine_cpy.py -> build/lib.linux-x86_64-2.7/cffi
copying cffi/_cffi_include.h -> build/lib.linux-x86_64-2.7/cffi
copying cffi/parse_c_type.h -> build/lib.linux-x86_64-2.7/cffi
copying cffi/_embedding.h -> build/lib.linux-x86_64-2.7/cffi
copying cffi/_cffi_errors.h -> build/lib.linux-x86_64-2.7/cffi
running build_ext
building '_cffi_backend' extension
creating build/temp.linux-x86_64-2.7
creating build/temp.linux-x86_64-2.7/c
gcc -pthread -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector --param=ssp-buffer-size=4 -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/opt/rh/python27/root/usr/include/python2.7 -c c/_cffi_backend.c -o build/temp.linux-x86_64-2.7/c/_cffi_backend.o

stderr:
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing `libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing `libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing `libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing `libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
Package libffi was not found in the pkg-config search path.
Perhaps you should add the directory containing `libffi.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libffi' found
c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
 #include <ffi.h>
          ^~~~~~~
compilation terminated.
error: command 'gcc' failed with exit status 1
```

# Solution

yum install those packages.