### PR TITLE
Fix missing interpreter constraints bug when a Python target does not have sources

### DIFF
--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -122,9 +122,8 @@ class PythonBinaryCreate(Task):
           req_tgts.append(tgt)
         # Add target's interpreter compatibility constraints to pex info.
         if is_python_target(tgt):
-          if has_python_sources(tgt) or tgt.entry_point:
-            for constraint in tgt.compatibility:
-              builder.add_interpreter_constraint(constraint)
+          for constraint in tgt.compatibility:
+            builder.add_interpreter_constraint(constraint)
 
       # Dump everything into the builder's chroot.
       for tgt in source_tgts:

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -15,7 +15,7 @@ from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.tasks.pex_build_util import (dump_requirement_libs, dump_sources,
                                                        has_python_requirements, has_python_sources,
-                                                       has_resources)
+                                                       has_resources, is_python_target)
 from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.build_graph.target_scopes import Scopes
@@ -118,12 +118,13 @@ class PythonBinaryCreate(Task):
       for tgt in binary_tgt.closure(exclude_scopes=Scopes.COMPILE):
         if has_python_sources(tgt) or has_resources(tgt):
           source_tgts.append(tgt)
-          # Add target's interpreter compatibility constraints to pex info.
-          if has_python_sources(tgt):
-            for constraint in tgt.compatibility:
-              builder.add_interpreter_constraint(constraint)
         elif has_python_requirements(tgt):
           req_tgts.append(tgt)
+        # Add target's interpreter compatibility constraints to pex info.
+        if is_python_target(tgt):
+          if has_python_sources(tgt) or tgt.entry_point:
+            for constraint in tgt.compatibility:
+              builder.add_interpreter_constraint(constraint)
 
       # Dump everything into the builder's chroot.
       for tgt in source_tgts:

--- a/src/python/pants/backend/python/tasks/python_execution_task_base.py
+++ b/src/python/pants/backend/python/tasks/python_execution_task_base.py
@@ -14,7 +14,7 @@ from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_target import PythonTarget
 from pants.backend.python.tasks.gather_sources import GatherSources
-from pants.backend.python.tasks.pex_build_util import has_python_sources
+from pants.backend.python.tasks.pex_build_util import is_python_target
 from pants.backend.python.tasks.resolve_requirements import ResolveRequirements
 from pants.backend.python.tasks.resolve_requirements_task_base import ResolveRequirementsTaskBase
 from pants.backend.python.tasks.wrapped_pex import WrappedPEX
@@ -74,7 +74,7 @@ class PythonExecutionTaskBase(ResolveRequirementsTaskBase):
           # Add the extra requirements first, so they take precedence over any colliding version
           # in the target set's dependency closure.
           pexes = [extra_requirements_pex] + pexes
-        constraints = {constraint for rt in relevant_targets if has_python_sources(rt)
+        constraints = {constraint for rt in relevant_targets if is_python_target(rt)
                        for constraint in rt.compatibility}
         self.merge_pexes(path, pex_info, interpreter, pexes, constraints)
 

--- a/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
+++ b/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
@@ -4,5 +4,5 @@ python_binary(
     'testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project',
   ],
   entry_point='testprojects.src.python.interpreter_selection.test_target_with_no_sources.src.python.test_project',
-  compatibility=['CPython>=3.6']
+  compatibility=['CPython>3']
 )

--- a/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
+++ b/testprojects/src/python/interpreter_selection/test_target_with_no_sources/BUILD
@@ -1,0 +1,8 @@
+python_binary(
+  name='test_bin',
+  dependencies=[
+    'testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project',
+  ],
+  entry_point='testprojects.src.python.interpreter_selection.test_target_with_no_sources.src.python.test_project',
+  compatibility=['CPython>=3.6']
+)

--- a/testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project/BUILD
+++ b/testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project/BUILD
@@ -1,0 +1,3 @@
+python_library(
+  sources=globs('*.py')
+)

--- a/testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project/__main__.py
+++ b/testprojects/src/python/interpreter_selection/test_target_with_no_sources/src/python/test_project/__main__.py
@@ -1,0 +1,3 @@
+import sys
+print('I am in __main__.py!')
+print(sys.executable)

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -137,7 +137,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
           config=pants_ini_config
         )
         self.assert_success(pants_run_3)
-        self.assertIn('python3.6', pants_run_3.stdout_data)
+        self.assertIn('python3', pants_run_3.stdout_data)
 
       # Binary task.
       pants_ini_config = {'python-setup': {'interpreter_cache_dir': interpreters_cache}}

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -150,7 +150,7 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
     # Ensure proper interpreter constraints were passed to built pexes.
     py2_pex = os.path.join(os.getcwd(), 'dist', 'test_bin.pex')
     py2_info = get_pex_info(py2_pex)
-    self.assertIn('CPython>=3.6', py2_info.interpreter_constraints)
+    self.assertIn('CPython>3', py2_info.interpreter_constraints)
     # Cleanup.
     os.remove(py2_pex)
 


### PR DESCRIPTION
### Problem
Python targets without sources do not get their interpreter constraints plumbed through to the pex builder object (see #5485).

### Solution

Rather than just checking if a target has python sources before adding its constraints to a pex builder object, check if it is an instance of `PythonTarget` instead. This will include targets that do not specify any sources but have a valid entry point and compatibility constraints. 

### Result

Python targets that only specify entry points and dependencies will be able to supply interpreter constraints via the `compatibility` parameter.