### PR TITLE
add a dependency on the pants source to the integration test base target

### DIFF
--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -58,13 +58,11 @@ python_library(
     'src/python/pants/util:process_handler',
     'tests/python/pants_test/testutils:file_test_util',
     'tests/python/pants_test/testutils:pexrc_util',
-    # NB: Integration tests in the pants codebase find the pants script by absolute path, which
-    # escapes the chroot which tests are executed in, allowing them to use files they don't
-    # explicitly depend on. This dependency forces every test depending on this target to depend on
-    # ~all the pants source, so the result is invalidated when changing any relevant source files. If
-    # this is removed, the result of integration tests will be cached regardless of changes to
-    # source files that affect their behavior. This does not occur in CI due to the use of
-    # clean-all.
+    # NB: 'pants_run_integration_test.py' runs ./pants in a subprocess, so test results will depend
+    # on the pants binary and all of its transitive dependencies. Adding this dependency is our best
+    # proxy for ensuring that any test target depending on this target will be invalidated on
+    # changes to those undeclared dependencies. Note that this concern is not applicable in CI due
+    # to the use of clean-all.
     # There may be a better way to do this.
     'src/python/pants/bin:pants_local_binary',
   ]

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -5,7 +5,7 @@ python_library(
   name='test_infra',
   dependencies=[
     'tests/python/pants_test:base_test',
-    'tests/python/pants_test:int-test',
+    'tests/python/pants_test:int-test-for-export',
     'tests/python/pants_test/jvm:jar_task_test_base',
     'tests/python/pants_test/jvm:nailgun_task_test_base',
     'tests/python/pants_test/jvm:jvm_tool_task_test_base',
@@ -43,7 +43,7 @@ python_library(
 )
 
 python_library(
-  name = 'int-test',
+  name = 'int-test-for-export',
   sources = [
     'pants_run_integration_test.py'
   ],
@@ -58,6 +58,13 @@ python_library(
     'src/python/pants/util:process_handler',
     'tests/python/pants_test/testutils:file_test_util',
     'tests/python/pants_test/testutils:pexrc_util',
+  ]
+)
+
+target(
+  name = 'int-test',
+  dependencies=[
+    ':int-test-for-export',
     # NB: 'pants_run_integration_test.py' runs ./pants in a subprocess, so test results will depend
     # on the pants binary and all of its transitive dependencies. Adding this dependency is our best
     # proxy for ensuring that any test target depending on this target will be invalidated on
@@ -65,7 +72,7 @@ python_library(
     # to the use of clean-all.
     # There may be a better way to do this.
     'src/python/pants/bin:pants_local_binary',
-  ]
+  ],
 )
 
 python_tests(

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -58,6 +58,15 @@ python_library(
     'src/python/pants/util:process_handler',
     'tests/python/pants_test/testutils:file_test_util',
     'tests/python/pants_test/testutils:pexrc_util',
+    # NB: Integration tests in the pants codebase find the pants script by absolute path, which
+    # escapes the chroot which tests are executed in, allowing them to use files they don't
+    # explicitly depend on. This dependency forces every test depending on this target to depend on
+    # ~all the pants source, so the result is invalidated when changing any relevant source files. If
+    # this is removed, the result of integration tests will be cached regardless of changes to
+    # source files that affect their behavior. This does not occur in CI due to the use of
+    # clean-all.
+    # There may be a better way to do this.
+    'src/python/pants/bin:pants_local_binary',
   ]
 )
 

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -243,11 +243,6 @@ class PantsRunIntegrationTest(unittest.TestCase):
         ini.write(fp)
       args.append('--pants-config-files=' + ini_file_name)
 
-    # NB: This is an absolute path, and allows integration tests to escape the chroot, and make use
-    # of files they don't explicitly declare in their dependencies. There is a dependency on
-    # 'src/python/pants/bin:pants_local_binary' added to the target owning this file so that all
-    # tests subclassing this class are invalidated upon changes to the pants source.
-    # There may be a better way to do this.
     pants_script = os.path.join(build_root or get_buildroot(), self.PANTS_SCRIPT_NAME)
 
     # Permit usage of shell=True and string-based commands to allow e.g. `./pants | head`.

--- a/tests/python/pants_test/pants_run_integration_test.py
+++ b/tests/python/pants_test/pants_run_integration_test.py
@@ -243,6 +243,11 @@ class PantsRunIntegrationTest(unittest.TestCase):
         ini.write(fp)
       args.append('--pants-config-files=' + ini_file_name)
 
+    # NB: This is an absolute path, and allows integration tests to escape the chroot, and make use
+    # of files they don't explicitly declare in their dependencies. There is a dependency on
+    # 'src/python/pants/bin:pants_local_binary' added to the target owning this file so that all
+    # tests subclassing this class are invalidated upon changes to the pants source.
+    # There may be a better way to do this.
     pants_script = os.path.join(build_root or get_buildroot(), self.PANTS_SCRIPT_NAME)
 
     # Permit usage of shell=True and string-based commands to allow e.g. `./pants | head`.


### PR DESCRIPTION
### Problem

Integration test results are cached regardless of changes to source files governing their behavior.

### Solution

Add a dependency on `src/python/pants/bin:pants_local_binary` to `tests/python/pants_test:int-test`, and some explanatory comments.

### Result

Integration tests now depend on all relevant source files, and the results are invalidated whenever one is changed. This is obviously far too coarse, but it seems infeasible to do anything more refined without a lot of unnecessarily complex code.