### PR TITLE
Tighten `PytestRun` coverage plugin.

### DIFF
--- a/src/python/pants/backend/python/__init__.py
+++ b/src/python/pants/backend/python/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/python/pants/backend/python/tasks/__init__.py
+++ b/src/python/pants/backend/python/tasks/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -186,7 +186,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
   def _add_plugin_config(cls, cp, src_chroot_path, src_to_target_base):
     # We use a coverage plugin to map PEX chroot source paths back to their original repo paths for
     # report output.
-    plugin_module = 'pants.backend.python.tasks.coverage.plugin'
+    plugin_module = PytestPrep.PytestBinary.coverage_plugin_module()
     cls._ensure_section(cp, 'run')
     cp.set('run', 'plugins', plugin_module)
 


### PR DESCRIPTION
Re-name coverage plugin classes to reflect their roles and re-name the
coverage plugin module in the pytest binary chroot to avoid the needless
complication of sharing packages with pants code and thus previously
needing namespace packages where none otherwise would be needed.

Addresses feedback in #5534 and #5535