### PR TITLE
iterate on the new BinaryTool subsystem and use it to create a new LLVM subsystem

### DIFF
--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer_binary.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer_binary.py
@@ -19,12 +19,15 @@ logger = logging.getLogger(__name__)
 class BuildozerBinary(NativeTool):
   options_scope = 'buildozer-binary'
   name = 'buildozer'
-  # TODO: Move this to bin/buildozer - buildozer is a native binary.
-  support_dir = 'scripts/buildozer'
   default_version = '0.6.0.dce8b3c287652cbcaf43c8dd076b3f48c92ab44c'
 
   replaces_scope = 'buildozer'
   replaces_name = 'version'
+
+  # TODO: Move this to bin/buildozer - buildozer is a native binary.
+  @classmethod
+  def get_support_dir(cls):
+    return 'scripts/buildozer'
 
   def execute(self, buildozer_command, spec, context=None):
     try:

--- a/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
@@ -10,8 +10,12 @@ from pants.binaries.binary_tool import NativeTool
 
 class Protoc(NativeTool):
   options_scope = 'protoc'
-  name = 'protobuf'
   default_version = '2.4.1'
 
   replaces_scope = 'gen.protoc'
   replaces_name = 'version'
+
+  # 'protoc' is also the binary's filename.
+  @classmethod
+  def get_support_dir(cls):
+    return 'bin/protobuf'

--- a/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
@@ -10,7 +10,7 @@ from pants.binaries.binary_tool import NativeTool
 
 class Protoc(NativeTool):
   options_scope = 'protoc'
-  support_subdir = 'protobuf'
+  name = 'protobuf'
   default_version = '2.4.1'
 
   replaces_scope = 'gen.protoc'

--- a/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
@@ -10,7 +10,7 @@ from pants.binaries.binary_tool import NativeTool
 
 class Protoc(NativeTool):
   options_scope = 'protoc'
-  support_dir = 'bin/protobuf'
+  support_subdir = 'protobuf'
   default_version = '2.4.1'
 
   replaces_scope = 'gen.protoc'

--- a/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
@@ -10,7 +10,6 @@ from pants.binaries.binary_tool import NativeTool
 
 class Protoc(NativeTool):
   options_scope = 'protoc'
-  support_subdir = 'protobuf'
   default_version = '2.4.1'
 
   deprecated_option_scope = 'gen.protoc'

--- a/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
@@ -10,6 +10,7 @@ from pants.binaries.binary_tool import NativeTool
 
 class Protoc(NativeTool):
   options_scope = 'protoc'
+  support_subdir = 'protobuf'
   default_version = '2.4.1'
 
   deprecated_option_scope = 'gen.protoc'

--- a/src/python/pants/backend/native/subsystems/BUILD
+++ b/src/python/pants/backend/native/subsystems/BUILD
@@ -1,0 +1,8 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_library(
+  dependencies=[
+    'src/python/pants/binaries:binary_util',
+  ],
+)

--- a/src/python/pants/backend/native/subsystems/llvm.py
+++ b/src/python/pants/backend/native/subsystems/llvm.py
@@ -10,6 +10,6 @@ from pants.binaries.binary_tool import NativeTool
 
 class LLVM(NativeTool):
   options_scope = 'llvm'
-  support_subdir = 'llvm'
+  name = 'llvm'
   default_version = '5.0.1'
   archive_type = 'tgz'

--- a/src/python/pants/backend/native/subsystems/llvm.py
+++ b/src/python/pants/backend/native/subsystems/llvm.py
@@ -8,10 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.binaries.binary_tool import NativeTool
 
 
-class Protoc(NativeTool):
-  options_scope = 'protoc'
-  support_subdir = 'protobuf'
-  default_version = '2.4.1'
-
-  deprecated_option_scope = 'gen.protoc'
-  deprecated_option_name = 'version'
+class LLVM(NativeTool):
+  options_scope = 'llvm'
+  default_version = '5.0.1'
+  archive_type = 'tgz'

--- a/src/python/pants/backend/native/subsystems/llvm.py
+++ b/src/python/pants/backend/native/subsystems/llvm.py
@@ -10,6 +10,5 @@ from pants.binaries.binary_tool import NativeTool
 
 class LLVM(NativeTool):
   options_scope = 'llvm'
-  name = 'llvm'
   default_version = '5.0.1'
   archive_type = 'tgz'

--- a/src/python/pants/backend/native/subsystems/llvm.py
+++ b/src/python/pants/backend/native/subsystems/llvm.py
@@ -10,6 +10,6 @@ from pants.binaries.binary_tool import NativeTool
 
 class LLVM(NativeTool):
   options_scope = 'llvm'
-  support_dir = 'bin/llvm'
+  support_subdir = 'llvm'
   default_version = '5.0.1'
   archive_type = 'tgz'

--- a/src/python/pants/binaries/BUILD
+++ b/src/python/pants/binaries/BUILD
@@ -3,12 +3,13 @@
 
 python_library(
   name='binary_util',
-  sources=['binary_tool.py', 'binary_tool_mixin.py', 'binary_util.py'],
+  sources=['binary_tool.py', 'binary_util.py'],
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     'src/python/pants/base:build_environment',
     'src/python/pants/base:deprecated',
     'src/python/pants/base:exceptions',
+    'src/python/pants/fs',
     'src/python/pants/net',
     'src/python/pants/option',
     'src/python/pants/subsystem',

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import os
 
-from pants.base.exceptions import TaskError
 from pants.binaries.binary_util import BinaryUtil
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -19,14 +19,9 @@ class BinaryToolBase(Subsystem):
 
   :API: public
   """
-  # All subsystems inheriting from BinaryToolBase will go under
-  # bin/`support_subdir` unless they specify an explicit `support_dir`.
-  SUPPORTDIR_PARENT_DIRNAME = 'bin'
-
   # Subclasses must set these to appropriate values for the tool they define.
   # They must also set options_scope appropriately.
   support_dir = None
-  support_subdir = None
   platform_dependent = None
   archive_type = None
   default_version = None
@@ -90,13 +85,13 @@ class BinaryToolBase(Subsystem):
     return BinaryUtil.Factory.create()
 
   @classmethod
-  def _resolve_binaryutil_supportdir(cls):
-    return cls.support_dir or '{}/{}'.format(self.SUPPORTDIR_PARENT_DIRNAME, cls._get_name())
+  def get_support_dir(cls):
+    return cls.support_dir or 'bin/{}'.format(cls._get_name())
 
   @memoized_method
   def _select_for_version(self, version):
     return self._binary_util.select(
-      support_dir=self._resolve_binaryutil_supportdir(),
+      support_dir=self.get_support_dir(),
       version=version,
       name=self._get_name(),
       platform_dependent=self.platform_dependent,

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -21,7 +21,6 @@ class BinaryToolBase(Subsystem):
   """
   # Subclasses must set these to appropriate values for the tool they define.
   # They must also set options_scope appropriately.
-  support_dir = None
   platform_dependent = None
   archive_type = None
   default_version = None

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -20,9 +20,6 @@ class BinaryToolBase(Subsystem):
 
   :API: public
   """
-  # all subsystems inheriting from BinaryToolBase will go under bin/
-  SUPPORTDIR_PARENT_DIRNAME = 'bin'
-
   # Subclasses must set these to appropriate values for the tool they define.
   # They must also set options_scope appropriately.
   support_dir = None

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -5,8 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import os
-
 from pants.binaries.binary_util import BinaryUtil
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -25,6 +25,7 @@ class BinaryToolBase(Subsystem):
 
   # Subclasses must set these to appropriate values for the tool they define.
   # They must also set options_scope to the tool name as understood by BinaryUtil.
+  support_subdir = None
   platform_dependent = None
   archive_type = None
   default_version = None
@@ -87,9 +88,11 @@ class BinaryToolBase(Subsystem):
 
   @memoized_method
   def _select_for_version(self, version):
+    subdir = self.support_subdir or self.options_scope
+    binaryutil_supportdir = os.path.join(self.SUPPORTDIR_PARENT_DIRNAME, subdir)
+
     return self._binary_util.select(
-      supportdir=os.path.join(self.SUPPORTDIR_PARENT_DIRNAME,
-                              self.options_scope),
+      supportdir=binaryutil_supportdir,
       version=version,
       name=self.options_scope,
       platform_dependent=self.platform_dependent,

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -20,9 +20,14 @@ class BinaryToolBase(Subsystem):
 
   :API: public
   """
+  # All subsystems inheriting from BinaryToolBase will go under
+  # bin/`support_subdir` unless they specify an explicit `support_dir`.
+  SUPPORTDIR_PARENT_DIRNAME = 'bin'
+
   # Subclasses must set these to appropriate values for the tool they define.
   # They must also set options_scope appropriately.
   support_dir = None
+  support_subdir = None
   platform_dependent = None
   archive_type = None
   default_version = None
@@ -85,10 +90,14 @@ class BinaryToolBase(Subsystem):
   def _binary_util(self):
     return BinaryUtil.Factory.create()
 
+  @classmethod
+  def _resolve_binaryutil_supportdir(cls):
+    return cls.support_dir or '{}/{}'.format(self.SUPPORTDIR_PARENT_DIRNAME, cls._get_name())
+
   @memoized_method
   def _select_for_version(self, version):
     return self._binary_util.select(
-      support_dir=self.support_dir,
+      support_dir=self._resolve_binaryutil_supportdir(),
       version=version,
       name=self._get_name(),
       platform_dependent=self.platform_dependent,

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -51,7 +51,7 @@ class BinaryToolBase(Subsystem):
       version_registration_kwargs.update(cls.extra_version_option_kwargs)
     version_registration_kwargs['help'] = (
       version_registration_kwargs.get('help') or
-      'Version of the {} {} to use'.format(cls.get_name(),
+      'Version of the {} {} to use'.format(cls._get_name(),
                                            'binary' if cls.platform_dependent else 'script')
     )
     # The default for fingerprint in register() is False, but we want to default to True.
@@ -83,19 +83,19 @@ class BinaryToolBase(Subsystem):
 
   @classmethod
   def get_support_dir(cls):
-    return 'bin/{}'.format(cls.get_name())
+    return 'bin/{}'.format(cls._get_name())
 
   @memoized_method
   def _select_for_version(self, version):
     return self._binary_util.select(
       supportdir=self.get_support_dir(),
       version=version,
-      name=self.get_name(),
+      name=self._get_name(),
       platform_dependent=self.platform_dependent,
       archive_type=self.archive_type)
 
   @classmethod
-  def get_name(cls):
+  def _get_name(cls):
     return cls.name or cls.options_scope
 
 

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -54,7 +54,7 @@ class BinaryToolBase(Subsystem):
       version_registration_kwargs.update(cls.extra_version_option_kwargs)
     version_registration_kwargs['help'] = (
       version_registration_kwargs.get('help') or
-      'Version of the {} {} to use'.format(cls._get_name(),
+      'Version of the {} {} to use'.format(cls.get_name(),
                                            'binary' if cls.platform_dependent else 'script')
     )
     # The default for fingerprint in register() is False, but we want to default to True.
@@ -86,19 +86,19 @@ class BinaryToolBase(Subsystem):
 
   @classmethod
   def get_support_dir(cls):
-    return cls.support_dir or 'bin/{}'.format(cls._get_name())
+    return 'bin/{}'.format(cls.get_name())
 
   @memoized_method
   def _select_for_version(self, version):
     return self._binary_util.select(
-      support_dir=self.get_support_dir(),
+      supportdir=self.get_support_dir(),
       version=version,
-      name=self._get_name(),
+      name=self.get_name(),
       platform_dependent=self.platform_dependent,
       archive_type=self.archive_type)
 
   @classmethod
-  def _get_name(cls):
+  def get_name(cls):
     return cls.name or cls.options_scope
 
 

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -14,7 +14,7 @@ from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
-from pants.fs.archive import archive_extensions, archiver
+from pants.fs.archive import archiver
 from pants.net.http.fetcher import Fetcher
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import temporary_file
@@ -130,64 +130,67 @@ class BinaryUtil(object):
     if path_by_id:
       self._path_by_id.update((tuple(k), tuple(v)) for k, v in path_by_id.items())
 
-  def select(self, supportdir, version, name, platform_dependent, archive_type):
-    if archive_type is None:
-      full_name = name
-    else:
-      # TODO: throw a subclassed exception here if archive type doesn't exist!
-      arch_ext = archive_extensions[archive_type]
-      full_name = '{}.{}'.format(name, arch_ext)
-
-    if platform_dependent:
-      downloaded_file = self._select_binary(supportdir, version, full_name)
-    else:
-      downloaded_file = self._select_script(supportdir, version, full_name)
-
-    if archive_type is None:
-      return downloaded_file
-
-    selected_archiver = archiver(archive_type)
-    # use filename without extension as the directory name
-    unpacked_dirname, _ = os.path.splitext(downloaded_file)
-    selected_archiver.extract(downloaded_file, unpacked_dirname)
-    return unpacked_dirname
-
-  def select_binary(self, supportdir, version, name):
-    return self._select_binary(supportdir, version, name)
-
-  def select_script(self, supportdir, version, name):
-    return self._select_script(supportdir, version, name)
-
   # TODO: Deprecate passing in an explicit supportdir? Seems like we should be able to
   # organize our binary hosting so that it's not needed.
-  def _select_binary(self, supportdir, version, name):
-    """Selects a binary matching the current os and architecture.
+  def select(self, supportdir, version, name, platform_dependent, archive_type):
+    """Fetches a file, unpacking it if necessary."""
+    if archive_type is None:
+      return self._select_file(supportdir, version, name, platform_dependent)
+    selected_archiver = archiver(archive_type)
+    return self._select_archive(supportdir, version, name, platform_dependent, selected_archiver)
+
+  def _select_file(self, supportdir, version, name, platform_dependent):
+    """Generates a path to request a file and fetches the file located at that path.
 
     :param string supportdir: The path the `name` binaries are stored under.
     :param string version: The version number of the binary to select.
-    :param string name: The name of the binary to fetch.
-    :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no binary of the given version
+    :param string name: The name of the file to fetch.
+    :param bool platform_dependent: Whether the file content differs depending
+      on the current platform.
+    :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no file of the given version
       and name could be found for the current platform.
     """
-    # TODO(John Sirois): finish doc of the path structure expected under base_path.
-    binary_path = self._select_binary_base_path(supportdir, version, name)
+    binary_path = self._binary_path_to_fetch(supportdir, version, name, platform_dependent)
     return self._fetch_binary(name=name, binary_path=binary_path)
 
-  def _select_script(self, supportdir, version, name):
-    """Selects a platform-independent script.
+  def _select_archive(self, supportdir, version, name, platform_dependent, archiver):
+    """Generates a path to fetch, fetches the archive file, and unpacks the archive.
 
-    :param string supportdir: The path the `name` scripts are stored under.
-    :param string version: The version number of the script to select.
-    :param string name: The name of the script to fetch.
-    :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no script of the given version
-      and name could be found.
+    :param string supportdir: The path the `name` binaries are stored under.
+    :param string version: The version number of the binary to select.
+    :param string name: The name of the file to fetch.
+    :param bool platform_dependent: Whether the file content differs depending
+      on the current platform.
+    :param archiver: The archiver object which provides the file extension and
+      unpacks the archive.
+    :type: :class:`pants.fs.archive.Archiver`
+    :raises: :class:`pants.binary_util.BinaryUtil.BinaryNotFound` if no file of the given version
+      and name could be found for the current platform.
     """
-    binary_path = os.path.join(supportdir, version, name)
-    return self._fetch_binary(name=name, binary_path=binary_path)
+    full_name = '{}.{}'.format(name, archiver.extension)
+    downloaded_file = self._select_file(supportdir, version, full_name, platform_dependent)
+    # use filename without extension as the directory name
+    unpacked_dirname, _ = os.path.splitext(downloaded_file)
+    archiver.extract(downloaded_file, unpacked_dirname)
+    return unpacked_dirname
+
+  def _binary_path_to_fetch(self, supportdir, version, name, platform_dependent):
+    if platform_dependent:
+      # TODO(John Sirois): finish doc of the path structure expected under base_path.
+      return self._select_binary_base_path(supportdir, version, name)
+    return os.path.join(supportdir, version, name)
+
+  def select_binary(self, supportdir, version, name):
+    return self._select_file(
+      supportdir, version, name=name, filename=name, platform_dependent=True)
+
+  def select_script(self, supportdir, version, name):
+    return self._select_file(
+      supportdir, version, name=name, filename=name, platform_dependent=False)
 
   @contextmanager
   def _select_binary_stream(self, name, binary_path, fetcher=None):
-    """Select a binary matching the current os and architecture.
+    """Select a binary located at a given path.
 
     :param string binary_path: The path to the binary to fetch.
     :param fetcher: Optional argument used only for testing, to 'pretend' to open urls.

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -182,11 +182,11 @@ class BinaryUtil(object):
 
   def select_binary(self, supportdir, version, name):
     return self._select_file(
-      supportdir, version, name=name, filename=name, platform_dependent=True)
+      supportdir, version, name, platform_dependent=True)
 
   def select_script(self, supportdir, version, name):
     return self._select_file(
-      supportdir, version, name=name, filename=name, platform_dependent=False)
+      supportdir, version, name, platform_dependent=False)
 
   @contextmanager
   def _select_binary_stream(self, name, binary_path, fetcher=None):

--- a/src/python/pants/fs/archive.py
+++ b/src/python/pants/fs/archive.py
@@ -55,6 +55,9 @@ class Archiver(AbstractClass):
     If prefix is specified, it should be prepended to all archive paths.
     """
 
+  def __init__(self, extension):
+    self.extension = extension
+
 
 class TarArchiver(Archiver):
   """An archiver that stores files in a tar file with optional compression.
@@ -71,7 +74,7 @@ class TarArchiver(Archiver):
     """
     :API: public
     """
-    super(TarArchiver, self).__init__()
+    super(TarArchiver, self).__init__(extension)
     self.mode = mode
     self.extension = extension
 
@@ -108,7 +111,7 @@ class ZipArchiver(Archiver):
     """
     :API: public
     """
-    super(ZipArchiver, self).__init__()
+    super(ZipArchiver, self).__init__(extension)
     self.compression = compression
     self.extension = extension
 

--- a/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/BUILD
@@ -2,20 +2,20 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-    name = "Y",
+    name = "X",
 )
 
 java_library(
     name = "A",
-    dependencies = [":Y"],
+    dependencies = [":X"],
 )
 
 java_library(
     name = "B",
-    dependencies = [":Y"],
+    dependencies = [":X"],
 )
 
 java_library(
     name = "C",
-    dependencies = [":Y"],
+    dependencies = [":X"],
 )

--- a/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/buildrefactor/BUILD
@@ -2,20 +2,20 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 java_library(
-    name = "X",
+    name = "Y",
 )
 
 java_library(
     name = "A",
-    dependencies = [":X"],
+    dependencies = [":Y"],
 )
 
 java_library(
     name = "B",
-    dependencies = [":X"],
+    dependencies = [":Y"],
 )
 
 java_library(
     name = "C",
-    dependencies = [":X"],
+    dependencies = [":Y"],
 )


### PR DESCRIPTION
### Problem/Solution

I'm working on providing a "native" (C/C++) compilation toolchain with BinaryUtil so that we can build `python_dist()` targets in a controlled environment, and so users don't have to provide all the elements of the toolchain on every machine they might want to run Pants on.

In #5443, @benjyw provided a very slick way to define subsystems which provide downloaded files using BinaryUtil. This PR iterates on that and uses it to define an example "LLVM" subsystem, which does not yet exist in BinaryUtil, but shows how simple it is to compose elements of the BinaryTool class.

### Result

It is now possible to compose supportdirs to easily make families of subsystems by overriding `support_dir_paths()`, as is done in `NativeTool` and `Script`, and which is consumed by the `Protoc` and `LLVM` subsystems.

It is also now possible to very easily provide a compressed archive using BinaryTool or BinaryUtil, for platform-dependent code or scripts, using the archivers defined in `fs/archive.py`, by specifying e.g. `archive_type = 'tgz'` in a subclass of BinaryTool. This makes it much easier to provide complex toolchains, such as a native code compilation toolchain.

I'm preparing another PR on top of this, which consumes the LLVM subsystem and plumbs it into `BuildLocalPythonDistributions` to compile native code specified in a `python_dist()` target.