### PR TITLE
Incorporate the more-frequent-stable release proposal

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -11,6 +11,7 @@ Active Committers
 * Nick Howard
 * Stu Hood
 * Yi Cheng
+* Daniel Wagner-Hall
 
 Emeritus
 ========

--- a/src/docs/deprecation_policy.md
+++ b/src/docs/deprecation_policy.md
@@ -1,9 +1,9 @@
 Pants Deprecation Policy
 ========================
 
-For releases after 1.0.0, deprecations are in effect for release branches for the next 5 minor releases (e.g. if a feature is deprecated in 1.0.x it should remain available but deprecated until the 1.5.x stable branch has been cut, and can be removed when master bumps to 1.6.0.dev0).
+Deprecations should live for one entire `dev` series and stable release branch (at the minimum) before their code is removed. This ensures that there is always at least one stable release containing a deprecation, and allows users upgrading their copy of pants to consume only stable releases in order to observe all deprecations.
 
-This assumes an approximately one month lifetime per minor release, allowing for about 6 months warning between deprecation and removal.
+As an example: if a feature is deprecated during the `1.0.0.dev` series, it should remain available but deprecated for the entire `1.1.0.dev` series, and can be removed when master bumps to `1.2.0.dev0`.
 
 API Definition
 --------------

--- a/src/docs/deprecation_policy.md
+++ b/src/docs/deprecation_policy.md
@@ -1,9 +1,9 @@
 Pants Deprecation Policy
 ========================
 
-For releases after 1.0.0, deprecations are in effect for release branches until the next 2 minor releases (e.g. if the feature is available in 1.0.x it should continue to be available in 1.1.x and 1.2.x and can be removed in 1.3.x).
+For releases after 1.0.0, deprecations are in effect for release branches for the next 5 minor releases (e.g. if a feature is deprecated in 1.0.x it should remain available but deprecated until the 1.5.x stable branch has been cut, and can be removed when master bumps to 1.6.0.dev0).
 
-This assumes a rough timeline of 3 months lifetime per minor release.
+This assumes an approximately one month lifetime per minor release, allowing for about 6 months warning between deprecation and removal.
 
 API Definition
 --------------

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -202,13 +202,11 @@ Name              | Email                       | PYPI Usename
 ------------------|-----------------------------|---------------
 John Sirois       | john.sirois@gmail.com       | john.sirois
 Benjy Weinberger  | benjyw@gmail.com            | benjyw
-Eric Ayers        | ericzundel@squareup.com     | ericzundel
 Ity Kaul          | itykaul@gmail.com           | ity
 Stu Hood          | stuhood@gmail.com           | stuhood
-Patrick Lawson    | patrick.a.lawson@gmail.com  | Patrick.Lawson
-Garrett Malmquist | garrett.malmquist@gmail.com | gmalmquist
-Matt Olsen        | digwanderlust@gmail.com     | digiwanderlust
 Mateo Rodriguez   | mateorod9@gmail.com         | mateor
+Yi Cheng          | wisechengyi@gmail.com       | wisechengyi
+Daniel Wagner-Hall| dawagner@gmail.com          | illicitonion
 
 And the current list of packages that these folks can release can
 be obtained via:

--- a/src/docs/release_strategy.md
+++ b/src/docs/release_strategy.md
@@ -21,11 +21,13 @@ or `rc` release from master should happen every week. Stable branches will be cr
 following criteria:
 
 1. Decide whether to create a _new_ `stable` branch:
-    * If it has been approximately [[three months|pants('src/docs:deprecation_policy')]] since the
+    * If it has been approximately [[one month|pants('src/docs:deprecation_policy')]] since the
 previous `stable` branch, the release manager should inspect the changes in the current
-[release milestone](https://github.com/pantsbuild/pants/milestones), and decide whether the changes
-justify a new `stable` release (this is intentionally left open for discussion). If a new `stable`
-release is justified, it will be made from either a `major` or `minor` stable branch (described below).
+[release milestone](https://github.com/pantsbuild/pants/milestones), and decide whether changes
+that are still open justify delaying the `stable` release (this is intentionally left open for
+discussion). If the `stable` release is not blocked (in general, we should bias toward creating
+stable releases frequently), it will be made from either a `major` or `minor` stable branch
+(described below).
     * If a new `stable` branch is _not_ created (because of insufficient time/change to justify the
 stable vetting process), the release manager must cut a `dev` release from master instead.
 2. In addition to any `dev` release or newly-created `stable` branches, the release manager should
@@ -46,18 +48,17 @@ is applied to `stable` releases. They help to ensure a steady release cadence fr
 in the gaps between the (generally more time consuming) `stable` releases.
 
 ### `stable` releases
-`stable` release cycles generally happen every few months, provided that there are enough user
+`stable` release cycles generally happen every month, provided that there are enough user
 facing changes to warrant a new `stable` release. For each release candidate for a `stable` release,
 five business days should be allocated to bugfixing and testing by pants contributors on a release
 candidate announcement thread (described below).  If any changes are needed to the stable release
-based on feedback a new `rc` release will be created from the stable branch.
+based on feedback, a new `rc` release will be created from the stable branch.
 
 #### `major` and `minor` stable branches
 The decision to create a `major` or a `minor` stable branch is based on consensus on
 [[pants-devel@|pants('src/docs:howto_contribute')]] as to the impact of the changes.
 `major` releases signify large or breaking changes. `minor` releases however should be compatible
-with the last two `minor` releases. In other words if a feature is deprecated in version `1.2.x`
-you should be able to continue using that feature at least through version `1.4.0`.
+with the last five `minor` releases (see the [[deprecation policy|pants('src/docs:deprecation_policy')]]).
 
 #### `patch` stable Releases
 In order to allow us to react quickly to bugs, `patch` fixes are released for `stable` branches as


### PR DESCRIPTION
### Problem

As described in https://groups.google.com/d/topic/pants-devel/axaMpP-Z8nU/discussion, infrequent stable releases have meant that Twitter has needed to cut internal releases, which do much less to benefit the community than stable releases would.

### Solution

Increase the suggested frequency of stable releases to monthly. Twitter will attempt to consume only stable releases or release candidates internally. Additionally, update the PyPI owners and committers lists.