### PR TITLE
Store and remote::ByteStore use Digests not Fingerprints

### DIFF
--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -76,7 +76,7 @@ impl AsRef<[u8]> for Fingerprint {
 /// It is equivalent to a Bazel Remote Execution Digest, but without the overhead (and awkward API)
 /// of needing to create an entire protobuf to pass around the two fields.
 ///
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Digest(pub Fingerprint, pub usize);
 
 impl<'a> From<&'a Digest> for bazel_protos::remote_execution::Digest {

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -537,9 +537,7 @@ pub extern "C" fn garbage_collect_store(scheduler_ptr: *mut Scheduler) {
 pub extern "C" fn lease_files_in_graph(scheduler_ptr: *mut Scheduler) {
   with_scheduler(scheduler_ptr, |scheduler| {
     let digests = scheduler.core.graph.all_digests();
-    match scheduler.core.store.lease_all(
-      digests.iter().map(|digest| digest.0),
-    ) {
+    match scheduler.core.store.lease_all(digests.iter()) {
       Ok(_) => {}
       Err(err) => externs::log(externs::LogLevel::Critical, &err),
     }


### PR DESCRIPTION
local::ByteStore still uses Fingerprints

This allows us to use proper identifiers when interacting with a CAS,
which are specified to include length.

It also means that Store's interface better matches the Graph's
interfaces.

This is a breaking change for fs_util, as it no has an extra required
argument wherever before it just took a fingerprint.