### PR TITLE
url quote classpath in MANIFEST.MF

### DIFF
--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -276,7 +276,7 @@ def safe_classpath(classpath, synthetic_jar_dir, custom_name=None):
     synthetic_jar_dir = safe_mkdtemp()
 
   # Quote the paths so that if they contain reserved characters can be safely passed to JVM classloader.
-  bundled_classpath = map(lambda x: urllib.quote(x), relativize_classpath(classpath, synthetic_jar_dir))
+  bundled_classpath = map(urllib.quote, relativize_classpath(classpath, synthetic_jar_dir))
 
   manifest = Manifest()
   manifest.addentry(Manifest.CLASS_PATH, ' '.join(bundled_classpath))

--- a/src/python/pants/java/util.py
+++ b/src/python/pants/java/util.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 import sys
+import urllib
 from zipfile import ZIP_STORED
 
 from pants.base.workunit import WorkUnit, WorkUnitLabel
@@ -274,7 +275,8 @@ def safe_classpath(classpath, synthetic_jar_dir, custom_name=None):
   else:
     synthetic_jar_dir = safe_mkdtemp()
 
-  bundled_classpath = relativize_classpath(classpath, synthetic_jar_dir)
+  # Quote the paths so that if they contain reserved characters can be safely passed to JVM classloader.
+  bundled_classpath = map(lambda x: urllib.quote(x), relativize_classpath(classpath, synthetic_jar_dir))
 
   manifest = Manifest()
   manifest.addentry(Manifest.CLASS_PATH, ' '.join(bundled_classpath))

--- a/tests/python/pants_test/java/BUILD
+++ b/tests/python/pants_test/java/BUILD
@@ -73,3 +73,14 @@ python_tests(
   ],
   tags = {'integration'},
 )
+
+python_tests(
+  name = 'test_runjava',
+  sources = ['test_runjava_synthetic_classpath.py'],
+  dependencies = [
+    'src/python/pants/java:util',
+    'src/python/pants/util:dirutil',
+    'tests/python/pants_test/jvm:jvm_tool_task_test_base',
+    'src/python/pants/backend/jvm/tasks:nailgun_task',
+  ]
+)

--- a/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
+++ b/tests/python/pants_test/java/test_runjava_synthetic_classpath.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.backend.jvm.tasks.nailgun_task import NailgunTask
+from pants.base.build_environment import get_buildroot
+from pants.java import util
+from pants.net.http.fetcher import Fetcher
+from pants.util.contextutil import temporary_file
+from pants.util.dirutil import safe_concurrent_rename
+from pants_test.jvm.jvm_tool_task_test_base import JvmToolTaskTestBase
+
+
+class DummyRunJavaTask(NailgunTask):
+  def execute(self):
+    pass
+
+
+class SyntheticClasspathTest(JvmToolTaskTestBase):
+  @classmethod
+  def task_type(cls):
+    return DummyRunJavaTask
+
+  def setUp(self):
+    super(SyntheticClasspathTest, self).setUp()
+    self.set_options(use_nailgun=False)
+
+  def test_execute_java_no_error_weird_path(self):
+    """
+    :API: public
+    """
+    with temporary_file(suffix='.jar') as temp_path:
+      fetcher = Fetcher(get_buildroot())
+      try:
+        # Download a jar that echoes things.
+        fetcher.download('https://repo1.maven.org/maven2/io/get-coursier/echo/1.0.0/echo-1.0.0.jar',
+                         path_or_fd=temp_path.name,
+                         timeout_secs=2)
+      except fetcher.Error:
+        self.fail("fail to download echo jar")
+
+      task = self.execute(self.context([]))
+      executor = task.create_java_executor()
+
+      # Executing the jar as is should work.
+      self.assertEquals(0, util.execute_java(
+        executor=executor,
+        classpath=[temp_path.name],
+        main='coursier.echo.Echo',
+        args=['Hello World'],
+        create_synthetic_jar=True))
+
+      # Rename the jar to contain reserved characters.
+      new_path = os.path.join(os.path.dirname(temp_path.name), "%%!!!===++.jar")
+      safe_concurrent_rename(temp_path.name, new_path)
+
+      # Executing the new path should work.
+      self.assertEquals(0, util.execute_java(
+        executor=executor,
+        classpath=[new_path],
+        main='coursier.echo.Echo',
+        args=['Hello World'],
+        create_synthetic_jar=True))


### PR DESCRIPTION
### Problem

Like mentioned in #5288

For example, a file path like
```
$ ls org/apache/pig/pig/0.13.0%2B38/pig-0.13.0%2B38-h2.jar
org/apache/pig/pig/0.13.0%2B38/pig-0.13.0%2B38-h2.jar
```
will appear as is in `MANIFEST.MF`

Whereas JVM classloader treats it as a uri and tries to decode it to `org/apache/pig/pig/0.13.0+38/pig-0.13.0+38-h2.jar`, which is not valid anymore, causing ClassNotFound. 

The proper path to be in MANIFEST.MF is:
```
org/apache/pig/pig/0.13.0%252B38/pig-0.13.0%252B38-h2.jar
```
which gets decoded to `org/apache/pig/pig/0.13.0%2B38/pig-0.13.0%2B38-h2.jar`

### Solution

url quote each classpath

### Result

See added tests
  