### PR TITLE
Index remote sources correctly.

### DIFF
--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/indexable_java_targets.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/indexable_java_targets.py
@@ -38,6 +38,6 @@ class IndexableJavaTargets(Subsystem):
     # jar_library we actually want to act on the derived java_library wrapping the decompiled
     # sources.
     for t in requested_targets:
-      requested_targets.extend(context.build_graph.get_all_derivatives(t.address))
+      expanded_targets.extend(context.build_graph.get_all_derivatives(t.address))
 
     return [t for t in expanded_targets if isinstance(t, JvmTarget) and t.has_sources('.java')]


### PR DESCRIPTION
Previously, if indexing only target roots, we didn't act on
the synthetic targets that wrap remote sources.  This change
ensures that we follow the sources_target property in this case.
