### PR TITLE
Native engine is a stripped cdylib

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -265,7 +265,7 @@ def bootstrap_c_source(output_dir, module_name=NATIVE_ENGINE_MODULE):
   temp_output_prefix = os.path.join(tempdir, module_name)
   real_output_prefix = os.path.join(output_dir, module_name)
   temp_c_file = '{}.c'.format(temp_output_prefix)
-  real_c_file = '{}.c'.format(real_output_prefix)
+  c_file = '{}.c'.format(real_output_prefix)
   env_script = '{}.cflags'.format(real_output_prefix)
 
   ffibuilder = cffi.FFI()
@@ -275,10 +275,23 @@ def bootstrap_c_source(output_dir, module_name=NATIVE_ENGINE_MODULE):
   ffibuilder.set_source(module_name, CFFI_TYPEDEFS + CFFI_HEADERS)
   ffibuilder.emit_c_code(six.binary_type(temp_c_file))
 
+  # Work around https://github.com/rust-lang/rust/issues/36342 by renaming initnative_engine to
+  # wrapped_initnative_engine so that the rust code can define the symbol initnative_engine.
+  #
+  # If we dont do this, we end up at the mercy of the implementation details of rust's stripping
+  # and LTO. In the past we have found ways to trick it into not stripping symbols which was handy
+  # (it kept the binary working) but inconvenient (it was relying on unspecified behavior, it meant
+  # our binaries couldn't be stripped which inflated them by 2~3x, and it reduced the amount of LTO
+  # we could use, which led to unmeasured performance hits).
   with open(temp_c_file, 'rb') as f:
-    file_content = f.read()
+    lines = f.readlines()
+  for i, line in enumerate(lines):
+    # This is an optimistic heuristic for renaming the initnative_engine symbol and nothing else.
+    if line.startswith(b'init{}'.format(module_name)):
+      lines[i] = 'wrapped_' + line
+  file_content = ''.join(lines)
 
-  _replace_file(real_c_file, file_content)
+  _replace_file(c_file, file_content)
 
   # Write a shell script to be sourced at build time that contains inherited CFLAGS.
   _replace_file(env_script, get_build_cflags())

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -17,7 +17,7 @@ import cffi
 import pkg_resources
 import six
 
-from pants.util.dirutil import safe_mkdir, safe_mkdtemp, touch
+from pants.util.dirutil import safe_mkdir, safe_mkdtemp
 from pants.util.memo import memoized_property
 from pants.util.objects import datatype
 
@@ -257,33 +257,45 @@ def get_build_cflags():
 
 def bootstrap_c_source(output_dir, module_name=NATIVE_ENGINE_MODULE):
   """Bootstrap an external CFFI C source file."""
+
+  tempdir = safe_mkdtemp()
+
   safe_mkdir(output_dir)
 
-  output_prefix = os.path.join(output_dir, module_name)
-  c_file = '{}.c'.format(output_prefix)
-  env_script = '{}.cflags'.format(output_prefix)
+  temp_output_prefix = os.path.join(tempdir, module_name)
+  real_output_prefix = os.path.join(output_dir, module_name)
+  temp_c_file = '{}.c'.format(temp_output_prefix)
+  real_c_file = '{}.c'.format(real_output_prefix)
+  env_script = '{}.cflags'.format(real_output_prefix)
 
   ffibuilder = cffi.FFI()
   ffibuilder.cdef(CFFI_TYPEDEFS)
   ffibuilder.cdef(CFFI_HEADERS)
   ffibuilder.cdef(CFFI_EXTERNS)
   ffibuilder.set_source(module_name, CFFI_TYPEDEFS + CFFI_HEADERS)
-  ffibuilder.emit_c_code(six.binary_type(c_file))
+  ffibuilder.emit_c_code(six.binary_type(temp_c_file))
+
+  with open(temp_c_file, 'rb') as f:
+    file_content = f.read()
+
+  _replace_file(real_c_file, file_content)
 
   # Write a shell script to be sourced at build time that contains inherited CFLAGS.
-  with open(env_script, 'wb') as f:
-    f.write(get_build_cflags())
+  _replace_file(env_script, get_build_cflags())
 
-  # These files are built by Cargo which looks at mtime to determine when to rebuild. Since
-  # this source file contains the generated contents this is a simple way to make sure we don't
-  # trigger Cargo rebuilds un-necessarily.
-  source_mtime = os.stat(__file__).st_mtime
 
-  def fixup_times(path):
-    touch(path, times=(source_mtime, source_mtime))
+def _replace_file(path, content):
+  """Writes a file if it doesn't already exist with the same content.
 
-  fixup_times(c_file)
-  fixup_times(env_script)
+  This is useful because cargo uses timestamps to decide whether to compile things."""
+  if os.path.exists(path):
+    with open(path, 'rb') as f:
+      if content == f.read():
+        print("Not overwriting {} because it is unchanged".format(path), file=sys.stderr)
+        return
+
+  with open(path, 'wb') as f:
+    f.write(content)
 
 
 def _initialize_externs(ffi):

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -12,13 +12,10 @@ debug = true
 codegen-units = 1
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [build-dependencies]
 cc = "1.0"
-
-# TODO: Enable workspace when https://github.com/rust-lang/rust/issues/44862 is resolved.
-# [workspace]
 
 [dependencies]
 boxfuture = { path = "boxfuture" }

--- a/src/rust/engine/src/cffi_externs.rs
+++ b/src/rust/engine/src/cffi_externs.rs
@@ -1,0 +1,17 @@
+// This file creates the unmangled symbol initnative_engine which cffi will use as the entry point
+// to this shared library.
+//
+// It calls the extern'd wrapped_initnative_engine (generated in
+// src/rust/engine/src/cffi/native_engine.c by build-support/native-engine/bootstrap_cffi.py).
+// This is a bit awkward and fiddly, but necessary because rust doesn't currently have a way to
+// re-export symbols from C libraries, other than this.
+// See https://github.com/rust-lang/rust/issues/36342
+
+extern "C" {
+  pub fn wrapped_initnative_engine();
+}
+
+#[no_mangle]
+pub extern "C" fn initnative_engine() {
+  unsafe { wrapped_initnative_engine() }
+}

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+pub mod cffi_externs;
 mod context;
 mod core;
 mod externs;


### PR DESCRIPTION
**How**

1. Make our output type a cdylib not a dylib.
2. Rename the cffi-provided `initnative_engine` function to
   `wrapped_initnative_engine`, and create `initnative_engine` in Rust,
   which calls the C version. This is required because otherwise the
   linker will strip `initnative_engine` out of the binary.

**Why**

1. This is the supported path in rust. The fact that making a `dylib`
   happened to work before isn't particularly well defined behavior in
   Rust, but was a nice accident.
2. Binary size. When building a cdylib, the linker can strip dead code,
   and perform LTO. Note that LTO is not enabled in this commit, but
   will be a seprate PR. The following size improvements were observed
   in release mode:
   OSX:
    - dylib (before this change): 16M
    - cdylib (with this change): 2.9M

   Linux:
    - dylib (before this change): 66M
    - cdylib (with this change): 51M

3. Performance. This allows the toolchain to be much more aggressive
   with optimisations (particularly when we enable LTO in the future).
   Time to list a large repo (2nd invocation, without daemon):
   OSX:
    - Before: 4m29
    - After: 4m12

   Linux:
    - Before: 4m11
    - After: 4m7

**Drawbacks**

Slows down release mode compilation.
OSX:
 - Before: 323s
 - After: 348s

Linux (on travis, which has somewhat variable performance):
 - Before: 436s
 - After: 556s