### PR TITLE
Bump release.sh to pex 1.2.16.

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -682,7 +682,7 @@ function build_pex() {
 
   local dest="${ROOT}/dist/pants.${PANTS_UNSTABLE_VERSION}.pex"
 
-  activate_tmp_venv && trap deactivate RETURN && pip install "pex==1.2.13" || die "Failed to install pex."
+  activate_tmp_venv && trap deactivate RETURN && pip install "pex==1.2.16" || die "Failed to install pex."
 
   local requirements_string=""
   for pkg_name in $PANTS_PEX_PACKAGES; do


### PR DESCRIPTION
This helps pick up recent runtime changes (`PEX_PYTHON_PATH` et al) for pants as built as a pex.