### PR TITLE
Enable workdir-max-build-entries by default

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -237,7 +237,7 @@ class GlobalOptionsRegistrar(Optionable):
                   'to process the non-erroneous subset of the input.')
     register('--cache-key-gen-version', advanced=True, default='200', recursive=True,
              help='The cache key generation. Bump this to invalidate every artifact for a scope.')
-    register('--workdir-max-build-entries', advanced=True, type=int, default=None,
+    register('--workdir-max-build-entries', advanced=True, type=int, default=8,
              help='Maximum number of previous builds to keep per task target pair in workdir. '
              'If set, minimum 2 will always be kept to support incremental compilation.')
     register('--max-subprocess-args', advanced=True, type=int, default=100, recursive=True,


### PR DESCRIPTION
### Problem

There is a setting to enable some automatic cleanup of the workdir, but it is not enabled by default. Twitter has used it for a while with no issues.

### Solution

Enable `--workdir-max-build-entries=8` by default.