### PR TITLE
Sort the indexable targets consistently.

### DIFF
--- a/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/indexable_java_targets.py
+++ b/contrib/codeanalysis/src/python/pants/contrib/codeanalysis/tasks/indexable_java_targets.py
@@ -40,4 +40,6 @@ class IndexableJavaTargets(Subsystem):
     for t in requested_targets:
       expanded_targets.extend(context.build_graph.get_all_derivatives(t.address))
 
-    return [t for t in expanded_targets if isinstance(t, JvmTarget) and t.has_sources('.java')]
+    return tuple(sorted(
+      [t for t in expanded_targets if isinstance(t, JvmTarget) and t.has_sources('.java')],
+      key=lambda t: t.address.spec))


### PR DESCRIPTION
Useful when merging indexes for multiple targets: we can
use the list of targets as a key into products, and be sure
we get a consistent key without having to sort in each task.
