### PR TITLE
Do not downloading node package multiple times

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -99,7 +99,7 @@ class NodeDistribution(object):
     tarball_filepath = self._binary_util.select_binary(
       supportdir=supportdir, version=version, name=filename)
     logger.debug('Tarball for %s(%s): %s', supportdir, version, tarball_filepath)
-    work_dir = os.path.dirname(tarball_filepath)
+    work_dir = os.path.join(os.path.dirname(tarball_filepath), 'out')
     TGZ.extract(tarball_filepath, work_dir, concurrency_safe=True)
     return work_dir
 

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -38,7 +38,7 @@ class Archiver(AbstractClass):
     """
     if concurrency_safe:
       with temporary_dir() as temp_dir:
-        cls._extract(path, temp_dir)
+        cls._extract(path, temp_dir, filter_func=filter_func)
         safe_concurrent_rename(temp_dir, outdir)
     else:
       # Leave the existing default behavior unchanged and allows overlay of contents.


### PR DESCRIPTION
### Problem
With PR 5248, we are downloading node.js package multiple times because the package directory is overwritten.

### Solution
Move the output directory to be sibling, instead of parent, of the downloaded tgz file.

### Result

Only download node.js once.