### PR TITLE
Don't special-case python dists in resolve_requirements().

### DIFF
--- a/src/python/pants/backend/python/tasks/resolve_requirements.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-from pants.backend.python.tasks.pex_build_util import has_python_requirements, is_local_python_dist
+from pants.backend.python.tasks.pex_build_util import has_python_requirements
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
 
 
@@ -18,8 +18,5 @@ class ResolveRequirements(ResolveRequirementsTaskBase):
     return [cls.REQUIREMENTS_PEX]
 
   def execute(self):
-    req_libs = self.context.targets(has_python_requirements)
-    dist_tgts = self.context.targets(is_local_python_dist)
-    if req_libs or dist_tgts:
-      pex = self.resolve_requirements(req_libs, dist_tgts)
-      self.context.products.register_data(self.REQUIREMENTS_PEX, pex)
+    pex = self.resolve_requirements(self.context.targets(has_python_requirements))
+    self.context.products.register_data(self.REQUIREMENTS_PEX, pex)

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -39,8 +39,7 @@ class ResolveRequirementsTaskBase(Task):
     :param req_libs: A list of :class:`PythonRequirementLibrary` targets to resolve.
     :returns: a PEX containing target requirements and any specified python dist targets.
     """
-    tgts = req_libs
-    with self.invalidated(tgts) as invalidation_check:
+    with self.invalidated(req_libs) as invalidation_check:
       # If there are no relevant targets, we still go through the motions of resolving
       # an empty set of requirements, to prevent downstream tasks from having to check
       # for this special case.

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -33,16 +33,13 @@ class ResolveRequirementsTaskBase(Task):
     round_manager.require_data(PythonInterpreter)
     round_manager.optional_product(PythonRequirementLibrary)  # For local dists.
 
-  def resolve_requirements(self, req_libs, local_dist_targets=None):
+  def resolve_requirements(self, req_libs):
     """Requirements resolution for PEX files.
 
     :param req_libs: A list of :class:`PythonRequirementLibrary` targets to resolve.
-    :param local_dist_targets: A list of :class:`PythonDistribution` targets to resolve.
     :returns: a PEX containing target requirements and any specified python dist targets.
     """
     tgts = req_libs
-    if local_dist_targets:
-      tgts = req_libs + local_dist_targets
     with self.invalidated(tgts) as invalidation_check:
       # If there are no relevant targets, we still go through the motions of resolving
       # an empty set of requirements, to prevent downstream tasks from having to check

--- a/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
+++ b/tests/python/pants_test/backend/python/tasks/test_resolve_requirements.py
@@ -26,11 +26,6 @@ class ResolveRequirementsTest(TaskTestBase):
   def task_type(cls):
     return ResolveRequirements
 
-  def test_resolve_no_targets(self):
-    empty_tgt = self.make_target(spec=':empty')
-    pex = self._resolve_requirements([empty_tgt])
-    self.assertTrue(pex is None)
-
   def test_resolve_simple_requirements(self):
     noreqs_tgt = self._fake_target('noreqs', [])
     ansicolors_tgt = self._fake_target('ansicolors', ['ansicolors==1.0.2'])


### PR DESCRIPTION
Since we now synthesize PythonRequirementLibrary targets for
each local dist, there's no need to handle them specially.

Also, ensure we create the required product even on an empty
set of requirements, so downstream code doesn't have to 
check for this case.