### PR TITLE
Make the thrift linter use the standard linter mixin.

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -162,7 +162,7 @@ fi
 if [[ "${skip_lint:-false}" == "false" ]]; then
   start_travis_section "Lint" "Running lint checks"
   (
-    ./pants.pex ${PANTS_ARGS[@]} lint contrib:: examples:: src:: tests:: zinc::
+    ./pants.pex ${PANTS_ARGS[@]} --tag=-nolint lint contrib:: examples:: src:: tests:: zinc::
   ) || die "Lint check failure"
   end_travis_section
 fi

--- a/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/dummy_generator/BUILD
+++ b/contrib/scrooge/examples/src/thrift/org/pantsbuild/contrib/scrooge/dummy_generator/BUILD
@@ -3,5 +3,6 @@ java_thrift_library(
   compiler='scrooge',
   language='android',
   compiler_args=['--finagle'],
-  dependencies=['3rdparty:thrift-0.6.1']
+  dependencies=['3rdparty:thrift-0.6.1'],
+  tags=['nolint']
 )

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/register.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/register.py
@@ -8,9 +8,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.scrooge.tasks.scrooge_gen import ScroogeGen
-from pants.contrib.scrooge.tasks.thrift_linter import ThriftLinter
+from pants.contrib.scrooge.tasks.thrift_linter import DeprecatedThriftLinter, ThriftLinter
 
 
 def register_goals():
-  task(name='thrift-linter', action=ThriftLinter).install()
+  # Remove in 1.7.0.dev0.
+  task(name='thrift-linter', action=DeprecatedThriftLinter).install()
+  task(name='thrift', action=ThriftLinter).install('lint')
   task(name='scrooge', action=ScroogeGen).install('gen')

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/BUILD
@@ -37,6 +37,7 @@ python_library(
     ':thrift_util',
     'src/python/pants/backend/codegen/thrift/java',
     'src/python/pants/backend/jvm/tasks:nailgun_task',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:workunit',
     'src/python/pants/option',

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -14,9 +14,9 @@ from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work, WorkerPool
 from pants.base.workunit import WorkUnitLabel
 from pants.option.ranked_value import RankedValue
+from pants.task.lint_task_mixin import LintTaskMixin
 
 from pants.contrib.scrooge.tasks.thrift_util import calculate_compile_sources
-from pants.task.lint_task_mixin import LintTaskMixin
 
 
 class ThriftLintError(Exception):

--- a/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
+++ b/contrib/scrooge/src/python/pants/contrib/scrooge/tasks/thrift_linter.py
@@ -24,8 +24,6 @@ class ThriftLintError(Exception):
 
 
 class ThriftLinterBase(NailgunTask):
-  """Print linter warnings for thrift files."""
-
   @staticmethod
   def _is_thrift(target):
     return isinstance(target, JavaThriftLibrary)
@@ -137,6 +135,8 @@ class ThriftLinterBase(NailgunTask):
 
 
 class DeprecatedThriftLinter(ThriftLinterBase):
+  """Print lint warnings for thrift files."""
+  
   @classmethod
   def register_options(cls, register):
     super(DeprecatedThriftLinter, cls).register_options(register)
@@ -151,6 +151,8 @@ class DeprecatedThriftLinter(ThriftLinterBase):
 
 
 # TODO: After removing DeprecatedThriftLinter, merge this with ThriftLinterBase
-# (i.e., mix LintTaskMixin into ThriftLinterBase and rename it to ThriftLinter).
+# (i.e., mix LintTaskMixin into ThriftLinterBase, copy the docstring,
+# and rename ThriftLinterBase to ThriftLinter).
 class ThriftLinter(LintTaskMixin, ThriftLinterBase):
+  """Print lint warnings for thrift files."""
   pass

--- a/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
+++ b/contrib/scrooge/tests/python/pants_test/contrib/scrooge/tasks/test_thrift_linter_integration.py
@@ -37,41 +37,35 @@ class ThriftLinterTest(PantsRunIntegrationTest):
 
   def test_good(self):
     # thrift-linter should pass without warnings with correct thrift files.
-    cmd = ['thrift-linter', self.thrift_test_target('good-thrift')]
-    pants_run = self.run_pants(cmd)
-    self.assert_success(pants_run)
-    self.assertNotIn(self.lint_error_token, pants_run.stdout_data)
-
-  def test_skip_skips_execution(self):
-    cmd = ['thrift-linter', '--skip', self.thrift_test_target('bad-thrift-strict')]
+    cmd = ['lint.thrift', self.thrift_test_target('good-thrift')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
     self.assertNotIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_default(self):
     # thrift-linter fails on linter errors.
-    cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-default')]
+    cmd = ['lint.thrift', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=True)
-    cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-strict')]
+    cmd = ['lint.thrift', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_non_strict(self):
     # thrift-linter fails on linter errors (BUILD target defines thrift_linter_strict=False)
-    cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-non-strict')]
+    cmd = ['lint.thrift', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_default_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
-    cmd = ['thrift-linter', '--strict', self.thrift_test_target('bad-thrift-default')]
+    cmd = ['lint.thrift', '--strict', self.thrift_test_target('bad-thrift-default')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
@@ -81,7 +75,7 @@ class ThriftLinterTest(PantsRunIntegrationTest):
     target_a = self.thrift_test_target('bad-thrift-strict')
     target_b = self.thrift_test_target('bad-thrift-strict2')
     cmd = ['-q',
-           'thrift-linter',
+           'lint.thrift',
            '--strict',
            target_a,
            target_b,
@@ -95,22 +89,22 @@ class ThriftLinterTest(PantsRunIntegrationTest):
 
   def test_bad_strict_override(self):
     # thrift-linter passes with non-strict command line flag overriding the BUILD section.
-    cmd = ['thrift-linter', '--no-strict', self.thrift_test_target('bad-thrift-strict')]
+    cmd = ['lint.thrift', '--no-strict', self.thrift_test_target('bad-thrift-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_non_strict_override(self):
     # thrift-linter fails with command line flag overriding the BUILD section.
-    cmd = ['thrift-linter', '--strict', self.thrift_test_target('bad-thrift-non-strict')]
+    cmd = ['lint.thrift', '--strict', self.thrift_test_target('bad-thrift-non-strict')]
     pants_run = self.run_pants(cmd)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
 
   def test_bad_pants_ini_strict(self):
     # thrift-linter fails if pants.ini has a thrift-linter:strict=True setting.
-    cmd = ['thrift-linter', self.thrift_test_target('bad-thrift-default')]
-    pants_ini_config = {'thrift-linter': {'strict': True}}
+    cmd = ['lint.thrift', self.thrift_test_target('bad-thrift-default')]
+    pants_ini_config = {'lint.thrift': {'strict': True}}
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_failure(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)
@@ -118,8 +112,8 @@ class ThriftLinterTest(PantsRunIntegrationTest):
   def test_bad_pants_ini_strict_overridden(self):
     # thrift-linter passes if pants.ini has a thrift-linter:strict=True setting and
     # a command line non-strict flag is passed.
-    cmd = ['thrift-linter', '--no-strict', self.thrift_test_target('bad-thrift-default')]
-    pants_ini_config = {'thrift-linter': {'strict': True}}
+    cmd = ['lint.thrift', '--no-strict', self.thrift_test_target('bad-thrift-default')]
+    pants_ini_config = {'lint.thrift': {'strict': True}}
     pants_run = self.run_pants(cmd, config=pants_ini_config)
     self.assert_success(pants_run)
     self.assertIn(self.lint_error_token, pants_run.stdout_data)

--- a/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/BUILD
+++ b/contrib/scrooge/tests/thrift/org/pantsbuild/contrib/scrooge/thrift_linter/BUILD
@@ -4,6 +4,7 @@
 java_thrift_library(
   name = 'bad-thrift-default',
   sources = ['bad-default.thrift'],
+  tags=['nolint'],
   # thrift_linter_strict not defined
 )
 
@@ -11,22 +12,26 @@ java_thrift_library(
   name = 'bad-thrift-strict',
   sources = ['bad-strict.thrift'],
   thrift_linter_strict=True,
+  tags=['nolint'],
 )
 
 java_thrift_library(
   name = 'bad-thrift-strict2',
   sources = ['bad-strict2.thrift'],
   thrift_linter_strict=True,
+  tags=['nolint'],
 )
 
 java_thrift_library(
   name = 'bad-thrift-non-strict',
   sources = ['bad-non-strict.thrift'],
   thrift_linter_strict=False,
+  tags=['nolint'],
 )
 
 java_thrift_library(
   name = 'good-thrift',
   sources = ['good.thrift'],
   thrift_linter_strict=True,
+  tags=['nolint'],
 )


### PR DESCRIPTION
Deprecates its old goal (thrift-linter) in favor of the
standard lint goal.
