### PR TITLE
Fix fail-fast tests.

### DIFF
--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -463,15 +463,14 @@ class PytestTest(PytestTestBase):
     self.run_failing_tests(targets=[self.red, self.red_in_class],
                            failed_targets=[self.red],
                            fail_fast=True,
-                           fast=False)
-
-  @unittest.skip('TODO: Skipped to expedite landing #5363; see: #5369.')
-  @ensure_cached(PytestRun, expected_num_artifacts=0)
-  def test_fail_fast_skips_second_red_test_with_isolated_chroot(self):
-    self.run_failing_tests(targets=[self.red, self.red_in_class],
-                           failed_targets=[self.red_in_class],
-                           fail_fast=True,
                            fast=True)
+
+  @ensure_cached(PytestRun, expected_num_artifacts=0)
+  def test_fail_fast_skips_second_red_test_with_isolated_chroots(self):
+    self.run_failing_tests(targets=[self.red, self.red_in_class],
+                           failed_targets=[self.red],
+                           fail_fast=True,
+                           fast=False)
 
   @ensure_cached(PytestRun, expected_num_artifacts=0)
   def test_red_test_in_class(self):

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import unittest
 from textwrap import dedent
 
 import coverage


### PR DESCRIPTION
It is not clear how the
`test_fail_fast_skips_second_red_test_with_isolated_chroot` test was
passing since its modification in ae1ea88 in May of 2017. Fix the test
expectation and adjust in-accurate test names.

Fixes #5369
