### PR TITLE
remove support dir overrides

### DIFF
--- a/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer_binary.py
+++ b/contrib/buildrefactor/src/python/pants/contrib/buildrefactor/buildozer_binary.py
@@ -24,11 +24,6 @@ class BuildozerBinary(NativeTool):
   replaces_scope = 'buildozer'
   replaces_name = 'version'
 
-  # TODO: Move this to bin/buildozer - buildozer is a native binary.
-  @classmethod
-  def get_support_dir(cls):
-    return 'scripts/buildozer'
-
   def execute(self, buildozer_command, spec, context=None):
     try:
       subprocess.check_call([self.select(context), buildozer_command, spec], cwd=get_buildroot())

--- a/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
+++ b/src/python/pants/backend/codegen/protobuf/subsystem/protoc.py
@@ -14,8 +14,3 @@ class Protoc(NativeTool):
 
   replaces_scope = 'gen.protoc'
   replaces_name = 'version'
-
-  # 'protoc' is also the binary's filename.
-  @classmethod
-  def get_support_dir(cls):
-    return 'bin/protobuf'


### PR DESCRIPTION
### Problem/Solution

@benjyw and I left in some manual `get_support_dir()` overrides for the buildozer and protoc subsystems subclassing `BinaryTool` in #5471. The paths have since been copied over in s3 so that these overrides can be removed.

### Result

`./pants test contrib/buildrefactor/tests/python/pants_test/contrib/buildrefactor:: tests/python/pants_test/backend/codegen/protobuf/java::` succeeded locally.