### PR TITLE
Fix reference html/js: expand/collapse toggle in Firefox

### DIFF
--- a/src/python/pants/backend/docgen/tasks/templates/reference/reference.css.mustache
+++ b/src/python/pants/backend/docgen/tasks/templates/reference/reference.css.mustache
@@ -83,6 +83,7 @@ ul.collapsible > li.collapsed:before {
     font-family: monospace;
     display: block;
     float: left;
+    cursor: pointer;
 }
 ul.collapsible > li.expanded:before {
     content: "▼";
@@ -90,6 +91,7 @@ ul.collapsible > li.expanded:before {
     font-family: monospace;
     display: block;
     float: left;
+    cursor: pointer;
 }
 ul.collapsible > li.collapsed > ul {
     display: none;

--- a/src/python/pants/backend/docgen/tasks/templates/reference/reference.js.mustache
+++ b/src/python/pants/backend/docgen/tasks/templates/reference/reference.js.mustache
@@ -1,5 +1,5 @@
 function toggleTreeView(evt, elem) {
-  if (evt.srcElement == elem) {
+  if (evt.target == elem) {
     elem.classList.toggle('expanded');
     elem.classList.toggle('collapsed');
   }


### PR DESCRIPTION
### Problem

Clicking the little bullet triangle before each list item on https://www.pantsbuild.org/build_dictionary.html will expand/collapse the item in Chrome, but not in Firefox. The Expand/Collapse All works in both.

### Solution

Changing from the non-standard `Event.srcElement` to the standard `Event.target` in the click handler solves the issue.
See https://developer.mozilla.org/en-US/docs/Web/API/Event/srcElement

### Result

As a result clicking the small bullet triangle will now expand/collapse the list items also on Firefox. As a bonus I've added pointer cursors to the bullet triangles, to make it visible that they are in fact click-able.