### PR TITLE
Better `PantsRunIntegrationTest` invalidation.

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -60,6 +60,7 @@ function calculate_current_hash() {
      "${REPO_ROOT}/src/python/pants/engine/native.py" \
      "${REPO_ROOT}/build-support/bin/native" \
      "${REPO_ROOT}/3rdparty/python/requirements.txt" \
+   | grep -v -e "/BUILD" -e "/*.md" \
    | git hash-object -t blob --stdin-paths) | fingerprint_data
   )
 }

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -60,7 +60,7 @@ function calculate_current_hash() {
      "${REPO_ROOT}/src/python/pants/engine/native.py" \
      "${REPO_ROOT}/build-support/bin/native" \
      "${REPO_ROOT}/3rdparty/python/requirements.txt" \
-   | grep -v -e "/BUILD" -e "/*.md" \
+   | grep -v -E -e "/BUILD$" -e "/[^/]*\.md$" \
    | git hash-object -t blob --stdin-paths) | fingerprint_data
   )
 }

--- a/src/rust/engine/BUILD
+++ b/src/rust/engine/BUILD
@@ -1,0 +1,17 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Track files depended on to build the native engine to allow for downstream invalidations.
+files(
+  sources=zglobs(
+    '**/Cargo.*',
+    '**/*.rs',
+    exclude=[
+      zglobs('**/target/*'),
+      'process_execution/bazel_protos'
+    ]
+  ),
+  dependencies=[
+    'src/rust/engine/process_execution/bazel_protos'
+  ]
+)

--- a/src/rust/engine/process_execution/bazel_protos/BUILD
+++ b/src/rust/engine/process_execution/bazel_protos/BUILD
@@ -1,0 +1,14 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Track files depended on to build the native engine to allow for downstream invalidations.
+files(
+  sources=zglobs(
+    'generate-grpc.sh',
+    '**/Cargo.*',
+    '**/*.rs',
+    exclude=[
+      zglobs('**/target/*'),
+    ]
+  )
+)

--- a/tests/python/pants_test/BUILD
+++ b/tests/python/pants_test/BUILD
@@ -65,13 +65,13 @@ target(
   name = 'int-test',
   dependencies=[
     ':int-test-for-export',
+
     # NB: 'pants_run_integration_test.py' runs ./pants in a subprocess, so test results will depend
-    # on the pants binary and all of its transitive dependencies. Adding this dependency is our best
-    # proxy for ensuring that any test target depending on this target will be invalidated on
-    # changes to those undeclared dependencies. Note that this concern is not applicable in CI due
-    # to the use of clean-all.
-    # There may be a better way to do this.
+    # on the pants binary and all of its transitive dependencies. Adding the dependencies below is
+    # our best proxy for ensuring that any test target depending on this target will be invalidated
+    # on changes to those undeclared dependencies.
     'src/python/pants/bin:pants_local_binary',
+    'src/rust/engine',
   ],
 )
 


### PR DESCRIPTION
Previously, files that made up the native engine binary used by pants
were not tracked against invalidations of integration tests.