### PR TITLE
Snapshot is backed by LMDB not tar files

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -52,7 +52,7 @@ class PathGlobs(datatype('PathGlobs', ['include', 'exclude'])):
                      tuple(join(relative_to, f) for f in exclude))
 
 
-class Snapshot(datatype('Snapshot', ['fingerprint', 'path_stats'])):
+class Snapshot(datatype('Snapshot', ['fingerprint', 'digest_length', 'path_stats'])):
   """A Snapshot is a collection of Files and Dirs fingerprinted by their names/content.
 
   Snapshots are used to make it easier to isolate process execution by fixing the contents
@@ -77,7 +77,7 @@ class Snapshot(datatype('Snapshot', ['fingerprint', 'path_stats'])):
     return [p.stat for p in self.files]
 
   def __repr__(self):
-    return '''Snapshot(fingerprint='{}', entries={})'''.format(hexlify(self.fingerprint)[:8], len(self.path_stats))
+    return '''Snapshot(fingerprint='{}', digest_length='{}', entries={})'''.format(hexlify(self.fingerprint)[:8], self.digest_length, len(self.path_stats))
 
   def __str__(self):
     return repr(self)

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -201,10 +201,10 @@ class ExecuteProcess(object):
     return TaskRule(product_type, inputs, func)
 
 
-class ExecuteProcessRequest(datatype('ExecuteProcessRequest', ['argv', 'env'])):
+class ExecuteProcessRequest(datatype('ExecuteProcessRequest', ['argv', 'env', 'input_files_digest', 'digest_length'])):
   """Request for execution with args and snapshots to extract."""
 
-  def __new__(cls, argv, env):
+  def __new__(cls, argv, env, input_files_digest, digest_length):
     """
 
     :param args: Arguments to the process being run.
@@ -212,7 +212,7 @@ class ExecuteProcessRequest(datatype('ExecuteProcessRequest', ['argv', 'env'])):
     """
     if not isinstance(argv, tuple):
       raise ValueError('argv must be a tuple.')
-    return super(ExecuteProcessRequest, cls).__new__(cls, argv, tuple(env))
+    return super(ExecuteProcessRequest, cls).__new__(cls, argv, tuple(env), input_files_digest, digest_length)
 
 
 class ExecuteProcessResult(datatype('ExecuteProcessResult', ['stdout', 'stderr', 'exit_code'])):

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -14,8 +14,8 @@ import six
 
 from pants.base.build_environment import get_buildroot
 from pants.base.hash_utils import stable_json_hash
-from pants.option.custom_types import (UnsetBool, dict_with_files_option, dir_option,
-                                       file_option, target_option)
+from pants.option.custom_types import (UnsetBool, dict_with_files_option, dir_option, file_option,
+                                       target_option)
 
 
 class Encoder(json.JSONEncoder):

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -101,6 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "engine"
 version = "0.0.1"
 dependencies = [
+ "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -118,16 +119,6 @@ dependencies = [
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "filetime"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "fixedbitset"
@@ -161,7 +152,6 @@ dependencies = [
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -397,9 +387,12 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -418,11 +411,6 @@ dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
@@ -459,17 +447,6 @@ dependencies = [
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -544,14 +521,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
-[[package]]
-name = "xattr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
@@ -567,7 +536,6 @@ dependencies = [
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "aa75ec8f7927063335a9583e7fa87b0110bb888cf766dc01b54c0ff70d760c8e"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -600,12 +568,10 @@ dependencies = [
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bec26e67194b7d991908145fdf21b7cae8b08423d96dcb9e860cd31f854b9506"
 "checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
-"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
-"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
@@ -617,4 +583,3 @@ dependencies = [
 "checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
 "checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
 "checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
-"checksum xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5f04de8a1346489a2f9e9bd8526b73d135ec554227b17568456e86aa35b6f3fc"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -21,6 +21,7 @@ cc = "1.0"
 # [workspace]
 
 [dependencies]
+bazel_protos = { path = "process_execution/bazel_protos" }
 boxfuture = { path = "boxfuture" }
 fnv = "1.0.5"
 fs = { path = "fs" }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -22,7 +22,6 @@ lmdb = "0.7.2"
 ordermap = "0.2.8"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"
-tar = "0.4.13"
 tempdir = "0.3.5"
 
 [dev-dependencies]

--- a/src/rust/engine/fs/fs_util/Cargo.lock
+++ b/src/rust/engine/fs/fs_util/Cargo.lock
@@ -16,9 +16,9 @@ name = "atty"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -26,7 +26,7 @@ name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -54,7 +54,7 @@ dependencies = [
 name = "boxfuture"
 version = "0.0.1"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -73,12 +73,12 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -88,13 +88,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.29.0"
+version = "2.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -105,7 +105,7 @@ name = "cmake"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,16 +132,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "filetime"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,21 +145,20 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -179,9 +168,9 @@ dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -202,7 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -210,7 +199,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -242,7 +231,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -250,9 +239,9 @@ name = "grpcio"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -262,9 +251,9 @@ name = "grpcio-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -293,27 +282,36 @@ dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "same-file 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "iovec"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -328,7 +326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -337,7 +335,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -347,7 +345,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -372,7 +370,7 @@ name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -385,7 +383,7 @@ name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -408,11 +406,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.20"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -430,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -446,11 +445,20 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "same-file"
-version = "1.0.1"
+name = "remove_dir_all"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -467,26 +475,16 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "tar"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "tempdir"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -494,7 +492,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -551,10 +549,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walkdir"
-version = "2.0.1"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "same-file 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -564,30 +563,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi-i686-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "xattr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
@@ -599,19 +595,18 @@ dependencies = [
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
-"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
+"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
+"checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
 "checksum cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "56d741ea7a69e577f6d06b36b7dff4738f680593dc27a701ffa8506b73ce28bb"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
+"checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
@@ -621,11 +616,12 @@ dependencies = [
 "checksum grpcio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8253f10312996bfa7ad164f05ec89d9d5c0d7277c36846379aea7c91daac412a"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
 "checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"
-"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
-"checksum itertools 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a3f195c9c60b8d747d73357694c3ebcaeb229ea574bd92999260954f851d59c2"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b07332223953b5051bceb67e8c4700aa65291535568e1f12408c43c4a42c0394"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)" = "96264e9b293e95d25bfcbbf8a88ffd1aedc85b754eba8b7d78012f638ba220eb"
+"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
 "checksum lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "44ac7bf1552c1386b70e77ff9d801971f19641bf2dc08b981cd2397bf812c65d"
 "checksum lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3db58e1767416fc1e9e3265635d3bb7bf3677a0dc8d4e8d6ee14850ec5c11ae9"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
@@ -636,16 +632,16 @@ dependencies = [
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bec26e67194b7d991908145fdf21b7cae8b08423d96dcb9e860cd31f854b9506"
-"checksum rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "512870020642bb8c221bf68baa1b2573da814f6ccfe5c9699b1c303047abe9b1"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "744554e01ccbd98fff8c457c3b092cd67af62a555a43bfe97ae8a0451f7799fa"
+"checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum same-file 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3257af0472da4b8b8902102a57bafffd9991f0f43772a8af6153d597e6e4ae2"
+"checksum remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5"
+"checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
-"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
-"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
@@ -655,9 +651,9 @@ dependencies = [
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum walkdir 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40b6d201f4f8998a837196b6de9c73e35af14c992cbb92c4ab641d2c2dce52de"
+"checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
-"checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
-"checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
-"checksum xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5f04de8a1346489a2f9e9bd8526b73d135ec554227b17568456e86aa35b6f3fc"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -181,7 +181,7 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
         e
       )
     })?;
-    (Arc::new(store), store_has_remote)
+    (store, store_has_remote)
   };
 
   match top_match.subcommand() {
@@ -292,7 +292,7 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
                 paths,
               )
             })
-            .map(|snapshot| snapshot.digest.unwrap())
+            .map(|snapshot| snapshot.digest)
             .wait()?;
           if store_has_remote {
             store.ensure_remote_has_recursive(vec![digest]).wait()?;
@@ -382,7 +382,7 @@ fn make_posix_fs<P: AsRef<Path>>(root: P, pool: Arc<ResettablePool>) -> fs::Posi
 
 #[derive(Clone)]
 struct FileSaver {
-  store: Arc<Store>,
+  store: Store,
   posix_fs: Arc<fs::PosixFS>,
 }
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 mod snapshot;
-pub use snapshot::{Snapshot, StoreFileByDigest};
+pub use snapshot::{EMPTY_DIGEST, Snapshot, StoreFileByDigest};
 mod store;
 pub use store::Store;
 mod pool;
@@ -29,25 +29,21 @@ extern crate mock;
 extern crate ordermap;
 extern crate protobuf;
 extern crate sha2;
-extern crate tar;
 extern crate tempdir;
 
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{fmt, fs};
 use std::io::{self, Read};
 use std::cmp::min;
 
 use bytes::Bytes;
 use futures::future::{self, Future};
-use futures_cpupool::CpuFuture;
 use glob::Pattern;
-use hashing::{Fingerprint, WriterHasher};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ordermap::OrderMap;
-use tempdir::TempDir;
 
 use boxfuture::{Boxable, BoxFuture};
 
@@ -829,242 +825,6 @@ fn safe_create_dir_all(path: &Path) -> Result<(), String> {
   })
 }
 
-fn safe_create_tmpdir_in(base_dir: &Path, prefix: &str) -> Result<TempDir, String> {
-  safe_create_dir_all(&base_dir)?;
-  Ok(TempDir::new_in(&base_dir, prefix).map_err(|e| {
-    format!("Failed to create tempdir {:?} due to {:?}", base_dir, e)
-  })?)
-}
-
-///
-/// A facade for the snapshot directory, which lives under the pants workdir.
-///
-pub struct Snapshots {
-  snapshots_dir: PathBuf,
-  snapshots_generator: Mutex<(TempDir, usize)>,
-}
-
-impl Snapshots {
-  pub fn new(snapshots_dir: PathBuf) -> Result<Snapshots, String> {
-    let snapshots_tmpdir = safe_create_tmpdir_in(&snapshots_dir, ".tmp")?;
-
-    Ok(Snapshots {
-      snapshots_dir: snapshots_dir,
-      snapshots_generator: Mutex::new((snapshots_tmpdir, 0)),
-    })
-  }
-
-  pub fn snapshot_path(&self) -> &Path {
-    self.snapshots_dir.as_path()
-  }
-
-  fn next_temp_path(&self) -> Result<PathBuf, String> {
-    let mut gen = self.snapshots_generator.lock().unwrap();
-    gen.1 += 1;
-
-    // N.B. Sometimes, in e.g. a `./pants clean-all test ...` the snapshot tempdir created at the
-    // beginning of a run can be removed out from under us by e.g. the `clean-all` task. Here, we
-    // we double check existence of the `TempDir`'s path when the path is accessed and replace if
-    // necessary.
-    if !gen.0.path().exists() {
-      gen.0 = safe_create_tmpdir_in(&self.snapshots_dir, ".tmp")?;
-    }
-
-    Ok(gen.0.path().join(format!("{}.tmp", gen.1)))
-  }
-
-  ///
-  /// A non-canonical (does not expand symlinks) in-memory form of normalize. Used to collapse
-  /// parent and cur components, which are legal in symbolic paths in PathStats, but not in
-  /// Tar files.
-  ///
-  fn normalize(path: &Path) -> Result<PathBuf, String> {
-    let mut res = PathBuf::new();
-    for component in path.components() {
-      match component {
-        Component::Prefix(..) |
-        Component::RootDir => return Err(format!("Absolute paths not supported: {:?}", path)),
-        Component::CurDir => continue,
-        Component::ParentDir => {
-          // Pop the previous component.
-          if !res.pop() {
-            return Err(format!(
-              "Globs may not traverse outside the root: {:?}",
-              path
-            ));
-          } else {
-            continue;
-          }
-        }
-        Component::Normal(p) => res.push(p),
-      }
-    }
-    Ok(res)
-  }
-
-  ///
-  /// Create a tar file on the given Write instance containing the given paths, or
-  /// return an error string.
-  ///
-  fn tar_create<W: io::Write>(
-    dest: W,
-    paths: &Vec<PathStat>,
-    relative_to: &Dir,
-  ) -> Result<W, String> {
-    let mut tar_builder = tar::Builder::new(dest);
-    tar_builder.mode(tar::HeaderMode::Deterministic);
-    for path_stat in paths {
-      // Append the PathStat using the symbolic name and underlying stat.
-      let append_res = match path_stat {
-        &PathStat::File { ref path, ref stat } => {
-          let normalized = Snapshots::normalize(path)?;
-          let mut input = fs::File::open(relative_to.0.join(stat.path.as_path()))
-            .map_err(|e| format!("Failed to open {:?}: {:?}", path_stat, e))?;
-          tar_builder.append_file(normalized, &mut input)
-        }
-        &PathStat::Dir { ref path, ref stat } => {
-          let normalized = Snapshots::normalize(path)?;
-          tar_builder.append_dir(normalized, relative_to.0.join(stat.0.as_path()))
-        }
-      };
-      append_res.map_err(|e| {
-        format!("Failed to tar {:?}: {:?}", path_stat, e)
-      })?;
-    }
-
-    // Finish the tar file, returning ownership of the stream to the caller.
-    Ok(tar_builder.into_inner().map_err(|e| {
-      format!("Failed to finalize snapshot tar: {:?}", e)
-    })?)
-  }
-
-  ///
-  /// Create a tar file at the given dest Path containing the given paths, while
-  /// fingerprinting the written stream.
-  ///
-  fn tar_create_fingerprinted(
-    dest: &Path,
-    paths: &Vec<PathStat>,
-    relative_to: &Dir,
-  ) -> Result<Fingerprint, String> {
-    // Wrap buffering around a fingerprinted stream above a File.
-    let stream = io::BufWriter::new(WriterHasher::new(fs::File::create(dest).map_err(|e| {
-      format!("Failed to create destination file: {:?}", e)
-    })?));
-
-    // Then append the tar to the stream, and retrieve the Fingerprint to flush all writers.
-    Ok(
-      Snapshots::tar_create(stream, paths, relative_to)?
-        .into_inner()
-        .map_err(|e| {
-          format!("Failed to flush to {:?}: {:?}", dest, e.error())
-        })?
-        .finish(),
-    )
-  }
-
-  ///
-  /// Attempts to rename src to dst, and _succeeds_ if dst already exists. This is safe in
-  /// the case of Snapshots because the destination path is unique to its content.
-  ///
-  fn finalize(temp_path: &Path, dest_path: &Path) -> Result<(), String> {
-    if dest_path.is_file() {
-      // The Snapshot has already been created.
-      fs::remove_file(temp_path).unwrap_or(());
-      Ok(())
-    } else {
-      let dest_dir = dest_path.parent().expect(
-        "All snapshot paths must have parent directories.",
-      );
-      safe_create_dir_all(dest_dir)?;
-      match fs::rename(temp_path, dest_path) {
-        Ok(_) => Ok(()),
-        Err(_) if dest_path.is_file() => Ok(()),
-        Err(e) => Err(format!(
-          "Failed to finalize snapshot at {:?}: {:?}",
-          dest_path,
-          e
-        )),
-      }
-    }
-  }
-
-  fn path_for(&self, fingerprint: &Fingerprint) -> PathBuf {
-    Snapshots::path_under_for(self.snapshot_path(), fingerprint)
-  }
-
-  fn path_under_for(path: &Path, fingerprint: &Fingerprint) -> PathBuf {
-    let hex = fingerprint.to_hex();
-    path.join(&hex[0..2]).join(&hex[2..4]).join(
-      format!("{}.tar", hex),
-    )
-  }
-
-  ///
-  /// Creates a Snapshot for the given paths under the given VFS.
-  ///
-  pub fn create(&self, fs: &PosixFS, paths: Vec<PathStat>) -> CpuFuture<Snapshot, String> {
-    let dest_dir = self.snapshot_path().to_owned();
-    let root = fs.root.clone();
-    let temp_path = self.next_temp_path().expect(
-      "Couldn't get the next temp path.",
-    );
-
-    fs.pool.spawn_fn(move || {
-      // Write the tar deterministically to a temporary file while fingerprinting.
-      let fingerprint = Snapshots::tar_create_fingerprinted(temp_path.as_path(), &paths, &root)?;
-
-      // Rename to the final path if it does not already exist.
-      Snapshots::finalize(
-        temp_path.as_path(),
-        Snapshots::path_under_for(&dest_dir, &fingerprint).as_path(),
-      )?;
-
-      Ok(Snapshot {
-        fingerprint: fingerprint,
-        digest: None,
-        path_stats: paths,
-      })
-    })
-  }
-
-  fn contents_for_sync(snapshot: Snapshot, path: PathBuf) -> Result<Vec<FileContent>, io::Error> {
-    let mut archive = fs::File::open(path).map(|f| tar::Archive::new(f))?;
-
-    // Zip the in-memory Snapshot to the on disk representation, validating as we go.
-    let mut files_content = Vec::new();
-    for (entry_res, path_stat) in archive.entries()?.zip(snapshot.path_stats.into_iter()) {
-      let mut entry = entry_res?;
-      if entry.header().entry_type() == tar::EntryType::file() {
-        let path = match path_stat {
-          PathStat::File { path, .. } => path,
-          PathStat::Dir { .. } => panic!("Snapshot contents changed after storage."),
-        };
-        let mut content = Vec::new();
-        io::Read::read_to_end(&mut entry, &mut content)?;
-        files_content.push(FileContent {
-          path: path,
-          content: Bytes::from(content),
-        });
-      }
-    }
-    Ok(files_content)
-  }
-
-  pub fn contents_for(
-    &self,
-    fs: &PosixFS,
-    snapshot: Snapshot,
-  ) -> CpuFuture<Vec<FileContent>, String> {
-    let archive_path = self.path_for(&snapshot.fingerprint);
-    fs.pool.spawn_fn(move || {
-      let snapshot_str = format!("{:?}", snapshot);
-      Snapshots::contents_for_sync(snapshot, archive_path).map_err(|e| {
-        format!("Failed to open Snapshot {}: {:?}", snapshot_str, e)
-      })
-    })
-  }
-}
 
 #[cfg(test)]
 mod posixfs_test {

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -437,8 +437,8 @@ mod local {
   use bytes::Bytes;
   use digest::{Digest as DigestTrait, FixedOutput};
   use hashing::{Digest, Fingerprint};
-  use lmdb::{self, Cursor, Database, DatabaseFlags, Environment, NO_OVERWRITE, RwTransaction,
-             Transaction, WriteFlags};
+  use lmdb::{self, Cursor, Database, DatabaseFlags, Environment, NO_OVERWRITE, NO_TLS,
+             RwTransaction, Transaction, WriteFlags};
   use lmdb::Error::{KeyExist, MapFull, NotFound};
   use sha2::Sha256;
   use std::collections::BinaryHeap;
@@ -467,8 +467,20 @@ mod local {
 
   impl ByteStore {
     pub fn new<P: AsRef<Path>>(path: P, pool: Arc<ResettablePool>) -> Result<ByteStore, String> {
-      // 3 DBs; one for file contents, one for directories, one for leases.
       let env = Environment::new()
+        // Without this flag, each time a read transaction is started, it eats into our transaction
+        // limit (default: 126) until that thread dies.
+        //
+        // This flag makes transactions are removed from that limit when they are dropped, rather
+        // than when their thread dies. This is important, because we perform reads from a thread
+        // pool, so our threads never die. Without this flag, all read requests will fail after the
+        // first 126.
+        //
+        // The only down-side is that you need to make sure that any individual OS thread must not
+        // try to perform multiple write transactions concurrently. Fortunately, this property
+        // holds for us.
+        .set_flags(NO_TLS)
+          // 3 DBs; one for file contents, one for directories, one for leases.
         .set_max_dbs(3)
         .set_map_size(MAX_LOCAL_STORE_SIZE_BYTES)
         .open(path.as_ref())

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -471,7 +471,7 @@ mod local {
         // Without this flag, each time a read transaction is started, it eats into our transaction
         // limit (default: 126) until that thread dies.
         //
-        // This flag makes transactions are removed from that limit when they are dropped, rather
+        // This flag makes transactions be removed from that limit when they are dropped, rather
         // than when their thread dies. This is important, because we perform reads from a thread
         // pool, so our threads never die. Without this flag, all read requests will fail after the
         // first 126.

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -6,9 +6,12 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 [dependencies]
 bazel_protos = { path = "bazel_protos" }
 digest = "0.6.2"
+fs = { path = "../fs" }
 grpcio = { version = "0.2.0", features = ["secure"] }
+hashing = { path = "../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"
+tempdir = "0.3.5"
 
 [dev-dependencies]
 bytes = "0.4.5"

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -2,7 +2,9 @@ extern crate bazel_protos;
 #[cfg(test)]
 extern crate bytes;
 extern crate digest;
+extern crate fs;
 extern crate grpcio;
+extern crate hashing;
 #[cfg(test)]
 extern crate mock;
 extern crate protobuf;
@@ -36,6 +38,8 @@ pub struct ExecuteProcessRequest {
   /// No other environment variables will be set (except possibly for an empty PATH variable).
   ///
   pub env: BTreeMap<String, String>,
+
+  pub input_files: hashing::Digest,
 }
 
 ///

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -1,3 +1,5 @@
+extern crate tempdir;
+
 use std::io::Error;
 use std::path::Path;
 use std::process::Command;
@@ -11,7 +13,6 @@ pub fn run_command_locally(
   req: ExecuteProcessRequest,
   workdir: &Path,
 ) -> Result<ExecuteProcessResult, Error> {
-  println!("executing in workdir: {:?}", &workdir);
   Command::new(&req.argv[0])
     .args(&req.argv[1..])
     .current_dir(workdir)
@@ -34,6 +35,7 @@ mod tests {
   extern crate testutil;
 
   use super::{ExecuteProcessRequest, ExecuteProcessResult, run_command_locally};
+  use fs;
   use std::collections::BTreeMap;
   use std::path::PathBuf;
   use self::testutil::{owned_string_vec, as_byte_owned_vec};
@@ -45,6 +47,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
         env: BTreeMap::new(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     );
@@ -68,6 +71,7 @@ mod tests {
           &["/bin/bash", "-c", "echo -n foo ; echo >&2 -n bar ; exit 1"],
         ),
         env: BTreeMap::new(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     );
@@ -93,6 +97,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["/usr/bin/env"]),
         env: env.clone(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     );
@@ -125,6 +130,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["/usr/bin/env"]),
         env: env,
+        input_files: fs::EMPTY_DIGEST,
       }
     }
 
@@ -140,6 +146,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["echo", "-n", "foo"]),
         env: BTreeMap::new(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     ).expect_err("Want Err");

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -157,6 +157,7 @@ fn digest(message: &protobuf::Message) -> Result<bazel_protos::remote_execution:
 mod tests {
   use bazel_protos;
   use bytes::Bytes;
+  use fs;
   use protobuf::{self, Message, ProtobufEnum};
   use mock;
   use testutil::{owned_string_vec, as_byte_owned_vec};
@@ -176,6 +177,7 @@ mod tests {
           super::make_execute_request(&ExecuteProcessRequest {
             argv: owned_string_vec(&["/bin/echo", "-n", "bar"]),
             env: BTreeMap::new(),
+            input_files: fs::EMPTY_DIGEST,
           }).unwrap(),
           vec![],
         ).unwrap(),
@@ -469,6 +471,7 @@ mod tests {
     ExecuteProcessRequest {
       argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
       env: BTreeMap::new(),
+      input_files: fs::EMPTY_DIGEST,
     }
   }
 

--- a/src/rust/engine/process_executor/Cargo.lock
+++ b/src/rust/engine/process_executor/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8,9 +16,9 @@ name = "atty"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -18,10 +26,15 @@ name = "bazel_protos"
 version = "0.0.1"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -35,6 +48,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "boxfuture"
+version = "0.0.1"
+dependencies = [
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -53,12 +73,12 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -68,13 +88,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.29.0"
+version = "2.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,8 +105,13 @@ name = "cmake"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "crossbeam"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "digest"
@@ -97,13 +122,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fs"
+version = "0.0.1"
+dependencies = [
+ "bazel_protos 0.0.1",
+ "boxfuture 0.0.1",
+ "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
+ "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures"
-version = "0.1.17"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-cpupool"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -116,13 +204,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "globset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "grpcio"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -132,25 +237,103 @@ name = "grpcio-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.1"
+name = "hashing"
+version = "0.0.1"
+dependencies = [
+ "bazel_protos 0.0.1",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ignore"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.35"
+name = "itertools"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lmdb"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lmdb-sys"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "log"
@@ -169,8 +352,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num_cpus"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ordermap"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -184,16 +388,20 @@ version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
  "grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "process_executor"
 version = "0.0.1"
 dependencies = [
- "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
  "process_execution 0.0.1",
 ]
 
@@ -203,6 +411,16 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -219,6 +437,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,15 +484,24 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tempdir"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -254,6 +515,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,9 +534,36 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -275,58 +572,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi-i686-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
-"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
+"checksum cc 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "deaf9ec656256bb25b404c51ef50097207b9cbb29c933d31f92cae5a8a0ffee0"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "110d43e343eb29f4f51c1db31beb879d546db27998577e5715270a54bcf41d3f"
+"checksum clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c07b9257a00f3fc93b7f3c417fc15607ec7a56823bc2c37ec744e266387de5b"
 "checksum cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "56d741ea7a69e577f6d06b36b7dff4738f680593dc27a701ffa8506b73ce28bb"
+"checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
+"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
+"checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "464627f948c3190ae3d04b1bc6d7dca2f785bda0ac01278e6db129ad383dbeb6"
 "checksum grpcio 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "473a8a5620d6a58a17f236588c8e5bfb05f4a55a7c406e100a5afe888a923536"
 "checksum grpcio-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8253f10312996bfa7ad164f05ec89d9d5c0d7277c36846379aea7c91daac412a"
-"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
-"checksum libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)" = "96264e9b293e95d25bfcbbf8a88ffd1aedc85b754eba8b7d78012f638ba220eb"
+"checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
+"checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b07332223953b5051bceb67e8c4700aa65291535568e1f12408c43c4a42c0394"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "1e5d97d6708edaa407429faa671b942dc0f2727222fb6b6539bf1db936e4b121"
+"checksum lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "44ac7bf1552c1386b70e77ff9d801971f19641bf2dc08b981cd2397bf812c65d"
+"checksum lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3db58e1767416fc1e9e3265635d3bb7bf3677a0dc8d4e8d6ee14850ec5c11ae9"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bec26e67194b7d991908145fdf21b7cae8b08423d96dcb9e860cd31f854b9506"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5be5347bde0c48cfd8c3fdc0766cdfe9d8a755ef84d620d6794c778c91de8b2b"
+"checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
+"checksum remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5d2f806b0fcdabd98acd380dc8daef485e22bcb7cddc811d1337967f2528cf5"
+"checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b09fb3b6f248ea4cd42c9a65113a847d612e17505d6ebd1f7357ad68a8bf8693"
-"checksum winapi-i686-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ec6667f60c23eca65c561e63a13d81b44234c2e38a6b6c959025ee907ec614cc"
-"checksum winapi-x86_64-pc-windows-gnu 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98f12c52b2630cd05d2c3ffd8e008f7f48252c042b4871c72aed9dc733b96668"
+"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -5,4 +5,5 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
 clap = "2"
-process_execution = {path = "../process_execution"}
+fs = { path = "../fs" }
+process_execution = { path = "../process_execution" }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -1,8 +1,10 @@
 extern crate clap;
+extern crate fs;
 extern crate process_execution;
 
 use clap::{App, AppSettings, Arg};
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::process::exit;
 
 use std::iter::Iterator;
@@ -60,7 +62,13 @@ If unspecified, local execution will be performed.",
   };
   let server = args.value_of("server");
 
-  let request = process_execution::ExecuteProcessRequest { argv, env };
+  // TODO: Capture the working directory as a snapshot, and materialize it to a temporary directory.
+  let input_files = fs::EMPTY_DIGEST;
+  let request = process_execution::ExecuteProcessRequest {
+    argv,
+    env,
+    input_files,
+  };
   let result = match server {
     Some(addr) => {
       process_execution::remote::CommandRunner::new(addr, 1)

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -2,16 +2,17 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std;
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use core::TypeId;
+use boxfuture::BoxFuture;
+use core::{Failure, TypeId};
 use externs;
-use fs::{PosixFS, Snapshots, Store, safe_create_dir_all_ioerror, ResettablePool};
+use fs::{File, PosixFS, Store, safe_create_dir_all_ioerror, ResettablePool, StoreFileByDigest};
 use graph::{EntryId, Graph};
 use handles::maybe_drain_handles;
-use nodes::{Node, NodeFuture};
+use hashing::Digest;
+use nodes::{DigestFile, Node, NodeFuture};
 use rule_graph::RuleGraph;
 use tasks::Tasks;
 use types::Types;
@@ -26,7 +27,6 @@ pub struct Core {
   pub rule_graph: RuleGraph,
   pub types: Types,
   pub pool: Arc<ResettablePool>,
-  pub snapshots: Snapshots,
   pub store: Store,
   pub vfs: PosixFS,
 }
@@ -34,7 +34,7 @@ pub struct Core {
 impl Core {
   pub fn new(
     root_subject_types: Vec<TypeId>,
-    mut tasks: Tasks,
+    tasks: Tasks,
     types: Types,
     build_root: &Path,
     ignore_patterns: Vec<String>,
@@ -59,20 +59,6 @@ impl Core {
       },
     );
 
-    // TODO: Create the Snapshots directory, and then expose it as a singleton to python.
-    //   see: https://github.com/pantsbuild/pants/issues/4397
-    let snapshots = Snapshots::new(snapshots_dir).unwrap_or_else(|e| {
-      panic!("Could not initialize Snapshot directory: {:?}", e);
-    });
-    tasks.singleton_replace(
-      externs::unsafe_call(
-        &types.construct_snapshots,
-        &vec![
-          externs::store_bytes(snapshots.snapshot_path().as_os_str().as_bytes()),
-        ],
-      ),
-      types.snapshots.clone(),
-    );
     let rule_graph = RuleGraph::new(&tasks, root_subject_types);
 
     Core {
@@ -81,7 +67,6 @@ impl Core {
       rule_graph: rule_graph,
       types: types,
       pool: pool.clone(),
-      snapshots: snapshots,
       store: store,
       // FIXME: Errors in initialization should definitely be exposed as python
       // exceptions, rather than as panics.
@@ -117,6 +102,12 @@ impl Context {
     // TODO: Odd place for this... could do it periodically in the background?
     maybe_drain_handles().map(|handles| { externs::drop_handles(handles); });
     self.core.graph.get(self.entry_id, self, node)
+  }
+}
+
+impl StoreFileByDigest<Failure> for Context {
+  fn store_by_digest(&self, file: &File) -> BoxFuture<Digest, Failure> {
+    self.get(DigestFile(file.clone()))
   }
 }
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -5,14 +5,12 @@ use std;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use boxfuture::BoxFuture;
-use core::{Failure, TypeId};
+use core::TypeId;
 use externs;
-use fs::{File, PosixFS, Store, safe_create_dir_all_ioerror, ResettablePool, StoreFileByDigest};
+use fs::{PosixFS, Store, safe_create_dir_all_ioerror, ResettablePool};
 use graph::{EntryId, Graph};
 use handles::maybe_drain_handles;
-use hashing::Digest;
-use nodes::{DigestFile, Node, NodeFuture};
+use nodes::{Node, NodeFuture};
 use rule_graph::RuleGraph;
 use tasks::Tasks;
 use types::Types;
@@ -102,12 +100,6 @@ impl Context {
     // TODO: Odd place for this... could do it periodically in the background?
     maybe_drain_handles().map(|handles| { externs::drop_handles(handles); });
     self.core.graph.get(self.entry_id, self, node)
-  }
-}
-
-impl StoreFileByDigest<Failure> for Context {
-  fn store_by_digest(&self, file: &File) -> BoxFuture<Digest, Failure> {
-    self.get(DigestFile(file.clone()))
   }
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1,6 +1,9 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+extern crate bazel_protos;
+extern crate tempdir;
+
 use std::error::Error;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
@@ -44,7 +47,7 @@ fn was_required(failure: Failure) -> Failure {
   }
 }
 
-trait GetNode {
+pub trait GetNode {
   fn get<N: Node>(&self, node: N) -> NodeFuture<N::Output>;
 }
 
@@ -283,17 +286,17 @@ impl Select {
       vec![
         self
           .get_snapshot(&context)
-          .and_then(move |snapshot|
+          .and_then(
+            move |snapshot|
             // Request the file contents of the Snapshot, and then store them.
-            context.core.snapshots.contents_for(&context.core.vfs, snapshot)
-              .then(move |files_content_res| match files_content_res {
-                Ok(files_content) => Ok(Snapshot::store_files_content(&context, &files_content)),
-                Err(e) => Err(throw(&e)),
-              }))
+            snapshot.contents(context.core.store.clone()).map_err(|e| throw(&e))
+              .map(move |files_content| Snapshot::store_files_content(&context, &files_content))
+          )
           .to_boxed(),
       ]
     } else if self.product() == &context.core.types.process_result {
       let value = externs::val_for_id(self.subject.id());
+
       let mut env: BTreeMap<String, String> = BTreeMap::new();
       let env_var_parts = externs::project_multi_strs(&value, "env");
       // TODO: Error if env_var_parts.len() % 2 != 0
@@ -303,14 +306,31 @@ impl Select {
           env_var_parts[2 * i + 1].clone(),
         );
       }
+
+      // TODO: Make this much less unwrap-happy as part of moving this to run off-thread and
+      // asynchronously.
+
+      let fingerprint = externs::project_str(&value, "input_files_digest");
+      let digest_length = externs::project_str(&value, "digest_length");
+      let digest_length_as_usize = digest_length.parse::<usize>().unwrap();
+      let digest = hashing::Digest(
+        hashing::Fingerprint::from_hex_string(&fingerprint).unwrap(),
+        digest_length_as_usize,
+      );
+
       let request = process_executor::ExecuteProcessRequest {
         argv: externs::project_multi_strs(&value, "argv"),
         env: env,
+        input_files: digest,
       };
-
       let tmpdir = TempDir::new("process-execution").unwrap();
-      // TODO: Materialize the snapshot into the tmpdir when ExecuteProcessRequest has a Snapshot.
 
+      context
+        .core
+        .store
+        .materialize_directory(tmpdir.path().to_owned(), digest)
+        .wait()
+        .unwrap();
       // TODO: this should run off-thread, and asynchronously
       // TODO: request the Node that invokes the process, rather than invoke directly
       let result = process_executor::local::run_command_locally(request, tmpdir.path()).unwrap();
@@ -767,12 +787,19 @@ pub struct ProcessResult(process_executor::ExecuteProcessResult);
 impl Node for ExecuteProcess {
   type Output = ProcessResult;
 
-  fn run(self, _: Context) -> NodeFuture<ProcessResult> {
+  fn run(self, context: Context) -> NodeFuture<ProcessResult> {
     let request = self.0.clone();
 
-    let tmpdir = TempDir::new("process-execution").unwrap();
-    // TODO: Materialize the snapshot into the tmpdir when ExecuteProcessRequest has a Snapshot.
+    // TODO: Make this much less unwrap-happy as part of moving this to run off-thread and
+    // asynchronously.
 
+    let tmpdir = TempDir::new("process-execution").unwrap();
+    context
+      .core
+      .store
+      .materialize_directory(tmpdir.path().to_owned(), request.input_files)
+      .wait()
+      .unwrap();
     // TODO: this should run off-thread, and asynchronously
     future::ok(ProcessResult(
       process_executor::local::run_command_locally(
@@ -825,7 +852,7 @@ impl From<ReadLink> for NodeKey {
 /// A Node that represents reading a file and fingerprinting its contents.
 ///
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DigestFile(File);
+pub struct DigestFile(pub File);
 
 impl Node for DigestFile {
   type Output = hashing::Digest;
@@ -857,31 +884,6 @@ impl Node for DigestFile {
 impl From<DigestFile> for NodeKey {
   fn from(n: DigestFile) -> Self {
     NodeKey::DigestFile(n)
-  }
-}
-
-///
-/// A Node that represents consuming the stat for some path.
-///
-/// NB: Because the `Scandir` operation gets the stats for a parent directory in a single syscall,
-/// this operation results in no data, and is simply a placeholder for `Snapshot` Nodes to use to
-/// declare a dependency on the existence/content of a particular path. This makes them more error
-/// prone, unfortunately.
-///
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Stat(PathBuf);
-
-impl Node for Stat {
-  type Output = ();
-
-  fn run(self, _: Context) -> NodeFuture<()> {
-    future::ok(()).to_boxed()
-  }
-}
-
-impl From<Stat> for NodeKey {
-  fn from(n: Stat) -> Self {
-    NodeKey::Stat(n)
   }
 }
 
@@ -934,33 +936,17 @@ pub struct Snapshot {
 
 impl Snapshot {
   fn create(context: Context, path_globs: PathGlobs) -> NodeFuture<fs::Snapshot> {
-    // Recursively expand PathGlobs into PathStats while tracking their dependencies.
+    // Recursively expand PathGlobs into PathStats.
+    // We rely on Context::expand tracking dependencies for scandirs,
+    // and fs::Snapshot::from_path_stats tracking dependencies for file digests.
     context
       .expand(path_globs)
-      .then(move |path_stats_res| match path_stats_res {
-        Ok(path_stats) => {
-          // Declare dependencies on the relevant Stats, and then create a Snapshot.
-          let stats = future::join_all(
-            path_stats
-              .iter()
-              .map(
-                |path_stat| context.get(Stat(path_stat.path().to_owned())), // for recording only
-              )
-              .collect::<Vec<_>>(),
-          );
-          // And then create a Snapshot.
-          stats
-            .and_then(move |_| {
-              context
-                .core
-                .snapshots
-                .create(&context.core.vfs, path_stats)
-                .map_err(move |e| throw(&format!("Snapshot failed: {}", e)))
-            })
-            .to_boxed()
-        }
-        Err(e) => err(throw(&format!("PathGlobs expansion failed: {:?}", e))),
+      .map_err(|e| format!("PlatGlobs expansion failed: {:?}", e))
+      .and_then(move |path_stats| {
+        fs::Snapshot::from_path_stats(context.core.store.clone(), context.clone(), path_stats)
+          .map_err(move |e| format!("Snapshot failed: {}", e))
       })
+      .map_err(|e| throw(&e))
       .to_boxed()
   }
 
@@ -986,7 +972,8 @@ impl Snapshot {
     externs::unsafe_call(
       &context.core.types.construct_snapshot,
       &vec![
-        externs::store_bytes(&item.fingerprint.0),
+        externs::store_bytes(&(item.digest.0).to_hex().as_bytes()),
+        externs::store_i32((item.digest.1 as i32)),
         externs::store_list(path_stats.iter().collect(), false),
       ],
     )
@@ -1147,7 +1134,6 @@ pub enum NodeKey {
   ExecuteProcess(ExecuteProcess),
   ReadLink(ReadLink),
   Scandir(Scandir),
-  Stat(Stat),
   Select(Select),
   Snapshot(Snapshot),
   Task(Task),
@@ -1166,7 +1152,6 @@ impl NodeKey {
       &NodeKey::ExecuteProcess(ref s) => format!("ExecuteProcess({:?}", s.0),
       &NodeKey::ReadLink(ref s) => format!("ReadLink({:?})", s.0),
       &NodeKey::Scandir(ref s) => format!("Scandir({:?})", s.0),
-      &NodeKey::Stat(ref s) => format!("Stat({:?})", s.0),
       &NodeKey::Select(ref s) => {
         format!(
           "Select({}, {})",
@@ -1198,7 +1183,6 @@ impl NodeKey {
       &NodeKey::DigestFile(..) => "DigestFile".to_string(),
       &NodeKey::ReadLink(..) => "LinkDest".to_string(),
       &NodeKey::Scandir(..) => "DirectoryListing".to_string(),
-      &NodeKey::Stat(..) => "Stat".to_string(),
     }
   }
 
@@ -1207,10 +1191,18 @@ impl NodeKey {
   ///
   pub fn fs_subject(&self) -> Option<&Path> {
     match self {
+      &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),
       &NodeKey::ReadLink(ref s) => Some((s.0).0.as_path()),
       &NodeKey::Scandir(ref s) => Some((s.0).0.as_path()),
-      &NodeKey::Stat(ref s) => Some(s.0.as_path()),
-      _ => None,
+
+      // Not FS operations:
+      // Explicitly listed so that if people add new NodeKeys they need to consider whether their
+      // NodeKey represents an FS operation, and accordingly whether they need to add it to the
+      // above list or the below list.
+      &NodeKey::ExecuteProcess { .. } |
+      &NodeKey::Select { .. } |
+      &NodeKey::Snapshot { .. } |
+      &NodeKey::Task { .. } => None,
     }
   }
 }
@@ -1223,7 +1215,6 @@ impl Node for NodeKey {
       NodeKey::DigestFile(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::ExecuteProcess(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::ReadLink(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::Stat(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Scandir(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Select(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Snapshot(n) => n.run(context).map(|v| v.into()).to_boxed(),

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -86,16 +86,6 @@ impl Tasks {
     );
   }
 
-  // TODO: Only exists in order to support the `Snapshots` singleton replacement in `context.rs`:
-  // Fix by porting isolated processes to rust:
-  //   see: https://github.com/pantsbuild/pants/issues/4397
-  pub fn singleton_replace(&mut self, value: Value, product: TypeConstraint) {
-    self.singletons.insert(
-      product,
-      (externs::key_for(&value), value),
-    );
-  }
-
   ///
   /// The following methods define the Task registration lifecycle.
   ///

--- a/tests/python/pants_test/engine/examples/scheduler_inputs/src/java/simple/Broken.java
+++ b/tests/python/pants_test/engine/examples/scheduler_inputs/src/java/simple/Broken.java
@@ -1,5 +1,5 @@
 package simple;
 // Placeholder file.
-class Simple {
-
+class Broken {
+  NOT VALID JAVA!
 }

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -88,8 +88,17 @@ def process_request_from_java_sources(binary):
   env = []
   return ExecuteProcessRequest(
     argv=binary.prefix_of_command() + ('-version',),
-    env=env)
+    env=env,
+    input_files_digest="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    digest_length=0)
 
+def process_request_java_args_from_java_sources(binary, sources_snapshot, out_dir):
+  env = []
+  return ExecuteProcessRequest(
+    argv=binary.prefix_of_command() + tuple(f.path for f in sources_snapshot.files),
+    input_files_digest=str(sources_snapshot.fingerprint),
+    digest_length=sources_snapshot.digest_length,
+    env=env)
 
 class ClasspathEntry(datatype('ClasspathEntry', ['path'])):
   """A classpath entry for a subject."""
@@ -119,6 +128,8 @@ class SnapshottedProcessRequestTest(SchedulerTestBase, unittest.TestCase):
 
 
 class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
+  # TODO: Re-write this test to work with non-tar-file snapshots
+  @unittest.skip
   def test_integration_concat_with_snapshot_subjects_test(self):
     scheduler = self.mk_scheduler_in_example_fs([
       # subject to files / product of subject to files for snapshot.
@@ -157,6 +168,8 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     self.assertEqual(0, result.exit_code)
     self.assertIn('javac', result.stderr)
 
+  # TODO: Re-write this test to work with non-tar-file snapshots
+  @unittest.skip
   def test_javac_compilation_example(self):
     sources = PathGlobs.create('', include=['scheduler_inputs/src/java/simple/Simple.java'])
 
@@ -181,6 +194,49 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     self.assertIsInstance(classpath_entry, ClasspathEntry)
     self.assertTrue(os.path.exists(os.path.join(classpath_entry.path, 'simple', 'Simple.class')))
 
+  def test_javac_compilation_example_rust_success(self):
+    sources = PathGlobs.create('', include=['scheduler_inputs/src/java/simple/Simple.java'])
+
+    scheduler = self.mk_scheduler_in_example_fs([
+      ExecuteProcess.create_in(
+        product_type=ExecuteProcessRequest,
+        input_selectors=(Select(Javac), Select(Snapshot), Select(JavaOutputDir)),
+        input_conversion=process_request_java_args_from_java_sources),
+      SingletonRule(JavaOutputDir, JavaOutputDir('testing')),
+      SingletonRule(Javac, Javac()),
+    ])
+    req = scheduler.product_request(ExecuteProcessRequest, [sources])
+    request = scheduler.execution_request([ExecuteProcessResult], req)
+
+    root_entries = scheduler.execute(request).root_products
+    self.assertEquals(1, len(root_entries))
+    state = self.assertFirstEntryIsReturn(root_entries, scheduler, request)
+    execution_result = state.value
+    self.assertEqual(0, execution_result.exit_code)
+
+    # TODO: Test that the output snapshot is good
+
+  def test_javac_compilation_example_rust_failure(self):
+    sources = PathGlobs.create('', include=['scheduler_inputs/src/java/simple/Broken.java'])
+
+    scheduler = self.mk_scheduler_in_example_fs([
+      ExecuteProcess.create_in(
+        product_type=ExecuteProcessRequest,
+        input_selectors=(Select(Javac), Select(Snapshot), Select(JavaOutputDir)),
+        input_conversion=process_request_java_args_from_java_sources),
+      SingletonRule(JavaOutputDir, JavaOutputDir('testing')),
+      SingletonRule(Javac, Javac()),
+    ])
+    req = scheduler.product_request(ExecuteProcessRequest, [sources])
+    request = scheduler.execution_request([ExecuteProcessResult], req)
+
+    root_entries = scheduler.execute(request).root_products
+    self.assertEquals(1, len(root_entries))
+    state = self.assertFirstEntryIsReturn(root_entries, scheduler, request)
+    execution_result = state.value
+    self.assertEqual(1, execution_result.exit_code)
+    self.assertIn("NOT VALID JAVA", execution_result.stderr)
+
   def test_failed_command_propagates_throw(self):
     scheduler = self.mk_scheduler_in_example_fs([
       # subject to files / product of subject to files for snapshot.
@@ -200,6 +256,8 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     self.assertFirstEntryIsThrow(root_entries,
                                  in_msg='Running ShellFailCommand failed with non-zero exit code: 1')
 
+  # TODO: Enable a test when input/output conversions are worked out
+  @unittest.skip
   def test_failed_output_conversion_propagates_throw(self):
     scheduler = self.mk_scheduler_in_example_fs([
       # subject to files / product of subject to files for snapshot.

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -92,6 +92,7 @@ def process_request_from_java_sources(binary):
     input_files_digest="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
     digest_length=0)
 
+
 def process_request_java_args_from_java_sources(binary, sources_snapshot, out_dir):
   env = []
   return ExecuteProcessRequest(
@@ -99,6 +100,7 @@ def process_request_java_args_from_java_sources(binary, sources_snapshot, out_di
     input_files_digest=str(sources_snapshot.fingerprint),
     digest_length=sources_snapshot.digest_length,
     env=env)
+
 
 class ClasspathEntry(datatype('ClasspathEntry', ['path'])):
   """A classpath entry for a subject."""
@@ -128,6 +130,7 @@ class SnapshottedProcessRequestTest(SchedulerTestBase, unittest.TestCase):
 
 
 class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
+
   # TODO: Re-write this test to work with non-tar-file snapshots
   @unittest.skip
   def test_integration_concat_with_snapshot_subjects_test(self):

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -216,7 +216,6 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     state = self.assertFirstEntryIsReturn(root_entries, scheduler, request)
     execution_result = state.value
     self.assertEqual(0, execution_result.exit_code)
-
     # TODO: Test that the output snapshot is good
 
   def test_javac_compilation_example_rust_failure(self):


### PR DESCRIPTION
This is much more incremental, and will help us to support remote
execution (where Directory protos are the lingua franca).

There are still several significant things to clean up here:
 * Some IsolatedProcess tests are disabled
 * We need to work out how to do input/output conversions for
IsolatedProcess for real
 * Process execution is hard-coded to be local, synchronous, and a
little panic-y

but as this is already a very large change, and the process execution
pieces aren't actually used in production codepaths, I'd like those to
be follow-ups.