### PR TITLE
A mixin to provide a --transitive options for tasks that can use it.

### DIFF
--- a/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/BUILD
+++ b/contrib/errorprone/src/python/pants/contrib/errorprone/tasks/BUILD
@@ -2,9 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=[
-    'errorprone.py',
-  ],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/backend/jvm/subsystems:shader',
@@ -13,6 +10,7 @@ python_library(
     'src/python/pants/java/jar',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
+    'src/python/pants/task',
     'src/python/pants/util:dirutil',
   ]
 )

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/BUILD
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/BUILD
@@ -14,6 +14,7 @@ python_library(
     'src/python/pants/base:build_environment',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
+    'src/python/pants/task',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:xml_parser',
   ]

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_checkstyle.py
@@ -16,11 +16,6 @@ class GoCheckstyle(GoFmtTaskBase):
   deprecated_options_scope = 'compile.gofmt'
   deprecated_options_scope_removal_version = '1.5.0.dev0'
 
-  @classmethod
-  def register_options(cls, register):
-    super(GoCheckstyle, cls).register_options(register)
-    register('--skip', type=bool, fingerprint=True, help='Skip checkstyle.')
-
   def execute(self):
     if self.get_options().skip:
       return

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -33,14 +33,10 @@ class JavascriptStyle(NodeTask):
   @classmethod
   def register_options(cls, register):
     super(JavascriptStyle, cls).register_options(register)
-    register('--skip', type=bool, fingerprint=True, help='Skip javascriptstyle.')
     register('--fail-slow', type=bool,
              help='Check all targets and present the full list of errors.')
     register('--javascriptstyle-dir', advanced=True, fingerprint=True,
              help='Package directory for lint tool.')
-    register('--transitive', type=bool, default=True,
-             help='True to run the tool transitively on targets in the context, false to run '
-                  'for only roots specified on the commandline.')
 
   def get_lintable_node_targets(self, targets):
     return filter(
@@ -57,12 +53,12 @@ class JavascriptStyle(NodeTask):
                        source.endswith(self._JSX_SOURCE_EXTENSION)))
     return sources
 
-  def _is_javascriptstyle_dir_valid(self, javascriptstyle_dir):
+  @staticmethod
+  def _is_javascriptstyle_dir_valid(javascriptstyle_dir):
     dir_exists = os.path.isdir(javascriptstyle_dir)
     if not dir_exists:
       raise TaskError(
         'javascriptstyle package does not exist: {}.'.format(javascriptstyle_dir))
-      return False
     else:
       lock_file = os.path.join(javascriptstyle_dir, 'yarn.lock')
       package_json = os.path.join(javascriptstyle_dir, 'package.json')
@@ -71,7 +67,6 @@ class JavascriptStyle(NodeTask):
         raise TaskError(
           'javascriptstyle cannot be installed because yarn.lock '
           'or package.json does not exist.')
-        return False
     return True
 
   @memoized_method

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -64,9 +64,6 @@ class PythonCheckStyleTask(Task):
              help='Only messages at this severity or higher are logged. [COMMENT WARNING ERROR].')
     register('--strict', fingerprint=True, type=bool,
              help='If enabled, have non-zero exit status for any nit at WARNING or higher.')
-    # Skip short circuits before fingerprinting
-    register('--skip', type=bool,
-             help='If enabled, skip this style checker.')
     register('--suppress', fingerprint=True, type=file_option, default=None,
              help='Takes a XML file where specific rules on specific files will be skipped.')
     register('--fail', fingerprint=True, default=True, type=bool,

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/python_eval.py
@@ -36,8 +36,6 @@ class PythonEval(PythonTask):
   @classmethod
   def register_options(cls, register):
     super(PythonEval, cls).register_options(register)
-    register('--skip', type=bool,
-             help='If enabled, skip eval of python targets.')
     register('--fail-slow', type=bool,
              help='Compile all targets and present the full list of errors.')
     register('--closure', type=bool,

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks2/python_eval.py
@@ -62,8 +62,6 @@ class PythonEval(ResolveRequirementsTaskBase):
   @classmethod
   def register_options(cls, register):
     super(PythonEval, cls).register_options(register)
-    register('--skip', type=bool,
-             help='If enabled, skip eval of python targets.')
     register('--fail-slow', type=bool,
              help='Compile all targets and present the full list of errors.')
     register('--closure', type=bool,

--- a/src/python/pants/backend/jvm/tasks/checkstyle.py
+++ b/src/python/pants/backend/jvm/tasks/checkstyle.py
@@ -36,8 +36,6 @@ class Checkstyle(NailgunTask):
   @classmethod
   def register_options(cls, register):
     super(Checkstyle, cls).register_options(register)
-    register('--skip', type=bool, fingerprint=True,
-             help='Skip checkstyle.')
     register('--configuration', advanced=True, type=file_option, fingerprint=True,
              help='Path to the checkstyle configuration file.')
     register('--properties', advanced=True, type=dict_with_files_option, default={},

--- a/src/python/pants/backend/jvm/tasks/scala_rewrite_base.py
+++ b/src/python/pants/backend/jvm/tasks/scala_rewrite_base.py
@@ -22,14 +22,10 @@ class ScalaRewriteBase(NailgunTask, AbstractClass):
   @classmethod
   def register_options(cls, register):
     super(ScalaRewriteBase, cls).register_options(register)
-    register('--skip', type=bool, default=False, help='Skip running the tool.')
     register('--target-types',
              default=['scala_library', 'junit_tests', 'java_tests'],
              advanced=True, type=list,
              help='The target types to apply formatting to.')
-    register('--transitive', type=bool, default=True,
-             help='True to run the tool transitively on targets in the context, false to run '
-                  'for only roots specified on the commandline.')
 
   @memoized_property
   def _formatted_target_types(self):

--- a/src/python/pants/backend/jvm/tasks/scalastyle.py
+++ b/src/python/pants/backend/jvm/tasks/scalastyle.py
@@ -72,7 +72,6 @@ class Scalastyle(NailgunTask):
   @classmethod
   def register_options(cls, register):
     super(Scalastyle, cls).register_options(register)
-    register('--skip', type=bool, fingerprint=True, help='Skip scalastyle.')
     register('--config', type=file_option, advanced=True, fingerprint=True,
              help='Path to scalastyle config file.')
     register('--excludes', type=file_option, advanced=True, fingerprint=True,

--- a/src/python/pants/backend/python/tasks/python_isort.py
+++ b/src/python/pants/backend/python/tasks/python_isort.py
@@ -48,8 +48,6 @@ class IsortPythonTask(Task):
   @classmethod
   def register_options(cls, register):
     super(IsortPythonTask, cls).register_options(register)
-    register('--skip', type=bool, default=False,
-             help='If true, skip isort task.')
     register('--version', advanced=True, fingerprint=True, default='4.2.5',
              help='Version of isort.')
 

--- a/src/python/pants/core_tasks/goal_options_registrars.py
+++ b/src/python/pants/core_tasks/goal_options_registrars.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.goal.goal_options_registrar import GoalOptionsRegistrar
+
+
+"""GoalOptionsRegistrar subclasses for various core goals."""
+
+
+class _CodeCheckerGoalOptionsRegistrarBase(GoalOptionsRegistrar):
+  """Registers recursive options on all tasks in the lint/fmt goals."""
+
+  @classmethod
+  def register_options(cls, register):
+    register('--skip', type=bool, default=False, fingerprint=True, recursive=True,
+             help='Skip task.')
+    register('--transitive', type=bool, default=True, fingerprint=True, recursive=True,
+             help="If false, act only on the targets directly specified on the command line. "
+                  "If true, act on the transitive dependency closure of those targets.")
+
+
+class LintGoalOptionsRegistrar(_CodeCheckerGoalOptionsRegistrarBase):
+  options_scope = 'lint'
+
+
+class FmtGoalOptionsRegistrar(_CodeCheckerGoalOptionsRegistrarBase):
+  options_scope = 'fmt'

--- a/src/python/pants/core_tasks/register.py
+++ b/src/python/pants/core_tasks/register.py
@@ -10,6 +10,8 @@ from pants.core_tasks.changed_target_tasks import CompileChanged, TestChanged
 from pants.core_tasks.clean import Clean
 from pants.core_tasks.deferred_sources_mapper import DeferredSourcesMapper
 from pants.core_tasks.explain_options_task import ExplainOptionsTask
+from pants.core_tasks.goal_options_registrars import (
+  FmtGoalOptionsRegistrar, LintGoalOptionsRegistrar)
 from pants.core_tasks.invalidate import Invalidate
 from pants.core_tasks.list_goals import ListGoals
 from pants.core_tasks.noop import NoopCompile, NoopTest
@@ -47,8 +49,8 @@ def register_goals():
   Goal.register('doc', 'Generate documentation.')
   Goal.register('publish', 'Publish a build artifact.')
   Goal.register('dep-usage', 'Collect target dependency usage data.')
-  Goal.register('lint', 'Find formatting errors in source code.')
-  Goal.register('fmt', 'Autoformat source code.')
+  Goal.register('lint', 'Find formatting errors in source code.', LintGoalOptionsRegistrar)
+  Goal.register('fmt', 'Autoformat source code.', FmtGoalOptionsRegistrar)
   Goal.register('buildozer', 'Manipulate BUILD files.')
 
   # Register tasks.
@@ -99,5 +101,5 @@ def register_goals():
   task(name='deferred-sources', action=DeferredSourcesMapper).install()
 
   # Processing aliased targets has to occur very early.
-  task(name='substitute-aliased-targets', action=SubstituteAliasedTargets).install('bootstrap',
-                                                                                   first=True)
+  task(name='substitute-aliased-targets', action=SubstituteAliasedTargets).install(
+    'bootstrap', first=True)

--- a/src/python/pants/goal/goal_options_registrar.py
+++ b/src/python/pants/goal/goal_options_registrar.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.option.optionable import Optionable
+from pants.option.scope import ScopeInfo
+
+
+class GoalOptionsRegistrar(Optionable):
+  """Subclass this to register recursive options on all tasks in a goal."""
+  options_scope_category = ScopeInfo.GOAL

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -237,7 +237,6 @@ class GlobalOptionsRegistrar(Optionable):
              help="Include only targets with these tags (optional '+' prefix) or without these "
                   "tags ('-' prefix).  Useful with ::, to find subsets of targets "
                   "(e.g., integration tests.)")
-
     register('-t', '--timeout', advanced=True, type=int, metavar='<seconds>',
              help='Number of seconds to wait for http connections.')
     # TODO: After moving to the new options system these abstraction leaks can go away.

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -13,6 +13,7 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
 
   # Symbolic constants for different categories of scope.
   GLOBAL = 'GLOBAL'
+  GOAL = 'GOAL'
   TASK = 'TASK'
   SUBSYSTEM = 'SUBSYSTEM'
   INTERMEDIATE = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.

--- a/src/python/pants/task/transitive_option_mixin.py
+++ b/src/python/pants/task/transitive_option_mixin.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+
+class TransitiveOptionMixin(object):
+  """A mixin for tasks that optionally act on the entire dependency closure of the target roots.
+
+  Some tasks must always act on the entire closure. E.g., when compiling, one must compile all
+  of a target's dependencies before compiling that target.
+
+  Other tasks must always act only on the target roots (the targets explicitly specified by the
+  user on the command line). E.g., when finding paths between two user-specified targets.
+
+  Still other tasks may optionally act on either the target roots or the entire closure,
+  as the user prefers in each case. E.g., when invoking a linter. This mixin supports such tasks.
+  """
+  # Subclasses may override to provide a different default.
+  transitive_default = False
+
+  @classmethod
+  def register_options(cls, register):
+    super(TransitiveOptionMixin, cls).register_options(register)
+    register('--transitive', default=cls.transitive_default, type=bool,
+             help='Act on the transitive dependencies of targets specified on the command line. '
+                  'Otherwise, act only on the targets directly specified on the command line.')
+
+  def targets_to_act_on(self, predicate=None):
+    if self.get_options().transitive:
+      return self.context.targets(predicate)
+    else:
+      return filter(predicate, self.context.target_roots)


### PR DESCRIPTION
Retrofits two tasks (errorprone and findbugs) to use tihs mixin,
instead of their own --transitive logic.

Future changes will retrofit other tasks.

This change also fixes style issues in those two tasks, and
improves the target selection predicate, so that on the one hand
all jvm targets with .java sources can be selected (previously findbugs
wouldn't act on a jvm_binary with a source=), but on the other hand
non-jvm targets that happen to have .java sources (e.g., a resource
bundle) won't be acted on (previously errorprone would act on these).

