### PR TITLE
[pantsd] Repair console interactivity in pantsd runs.

### DIFF
--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -52,5 +52,4 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
   # NB: **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):
     env = pex_run_kwargs.pop('env', os.environ).copy()
-    po = pex.run(blocking=False, env=env, **pex_run_kwargs)
-    po.wait()
+    pex.run(env=env, **pex_run_kwargs)

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import signal
 
 from pex.pex_info import PexInfo
 
@@ -13,6 +14,7 @@ from pants.backend.python.targets.python_requirement_library import PythonRequir
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.python_execution_task_base import PythonExecutionTaskBase
 from pants.task.repl_task_mixin import ReplTaskMixin
+from pants.util.contextutil import signal_handler_as
 
 
 class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
@@ -51,5 +53,11 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
 
   # NB: **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):
-    env = pex_run_kwargs.pop('env', os.environ).copy()
-    pex.run(env=env, **pex_run_kwargs)
+    # N.B. while the repl subprocess is synchronously spawned, we rely on process
+    # group signalling for a SIGINT to reach the repl subprocess directly - and want
+    # to do nothing in response on the parent side.
+    def ignore_control_c(signum, frame): pass
+
+    with signal_handler_as(signal.SIGINT, ignore_control_c):
+      env = pex_run_kwargs.pop('env', os.environ).copy()
+      pex.run(env=env, **pex_run_kwargs)

--- a/src/python/pants/backend/python/tasks/python_repl.py
+++ b/src/python/pants/backend/python/tasks/python_repl.py
@@ -51,11 +51,11 @@ class PythonRepl(ReplTaskMixin, PythonExecutionTaskBase):
     pex_info.entry_point = entry_point
     return self.create_pex(pex_info)
 
-  # NB: **pex_run_kwargs is used by tests only.
+  # N.B. **pex_run_kwargs is used by tests only.
   def launch_repl(self, pex, **pex_run_kwargs):
-    # N.B. while the repl subprocess is synchronously spawned, we rely on process
-    # group signalling for a SIGINT to reach the repl subprocess directly - and want
-    # to do nothing in response on the parent side.
+    # While the repl subprocess is synchronously spawned, we rely on process group
+    # signalling for a SIGINT to reach the repl subprocess directly - and want to
+    # do nothing in response on the parent side.
     def ignore_control_c(signum, frame): pass
 
     with signal_handler_as(signal.SIGINT, ignore_control_c):

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -150,6 +150,8 @@ class DaemonPantsRunner(ProcessManager):
             writer.join()
             stdout.close()
             stderr.close()
+        # Instruct the thin client to begin reading and sending stdin.
+        NailgunProtocol.send_start_reading_input(sock)
         yield finalizer
 
   def _setup_sigint_handler(self):

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -150,8 +150,6 @@ class DaemonPantsRunner(ProcessManager):
             writer.join()
             stdout.close()
             stderr.close()
-        # Instruct the thin client to begin reading and sending stdin.
-        NailgunProtocol.send_start_reading_input(sock)
         yield finalizer
 
   def _setup_sigint_handler(self):
@@ -204,7 +202,7 @@ class DaemonPantsRunner(ProcessManager):
     set_process_title('pantsd-runner [{}]'.format(' '.join(self._args)))
 
     # Broadcast our process group ID (in PID form - i.e. negated) to the remote client so
-    # they can send signals (i.e. SIGINT) to all processes in the runners process group.
+    # they can send signals (e.g. SIGINT) to all processes in the runners process group.
     NailgunProtocol.send_pid(self._socket, bytes(os.getpgrp() * -1))
 
     # Setup a SIGINT signal handler.

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -9,6 +9,7 @@ import datetime
 import os
 import signal
 import sys
+import termios
 import time
 from contextlib import contextmanager
 
@@ -110,31 +111,46 @@ class DaemonPantsRunner(ProcessManager):
     # Determine output tty capabilities from the environment.
     stdin_isatty, stdout_isatty, stderr_isatty = NailgunProtocol.isatty_from_env(self._env)
 
-    # Launch a thread to read stdin data from the socket (the only messages expected from the client
-    # for the remainder of the protocol), and threads to copy from stdout/stderr pipes onto the
-    # socket.
-    with NailgunStreamWriter.open_multi(
-           sock,
-           (ChunkType.STDOUT, ChunkType.STDERR),
-           None,
-           (stdout_isatty, stderr_isatty)
-         ) as ((stdout_fd, stderr_fd), writer),\
-         NailgunStreamStdinReader.open(sock, stdin_isatty) as stdin_fd,\
-         stdio_as(stdout_fd=stdout_fd, stderr_fd=stderr_fd, stdin_fd=stdin_fd):
-      # N.B. This will be passed to and called by the `DaemonExiter` prior to sending an
-      # exit chunk, to avoid any socket shutdown vs write races.
-      stdout, stderr = sys.stdout, sys.stderr
-      def finalizer():
-        try:
-          stdout.flush()
-          stderr.flush()
-        finally:
-          time.sleep(.001)  # HACK: Sleep 1ms in the main thread to free the GIL.
-          writer.stop()
-          writer.join()
-          stdout.close()
-          stderr.close()
-      yield finalizer
+    # If all stdio is a tty, there's only one logical I/O device (the tty device). This happens to
+    # be addressable as a file in OSX and Linux, so we take advantage of that and directly open the
+    # character device for output redirection - eliminating the need to directly marshall any
+    # interactive stdio back/forth across the socket and permitting full, correct tty control with
+    # no middle-man.
+    if all((stdin_isatty, stdout_isatty, stderr_isatty)):
+      stdin_ttyname, stdout_ttyname, stderr_ttyname = NailgunProtocol.ttynames_from_env(self._env)
+      assert stdin_ttyname == stdout_ttyname == stderr_ttyname, (
+        'expected all stdio ttys to be the same! '
+        'please file a bug at http://github.com/pantsbuild/pants'
+      )
+      with open(stdin_ttyname, 'rb+wb', 0) as tty:
+        tty_fileno = tty.fileno()
+        with stdio_as(stdin_fd=tty_fileno, stdout_fd=tty_fileno, stderr_fd=tty_fileno):
+          def finalizer():
+            termios.tcdrain(tty_fileno)
+          yield finalizer
+    else:
+      stdio_writers = (
+        (ChunkType.STDOUT, stdout_isatty),
+        (ChunkType.STDERR, stderr_isatty)
+      )
+      types, ttys = zip(*(stdio_writers))
+      with NailgunStreamStdinReader.open(sock, stdin_isatty) as stdin_fd,\
+           NailgunStreamWriter.open_multi(sock, types, ttys) as ((stdout_fd, stderr_fd), writer),\
+           stdio_as(stdout_fd=stdout_fd, stderr_fd=stderr_fd, stdin_fd=stdin_fd):
+        # N.B. This will be passed to and called by the `DaemonExiter` prior to sending an
+        # exit chunk, to avoid any socket shutdown vs write races.
+        stdout, stderr = sys.stdout, sys.stderr
+        def finalizer():
+          try:
+            stdout.flush()
+            stderr.flush()
+          finally:
+            time.sleep(.001)  # HACK: Sleep 1ms in the main thread to free the GIL.
+            writer.stop()
+            writer.join()
+            stdout.close()
+            stderr.close()
+        yield finalizer
 
   def _setup_sigint_handler(self):
     """Sets up a control-c signal handler for the daemon runner context."""

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -119,8 +119,9 @@ class DaemonPantsRunner(ProcessManager):
     if all((stdin_isatty, stdout_isatty, stderr_isatty)):
       stdin_ttyname, stdout_ttyname, stderr_ttyname = NailgunProtocol.ttynames_from_env(self._env)
       assert stdin_ttyname == stdout_ttyname == stderr_ttyname, (
-        'expected all stdio ttys to be the same! '
+        'expected all stdio ttys to be the same, but instead got: {}\n'
         'please file a bug at http://github.com/pantsbuild/pants'
+        .format([stdin_ttyname, stdout_ttyname, stderr_ttyname])
       )
       with open(stdin_ttyname, 'rb+wb', 0) as tty:
         tty_fileno = tty.fileno()

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -201,8 +201,9 @@ class DaemonPantsRunner(ProcessManager):
     # Set context in the process title.
     set_process_title('pantsd-runner [{}]'.format(' '.join(self._args)))
 
-    # Broadcast our pid to the remote client so they can send us signals (i.e. SIGINT).
-    NailgunProtocol.send_pid(self._socket, bytes(os.getpid()))
+    # Broadcast our process group ID (in PID form - i.e. negated) to the remote client so
+    # they can send signals (i.e. SIGINT) to all processes in the runners process group.
+    NailgunProtocol.send_pid(self._socket, bytes(os.getpgrp() * -1))
 
     # Setup a SIGINT signal handler.
     self._setup_sigint_handler()

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -8,8 +8,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import signal
 import sys
-import termios
-import tty
+# import termios
+# import tty
 from contextlib import contextmanager
 
 from pants.console.stty_utils import STTYSettings

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -60,17 +60,12 @@ class RemotePantsRunner(object):
     """A contextmanager that overrides the SIGINT (control-c) and SIGQUIT (control-\) handlers
     and handles them remotely."""
     def handle_control_c(signum, frame):
-      sys.stderr.write('^C')
-      client.send_control_c()
-
-    def handle_control_slash(signum, frame):
-      sys.stderr.write('^\\')
       client.send_control_c()
 
     existing_sigint_handler = signal.signal(signal.SIGINT, handle_control_c)
     # N.B. SIGQUIT will abruptly kill the pantsd-runner, which will shut down the other end
     # of the Pailgun connection - so we send a gentler SIGINT here instead.
-    existing_sigquit_handler = signal.signal(signal.SIGQUIT, handle_control_slash)
+    existing_sigquit_handler = signal.signal(signal.SIGQUIT, handle_control_c)
 
     # Retry interrupted system calls.
     signal.siginterrupt(signal.SIGINT, False)

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -62,13 +62,17 @@ class RemotePantsRunner(object):
     """A contextmanager that overrides the SIGINT (control-c) and SIGQUIT (control-\) handlers
     and handles them remotely."""
     def handle_control_c(signum, frame):
-      sys.stderr.write('User interrupt.')
+      sys.stderr.write('^C')
+      client.send_control_c()
+
+    def handle_control_slash(signum, frame):
+      sys.stderr.write('^\\')
       client.send_control_c()
 
     existing_sigint_handler = signal.signal(signal.SIGINT, handle_control_c)
     # N.B. SIGQUIT will abruptly kill the pantsd-runner, which will shut down the other end
     # of the Pailgun connection - so we send a gentler SIGINT here instead.
-    existing_sigquit_handler = signal.signal(signal.SIGQUIT, handle_control_c)
+    existing_sigquit_handler = signal.signal(signal.SIGQUIT, handle_control_slash)
 
     # Retry interrupted system calls.
     signal.siginterrupt(signal.SIGINT, False)

--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -8,8 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import signal
 import sys
-# import termios
-# import tty
 from contextlib import contextmanager
 
 from pants.console.stty_utils import STTYSettings
@@ -111,9 +109,6 @@ class RemotePantsRunner(object):
                            exit_on_broken_pipe=True)
 
     with self._trapped_signals(client), STTYSettings.preserved():
-      # attrs = tty.tcgetattr(self._stdin.fileno())
-      # attrs[3] = attrs[3] & ~termios.ICANON
-      # tty.tcsetattr(self._stdin.fileno(), termios.TCSANOW, attrs)
       # Execute the command on the pailgun.
       result = client.execute(self.PANTS_COMMAND, *self._args, **modified_env)
 

--- a/src/python/pants/console/stty_utils.py
+++ b/src/python/pants/console/stty_utils.py
@@ -34,13 +34,14 @@ class STTYSettings(object):
 
   def save_tty_flags(self):
     # N.B. `stty(1)` operates against stdin.
-    self._tty_flags = tty.tcgetattr(sys.stdin.fileno())
+    try:
+      self._tty_flags = tty.tcgetattr(sys.stdin.fileno())
+    except termios.error as e:
+      logger.debug('masking tcgetattr exception: {!r}'.format(e))
 
   def restore_tty_flags(self):
     if self._tty_flags:
       try:
         tty.tcsetattr(sys.stdin.fileno(), tty.TCSANOW, self._tty_flags)
       except termios.error as e:
-        # N.B. This can happen if e.g. sys.stdin is closed (EBADF) etc and
-        # shouldn't necessarily result in a pants error.
         logger.debug('masking tcsetattr exception: {!r}'.format(e))

--- a/src/python/pants/console/stty_utils.py
+++ b/src/python/pants/console/stty_utils.py
@@ -5,33 +5,42 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
+import sys
+import termios
+import tty
 from contextlib import contextmanager
 
-from pants.util.process_handler import subprocess
 
-
-@contextmanager
-def preserve_stty_settings():
-  """Run potentially stty-modifying operations, e.g., REPL execution, in this contextmanager."""
-  stty_settings = STTYSettings()
-  stty_settings.save_stty_options()
-  yield
-  stty_settings.restore_ssty_options()
+logger = logging.getLogger(__name__)
 
 
 class STTYSettings(object):
   """Saves/restores stty settings, e.g., during REPL execution."""
 
+  @classmethod
+  @contextmanager
+  def preserved(cls):
+    """Run potentially stty-modifying operations, e.g., REPL execution, in this contextmanager."""
+    inst = cls()
+    inst.save_tty_flags()
+    try:
+      yield
+    finally:
+      inst.restore_tty_flags()
+
   def __init__(self):
-    self._stty_options = None
+    self._tty_flags = None
 
-  def save_stty_options(self):
-    self._stty_options = self._run_cmd('stty -g 2>/dev/null')
+  def save_tty_flags(self):
+    # N.B. `stty(1)` operates against stdin.
+    self._tty_flags = tty.tcgetattr(sys.stdin.fileno())
 
-  def restore_ssty_options(self):
-    self._run_cmd('stty ' + self._stty_options)
-
-  def _run_cmd(self, cmd):
-    po = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
-    stdout, _ = po.communicate()
-    return stdout
+  def restore_tty_flags(self):
+    if self._tty_flags:
+      try:
+        tty.tcsetattr(sys.stdin.fileno(), tty.TCSANOW, self._tty_flags)
+      except termios.error as e:
+        # N.B. This can happen if e.g. sys.stdin is closed (EBADF) etc and
+        # shouldn't necessarily result in a pants error.
+        logger.debug('masking tcsetattr exception: {!r}'.format(e))

--- a/src/python/pants/console/stty_utils.py
+++ b/src/python/pants/console/stty_utils.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import sys
 import termios
-import tty
 from contextlib import contextmanager
 
 
@@ -35,13 +34,13 @@ class STTYSettings(object):
   def save_tty_flags(self):
     # N.B. `stty(1)` operates against stdin.
     try:
-      self._tty_flags = tty.tcgetattr(sys.stdin.fileno())
+      self._tty_flags = termios.tcgetattr(sys.stdin.fileno())
     except termios.error as e:
       logger.debug('masking tcgetattr exception: {!r}'.format(e))
 
   def restore_tty_flags(self):
     if self._tty_flags:
       try:
-        tty.tcsetattr(sys.stdin.fileno(), tty.TCSANOW, self._tty_flags)
+        termios.tcsetattr(sys.stdin.fileno(), termios.TCSANOW, self._tty_flags)
       except termios.error as e:
         logger.debug('masking tcsetattr exception: {!r}'.format(e))

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -85,6 +85,8 @@ class NailgunStreamStdinReader(_StoppableDaemonThread):
     with _pipe(isatty) as (read_fd, write_fd):
       reader = NailgunStreamStdinReader(sock, os.fdopen(write_fd, 'wb'))
       with reader.running():
+        # Instruct the thin client to begin reading and sending stdin.
+        NailgunProtocol.send_start_reading_input(sock)
         yield read_fd
 
   def run(self):

--- a/src/python/pants/java/nailgun_io.py
+++ b/src/python/pants/java/nailgun_io.py
@@ -140,14 +140,20 @@ class NailgunStreamWriter(_StoppableDaemonThread):
 
   @classmethod
   @contextmanager
-  def open(cls, sock, chunk_type, chunk_eof_type, isatty, buf_size=None, select_timeout=None):
-    """Yields the write side of a pipe that will copy appropriately chunked values to the socket."""
-    with cls.open_multi(sock, (chunk_type,), chunk_eof_type, isattys=(isatty,)) as ctx:
+  def open(cls, sock, chunk_type, isatty, chunk_eof_type=None, buf_size=None, select_timeout=None):
+    """Yields the write side of a pipe that will copy appropriately chunked values to a socket."""
+    with cls.open_multi(sock,
+                        (chunk_type,),
+                        (isatty,),
+                        chunk_eof_type,
+                        buf_size,
+                        select_timeout) as ctx:
       yield ctx
 
   @classmethod
   @contextmanager
-  def open_multi(cls, sock, chunk_types, chunk_eof_type, isattys, buf_size=None, select_timeout=None):
+  def open_multi(cls, sock, chunk_types, isattys, chunk_eof_type=None, buf_size=None,
+                 select_timeout=None):
     """Yields the write sides of pipes that will copy appropriately chunked values to the socket."""
     cls._assert_aligned(chunk_types, isattys)
 

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import struct
 
 import six
@@ -63,6 +64,7 @@ class NailgunProtocol(object):
 
   ENVIRON_SEP = '='
   TTY_ENV_TMPL = 'NAILGUN_TTY_{}'
+  TTY_PATH_ENV = 'NAILGUN_TTY_PATH_{}'
   HEADER_FMT = b'>Ic'
   HEADER_BYTES = 5
 
@@ -237,10 +239,13 @@ class NailgunProtocol(object):
     :param file stderr: The stream to check for stderr tty capabilities.
     :returns: A dict containing the tty capability environment variables.
     """
-    fds = (stdin, stdout, stderr)
-    return {
-      cls.TTY_ENV_TMPL.format(fd_id): bytes(int(fd.isatty())) for fd_id, fd in enumerate(fds)
-    }
+    def gen_env_vars():
+      for fd_id, fd in enumerate((stdin, stdout, stderr)):
+        is_atty = fd.isatty()
+        yield (cls.TTY_ENV_TMPL.format(fd_id), bytes(int(is_atty)))
+        if is_atty:
+          yield (cls.TTY_PATH_ENV.format(fd_id), os.ttyname(fd.fileno()) or '')
+    return dict(gen_env_vars())
 
   @classmethod
   def isatty_from_env(cls, env):
@@ -253,3 +258,12 @@ class NailgunProtocol(object):
       return i.isdigit() and bool(int(i))  # Environment variable values should always be strings.
 
     return tuple(str_int_bool(env.get(cls.TTY_ENV_TMPL.format(fd_id), '0')) for fd_id in range(3))
+
+  @classmethod
+  def ttynames_from_env(cls, env):
+    """Determines the ttynames for remote file descriptors (if ttys).
+
+    :param dict env: A dictionary representing the environment.
+    :returns: A tuple of boolean values indicating ttyname paths or None for (stdin, stdout, stderr).
+    """
+    return tuple(env.get(cls.TTY_PATH_ENV.format(fd_id)) for fd_id in range(3))

--- a/src/python/pants/java/nailgun_protocol.py
+++ b/src/python/pants/java/nailgun_protocol.py
@@ -11,6 +11,9 @@ import struct
 import six
 
 
+STDIO_DESCRIPTORS = (0, 1, 2)
+
+
 class ChunkType(object):
   """Nailgun protocol chunk types.
 
@@ -240,7 +243,7 @@ class NailgunProtocol(object):
     :returns: A dict containing the tty capability environment variables.
     """
     def gen_env_vars():
-      for fd_id, fd in enumerate((stdin, stdout, stderr)):
+      for fd_id, fd in zip(STDIO_DESCRIPTORS, (stdin, stdout, stderr)):
         is_atty = fd.isatty()
         yield (cls.TTY_ENV_TMPL.format(fd_id), bytes(int(is_atty)))
         if is_atty:
@@ -257,7 +260,9 @@ class NailgunProtocol(object):
     def str_int_bool(i):
       return i.isdigit() and bool(int(i))  # Environment variable values should always be strings.
 
-    return tuple(str_int_bool(env.get(cls.TTY_ENV_TMPL.format(fd_id), '0')) for fd_id in range(3))
+    return tuple(
+      str_int_bool(env.get(cls.TTY_ENV_TMPL.format(fd_id), '0')) for fd_id in STDIO_DESCRIPTORS
+    )
 
   @classmethod
   def ttynames_from_env(cls, env):
@@ -266,4 +271,4 @@ class NailgunProtocol(object):
     :param dict env: A dictionary representing the environment.
     :returns: A tuple of boolean values indicating ttyname paths or None for (stdin, stdout, stderr).
     """
-    return tuple(env.get(cls.TTY_PATH_ENV.format(fd_id)) for fd_id in range(3))
+    return tuple(env.get(cls.TTY_PATH_ENV.format(fd_id)) for fd_id in STDIO_DESCRIPTORS)

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -73,9 +73,6 @@ class PailgunHandler(PailgunHandlerBase):
     self.logger.info('handling pailgun request: `{}`'.format(' '.join(arguments)))
     self.logger.debug('pailgun request environment: %s', environment)
 
-    # Instruct the client to send stdin (if applicable).
-    NailgunProtocol.send_start_reading_input(self.request)
-
     # Execute the requested command with optional daemon-side profiling.
     with maybe_profiled(environment.get('PANTSD_PROFILE')):
       self._run_pants(self.request, arguments, environment)

--- a/src/python/pants/task/repl_task_mixin.py
+++ b/src/python/pants/task/repl_task_mixin.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from abc import abstractmethod
 
 from pants.base.workunit import WorkUnitLabel
-from pants.console import stty_utils
+from pants.console.stty_utils import STTYSettings
 from pants.task.mutex_task_mixin import MutexTaskMixin
 
 
@@ -50,7 +50,7 @@ class ReplTaskMixin(MutexTaskMixin):
   def execute_for(self, targets):
     session_setup = self.setup_repl_session(targets)
     self.context.release_lock()
-    with stty_utils.preserve_stty_settings():
+    with STTYSettings.preserved():
       with self.context.new_workunit(name='repl', labels=[WorkUnitLabel.RUN]):
         print('')  # Start REPL output on a new line.
         try:

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import os
 import shutil
+import signal
 import sys
 import tempfile
 import time
@@ -96,6 +97,15 @@ def stdio_as(stdout_fd, stderr_fd, stdin_fd):
        _stdio_stream_as(stdout_fd, 1, 'stdout', 'wb'),\
        _stdio_stream_as(stderr_fd, 2, 'stderr', 'wb'):
     yield
+
+
+@contextmanager
+def signal_handler_as(sig, handler):
+  old_handler = signal.signal(sig, handler)
+  try:
+    yield
+  finally:
+    signal.signal(sig, old_handler)
 
 
 @contextmanager

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -101,6 +101,11 @@ def stdio_as(stdout_fd, stderr_fd, stdin_fd):
 
 @contextmanager
 def signal_handler_as(sig, handler):
+  """Temporarily replaces a signal handler for the given signal and restores the old handler.
+
+  :param int sig: The target signal to replace the handler for (e.g. signal.SIGINT).
+  :param func handler: The new temporary handler.
+  """
   old_handler = signal.signal(sig, handler)
   try:
     yield


### PR DESCRIPTION
### Problem

Currently, in the case of pantsd-based runs, because we marshall stdio across a socket via the nailgun protocol we have no way for subprocesses to indicate tty settings like they normally would when directly connected to a tty device.

This causes interactive things like `./pants repl` (which rely on libraries like jline/readline) to behave strangely - not responding to up/down/left/right/^U/^K/^D, echoing double lines or double chars, etc. The same case is present for `./pants run` of interactive programs. These are all things normally controlled via the tty.

### Solution

Send the fully qualified path to the tty via the /dev filesystem as nailgun environment variables. If we detect the thin client as connected to the same tty on all 3 stdio descriptors, we'll now directly open the TTY in the pantsd-runner process and redirect stdio to it. This is inherited by subprocesses, too.

In order to ensure subprocesses potentially connected to the thin clients tty don't outlive the pants run, we now also send SIGINT on `^C`/`^\` to the runners entire process group to ensure any subprocesses also receive the signal (they may still ignore it tho, in some cases - see below).

Additionally, in the case of the python repl (which ignores `^C` by default) - we now wrap that with a new `signal_handler_as` contextmanager to ignore `^C` in the pants-side process to mimic the correct behavior of a vanilla python repl (which is to log a handled `KeyboardInterrupt`).

I've also ported `STTYSettings` to use of `tcgetattr`/`tcsetattr` (to avoid subprocess invokes of `stty`) and wrapped the thin client invoke in that.

### Result

Both the python and scala repl cases behave as expected in the daemon.

Fixes #5174
Fixes #5058
