### PR TITLE
Fix up remote process execution

### DIFF
--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -17,7 +17,6 @@ sha2 = "0.6.0"
 tempdir = "0.3.5"
 
 [dev-dependencies]
-bytes = "0.4.5"
 mock = { path = "../testutil/mock" }
 tempdir = "0.3.5"
 testutil = { path = "../testutil" }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate bazel_protos;
 extern crate boxfuture;
-#[cfg(test)]
 extern crate bytes;
 extern crate digest;
 extern crate fs;

--- a/src/rust/engine/process_executor/Cargo.lock
+++ b/src/rust/engine/process_executor/Cargo.lock
@@ -403,10 +403,13 @@ dependencies = [
 name = "process_executor"
 version = "0.0.1"
 dependencies = [
+ "boxfuture 0.0.1",
  "clap 2.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "process_execution 0.0.1",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -4,7 +4,10 @@ name = "process_executor"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
+boxfuture = { path = "../boxfuture" }
 clap = "2"
 fs = { path = "../fs" }
+hashing = { path = "../hashing" }
 futures = "0.1.16"
 process_execution = { path = "../process_execution" }
+tempdir = "0.3.5"

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -1,14 +1,21 @@
+extern crate boxfuture;
 extern crate clap;
 extern crate fs;
+extern crate hashing;
 extern crate futures;
 extern crate process_execution;
+extern crate tempdir;
 
+use boxfuture::{BoxFuture, Boxable};
 use clap::{App, AppSettings, Arg};
+use fs::{StoreFileByDigest, VFS};
 use futures::future::Future;
+use tempdir::TempDir;
 use std::collections::BTreeMap;
-use std::process::exit;
-
 use std::iter::Iterator;
+use std::process::exit;
+use std::sync::Arc;
+use std::time::Duration;
 
 /// A binary which takes args of format:
 ///  process_executor --env=FOO=bar --env=SOME=value -- /path/to/binary --flag --otherflag
@@ -19,6 +26,20 @@ use std::iter::Iterator;
 fn main() {
   let args = App::new("process_executor")
     .arg(
+      Arg::with_name("local-store-path")
+        .long("local-store-path")
+        .takes_value(true)
+        .required(true)
+        .help("TODO"),
+    )
+    .arg(
+      Arg::with_name("globs")
+        .long("globs")
+        .takes_value(true)
+        .multiple(true)
+        .help("TODO"),
+    )
+    .arg(
       Arg::with_name("server")
         .long("server")
         .takes_value(true)
@@ -26,6 +47,12 @@ fn main() {
           "The host:port of the gRPC server to connect to. Forces remote execution. \
 If unspecified, local execution will be performed.",
         ),
+    )
+    .arg(
+      Arg::with_name("cas-server")
+        .long("cas-server")
+        .takes_value(true)
+        .help("The host:port of the gRPC CAS server to connect to."),
     )
     .arg(
       Arg::with_name("env")
@@ -61,28 +88,97 @@ If unspecified, local execution will be performed.",
     }
     None => BTreeMap::new(),
   };
-  let server = args.value_of("server");
+  let local_store_path = args.value_of("local-store-path").unwrap();
+  let pool = Arc::new(fs::ResettablePool::new("process-executor-".to_owned()));
+  let server_arg = args.value_of("server");
+  let store = match (server_arg, args.value_of("cas-server")) {
+    (Some(_server), Some(cas_server)) => {
+      fs::Store::with_remote(
+        local_store_path,
+        pool.clone(),
+        cas_server,
+        1,
+        10 * 1024 * 1024,
+        Duration::from_secs(30),
+      )
+    }
+    (None, None) => fs::Store::local_only(local_store_path, pool.clone()),
+    _ => panic!("Must specify either both --server and --cas-server or neither."),
+  }.expect("Error making store");
 
-  // TODO: Capture the working directory as a snapshot, and materialize it to a temporary directory.
-  let input_files = fs::EMPTY_DIGEST;
+  let posix_fs = Arc::new(fs::PosixFS::new(".", pool, vec![]).unwrap());
+  let store_copy = store.clone();
+  let input_files = posix_fs
+    .expand(
+      fs::PathGlobs::create(
+        &args
+          .values_of("globs")
+          .expect("Bad globs")
+          .map(|s| s.to_string())
+          .collect::<Vec<String>>(),
+        &[],
+      ).expect("Error creating globs"),
+    )
+    .map_err(|err| format!("Error expanding globs: {}", err))
+    .and_then(move |paths| {
+      fs::Snapshot::from_path_stats(
+        store_copy.clone(),
+        FileSaver {
+          store: store_copy,
+          posix_fs: posix_fs,
+        },
+        paths,
+      )
+    })
+    .map(|snapshot| snapshot.digest)
+    .wait()
+    .expect("Error reading input files");
+
   let request = process_execution::ExecuteProcessRequest {
     argv,
     env,
     input_files,
   };
-  let result = match server {
-    Some(addr) => {
-      process_execution::remote::CommandRunner::new(addr, 1, None)
+
+  let result = match server_arg {
+    Some(address) => {
+      process_execution::remote::CommandRunner::new(address, 1, store)
         .run_command_remote(request)
         .wait()
-        .unwrap()
+        .expect("Error executing remotely")
     }
     None => {
-      process_execution::local::run_command_locally(request, &std::env::current_dir().unwrap())
-        .unwrap()
+      let dir = TempDir::new("process-execution").expect("Error making temporary directory");
+      store
+        .materialize_directory(dir.path().to_owned(), request.input_files)
+        .wait()
+        .expect("Error materializing directory");
+      process_execution::local::run_command_locally(request, dir.path())
+        .expect("Error executing locally")
     }
   };
   print!("{}", String::from_utf8(result.stdout).unwrap());
   eprint!("{}", String::from_utf8(result.stderr).unwrap());
   exit(result.exit_code);
+}
+
+#[derive(Clone)]
+struct FileSaver {
+  store: fs::Store,
+  posix_fs: Arc<fs::PosixFS>,
+}
+
+impl StoreFileByDigest<String> for FileSaver {
+  fn store_by_digest(&self, file: &fs::File) -> BoxFuture<hashing::Digest, String> {
+    let file_copy = file.clone();
+    let store = self.store.clone();
+    self
+      .posix_fs
+      .read_file(&file)
+      .map_err(move |err| {
+        format!("Error reading file {:?}: {:?}", file_copy, err)
+      })
+      .and_then(move |content| store.store_file_bytes(content.content, true))
+      .to_boxed()
+  }
 }


### PR DESCRIPTION
This PR does a lot of things, but after it, remote process execution actually works!

* Include command digest in executon request
* Upload command digest to remote CAS
* Log what we send and receive
* Require a `Store` to do remote execution
* `process_executor` can do remote execution
* `process_executor` takes an input-files digest