### PR TITLE
python: do not resolve requirements if no python targets in targets' closure

### DIFF
--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -19,5 +19,6 @@ class ResolveRequirements(ResolveRequirementsTaskBase):
 
   def execute(self):
     req_libs = self.context.targets(has_python_requirements)
-    pex = self.resolve_requirements(req_libs)
-    self.context.products.register_data(self.REQUIREMENTS_PEX, pex)
+    if req_libs:
+      pex = self.resolve_requirements(req_libs)
+      self.context.products.register_data(self.REQUIREMENTS_PEX, pex)

--- a/tests/python/pants_test/backend/python/tasks2/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks2/test_resolve_requirements.py
@@ -26,6 +26,11 @@ class ResolveRequirementsTest(TaskTestBase):
   def task_type(cls):
     return ResolveRequirements
 
+  def test_resolve_no_targets(self):
+    empty_tgt = self.make_target(spec=':empty')
+    pex = self._resolve_requirements([empty_tgt])
+    self.assertTrue(pex is None)
+
   def test_resolve_simple_requirements(self):
     noreqs_tgt = self._fake_target('noreqs', [])
     ansicolors_tgt = self._fake_target('ansicolors', ['ansicolors==1.0.2'])


### PR DESCRIPTION
### Problem

If Python targets depend on `resources` targets, the resolve_requirements task will be invoked even if the current build does not have any Python targets in the targets to be processed. The resolve_requirements task should not do any work in that case.

### Solution

Only resolve requirements if there are requirements actually needing resolution.

### Result

Doesn't do the problematic work.