### PR TITLE
Fix tasks2 deprecations

### DIFF
--- a/src/python/pants/backend/python/BUILD
+++ b/src/python/pants/backend/python/BUILD
@@ -11,7 +11,7 @@ python_library(
     ':python_requirements',
     'src/python/pants/backend/python/targets:python',
     'src/python/pants/backend/python/tasks',
-    'src/python/pants/backend/python:tasks2',
+    'src/python/pants/backend/python/tasks2',
     'src/python/pants/build_graph',
     'src/python/pants/goal:task_registrar',
   ]
@@ -130,15 +130,6 @@ python_library(
   sources = ['sdist_builder.py'],
   dependencies = [
     '3rdparty/python:pex',
-  ]
-)
-
-python_library(
-  name = 'tasks2',
-  sources = ['tasks2.py'],
-  dependencies = [
-    'src/python/pants/backend/python/tasks',
-    'src/python/pants/base:deprecated',
   ]
 )
 

--- a/src/python/pants/backend/python/tasks2/BUILD
+++ b/src/python/pants/backend/python/tasks2/BUILD
@@ -1,0 +1,9 @@
+# Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  dependencies=[
+    'src/python/pants/backend/python/tasks',
+    'src/python/pants/base:deprecated',
+  ],
+)

--- a/src/python/pants/backend/python/tasks2/gather_sources.py
+++ b/src/python/pants/backend/python/tasks2/gather_sources.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import GatherSources
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+GatherSources = GatherSources

--- a/src/python/pants/backend/python/tasks2/pytest_prep.py
+++ b/src/python/pants/backend/python/tasks2/pytest_prep.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import PytestPrep
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+PytestPrep = PytestPrep

--- a/src/python/pants/backend/python/tasks2/pytest_run.py
+++ b/src/python/pants/backend/python/tasks2/pytest_run.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import PytestRun
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+PytestRun = PytestRun

--- a/src/python/pants/backend/python/tasks2/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks2/python_binary_create.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import PythonBinaryCreate
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+PythonBinaryCreate = PythonBinaryCreate

--- a/src/python/pants/backend/python/tasks2/python_repl.py
+++ b/src/python/pants/backend/python/tasks2/python_repl.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import PythonRepl
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+PythonRepl = PythonRepl

--- a/src/python/pants/backend/python/tasks2/python_run.py
+++ b/src/python/pants/backend/python/tasks2/python_run.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import PythonRun
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+PythonRun = PythonRun

--- a/src/python/pants/backend/python/tasks2/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks2/resolve_requirements.py
@@ -5,20 +5,10 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks import (GatherSources, PytestPrep, PytestRun, PythonBinaryCreate,
-                                        PythonRepl, PythonRun, ResolveRequirements,
-                                        SelectInterpreter, SetupPy)
+from pants.backend.python.tasks import ResolveRequirements
 from pants.base.deprecated import deprecated_module
 
 
 deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
 
-SelectInterpreter = SelectInterpreter
 ResolveRequirements = ResolveRequirements
-GatherSources = GatherSources
-PythonRun = PythonRun
-PytestPrep = PytestPrep
-PytestRun = PytestRun
-PythonRepl = PythonRepl
-SetupPy = SetupPy
-PythonBinaryCreate = PythonBinaryCreate

--- a/src/python/pants/backend/python/tasks2/select_interpreter.py
+++ b/src/python/pants/backend/python/tasks2/select_interpreter.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import SelectInterpreter
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+SelectInterpreter = SelectInterpreter

--- a/src/python/pants/backend/python/tasks2/setup_py.py
+++ b/src/python/pants/backend/python/tasks2/setup_py.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.tasks import SetupPy
+from pants.base.deprecated import deprecated_module
+
+
+deprecated_module('1.7.0.dev0', 'Use pants.backend.python.tasks instead')
+
+SetupPy = SetupPy


### PR DESCRIPTION
### Problem

The `tasks2` deprecations from #5363 did not each have their own modules, and thus were not importable ([see](https://github.com/pantsbuild/pants/pull/5363/files#r164906101)).

### Solution

Move the deprecations into their own modules/files.