### PR TITLE
Fix non-exportable library target subclasses

### DIFF
--- a/contrib/jax_ws/src/python/pants/contrib/jax_ws/targets/jax_ws_library.py
+++ b/contrib/jax_ws/src/python/pants/contrib/jax_ws/targets/jax_ws_library.py
@@ -5,17 +5,12 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import logging
-
-from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
+from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 
 
-logger = logging.getLogger(__name__)
-
-
-class JaxWsLibrary(ExportableJvmLibrary):
+class JaxWsLibrary(JvmTarget):
   """Generates a Java library from JAX-WS wsdl files."""
 
   def __init__(self,

--- a/src/python/pants/backend/codegen/wire/java/java_wire_library.py
+++ b/src/python/pants/backend/codegen/wire/java/java_wire_library.py
@@ -5,19 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import logging
-
-from pants.backend.jvm.targets.exportable_jvm_library import ExportableJvmLibrary
+from pants.backend.jvm.targets.jvm_target import JvmTarget
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.payload import Payload
 from pants.base.payload_field import PrimitiveField
 from pants.base.validation import assert_list
 
 
-logger = logging.getLogger(__name__)
-
-
-class JavaWireLibrary(ExportableJvmLibrary):
+class JavaWireLibrary(JvmTarget):
   """A Java library generated from Wire IDL files.
 
   Supports Wire 1.x only.


### PR DESCRIPTION
Change `JaxWsLibrary` and `JavaWireLibrary` to no longer subclass
`ExportableJvmLibrary` because these target types are not actually exportable,
since they represent codegen targets. The current configuration prevents these
targets from being exported.

Fixes pantsbuild/pants#5532