### PR TITLE
fix/tests: subsystems can't declare dependencies on non-globally-scoped subsystems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .factorypath
 .python
 .pydevproject
+.pytest_cache/
 build/
 codegen/classes/
 htmlcov/

--- a/src/python/pants/subsystem/subsystem.py
+++ b/src/python/pants/subsystem/subsystem.py
@@ -104,8 +104,8 @@ class Subsystem(SubsystemClientMixin, Optionable):
       path.add(subsystem)
       if subsystem not in known_subsystem_types:
         known_subsystem_types.add(subsystem)
-        for dependency in subsystem.subsystem_dependencies():
-          collect_subsystems(dependency)
+        for dependency in subsystem.subsystem_dependencies_iter():
+          collect_subsystems(dependency.subsystem_cls)
       path.remove(subsystem)
 
     for subsystem_type in subsystem_types:

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -28,6 +28,16 @@ class UninitializedSubsystem(Subsystem):
   options_scope = 'uninitialized-scope'
 
 
+class ScopedDependentSubsystem(Subsystem):
+  options_scope = 'scoped-dependent-subsystem'
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(ScopedDependentSubsystem, cls).subsystem_dependencies() + (
+      DummySubsystem.scoped(cls),
+    )
+
+
 class SubsystemTest(unittest.TestCase):
   def setUp(self):
     DummySubsystem._options = DummyOptions()
@@ -52,6 +62,8 @@ class SubsystemTest(unittest.TestCase):
 
   def test_closure_simple(self):
     self.assertEqual({DummySubsystem}, Subsystem.closure((DummySubsystem,)))
+    self.assertEqual({DummySubsystem, ScopedDependentSubsystem},
+                     Subsystem.closure((ScopedDependentSubsystem,)))
 
   def test_closure_tree(self):
     class SubsystemB(Subsystem):


### PR DESCRIPTION
### Problem

Subsystems haven't been able to declare dependencies on other scoped subsystems, just global instances. If you try to do, e.g. from [the new tests](https://github.com/cosmicexplorer/pants/blob/378e91bb79c18004cb69ce9cf233905e114e1a5d/tests/python/pants_test/subsystem/test_subsystem.py#L31):

```python
# ...
class ScopedDependentSubsystem(Subsystem):
  options_scope = 'scoped-dependent-subsystem'

  @classmethod
  def subsystem_dependencies(cls):
    return super(ScopedDependentSubsystem, cls).subsystem_dependencies() + (
      DummySubsystem.scoped(cls),
    )
# ...
```

You'll see:
```
...
>       for dependency in subsystem.subsystem_dependencies():
                     E       AttributeError: 'SubsystemDependency' object has no attribute 'subsystem_dependencies'
                     
                     src/python/pants/subsystem/subsystem.py:112: AttributeError
                     ======= 1 failed, 9 passed in 0.07 seconds =======
...
```

### Solution

The stacktrace helpfully gives the exact issue clearly -- `Subsystem.closure()` was not using `subsystem_dependencies_iter()`, and could therefore receive either a `Subsystem` or a `SubsystemDependency`. It has been assuming all dependencies were just `Subsystem`s, which I noticed when I tried to declare a dependency on a scoped subsystem.

Using `subsystem_dependencies_iter()` and extracting the `subsystem_cls` from the `SubsystemDependency` object now allows users to declare dependencies on non-globally-scoped subsystems, which is pretty neat.