### PR TITLE
[pantsd] Add RunTracker stats.

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -250,7 +250,7 @@ class GoalRunner(object):
 
     try:
       result = self._execute_engine()
-      self._run_tracker.pantsd_stats.set_resulting_graph_size(self._context.scheduler.graph_len())
+      self._context.set_resulting_graph_size_in_runtracker()
       if result:
         self._run_tracker.set_root_outcome(WorkUnit.FAILURE)
     except KeyboardInterrupt:

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -250,6 +250,7 @@ class GoalRunner(object):
 
     try:
       result = self._execute_engine()
+      self._run_tracker.pantsd_stats.set_resulting_graph_size(self._context.scheduler.graph_len())
       if result:
         self._run_tracker.set_root_outcome(WorkUnit.FAILURE)
     except KeyboardInterrupt:

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -75,7 +75,7 @@ class LocalPantsRunner(object):
         repro.capture(run_tracker.run_info.get_as_dict())
 
       # Record the preceding product graph size.
-      run_tracker.pantsd_stats.set_resident_graph_size(self._preceding_graph_size)
+      run_tracker.pantsd_stats.set_preceding_graph_size(self._preceding_graph_size)
 
       # Setup and run GoalRunner.
       goal_runner = GoalRunner.Factory(root_dir,

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -31,6 +31,10 @@ class LocalPantsRunner(object):
     self._env = env
     self._daemon_build_graph = daemon_build_graph
     self._options_bootstrapper = options_bootstrapper
+    self._preceding_graph_size = -1
+
+  def set_preceding_graph_size(self, size):
+    self._preceding_graph_size = size
 
   def run(self):
     profile_path = self._env.get('PANTS_PROFILE')
@@ -69,6 +73,9 @@ class LocalPantsRunner(object):
       repro = Reproducer.global_instance().create_repro()
       if repro:
         repro.capture(run_tracker.run_info.get_as_dict())
+
+      # Record the preceding product graph size.
+      run_tracker.pantsd_stats.set_resident_graph_size(self._preceding_graph_size)
 
       # Setup and run GoalRunner.
       goal_runner = GoalRunner.Factory(root_dir,

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -81,6 +81,7 @@ python_library(
   dependencies = [
     ':aggregated_timings',
     ':artifact_cache_stats',
+    ':pantsd_stats',
     '3rdparty/python:requests',
     '3rdparty/python:pyopenssl',
     'src/python/pants/base:build_environment',

--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -62,6 +62,11 @@ python_library(
 )
 
 python_library(
+  name = 'pantsd_stats',
+  sources = ['pantsd_stats.py'],
+)
+
+python_library(
   name = 'products',
   sources = ['products.py'],
   dependencies = [

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -80,8 +80,6 @@ class Context(object):
     self._workspace = workspace or (ScmWorkspace(self._scm) if self._scm else None)
     self._replace_targets(target_roots)
     self._invalidation_report = invalidation_report
-    # TODO(#4769): This should not be exposed to anyone.
-    # Note that the Context created in unit tests by BaseTest uses a different codepath.
     self._scheduler = scheduler
 
   @property
@@ -143,6 +141,11 @@ class Context(object):
     :API: public
     """
     return self._scm
+
+  @property
+  def scheduler(self):
+    """Returns the scheduler instance used for this run."""
+    return self._scheduler
 
   @property
   def workspace(self):

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -143,11 +143,6 @@ class Context(object):
     return self._scm
 
   @property
-  def scheduler(self):
-    """Returns the scheduler instance used for this run."""
-    return self._scheduler
-
-  @property
   def workspace(self):
     """Returns the current workspace, if any."""
     return self._workspace
@@ -159,6 +154,12 @@ class Context(object):
   def __str__(self):
     ident = Target.identify(self.targets())
     return 'Context(id:{}, targets:{})'.format(ident, self.targets())
+
+  def set_resulting_graph_size_in_runtracker(self):
+    """Sets the resulting graph size in the run tracker's daemon stats object."""
+    node_count = self._scheduler.graph_len()
+    self.run_tracker.pantsd_stats.set_resulting_graph_size(node_count)
+    return node_count
 
   def submit_background_work_chain(self, work_chain, parent_workunit_name=None):
     """

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -10,17 +10,17 @@ class PantsDaemonStats(object):
   """Tracks various stats about the daemon."""
 
   def __init__(self):
-    self.resident_graph_size = None
+    self.preceding_graph_size = None
     self.resulting_graph_size = None
 
-  def set_resident_graph_size(self, size):
-    self.resident_graph_size = size
+  def set_preceding_graph_size(self, size):
+    self.preceding_graph_size = size
 
   def set_resulting_graph_size(self, size):
     self.resulting_graph_size = size
 
   def get_all(self):
     return {
-      'resident_graph_size': self.resident_graph_size,
+      'preceding_graph_size': self.preceding_graph_size,
       'resulting_graph_size': self.resulting_graph_size,
     }

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+
+class PantsDaemonStats(object):
+  """Tracks various stats about the daemon."""
+
+  def __init__(self, dir):
+    self.resident_graph_size = None
+    self.resulting_graph_size = None
+    # TODO: Dir is currently unused, but plumbed for later use.
+    self._dir = dir
+
+  def set_resident_graph_size(self, size):
+    self.resident_graph_size = size
+
+  def set_resulting_graph_size(self, size):
+    self.resulting_graph_size = size
+
+  def get_all(self):
+    return {
+      'resident_graph_size': self.resident_graph_size,
+      'resulting_graph_size': self.resulting_graph_size,
+    }

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -9,11 +9,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 class PantsDaemonStats(object):
   """Tracks various stats about the daemon."""
 
-  def __init__(self, dir):
+  def __init__(self):
     self.resident_graph_size = None
     self.resulting_graph_size = None
-    # TODO: Dir is currently unused, but plumbed for later use.
-    self._dir = dir
 
   def set_resident_graph_size(self, size):
     self.resident_graph_size = size

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -189,8 +189,8 @@ class RunTracker(Subsystem):
     self.artifact_cache_stats = ArtifactCacheStats(os.path.join(self.run_info_dir,
                                                                 'artifact_cache_stats'))
 
-    # Hit/miss stats for the artifact cache.
-    self.pantsd_stats = PantsDaemonStats(os.path.join(self.run_info_dir, 'pantsd_stats'))
+    # Daemon stats.
+    self.pantsd_stats = PantsDaemonStats()
 
     return run_id
 

--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -25,6 +25,7 @@ from pants.base.workunit import WorkUnit
 from pants.build_graph.target import Target
 from pants.goal.aggregated_timings import AggregatedTimings
 from pants.goal.artifact_cache_stats import ArtifactCacheStats
+from pants.goal.pantsd_stats import PantsDaemonStats
 from pants.reporting.report import Report
 from pants.stats.statsdb import StatsDBFactory
 from pants.subsystem.subsystem import Subsystem
@@ -92,6 +93,7 @@ class RunTracker(Subsystem):
     self.cumulative_timings = None
     self.self_timings = None
     self.artifact_cache_stats = None
+    self.pantsd_stats = None
 
     # Initialized in `start()`.
     self.report = None
@@ -160,8 +162,10 @@ class RunTracker(Subsystem):
     # Initialize the run.
     millis = int((self._run_timestamp * 1000) % 1000)
     run_id = 'pants_run_{}_{}_{}'.format(
-      time.strftime('%Y_%m_%d_%H_%M_%S', time.localtime(self._run_timestamp)), millis,
-      uuid.uuid4().hex)
+      time.strftime('%Y_%m_%d_%H_%M_%S', time.localtime(self._run_timestamp)),
+      millis,
+      uuid.uuid4().hex
+    )
 
     info_dir = os.path.join(self.get_options().pants_workdir, self.options_scope)
     self.run_info_dir = os.path.join(info_dir, run_id)
@@ -182,8 +186,11 @@ class RunTracker(Subsystem):
     self.self_timings = AggregatedTimings(os.path.join(self.run_info_dir, 'self_timings'))
 
     # Hit/miss stats for the artifact cache.
-    self.artifact_cache_stats = \
-      ArtifactCacheStats(os.path.join(self.run_info_dir, 'artifact_cache_stats'))
+    self.artifact_cache_stats = ArtifactCacheStats(os.path.join(self.run_info_dir,
+                                                                'artifact_cache_stats'))
+
+    # Hit/miss stats for the artifact cache.
+    self.pantsd_stats = PantsDaemonStats(os.path.join(self.run_info_dir, 'pantsd_stats'))
 
     return run_id
 
@@ -342,6 +349,7 @@ class RunTracker(Subsystem):
       'cumulative_timings': self.cumulative_timings.get_all(),
       'self_timings': self.self_timings.get_all(),
       'artifact_cache_stats': self.artifact_cache_stats.get_all(),
+      'pantsd_stats': self.pantsd_stats.get_all(),
       'outcomes': self.outcomes
     }
     # Dump individual stat file.

--- a/src/python/pants/pantsd/service/scheduler_service.py
+++ b/src/python/pants/pantsd/service/scheduler_service.py
@@ -87,6 +87,13 @@ class SchedulerService(PantsService):
 
     self._event_queue.task_done()
 
+  def product_graph_len(self):
+    """Provides the size of the captive product graph.
+
+    :returns: The node count for the captive product graph.
+    """
+    return self._scheduler.graph_len()
+
   def warm_product_graph(self, spec_roots):
     """Runs an execution request against the captive scheduler given a set of input specs to warm.
 

--- a/tests/python/pants_test/goal/test_run_tracker_integration.py
+++ b/tests/python/pants_test/goal/test_run_tracker_integration.py
@@ -28,6 +28,7 @@ class RunTrackerIntegrationTest(PantsRunIntegrationTest):
         self.assertIn('run_info', stats_json)
         self.assertIn('self_timings', stats_json)
         self.assertIn('cumulative_timings', stats_json)
+        self.assertIn('pantsd_stats', stats_json)
 
   def test_workunit_failure(self):
     pants_run = self.run_pants([


### PR DESCRIPTION
```
[omerta pants (kwlzn/pantsd_stats)]$ ./pants -q list : --run-tracker-stats-local-json-file=test.json >/dev/null; cat test.json | jq '.pantsd_stats'

{
  "resident_graph_size": -1,
  "resulting_graph_size": 81
}
[omerta pants (kwlzn/pantsd_stats)]$ PANTS_ENABLE_PANTSD=True ./pants -q list : --run-tracker-stats-local-json-file=test.json >/dev/null; cat test.json | jq '.pantsd_stats'

{
  "resident_graph_size": 0,
  "resulting_graph_size": 81
}
[omerta pants (kwlzn/pantsd_stats)]$ PANTS_ENABLE_PANTSD=True ./pants -q list : --run-tracker-stats-local-json-file=test.json >/dev/null; cat test.json | jq '.pantsd_stats'

{
  "resident_graph_size": 15,
  "resulting_graph_size": 81
}
[omerta pants (kwlzn/pantsd_stats)]$ PANTS_ENABLE_PANTSD=True ./pants -q list :: --run-tracker-stats-local-json-file=test.json >/dev/null; cat test.json | jq '.pantsd_stats'

{
  "resident_graph_size": 15,
  "resulting_graph_size": 14634
}
[omerta pants (kwlzn/pantsd_stats)]$ PANTS_ENABLE_PANTSD=True ./pants -q list :: --run-tracker-stats-local-json-file=test.json >/dev/null; cat test.json | jq '.pantsd_stats'

{
  "resident_graph_size": 6198,
  "resulting_graph_size": 14634
}
```

Fixes #4644