### PR TITLE
[v2-engine errors] Sort suggestions for typo'd targets. dedup errors w/o trace

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -107,7 +107,8 @@ class UnhydratedStruct(datatype('UnhydratedStruct', ['address', 'struct', 'depen
 
 
 def _raise_did_you_mean(address_family, name):
-  possibilities = '\n  '.join(':{}'.format(a.target_name) for a in address_family.addressables)
+  names = [a.target_name for a in address_family.addressables]
+  possibilities = '\n  '.join(':{}'.format(target_name) for target_name in sorted(names))
   raise ResolveError('"{}" was not found in namespace "{}". '
                      'Did you mean one of:\n  {}'
                      .format(name, address_family.namespace, possibilities))

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -487,12 +487,13 @@ class LocalScheduler(object):
         cumulative_trace = '\n'.join(self.trace(request))
         raise ExecutionError('Received unexpected Throw state(s):\n{}'.format(cumulative_trace))
 
-      if len(throw_root_states) == 1:
+      unique_exceptions = set(t.exc for t in throw_root_states)
+      if len(unique_exceptions) == 1:
         raise throw_root_states[0].exc
       else:
         raise ExecutionError('Multiple exceptions encountered:\n  {}'
-                             .format('\n  '.join('{}: {}'.format(type(t.exc).__name__, str(t.exc))
-                                                 for t in throw_root_states)))
+                             .format('\n  '.join('{}: {}'.format(type(t).__name__, str(t))
+                                                                 for t in unique_exceptions)))
 
     # Everything is a Return: we rely on the fact that roots are ordered to preserve subject
     # order in output lists.


### PR DESCRIPTION
### Problem

When there are a large number of suggestions, the lack of alphanumeric sorting is frustrating. #4788
### Solution

Sort the suggestions. Additionally, I noticed that because of where this happens, there may be multiple copies of the error message that show up. I changed the default behavior to dedup common errors.

### Result

```
./pants list 3rdparty/python:rutaba --no-print-exception-stacktrace
Exception caught: (<class 'pants.build_graph.address_lookup_error.AddressLookupError'>)

Exception message: "rutaba" was not found in namespace "3rdparty/python". Did you mean one of:
  :Markdown
  :Pygments
  :ansicolors
```

Instead of
```
Exception caught: (<class 'pants.build_graph.address_lookup_error.AddressLookupError'>)

Exception message: Build graph construction failed: ExecutionError Multiple exceptions encountered:
  ResolveError: "rutaba" was not found in namespace "3rdparty/python". Did you mean one of:
  :psutil
  :isort
  :pywatchman
  :pytest-cov
...
  :scandir
  :setuptools
  ResolveError: "rutaba" was not found in namespace "3rdparty/python". Did you mean one of:
  :psutil
  :isort
  :pywatchman
  :pytest-cov
  :setproctitle
...
  :scandir
  :setuptools

```