### PR TITLE
fix python_dist() caching

### DIFF
--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -134,10 +134,10 @@ class PythonBinaryCreate(Task):
       # Handle locally-built python distribution dependencies.
       built_dists = self.context.products.get_data(BuildLocalPythonDistributions.PYTHON_DISTS)
       if built_dists:
-        req_tgts = inject_synthetic_dist_requirements(self.context.build_graph,
-                                                      built_dists,
-                                                      ':'.join(2 * [binary_tgt.invalidation_hash()]),
-                                                      binary_tgt) + req_tgts
+        synthetic_address = ':'.join(2 * [binary_tgt.invalidation_hash()])
+        locally_built_dist_libs = inject_synthetic_dist_requirements(
+          self.context.build_graph, built_dists, synthetic_address, binary_tgt.closure())
+        req_tgts = locally_built_dist_libs + req_tgts
 
       dump_requirements(builder, interpreter, req_tgts, self.context.log, binary_tgt.platforms)
 

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -65,10 +65,15 @@ class ResolveRequirementsTaskBase(Task):
             req_libs = inject_synthetic_dist_requirements(self.context.build_graph,
                                                           built_dists,
                                                           ':'.join(2 * [target_set_id])) + req_libs
-          self._build_requirements_pex(interpreter, safe_path, req_libs)
+          self._build_requirements_pex(interpreter, safe_path, req_libs, built_dists)
     return PEX(path, interpreter=interpreter)
 
-  def _build_requirements_pex(self, interpreter, path, req_libs):
+  def _build_requirements_pex(self, interpreter, path, req_libs, built_dists):
     builder = PEXBuilder(path=path, interpreter=interpreter, copy=True)
     dump_requirements(builder, interpreter, req_libs, self.context.log)
+
+    if built_dists:
+      for dist in built_dists:
+        builder.add_dist_location(dist)
+
     builder.freeze()

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -62,10 +62,13 @@ class ResolveRequirementsTaskBase(Task):
           # Handle locally-built python distribution dependencies.
           built_dists = self.context.products.get_data(BuildLocalPythonDistributions.PYTHON_DISTS)
           if built_dists:
-            req_libs = inject_synthetic_dist_requirements(self.context.build_graph,
-                                                          built_dists,
-                                                          ':'.join(2 * [target_set_id])) + req_libs
+            synthetic_address = ':'.join(2 * [target_set_id])
+            locally_built_dist_libs = inject_synthetic_dist_requirements(
+              self.context.build_graph, built_dists, synthetic_address)
+            req_libs = locally_built_dist_libs + req_libs
+
           self._build_requirements_pex(interpreter, safe_path, req_libs, built_dists)
+
     return PEX(path, interpreter=interpreter)
 
   def _build_requirements_pex(self, interpreter, path, req_libs, built_dists):


### PR DESCRIPTION
### Problem

`python_dist()` doesn't update the binary created when sources change. On master, you can run:

```
> ./pants run testprojects/src/python/python_distribution/fasthello_with_install_requires:main_with_no_conflict
...
Super hello
United States
...
```

Then, change either `super_greet.c` or `hello.py` to modify the output (I added an exclamation point to `"Super hello!"` in `super_greet.c`). Then run:

```
> ./pants run testprojects/src/python/python_distribution/fasthello_with_install_requires:main_with_no_conflict
...
Super hello
United States
...
```

The same output appears. **This also occurs after a `clean-all`** -- I'm not exactly sure why.

### Solution

Add the built dists to the pex builder in `ResolveRequirementsTaskBase#_build_requirements_pex()`. I haven't investigated enough into pex or python dists in pants enough to know exactly why this works yet.

### Result

Binaries built with `python_dist()` are now updated when source files change. I have added a `test_invalidation()` test to `test_python_distribution_integration.py`, but **I'm not sure whether this tests everything it should be**, as the change that fixes it isn't in binary creation, but in `resolve_requirements_task_base.py`. I would love if someone with more experience with the python backend could give me more insight on that (but will totally investigate myself before this is merged). I would also like to know why the original error would occur even after a clean-all, which seems indicative of some greater issue, but might be nothing.