### PR TITLE
Never allow the shader to rewrite the empty-string package.

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -108,6 +108,7 @@ python_library(
     'src/python/pants/java:executor',
     'src/python/pants/subsystem',
     'src/python/pants/util:contextutil',
+    'src/python/pants/util:memo',
     'src/python/pants/util:objects',
   ]
 )


### PR DESCRIPTION
Some files in jars (e.g., module-info.class) will confuse the shader
into trying to shade the '' package, which leads to, among other
things, rewriting every single string literal.

This change checks that a package name is not empty before
creating a shader rule from it.

While in this code, this change also properly caches the
system packages on the Shader class (keyed by distribution).
Previously they were cached on each Shader instance, but 
since we don't reuse those instances, that caching was not effective.
