### PR TITLE
Introduce a single-target mode to `JUnitRun`.

### DIFF
--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -39,7 +39,7 @@ from pants.java.distribution.distribution import DistributionLocator
 from pants.java.executor import SubprocessExecutor
 from pants.java.junit.junit_xml_parser import RegistryOfTests, Test, parse_failed_targets
 from pants.process.lock import OwnerPrintingInterProcessFileLock
-from pants.task.testrunner_task_mixin import TestRunnerTaskMixin
+from pants.task.testrunner_task_mixin import TestResult, TestRunnerTaskMixin
 from pants.util import desktop
 from pants.util.argutil import ensure_arg, remove_arg
 from pants.util.contextutil import environment_as, temporary_dir
@@ -146,6 +146,10 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
   def register_options(cls, register):
     super(JUnitRun, cls).register_options(register)
 
+    register('--fast', type=bool, default=True, fingerprint=True,
+             help='Run all tests in a single junit invocation. If turned off, each test target '
+                  'will run in its own junit invocation, which will be slower, but isolates '
+                  'tests from process-wide state created by tests in other targets.')
     register('--batch-size', advanced=True, type=int, default=cls._BATCH_ALL, fingerprint=True,
              help='Run at most this many tests in a single test process.')
     register('--test', type=list, fingerprint=True,
@@ -395,10 +399,14 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
         yield chroot
 
   @property
+  def _per_target(self):
+    return not self.get_options().fast
+
+  @property
   def _batched(self):
     return self._batch_size != self._BATCH_ALL
 
-  def _run_tests(self, test_registry, output_dir, coverage):
+  def _run_junit(self, test_registry, output_dir, coverage):
     coverage.instrument(output_dir)
 
     def parse_error_handler(parse_error):
@@ -412,7 +420,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
     classpath_product = self.context.products.get_data('instrument_classpath')
 
     result = 0
-    for batch_id, (properties, batch) in enumerate(self._partition(test_registry)):
+    for batch_id, (properties, batch) in enumerate(self._iter_batches(test_registry)):
       (workdir, platform, target_jvm_options, target_env_vars, concurrency, threads) = properties
 
       batch_output_dir = output_dir
@@ -486,34 +494,36 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
         if result != 0 and self._fail_fast:
           break
 
-    if result != 0:
-      target_to_failed_test = parse_failed_targets(test_registry, output_dir, parse_error_handler)
+    if result == 0:
+      return TestResult.rc(0)
 
-      def sort_owning_target(t):
-        return t.address.spec if t else None
+    target_to_failed_test = parse_failed_targets(test_registry, output_dir, parse_error_handler)
 
-      failed_targets = sorted(target_to_failed_test, key=sort_owning_target)
-      error_message_lines = []
-      if self._failure_summary:
-        def render_owning_target(t):
-          return t.address.spec if t else '<Unknown Target>'
+    def sort_owning_target(t):
+      return t.address.spec if t else None
 
-        for target in failed_targets:
-          error_message_lines.append('\n{indent}{owner}'.format(indent=' ' * 4,
-                                                                owner=render_owning_target(target)))
-          for test in sorted(target_to_failed_test[target]):
-            error_message_lines.append('{indent}{classname}#{methodname}'
-                                       .format(indent=' ' * 8,
-                                               classname=test.classname,
-                                               methodname=test.methodname))
-      error_message_lines.append(
-        '\njava {main} ... exited non-zero ({code}); {failed} failed {targets}.'
-          .format(main=JUnit.RUNNER_MAIN, code=result, failed=len(failed_targets),
-                  targets=pluralize(len(failed_targets), 'target'))
-      )
-      raise ErrorWhileTesting('\n'.join(error_message_lines), failed_targets=list(failed_targets))
+    failed_targets = sorted(target_to_failed_test, key=sort_owning_target)
+    error_message_lines = []
+    if self._failure_summary:
+      def render_owning_target(t):
+        return t.address.reference() if t else '<Unknown Target>'
 
-  def _partition(self, test_registry):
+      for target in failed_targets:
+        error_message_lines.append('\n{indent}{owner}'.format(indent=' ' * 4,
+                                                              owner=render_owning_target(target)))
+        for test in sorted(target_to_failed_test[target]):
+          error_message_lines.append('{indent}{classname}#{methodname}'
+                                     .format(indent=' ' * 8,
+                                             classname=test.classname,
+                                             methodname=test.methodname))
+    error_message_lines.append(
+      '\njava {main} ... exited non-zero ({code}); {failed} failed {targets}.'
+        .format(main=JUnit.RUNNER_MAIN, code=result, failed=len(failed_targets),
+                targets=pluralize(len(failed_targets), 'target'))
+    )
+    return TestResult(msg='\n'.join(error_message_lines), rc=result, failed_targets=failed_targets)
+
+  def _iter_batches(self, test_registry):
     tests_by_properties = test_registry.index(
       lambda tgt: tgt.cwd if tgt.cwd is not None else self._working_dir,
       lambda tgt: tgt.test_platform,
@@ -575,13 +585,65 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
           yield os.path.join(dir_path, filename)
     return list(files_iter())
 
-  def _execute(self, all_targets):
-    # NB: We only run tests within junit_tests targets, but if coverage options are
-    # specified, we want to instrument and report on all the original targets, not
-    # just the test targets.
-    partition = all_targets if self.get_options().coverage else self._get_test_targets()
+  def _iter_partitions(self, targets, output_dir):
+    if self._per_target:
+      for target in targets:
+        yield (target,), os.path.join(output_dir, target.id)
+    else:
+      yield tuple(targets), output_dir
 
-    with self.invalidated(targets=partition,
+  def _execute(self, all_targets):
+    with self._isolation(all_targets) as (output_dir, reports, coverage):
+      results = {}
+      failure = False
+      for (partition, partition_output_dir) in self._iter_partitions(self._get_test_targets(),
+                                                                     output_dir):
+        try:
+          rv = self._run_partition(partition, partition_output_dir, coverage)
+        except ErrorWhileTesting as e:
+          rv = TestResult.from_error(e)
+
+        results[partition] = rv
+        if not rv.success:
+          failure = True
+          if self._fail_fast:
+            break
+
+      for partition in sorted(results):
+        rv = results[partition]
+        if len(partition) == 1 or rv.success:
+          log = self.context.log.info if rv.success else self.context.log.error
+          for target in partition:
+            log('{0:80}.....{1:>10}'.format(target.address.reference(), rv))
+        else:
+          # There is not much useful we can display in summary for a multi-target partition with
+          # failures without parsing those failures to link them to individual targets; ie: targets
+          # 2 and 8 failed in this partition of 10 targets.
+          # TODO(John Sirois): Punting here works since we have in practice just 2 partitionings:
+          # 1. All targets in singleton partitions
+          # 2. All targets in 1 partition
+          # If we get to the point where we have multiple partitions with multiple targets, some
+          # sort of summary for the multi-target partitions will probably be needed.
+          pass
+
+      msgs = [str(_rv) for _rv in results.values() if not _rv.success]
+      failed_targets = [target
+                        for _rv in results.values() if not _rv.success
+                        for target in _rv.failed_targets]
+      if len(failed_targets) > 0:
+        error = ErrorWhileTesting('\n'.join(msgs), failed_targets=failed_targets)
+      elif failure:
+        # A low-level test execution failure occurred before tests were run.
+        error = TaskError()
+      else:
+        error = None
+
+      reports.generate(output_dir, exc=error)
+      if error:
+        raise error
+
+  def _run_partition(self, targets, output_dir, coverage):
+    with self.invalidated(targets=targets,
                           # Re-run tests when the code they test (and depend on) changes.
                           invalidate_dependents=True) as invalidation_check:
 
@@ -594,41 +656,37 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
           invalid_test_tgts.extend(test_targets)
 
       test_registry = self._collect_test_targets(invalid_test_tgts)
+      if test_registry.empty:
+        return TestResult.rc(0)
 
       # Processing proceeds through:
       # 1.) output -> output_dir
       # 2.) [iff all == invalid] output_dir -> cache: We do this manually for now.
       # 3.) [iff invalid == 0 and all > 0] cache -> workdir: Done transparently by `invalidated`.
-      # 4.) [iff user-specified final locations] workdir -> final-locations: We perform this step
-      #     as an unconditional post-process in `_isolation`.
-      with self._isolation(all_targets) as (output_dir, reports, coverage):
-        if not test_registry.empty:
-          try:
-            # 1.) Write all results that will be potentially cached to output_dir.
-            self._run_tests(test_registry, output_dir, coverage)
 
-            cache_vts = self._vts_for_partition(invalidation_check)
-            if set(all_test_tgts) == set(invalid_test_tgts):
-              # 2.) All tests in the partition were invalid, cache the test results.
-              if self.artifact_cache_writes_enabled():
-                self.update_artifact_cache([(cache_vts, self._collect_files(output_dir))])
-            elif not invalidation_check.invalid_vts:
-              # 3.) The full partition was valid, our results will have been staged for/by caching
-              # if not already local.
-              pass
-            else:
-              # The partition was partially invalid.
+      # 1.) Write all results that will be potentially cached to output_dir.
+      result = self._run_junit(test_registry, output_dir, coverage).checked()
 
-              # We don't cache results; so others will need to re-run this partition.
-              # NB: We will presumably commit this change now though and so others will get this
-              # partition in a state that executes successfully; so when the 1st of the others
-              # executes against this partition; they will hit `all_vts == invalid_vts` and
-              # cache the results. That 1st of others is hopefully CI!
-              cache_vts.force_invalidate()
-          except TaskError as e:
-            reports.generate(output_dir, exc=e)
-            raise
-        reports.generate(output_dir)
+      cache_vts = self._vts_for_partition(invalidation_check)
+      if invalidation_check.all_vts == invalidation_check.invalid_vts:
+        # 2.) All tests in the partition were invalid, cache successful test results.
+        if result.success and self.artifact_cache_writes_enabled():
+          self.update_artifact_cache([(cache_vts, self._collect_files(output_dir))])
+      elif not invalidation_check.invalid_vts:
+        # 3.) The full partition was valid, our results will have been staged for/by caching
+        # if not already local.
+        pass
+      else:
+        # The partition was partially invalid.
+
+        # We don't cache results; so others will need to re-run this partition.
+        # NB: We will presumably commit this change now though and so others will get this
+        # partition in a state that executes successfully; so when the 1st of the others
+        # executes against this partition; they will hit `all_vts == invalid_vts` and
+        # cache the results. That 1st of others is hopefully CI!
+        cache_vts.force_invalidate()
+
+      return result
 
   class Reports(object):
     def __init__(self, junit_html_report, coverage):
@@ -652,8 +710,13 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
   @contextmanager
   def _isolation(self, all_targets):
     run_dir = '_runs'
+    mode_dir = 'isolated' if self._per_target else 'combined'
     batch_dir = str(self._batch_size) if self._batched else 'all'
-    output_dir = os.path.join(self.workdir, run_dir, Target.identify(all_targets), batch_dir)
+    output_dir = os.path.join(self.workdir,
+                              run_dir,
+                              Target.identify(all_targets),
+                              mode_dir,
+                              batch_dir)
     safe_mkdir(output_dir, clean=False)
 
     if self._html_report:

--- a/src/python/pants/backend/jvm/tasks/junit_run.py
+++ b/src/python/pants/backend/jvm/tasks/junit_run.py
@@ -138,7 +138,7 @@ class JUnitRun(TestRunnerTaskMixin, JvmToolTaskMixin, JvmTask):
 
   @classmethod
   def implementation_version(cls):
-    return super(JUnitRun, cls).implementation_version() + [('JUnitRun', 2)]
+    return super(JUnitRun, cls).implementation_version() + [('JUnitRun', 3)]
 
   _BATCH_ALL = sys.maxint
 

--- a/src/python/pants/java/junit/BUILD
+++ b/src/python/pants/java/junit/BUILD
@@ -4,6 +4,7 @@
 python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
+    'src/python/pants/util:dirutil',
     'src/python/pants/util:objects',
     'src/python/pants/util:xml_parser',
   ]

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_tests_integration.py
@@ -238,7 +238,7 @@ class JunitTestsIntegrationTest(PantsRunIntegrationTest):
                                                  mixed_addr],
                                                 workdir)
         group = [
-            'org/pantsbuild/tmp/tests:tests',
+            'org/pantsbuild/tmp/tests',
             'org.pantsbuild.tmp.tests.AllTests#test1Failure',
             'org.pantsbuild.tmp.tests.AllTests#test3Failure',
             'org.pantsbuild.tmp.tests.AllTests#test4Error',

--- a/tests/python/pants_test/java/junit/test_junit_xml_parser.py
+++ b/tests/python/pants_test/java/junit/test_junit_xml_parser.py
@@ -115,7 +115,8 @@ class TestParseFailedTargets(unittest.TestCase):
   def test_parse_failed_targets_nominal(self):
     registry = RegistryOfTests({JUnitTest('org.pantsbuild.Failure'): 'Bob',
                                 JUnitTest('org.pantsbuild.Error'): 'Jane',
-                                JUnitTest('org.pantsbuild.AnotherError'): 'Bob'})
+                                JUnitTest('org.pantsbuild.AnotherError'): 'Bob',
+                                JUnitTest('org.pantsbuild.subpackage.AnotherFailure'): 'Mary'})
 
     with temporary_dir() as junit_xml_dir:
       with open(os.path.join(junit_xml_dir, 'TEST-a.xml'), 'w') as fp:
@@ -141,12 +142,20 @@ class TestParseFailedTargets(unittest.TestCase):
       with open(os.path.join(junit_xml_dir, 'random.xml'), 'w') as fp:
         fp.write('<invalid></xml>')
       with safe_open(os.path.join(junit_xml_dir, 'subdir', 'TEST-c.xml'), 'w') as fp:
-        fp.write('<invalid></xml>')
+        fp.write("""
+        <testsuite failures="1" errors="0">
+          <testcase classname="org.pantsbuild.subpackage.AnotherFailure" name="testAnotherFailue">
+            <failure/>
+          </testcase>
+        </testsuite>
+        """)
 
       failed_targets = parse_failed_targets(registry, junit_xml_dir, self._raise_handler)
       self.assertEqual({'Bob': {JUnitTest('org.pantsbuild.Failure', 'testFailure'),
                                 JUnitTest('org.pantsbuild.AnotherError', 'testAnotherError')},
-                        'Jane': {JUnitTest('org.pantsbuild.Error', 'testError')}},
+                        'Jane': {JUnitTest('org.pantsbuild.Error', 'testError')},
+                        'Mary': {JUnitTest('org.pantsbuild.subpackage.AnotherFailure',
+                                           'testAnotherFailue')}},
                        failed_targets)
 
   def test_parse_failed_targets_error_raise(self):


### PR DESCRIPTION
This mode, enabled via `./pants test.junit --no-fast`, mirrors the same
mode in `PyestRun` and can be used for effective successful test result
caching.

Fixes #5256