### PR TITLE
Don't reinstall plugin wheels on every invocation.

### DIFF
--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -39,7 +39,7 @@ class PluginResolver(object):
     if not os.path.isdir(install_dir):
       with temporary_dir(root_dir=os.path.dirname(install_dir)) as tmp:
         cls._install_wheel(wheel_path, tmp)
-      os.rename(tmp, install_dir)
+        os.rename(tmp, install_dir)
     # Activate any .pth files installed above.
     site.addsitedir(install_dir)
     return install_dir

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -19,6 +19,7 @@ from wheel.install import WheelFile
 from pants.option.global_options import GlobalOptionsRegistrar
 from pants.python.python_repos import PythonRepos
 from pants.subsystem.subsystem import Subsystem
+from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_open
 from pants.util.memo import memoized_property
 from pants.version import PANTS_SEMVER
@@ -32,9 +33,19 @@ class PluginResolver(object):
   def _is_wheel(path):
     return os.path.isfile(path) and path.endswith('.whl')
 
-  @staticmethod
-  def _activate_wheel(wheel_path):
+  @classmethod
+  def _activate_wheel(cls, wheel_path):
     install_dir = '{}-install'.format(wheel_path)
+    if not os.path.isdir(install_dir):
+      with temporary_dir(root_dir=os.path.dirname(install_dir)) as tmp:
+        cls._install_wheel(wheel_path, tmp)
+      os.rename(tmp, install_dir)
+    # Activate any .pth files installed above.
+    site.addsitedir(install_dir)
+    return install_dir
+
+  @classmethod
+  def _install_wheel(cls, wheel_path, install_dir):
     safe_mkdir(install_dir, clean=True)
     WheelFile(wheel_path).install(force=True,
                                   overrides={
@@ -44,9 +55,6 @@ class PluginResolver(object):
                                     'platlib': install_dir,
                                     'data': install_dir
                                   })
-    # Activate any .pth files installed above.
-    site.addsitedir(install_dir)
-    return install_dir
 
   def __init__(self, options_bootstrapper):
     self._options_bootstrapper = options_bootstrapper


### PR DESCRIPTION
The wheel install dir path completely qualifies it. So, assuming
it was moved atomically to that path, we can take existence of
the directory to imply that it contains the installed wheel.

This saves ~2 seconds (70%) of the no-op ./pants invocation time
in a repo with just a handful of plugins.
