### PR TITLE
Garbage collect Store entries

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -207,6 +207,10 @@ void rule_subgraph_visualize(Scheduler*, TypeId, TypeConstraint, char*);
 void nodes_destroy(RawNodes*);
 
 void set_panic_handler(void);
+
+void lease_files_in_graph(Scheduler*);
+
+void garbage_collect_store(Scheduler*);
 '''
 
 CFFI_EXTERNS = '''

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -296,6 +296,12 @@ class WrappedNativeScheduler(object):
       self._native.lib.nodes_destroy(raw_roots)
     return roots
 
+  def lease_files_in_graph(self):
+    self._native.lib.lease_files_in_graph(self._scheduler)
+
+  def garbage_collect_store(self):
+    self._native.lib.garbage_collect_store(self._scheduler)
+
 
 class LocalScheduler(object):
   """A scheduler that expands a product Graph by executing user defined Rules."""
@@ -503,3 +509,9 @@ class LocalScheduler(object):
     :returns: A list of the requested products, with length match len(subjects).
     """
     return self.products_request([product], subjects)[product]
+
+  def lease_files_in_graph(self):
+    self._scheduler.lease_files_in_graph()
+
+  def garbage_collect_store(self):
+    self._scheduler.garbage_collect_store()

--- a/src/python/pants/pantsd/BUILD
+++ b/src/python/pants/pantsd/BUILD
@@ -68,6 +68,7 @@ python_library(
     'src/python/pants/pantsd/service:fs_event_service',
     'src/python/pants/pantsd/service:pailgun_service',
     'src/python/pants/pantsd/service:scheduler_service',
+    'src/python/pants/pantsd/service:store_gc_service',
     'src/python/pants/util:collections',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:memo',

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -27,6 +27,7 @@ from pants.pantsd.process_manager import FingerprintedProcessManager
 from pants.pantsd.service.fs_event_service import FSEventService
 from pants.pantsd.service.pailgun_service import PailgunService
 from pants.pantsd.service.scheduler_service import SchedulerService
+from pants.pantsd.service.store_gc_service import StoreGCService
 from pants.pantsd.watchman_launcher import WatchmanLauncher
 from pants.util.collections import combined_dict
 from pants.util.contextutil import stdio_as
@@ -137,10 +138,11 @@ class PantsDaemon(FingerprintedProcessManager):
         target_roots_class=TargetRoots,
         scheduler_service=scheduler_service
       )
+      store_gc_service = StoreGCService(legacy_graph_helper.scheduler)
 
       return (
         # Services.
-        (fs_event_service, scheduler_service, pailgun_service),
+        (fs_event_service, scheduler_service, pailgun_service, store_gc_service),
         # Port map.
         dict(pailgun=pailgun_service.pailgun_port)
       )

--- a/src/python/pants/pantsd/service/BUILD
+++ b/src/python/pants/pantsd/service/BUILD
@@ -36,3 +36,11 @@ python_library(
     ':pants_service'
   ]
 )
+
+python_library(
+  name = 'store_gc_service',
+  sources = ['store_gc_service.py'],
+  dependencies = [
+    ':pants_service',
+  ]
+)

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -14,6 +14,7 @@ from pants.pantsd.service.pants_service import PantsService
 _LEASE_EXTENSION_INTERVAL_SECONDS = 30 * 60
 _GARBAGE_COLLECTION_INTERVAL_SECONDS = 4 * 60 * 60
 
+
 class StoreGCService(PantsService):
   """Store Garbage Collection Service.
 

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+import threading
+import time
+
+from pants.pantsd.service.pants_service import PantsService
+
+class StoreGCService(PantsService):
+  """Store Garbage Collection Service.
+
+  This service both ensures that in-use files continue to be present in the engine's Store, and
+  performs occasional garbage collection to bound the size of the engine's Store.
+  """
+
+  def __init__(self, scheduler):
+    super(StoreGCService, self).__init__()
+    self._scheduler = scheduler
+    self._logger = logging.getLogger(__name__)
+    self._lease_extension_thread = None
+    self._garbage_collection_thread = None
+
+  def setup(self, lifecycle_lock, fork_lock):
+    super(StoreGCService, self).setup(lifecycle_lock, fork_lock)
+
+  def _extend_lease(self):
+    while True:
+      self._logger.debug("Extending leases")
+      self._scheduler.lease_files_in_graph()
+      self._logger.debug("Done extending leases")
+      time.sleep(30 * 60)
+
+  def _garbage_collect(self):
+    while True:
+      time.sleep(4 * 60 * 60)
+      # Grab the fork lock to ensure this thread isn't cloned by a fork while holding the graph
+      # lock.
+      self.fork_lock.acquire()
+      try:
+        self._logger.debug("Garbage collecting store")
+        self._scheduler.garbage_collect_store()
+      finally:
+        self.fork_lock.release()
+        self._logger.debug("Done garbage collecting store")
+
+  def run(self):
+    """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""
+    self._lease_extension_thread = threading.Thread(target=self._extend_lease)
+    self._lease_extension_thread.daemon = False
+    self._lease_extension_thread.start()
+
+    self._garbage_collection_thread = threading.Thread(target=self._garbage_collect)
+    self._garbage_collection_thread.daemon = False
+    self._garbage_collection_thread.start()
+
+    while not self.is_killed:
+      time.sleep(1)

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -143,6 +143,7 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 [dependencies]
 bazel_protos = { path = "../process_execution/bazel_protos" }
 boxfuture = { path = "../boxfuture" }
+byteorder = "1"
 bytes = "0.4.5"
 digest = "0.6.2"
 futures = "0.1.16"

--- a/src/rust/engine/fs/fs_util/Cargo.lock
+++ b/src/rust/engine/fs/fs_util/Cargo.lock
@@ -151,6 +151,7 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -346,7 +346,7 @@ impl GetFileDigest<String> for FileSaver {
       .map_err(move |err| {
         format!("Error reading file {:?}: {}", file_copy, err.description())
       })
-      .and_then(move |content| store.store_file_bytes(content.content))
+      .and_then(move |content| store.store_file_bytes(content.content, true))
       .to_boxed()
   }
 }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -10,6 +10,7 @@ pub use pool::ResettablePool;
 
 extern crate bazel_protos;
 extern crate boxfuture;
+extern crate byteorder;
 extern crate bytes;
 extern crate digest;
 extern crate futures;

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -75,7 +75,7 @@ impl Snapshot {
             // Because there are no children of this Dir, it must be empty.
             dir_futures.push(
               store
-                .record_directory(&bazel_protos::remote_execution::Directory::new())
+                .record_directory(&bazel_protos::remote_execution::Directory::new(), true)
                 .map(move |digest| {
                   let mut directory_node = bazel_protos::remote_execution::DirectoryNode::new();
                   directory_node.set_name(osstring_as_utf8(first_component).unwrap());
@@ -109,7 +109,7 @@ impl Snapshot {
         let mut directory = bazel_protos::remote_execution::Directory::new();
         directory.set_directories(protobuf::RepeatedField::from_vec(dirs));
         directory.set_files(protobuf::RepeatedField::from_vec(files));
-        store.record_directory(&directory).map(move |digest| {
+        store.record_directory(&directory, true).map(move |digest| {
           Snapshot {
             fingerprint: digest.0,
             digest: Some(digest),
@@ -292,7 +292,7 @@ mod tests {
         .map_err(move |err| {
           format!("Error reading file {:?}: {}", file_copy, err.description())
         })
-        .and_then(move |content| store.store_file_bytes(content.content))
+        .and_then(move |content| store.store_file_bytes(content.content, true))
         .to_boxed()
     }
   }

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 
 use pool::ResettablePool;
 
+const MAX_LOCAL_STORE_SIZE_BYTES: usize = 4 * 1024 * 1024 * 1024;
+
 ///
 /// A content-addressed store of file contents, and Directories.
 ///
@@ -64,8 +66,12 @@ impl Store {
     })
   }
 
-  pub fn store_file_bytes(&self, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
-    self.local.store_bytes(EntryType::File, bytes)
+  pub fn store_file_bytes(&self, bytes: Vec<u8>, initial_lease: bool) -> BoxFuture<Digest, String> {
+    self.local.store_bytes(
+      EntryType::File,
+      bytes,
+      initial_lease,
+    )
   }
 
   ///
@@ -97,11 +103,14 @@ impl Store {
   pub fn record_directory(
     &self,
     directory: &bazel_protos::remote_execution::Directory,
+    initial_lease: bool,
   ) -> BoxFuture<Digest, String> {
     let local = self.local.clone();
     future::result(directory.write_to_bytes().map_err(|e| {
       format!("Error serializing directory proto {:?}: {:?}", directory, e)
-    })).and_then(move |bytes| local.store_bytes(EntryType::Directory, bytes))
+    })).and_then(move |bytes| {
+      local.store_bytes(EntryType::Directory, bytes, initial_lease)
+    })
       .to_boxed()
   }
 
@@ -184,17 +193,17 @@ impl Store {
               Some(bytes) => {
                 future::done(f_remote(&bytes))
                   .and_then(move |value| {
-                    local.store_bytes(entry_type, bytes).and_then(
-                      move |digest| if digest.0 ==
-                        fingerprint
-                      {
-                        Ok(Some(value))
-                      } else {
-                        Err(format!(
-                          "CAS gave wrong fingerprint: expected {}, got {}",
-                          fingerprint,
-                          digest.0
-                        ))
+                    local.store_bytes(entry_type, bytes, true).and_then(
+                      move |digest| {
+                        if digest.0 == fingerprint {
+                          Ok(Some(value))
+                        } else {
+                          Err(format!(
+                            "CAS gave wrong fingerprint: expected {}, got {}",
+                            fingerprint,
+                            digest.0
+                          ))
+                        }
                       },
                     )
                   })
@@ -207,6 +216,30 @@ impl Store {
       })
       .to_boxed()
   }
+
+  pub fn lease_all<Fs: Iterator<Item = Fingerprint>>(
+    &self,
+    fingerprints: Fs,
+  ) -> Result<(), String> {
+    self.local.lease_all(fingerprints)
+  }
+
+  pub fn garbage_collect(&self) -> Result<(), String> {
+    let target = MAX_LOCAL_STORE_SIZE_BYTES / 2;
+    match self.local.shrink(target) {
+      Ok(size) => {
+        if size > target {
+          return Err(format!(
+            "Garbage collection attempted to target {} bytes but could only shrink to {} bytes",
+            target,
+            size
+          ));
+        }
+      }
+      Err(err) => return Err(format!("Garbage collection failed: {:?}", err)),
+    };
+    Ok(())
+  }
 }
 
 // Only public for testing.
@@ -216,37 +249,27 @@ pub enum EntryType {
   File,
 }
 
-///
-/// ByteStore allows read and write access to byte-buffers of two types:
-/// 1. File contents (arbitrary blobs with no particular assumed structure).
-/// 2. Directory protos, serialized using the standard protobuf binary serialization.
-///
-pub trait ByteStore {
-  fn store_bytes(&self, entry_type: EntryType, bytes: Vec<u8>) -> BoxFuture<Digest, String>;
-
-  fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
-    &self,
-    entry_type: EntryType,
-    fingerprint: Fingerprint,
-    f: F,
-  ) -> BoxFuture<Option<T>, String>;
-}
-
 mod local {
   use super::EntryType;
 
   use boxfuture::{Boxable, BoxFuture};
+  use byteorder::{ByteOrder, LittleEndian};
   use digest::{Digest as DigestTrait, FixedOutput};
   use futures::Future;
   use hashing::{Digest, Fingerprint};
-  use lmdb::{Database, DatabaseFlags, Environment, NO_OVERWRITE, Transaction};
-  use lmdb::Error::{KeyExist, NotFound};
+  use lmdb::{self, Cursor, Database, DatabaseFlags, Environment, NO_OVERWRITE, RwTransaction,
+             Transaction, WriteFlags};
+  use lmdb::Error::{KeyExist, MapFull, NotFound};
   use sha2::Sha256;
+  use std::cmp::{Ord, Ordering};
+  use std::collections::BinaryHeap;
   use std::error::Error;
   use std::path::Path;
   use std::sync::Arc;
+  use std::time;
 
   use pool::ResettablePool;
+  use super::MAX_LOCAL_STORE_SIZE_BYTES;
 
   #[derive(Clone)]
   pub struct ByteStore {
@@ -256,54 +279,201 @@ mod local {
   struct InnerStore {
     env: Environment,
     pool: Arc<ResettablePool>,
-    file_store: Database,
+    file_database: Database,
     // Store directories separately from files because:
     //  1. They may have different lifetimes.
     //  2. It's nice to know whether we should be able to parse something as a proto.
-    directory_store: Database,
+    directory_database: Database,
+    lease_database: Database,
   }
 
   impl ByteStore {
     pub fn new<P: AsRef<Path>>(path: P, pool: Arc<ResettablePool>) -> Result<ByteStore, String> {
-      // 2 DBs; one for file contents, one for directories.
+      // 3 DBs; one for file contents, one for directories, one for leases.
       let env = Environment::new()
-        .set_max_dbs(2)
-        .set_map_size(16 * 1024 * 1024 * 1024)
+        .set_max_dbs(3)
+        .set_map_size(MAX_LOCAL_STORE_SIZE_BYTES)
         .open(path.as_ref())
-        .map_err(|e| format!("Error making env: {}", e.description()))?;
+        .map_err(|e| format!("Error making env: {:?}", e))?;
       let file_database = env
         .create_db(Some("files"), DatabaseFlags::empty())
         .map_err(|e| {
-          format!("Error creating/opening files database: {}", e.description())
+          format!("Error creating/opening files database: {:?}", e)
         })?;
       let directory_database = env
         .create_db(Some("directories"), DatabaseFlags::empty())
         .map_err(|e| {
-          format!(
-            "Error creating/opening directories database: {}",
-            e.description()
-          )
+          format!("Error creating/opening directories database: {:?}", e)
+        })?;
+      let lease_database = env
+        .create_db(Some("leases"), DatabaseFlags::empty())
+        .map_err(|e| {
+          format!("Error creating/opening leases database: {:?}", e)
         })?;
       Ok(ByteStore {
         inner: Arc::new(InnerStore {
-          env: env,
-          pool: pool,
-          file_store: file_database,
-          directory_store: directory_database,
+          env,
+          pool,
+          file_database,
+          directory_database,
+          lease_database,
         }),
       })
     }
-  }
 
-  impl super::ByteStore for ByteStore {
-    fn store_bytes(&self, entry_type: EntryType, bytes: Vec<u8>) -> BoxFuture<Digest, String> {
+    pub fn lease_all<Fs: Iterator<Item = Fingerprint>>(
+      &self,
+      fingerprints: Fs,
+    ) -> Result<(), String> {
+      self
+        .inner
+        .env
+        .begin_rw_txn()
+        .map_err(|err| format!("Error making lmdb transaction: {:?}", err))
+        .and_then(|mut txn| {
+          for fingerprint in fingerprints {
+            self.lease(&fingerprint, &mut txn).map_err(|e| {
+              format!("Error leasing fingerprint {}: {:?}", fingerprint, e)
+            })?;
+          }
+          Ok(txn)
+        })
+        .and_then(|txn| {
+          txn.commit().map_err(
+            |e| format!("Error writing lease: {:?}", e),
+          )
+        })
+    }
+
+    fn lease(&self, fingerprint: &Fingerprint, txn: &mut RwTransaction) -> Result<(), lmdb::Error> {
+      let now_since_epoch = time::SystemTime::now()
+        .duration_since(time::UNIX_EPOCH)
+        .expect("Surely you're not before the unix epoch?");
+      let expires_at = (now_since_epoch + time::Duration::from_secs(60 * 60 * 2)).as_secs();
+      let mut buf = [0; 8];
+      LittleEndian::write_u64(&mut buf, expires_at);
+      // This needs to be a standalone variable because otherwise rustfmt will complain.
+      txn.put(
+        self.inner.lease_database,
+        &fingerprint.as_ref(),
+        &buf,
+        WriteFlags::empty(),
+      )
+    }
+
+    ///
+    /// Attempts to shrink the stored files to be no bigger than target_bytes
+    /// (excluding lmdb overhead).
+    ///
+    /// Returns the size it was shrunk to, which may be larger than target_bytes.
+    ///
+    pub fn shrink(&self, target_bytes: usize) -> Result<usize, String> {
+      let mut used_bytes: usize = 0;
+      let mut fingerprints_by_expired_ago = BinaryHeap::new();
+
+      self
+        .inner
+        .env
+        .begin_rw_txn()
+        .and_then(|mut txn| {
+          {
+            self.aged_fingerprints(
+              &txn,
+              self.inner.file_database,
+              &mut used_bytes,
+              &mut fingerprints_by_expired_ago,
+            );
+            self.aged_fingerprints(
+              &txn,
+              self.inner.directory_database,
+              &mut used_bytes,
+              &mut fingerprints_by_expired_ago,
+            );
+          }
+          while used_bytes > target_bytes {
+            let aged_fingerprint = fingerprints_by_expired_ago.pop().expect(
+              "lmdb corruption detected, sum of size of blobs exceeded stored blobs",
+            );
+            if aged_fingerprint.expired_seconds_ago == 0 {
+              // Ran out of expired blobs - everything remaining is leased and cannot be collected.
+              return Err(MapFull);
+            }
+            txn
+              .del(
+                aged_fingerprint.database,
+                &aged_fingerprint.fingerprint.as_ref(),
+                None,
+              )
+              .expect("Failed to delete lmdb blob");
+            used_bytes -= aged_fingerprint.size_bytes;
+          }
+          txn.commit()
+        })
+        .or_else(|e| match e {
+          MapFull => Ok(()),
+          e => Err(format!("Error shrinking store: {:?}", e)),
+        })?;
+      Ok(used_bytes)
+    }
+
+    fn aged_fingerprints<T>(
+      &self,
+      txn: &T,
+      database: Database,
+      used_bytes: &mut usize,
+      fingerprints_by_expired_ago: &mut BinaryHeap<AgedFingerprint>,
+    ) where
+      T: Transaction,
+    {
+      let mut cursor = txn.open_ro_cursor(database).expect(
+        "Failed to open lmdb read cursor",
+      );
+      for (key, bytes) in cursor.iter() {
+        *used_bytes = *used_bytes + bytes.len();
+
+        // Random access into the lease_database is slower than iterating, but hopefully garbage
+        // collection is rare enough that we can get away with this, rather than do two passes here
+        // (either to populate leases into pre-populated AgedFingerprints, or to read sizes when
+        // we delete from lmdb to track how much we've freed).
+        let lease_until_unix_timestamp = txn
+          .get(self.inner.lease_database, &key)
+          .map(|b| LittleEndian::read_u64(b))
+          .unwrap_or_else(|e| match e {
+            NotFound => 0,
+            e => panic!("Error reading lease, probable lmdb corruption: {:?}", e),
+          });
+
+        let leased_until = time::UNIX_EPOCH + time::Duration::from_secs(lease_until_unix_timestamp);
+
+        let expired_seconds_ago = time::SystemTime::now()
+          .duration_since(leased_until)
+          .map(|t| t.as_secs())
+          // 0 indicates unleased.
+          .unwrap_or(0);
+
+        fingerprints_by_expired_ago.push(AgedFingerprint {
+          fingerprint: Fingerprint::from_bytes_unsafe(key),
+          size_bytes: bytes.len(),
+          database: database,
+          expired_seconds_ago: expired_seconds_ago,
+        });
+      }
+    }
+
+    pub fn store_bytes(
+      &self,
+      entry_type: EntryType,
+      bytes: Vec<u8>,
+      initial_lease: bool,
+    ) -> BoxFuture<Digest, String> {
       let len = bytes.len();
       let db = match entry_type {
-        EntryType::Directory => self.inner.directory_store,
-        EntryType::File => self.inner.file_store,
+        EntryType::Directory => self.inner.directory_database,
+        EntryType::File => self.inner.file_database,
       }.clone();
 
       let inner = self.inner.clone();
+      let bytestore = self.clone();
       self
         .inner
         .pool
@@ -315,18 +485,20 @@ mod local {
           };
 
           let put_res = inner.env.begin_rw_txn().and_then(|mut txn| {
-            txn.put(db, &fingerprint, &bytes, NO_OVERWRITE).and_then(
-            |()| txn.commit(),
-          )
+            txn.put(db, &fingerprint, &bytes, NO_OVERWRITE)?;
+            if initial_lease {
+              bytestore.lease(&fingerprint, &mut txn)?;
+            }
+            txn.commit()
           });
 
           match put_res {
             Ok(()) => Ok(fingerprint),
             Err(KeyExist) => Ok(fingerprint),
             Err(err) => Err(format!(
-              "Error storing fingerprint {}: {}",
+              "Error storing fingerprint {}: {:?}",
               fingerprint,
-              err.description()
+              err
             )),
           }
         })
@@ -334,15 +506,15 @@ mod local {
         .to_boxed()
     }
 
-    fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+    pub fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
       &self,
       entry_type: EntryType,
       fingerprint: Fingerprint,
       f: F,
     ) -> BoxFuture<Option<T>, String> {
       let db = match entry_type {
-        EntryType::Directory => self.inner.directory_store,
-        EntryType::File => self.inner.file_store,
+        EntryType::Directory => self.inner.directory_database,
+        EntryType::File => self.inner.file_database,
       }.clone();
 
       let store = self.inner.clone();
@@ -370,11 +542,32 @@ mod local {
     }
   }
 
+  #[derive(Eq, PartialEq)]
+  struct AgedFingerprint {
+    pub fingerprint: Fingerprint,
+    pub size_bytes: usize,
+    pub database: Database,
+    pub expired_seconds_ago: u64,
+  }
+
+  impl PartialOrd for AgedFingerprint {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+      self.expired_seconds_ago.partial_cmp(
+        &other.expired_seconds_ago,
+      )
+    }
+  }
+
+  impl Ord for AgedFingerprint {
+    fn cmp(&self, other: &Self) -> Ordering {
+      self.expired_seconds_ago.cmp(&other.expired_seconds_ago)
+    }
+  }
+
   #[cfg(test)]
   pub mod tests {
     use futures::Future;
     use super::{ByteStore, EntryType, Fingerprint, ResettablePool};
-    use super::super::ByteStore as _ByteStore;
     use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
     use protobuf::Message;
     use std::path::Path;
@@ -382,7 +575,7 @@ mod local {
     use tempdir::TempDir;
 
     use super::super::tests::{DIRECTORY_HASH, HASH, digest, directory, directory_fingerprint,
-                              fingerprint, load_directory_proto_bytes, load_file_bytes, str_bytes};
+                              fingerprint, other_directory, other_directory_fingerprint, str_bytes};
 
     #[test]
     fn save_file() {
@@ -390,7 +583,7 @@ mod local {
 
       assert_eq!(
         new_store(dir.path())
-          .store_bytes(EntryType::File, str_bytes())
+          .store_bytes(EntryType::File, str_bytes(), false)
           .wait(),
         Ok(digest())
       );
@@ -401,12 +594,12 @@ mod local {
       let dir = TempDir::new("store").unwrap();
 
       new_store(dir.path())
-        .store_bytes(EntryType::File, str_bytes())
+        .store_bytes(EntryType::File, str_bytes(), false)
         .wait()
         .unwrap();
       assert_eq!(
         new_store(dir.path())
-          .store_bytes(EntryType::File, str_bytes())
+          .store_bytes(EntryType::File, str_bytes(), false)
           .wait(),
         Ok(digest())
       );
@@ -436,7 +629,7 @@ mod local {
 
       assert_eq!(
         new_store(dir.path())
-          .store_bytes(EntryType::File, str_bytes())
+          .store_bytes(EntryType::File, str_bytes(), false)
           .wait(),
         Ok(digest())
       );
@@ -454,7 +647,7 @@ mod local {
 
       let store = new_store(dir.path());
       let hash = store
-        .store_bytes(EntryType::File, data.clone())
+        .store_bytes(EntryType::File, data.clone(), false)
         .wait()
         .unwrap();
       assert_eq!(load_file_bytes(&store, hash.0), Ok(Some(data)));
@@ -475,7 +668,11 @@ mod local {
 
       assert_eq!(
         &new_store(dir.path())
-          .store_bytes(EntryType::Directory, directory().write_to_bytes().unwrap())
+          .store_bytes(
+            EntryType::Directory,
+            directory().write_to_bytes().unwrap(),
+            false,
+          )
           .wait()
           .unwrap()
           .0
@@ -504,7 +701,7 @@ mod local {
       let dir = TempDir::new("store").unwrap();
 
       new_store(dir.path())
-        .store_bytes(EntryType::File, str_bytes())
+        .store_bytes(EntryType::File, str_bytes(), false)
         .wait()
         .unwrap();
 
@@ -514,8 +711,304 @@ mod local {
       );
     }
 
+    #[test]
+    fn garbage_collect_nothing_to_do() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+      let bytes = "0123456789".as_bytes().to_vec();
+      store
+        .store_bytes(EntryType::File, bytes.clone(), false)
+        .wait()
+        .expect("Error storing");
+      store.shrink(10).expect("Error shrinking");
+      assert_eq!(
+        load_bytes(
+          &store,
+          EntryType::File,
+          Fingerprint::from_hex_string(
+            "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
+          ).unwrap(),
+        ),
+        Ok(Some(bytes))
+      );
+    }
+
+    #[test]
+    fn garbage_collect_nothing_to_do_with_lease() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+      let bytes = "0123456789".as_bytes().to_vec();
+      store
+        .store_bytes(EntryType::File, bytes.clone(), false)
+        .wait()
+        .expect("Error storing");
+      let file_fingerprint = Fingerprint::from_hex_string(
+        "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
+      ).unwrap();
+      store.lease_all(vec![file_fingerprint].into_iter()).expect(
+        "Error leasing",
+      );
+      store.shrink(10).expect("Error shrinking");
+      assert_eq!(
+        load_bytes(&store, EntryType::File, file_fingerprint),
+        Ok(Some(bytes))
+      );
+    }
+
+    #[test]
+    fn garbage_collect_remove_one_of_two_files_no_leases() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+      let bytes_1 = "0123456789".as_bytes().to_vec();
+      let fingerprint_1 = Fingerprint::from_hex_string(
+        "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
+      ).unwrap();
+      let bytes_2 = "9876543210".as_bytes().to_vec();
+      let fingerprint_2 = Fingerprint::from_hex_string(
+        "7619ee8cea49187f309616e30ecf54be072259b43760f1f550a644945d5572f2",
+      ).unwrap();
+      store
+        .store_bytes(EntryType::File, bytes_1.clone(), false)
+        .wait()
+        .expect("Error storing");
+      store
+        .store_bytes(EntryType::File, bytes_2.clone(), false)
+        .wait()
+        .expect("Error storing");
+      store.shrink(10).expect("Error shrinking");
+      let mut entries = Vec::new();
+      entries.push(load_bytes(&store, EntryType::File, fingerprint_1).expect(
+        "Error loading bytes",
+      ));
+      entries.push(load_bytes(&store, EntryType::File, fingerprint_2).expect(
+        "Error loading bytes",
+      ));
+      assert_eq!(
+        1,
+        entries.iter().filter(|maybe| maybe.is_some()).count(),
+        "Want one Some but got: {:?}",
+        entries
+      );
+    }
+
+    #[test]
+    fn garbage_collect_remove_both_files_no_leases() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+      let bytes_1 = "0123456789".as_bytes().to_vec();
+      let fingerprint_1 = Fingerprint::from_hex_string(
+        "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
+      ).unwrap();
+      let bytes_2 = "9876543210".as_bytes().to_vec();
+      let fingerprint_2 = Fingerprint::from_hex_string(
+        "7619ee8cea49187f309616e30ecf54be072259b43760f1f550a644945d5572f2",
+      ).unwrap();
+      store
+        .store_bytes(EntryType::File, bytes_1.clone(), false)
+        .wait()
+        .expect("Error storing");
+      store
+        .store_bytes(EntryType::File, bytes_2.clone(), false)
+        .wait()
+        .expect("Error storing");
+      store.shrink(1).expect("Error shrinking");
+      assert_eq!(
+        load_bytes(&store, EntryType::File, fingerprint_1),
+        Ok(None),
+        "Should have garbage collected {:?}",
+        fingerprint_1
+      );
+      assert_eq!(
+        load_bytes(&store, EntryType::File, fingerprint_2),
+        Ok(None),
+        "Should have garbage collected {:?}",
+        fingerprint_2
+      );
+    }
+
+    #[test]
+    fn garbage_collect_remove_one_of_two_directories_no_leases() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+      store
+        .store_bytes(
+          EntryType::Directory,
+          directory().write_to_bytes().unwrap(),
+          false,
+        )
+        .wait()
+        .expect("Error storing");
+      store
+        .store_bytes(
+          EntryType::Directory,
+          other_directory().write_to_bytes().unwrap(),
+          false,
+        )
+        .wait()
+        .expect("Error storing");
+      store.shrink(80).expect("Error shrinking");
+      let mut entries = Vec::new();
+      entries.push(
+        load_bytes(&store, EntryType::Directory, directory_fingerprint())
+          .expect("Error loading bytes"),
+      );
+      entries.push(
+        load_bytes(&store, EntryType::Directory, other_directory_fingerprint())
+          .expect("Error loading bytes"),
+      );
+      assert_eq!(
+        1,
+        entries.iter().filter(|maybe| maybe.is_some()).count(),
+        "Want one Some but got: {:?}",
+        entries
+      );
+    }
+
+    #[test]
+    fn garbage_collect_remove_file_with_leased_directory() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+
+      let directory_bytes = directory().write_to_bytes().unwrap();
+      store
+        .store_bytes(EntryType::Directory, directory_bytes.clone(), true)
+        .wait()
+        .expect("Error storing");
+
+      let file_bytes = "0123456789012345678901234567890123456789\
+0123456789012345678901234567890123456789"
+        .as_bytes()
+        .to_vec();
+      let file_fingerprint = Fingerprint::from_hex_string(
+        "af1909413b96cbb29927b3a67f3a8879c801a37be383e5f9b31df5fa8d10fa2b",
+      ).unwrap();
+      store
+        .store_bytes(EntryType::File, file_bytes.clone(), false)
+        .wait()
+        .expect("Error storing");
+
+      store.shrink(80).expect("Error shrinking");
+
+      assert_eq!(
+        load_bytes(&store, EntryType::File, file_fingerprint),
+        Ok(None),
+        "File was present when it should've been garbage collected"
+      );
+      assert_eq!(
+        load_bytes(&store, EntryType::Directory, directory_fingerprint()),
+        Ok(Some(directory_bytes)),
+        "Directory was missing despite lease"
+      );
+    }
+
+    #[test]
+    fn garbage_collect_remove_file_while_leased_file() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+      store
+        .store_bytes(
+          EntryType::Directory,
+          directory().write_to_bytes().unwrap(),
+          false,
+        )
+        .wait()
+        .expect("Error storing");
+      let file_bytes = "0123456789012345678901234567890123456789\
+0123456789012345678901234567890123456789"
+        .as_bytes()
+        .to_vec();
+      let file_fingerprint = Fingerprint::from_hex_string(
+        "af1909413b96cbb29927b3a67f3a8879c801a37be383e5f9b31df5fa8d10fa2b",
+      ).unwrap();
+      store
+        .store_bytes(EntryType::File, file_bytes.clone(), true)
+        .wait()
+        .expect("Error storing");
+
+      store.shrink(80).expect("Error shrinking");
+
+      assert_eq!(
+        load_bytes(&store, EntryType::File, file_fingerprint),
+        Ok(Some(file_bytes)),
+        "File was missing despite lease"
+      );
+      assert_eq!(
+        load_bytes(&store, EntryType::Directory, directory_fingerprint()),
+        Ok(None),
+        "Directory was present when it should've been garbage collected"
+      );
+    }
+
+    #[test]
+    fn garbage_collect_fail_because_too_many_leases() {
+      let dir = TempDir::new("store").unwrap();
+      let store = new_store(dir.path());
+      store
+        .store_bytes(
+          EntryType::Directory,
+          directory().write_to_bytes().unwrap(),
+          true,
+        )
+        .wait()
+        .expect("Error storing");
+      let file_bytes = "01234567890123456789012345678901234567890\
+123456789012345678901234567890123456789"
+        .as_bytes()
+        .to_vec();
+      let file_fingerprint = Fingerprint::from_hex_string(
+        "af1909413b96cbb29927b3a67f3a8879c801a37be383e5f9b31df5fa8d10fa2b",
+      ).unwrap();
+      store
+        .store_bytes(EntryType::File, file_bytes.clone(), true)
+        .wait()
+        .expect("Error storing");
+
+      store
+        .store_bytes(EntryType::File, str_bytes(), false)
+        .wait()
+        .expect("Error storing");
+
+      assert_eq!(store.shrink(80), Ok(160));
+
+      assert_eq!(
+        load_bytes(&store, EntryType::File, file_fingerprint),
+        Ok(Some(file_bytes)),
+        "Leased file should still be present"
+      );
+      assert_eq!(
+        load_bytes(&store, EntryType::Directory, directory_fingerprint()),
+        Ok(Some(directory().write_to_bytes().unwrap())),
+        "Leased directory should still be present"
+      );
+      // Whether the unleased file is present is undefined.
+    }
+
     pub fn new_store<P: AsRef<Path>>(dir: P) -> ByteStore {
       ByteStore::new(dir, Arc::new(ResettablePool::new("test-pool-".to_string()))).unwrap()
+    }
+
+    pub fn load_file_bytes(
+      store: &ByteStore,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      load_bytes(&store, EntryType::File, fingerprint)
+    }
+
+    pub fn load_directory_proto_bytes(
+      store: &ByteStore,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      load_bytes(&store, EntryType::Directory, fingerprint)
+    }
+
+    fn load_bytes(
+      store: &ByteStore,
+      entry_type: EntryType,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      store
+        .load_bytes_with(entry_type, fingerprint, |b| b.to_vec())
+        .wait()
     }
   }
 }
@@ -562,11 +1055,8 @@ mod remote {
         upload_timeout,
       }
     }
-  }
 
-
-  impl super::ByteStore for ByteStore {
-    fn store_bytes(&self, _entry_type: EntryType, bytes_vec: Vec<u8>) -> BoxFuture<Digest, String> {
+    pub fn store_bytes(&self, bytes_vec: Vec<u8>) -> BoxFuture<Digest, String> {
       let bytes = Bytes::from(bytes_vec);
       let mut hasher = Sha256::default();
       hasher.input(&bytes);
@@ -645,7 +1135,7 @@ mod remote {
       }
     }
 
-    fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+    pub fn load_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
       &self,
       _entry_type: EntryType,
       fingerprint: Fingerprint,
@@ -696,8 +1186,9 @@ mod remote {
     extern crate tempdir;
 
     use super::{ByteStore, Fingerprint};
-    use super::super::{ByteStore as ByteStoreTrait, Digest, EntryType};
+    use super::super::EntryType;
     use futures::Future;
+    use hashing::Digest;
     use mock::StubCAS;
     use protobuf::Message;
     use std::fs::File;
@@ -705,8 +1196,7 @@ mod remote {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    use super::super::tests::{directory, directory_fingerprint, fingerprint,
-                              load_directory_proto_bytes, load_file_bytes, new_cas, str_bytes};
+    use super::super::tests::{directory, directory_fingerprint, fingerprint, new_cas, str_bytes};
 
     #[test]
     fn loads_file() {
@@ -818,7 +1308,7 @@ mod remote {
 
       let store = new_byte_store(&cas);
       assert_eq!(
-        store.store_bytes(EntryType::File, str_bytes()).wait(),
+        store.store_bytes(str_bytes()).wait(),
         Ok(Digest(fingerprint(), str_bytes().len()))
       );
 
@@ -850,9 +1340,7 @@ mod remote {
       ).unwrap();
 
       assert_eq!(
-        store
-          .store_bytes(EntryType::File, all_the_henries.clone())
-          .wait(),
+        store.store_bytes(all_the_henries.clone()).wait(),
         Ok(Digest(fingerprint, all_the_henries.len()))
       );
 
@@ -878,10 +1366,9 @@ mod remote {
       let cas = StubCAS::always_errors();
 
       let store = new_byte_store(&cas);
-      let error = store
-        .store_bytes(EntryType::File, str_bytes())
-        .wait()
-        .expect_err("Want error");
+      let error = store.store_bytes(str_bytes()).wait().expect_err(
+        "Want error",
+      );
       assert!(
         error.contains("Error from server"),
         format!("Bad error message, got: {}", error)
@@ -900,10 +1387,9 @@ mod remote {
         10 * 1024 * 1024,
         Duration::from_secs(1),
       );
-      let error = store
-        .store_bytes(EntryType::File, str_bytes())
-        .wait()
-        .expect_err("Want error");
+      let error = store.store_bytes(str_bytes()).wait().expect_err(
+        "Want error",
+      );
       assert!(
         error.contains("Error attempting to upload fingerprint"),
         format!("Bad error message, got: {}", error)
@@ -913,12 +1399,36 @@ mod remote {
     fn new_byte_store(cas: &StubCAS) -> ByteStore {
       ByteStore::new(&cas.address(), 1, 10 * 1024 * 1024, Duration::from_secs(1))
     }
+
+    pub fn load_file_bytes(
+      store: &ByteStore,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      load_bytes(&store, EntryType::File, fingerprint)
+    }
+
+    pub fn load_directory_proto_bytes(
+      store: &ByteStore,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      load_bytes(&store, EntryType::Directory, fingerprint)
+    }
+
+    fn load_bytes(
+      store: &ByteStore,
+      entry_type: EntryType,
+      fingerprint: Fingerprint,
+    ) -> Result<Option<Vec<u8>>, String> {
+      store
+        .load_bytes_with(entry_type, fingerprint, |b| b.to_vec())
+        .wait()
+    }
   }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::{ByteStore, EntryType, Store, local};
+  use super::{EntryType, Store, local};
 
   use bazel_protos;
   use digest::{Digest as DigestTrait, FixedOutput};
@@ -937,6 +1447,8 @@ mod tests {
   pub const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
   pub const DIRECTORY_HASH: &str = "63949aa823baf765eff07b946050d76e\
 c0033144c785a94d3ebd82baa931cd16";
+  pub const OTHER_DIRECTORY_HASH: &str = "1b9357331e7df1f6efb50fe0b15ecb2b\
+ca58002b3fa97478e7c2c97640e72ee1";
   const EMPTY_DIRECTORY_HASH: &str = "e3b0c44298fc1c149afbf4c8996fb924\
 27ae41e4649b934ca495991b7852b855";
 
@@ -953,10 +1465,18 @@ c0033144c785a94d3ebd82baa931cd16";
   }
 
   pub fn directory() -> bazel_protos::remote_execution::Directory {
+    make_directory("roland")
+  }
+
+  pub fn other_directory() -> bazel_protos::remote_execution::Directory {
+    make_directory("dnalor")
+  }
+
+  pub fn make_directory(file_name: &str) -> bazel_protos::remote_execution::Directory {
     let mut directory = bazel_protos::remote_execution::Directory::new();
     directory.mut_files().push({
       let mut file = bazel_protos::remote_execution::FileNode::new();
-      file.set_name("roland".to_string());
+      file.set_name(file_name.to_string());
       file.set_digest({
         let mut digest = bazel_protos::remote_execution::Digest::new();
         digest.set_hash(HASH.to_string());
@@ -973,34 +1493,16 @@ c0033144c785a94d3ebd82baa931cd16";
     Fingerprint::from_hex_string(DIRECTORY_HASH).unwrap()
   }
 
-  pub fn load_file_bytes<B: ByteStore>(
-    store: &B,
-    fingerprint: Fingerprint,
-  ) -> Result<Option<Vec<u8>>, String> {
-    store
-      .load_bytes_with(EntryType::File, fingerprint, |bytes: &[u8]| bytes.to_vec())
-      .wait()
+  pub fn other_directory_fingerprint() -> Fingerprint {
+    Fingerprint::from_hex_string(OTHER_DIRECTORY_HASH).unwrap()
   }
 
-  pub fn load_file_bytes_from_store(
+  pub fn load_file_bytes(
     store: &Store,
     fingerprint: Fingerprint,
   ) -> Result<Option<Vec<u8>>, String> {
     store
       .load_file_bytes_with(fingerprint, |bytes: &[u8]| bytes.to_vec())
-      .wait()
-  }
-
-  pub fn load_directory_proto_bytes<B: ByteStore>(
-    store: &B,
-    fingerprint: Fingerprint,
-  ) -> Result<Option<Vec<u8>>, String> {
-    store
-      .load_bytes_with(
-        EntryType::Directory,
-        fingerprint,
-        |bytes: &[u8]| bytes.to_vec(),
-      )
       .wait()
   }
 
@@ -1034,13 +1536,13 @@ c0033144c785a94d3ebd82baa931cd16";
     let dir = TempDir::new("store").unwrap();
 
     local::tests::new_store(dir.path())
-      .store_bytes(EntryType::File, str_bytes())
+      .store_bytes(EntryType::File, str_bytes(), false)
       .wait()
       .expect("Store failed");
 
     let cas = new_cas(1024);
     assert_eq!(
-      load_file_bytes_from_store(&new_store(dir.path(), cas.address()), fingerprint()),
+      load_file_bytes(&new_store(dir.path(), cas.address()), fingerprint()),
       Ok(Some(str_bytes()))
     );
     assert_eq!(0, cas.read_request_count());
@@ -1051,7 +1553,11 @@ c0033144c785a94d3ebd82baa931cd16";
     let dir = TempDir::new("store").unwrap();
 
     local::tests::new_store(dir.path())
-      .store_bytes(EntryType::Directory, directory().write_to_bytes().unwrap())
+      .store_bytes(
+        EntryType::Directory,
+        directory().write_to_bytes().unwrap(),
+        false,
+      )
       .wait()
       .expect("Store failed");
 
@@ -1071,13 +1577,13 @@ c0033144c785a94d3ebd82baa931cd16";
 
     let cas = new_cas(1024);
     assert_eq!(
-      load_file_bytes_from_store(&new_store(dir.path(), cas.address()), fingerprint()),
+      load_file_bytes(&new_store(dir.path(), cas.address()), fingerprint()),
       Ok(Some(str_bytes())),
       "Read from CAS"
     );
     assert_eq!(1, cas.read_request_count());
     assert_eq!(
-      load_file_bytes(&local::tests::new_store(dir.path()), fingerprint()),
+      local::tests::load_file_bytes(&local::tests::new_store(dir.path()), fingerprint()),
       Ok(Some(str_bytes())),
       "Read from local cache"
     );
@@ -1096,7 +1602,7 @@ c0033144c785a94d3ebd82baa931cd16";
     );
     assert_eq!(1, cas.read_request_count());
     assert_eq!(
-      load_directory_proto_bytes(
+      local::tests::load_directory_proto_bytes(
         &local::tests::new_store(dir.path()),
         directory_fingerprint(),
       ),
@@ -1110,7 +1616,7 @@ c0033144c785a94d3ebd82baa931cd16";
 
     let cas = StubCAS::empty();
     assert_eq!(
-      load_file_bytes_from_store(&new_store(dir.path(), cas.address()), fingerprint()),
+      load_file_bytes(&new_store(dir.path(), cas.address()), fingerprint()),
       Ok(None)
     );
     assert_eq!(1, cas.read_request_count());
@@ -1136,7 +1642,7 @@ c0033144c785a94d3ebd82baa931cd16";
     let dir = TempDir::new("store").unwrap();
 
     let cas = StubCAS::always_errors();
-    let error = load_file_bytes_from_store(&new_store(dir.path(), cas.address()), fingerprint())
+    let error = load_file_bytes(&new_store(dir.path(), cas.address()), fingerprint())
       .expect_err("Want error");
     assert_eq!(1, cas.read_request_count());
     assert!(
@@ -1172,7 +1678,7 @@ c0033144c785a94d3ebd82baa931cd16";
       .expect_err("Want error");
 
     assert_eq!(
-      load_directory_proto_bytes(&local::tests::new_store(dir.path()), fingerprint()),
+      local::tests::load_directory_proto_bytes(&local::tests::new_store(dir.path()), fingerprint()),
       Ok(None)
     );
   }
@@ -1212,7 +1718,10 @@ c0033144c785a94d3ebd82baa931cd16";
       .expect_err("Want error");
 
     assert_eq!(
-      load_directory_proto_bytes(&local::tests::new_store(dir.path()), directory_fingerprint),
+      local::tests::load_directory_proto_bytes(
+        &local::tests::new_store(dir.path()),
+        directory_fingerprint,
+      ),
       Ok(None)
     );
   }
@@ -1227,11 +1736,10 @@ c0033144c785a94d3ebd82baa931cd16";
         .into_iter()
         .collect(),
     );
-    load_file_bytes_from_store(&new_store(dir.path(), cas.address()), fingerprint())
-      .expect_err("Want error");
+    load_file_bytes(&new_store(dir.path(), cas.address()), fingerprint()).expect_err("Want error");
 
     assert_eq!(
-      load_file_bytes(&local::tests::new_store(dir.path()), fingerprint()),
+      local::tests::load_file_bytes(&local::tests::new_store(dir.path()), fingerprint()),
       Ok(None)
     );
   }
@@ -1247,11 +1755,11 @@ c0033144c785a94d3ebd82baa931cd16";
         .into_iter()
         .collect(),
     );
-    load_file_bytes_from_store(&new_store(dir.path(), cas.address()), empty_fingerprint)
+    load_file_bytes(&new_store(dir.path(), cas.address()), empty_fingerprint)
       .expect_err("Want error");
 
     assert_eq!(
-      load_file_bytes(&local::tests::new_store(dir.path()), empty_fingerprint),
+      local::tests::load_file_bytes(&local::tests::new_store(dir.path()), empty_fingerprint),
       Ok(None)
     );
   }

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -15,7 +15,7 @@ use std::io::{self, Write};
 
 const FINGERPRINT_SIZE: usize = 32;
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Fingerprint(pub [u8; FINGERPRINT_SIZE]);
 
 impl Fingerprint {

--- a/src/rust/engine/src/graph.rs
+++ b/src/rust/engine/src/graph.rs
@@ -6,19 +6,18 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use petgraph::Direction;
 use petgraph::stable_graph::{NodeIndex, StableDiGraph, StableGraph};
-use futures::Async;
 use futures::future::{self, Future};
 
 use externs;
 use boxfuture::{BoxFuture, Boxable};
-use context::{Context, ContextFactory, Core};
+use context::ContextFactory;
 use core::{Failure, FNV, Noop};
 use hashing;
-use nodes::{Node, NodeFuture, NodeKey, NodeResult, TryInto};
+use nodes::{DigestFile, Node, NodeFuture, NodeKey, NodeResult, TryInto};
 
 
 // 2^32 Nodes ought to be more than enough for anyone!
@@ -446,32 +445,19 @@ impl InnerGraph {
     Ok(())
   }
 
-  pub fn all_digests(&self, core: Arc<Core>) -> Vec<hashing::Digest> {
+  pub fn all_digests(&self) -> Vec<hashing::Digest> {
     self
-      .nodes
-      .keys()
-      .map(|key| self.entry(key))
+      .pg
+      .node_indices()
+      .map(|node_index| self.pg.node_weight(node_index))
       .filter_map(|maybe_entry| maybe_entry)
-      .map(|entry| entry.node.clone())
-      .filter_map(|node| {
-        let node_key = node.content();
-        match (node_key, self.entry_id(&node)) {
-          (&NodeKey::DigestFile(ref digest_file), Some(entry_id)) => Some((
-            entry_id.clone(),
-            digest_file.clone(),
-          )),
-          _ => None,
-        }
+      .filter_map(|entry| match entry.node.content() {
+        &NodeKey::DigestFile(_) => Some(entry.peek::<DigestFile>()),
+        _ => None,
       })
-      .filter_map(|(entry_id, digest_file)| {
-        let context = Context {
-          entry_id: entry_id,
-          core: core.clone(),
-        };
-        match digest_file.run(context).poll() {
-          Ok(Async::Ready(digest)) => Some(digest),
-          _ => None,
-        }
+      .filter_map(|output| match output {
+        Some(Ok(digest)) => Some(digest),
+        _ => None,
       })
       .collect()
   }
@@ -586,9 +572,9 @@ impl Graph {
     inner.visualize(roots, path)
   }
 
-  pub fn all_digests(&self, core: Arc<Core>) -> Vec<hashing::Digest> {
+  pub fn all_digests(&self) -> Vec<hashing::Digest> {
     let inner = self.inner.lock().unwrap();
-    inner.all_digests(core)
+    inner.all_digests()
   }
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -536,7 +536,7 @@ pub extern "C" fn garbage_collect_store(scheduler_ptr: *mut Scheduler) {
 #[no_mangle]
 pub extern "C" fn lease_files_in_graph(scheduler_ptr: *mut Scheduler) {
   with_scheduler(scheduler_ptr, |scheduler| {
-    let digests = scheduler.core.graph.all_digests(scheduler.core.clone());
+    let digests = scheduler.core.graph.all_digests();
     match scheduler.core.store.lease_all(
       digests.iter().map(|digest| digest.0),
     ) {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -833,9 +833,11 @@ impl Node for DigestFile {
         ))
       })
       .and_then(move |c| {
-        context.core.store.store_file_bytes(c.content).map_err(
-          |e| throw(&e),
-        )
+        context
+          .core
+          .store
+          .store_file_bytes(c.content, true)
+          .map_err(|e| throw(&e))
       })
       .to_boxed()
   }


### PR DESCRIPTION
A caller may lease a blob in the Store which will ensure it isn't
garbage collected for a time period.

A caller may shrink the store to n bytes (ignoring lmdb overhead), which
will walk a list of blobs which are unleased, and delete them in the
order which their most recent lease expired, until the store is small
enough.

The pantsd python code occasionally triggers lease extensions of
everything currently present in the Graph, and occasionally triggers
garbage collection.

This also removes the `ByteStore` trait which existed on local and
remote `ByteStore`s to make testing easier. They no longer have the
same API, because the local one cares about leases (to be fair, they
didn't have the same API before either, but I pretended they did for
testing convenience).

Fixes https://github.com/pantsbuild/pants/issues/5136