### PR TITLE
Switch binary tool consumption to a registration model.

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/java/BUILD
+++ b/src/python/pants/backend/codegen/protobuf/java/BUILD
@@ -17,7 +17,6 @@ python_library(
     'src/python/pants/fs',
     'src/python/pants/goal:task_registrar',
     'src/python/pants/task',
-    'src/python/pants/util:memo',
     'src/python/pants/util:process_handler',
   ],
 )

--- a/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
+++ b/src/python/pants/backend/jvm/subsystems/jvm_tool_mixin.py
@@ -16,6 +16,8 @@ class JvmToolMixin(object):
   """A mixin for registering and accessing JVM-based tools.
 
   Must be mixed in to something that can register and use options, e.g., a Task or a Subsystem.
+
+  :API: public
   """
   class InvalidToolClasspath(TaskError):
     """Indicates an invalid jvm tool classpath."""
@@ -81,7 +83,7 @@ class JvmToolMixin(object):
                         removal_hint=None):
     """Registers a jvm tool under `key` for lazy classpath resolution.
 
-    Classpaths can be retrieved in `execute` scope via `tool_classpath`.
+    Classpaths can be retrieved in `execute` scope via `tool_classpath_from_products`.
 
     NB: If the tool's `main` class name is supplied the tool classpath will be shaded.
 
@@ -175,7 +177,8 @@ class JvmToolMixin(object):
                                       'jar, instead found {count}:\n\t{classpath}'.format(**params))
     return classpath[0]
 
-  def tool_classpath_from_products(self, products, key, scope):
+  @staticmethod
+  def tool_classpath_from_products(products, key, scope):
     """Get a classpath for the tool previously registered under key in the given scope.
 
     :param products: The products of the current pants run.

--- a/src/python/pants/binaries/BUILD
+++ b/src/python/pants/binaries/BUILD
@@ -3,16 +3,18 @@
 
 python_library(
   name='binary_util',
-  sources=['binary_util.py'],
+  sources=['binary_tool_mixin.py', 'binary_util.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
+    'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
     'src/python/pants/net',
     'src/python/pants/option',
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
     'src/python/pants/util:osutil',
   ],
 )

--- a/src/python/pants/binaries/binary_tool_mixin.py
+++ b/src/python/pants/binaries/binary_tool_mixin.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from collections import namedtuple
+
+from pants.binaries.binary_util import BinaryUtil
+from pants.util.memo import memoized_method
+
+
+class BinaryToolMixin(object):
+  """Mixin for classes that use binary executables.
+
+  Must be mixed in to something that can register and use options, e.g., a Task or a Subsystem.
+  Specifically, the class this is mixed into must have a get_options() method.
+
+  :API: public
+  """
+  class BinaryTool(namedtuple('BinaryTool', ['scope', 'supportdir', 'name', 'platform_dependent',
+                                             'replaces_scope', 'replaces_name'])):
+
+    # TODO(benjy): Remove replaces_scope/replaces_name after migration to this mixin is complete.
+    def select(self, options):
+      version = getattr(options.for_scope(self.scope), '{}_version'.format(self.name))
+      if self.replaces_scope and self.replaces_name:
+        # If the old option is provided explicitly, let it take precedence.
+        old_opts = options.for_scope(self.replaces_scope)
+        if not old_opts.is_default(self.replaces_name):
+          version = old_opts.get(self.replaces_name)
+      return BinaryUtil.Factory.create().select(
+        self.supportdir, version, self.name, self.platform_dependent)
+
+  @staticmethod
+  def get_registered_tools():
+    """Returns a map of name to BinaryTool."""
+    return BinaryToolMixin._binary_tools
+
+  @staticmethod
+  def reset_registered_tools():
+    """Needed only for test isolation."""
+    BinaryToolMixin._binary_tools = {}
+
+  _binary_tools = {}  # name -> BinaryTool objects.
+
+  @classmethod
+  def register_binary_tool(cls,
+                           register,
+                           supportdir,
+                           name,
+                           default_version,
+                           platform_dependent,
+                           fingerprint=True,
+                           help=None,
+                           removal_version=None,
+                           removal_hint=None,
+                           # Temporary params, while migrating existing version options.
+                           replaces_scope=None,
+                           replaces_name=None):
+    """Registers a binary tool under `name` for lazy fetching.
+
+    Binaries can be retrieved in `execute` scope via `select_binary`.
+
+    :param register: A function that can register options with the option system.
+    :param string supportdir: The dir to find the tool under, as known to BinaryUtil.
+    :param string name: The name of the tool, as known to BinaryUtil.
+    :param string default_version: The default version of the tool.
+    :param bool platform_dependent: Is the binary qualified by platform,
+                                    or is it a platform-independent script.
+    :param bool fingerprint: Indicates whether to include the tool in the task's fingerprint.
+                             Note that unlike for other options, fingerprinting is enabled for
+                             tools by default.
+    :param unicode help: An optional custom help string; otherwise a reasonable one is generated.
+    :param string removal_version: A semver at which this tool will be removed.
+    :param string removal_hint: A hint on how to migrate away from this tool.
+    :param string replaces_scope: Replaces a previous option in this scope.
+    :param string replaces_name: Replaces a previous option of this name in replaces_scope.
+    """
+    help = help or 'Version of the {} {} to use'.format(
+      name, 'binary' if platform_dependent else 'script')
+    register('--{}-version'.format(name),
+             advanced=True,
+             type=str,
+             default=default_version,
+             help=help,
+             fingerprint=fingerprint,
+             removal_version=removal_version,
+             removal_hint=removal_hint)
+
+    binary_tool = cls.BinaryTool(register.scope, supportdir, name, platform_dependent,
+                                 replaces_scope, replaces_name)
+    BinaryToolMixin._binary_tools[name] = binary_tool
+
+  @memoized_method
+  def select_binary(self, name):
+    return self._binary_tools[name].select(self.context.options)


### PR DESCRIPTION
Registration creates an option to set the tool's version,
and provides a convenient mechanism for retrieving
the tool lazily as needed.

Provides a convenient migration path from existing tool
version options to this standardized one.

This is similar to what we already do for JVM tools.
It will allow us to optionally eagerly fetch all binary
tools, e.g., to build a warm Docker image, or to enable
working offline.

This change switches just one usage to the new mechanism.
The others will be switched in followup changes.
