### PR TITLE
Add ability for pants to call coursier with the new url attribute

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -36,14 +36,14 @@ class CoursierSubsystem(Subsystem):
     register('--fetch-options', type=list, fingerprint=True,
              help='Additional options to pass to coursier fetch. See `coursier fetch --help`')
     register('--bootstrap-jar-url', fingerprint=True,
-             default='https://dl.dropboxusercontent.com/s/nd3lfi6fqvlyn9q/coursier-cli.jar?dl=0',
+             default='https://dl.dropboxusercontent.com/s/a1xr4qxzj5aoait/coursier-cli-1.0.2.3e4a65d5ee66f043c2467972bd6e29f48b570715.jar?dl=0',
              help='Location to download a bootstrap version of Coursier.')
     # TODO(wisechengyi): currently using a custom url for fast iteration.
     # Once the coursier builds are stable, move the logic to binary_util. https://github.com/pantsbuild/pants/issues/5381
-    # Ths sha in the version corresponds to the sha in the PR https://github.com/coursier/coursier/pull/735
+    # Ths sha in the version corresponds to the sha in the PR https://github.com/coursier/coursier/pull/774
     # The jar is built by following https://github.com/coursier/coursier/blob/master/DEVELOPMENT.md#build-with-pants
     register('--version', type=str, fingerprint=True,
-             default='1.0.0.d5de1477516e3429f4d0a522fc0361f2d7b27944',
+             default='1.0.2.3e4a65d5ee66f043c2467972bd6e29f48b570715',
              help='Version paired with --bootstrap-jar-url, in order to invalidate and fetch the new version.')
     register('--bootstrap-fetch-timeout-secs', type=int, advanced=True, default=10,
              help='Timeout the fetch if the connection is idle for longer than this value.')

--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -36,7 +36,7 @@ class CoursierSubsystem(Subsystem):
     register('--fetch-options', type=list, fingerprint=True,
              help='Additional options to pass to coursier fetch. See `coursier fetch --help`')
     register('--bootstrap-jar-url', fingerprint=True,
-             default='https://dl.dropboxusercontent.com/s/iqdg7iht09rlvsy/coursier-cli-1.0.0.d5de1477516e3429f4d0a522fc0361f2d7b27944.jar?dl=0',
+             default='https://dl.dropboxusercontent.com/s/nd3lfi6fqvlyn9q/coursier-cli.jar?dl=0',
              help='Location to download a bootstrap version of Coursier.')
     # TODO(wisechengyi): currently using a custom url for fast iteration.
     # Once the coursier builds are stable, move the logic to binary_util. https://github.com/pantsbuild/pants/issues/5381

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -603,6 +603,9 @@ class CoursierMixin(NailgunTask):
     :return:
     """
     if os.path.abspath(coursier_cache_path) not in os.path.abspath(jar_path):
+      # Appending the string 'absolute' to the jar_path and joining that is a hack to work around
+      # python's os.path.join behavior of throwing away all components that come before an
+      # absolute path. See https://docs.python.org/3.3/library/os.path.html#os.path.join
       return os.path.join(pants_jar_path_base, os.path.normpath('absolute/' + jar_path))
     else:
       return os.path.join(pants_jar_path_base, 'relative', os.path.relpath(jar_path, coursier_cache_path))

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -636,6 +636,10 @@ class CoursierResolve(CoursierMixin):
   def register_options(cls, register):
     super(CoursierResolve, cls).register_options(register)
 
+  @classmethod
+  def implementation_version(cls):
+    return super(CoursierResolve, cls).implementation_version() + [('CoursierResolve', 1)]
+  
   def execute(self):
     """Resolves the specified confs for the configured targets and returns an iterator over
     tuples of (conf, jar path).

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_resolve.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import tempfile
 from contextlib import contextmanager
 
 from mock import MagicMock


### PR DESCRIPTION
### Problem
We need to fetch a jar with a url using coursier but previously this was not something coursier could do. With the [update to coursier](https://github.com/coursier/coursier/commit/3e4a65d5ee66f043c2467972bd6e29f48b570715) that adds this functionality, we need to update pants to use it. 

### Solution
All that is required to integrate the coursier changes is to check if the url is present for the jar dep and call coursier with that jar dep. An additional change was made to adjust the path of the jar file if it is a local url (coursier doesn't symlink local files to it's cache).

### Result
After updating the coursier jar link, it works! I am able to fetch the jar file for a dependency that has defined the url.