### PR TITLE
Native engine is a stripped cdylib

### DIFF
--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -12,13 +12,10 @@ debug = true
 codegen-units = 1
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [build-dependencies]
 cc = "1.0"
-
-# TODO: Enable workspace when https://github.com/rust-lang/rust/issues/44862 is resolved.
-# [workspace]
 
 [dependencies]
 boxfuture = { path = "boxfuture" }

--- a/src/rust/engine/src/cffi_externs.rs
+++ b/src/rust/engine/src/cffi_externs.rs
@@ -1,0 +1,17 @@
+// This file creates the unmangled symbol initnative_engine which cffi will use as the entry point
+// to this shared library.
+//
+// It calls the extern'd wrapped_initnative_engine (generated in
+// src/rust/engine/src/cffi/native_engine.c by build-support/native-engine/bootstrap_cffi.py).
+// This is a bit awkward and fiddly, but necessary because rust doesn't currently have a way to
+// re-export symbols from C libraries, other than this.
+// See https://github.com/rust-lang/rust/issues/36342
+
+extern "C" {
+  pub fn wrapped_initnative_engine();
+}
+
+#[no_mangle]
+pub extern "C" fn initnative_engine() {
+  unsafe { wrapped_initnative_engine() }
+}

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+pub mod cffi_externs;
 mod context;
 mod core;
 mod externs;


### PR DESCRIPTION
**How**

1. Make our output type a cdylib not a dylib.
2. Rename the cffi-provided `initnative_engine` function to
   `wrapped_initnative_engine`, and create `initnative_engine` in Rust,
   which calls the C version. This is required because otherwise the
   linker will strip `initnative_engine` out of the binary.

**Why**

1. This is the supported path in rust. The fact that making a `dylib`
   happened to work before isn't particularly well defined behavior in
   Rust, but was a nice accident.
2. Binary size. When building a cdylib, the linker can strip dead code,
   and perform LTO. Note that LTO is not enabled in this commit, but
   will be a seprate PR. The following size improvements were observed
   in release mode:
   OSX:
    - dylib (before this change): 16M
    - cdylib (with this change): 2.9M

   Linux:
    - dylib (before this change): 66M
    - cdylib (with this change): 51M

3. Performance. This allows the toolchain to be much more aggressive
   with optimisations (particularly when we enable LTO in the future).
   Time to list a large repo (2nd invocation, without daemon):
   OSX:
    - Before: 4m29
    - After: 4m12

   Linux:
    - Before: 4m11
    - After: 4m7

**Drawbacks**

Slows down release mode compilation.
OSX:
 - Before: 323s
 - After: 348s

Linux (on travis, which has somewhat variable performance):
 - Before: 436s
 - After: 556s