### PR TITLE
Only shift once, not twice

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -2,6 +2,8 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+set -e
+
 ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") && cd "$(git rev-parse --show-toplevel)" && pwd)
 source ${ROOT}/build-support/common.sh
 
@@ -275,7 +277,7 @@ EOM
 
 function install_and_test_packages() {
   local VERSION=$1
-  shift 2
+  shift
   local PIP_ARGS=(
     "${VERSION}"
     "$@"


### PR DESCRIPTION
cb72c2aa5f188e26ef93a8fb2a18524daa75a1ac removed the CORE_ONLY which was
the second shift target.

It turns out that bash no-ops if you `shift 2` when there is only one
arg. So that's fun.

Also, `set -e` for this script. Note that it doesn't actually do
anything about the `shift` error (that would be far too useful), but
it's something we should generally be doing.

But also, we should rewrite this script in python or something, because
it's gotten insane. Filed
https://github.com/pantsbuild/pants/issues/5551 to track that.