### PR TITLE
Document release reset of master.

### DIFF
--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -160,10 +160,10 @@ is not required.
 3. Publish to PyPi
 ------------------
 
-Once the first two travis shards (the "binary builder" shards) have completed for your
-release commit, you can publish to PyPi. First, ensure your are on your clone's master
-branch at the release commit. If new commits have landed after your release commit,
-you can reset to your commit (`git reset --hard <sha>`). Then, publish the release:
+Once the first two travis shards (the "binary builder" shards) have completed for your release
+commit, you can publish to PyPi. First, ensure you are on the master branch at the release commit.
+If new commits have landed after your release commit, you can reset to your commit
+(`git reset --hard <sha>`). Then, publish the release:
 
     :::bash
     $ ./build-support/bin/release.sh

--- a/src/docs/release.md
+++ b/src/docs/release.md
@@ -161,7 +161,9 @@ is not required.
 ------------------
 
 Once the first two travis shards (the "binary builder" shards) have completed for your
-release commit, you can publish to PyPi:
+release commit, you can publish to PyPi. First, ensure your are on your clone's master
+branch at the release commit. If new commits have landed after your release commit,
+you can reset to your commit (`git reset --hard <sha>`). Then, publish the release:
 
     :::bash
     $ ./build-support/bin/release.sh


### PR DESCRIPTION
Make it clear that releases can be performed in the face of rapid
changes hitting master by documenting the pre-release step of getting
the releaser's local clone set to the release commit.
