### PR TITLE
Set the log level when capturing logs in tests.

### DIFF
--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -483,9 +483,16 @@ class BaseTest(unittest.TestCase):
       return self._messages_for_level('WARNING')
 
   @contextmanager
-  def captured_logging(self):
+  def captured_logging(self, level=None):
+    root_logger = logging.getLogger()
+
+    old_level = root_logger.level
+    root_logger.setLevel(level or logging.NOTSET)
+
     handler = self.LoggingRecorder()
-    logger = logging.getLogger('')
-    logger.addHandler(handler)
-    yield handler
-    logger.removeHandler(handler)
+    root_logger.addHandler(handler)
+    try:
+      yield handler
+    finally:
+      root_logger.setLevel(old_level)
+      root_logger.removeHandler(handler)

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 import mock
 import psutil
 
-from pants.pantsd import process_manager
 from pants.pantsd.process_manager import (ProcessGroup, ProcessManager, ProcessMetadataManager,
                                           swallow_psutil_exceptions)
 from pants.util.contextutil import temporary_dir

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import errno
+import logging
 import os
 import sys
 from contextlib import contextmanager
@@ -13,6 +14,7 @@ from contextlib import contextmanager
 import mock
 import psutil
 
+from pants.pantsd import process_manager
 from pants.pantsd.process_manager import (ProcessGroup, ProcessManager, ProcessMetadataManager,
                                           swallow_psutil_exceptions)
 from pants.util.contextutil import temporary_dir
@@ -141,7 +143,7 @@ class TestProcessMetadataManager(BaseTest):
 
   def test_deadline_until(self):
     with self.assertRaises(self.pmm.Timeout):
-      with self.captured_logging() as captured:
+      with self.captured_logging(logging.INFO) as captured:
         self.pmm._deadline_until(lambda: False, 'the impossible', timeout=.5, info_interval=.1)
     self.assertTrue(4 <= len(captured.infos()) <= 6,
                     'Expected between 4 and 6 infos, got: {}'.format(captured.infos()))

--- a/tests/python/pants_test/util/test_osutil.py
+++ b/tests/python/pants_test/util/test_osutil.py
@@ -5,6 +5,8 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
+
 from pants.util.osutil import OS_ALIASES, known_os_names, normalize_os_name
 from pants_test.base_test import BaseTest
 
@@ -22,14 +24,14 @@ class OsutilTest(BaseTest):
 
   def test_no_warnings_on_known_names(self):
     for name in known_os_names():
-      with self.captured_logging() as captured:
+      with self.captured_logging(logging.WARNING) as captured:
         normalize_os_name(name)
         self.assertEqual(0, len(captured.warnings()),
                          'Recieved unexpected warnings: {}'.format(captured.warnings()))
 
   def test_warnings_on_unknown_names(self):
     name = 'I really hope no one ever names an operating system with this string.'
-    with self.captured_logging() as captured:
+    with self.captured_logging(logging.WARNING) as captured:
       normalize_os_name(name)
       self.assertEqual(1, len(captured.warnings()),
                        'Expected exactly one warning, but got: {}'.format(captured.warnings()))


### PR DESCRIPTION
This allows the test writer to ensure their log statements fire when
expected in the face of non-local manipulation of the global python
logging subsystem.

Fixes #5417