### PR TITLE
Simplify fake options creation in tests.

### DIFF
--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -285,7 +285,6 @@ class BaseTest(unittest.TestCase):
     # Many tests use source root functionality via the SourceRootConfig.global_instance().
     # (typically accessed via Target.target_base), so we always set it up, for convenience.
     optionables = {SourceRootConfig}
-    extra_scopes = set()
 
     for_subsystems = for_subsystems or ()
     for subsystem in for_subsystems:
@@ -308,7 +307,6 @@ class BaseTest(unittest.TestCase):
         optionables.add(type(subclass_name, (task_type.goal_options_registrar_cls, ),
                              {b'options_scope': task_type.options_scope}))
 
-      extra_scopes.update([si.scope for si in task_type.known_scope_infos()])
       optionables.update(Subsystem.closure(
         set([dep.subsystem_cls for dep in task_type.subsystem_dependencies_iter()]) |
             self._build_configuration.subsystems()))
@@ -321,7 +319,7 @@ class BaseTest(unittest.TestCase):
       scoped_opts.update(opts)
 
     fake_options = create_options_for_optionables(
-      optionables, extra_scopes=extra_scopes, options=options, **kwargs)
+      optionables, options=options, **kwargs)
 
     Subsystem.reset(reset_options=True)
     Subsystem.set_options(fake_options)

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -45,25 +45,29 @@ class _FakeOptionValues(object):
   def is_default(self, key):
     return self.get_rank(key) in (RankedValue.NONE, RankedValue.HARDCODED)
 
+  @property
+  def option_values(self):
+    return self._option_values
+
 
 def _options_registration_function(defaults, fingerprintables):
   def register(*args, **kwargs):
     option_name = Parser.parse_dest(*args, **kwargs)
 
-    default = kwargs.get('default')
+    default = kwargs.get(b'default')
     if default is None:
-      if kwargs.get('type') == bool:
+      if kwargs.get(b'type') == bool:
         default = False
-      if kwargs.get('type') == list:
+      if kwargs.get(b'type') == list:
         default = []
     defaults[option_name] = RankedValue(RankedValue.HARDCODED, default)
 
-    fingerprint = kwargs.get('fingerprint', False)
+    fingerprint = kwargs.get(b'fingerprint', False)
     if fingerprint:
       if is_list_option(kwargs):
-        val_type = kwargs.get('member_type', str)
+        val_type = kwargs.get(b'member_type', str)
       else:
-        val_type = kwargs.get('type', str)
+        val_type = kwargs.get(b'type', str)
       fingerprintables[option_name] = val_type
 
   return register
@@ -87,14 +91,18 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
 
   class FakeOptions(object):
     def for_scope(self, scope):
-      scoped_options = options[scope]
       # TODO(John Sirois): Some users pass in A dict of scope -> _FakeOptionValues instead of a
       # dict of scope -> (dict of option name -> value).  Clean up these usages and kill this
       # accomodation.
-      if isinstance(scoped_options, _FakeOptionValues):
-        return scoped_options
-      else:
-        return _FakeOptionValues(scoped_options)
+      options_for_this_scope = options.get(scope) or {}
+      if isinstance(options_for_this_scope, _FakeOptionValues):
+        options_for_this_scope = options_for_this_scope.option_values
+
+      scoped_options = {}
+      if scope:
+        scoped_options.update(self.for_scope(enclosing_scope(scope)).option_values)
+      scoped_options.update(options_for_this_scope)
+      return _FakeOptionValues(scoped_options)
 
     def for_global_scope(self):
       return self.for_scope('')
@@ -122,8 +130,8 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
       """
       pairs = []
       if include_passthru:
-        passthru_args = self.passthru_args_for_scope(bottom_scope)
-        pairs.extend((str, arg) for arg in passthru_args)
+        pu_args = self.passthru_args_for_scope(bottom_scope)
+        pairs.extend((str, arg) for arg in pu_args)
 
       option_values = self.for_scope(bottom_scope)
       for option_name, option_type in fingerprintable[bottom_scope].items():
@@ -137,7 +145,6 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
 
 
 def create_options_for_optionables(optionables,
-                                   extra_scopes=None,
                                    options=None,
                                    options_fingerprintable=None,
                                    passthru_args=None):
@@ -146,7 +153,6 @@ def create_options_for_optionables(optionables,
   Any scoped `options` provided will override defaults, behaving as-if set on the command line.
 
   :param iterable optionables: A series of `Optionable` types to register default options for.
-  :param iterable extra_scopes: An optional series of extra known scopes in play.
   :param dict options: A dict of scope -> (dict of option name -> value) representing option values
                        explicitly set via the command line.
   :param dict options_fingerprintable: A dict of scope -> (dict of option name -> option type)
@@ -160,28 +166,9 @@ def create_options_for_optionables(optionables,
   fingerprintable_options = defaultdict(dict)
   bootstrap_option_values = None
 
-  # NB(cosmicexplorer): we do this again for all_options after calling
-  # register_func below, this is a hack
-  if options:
-    for scope, opts in options.items():
-      all_options[scope].update(opts)
   if options_fingerprintable:
     for scope, opts in options_fingerprintable.items():
       fingerprintable_options[scope].update(opts)
-
-  def complete_scopes(scopes):
-    """Return all enclosing scopes.
-
-    This is similar to what `complete_scopes` does in `pants.option.options.Options` without
-    creating `ScopeInfo`s.
-    """
-    completed_scopes = set(scopes)
-    for scope in scopes:
-      while scope != GLOBAL_SCOPE:
-        if scope not in completed_scopes:
-          completed_scopes.add(scope)
-        scope = enclosing_scope(scope)
-    return completed_scopes
 
   def register_func(on_scope):
     scoped_options = all_options[on_scope]
@@ -203,33 +190,9 @@ def create_options_for_optionables(optionables,
   for optionable in optionables:
     optionable.register_options(register_func(optionable.options_scope))
 
-  # Make inner scopes inherit option values from their enclosing scopes.
-  all_scopes = set(all_options.keys())
-
-  # TODO(John Sirois): Kill extra scopes one this goes in:
-  #   https://github.com/pantsbuild/pants/issues/1957
-  # For now we need a way for users of this utility to provide extra derived scopes out of band.
-  # With #1957 resolved, the extra scopes will be embedded in the Optionable's option_scope
-  # directly.
-  if extra_scopes:
-    all_scopes.update(extra_scopes)
-
-  all_scopes = complete_scopes(all_scopes)
-
-  # We need to update options before completing them based on inner/outer relation.
   if options:
     for scope, opts in options.items():
       all_options[scope].update(opts)
-
-  # Iterating in sorted order guarantees that we see outer scopes before inner scopes,
-  # and therefore only have to inherit from our immediately enclosing scope.
-  for s in sorted(all_scopes):
-    if s != GLOBAL_SCOPE:
-      scope = enclosing_scope(s)
-      opts = all_options[s]
-      for key, val in all_options.get(scope, {}).items():
-        if key not in opts:  # Inner scope values override the inherited ones.
-          opts[key] = val
 
   return create_options(all_options,
                         passthru_args=passthru_args,


### PR DESCRIPTION
The main change is to inherit option values from enclosing scopes
at read time, instead of attempting to eagerly cascade the options
downward at init time. This is much simpler, and closer to what the
production options system does.

Also removes the long-unnecessary extra_scopes functionality.
