### PR TITLE
Deprecate the v1 engine option.

### DIFF
--- a/pants.daemon.ini
+++ b/pants.daemon.ini
@@ -1,29 +1,32 @@
-# A config override that enables use of pantsd + watchman + buildgraph caching via the new engine.
+# A config override that enables use of pantsd. This is currently recommended for beta testers.
 #
-# N.B. This is currently recommended only for development use.
+# Usage:
 #
-# Development Usage:
+#    In a shell that you want to use the daemon in:
 #
-#    # Launch the daemon via an initial invocation with `-ldebug` for better logging:
-#    $ ./pants -ldebug --pants-config-files=pants.daemon.ini help
+#      $ export PANTS_CONFIG_FILES="$(pwd)/pants.daemon.ini"
 #
-#    # In another window, tail the pantsd log file:
+#    And then use pants as you normally would:
+#
+#      $ ./pants ...
+#
+#    To kill the daemon, you can run either `clean-all` or `kill-pantsd`:
+#
+#      $ ./pants clean-all
+#      $ ./pants kill-pantsd
+#
+#
+# Observation Tools:
+#
+#  To see what's going on with the daemon, you can tail the pantsd log file in another window:
+#
+#    $ cd $SOURCE
 #    $ tail -F .pants.d/pantsd/pantsd.log
 #
-#    # Populate the resident scheduler with an initial pantsd-based run:
-#    $ ./pants --pants-config-files=pants.daemon.ini list 3rdparty::
+#  To see what's going on with the client, runner and daemon processes you can watch the process table:
 #
-#    # Re-run to utilize the buildgraph caching:
-#    $ ./pants --pants-config-files=pants.daemon.ini list 3rdparty::
-#
-#    # Kill pantsd and watchman:
-#    $ ./pants -ldebug --pants-config-files=pants.daemon.ini clean-all
-#
-# You can also export this for all pants runs using environment variables:
-#
-#    $ export PANTS_CONFIG_FILES="$(pwd)/pants.daemon.ini"
+#    $ watch -n.1 "ps -ef | grep -v grep | grep pants"
 #
 
 [GLOBAL]
 enable_pantsd: True
-level: debug

--- a/src/docs/invoking.md
+++ b/src/docs/invoking.md
@@ -111,11 +111,12 @@ through all tasks in `test` that support them. In this case, it would pass them 
 So it only makes sense to do this if you know that JUnit won't be invoked in practice (because
 you're not invoking Pants on any Java tests).
 
-The Pants Daemon
-----------------
+The Pants Daemon (pantsd)
+-------------------------
 
-The `1.3.0` release of pants includes an alpha release of a daemon to accelerate common
-graph operations including build file parsing and source fingerprinting.
+The `1.3.0` release of pants included an alpha release of a daemon (`pantsd`) to accelerate common
+graph operations including build file parsing and source fingerprinting. As of the `1.4.0` release,
+we now consider the daemon to be of late beta quality: it's nearly ready to be enabled by default!
 
 ### Benefits
 
@@ -125,12 +126,11 @@ cases where relatively small portions of the repo have changed since the previou
 
 ### Caveats
 
-In this "alpha" release, there are two significant caveats to using the daemon:
+As of `1.4.0`, there is one remaining set of caveats to using the daemon:
 
-1. Changes to `pants.ini` [require running clean-all](https://github.com/pantsbuild/pants/issues/3941)
-in order to force re-reading configuration. While this is unlikely to happen directly within your
-branch, it will occasionally happen when switching back and forth between branches.
-2. `./pants repl` and `./pants run` are [not yet supported](https://github.com/pantsbuild/pants/issues/3774).
+* Although `./pants repl` works, it is missing some advanced TTY integrations which prevent
+  line editing and some control sequences from being propagated. See the
+  [Daemon Beta milestone](https://github.com/pantsbuild/pants/milestone/11) for a summary.
 
 ### Usage
 
@@ -140,6 +140,5 @@ To enable the daemon, see the example in `pants.daemon.ini` in the root of the p
 
 ### Rollout
 
-The daemon will be in "alpha" until the Caveats mentioned above are addressed, after which we
-hope to move it into a "beta" period where we recommend its use more widely. Finally, we hope to
-enable the daemon by default for the [`1.4.0` release of pants](https://github.com/pantsbuild/pants/milestone/9).
+The daemon will be in beta until the caveat mentioned above is addressed, but we hope to
+enable the daemon by default for the [`1.5.0` release of pants](https://github.com/pantsbuild/pants/milestone/12).

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -136,9 +136,7 @@ class GlobalOptionsRegistrar(Optionable):
              default=['.*/', default_rel_distdir],
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
-                  'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore). '
-                  'This currently only affects the v2 engine. '
-                  'To experiment with v2 engine, try --enable-v2-engine option.')
+                  'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
     register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,
              metavar='<regexp>', help='Exclude target roots that match these regexes.')
     register('--subproject-roots', type=list, advanced=True, fromfile=True, default=[],
@@ -157,8 +155,9 @@ class GlobalOptionsRegistrar(Optionable):
              help='Enables use of the pants daemon (and implicitly, the v2 engine). (Beta)')
 
     # This facilitates use of the v2 engine, sans daemon.
-    # TODO: Add removal_version='1.5.0.dev0' before 1.4 lands.
     register('--enable-v2-engine', advanced=True, type=bool, default=True,
+             removal_version='1.5.0.dev0',
+             removal_hint='The v2 engine is necessary to use pantsd, and will soon be required.',
              help='Enables use of the v2 engine.')
 
     # These facilitate configuring the native engine.


### PR DESCRIPTION
### Problem

The v1 engine is on the way out, but we have not yet deprecated enabling it. Part of the reason for waiting is that we wanted the daemon to be in a usable state before requiring usage of v2: it now is.

### Solution

Deprecate enabling the v1 engine. Will be cherry-picked to the `1.4.x` branch.