### PR TITLE
Reenable lighter contrib sanity checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
         - SHARD="OSX Native Engine Binary Builder"
         - PREPARE_DEPLOY=1
       script:
-        - ./pants --version && ./build-support/bin/release.sh -nc
+        - ./pants --version && ./build-support/bin/release.sh -n
 
     - os: linux
       language: generic
@@ -82,7 +82,7 @@ matrix:
           -v "${HOME}:/travis/home"
           -v "${TRAVIS_BUILD_DIR}:/travis/workdir"
           travis_ci:latest
-          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -nc"
+          sh -c "git clean -xfd && ./pants --version && ./build-support/bin/release.sh -n"
 
     - os: linux
       dist: trusty

--- a/build-support/README.md
+++ b/build-support/README.md
@@ -22,3 +22,5 @@ function pkg_<name>_install_test() {
 
 The arguments to the `pkg_<name>_install_test` function are the version string to test,
 follow be zero or more pip args (for use if pip is going to be used to test the package).
+All contrib tests are run as part of CI, so the `pkg_<name>_install_test` function should
+generally only sanity check that a module is properly importable as a plugin.

--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -275,7 +275,6 @@ EOM
 
 function install_and_test_packages() {
   local VERSION=$1
-  local CORE_ONLY=$2
   shift 2
   local PIP_ARGS=(
     "${VERSION}"
@@ -291,12 +290,7 @@ function install_and_test_packages() {
   export PANTS_PLUGIN_CACHE_DIR=$(mktemp -d -t plugins_cache.XXXXX)
   trap "rm -rf ${PANTS_PLUGIN_CACHE_DIR}" EXIT
 
-  if [[ "${CORE_ONLY}" == "true" ]]
-  then
-    PACKAGES=("${CORE_PACKAGES[@]}")
-  else
-    PACKAGES=("${RELEASE_PACKAGES[@]}")
-  fi
+  PACKAGES=("${RELEASE_PACKAGES[@]}")
 
   export PANTS_PYTHON_REPOS_REPOS="${DEPLOY_PANTS_WHEEL_DIR}/${VERSION}"
   for PACKAGE in "${PACKAGES[@]}"
@@ -316,11 +310,10 @@ function install_and_test_packages() {
 
 function dry_run_install() {
   # Build a complete set of whls, and then ensure that we can install pants using only whls.
-  local CORE_ONLY=$1
   local VERSION="${PANTS_UNSTABLE_VERSION}"
   build_pants_packages "${VERSION}" && \
   build_3rdparty_packages "${VERSION}" && \
-  install_and_test_packages "${VERSION}" "${CORE_ONLY}" \
+  install_and_test_packages "${VERSION}" \
     --only-binary=:all: \
     -f "${DEPLOY_3RDPARTY_WHEEL_DIR}/${VERSION}" -f "${DEPLOY_PANTS_WHEEL_DIR}/${VERSION}"
 }
@@ -757,14 +750,12 @@ function usage() {
   echo " -t  Tests a live release."
   echo "       Ensures the latest packages have been propagated to PyPi"
   echo "       and can be installed in an ephemeral virtualenv."
-  echo " -c  Skips contrib during a dry or test run."
-  echo "       It is still necessary to pass -n or -t to trigger the test/dry run."
   echo " -l  Lists all pantsbuild packages that this script releases."
   echo " -o  Lists all pantsbuild package owners."
   echo " -e  Check that wheels are prebuilt for this release."
   echo " -p  Build a pex from prebuilt wheels for this release."
   echo
-  echo "All options (except for '-d' and '-c') are mutually exclusive."
+  echo "All options (except for '-d') are mutually exclusive."
 
   if (( $# > 0 )); then
     die "$@"
@@ -779,7 +770,6 @@ while getopts "hdntcloep" opt; do
     d) debug="true" ;;
     n) dry_run="true" ;;
     t) test_release="true" ;;
-    c) core_only="true" ;;
     l) list_packages ; exit $? ;;
     o) list_owners ; exit $? ;;
     e) fetch_and_check_prebuilt_wheels ; exit $? ;;
@@ -798,13 +788,13 @@ if [[ "${dry_run}" == "true" && "${test_release}" == "true" ]]; then
 elif [[ "${dry_run}" == "true" ]]; then
   banner "Performing a dry run release" && \
   (
-    dry_run_install "${core_only}" && \
+    dry_run_install && \
     banner "Dry run release succeeded"
   ) || die "Dry run release failed."
 elif [[ "${test_release}" == "true" ]]; then
   banner "Installing and testing the latest released packages" && \
   (
-    install_and_test_packages "${PANTS_STABLE_VERSION}" "${core_only}" && \
+    install_and_test_packages "${PANTS_STABLE_VERSION}" && \
     banner "Successfully installed and tested the latest released packages"
   ) || die "Failed to install and test the latest released packages."
 else

--- a/contrib/confluence/src/python/pants/contrib/confluence/BUILD
+++ b/contrib/confluence/src/python/pants/contrib/confluence/BUILD
@@ -13,5 +13,4 @@ contrib_plugin(
   distribution_name='pantsbuild.pants.contrib.confluence',
   description='Confluence pants plugin',
   register_goals=True,
-  build_file_aliases=True,
 )

--- a/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
+++ b/contrib/confluence/src/python/pants/contrib/confluence/tasks/confluence_publish.py
@@ -45,9 +45,6 @@ class ConfluencePublish(Task):
     super(ConfluencePublish, self).__init__(*args, **kwargs)
     
     self.url = self.get_options().url
-    if not self.url:
-      raise TaskError('Unable to proceed publishing to confluence. Please set the url option.')
-    
     self.force = self.get_options().force
     self.open = self.get_options().open
     self._wiki = None
@@ -60,6 +57,9 @@ class ConfluencePublish(Task):
     return 'confluence1'
   
   def execute(self):
+    if not self.url:
+      raise TaskError('Unable to proceed publishing to confluence. Please set the url option.')
+
     pages = []
     targets = self.context.targets()
     for target in targets:

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -56,7 +56,7 @@ function pkg_go_install_test() {
   local version=$1
   execute_packaged_pants_with_internal_backends \
       --plugins="['pantsbuild.pants.contrib.go==${version}']" \
-      buildgen test contrib/go/examples::
+      --explain test | grep "GoTest_test_go" &> /dev/null
 }
 
 PKG_NODE=(
@@ -68,7 +68,7 @@ function pkg_node_install_test() {
   local version=$1
   execute_packaged_pants_with_internal_backends \
       --plugins="['pantsbuild.pants.contrib.node==${version}']" \
-      test.node contrib/node/examples::
+      --explain test | grep "NodeTest_test_node" &> /dev/null
 }
 
 PKG_SCALAJS=(
@@ -80,7 +80,7 @@ function pkg_scalajs_install_test() {
   local version=$1
   execute_packaged_pants_with_internal_backends \
       --plugins="['pantsbuild.pants.contrib.scalajs==${version}']" \
-      test.pytest --no-timeouts contrib/scalajs::
+      --explain compile | grep "scala-js-link" &> /dev/null
 }
 
 PKG_PYTHON_CHECKS=(
@@ -131,7 +131,7 @@ function pkg_confluence_install_test() {
   local version=$1
   execute_packaged_pants_with_internal_backends \
       --plugins="['pantsbuild.pants.contrib.confluence==${version}']" \
-      --explain compile | grep "confluence" &> /dev/null
+      --explain confluence | grep "ConfluencePublish_confluence" &> /dev/null
 }
 
 PKG_ERRORPRONE=(

--- a/contrib/release_packages.sh
+++ b/contrib/release_packages.sh
@@ -155,7 +155,7 @@ function pkg_codeanalysis_install_test() {
   local version=$1
   execute_packaged_pants_with_internal_backends \
       --plugins="['pantsbuild.pants.contrib.codeanalysis==${version}']" \
-      --explain compile | grep "kythe" &> /dev/null
+      --explain index | grep "kythe" &> /dev/null
 }
 
 PKG_JAXWS=(

--- a/src/python/pants/backend/docgen/tasks/confluence_publish.py
+++ b/src/python/pants/backend/docgen/tasks/confluence_publish.py
@@ -45,9 +45,6 @@ class ConfluencePublish(Task):
     super(ConfluencePublish, self).__init__(*args, **kwargs)
 
     self.url = self.get_options().url
-    if not self.url:
-      raise TaskError('Unable to proceed publishing to confluence. Please set the url option.')
-
     self.force = self.get_options().force
     self.open = self.get_options().open
     self._wiki = None
@@ -60,6 +57,8 @@ class ConfluencePublish(Task):
     return 'confluence1'
 
   def execute(self):
+    if not self.url:
+      raise TaskError('Unable to proceed publishing to confluence. Please set the url option.')
     deprecated_conditional(
       lambda: True,
       '1.6.0.dev0',


### PR DESCRIPTION
### Problem

In short: #4992 skipped running the `pkg_<name>_install_test` function for contrib modules because some of those modules defined expensive checks, and because all contrib tests are run on dedicated Contrib shards already. But that, unfortunately, meant that we didn't even sanity check that contrib modules could be loaded as plugins.

### Solution

Simplify all `pkg_<name>_install_test` functions to be simple checks that tasks are appropriately registered, and re-enable running them on the binary builder shard. Also, fix some registration issues that slipped through with the confluence module due to this gap.

### Result

#5339 is fixed.