### PR TITLE
[pantsd] Reduce logger.INFO logging for filesystem events.

### DIFF
--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -402,7 +402,7 @@ class LocalScheduler(object):
     if logger.isEnabledFor(logging.DEBUG):
       logger.debug('invalidated %d nodes for: %s', invalidated, filenames)
     else:
-      logger.info('invalidated %d nodes for %s file changes', invalidated, len(filenames))
+      logger.info('invalidated %d nodes for %d file changes', invalidated, len(filenames))
     return invalidated
 
   def node_count(self):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -399,7 +399,10 @@ class LocalScheduler(object):
     filenames = set(direct_filenames)
     filenames.update(os.path.dirname(f) for f in direct_filenames)
     invalidated = self._scheduler.invalidate(filenames)
-    logger.info('invalidated %d nodes for: %s', invalidated, filenames)
+    if logger.isEnabledFor(logging.DEBUG):
+      logger.debug('invalidated %d nodes for: %s', invalidated, filenames)
+    else:
+      logger.info('invalidated %d nodes for %s file changes', invalidated, len(filenames))
     return invalidated
 
   def node_count(self):


### PR DESCRIPTION
This reduces the amount of output in the `pantsd.log` for users with highly active filesystems in favor of debug-only filename logging. Related/exacerbates #5354.