### PR TITLE
[pantsd] Set the remote environment for pantsd-runner and child processes.

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -21,7 +21,7 @@ from pants.init.util import clean_global_runtime_state
 from pants.java.nailgun_io import NailgunStreamStdinReader, NailgunStreamWriter
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 from pants.pantsd.process_manager import ProcessManager
-from pants.util.contextutil import HardSystemExit, environment_as, stdio_as
+from pants.util.contextutil import HardSystemExit, hermetic_environment_as, stdio_as
 from pants.util.socket import teardown_socket
 
 
@@ -222,7 +222,7 @@ class DaemonPantsRunner(ProcessManager):
     self._setup_sigint_handler()
 
     # Invoke a Pants run with stdio redirected and a proxied environment.
-    with self._nailgunned_stdio(self._socket) as finalizer, environment_as(**self._env):
+    with self._nailgunned_stdio(self._socket) as finalizer, hermetic_environment_as(**self._env):
       try:
         # Setup the Exiter's finalizer.
         self._exiter.set_finalizer(finalizer)

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -21,7 +21,7 @@ from pants.init.util import clean_global_runtime_state
 from pants.java.nailgun_io import NailgunStreamStdinReader, NailgunStreamWriter
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 from pants.pantsd.process_manager import ProcessManager
-from pants.util.contextutil import HardSystemExit, stdio_as, environment_as
+from pants.util.contextutil import HardSystemExit, environment_as, stdio_as
 from pants.util.socket import teardown_socket
 
 

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -21,7 +21,7 @@ from pants.init.util import clean_global_runtime_state
 from pants.java.nailgun_io import NailgunStreamStdinReader, NailgunStreamWriter
 from pants.java.nailgun_protocol import ChunkType, NailgunProtocol
 from pants.pantsd.process_manager import ProcessManager
-from pants.util.contextutil import HardSystemExit, stdio_as
+from pants.util.contextutil import HardSystemExit, stdio_as, environment_as
 from pants.util.socket import teardown_socket
 
 
@@ -221,8 +221,8 @@ class DaemonPantsRunner(ProcessManager):
     # Setup a SIGINT signal handler.
     self._setup_sigint_handler()
 
-    # Invoke a Pants run with stdio redirected.
-    with self._nailgunned_stdio(self._socket) as finalizer:
+    # Invoke a Pants run with stdio redirected and a proxied environment.
+    with self._nailgunned_stdio(self._socket) as finalizer, environment_as(**self._env):
       try:
         # Setup the Exiter's finalizer.
         self._exiter.set_finalizer(finalizer)

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -56,6 +56,17 @@ def environment_as(**kwargs):
 
 
 @contextmanager
+def hermetic_environment_as(**kwargs):
+  """Set the environment to the supplied values from an empty state."""
+  old_environment, os.environ = os.environ, {}
+  try:
+    with environment_as(**kwargs):
+      yield
+  finally:
+    os.environ = old_environment
+
+
+@contextmanager
 def _stdio_stream_as(src_fd, dst_fd, dst_sys_attribute, mode):
   """Replace the given dst_fd and attribute on `sys` with an open handle to the given src_fd."""
   if src_fd == -1:

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -18,7 +18,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from pants.pantsd.process_manager import ProcessManager
 from pants.util.collections import combined_dict
-from pants.util.contextutil import temporary_dir
+from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import touch
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 from pants_test.testutils.process_test_util import no_lingering_process_by_command
@@ -342,3 +342,23 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
         checker.assert_running()
 
       join()
+
+  def test_pantsd_env_var_is_inherited_by_pantsd_runner_children(self):
+    EXPECTED_VALUE = '333'
+    with self.pantsd_successful_run_context() as (pantsd_run, checker, workdir):
+      # First, launch the daemon without any local env vars set.
+      pantsd_run(['help'])
+      checker.await_pantsd()
+
+      # Then, set an env var on the secondary call.
+      with environment_as(TEST_ENV_VAR_FOR_PANTSD_INTEGRATION_TEST=EXPECTED_VALUE):
+        result = pantsd_run(
+          ['run',
+           '-q',
+           'testprojects/src/python/print_env',
+           '--',
+           'TEST_ENV_VAR_FOR_PANTSD_INTEGRATION_TEST']
+        )
+        checker.assert_running()
+
+      self.assertEquals(EXPECTED_VALUE, ''.join(result.stdout_data).strip())

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -353,8 +353,8 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
       # Then, set an env var on the secondary call.
       with environment_as(TEST_ENV_VAR_FOR_PANTSD_INTEGRATION_TEST=EXPECTED_VALUE):
         result = pantsd_run(
-          ['run',
-           '-q',
+          ['-q',
+           'run',
            'testprojects/src/python/print_env',
            '--',
            'TEST_ENV_VAR_FOR_PANTSD_INTEGRATION_TEST']

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -18,9 +18,9 @@ from contextlib import contextmanager
 import mock
 
 from pants.util.contextutil import (HardSystemExit, InvalidZipPath, Timer, environment_as,
-                                    exception_logging, hard_exit_handler, hermetic_environment_as, maybe_profiled, open_zip,
-                                    pushd, signal_handler_as, stdio_as, temporary_dir,
-                                    temporary_file)
+                                    exception_logging, hard_exit_handler, hermetic_environment_as,
+                                    maybe_profiled, open_zip, pushd, signal_handler_as, stdio_as,
+                                    temporary_dir, temporary_file)
 from pants.util.process_handler import subprocess
 
 

--- a/tests/python/pants_test/util/test_contextutil.py
+++ b/tests/python/pants_test/util/test_contextutil.py
@@ -18,7 +18,7 @@ from contextlib import contextmanager
 import mock
 
 from pants.util.contextutil import (HardSystemExit, InvalidZipPath, Timer, environment_as,
-                                    exception_logging, hard_exit_handler, maybe_profiled, open_zip,
+                                    exception_logging, hard_exit_handler, hermetic_environment_as, maybe_profiled, open_zip,
                                     pushd, signal_handler_as, stdio_as, temporary_dir,
                                     temporary_file)
 from pants.util.process_handler import subprocess
@@ -58,6 +58,11 @@ class ContextutilTest(unittest.TestCase):
                            stdout=output).wait()
           output.seek(0)
           self.assertEquals('False\n', output.read())
+
+  def test_hermetic_environment(self):
+    self.assertIn('USER', os.environ)
+    with hermetic_environment_as(**{}):
+      self.assertNotIn('USER', os.environ)
 
   def test_simple_pushd(self):
     pre_cwd = os.getcwd()


### PR DESCRIPTION
### Problem

Currently, env vars set in post-pantsd-launching runs that use the daemon fail to inherit env vars correctly in child processes of pantsd-runners. Anything that relies on this will be broken with the daemon enabled for `./pants run`, `./pants test`, etc.

Additionally, env vars that are set during the pantsd-launching run will currently leak stale env state into child processes of pantsd-runners.

### Solution

Set the remote environment as the local environment for `DaemonPantsRunner` from a clean state.

### Result

Tests pass.