### PR TITLE
Improve python/rust boundary error handling

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -102,7 +102,8 @@ typedef Value            (*extern_ptr_project)(ExternContext*, Value*, uint8_t*,
 typedef ValueBuffer      (*extern_ptr_project_multi)(ExternContext*, Value*, uint8_t*, uint64_t);
 typedef Value            (*extern_ptr_project_ignoring_type)(ExternContext*, Value*, uint8_t*, uint64_t);
 typedef Value            (*extern_ptr_create_exception)(ExternContext*, uint8_t*, uint64_t);
-typedef PyResult (*extern_ptr_invoke_runnable)(ExternContext*, Value*, Value*, uint64_t, _Bool);
+typedef PyResult         (*extern_ptr_call)(ExternContext*, Value*, Value*, uint64_t);
+typedef PyResult         (*extern_ptr_eval)(ExternContext*, uint8_t*, uint64_t);
 
 typedef void Tasks;
 typedef void Scheduler;
@@ -126,6 +127,8 @@ typedef struct {
 CFFI_HEADERS = '''
 void externs_set(ExternContext*,
                  extern_ptr_log,
+                 extern_ptr_call,
+                 extern_ptr_eval,
                  extern_ptr_key_for,
                  extern_ptr_val_for,
                  extern_ptr_clone_val,
@@ -141,7 +144,6 @@ void externs_set(ExternContext*,
                  extern_ptr_project_ignoring_type,
                  extern_ptr_project_multi,
                  extern_ptr_create_exception,
-                 extern_ptr_invoke_runnable,
                  TypeId);
 
 Tasks* tasks_create(void);
@@ -215,6 +217,8 @@ void garbage_collect_store(Scheduler*);
 CFFI_EXTERNS = '''
 extern "Python" {
   void             extern_log(ExternContext*, uint8_t, uint8_t*, uint64_t);
+  PyResult         extern_call(ExternContext*, Value*, Value*, uint64_t);
+  PyResult         extern_eval(ExternContext*, uint8_t*, uint64_t);
   Key              extern_key_for(ExternContext*, Value*);
   Value            extern_val_for(ExternContext*, Key*);
   Value            extern_clone_val(ExternContext*, Value*);
@@ -230,7 +234,6 @@ extern "Python" {
   Value            extern_project_ignoring_type(ExternContext*, Value*, uint8_t*, uint64_t);
   ValueBuffer      extern_project_multi(ExternContext*, Value*, uint8_t*, uint64_t);
   Value            extern_create_exception(ExternContext*, uint8_t*, uint64_t);
-  PyResult         extern_invoke_runnable(ExternContext*, Value*, Value*, uint64_t);
 }
 '''
 
@@ -281,6 +284,17 @@ def _initialize_externs(ffi):
 
   def to_py_str(msg_ptr, msg_len):
     return bytes(ffi.buffer(msg_ptr, msg_len)).decode('utf-8')
+
+  def call(c, func, args):
+    try:
+      val = func(*args)
+      is_throw = False
+    except Exception as e:
+      val = e
+      is_throw = True
+      e._formatted_exc = traceback.format_exc()
+
+    return PyResult(is_throw, c.to_value(val))
 
   @ffi.def_extern()
   def extern_log(context_handle, level, msg_ptr, msg_len):
@@ -415,22 +429,18 @@ def _initialize_externs(ffi):
     return c.to_value(Exception(msg))
 
   @ffi.def_extern()
-  def extern_invoke_runnable(context_handle, func, args_ptr, args_len):
-    """Given a destructured rawRunnable, run it."""
+  def extern_call(context_handle, func, args_ptr, args_len):
+    """Given a callable, call it."""
     c = ffi.from_handle(context_handle)
     runnable = c.from_value(func)
     args = tuple(c.from_value(arg) for arg in ffi.unpack(args_ptr, args_len))
+    return call(c, runnable, args)
 
-    try:
-      val = runnable(*args)
-      is_throw = False
-      traceback_str = ''
-    except Exception as e:
-      val = e
-      is_throw = True
-      traceback_str = traceback.format_exc()
-
-    return PyResult(is_throw, c.to_value(val), c.utf8_buf(traceback_str))
+  @ffi.def_extern()
+  def extern_eval(context_handle, python_code_str_ptr, python_code_str_len):
+    """Given an evalable string, eval it and return a Value for its result."""
+    c = ffi.from_handle(context_handle)
+    return call(c, eval, [to_py_str(python_code_str_ptr, python_code_str_len)])
 
 
 class Value(datatype('Value', ['handle'])):
@@ -453,7 +463,7 @@ class TypeId(datatype('TypeId', ['id_'])):
   """Corresponds to the native object of the same name."""
 
 
-class PyResult(datatype('PyResult', ['is_throw', 'value', 'traceback'])):
+class PyResult(datatype('PyResult', ['is_throw', 'value'])):
   """Corresponds to the native object of the same name."""
 
 
@@ -631,6 +641,8 @@ class Native(object):
       context = ExternContext(self.ffi)
       self.lib.externs_set(context.handle,
                            self.ffi_lib.extern_log,
+                           self.ffi_lib.extern_call,
+                           self.ffi_lib.extern_eval,
                            self.ffi_lib.extern_key_for,
                            self.ffi_lib.extern_val_for,
                            self.ffi_lib.extern_clone_val,
@@ -646,7 +658,6 @@ class Native(object):
                            self.ffi_lib.extern_project_ignoring_type,
                            self.ffi_lib.extern_project_multi,
                            self.ffi_lib.extern_create_exception,
-                           self.ffi_lib.extern_invoke_runnable,
                            TypeId(context.to_id(str)))
       return context
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -265,10 +265,12 @@ class WrappedNativeScheduler(object):
     self._native.lib.execution_reset(self._scheduler)
 
   def add_root_selection(self, execution_request, subject, product):
-    self._native.lib.execution_add_root_select(self._scheduler,
-                                               execution_request,
-                                               self._to_key(subject),
-                                               self._to_constraint(product))
+    res = self._native.lib.execution_add_root_select(self._scheduler,
+                                                     execution_request,
+                                                     self._to_key(subject),
+                                                     self._to_constraint(product))
+    if res.is_throw:
+      raise self._from_value(res.value)
 
   def visualize_to_dir(self):
     return self._native.visualize_to_dir

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -65,7 +65,7 @@ impl Core {
       panic!("Could not initialize Snapshot directory: {:?}", e);
     });
     tasks.singleton_replace(
-      externs::invoke_unsafe(
+      externs::unsafe_call(
         &types.construct_snapshots,
         &vec![
           externs::store_bytes(snapshots.snapshot_path().as_os_str().as_bytes()),

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -36,9 +36,9 @@ use std::path::{Path, PathBuf};
 use context::Core;
 use core::{Failure, Function, Key, TypeConstraint, TypeId, Value};
 use externs::{Buffer, BufferBuffer, CloneValExtern, DropHandlesExtern, CreateExceptionExtern,
-              ExternContext, Externs, IdToStrExtern, InvokeRunnable, LogExtern, KeyForExtern,
-              ProjectExtern, ProjectMultiExtern, ProjectIgnoringTypeExtern, PyResult,
-              SatisfiedByExtern, StoreI32Extern, SatisfiedByTypeExtern, StoreListExtern,
+              ExternContext, Externs, IdToStrExtern, CallExtern, EvalExtern, LogExtern,
+              KeyForExtern, ProjectExtern, ProjectMultiExtern, ProjectIgnoringTypeExtern,
+              PyResult, SatisfiedByExtern, StoreI32Extern, SatisfiedByTypeExtern, StoreListExtern,
               StoreBytesExtern, TypeIdBuffer, ValForExtern, ValToStrExtern};
 use rule_graph::{GraphMaker, RuleGraph};
 use scheduler::{ExecutionRequest, RootResult, Scheduler};
@@ -119,6 +119,8 @@ impl RawNodes {
 pub extern "C" fn externs_set(
   ext_context: *const ExternContext,
   log: LogExtern,
+  call: CallExtern,
+  eval: EvalExtern,
   key_for: KeyForExtern,
   val_for: ValForExtern,
   clone_val: CloneValExtern,
@@ -134,12 +136,13 @@ pub extern "C" fn externs_set(
   project_ignoring_type: ProjectIgnoringTypeExtern,
   project_multi: ProjectMultiExtern,
   create_exception: CreateExceptionExtern,
-  invoke_runnable: InvokeRunnable,
   py_str_type: TypeId,
 ) {
   externs::set_externs(Externs::new(
     ext_context,
     log,
+    call,
+    eval,
     key_for,
     val_for,
     clone_val,
@@ -155,7 +158,6 @@ pub extern "C" fn externs_set(
     project_ignoring_type,
     project_multi,
     create_exception,
-    invoke_runnable,
     py_str_type,
   ));
 }

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -37,9 +37,9 @@ use context::Core;
 use core::{Failure, Function, Key, TypeConstraint, TypeId, Value};
 use externs::{Buffer, BufferBuffer, CloneValExtern, DropHandlesExtern, CreateExceptionExtern,
               ExternContext, Externs, IdToStrExtern, InvokeRunnable, LogExtern, KeyForExtern,
-              ProjectExtern, ProjectMultiExtern, ProjectIgnoringTypeExtern, SatisfiedByExtern,
-              StoreI32Extern, SatisfiedByTypeExtern, StoreListExtern, StoreBytesExtern,
-              TypeIdBuffer, ValForExtern, ValToStrExtern};
+              ProjectExtern, ProjectMultiExtern, ProjectIgnoringTypeExtern, PyResult,
+              SatisfiedByExtern, StoreI32Extern, SatisfiedByTypeExtern, StoreListExtern,
+              StoreBytesExtern, TypeIdBuffer, ValForExtern, ValToStrExtern};
 use rule_graph::{GraphMaker, RuleGraph};
 use scheduler::{ExecutionRequest, RootResult, Scheduler};
 use tasks::Tasks;
@@ -255,10 +255,12 @@ pub extern "C" fn execution_add_root_select(
   execution_request_ptr: *mut ExecutionRequest,
   subject: Key,
   product: TypeConstraint,
-) {
+) -> PyResult {
   with_scheduler(scheduler_ptr, |scheduler| {
     with_execution_request(execution_request_ptr, |execution_request| {
-      scheduler.add_root_select(execution_request, subject, product);
+      scheduler
+        .add_root_select(execution_request, subject, product)
+        .into()
     })
   })
 }

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -648,8 +648,9 @@ pub struct RuleGraph {
 }
 
 fn type_constraint_str(type_constraint: TypeConstraint) -> String {
-  let val = to_val(type_constraint);
-  call_on_val(&val, "graph_str")
+  let str_val = externs::call_method(&to_val(type_constraint), "graph_str", &[])
+    .expect("string from calling repr");
+  externs::val_to_str(&str_val)
 }
 
 fn to_val(type_constraint: TypeConstraint) -> Value {
@@ -663,15 +664,6 @@ fn to_val_from_func(func: &Function) -> Value {
 fn to_val_from_id(id: Id) -> Value {
   externs::val_for_id(id)
 }
-
-fn call_on_val(value: &Value, method: &str) -> String {
-  let rpr_val = externs::project_ignoring_type(&value, method);
-
-  let invoke_result =
-    externs::invoke_runnable(&rpr_val, &[], false).expect("string from calling repr");
-  externs::val_to_str(&invoke_result)
-}
-
 
 fn function_str(func: &Function) -> String {
   let as_val = to_val_from_func(func);

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -125,8 +125,8 @@ class EngineTraceTest(unittest.TestCase, SchedulerTestBase):
         Computing Task(<function nested_raise at 0xEEEEEEEEE>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
           Throw(An exception for B)
             Traceback (most recent call last):
-              File LOCATION-INFO, in extern_invoke_runnable
-                val = runnable(*args)
+              File LOCATION-INFO, in call
+                val = func(*args)
               File LOCATION-INFO, in nested_raise
                 fn_raises(x)
               File LOCATION-INFO, in fn_raises
@@ -156,8 +156,8 @@ class EngineTraceTest(unittest.TestCase, SchedulerTestBase):
           Computing Task(<function nested_raise at 0xEEEEEEEEE>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C)
             Throw(An exception for B)
               Traceback (most recent call last):
-                File LOCATION-INFO, in extern_invoke_runnable
-                  val = runnable(*args)
+                File LOCATION-INFO, in call
+                  val = func(*args)
                 File LOCATION-INFO, in nested_raise
                   fn_raises(x)
                 File LOCATION-INFO, in fn_raises

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -165,3 +165,16 @@ class EngineTraceTest(unittest.TestCase, SchedulerTestBase):
               Exception: An exception for B
       ''').lstrip()+'\n',
       remove_locations_from_traceback(str(cm.exception)))
+
+  def test_illegal_root_selection(self):
+    rules = [
+      RootRule(B),
+    ]
+
+    scheduler = self.scheduler(rules, include_trace_on_error=False)
+
+    # No rules are available to compute A.
+    with self.assertRaises(Exception) as cm:
+      list(scheduler.product_request(A, subjects=[(B())]))
+
+    self.assert_equal_with_printing('No installed rules can satisfy Select(A) for a root subject of type B.', str(cm.exception))

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -269,8 +269,8 @@ class SchedulerTraceTest(unittest.TestCase):
                        Computing Task(<function nested_raise at 0xEEEEEEEEE>, <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, =A)
                          Throw(An exception for B)
                            Traceback (most recent call last):
-                             File LOCATION-INFO, in extern_invoke_runnable
-                               val = runnable(*args)
+                             File LOCATION-INFO, in call
+                               val = func(*args)
                              File LOCATION-INFO, in nested_raise
                                fn_raises(x)
                              File LOCATION-INFO, in fn_raises


### PR DESCRIPTION
### Problem

For calls from python to rust, we didn't have a convention in place (with the exception of calls that returned `Node` values) for returning the equivalent of a rust `Result` type to python.

### Solution

Repurpose an existing Externs struct (`RunnableComplete`) as `PyResult`, and use it to remove a panicing TODO that was easy to trip on.

Additionally, rename `invoke_runnable` to `call`, and add `eval`.

### Result

Begins to fix #4208 (although we should still close it), and avoids a too-common panic.