### PR TITLE
Update our JVM-related config and documentation.

### DIFF
--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -218,7 +218,7 @@ classes for each JVM-based operation. Things go faster.
 Pants uses Zinc, a dependency tracking compiler facade that supports sub-target incremental
 compilation for Java and Scala.
 
-Java7 vs Java6, Which Java
+Java9 vs Java8, Which Java
 --------------------------
 
 Pants first looks through any JDKs specified by the `paths` map in pants.ini's jvm-distributions
@@ -228,11 +228,11 @@ section, eg:
     [jvm-distributions]
     paths = {
         'macos': [
-          '/Library/Java/JavaVirtualMachines/jdk1.7.0_79.jdk',
+          '/Library/Java/JavaVirtualMachines/jdk-9.0.4.jdk',
           '/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk',
         ],
         'linux': [
-          '/usr/java/jdk1.7.0_80',
+          '/usr/java/jdk1.8.0_152',
         ]
       }
 
@@ -241,18 +241,18 @@ or `PATH`. If no `paths` are specified in pants.ini, you can use JDK_HOME to set
 for just one pants invocation:
 
     :::bash
-    $ JDK_HOME=/usr/lib/jvm/java-1.7.0-openjdk-amd64 ./pants ...
+    $ JDK_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64 ./pants ...
 
-If you sometimes need to compile some code in Java 6 and sometimes Java 7, you can define
+If you sometimes need to compile some code in Java 8 and sometimes Java 9, you can define
 jvm-platforms in pants.ini, and set what targets use which platforms. For example, in pants.ini:
 
     :::ini
     [jvm-platform]
-    default_platform: java6
+    default_platform: java8
     platforms: {
-        'java6': {'source': '6', 'target': '6', 'args': [] },
         'java7': {'source': '7', 'target': '7', 'args': [] },
         'java8': {'source': '8', 'target': '8', 'args': [] },
+        java9': {'source': '9', 'target': '9', 'args': [] },
       }
 
 And then in a BUILD file:
@@ -260,13 +260,13 @@ And then in a BUILD file:
     :::python
     java_library(name='my-library',
       sources=globs('*.java'),
-      platform='java7',
+      platform='java8',
     )
 
 You can also override these on the cli:
 
     :::bash
-    ./pants compile --jvm-platform-default-platform=java8 examples/src/java/org/pantsbuild/example/hello/main
+    ./pants compile --jvm-platform-default-platform=java9 examples/src/java/org/pantsbuild/example/hello/main
 
 If you want to set the `-bootclasspath` (or `-Xbootclasspath`) to use the
 appropriate java distribution, you can use the `$JAVA_HOME` symbol in the
@@ -274,7 +274,7 @@ appropriate java distribution, you can use the `$JAVA_HOME` symbol in the
 
     :::ini
     [jvm-platform]
-    default_platform: java6
+    default_platform: java8
     platforms: {
         'java7': {'source': '7', 'target': '7', 'args': ["-C-bootclasspath:$JAVA_HOME/jre/lib/resources.jar:$JAVA_HOME/jre/lib/rt.jar:$JAVA_HOME/jre/lib/sunrsasign.jar:$JAVA_HOME/jre/lib/jsse.jar:$JAVA_HOME/jre/lib/jce.jar:$JAVA_HOME/jre/lib/charsets.jar:$JAVA_HOME/jre/lib/jfr.jar:$JAVA_HOME/jre/classes"] },
       }

--- a/pants.ini
+++ b/pants.ini
@@ -251,10 +251,6 @@ platforms: {
     'java8': {'source': '8', 'target': '8', 'args': [] },
   }
 
-[jvm-distributions]
-minimum_version: 1.8.0
-maximum_version: 1.8.999
-
 
 [idea]
 python_source_paths: ["src/python"]

--- a/pants.ini
+++ b/pants.ini
@@ -13,7 +13,7 @@
 # options not in global scope but available in certain subsystems or tasks.
 [DEFAULT]
 # TODO: Still needed until we migrate jvm tools to subsystems.
-jvm_options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+jvm_options: ["-Xmx1g"]
 
 local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
 
@@ -149,7 +149,7 @@ exclude_patterns: [
 
 [compile.zinc]
 jvm_options: [
-    '-Xmx4g', '-XX:MaxPermSize=512m', '-XX:+UseConcMarkSweepGC', '-XX:ParallelGCThreads=4',
+    '-Xmx4g', '-XX:+UseConcMarkSweepGC', '-XX:ParallelGCThreads=4',
     # bigger cache size for our big projects (default is just 5)
     '-Dzinc.analysis.cache.limit=1000',
   ]
@@ -226,17 +226,17 @@ version: 2.11
 strict_deps: True
 
 [jvm]
-options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+options: ["-Xmx1g"]
 
 [jvm.bench]
-options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+options: ["-Xmx1g"]
 
 [jvm.run.jvm]
-options: ["-Xmx1g", "-XX:MaxPermSize=256m"]
+options: ["-Xmx1g"]
 
 [jvm.test.junit]
 options: [
-    "-Djava.awt.headless=true", "-Xmx1g", "-XX:MaxPermSize=256m",
+    "-Djava.awt.headless=true", "-Xmx1g",
   ]
 
 # NB(gmalmquist): You can set the bootclasspath relative to the
@@ -250,6 +250,10 @@ platforms: {
     'java7': {'source': '7', 'target': '7', 'args': [] },
     'java8': {'source': '8', 'target': '8', 'args': [] },
   }
+
+[jvm-distributions]
+minimum_version: 1.8.0
+maximum_version: 1.8.999
 
 
 [idea]

--- a/src/docs/export.md
+++ b/src/docs/export.md
@@ -90,13 +90,13 @@ The following is an abbreviated export file from a command in the pants repo:
     },
    "jvm_platforms": {
         "platforms": {
-            "java6": {
-                "source_level": "1.6",
+            "java8": {
+                "source_level": "1.8",
                 "args": [],
-                "target_level": "1.6"
+                "target_level": "1.8"
             }
         },
-        "default_platform": "java6"
+        "default_platform": "java8"
     },
     "python_setup": {
         "interpreters": {
@@ -117,7 +117,7 @@ The following is an abbreviated export file from a command in the pants repo:
                 "org.hamcrest:hamcrest-core:1.3",
                 "junit:junit:latest.integration"
             ],
-            "platform": "java6",
+            "platform": "java8",
             "pants_target_type": "junit_tests",
             "globs": {
                 "globs": [

--- a/src/python/pants/backend/jvm/tasks/coverage/manager.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/manager.py
@@ -80,7 +80,7 @@ class CodeCoverage(Subsystem, SubsystemClientMixin):
 
     register('--coverage-jvm-options', advanced=True, type=list, fingerprint=True,
              help='JVM flags to be added when running the coverage processor. For example: '
-                  '{flag}=-Xmx4g {flag}=-XX:MaxPermSize=1g'.format(flag='--coverage-jvm-options'))
+                  '{flag}=-Xmx4g {flag}=-Xms2g'.format(flag='--coverage-jvm-options'))
     register('--coverage-force', advanced=True, type=bool,
              help='Attempt to run the reporting phase of coverage even if tests failed '
                   '(defaults to False, as otherwise the coverage results would be unreliable).')

--- a/tests/python/pants_test/backend/project_info/tasks/test_export.py
+++ b/tests/python/pants_test/backend/project_info/tasks/test_export.py
@@ -183,9 +183,9 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
         'resolver': 'ivy'
       },
       JvmPlatform.options_scope: {
-        'default_platform': 'java6',
+        'default_platform': 'java8',
         'platforms': {
-          'java6': {'source': '1.6', 'target': '1.6'}
+          'java8': {'source': '1.8', 'target': '1.8'}
         }
       },
     }
@@ -300,7 +300,7 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
       'target_type': 'SOURCE',
       'transitive' : True,
       'pants_target_type': 'scala_library',
-      'platform': 'java6',
+      'platform': 'java8',
     }
     self.assertEqual(jvm_target, expected_jvm_target)
 
@@ -345,7 +345,7 @@ class ExportTest(InterpreterCacheTestMixin, ConsoleTaskTestBase):
 
   def test_target_platform(self):
     result = self.execute_export_json('project_info:target_type')
-    self.assertEqual('java6',
+    self.assertEqual('java8',
                      result['targets']['project_info:target_type']['platform'])
 
   def test_output_file(self):


### PR DESCRIPTION
Our docs referenced JVM 6 and 7, both of which were
end-of-lifed long ago. This change updates those to
reference 8 and 9, so the documentation doesn't look
outdated.

Also pins the JVM version we build and run on in the
Pants repo to 1.8, and removes uses of MaxPermSize,
which does nothing in JVM 8+ and generates a warning.

Note that this change does not modify tests for language
versioning, e.g., for cross-compiling to a specific Java
language version. Java 6 (the language version that, e.g.,
doesn't support the diamond operator) is still a valid
concept, even though JVM 6 is long dead.
