### PR TITLE
Protobuf implementation uses Bytes instead of Vec

### DIFF
--- a/3rdparty/protobuf/googleapis/README.md
+++ b/3rdparty/protobuf/googleapis/README.md
@@ -3,3 +3,12 @@ This is a dump of the .proto files from https://github.com/googleapis/googleapis
 This dump was taken at git sha e17dbfb19652240490cae8adeb89991d13cf9df7.
 
 It is a selective view of only the protos we actually need.
+
+The following script was run to enable Bytes fields for Rust:
+```
+sed -i '' '/^package /a\
+\
+import "rustproto.proto";\
+option (rustproto.carllerche_bytes_for_bytes_all) = true;\
+' {google/devtools/remoteexecution/v1test/remote_execution.proto,google/bytestream/bytestream.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto}
+```

--- a/3rdparty/protobuf/googleapis/google/bytestream/bytestream.proto
+++ b/3rdparty/protobuf/googleapis/google/bytestream/bytestream.proto
@@ -16,6 +16,9 @@ syntax = "proto3";
 
 package google.bytestream;
 
+import "rustproto.proto";
+option (rustproto.carllerche_bytes_for_bytes_all) = true;
+
 import "google/api/annotations.proto";
 import "google/protobuf/wrappers.proto";
 

--- a/3rdparty/protobuf/googleapis/google/devtools/remoteexecution/v1test/remote_execution.proto
+++ b/3rdparty/protobuf/googleapis/google/devtools/remoteexecution/v1test/remote_execution.proto
@@ -16,6 +16,9 @@ syntax = "proto3";
 
 package google.devtools.remoteexecution.v1test;
 
+import "rustproto.proto";
+option (rustproto.carllerche_bytes_for_bytes_all) = true;
+
 import "google/api/annotations.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/duration.proto";

--- a/3rdparty/protobuf/googleapis/google/longrunning/operations.proto
+++ b/3rdparty/protobuf/googleapis/google/longrunning/operations.proto
@@ -16,6 +16,9 @@ syntax = "proto3";
 
 package google.longrunning;
 
+import "rustproto.proto";
+option (rustproto.carllerche_bytes_for_bytes_all) = true;
+
 import "google/api/annotations.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";

--- a/3rdparty/protobuf/googleapis/google/rpc/code.proto
+++ b/3rdparty/protobuf/googleapis/google/rpc/code.proto
@@ -16,6 +16,9 @@ syntax = "proto3";
 
 package google.rpc;
 
+import "rustproto.proto";
+option (rustproto.carllerche_bytes_for_bytes_all) = true;
+
 option go_package = "google.golang.org/genproto/googleapis/rpc/code;code";
 option java_multiple_files = true;
 option java_outer_classname = "CodeProto";

--- a/3rdparty/protobuf/googleapis/google/rpc/status.proto
+++ b/3rdparty/protobuf/googleapis/google/rpc/status.proto
@@ -16,6 +16,9 @@ syntax = "proto3";
 
 package google.rpc;
 
+import "rustproto.proto";
+option (rustproto.carllerche_bytes_for_bytes_all) = true;
+
 import "google/protobuf/any.proto";
 
 option go_package = "google.golang.org/genproto/googleapis/rpc/status;status";

--- a/3rdparty/protobuf/rust-protobuf/LICENSE.txt
+++ b/3rdparty/protobuf/rust-protobuf/LICENSE.txt
@@ -1,0 +1,23 @@
+Copyright (c) 2013, Stepan Koltsov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/3rdparty/protobuf/rust-protobuf/README.md
+++ b/3rdparty/protobuf/rust-protobuf/README.md
@@ -1,0 +1,1 @@
+This is a dump of https://raw.githubusercontent.com/stepancheg/rust-protobuf/24579818a6e90b9f3f6a32d671063e36d6ad924a/proto/rustproto.proto

--- a/3rdparty/protobuf/rust-protobuf/rustproto.proto
+++ b/3rdparty/protobuf/rust-protobuf/rustproto.proto
@@ -1,0 +1,45 @@
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+// see https://github.com/gogo/protobuf/blob/master/gogoproto/gogo.proto
+// for the original idea
+
+package rustproto;
+
+extend google.protobuf.FileOptions {
+    // When true, oneof field is generated public
+    optional bool expose_oneof_all = 17001;
+    // When true all fields are public, and not accessors generated
+    optional bool expose_fields_all = 17003;
+    // When false, `get_`, `set_`, `mut_` etc. accessors are not generated
+    optional bool generate_accessors_all = 17004;
+    // Use `bytes::Bytes` for `bytes` fields
+    optional bool carllerche_bytes_for_bytes_all = 17011;
+    // Use `bytes::Bytes` for `string` fields
+    optional bool carllerche_bytes_for_string_all = 17012;
+}
+
+extend google.protobuf.MessageOptions {
+    // When true, oneof field is generated public
+    optional bool expose_oneof = 17001;
+    // When true all fields are public, and not accessors generated
+    optional bool expose_fields = 17003;
+    // When false, `get_`, `set_`, `mut_` etc. accessors are not generated
+    optional bool generate_accessors = 17004;
+    // Use `bytes::Bytes` for `bytes` fields
+    optional bool carllerche_bytes_for_bytes = 17011;
+    // Use `bytes::Bytes` for `string` fields
+    optional bool carllerche_bytes_for_string = 17012;
+}
+
+extend google.protobuf.FieldOptions {
+    // When true all fields are public, and not accessors generated
+    optional bool expose_fields_field = 17003;
+    // When false, `get_`, `set_`, `mut_` etc. accessors are not generated
+    optional bool generate_accessors_field = 17004;
+    // Use `bytes::Bytes` for `bytes` fields
+    optional bool carllerche_bytes_for_bytes_field = 17011;
+    // Use `bytes::Bytes` for `string` fields
+    optional bool carllerche_bytes_for_string_field = 17012;
+}

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
 name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -404,6 +405,9 @@ dependencies = [
 name = "protobuf"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.7.2"
 lazy_static = "0.2.2"
 lmdb = "0.7.2"
 ordermap = "0.2.8"
-protobuf = "1.4.1"
+protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"
 tar = "0.4.13"
 tempdir = "0.3.5"

--- a/src/rust/engine/fs/fs_util/Cargo.lock
+++ b/src/rust/engine/fs/fs_util/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
 name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,6 +178,7 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -400,6 +402,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "protobuf"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -6,8 +6,9 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 [dependencies]
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 boxfuture = { path = "../../boxfuture" }
+bytes = "0.4.5"
 clap = "2"
 fs = { path = ".." }
 futures = "0.1.16"
 hashing = { path = "../../hashing" }
-protobuf = "1.4.1"
+protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -40,6 +40,7 @@ use std::{fmt, fs};
 use std::io::{self, Read};
 use std::cmp::min;
 
+use bytes::Bytes;
 use futures::future::{self, Future};
 use futures_cpupool::CpuFuture;
 use glob::Pattern;
@@ -445,7 +446,10 @@ impl PosixFS {
         std::fs::File::open(&path_abs).and_then(|mut f| {
           let mut content = Vec::new();
           f.read_to_end(&mut content)?;
-          Ok(FileContent { path, content })
+          Ok(FileContent {
+            path: path,
+            content: Bytes::from(content),
+          })
         })
       })
       .to_boxed()
@@ -777,7 +781,7 @@ pub trait VFS<E: Send + Sync + 'static>: Clone + Send + Sync + 'static {
 
 pub struct FileContent {
   pub path: PathBuf,
-  pub content: Vec<u8>,
+  pub content: Bytes,
 }
 
 impl fmt::Debug for FileContent {
@@ -1040,7 +1044,7 @@ impl Snapshots {
         io::Read::read_to_end(&mut entry, &mut content)?;
         files_content.push(FileContent {
           path: path,
-          content: content,
+          content: Bytes::from(content),
         });
       }
     }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -7,9 +7,10 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 bazel_protos = { path = "bazel_protos" }
 digest = "0.6.2"
 grpcio = { version = "0.2.0", features = ["secure"] }
-protobuf = "1.4.1"
+protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"
 
 [dev-dependencies]
+bytes = "0.4.5"
 mock = { path = "../testutil/mock" }
 testutil = { path = "../testutil" }

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -4,6 +4,7 @@ name = "bazel_protos"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
+bytes = "0.4.5"
 futures = "0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
-protobuf = "1.4.1"
+protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
+++ b/src/rust/engine/process_execution/bazel_protos/generate-grpc.sh
@@ -12,4 +12,4 @@ googleapis="${thirdpartyprotobuf}/googleapis"
 outdir="${here}/src"
 mkdir -p "${outdir}"
 
-"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust/cargo/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/bytestream/bytestream.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"
+"${protoc}" --rust_out="${outdir}" --grpc_out="${outdir}" --plugin=protoc-gen-grpc="${HOME}/.cache/pants/rust/cargo/bin/grpc_rust_plugin" --proto_path="${googleapis}" --proto_path="${thirdpartyprotobuf}/standard" --proto_path="${thirdpartyprotobuf}/rust-protobuf" "${googleapis}"/{google/devtools/remoteexecution/v1test/remote_execution.proto,google/bytestream/bytestream.proto,google/rpc/{code,status}.proto,google/longrunning/operations.proto} "${thirdpartyprotobuf}/standard/google/protobuf/empty.proto"

--- a/src/rust/engine/process_execution/bazel_protos/src/lib.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate bytes;
 extern crate futures;
 extern crate grpcio;
 extern crate protobuf;

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate bazel_protos;
+#[cfg(test)]
+extern crate bytes;
 extern crate digest;
 extern crate grpcio;
 #[cfg(test)]

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -140,6 +140,7 @@ fn digest(message: &protobuf::Message) -> Result<bazel_protos::remote_execution:
 #[cfg(test)]
 mod tests {
   use bazel_protos;
+  use bytes::Bytes;
   use protobuf::{self, Message, ProtobufEnum};
   use mock;
   use testutil::{owned_string_vec, as_byte_owned_vec};
@@ -475,8 +476,8 @@ mod tests {
       let mut response_proto = bazel_protos::remote_execution::ExecuteResponse::new();
       response_proto.set_result({
         let mut action_result = bazel_protos::remote_execution::ActionResult::new();
-        action_result.set_stdout_raw(stdout.as_bytes().to_vec());
-        action_result.set_stderr_raw(stderr.as_bytes().to_vec());
+        action_result.set_stdout_raw(Bytes::from(stdout));
+        action_result.set_stderr_raw(Bytes::from(stderr));
         action_result.set_exit_code(exit_code);
         action_result
       });

--- a/src/rust/engine/process_executor/Cargo.lock
+++ b/src/rust/engine/process_executor/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
 name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -40,6 +41,20 @@ dependencies = [
 name = "byte-tools"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytes"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cc"
@@ -124,6 +139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +201,9 @@ dependencies = [
 name = "protobuf"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -243,6 +270,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -266,6 +298,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+"checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
+"checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
@@ -276,6 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "473a8a5620d6a58a17f236588c8e5bfb05f4a55a7c406e100a5afe888a923536"
 "checksum grpcio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8253f10312996bfa7ad164f05ec89d9d5c0d7277c36846379aea7c91daac412a"
+"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
 "checksum libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)" = "96264e9b293e95d25bfcbbf8a88ffd1aedc85b754eba8b7d78012f638ba220eb"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
@@ -291,6 +326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
 "checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
 "checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -5,7 +5,8 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
 bazel_protos = { path = "../../process_execution/bazel_protos" }
+bytes = "0.4.5"
 futures = "0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../../hashing" }
-protobuf = "1.4.1"
+protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/testutil/mock/src/lib.rs
+++ b/src/rust/engine/testutil/mock/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate bazel_protos;
+extern crate bytes;
 extern crate futures;
 extern crate grpcio;
 extern crate hashing;


### PR DESCRIPTION
This allows for less copying.