### PR TITLE
Prep 1.4.0rc3

### DIFF
--- a/src/python/pants/notes/1.4.x.rst
+++ b/src/python/pants/notes/1.4.x.rst
@@ -3,6 +3,23 @@
 
 This document describes releases leading up to the ``1.4.x`` ``stable`` series.
 
+1.4.0rc3 (03/05/2018)
+---------------------
+
+The fourth release candidate for the ``1.4.x`` stable branch.
+
+Bugfixes
+~~~~~~~~
+
+* [pantsd] Repair end to end runtracker timing for pantsd runs. (#5526)
+  `PR #5526 <https://github.com/pantsbuild/pants/pull/5526>`_
+
+Refactoring, Improvements, and Tooling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* [pantsd] Repair pantsd integration tests for execution via pantsd. (#5387)
+  `PR #5387 <https://github.com/pantsbuild/pants/pull/5387>`_
+
 1.4.0rc2 (02/23/2018)
 ---------------------
 


### PR DESCRIPTION
One more.

In hindsight, I should have released `1.4.0` final a few iterations ago and then had these be followup point releases. Apologies. I will cut `1.4.0` final by Wednesday at the latest.