### PR TITLE
Move fork context management to rust

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -212,7 +212,7 @@ Scheduler* scheduler_create(Tasks*,
                             uint64_t,
                             uint64_t,
                             _Bool);
-void scheduler_pre_fork(Scheduler*);
+PyResult scheduler_fork_context(Scheduler*, Function);
 Handle scheduler_metrics(Scheduler*, Session*);
 RawNodes* scheduler_execute(Scheduler*, Session*, ExecutionRequest*);
 void scheduler_destroy(Scheduler*);

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -313,8 +313,10 @@ class Scheduler(object):
     metrics_val = self._native.lib.scheduler_metrics(self._scheduler, session)
     return {k: v for k, v in self._from_value(metrics_val)}
 
-  def pre_fork(self):
-    self._native.lib.scheduler_pre_fork(self._scheduler)
+  def with_fork_context(self, func):
+    """See the rustdocs for `scheduler_fork_context` for more information."""
+    res = self._native.lib.scheduler_fork_context(self._scheduler, Function(self._to_key(func)))
+    return self._raise_or_return(res)
 
   def _run_and_return_roots(self, session, execution_request):
     raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
@@ -473,8 +475,8 @@ class SchedulerSession(object):
     """Returns metrics for this SchedulerSession as a dict of metric name to metric value."""
     return self._scheduler._metrics(self._session)
 
-  def pre_fork(self):
-    self._scheduler.pre_fork()
+  def with_fork_context(self, func):
+    return self._scheduler.with_fork_context(func)
 
   def _maybe_visualize(self):
     if self._scheduler.visualize_to_dir() is not None:

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -225,9 +225,6 @@ class PantsDaemon(FingerprintedProcessManager):
     # A lock to guard the service thread lifecycles. This can be used by individual services
     # to safeguard daemon-synchronous sections that should be protected from abrupt teardown.
     self._lifecycle_lock = threading.RLock()
-    # A lock to guard pantsd->runner forks. This can be used by services to safeguard resources
-    # held by threads at fork time, so that we can fork without deadlocking.
-    self._fork_lock = threading.RLock()
     # N.B. This Event is used as nothing more than a convenient atomic flag - nothing waits on it.
     self._kill_switch = threading.Event()
     self._exiter = Exiter()
@@ -302,10 +299,9 @@ class PantsDaemon(FingerprintedProcessManager):
 
   def _setup_services(self, services):
     assert self._lifecycle_lock is not None, 'PantsDaemon lock has not been set!'
-    assert self._fork_lock is not None, 'PantsDaemon fork lock has not been set!'
     for service in services:
       self._logger.info('setting up service {}'.format(service))
-      service.setup(self._lifecycle_lock, self._fork_lock)
+      service.setup(self._lifecycle_lock)
 
   @staticmethod
   def _make_thread(target):

--- a/src/python/pants/pantsd/service/fs_event_service.py
+++ b/src/python/pants/pantsd/service/fs_event_service.py
@@ -40,8 +40,8 @@ class FSEventService(PantsService):
     self._executor = None
     self._handlers = {}
 
-  def setup(self, lifecycle_lock, fork_lock, executor=None):
-    super(FSEventService, self).setup(lifecycle_lock, fork_lock)
+  def setup(self, lifecycle_lock, executor=None):
+    super(FSEventService, self).setup(lifecycle_lock)
     self._executor = executor or ThreadPoolExecutor(max_workers=self._worker_count)
 
   def terminate(self):

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -48,7 +48,6 @@ class PailgunService(PantsService):
         sock,
         arguments,
         environment,
-        self.fork_lock,
         self._scheduler_service
       )
 

--- a/src/python/pants/pantsd/service/pants_service.py
+++ b/src/python/pants/pantsd/service/pants_service.py
@@ -30,19 +30,15 @@ class PantsService(AbstractClass):
     """
     return self._kill_switch.is_set()
 
-  def setup(self, lifecycle_lock, fork_lock):
+  def setup(self, lifecycle_lock):
     """Called before `run` to allow for service->service or other side-effecting setup.
 
     :param threading.RLock lifecycle_lock: A lock to guard the service thread lifecycles. This
                                            can be used by individual services to safeguard
                                            daemon-synchronous sections that should be protected
                                            from abrupt teardown.
-    :param threading.RLock fork_lock: A lock to guard pantsd->runner forks. This can be used by
-                                      services to safeguard resources held by threads at fork
-                                      time, so that we can fork without deadlocking.
     """
     self.lifecycle_lock = lifecycle_lock
-    self.fork_lock = fork_lock
 
   @abstractmethod
   def run(self):

--- a/src/python/pants/pantsd/service/store_gc_service.py
+++ b/src/python/pants/pantsd/service/store_gc_service.py
@@ -35,21 +35,17 @@ class StoreGCService(PantsService):
 
   def _extend_lease(self):
     while 1:
-      # Use the fork lock to ensure this thread isn't cloned via fork while holding the graph lock.
-      with self.fork_lock:
-        self._logger.debug('Extending leases')
-        self._scheduler.lease_files_in_graph()
-        self._logger.debug('Done extending leases')
+      self._logger.debug('Extending leases')
+      self._scheduler.lease_files_in_graph()
+      self._logger.debug('Done extending leases')
       time.sleep(self._LEASE_EXTENSION_INTERVAL_SECONDS)
 
   def _garbage_collect(self):
     while 1:
       time.sleep(self._GARBAGE_COLLECTION_INTERVAL_SECONDS)
-      # Grab the fork lock in case lmdb internally isn't fork-without-exec-safe.
-      with self.fork_lock:
-        self._logger.debug('Garbage collecting store')
-        self._scheduler.garbage_collect_store()
-        self._logger.debug('Done garbage collecting store')
+      self._logger.debug('Garbage collecting store')
+      self._scheduler.garbage_collect_store()
+      self._logger.debug('Done garbage collecting store')
 
   def run(self):
     """Main service entrypoint. Called via Thread.start() via PantsDaemon.run()."""

--- a/src/rust/engine/fs/src/pool.rs
+++ b/src/rust/engine/fs/src/pool.rs
@@ -23,9 +23,15 @@ pub struct ResettablePool {
 impl ResettablePool {
   pub fn new(name_prefix: String) -> ResettablePool {
     ResettablePool {
-      name_prefix: name_prefix,
-      pool: RwLock::new(None),
+      name_prefix: name_prefix.clone(),
+      pool: RwLock::new(Some(Self::new_pool(name_prefix))),
     }
+  }
+
+  fn new_pool(name_prefix: String) -> CpuPool {
+    futures_cpupool::Builder::new()
+      .name_prefix(name_prefix)
+      .create()
   }
 
   ///
@@ -40,31 +46,24 @@ impl ResettablePool {
     R::Item: Send + 'static,
     R::Error: Send + 'static,
   {
-    {
-      // The happy path: pool is already initialized.
-      let pool_opt = self.pool.read().unwrap();
-      if let Some(ref pool) = *pool_opt {
-        return pool.spawn_fn(f);
-      }
-    }
-    {
-      // Initialize the pool, but then release the write lock.
-      let mut pool_opt = self.pool.write().unwrap();
-      pool_opt.get_or_insert_with(|| self.new_pool());
-    }
-
-    // Recurse to run the function under the read lock.
-    self.spawn_fn(f)
+    let pool_opt = self.pool.read().unwrap();
+    let pool = pool_opt
+      .as_ref()
+      .unwrap_or_else(|| panic!("A CpuPool cannot be used inside the fork context."));
+    pool.spawn_fn(f)
   }
 
-  pub fn reset(&self) {
+  ///
+  /// Run a function while the pool is shut down, and restore the pool after it completes.
+  ///
+  pub fn with_shutdown<F, T>(&self, f: F) -> T
+  where
+    F: FnOnce() -> T,
+  {
     let mut pool = self.pool.write().unwrap();
     *pool = None;
-  }
-
-  fn new_pool(&self) -> CpuPool {
-    futures_cpupool::Builder::new()
-      .name_prefix(self.name_prefix.clone())
-      .create()
+    let t = f();
+    *pool = Some(Self::new_pool(self.name_prefix.clone()));
+    t
   }
 }

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -95,7 +95,7 @@ impl Store {
   {
     self.local.with_reset(|| {
       if let Some(ref remote) = self.remote {
-        remote.with_reset(|| f())
+        remote.with_reset(f)
       } else {
         f()
       }
@@ -671,7 +671,7 @@ mod local {
       self
         .inner
         .file_dbs
-        .with_reset(|| self.inner.directory_dbs.with_reset(|| f()))
+        .with_reset(|| self.inner.directory_dbs.with_reset(f))
     }
 
     // Note: This performs IO on the calling thread. Hopefully the IO is small enough not to matter.
@@ -1641,7 +1641,7 @@ mod remote {
         self.env.with_reset(|| {
           self
             .cas_client
-            .with_reset(|| self.byte_stream_client.with_reset(|| f()))
+            .with_reset(|| self.byte_stream_client.with_reset(f))
         })
       })
     }

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1637,12 +1637,10 @@ mod remote {
     where
       F: FnOnce() -> (),
     {
-      self.channel.with_reset(|| {
-        self.env.with_reset(|| {
-          self
-            .cas_client
-            .with_reset(|| self.byte_stream_client.with_reset(f))
-        })
+      self.cas_client.with_reset(|| {
+        self
+          .byte_stream_client
+          .with_reset(|| self.channel.with_reset(|| self.env.with_reset(f)))
       })
     }
 

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -693,6 +693,14 @@ impl<N: Node> Graph<N> {
     let inner = self.inner.lock().unwrap();
     inner.all_digests()
   }
+
+  pub fn with_exclusive<F, T>(&self, f: F) -> T
+  where
+    F: FnOnce() -> T,
+  {
+    let _inner = self.inner.lock().unwrap();
+    f()
+  }
 }
 
 ///

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -107,7 +107,12 @@ pub struct FallibleExecuteProcessResult {
 pub trait CommandRunner: Send + Sync {
   fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<FallibleExecuteProcessResult, String>;
 
-  fn reset_prefork(&self);
+  ///
+  /// NB: Unlike other `with_shutdown` methods in the codebase, this method takes a Fn reference,
+  /// because in order to be "object safe", `CommandRunner` must not have functions with generic
+  /// parameters.
+  ///
+  fn with_shutdown(&self, f: &mut FnMut() -> ());
 }
 
 ///
@@ -133,7 +138,7 @@ impl CommandRunner for BoundedCommandRunner {
     self.sema.with_acquired(move || inner.run(req))
   }
 
-  fn reset_prefork(&self) {
-    self.inner.reset_prefork();
+  fn with_shutdown(&self, f: &mut FnMut() -> ()) {
+    self.inner.with_shutdown(f);
   }
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -310,9 +310,12 @@ impl super::CommandRunner for CommandRunner {
       .to_boxed()
   }
 
-  fn reset_prefork(&self) {
-    self.store.reset_prefork();
-    self.fs_pool.reset();
+  fn with_shutdown(&self, f: &mut FnMut() -> ()) {
+    // TODO: Although we have a Resettable<CpuPool>, we do not shut it down, because our caller
+    // will (and attempting to shut things down twice guarantees a deadlock because Resettable is
+    // not reentrant). This is fragile, and it would be nice to have type safety to prevent that
+    // case.
+    self.store.with_reset(|| f())
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -206,11 +206,14 @@ impl super::CommandRunner for CommandRunner {
     }
   }
 
-  fn reset_prefork(&self) {
-    self.channel.reset();
-    self.env.reset();
-    self.execution_client.reset();
-    self.operations_client.reset();
+  fn with_shutdown(&self, f: &mut FnMut() -> ()) {
+    self.channel.with_reset(|| {
+      self.env.with_reset(|| {
+        self
+          .execution_client
+          .with_reset(|| self.operations_client.with_reset(|| f()))
+      })
+    })
   }
 }
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -121,11 +121,25 @@ impl Core {
     }
   }
 
-  pub fn pre_fork(&self) {
-    self.fs_pool.reset();
-    self.store.reset_prefork();
-    self.runtime.reset();
-    self.command_runner.reset_prefork();
+  pub fn fork_context<F, T>(&self, f: F) -> T
+  where
+    F: Fn() -> T,
+  {
+    self.fs_pool.with_shutdown(|| {
+      self.runtime.with_reset(|| {
+        self.graph.with_exclusive(|| {
+          // TODO: In order for `CommandRunner` to be "object safe" (which it must be in order to
+          // be `Box`ed for use in the `Core` struct without generic parameters), it cannot have
+          // a generic return type. Rather than giving it a return type like `void*`, we set a
+          // mutable field here.
+          let mut res: Option<T> = None;
+          self.command_runner.with_shutdown(&mut || {
+            res = Some(f());
+          });
+          res.expect("with_shutdown method did not call its argument function.")
+        })
+      })
+    })
   }
 }
 

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -209,6 +209,17 @@ pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorRespons
 }
 
 ///
+/// Calls the given function with exclusive access to all locks managed by this module.
+/// Used to ensure that the main thread forks with all locks acquired.
+///
+pub fn exclusive_call(func: &Key) -> Result<Value, Failure> {
+  // NB: Acquiring the interns exclusively as well.
+  let interns = INTERNS.write().unwrap();
+  let func_val = interns.get(func);
+  with_externs_exclusive(|e| (e.call)(e.context, func_val as &Handle, &[].as_ptr(), 0)).into()
+}
+
+///
 /// NB: Panics on failure. Only recommended for use with built-in functions, such as
 /// those configured in types::Types.
 ///
@@ -225,6 +236,8 @@ pub fn unsafe_call(func: &Function, args: &[Value]) -> Value {
 /////////////////////////////////////////////////////////////////////////////////////////
 
 lazy_static! {
+  // NB: Unfortunately, it's not currently possible to merge these locks, because mutating
+  // the `Interns` requires calls to extern functions, which would be re-entrant.
   static ref EXTERNS: RwLock<Option<Externs>> = RwLock::new(None);
   static ref INTERNS: RwLock<Interns> = RwLock::new(Interns::new());
 }
@@ -258,6 +271,17 @@ where
   F: FnOnce(&Externs) -> T,
 {
   let externs_opt = EXTERNS.read().unwrap();
+  let externs = externs_opt
+    .as_ref()
+    .unwrap_or_else(|| panic!("externs used before static initialization."));
+  f(externs)
+}
+
+fn with_externs_exclusive<F, T>(f: F) -> T
+where
+  F: FnOnce(&Externs) -> T,
+{
+  let externs_opt = EXTERNS.write().unwrap();
   let externs = externs_opt
     .as_ref()
     .unwrap_or_else(|| panic!("externs used before static initialization."));

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -340,10 +340,22 @@ pub extern "C" fn scheduler_metrics(
   })
 }
 
+///
+/// Prepares to fork by shutting down any background threads used for execution, and then
+/// calling the given callback function (which should execute the fork) while holding exclusive
+/// access to all relevant locks.
+///
 #[no_mangle]
-pub extern "C" fn scheduler_pre_fork(scheduler_ptr: *mut Scheduler) {
+pub extern "C" fn scheduler_fork_context(
+  scheduler_ptr: *mut Scheduler,
+  func: Function,
+) -> PyResult {
   with_scheduler(scheduler_ptr, |scheduler| {
-    scheduler.core.pre_fork();
+    scheduler.core.fork_context(|| {
+      externs::exclusive_call(&func.0)
+        .map_err(|f| format!("{:?}", f))
+        .into()
+    })
   })
 }
 

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -231,7 +231,7 @@ python_tests(
   tags={'integration'},
 )
 
-python_tests(
+python_library(
   name='scheduler_test_base',
   sources=['scheduler_test_base.py'],
   dependencies=[

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -160,6 +160,15 @@ class EngineTest(unittest.TestCase, SchedulerTestBase):
       ''').lstrip()+'\n',
       remove_locations_from_traceback(str(cm.exception)))
 
+  def test_fork_context(self):
+    # A smoketest that confirms that we can successfully enter and exit the fork context, which
+    # implies acquiring and releasing all relevant Engine resources.
+    expected = "42"
+    def fork_context_body():
+      return expected
+    res = self.mk_scheduler().with_fork_context(fork_context_body)
+    self.assertEquals(res, expected)
+
   def test_trace_multi(self):
     # Tests that when multiple distinct failures occur, they are each rendered.
     rules = [

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -18,6 +18,7 @@ from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Get
 from pants.engine.struct import HasProducts, Struct
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS
+from pants.util.memo import memoized
 from pants.util.objects import SubclassesOf
 from pants_test.option.util.fakes import create_options_for_optionables
 from pants_test.subsystem.subsystem_util import init_subsystem
@@ -83,6 +84,7 @@ def run_rule(rule, *args):
       return res
 
 
+@memoized
 def init_native():
   """Initialize and return a `Native` instance."""
   init_subsystem(BinaryUtil.Factory)
@@ -90,9 +92,9 @@ def init_native():
   return Native.create(opts.for_global_scope())
 
 
-def create_scheduler(rules, validate=True):
+def create_scheduler(rules, validate=True, native=None):
   """Create a Scheduler."""
-  native = init_native()
+  native = native or init_native()
   return Scheduler(
     native,
     FileSystemProjectTree(os.getcwd()),

--- a/tests/python/pants_test/pantsd/service/test_fs_event_service.py
+++ b/tests/python/pants_test/pantsd/service/test_fs_event_service.py
@@ -37,7 +37,7 @@ class TestFSEventService(TestBase):
     super(TestFSEventService, self).setUp()
     self.mock_watchman = mock.create_autospec(Watchman, spec_set=True)
     self.service = FSEventService(self.mock_watchman, self.BUILD_ROOT, self.WORKER_COUNT)
-    self.service.setup(None, None, executor=TestExecutor())
+    self.service.setup(None, executor=TestExecutor())
     self.service.register_all_files_handler(lambda x: True, name='test')
     self.service.register_all_files_handler(lambda x: False, name='test2')
 

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -342,7 +342,7 @@ class TestBase(unittest.TestCase):
       self._scheduler.invalidate_all_files()
       # Eagerly free file handles, threads, connections, etc, held by the scheduler. In theory,
       # dropping the scheduler is equivalent, but it's easy for references to the scheduler to leak.
-      self._scheduler.pre_fork()
+      self._scheduler.with_fork_context(lambda: None)
 
   @property
   def build_root(self):

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -340,9 +340,6 @@ class TestBase(unittest.TestCase):
     if self._scheduler is not None:
       self._build_graph.reset()
       self._scheduler.invalidate_all_files()
-      # Eagerly free file handles, threads, connections, etc, held by the scheduler. In theory,
-      # dropping the scheduler is equivalent, but it's easy for references to the scheduler to leak.
-      self._scheduler.with_fork_context(lambda: None)
 
   @property
   def build_root(self):


### PR DESCRIPTION
### Problem

As described in #6356, we currently suspect that there are cases where resources within the engine are being used during a fork. The python-side `fork_lock` attempts to approximate a bunch of other locks which it would be more accurate to directly acquire instead. 

### Solution

Move "fork context" management to rust, and execute our double fork for `DaemonPantsRunner` inside the scheduler's fork context. This acquires all existing locks, which removes the need for a `fork_lock` that would approximate those locks. Also has the benefit that we can eagerly re-start the scheduler's CpuPool.

### Result

It should be easier to add additional threads and locks on the rust side, without worrying that we have acquired the `fork_lock` in enough places.

A series of replays of our internal benchmarks no longer reproduce the hang described in #6356, so this likely fixes #6356.