### PR TITLE
Set thrifty build_file_aliases (#5559)

### DIFF
--- a/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
+++ b/contrib/thrifty/src/python/pants/contrib/thrifty/BUILD
@@ -15,4 +15,5 @@ contrib_plugin(
     'Topic :: Software Development :: Code Generators'
   ],
   register_goals=True,
+  build_file_aliases=True,
 )


### PR DESCRIPTION
The recently added `java_thrifty_library` does not have
`build_file_aliases` set, which makes the new target type inaccessible
in build files. This requirement is already documented in
https://github.com/pantsbuild/pants/blob/master/contrib/README.md so
here we just fix the bug, vs. update the docs too.