### PR TITLE
Robustify `PantsRequirementIntegrationTest`.

### DIFF
--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -47,6 +47,8 @@ python_tests(
   sources=globs('*_integration.py'),
   dependencies=[
     'src/python/pants/base:build_environment',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},

--- a/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
@@ -6,8 +6,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import shutil
+import uuid
+from contextlib import contextmanager
 
-from pants.base.build_environment import get_buildroot
+from pants.base.build_environment import get_buildroot, pants_version
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_walk
 from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 
@@ -32,16 +37,54 @@ class PantsRequirementIntegrationTest(PantsRunIntegrationTest):
     command = pre_cmd_args + cmd
     return self.run_pants(command=command)
 
+  @contextmanager
+  def unstable_pants_version(self):
+    stable_version = pants_version()
+    unstable_version = b'{}+{}'.format(stable_version, uuid.uuid4().hex)
+    version_dir = os.path.join(get_buildroot(), 'src/python/pants')
+
+    with self.file_renamed(version_dir, 'VERSION', 'VERSION.orig'):
+      with open(os.path.join(version_dir, 'VERSION'), 'wb') as fp:
+        fp.write(unstable_version)
+
+      pants_run = self.run_pants(['--version'])
+      self.assert_success(pants_run)
+      self.assertEqual(unstable_version, pants_run.stdout_data.strip())
+
+      yield
+
+  def iter_wheels(self, path):
+    for root, _, files in safe_walk(path):
+      for f in files:
+        if f.endswith('.whl'):
+          yield os.path.join(root, f)
+
+  @contextmanager
+  def create_unstable_pants_distribution(self):
+    with self.unstable_pants_version():
+      with temporary_dir() as dist_dir:
+        create_pants_dist_cmd = ['--pants-distdir={}'.format(dist_dir),
+                                 'setup-py',
+                                 '--run=bdist_wheel',
+                                 'src/python/pants:pants-packaged']
+        pants_run = self.run_pants(create_pants_dist_cmd)
+        self.assert_success(pants_run)
+
+        # Create a flat wheel repo from the results of setup-py above.
+        with temporary_dir() as repo:
+          for wheel in self.iter_wheels(dist_dir):
+            shutil.copy(wheel, os.path.join(repo, os.path.basename(wheel)))
+
+          yield repo
+
   def test_pants_requirement(self):
     self.maxDiff = None
 
-    tests_dir = 'testprojects/pants-plugins/tests/python/test_pants_plugin'
-    command = [
-      'test',
-      tests_dir,
-    ]
-
-    tests_dir_absolute = os.path.join(get_buildroot(), tests_dir)
-    with self.file_renamed(tests_dir_absolute, 'TEST_BUILD', 'BUILD'):
-      pants_run = self.run_with_testproject_backend_pkgs(command)
-    self.assert_success(pants_run)
+    with self.create_unstable_pants_distribution() as repo:
+      tests_dir = 'testprojects/pants-plugins/tests/python/test_pants_plugin'
+      with self.file_renamed(os.path.join(get_buildroot(), tests_dir), 'TEST_BUILD', 'BUILD'):
+        test_pants_requirement_cmd = ['--python-repos-repos={}'.format(repo),
+                                      'test',
+                                      tests_dir]
+        pants_run = self.run_with_testproject_backend_pkgs(test_pants_requirement_cmd)
+        self.assert_success(pants_run)


### PR DESCRIPTION
Previously changes to `pantsbuild.pants` requirements on master between
releases would lead to resolution conflicts in the
`test_pants_requirement` test. Make the test robust to these sort of
changes by producing and consuming a unique `pantsbuild.pants`
distribution for each run of the test.

Fixes #5519