### PR TITLE
[pantsd] Bump to watchman 4.9.0-pants1.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -192,7 +192,7 @@ class GlobalOptionsRegistrar(Optionable):
              help='The number of workers to use for the filesystem event service executor pool.')
 
     # Watchman options.
-    register('--watchman-version', advanced=True, default='4.9.0', help='Watchman version.')
+    register('--watchman-version', advanced=True, default='4.9.0-pants1', help='Watchman version.')
     register('--watchman-supportdir', advanced=True, default='bin/watchman',
              help='Find watchman binaries under this dir. Used as part of the path to lookup '
                   'the binary with --binary-util-baseurls and --pants-bootstrapdir.')

--- a/src/python/pants/pantsd/watchman.py
+++ b/src/python/pants/pantsd/watchman.py
@@ -51,6 +51,7 @@ class Watchman(ProcessManager):
 
     self._state_file = os.path.join(self._watchman_work_dir, '{}.state'.format(self.name))
     self._log_file = os.path.join(self._watchman_work_dir, '{}.log'.format(self.name))
+    self._pid_file = os.path.join(self._watchman_work_dir, '{}.pid'.format(self.name))
     self._sock_file = socket_path_override or os.path.join(self._watchman_work_dir,
                                                            '{}.sock'.format(self.name))
 
@@ -83,10 +84,12 @@ class Watchman(ProcessManager):
     # Initialize watchman with an empty, but valid statefile so it doesn't complain on startup.
     safe_file_dump(self._state_file, '{}')
 
-  def _construct_cmd(self, cmd_parts, state_file, sock_file, log_file, log_level):
+  def _construct_cmd(self, cmd_parts, state_file, sock_file, pid_file, log_file, log_level):
     return [part for part in cmd_parts] + ['--no-save-state',
+                                           '--no-site-spawner',
                                            '--statefile={}'.format(state_file),
                                            '--sockname={}'.format(sock_file),
+                                           '--pidfile={}'.format(pid_file),
                                            '--logfile={}'.format(log_file),
                                            '--log-level', log_level]
 
@@ -111,6 +114,7 @@ class Watchman(ProcessManager):
     cmd = self._construct_cmd((self._watchman_path, 'get-pid'),
                               state_file=self._state_file,
                               sock_file=self._sock_file,
+                              pid_file=self._pid_file,
                               log_file=self._log_file,
                               log_level=str(self._log_level))
     self._logger.debug('watchman cmd is: {}'.format(' '.join(cmd)))

--- a/tests/python/pants_test/pantsd/test_watchman.py
+++ b/tests/python/pants_test/pantsd/test_watchman.py
@@ -69,6 +69,7 @@ class TestWatchman(BaseTest):
     output = self.watchman._construct_cmd(['cmd', 'parts', 'etc'],
                                           'state_file',
                                           'sock_file',
+                                          'pid_file',
                                           'log_file',
                                           'log_level')
 
@@ -76,8 +77,10 @@ class TestWatchman(BaseTest):
                                'parts',
                                'etc',
                                '--no-save-state',
+                               '--no-site-spawner',
                                '--statefile=state_file',
                                '--sockname=sock_file',
+                               '--pidfile=pid_file',
                                '--logfile=log_file',
                                '--log-level',
                                'log_level'])


### PR DESCRIPTION
This PR consumes the hotfixed watchman binaries and plumbs use of their updated options so that multiple pants-spawned watchmen may now co-exist.

Fixes #5224