### PR TITLE
Fix coursier resolve missing excludes for classpath product

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -439,6 +439,8 @@ class CoursierMixin(NailgunTask):
 
     for vt in invalidation_check.all_vts:
       t = vt.target
+      compile_classpath.add_excludes_for_targets([t])
+
       if isinstance(t, JarLibrary):
         def get_transitive_resolved_jars(my_simple_coord, resolved_jars):
           transitive_jar_path_for_coord = []

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -122,6 +122,8 @@ class CoursierMixin(NailgunTask):
       confs_for_fingerprint = ['sources'] * sources + ['javadoc'] * javadoc
       fp_strategy = CoursierResolveFingerprintStrategy(confs_for_fingerprint)
 
+      compile_classpath.add_excludes_for_targets(target_subset)
+
       with self.invalidated(target_subset,
                             invalidate_dependents=False,
                             silent=False,
@@ -439,8 +441,6 @@ class CoursierMixin(NailgunTask):
 
     for vt in invalidation_check.all_vts:
       t = vt.target
-      compile_classpath.add_excludes_for_targets([t])
-
       if isinstance(t, JarLibrary):
         def get_transitive_resolved_jars(my_simple_coord, resolved_jars):
           transitive_jar_path_for_coord = []

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 import sys
+import urllib
 from zipfile import ZIP_STORED
 
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -274,7 +275,8 @@ def safe_classpath(classpath, synthetic_jar_dir, custom_name=None):
   else:
     synthetic_jar_dir = safe_mkdtemp()
 
-  bundled_classpath = relativize_classpath(classpath, synthetic_jar_dir)
+  # Quote the path so that path containing reserved characters can be safely passed to JVM classloader.
+  bundled_classpath = map(lambda x: urllib.quote(x), relativize_classpath(classpath, synthetic_jar_dir))
 
   manifest = Manifest()
   manifest.addentry(Manifest.CLASS_PATH, ' '.join(bundled_classpath))

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 import sys
-import urllib
 from zipfile import ZIP_STORED
 
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -275,8 +274,7 @@ def safe_classpath(classpath, synthetic_jar_dir, custom_name=None):
   else:
     synthetic_jar_dir = safe_mkdtemp()
 
-  # Quote the path so that path containing reserved characters can be safely passed to JVM classloader.
-  bundled_classpath = map(lambda x: urllib.quote(x), relativize_classpath(classpath, synthetic_jar_dir))
+  bundled_classpath = relativize_classpath(classpath, synthetic_jar_dir)
 
   manifest = Manifest()
   manifest.addentry(Manifest.CLASS_PATH, ' '.join(bundled_classpath))

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -145,7 +145,7 @@ class CoursierResolveTest(JvmToolTaskTestBase):
     self.assertIn('junit:junit:4.12', simple_coords)
     self.assertIn('org.hamcrest:hamcrest-core:1.3', simple_coords)
 
-    # If we grab transitive closure of the coordinates just for junit along with JavaLibrary
+    # If we grab transitive closure of the coordinates for junit along with a JavaLibrary
     # target that excludes junit, then junit should not be on the classpath.
     simple_coords = get_coord_in_classpath(compile_classpath, [excluding_target, junit_jar_lib])
     self.assertNotIn('junit:junit:4.12', simple_coords)

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -17,6 +17,7 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDependencies
+from pants.backend.jvm.tasks.classpath_products import ArtifactClasspathEntry
 from pants.backend.jvm.tasks.coursier_resolve import (CoursierResolve,
                                                       CoursierResolveFingerprintStrategy)
 from pants.base.exceptions import TaskError
@@ -129,6 +130,26 @@ class CoursierResolveTest(JvmToolTaskTestBase):
 
     self.assertEquals(2, len(junit_jar_cp))
     self.assertEquals(0, len(excluding_cp))
+
+    def get_coord_in_classpath(cp, targets):
+      """
+      Get the simple coords that are going to be on the classpath
+      """
+      conf_art_tuples_ex = cp.get_classpath_entries_for_targets(targets)
+      simple_coords = set(x[1].coordinate.simple_coord for x in conf_art_tuples_ex)
+      return simple_coords
+
+    # If we grab the transitive closure of the coordinates just for junit, then
+    # both junit and hamcrest should be in it.
+    simple_coords = get_coord_in_classpath(compile_classpath, [junit_jar_lib])
+    self.assertIn('junit:junit:4.12', simple_coords)
+    self.assertIn('org.hamcrest:hamcrest-core:1.3', simple_coords)
+
+    # If we grab transitive closure of the coordinates just for junit along with JavaLibrary
+    # target that excludes junit, then junit should not be on the classpath.
+    simple_coords = get_coord_in_classpath(compile_classpath, [excluding_target, junit_jar_lib])
+    self.assertNotIn('junit:junit:4.12', simple_coords)
+    self.assertIn('org.hamcrest:hamcrest-core:1.3', simple_coords)
 
   def test_resolve_no_deps(self):
     # Resolve a library with no deps, and confirm that the empty product is created.

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -17,7 +17,6 @@ from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.managed_jar_dependencies import ManagedJarDependencies
-from pants.backend.jvm.tasks.classpath_products import ArtifactClasspathEntry
 from pants.backend.jvm.tasks.coursier_resolve import (CoursierResolve,
                                                       CoursierResolveFingerprintStrategy)
 from pants.base.exceptions import TaskError


### PR DESCRIPTION
### Problem

`JvmLibaray`s' excludes are not respected because coursier did not add them to the excludes.

### Solution

Add the excludes to `ClasspathProduct`like ivy does https://github.com/pantsbuild/pants/blob/9e843b8e79bcd86521367d01087edd55179f3e0b/src/python/pants/backend/jvm/tasks/ivy_task_mixin.py#L178

### Result

See added test. Also verified that without adding excludes, the test fails.