### PR TITLE
First of a series of changes to get rid of target labels.

### DIFF
--- a/contrib/confluence/src/python/pants/contrib/confluence/targets/doc_page.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/targets/doc_page.py
@@ -35,6 +35,9 @@ class WikiArtifact(object):
   def fingerprint(self):
     return combine_hashes([self.wiki.fingerprint(), stable_json_hash(self.config)])
 
+  def __str__(self):
+    return self.wiki.name
+
 
 class Wiki(object):
   """Identifies a wiki where pages can be published."""

--- a/src/python/pants/backend/docgen/targets/doc.py
+++ b/src/python/pants/backend/docgen/targets/doc.py
@@ -38,6 +38,9 @@ class WikiArtifact(object):
   def fingerprint(self):
     return combine_hashes([self.wiki.fingerprint(), stable_json_hash(self.config)])
 
+  def __str__(self):
+    return self.wiki.name
+
 
 class Wiki(object):
   """Identifies a wiki where pages can be published."""

--- a/src/python/pants/backend/graph_info/tasks/listtargets.py
+++ b/src/python/pants/backend/graph_info/tasks/listtargets.py
@@ -36,20 +36,16 @@ class ListTargets(ConsoleTask):
 
   def console_output(self, targets):
     if self._provides:
-      def extract_artifact_id(target):
-        provided_jar, _ = target.get_artifact_info()
-        return '{0}#{1}'.format(provided_jar.org, provided_jar.name)
-
       extractors = dict(
           address=lambda target: target.address.spec,
-          artifact_id=extract_artifact_id,
+          artifact_id=lambda target: str(target.provides),
           repo_name=lambda target: target.provides.repo.name,
           repo_url=lambda target: target.provides.repo.url,
           push_db_basedir=lambda target: target.provides.repo.push_db_basedir,
       )
 
       def print_provides(column_extractors, target):
-        if target.is_exported:
+        if hasattr(target, 'provides'):
           return ' '.join(extractor(target) for extractor in column_extractors)
 
       try:

--- a/src/python/pants/backend/graph_info/tasks/listtargets.py
+++ b/src/python/pants/backend/graph_info/tasks/listtargets.py
@@ -45,7 +45,7 @@ class ListTargets(ConsoleTask):
       )
 
       def print_provides(column_extractors, target):
-        if hasattr(target, 'provides'):
+        if getattr(target, 'provides', None):
           return ' '.join(extractor(target) for extractor in column_extractors)
 
       try:

--- a/src/python/pants/backend/jvm/artifact.py
+++ b/src/python/pants/backend/jvm/artifact.py
@@ -82,4 +82,7 @@ class Artifact(PayloadField):
     return not self.__eq__(other)
 
   def __repr__(self):
-    return "{}-{} -> {}".format(self.org, self.name, self.repo)
+    return '{}-{} -> {}'.format(self.org, self.name, self.repo)
+
+  def __str__(self):
+    return '{}#{}'.format(self.org, self.name)

--- a/src/python/pants/backend/jvm/ivy_utils.py
+++ b/src/python/pants/backend/jvm/ivy_utils.py
@@ -20,6 +20,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.backend.jvm.subsystems.jar_dependency_management import (JarDependencyManagement,
                                                                     PinnedJarArtifactSet)
+from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.base.generator import Generator, TemplateData
 from pants.base.revision import Revision
@@ -1068,7 +1069,7 @@ class IvyUtils(object):
         global_excludes.update(target_excludes)
 
     def collect_provide_excludes(target):
-      if not target.is_exported:
+      if not (isinstance(target, ExportableJvmLibrary) and target.provides):
         return
       logger.debug('Automatically excluding jar {}.{}, which is provided by {}'.format(
         target.provides.org, target.provides.name, target))

--- a/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
+++ b/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
@@ -19,7 +19,5 @@ class ExportableJvmLibrary(JvmTarget):
     :param provides:
       An optional Dependency object indicating the The ivy artifact to export.
     """
-
+    # TODO: Move provides argument out of the parent class and onto this one?
     super(ExportableJvmLibrary, self).__init__(*args, **kwargs)
-
-    self.add_labels('exportable')

--- a/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
+++ b/src/python/pants/backend/jvm/targets/exportable_jvm_library.py
@@ -16,8 +16,8 @@ class ExportableJvmLibrary(JvmTarget):
 
   def __init__(self, *args, **kwargs):
     """
-    :param provides:
-      An optional Dependency object indicating the The ivy artifact to export.
+    :param :class:`pants.backend.jvm.artifact.Artifact` provides:
+      An optional object indicating the ivy artifact to export.
     """
     # TODO: Move provides argument out of the parent class and onto this one?
     super(ExportableJvmLibrary, self).__init__(*args, **kwargs)

--- a/src/python/pants/backend/jvm/targets/jarable.py
+++ b/src/python/pants/backend/jvm/targets/jarable.py
@@ -37,8 +37,8 @@ class Jarable(AbstractClass):
     exported = bool(self.provides)
 
     org = self.provides.org if exported else 'internal'
-    module = self.provides.name if exported else self.identifier
+    name = self.provides.name if exported else self.identifier
 
     # TODO(John Sirois): This should return something less than a JarDependency encapsulating just
     # the org and name.  Perhaps a JarFamily?
-    return JarDependency(org=org, name=module, rev=None), exported
+    return JarDependency(org=org, name=name, rev=None), exported

--- a/src/python/pants/backend/jvm/tasks/check_published_deps.py
+++ b/src/python/pants/backend/jvm/tasks/check_published_deps.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.backend.jvm.targets.jar_library import JarLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.jar_publish import PushDb
@@ -30,7 +31,7 @@ class CheckPublishedDeps(ConsoleTask):
     self._artifacts_to_targets = {}
 
     def is_published(tgt):
-      return tgt.is_exported
+      return isinstance(tgt, ExportableJvmLibrary) and tgt.provides
 
     for target in self.context.scan().targets(predicate=is_published):
       provided_jar, _ = target.get_artifact_info()

--- a/src/python/pants/backend/jvm/tasks/classpath_products.py
+++ b/src/python/pants/backend/jvm/tasks/classpath_products.py
@@ -10,6 +10,7 @@ import re
 
 from twitter.common.collections import OrderedSet
 
+from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
 from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.tasks.classpath_util import ClasspathUtil
 from pants.base.exceptions import TaskError
@@ -436,7 +437,7 @@ class ClasspathProducts(object):
     return filter(_not_excluded_filter(excludes), classpath_target_tuples)
 
   def _add_excludes_for_target(self, target):
-    if target.is_exported:
+    if isinstance(target, ExportableJvmLibrary) and target.provides:
       self._excludes.add_for_target(target, [Exclude(target.provides.org,
                                                      target.provides.name)])
     if isinstance(target, JvmTarget) and target.excludes:

--- a/src/python/pants/backend/project_info/tasks/ide_gen.py
+++ b/src/python/pants/backend/project_info/tasks/ide_gen.py
@@ -16,6 +16,9 @@ from twitter.common.collections.orderedset import OrderedSet
 
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
 from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
+from pants.backend.jvm.targets.jar_library import JarLibrary
+from pants.backend.jvm.targets.java_library import JavaLibrary
+from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.backend.jvm.targets.scala_library import ScalaLibrary
 from pants.backend.jvm.tasks.classpath_products import ClasspathProducts
 from pants.backend.jvm.tasks.ivy_task_mixin import IvyTaskMixin
@@ -40,11 +43,13 @@ logger = logging.getLogger(__name__)
 #     common to write a BUILD and ./pants idea the target inside to start development at which
 #     point there are no source files yet - and the developer intents to add them using the ide.
 def is_scala(target):
-  return target.has_sources('.scala') or target.is_scala
+  return (isinstance(target, ScalaLibrary) or
+          isinstance(target, JvmTarget) and target.has_sources('.scala'))
 
 
 def is_java(target):
-  return target.has_sources('.java') or target.is_java
+  return (isinstance(target, JavaLibrary) or
+          isinstance(target, JvmTarget) and target.has_sources('.java'))
 
 
 class IdeGen(IvyTaskMixin, NailgunTask):
@@ -191,8 +196,7 @@ class IdeGen(IvyTaskMixin, NailgunTask):
     self.configure_compile_context(targets)
 
   def configure_project(self, targets, debug_port):
-    jvm_targets = [t for t in targets if t.has_label('jvm') or t.has_label('java') or
-                   isinstance(t, Resources)]
+    jvm_targets = [t for t in targets if isinstance(t, (JvmTarget, JarLibrary, Resources))]
     if self.intransitive:
       jvm_targets = set(self.context.target_roots).intersection(jvm_targets)
 

--- a/src/python/pants/backend/python/python_artifact.py
+++ b/src/python/pants/backend/python/python_artifact.py
@@ -66,6 +66,9 @@ class PythonArtifact(PayloadField):
   def binaries(self):
     return self._binaries
 
+  def __str__(self):
+    return self.name
+
   def _compute_fingerprint(self):
     return sha1(json.dumps((self._kw, self._binaries),
                            ensure_ascii=True,

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -107,6 +107,15 @@ class AbstractTarget(object):
     """
     return hasattr(self, 'resources') and self.resources
 
+  @property
+  @deprecated('1.6.0.dev0', 'use type tests and check the value of the `provides` attribute.')
+  def is_exported(self):
+    """Returns True if the target provides an artifact exportable from the repo.
+
+    :API: public
+    """
+    return getattr(self, 'provides', None) is not None
+
   # DEPRECATED  to be removed after 0.0.29
   # do not use this method, use  isinstance(..., JavaThriftLibrary) or a yet-to-be-defined mixin
   @property

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -108,7 +108,7 @@ class AbstractTarget(object):
     return hasattr(self, 'resources') and self.resources
 
   @property
-  @deprecated('1.6.0.dev0', 'use type tests and check the value of the `provides` attribute.')
+  @deprecated('1.7.0.dev0', 'use type tests and check the value of the `provides` attribute.')
   def is_exported(self):
     """Returns True if the target provides an artifact exportable from the repo.
 

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -107,15 +107,6 @@ class AbstractTarget(object):
     """
     return hasattr(self, 'resources') and self.resources
 
-  @property
-  def is_exported(self):
-    """Returns True if the target provides an artifact exportable from the repo.
-
-    :API: public
-    """
-    # TODO(John Sirois): fixup predicate dipping down into details here.
-    return self.has_label('exportable') and self.provides
-
   # DEPRECATED  to be removed after 0.0.29
   # do not use this method, use  isinstance(..., JavaThriftLibrary) or a yet-to-be-defined mixin
   @property
@@ -150,13 +141,6 @@ class AbstractTarget(object):
   def is_scala(self):
     """Returns True if the target has scala sources."""
     return self.has_label('scala')
-
-  # DEPRECATED to be removed after 0.0.29
-  #  do not use this method, use an isinstance check on a yet-to-be-defined mixin
-  @property
-  def is_scalac_plugin(self):
-    """Returns True if the target builds a scalac plugin."""
-    return self.has_label('scalac_plugin')
 
   # DEPRECATED to be removed after 0.0.29
   # do not use this method, use an isinstance check on a yet-to-be-defined mixin
@@ -423,8 +407,7 @@ class Target(AbstractTarget):
     self._cached_direct_transitive_fingerprint_map = {}
     self._cached_strict_dependencies_map = {}
     self._cached_exports_map = {}
-    if no_cache:
-      self.add_labels('no_cache')
+    self._no_cache = no_cache
     if kwargs:
       self.Arguments.check(self, kwargs)
 
@@ -435,6 +418,10 @@ class Target(AbstractTarget):
   @property
   def transitive(self):
     return self.payload.transitive
+
+  @property
+  def no_cache(self):
+    return self._no_cache
 
   @property
   def type_alias(self):

--- a/src/python/pants/goal/goal.py
+++ b/src/python/pants/goal/goal.py
@@ -167,10 +167,10 @@ class _Goal(object):
     subclass_name = b'{0}_{1}'.format(superclass.__name__,
                                       options_scope.replace('.', '_').replace('-', '_'))
     task_type = type(subclass_name, (superclass,), {
-      '__doc__': superclass.__doc__,
-      '__module__': superclass.__module__,
-      'options_scope': options_scope,
-      '_stable_name': superclass.stable_name()
+      b'__doc__': superclass.__doc__,
+      b'__module__': superclass.__module__,
+      b'options_scope': options_scope,
+      b'_stable_name': superclass.stable_name()
     })
 
     if first:

--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -192,7 +192,7 @@ class VersionedTarget(VersionedTargetSet):
     :return: `True` if this target's associated artifacts can be cached.
     :rtype: bool
     """
-    return super(VersionedTarget, self).cacheable and not self.target.has_label('no_cache')
+    return super(VersionedTarget, self).cacheable and not self.target.no_cache
 
   def create_results_dir(self):
     """Ensure that the empty results directory and a stable symlink exist for these versioned targets."""

--- a/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
@@ -31,7 +31,6 @@ class JavaWireLibraryTest(BaseTest):
 
   def test_label_fields(self):
     target = self.make_target('//:foo', JavaWireLibrary)
-    self.assertTrue(target.has_label('exportable'))
 
   def test_wire_service_options(self):
     target = self.make_target('//:wire_service_options', JavaWireLibrary,

--- a/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
+++ b/tests/python/pants_test/backend/codegen/wire/java/test_java_wire_library.py
@@ -29,9 +29,6 @@ class JavaWireLibraryTest(BaseTest):
                      target.payload.get_field_value('service_writer'))
     self.assertEqual([], target.payload.get_field_value('service_writer_options'))
 
-  def test_label_fields(self):
-    target = self.make_target('//:foo', JavaWireLibrary)
-
   def test_wire_service_options(self):
     target = self.make_target('//:wire_service_options', JavaWireLibrary,
                               service_writer='com.squareup.wire.RetrofitServiceWriter',

--- a/tests/python/pants_test/backend/graph_info/tasks/BUILD
+++ b/tests/python/pants_test/backend/graph_info/tasks/BUILD
@@ -74,6 +74,7 @@ python_tests(
     'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/build_graph',
     'src/python/pants/backend/python/targets:python',
+    'tests/python/pants_test/subsystem:subsystem_utils',
     'tests/python/pants_test/tasks:task_test_base',
   ],
 )


### PR DESCRIPTION
This functionality has been deprecated for years but we never
actually took the trouble to kill it.

This change starts that process. It does three things:

- Removes all direct label checks except for the ones in
  helper methods in Target, thus containing the problem.

- Inlines the "is_exported" check appropriately. In particular,
  listtarget no longer implicitly depends on JVM targets. Instead
  it simply requires than an exportable target have a member named
  "provides" whose str() is appropriate for display in the list.

- Removes some labels/checks we never actually used (e.g., for
  scala plugins).
