### PR TITLE
Move hashing utilities into their own crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -148,6 +149,7 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -240,6 +242,16 @@ dependencies = [
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hashing"
+version = "0.0.1"
+dependencies = [
+ "bazel_protos 0.0.1",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -23,6 +23,7 @@ boxfuture = { path = "boxfuture" }
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures = "0.1.16"
+hashing = { path = "hashing" }
 lazy_static = "0.2.2"
 ordermap = "0.2.8"
 petgraph = "0.4.5"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.1.16"
 futures-cpupool = "0.1.6"
 glob = "0.2.11"
 grpcio = { version = "0.2.0", features = ["secure"] }
+hashing = { path = "../hashing" }
 hex = "0.3.1"
 ignore = "0.3.1"
 itertools = "0.7.2"

--- a/src/rust/engine/fs/fs_util/Cargo.lock
+++ b/src/rust/engine/fs/fs_util/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -163,6 +164,7 @@ dependencies = [
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -246,6 +248,16 @@ dependencies = [
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hashing"
+version = "0.0.1"
+dependencies = [
+ "bazel_protos 0.0.1",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -9,4 +9,5 @@ boxfuture = { path = "../../boxfuture" }
 clap = "2"
 fs = { path = ".." }
 futures = "0.1.16"
+hashing = { path = "../../hashing" }
 protobuf = "1.4.1"

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -3,12 +3,14 @@ extern crate boxfuture;
 extern crate clap;
 extern crate fs;
 extern crate futures;
+extern crate hashing;
 extern crate protobuf;
 
 use boxfuture::{Boxable, BoxFuture};
 use clap::{App, Arg, SubCommand};
-use fs::{Fingerprint, GetFileDigest, ResettablePool, Snapshot, Store, VFS};
+use fs::{GetFileDigest, ResettablePool, Snapshot, Store, VFS};
 use futures::future::{self, Future, join_all};
+use hashing::{Digest, Fingerprint};
 use protobuf::Message;
 use std::error::Error;
 use std::fs::File;
@@ -335,7 +337,7 @@ struct FileSaver {
 }
 
 impl GetFileDigest<String> for FileSaver {
-  fn digest(&self, file: &fs::File) -> BoxFuture<fs::Digest, String> {
+  fn digest(&self, file: &fs::File) -> BoxFuture<Digest, String> {
     let file_copy = file.clone();
     let store = self.store.clone();
     self

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -1,12 +1,10 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-mod hash;
-pub use hash::Fingerprint;
 mod snapshot;
 pub use snapshot::{GetFileDigest, Snapshot};
 mod store;
-pub use store::{Digest, Store};
+pub use store::Store;
 mod pool;
 pub use pool::ResettablePool;
 
@@ -21,6 +19,7 @@ extern crate futures;
 extern crate futures_cpupool;
 extern crate glob;
 extern crate grpcio;
+extern crate hashing;
 extern crate hex;
 extern crate ignore;
 extern crate itertools;
@@ -44,12 +43,12 @@ use std::cmp::min;
 use futures::future::{self, Future};
 use futures_cpupool::CpuFuture;
 use glob::Pattern;
+use hashing::{Fingerprint, WriterHasher};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ordermap::OrderMap;
 use tempdir::TempDir;
 
 use boxfuture::{Boxable, BoxFuture};
-use hash::WriterHasher;
 
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -5,9 +5,9 @@ use bazel_protos;
 use boxfuture::{Boxable, BoxFuture};
 use futures::Future;
 use futures::future::join_all;
+use hashing::{Digest, Fingerprint};
 use itertools::Itertools;
-use {Digest, File, PathStat, Store};
-use hash::Fingerprint;
+use {File, PathStat, Store};
 use protobuf;
 use std::ffi::OsString;
 use std::fmt;
@@ -171,11 +171,12 @@ mod tests {
 
   use boxfuture::{BoxFuture, Boxable};
   use futures::future::Future;
+  use hashing::{Digest, Fingerprint};
   use tempdir::TempDir;
   use self::testutil::make_file;
 
-  use super::super::{Digest, File, Fingerprint, GetFileDigest, PathGlobs, PathStat, PosixFS,
-                     ResettablePool, Snapshot, Store, VFS};
+  use super::super::{File, GetFileDigest, PathGlobs, PathStat, PosixFS, ResettablePool, Snapshot,
+                     Store, VFS};
 
   use std;
   use std::error::Error;

--- a/src/rust/engine/fs/src/test_cas.rs
+++ b/src/rust/engine/fs/src/test_cas.rs
@@ -6,7 +6,7 @@ use futures;
 use grpcio;
 
 use futures::{Future, IntoFuture, Stream};
-use Fingerprint;
+use hashing::Fingerprint;
 
 ///
 /// Implements the ContentAddressableStorage gRPC API, answering read requests with either known

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hashing"
+version = "0.0.1"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+
+[dependencies]
+bazel_protos = { path = "../process_execution/bazel_protos" }
+digest = "0.6.2"
+hex = "0.3.1"
+sha2 = "0.6.0"

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -17,6 +17,7 @@ extern crate boxfuture;
 extern crate fnv;
 extern crate fs;
 extern crate futures;
+extern crate hashing;
 #[macro_use]
 extern crate lazy_static;
 extern crate ordermap;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -15,6 +15,7 @@ use context::Context;
 use core::{Failure, Key, Noop, TypeConstraint, Value, Variants, throw};
 use externs;
 use fs::{self, Dir, File, FileContent, Link, PathGlobs, PathStat, VFS};
+use hashing;
 use rule_graph;
 use selectors::{self, Selector};
 use tasks;
@@ -759,9 +760,9 @@ impl From<ReadLink> for NodeKey {
 pub struct DigestFile(File);
 
 impl Node for DigestFile {
-  type Output = fs::Digest;
+  type Output = hashing::Digest;
 
-  fn run(self, context: Context) -> NodeFuture<fs::Digest> {
+  fn run(self, context: Context) -> NodeFuture<hashing::Digest> {
     let file = self.0.clone();
     context
       .core
@@ -1162,7 +1163,7 @@ impl Node for NodeKey {
 #[derive(Clone, Debug)]
 pub enum NodeResult {
   Unit,
-  Digest(fs::Digest),
+  Digest(hashing::Digest),
   DirectoryListing(DirectoryListing),
   LinkDest(LinkDest),
   Snapshot(fs::Snapshot),
@@ -1187,8 +1188,8 @@ impl From<fs::Snapshot> for NodeResult {
   }
 }
 
-impl From<fs::Digest> for NodeResult {
-  fn from(v: fs::Digest) -> Self {
+impl From<hashing::Digest> for NodeResult {
+  fn from(v: hashing::Digest) -> Self {
     NodeResult::Digest(v)
   }
 }
@@ -1269,7 +1270,7 @@ impl TryFrom<NodeResult> for fs::Snapshot {
   }
 }
 
-impl TryFrom<NodeResult> for fs::Digest {
+impl TryFrom<NodeResult> for hashing::Digest {
   type Err = ();
 
   fn try_from(nr: NodeResult) -> Result<Self, ()> {


### PR DESCRIPTION
I'm about to create a circular dependency which I need to break.