### PR TITLE
Repoint the 'current' symlink even for valid VTs.

### DIFF
--- a/src/python/pants/invalidation/cache_manager.py
+++ b/src/python/pants/invalidation/cache_manager.py
@@ -196,13 +196,14 @@ class VersionedTarget(VersionedTargetSet):
 
   def create_results_dir(self):
     """Ensure that the empty results directory and a stable symlink exist for these versioned targets."""
-    self._current_results_dir = self._cache_manager.results_dir_path(self.cache_key, stable=False)
-    self._results_dir = self._cache_manager.results_dir_path(self.cache_key, stable=True)
+    self._current_results_dir = self._cache_manager._results_dir_path(self.cache_key, stable=False)
+    self._results_dir = self._cache_manager._results_dir_path(self.cache_key, stable=True)
 
     if not self.valid:
       # Clean the workspace for invalid vts.
       safe_mkdir(self._current_results_dir, clean=True)
-      relative_symlink(self._current_results_dir, self._results_dir)
+
+    relative_symlink(self._current_results_dir, self._results_dir)
     self.ensure_legal()
 
   def copy_previous_results(self):
@@ -215,7 +216,7 @@ class VersionedTarget(VersionedTargetSet):
     # incremental support.
     if not self.previous_cache_key:
       return None
-    previous_path = self._cache_manager.results_dir_path(self.previous_cache_key, stable=False)
+    previous_path = self._cache_manager._results_dir_path(self.previous_cache_key, stable=False)
     if os.path.isdir(previous_path):
       self.is_incremental = True
       safe_rmtree(self._current_results_dir)
@@ -335,7 +336,7 @@ class InvalidationCacheManager(object):
   def task_name(self):
     return self._task_name
 
-  def results_dir_path(self, key, stable):
+  def _results_dir_path(self, key, stable):
     """Return a results directory path for the given key.
 
     :param key: A CacheKey to generate an id for.

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -264,7 +264,7 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
     :API: public
     """
-    return self.cache_target_dirs or False
+    return self.cache_target_dirs
 
   @property
   def cache_target_dirs(self):


### PR DESCRIPTION
Previously we only repointed it for invalid ones, which meant
that the "current" link could be stale if you had two valid versions
of a target and were switching between them (e.g., by reverting
a change).

This change also renames results_dir_path() to _results_dir_path(),
to emphasize that it's not for outside consumption.

It also removes a superfluous arg to a test helper method, fixes
a bug in a test where we used assertTrue instead of assertEquals,
and removes a superfluous 'or False' from a boolean condition.
