### PR TITLE
Reenable LMDB store

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -52,7 +52,7 @@ class PathGlobs(datatype('PathGlobs', ['include', 'exclude'])):
                      tuple(join(relative_to, f) for f in exclude))
 
 
-class Snapshot(datatype('Snapshot', ['fingerprint', 'path_stats'])):
+class Snapshot(datatype('Snapshot', ['fingerprint', 'digest_length', 'path_stats'])):
   """A Snapshot is a collection of Files and Dirs fingerprinted by their names/content.
 
   Snapshots are used to make it easier to isolate process execution by fixing the contents
@@ -77,7 +77,7 @@ class Snapshot(datatype('Snapshot', ['fingerprint', 'path_stats'])):
     return [p.stat for p in self.files]
 
   def __repr__(self):
-    return '''Snapshot(fingerprint='{}', entries={})'''.format(hexlify(self.fingerprint)[:8], len(self.path_stats))
+    return '''Snapshot(fingerprint='{}', digest_length='{}', entries={})'''.format(hexlify(self.fingerprint)[:8], self.digest_length, len(self.path_stats))
 
   def __str__(self):
     return repr(self)

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -201,10 +201,10 @@ class ExecuteProcess(object):
     return TaskRule(product_type, inputs, func)
 
 
-class ExecuteProcessRequest(datatype('ExecuteProcessRequest', ['argv', 'env'])):
+class ExecuteProcessRequest(datatype('ExecuteProcessRequest', ['argv', 'env', 'input_files_digest', 'digest_length'])):
   """Request for execution with args and snapshots to extract."""
 
-  def __new__(cls, argv, env):
+  def __new__(cls, argv, env, input_files_digest, digest_length):
     """
 
     :param args: Arguments to the process being run.
@@ -212,7 +212,7 @@ class ExecuteProcessRequest(datatype('ExecuteProcessRequest', ['argv', 'env'])):
     """
     if not isinstance(argv, tuple):
       raise ValueError('argv must be a tuple.')
-    return super(ExecuteProcessRequest, cls).__new__(cls, argv, tuple(env))
+    return super(ExecuteProcessRequest, cls).__new__(cls, argv, tuple(env), input_files_digest, digest_length)
 
 
 class ExecuteProcessResult(datatype('ExecuteProcessResult', ['stdout', 'stderr', 'exit_code'])):

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "itertools 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -91,11 +91,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.31.0"
+version = "2.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -133,6 +133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "engine"
 version = "0.0.1"
 dependencies = [
+ "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "cc 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -140,6 +141,7 @@ dependencies = [
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
@@ -147,19 +149,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "filetime"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "fixedbitset"
@@ -194,7 +198,6 @@ dependencies = [
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
 ]
@@ -206,7 +209,8 @@ dependencies = [
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs 0.0.1",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
@@ -309,6 +313,14 @@ dependencies = [
 name = "hex"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ignore"
@@ -465,12 +477,18 @@ name = "process_execution"
 version = "0.0.1"
 dependencies = [
  "bazel_protos 0.0.1",
+ "boxfuture 0.0.1",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
  "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
 ]
 
@@ -478,8 +496,14 @@ dependencies = [
 name = "process_executor"
 version = "0.0.1"
 dependencies = [
- "clap 2.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "boxfuture 0.0.1",
+ "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "process_execution 0.0.1",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -489,6 +513,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
@@ -565,23 +594,20 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "tar"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tempdir"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -687,17 +713,17 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "xattr"
-version = "0.1.11"
+name = "wincolor"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
+"checksum atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "af80143d6f7608d746df1520709e5d141c96f240b0e62b0aa41bdfb53374d9d4"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
@@ -706,13 +732,13 @@ dependencies = [
 "checksum bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b7db437d718977f6dc9b2e3fd6fc343c02ac6b899b73fdd2179163447bd9ce9"
 "checksum cc 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9be26b24e988625409b19736d130f0c7d224f01d06454b5f81d8d23d6c1a618f"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum clap 2.31.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1421d46c072857aa41909d39261d2ffec2bb6235376d442d538053c078c8eeac"
+"checksum clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dc18f6f4005132120d9711636b32c46a233fad94df6217fa1d81c5e97a9f200"
 "checksum cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "56d741ea7a69e577f6d06b36b7dff4738f680593dc27a701ffa8506b73ce28bb"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
+"checksum env_logger 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f3cc21490995c841d68e00276eba02071ebb269ec24011d5728bd00eabd39e31"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -726,6 +752,7 @@ dependencies = [
 "checksum grpcio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c1bc34b5cf6d43923d2b8567635fb80ea7f7d15f0adedf9fa9cd3592f7ba045"
 "checksum grpcio-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43899079c21c006e2257ea2518a0644876ca53fc98cc059d76f4f5f922240437"
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
+"checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23d53b4c7394338044c3b9c8c5b2caaf7b40ae049ecd321578ebdc2e13738cd1"
@@ -745,6 +772,7 @@ dependencies = [
 "checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a06aeffc36f6abfaf86e6b5b350c5ab4ec81ed3d95215c17730e0e744dfdd2c5"
+"checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
@@ -754,8 +782,8 @@ dependencies = [
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum tar 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1605d3388ceb50252952ffebab4b5dc43017ead7e4481b175961c283bb951195"
 "checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
+"checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
@@ -771,4 +799,4 @@ dependencies = [
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum xattr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "5f04de8a1346489a2f9e9bd8526b73d135ec554227b17568456e86aa35b6f3fc"
+"checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -33,12 +33,14 @@ members = [
 ]
 
 [dependencies]
+bazel_protos = { path = "process_execution/bazel_protos" }
 boxfuture = { path = "boxfuture" }
 fnv = "1.0.5"
 fs = { path = "fs" }
 futures = "0.1.16"
 hashing = { path = "hashing" }
 lazy_static = "0.2.2"
+log = "0.4"
 ordermap = "0.2.8"
 petgraph = "0.4.5"
 process_execution = { path = "process_execution" }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -19,6 +19,7 @@ ignore = "0.3.1"
 itertools = "0.7.2"
 lazy_static = "0.2.2"
 lmdb = "0.7.2"
+log = "0.4"
 ordermap = "0.2.8"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -22,7 +22,6 @@ lmdb = "0.7.2"
 ordermap = "0.2.8"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"
-tar = "0.4.13"
 tempdir = "0.3.5"
 
 [dev-dependencies]

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -8,6 +8,7 @@ bazel_protos = { path = "../../process_execution/bazel_protos" }
 boxfuture = { path = "../../boxfuture" }
 bytes = "0.4.5"
 clap = "2"
+env_logger = "0.5.4"
 fs = { path = ".." }
 futures = "0.1.16"
 hashing = { path = "../../hashing" }

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -2,6 +2,7 @@ extern crate bazel_protos;
 extern crate boxfuture;
 extern crate bytes;
 extern crate clap;
+extern crate env_logger;
 extern crate fs;
 extern crate futures;
 extern crate hashing;
@@ -37,6 +38,8 @@ impl From<String> for ExitError {
 }
 
 fn main() {
+  env_logger::init();
+
   match execute(
     App::new("fs_util")
       .subcommand(
@@ -181,7 +184,7 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
         e
       )
     })?;
-    (Arc::new(store), store_has_remote)
+    (store, store_has_remote)
   };
 
   match top_match.subcommand() {
@@ -292,7 +295,7 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
                 paths,
               )
             })
-            .map(|snapshot| snapshot.digest.unwrap())
+            .map(|snapshot| snapshot.digest)
             .wait()?;
           if store_has_remote {
             store.ensure_remote_has_recursive(vec![digest]).wait()?;
@@ -382,7 +385,7 @@ fn make_posix_fs<P: AsRef<Path>>(root: P, pool: Arc<ResettablePool>) -> fs::Posi
 
 #[derive(Clone)]
 struct FileSaver {
-  store: Arc<Store>,
+  store: Store,
   posix_fs: Arc<fs::PosixFS>,
 }
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -24,6 +24,8 @@ extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
 extern crate lmdb;
+#[macro_use]
+extern crate log;
 #[cfg(test)]
 extern crate mock;
 extern crate ordermap;

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 mod snapshot;
-pub use snapshot::{Snapshot, StoreFileByDigest};
+pub use snapshot::{EMPTY_DIGEST, Snapshot, StoreFileByDigest};
 mod store;
 pub use store::Store;
 mod pool;
@@ -29,25 +29,21 @@ extern crate mock;
 extern crate ordermap;
 extern crate protobuf;
 extern crate sha2;
-extern crate tar;
 extern crate tempdir;
 
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::{fmt, fs};
 use std::io::{self, Read};
 use std::cmp::min;
 
 use bytes::Bytes;
 use futures::future::{self, Future};
-use futures_cpupool::CpuFuture;
 use glob::Pattern;
-use hashing::{Fingerprint, WriterHasher};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ordermap::OrderMap;
-use tempdir::TempDir;
 
 use boxfuture::{Boxable, BoxFuture};
 
@@ -829,242 +825,6 @@ fn safe_create_dir_all(path: &Path) -> Result<(), String> {
   })
 }
 
-fn safe_create_tmpdir_in(base_dir: &Path, prefix: &str) -> Result<TempDir, String> {
-  safe_create_dir_all(&base_dir)?;
-  Ok(TempDir::new_in(&base_dir, prefix).map_err(|e| {
-    format!("Failed to create tempdir {:?} due to {:?}", base_dir, e)
-  })?)
-}
-
-///
-/// A facade for the snapshot directory, which lives under the pants workdir.
-///
-pub struct Snapshots {
-  snapshots_dir: PathBuf,
-  snapshots_generator: Mutex<(TempDir, usize)>,
-}
-
-impl Snapshots {
-  pub fn new(snapshots_dir: PathBuf) -> Result<Snapshots, String> {
-    let snapshots_tmpdir = safe_create_tmpdir_in(&snapshots_dir, ".tmp")?;
-
-    Ok(Snapshots {
-      snapshots_dir: snapshots_dir,
-      snapshots_generator: Mutex::new((snapshots_tmpdir, 0)),
-    })
-  }
-
-  pub fn snapshot_path(&self) -> &Path {
-    self.snapshots_dir.as_path()
-  }
-
-  fn next_temp_path(&self) -> Result<PathBuf, String> {
-    let mut gen = self.snapshots_generator.lock().unwrap();
-    gen.1 += 1;
-
-    // N.B. Sometimes, in e.g. a `./pants clean-all test ...` the snapshot tempdir created at the
-    // beginning of a run can be removed out from under us by e.g. the `clean-all` task. Here, we
-    // we double check existence of the `TempDir`'s path when the path is accessed and replace if
-    // necessary.
-    if !gen.0.path().exists() {
-      gen.0 = safe_create_tmpdir_in(&self.snapshots_dir, ".tmp")?;
-    }
-
-    Ok(gen.0.path().join(format!("{}.tmp", gen.1)))
-  }
-
-  ///
-  /// A non-canonical (does not expand symlinks) in-memory form of normalize. Used to collapse
-  /// parent and cur components, which are legal in symbolic paths in PathStats, but not in
-  /// Tar files.
-  ///
-  fn normalize(path: &Path) -> Result<PathBuf, String> {
-    let mut res = PathBuf::new();
-    for component in path.components() {
-      match component {
-        Component::Prefix(..) |
-        Component::RootDir => return Err(format!("Absolute paths not supported: {:?}", path)),
-        Component::CurDir => continue,
-        Component::ParentDir => {
-          // Pop the previous component.
-          if !res.pop() {
-            return Err(format!(
-              "Globs may not traverse outside the root: {:?}",
-              path
-            ));
-          } else {
-            continue;
-          }
-        }
-        Component::Normal(p) => res.push(p),
-      }
-    }
-    Ok(res)
-  }
-
-  ///
-  /// Create a tar file on the given Write instance containing the given paths, or
-  /// return an error string.
-  ///
-  fn tar_create<W: io::Write>(
-    dest: W,
-    paths: &Vec<PathStat>,
-    relative_to: &Dir,
-  ) -> Result<W, String> {
-    let mut tar_builder = tar::Builder::new(dest);
-    tar_builder.mode(tar::HeaderMode::Deterministic);
-    for path_stat in paths {
-      // Append the PathStat using the symbolic name and underlying stat.
-      let append_res = match path_stat {
-        &PathStat::File { ref path, ref stat } => {
-          let normalized = Snapshots::normalize(path)?;
-          let mut input = fs::File::open(relative_to.0.join(stat.path.as_path()))
-            .map_err(|e| format!("Failed to open {:?}: {:?}", path_stat, e))?;
-          tar_builder.append_file(normalized, &mut input)
-        }
-        &PathStat::Dir { ref path, ref stat } => {
-          let normalized = Snapshots::normalize(path)?;
-          tar_builder.append_dir(normalized, relative_to.0.join(stat.0.as_path()))
-        }
-      };
-      append_res.map_err(|e| {
-        format!("Failed to tar {:?}: {:?}", path_stat, e)
-      })?;
-    }
-
-    // Finish the tar file, returning ownership of the stream to the caller.
-    Ok(tar_builder.into_inner().map_err(|e| {
-      format!("Failed to finalize snapshot tar: {:?}", e)
-    })?)
-  }
-
-  ///
-  /// Create a tar file at the given dest Path containing the given paths, while
-  /// fingerprinting the written stream.
-  ///
-  fn tar_create_fingerprinted(
-    dest: &Path,
-    paths: &Vec<PathStat>,
-    relative_to: &Dir,
-  ) -> Result<Fingerprint, String> {
-    // Wrap buffering around a fingerprinted stream above a File.
-    let stream = io::BufWriter::new(WriterHasher::new(fs::File::create(dest).map_err(|e| {
-      format!("Failed to create destination file: {:?}", e)
-    })?));
-
-    // Then append the tar to the stream, and retrieve the Fingerprint to flush all writers.
-    Ok(
-      Snapshots::tar_create(stream, paths, relative_to)?
-        .into_inner()
-        .map_err(|e| {
-          format!("Failed to flush to {:?}: {:?}", dest, e.error())
-        })?
-        .finish(),
-    )
-  }
-
-  ///
-  /// Attempts to rename src to dst, and _succeeds_ if dst already exists. This is safe in
-  /// the case of Snapshots because the destination path is unique to its content.
-  ///
-  fn finalize(temp_path: &Path, dest_path: &Path) -> Result<(), String> {
-    if dest_path.is_file() {
-      // The Snapshot has already been created.
-      fs::remove_file(temp_path).unwrap_or(());
-      Ok(())
-    } else {
-      let dest_dir = dest_path.parent().expect(
-        "All snapshot paths must have parent directories.",
-      );
-      safe_create_dir_all(dest_dir)?;
-      match fs::rename(temp_path, dest_path) {
-        Ok(_) => Ok(()),
-        Err(_) if dest_path.is_file() => Ok(()),
-        Err(e) => Err(format!(
-          "Failed to finalize snapshot at {:?}: {:?}",
-          dest_path,
-          e
-        )),
-      }
-    }
-  }
-
-  fn path_for(&self, fingerprint: &Fingerprint) -> PathBuf {
-    Snapshots::path_under_for(self.snapshot_path(), fingerprint)
-  }
-
-  fn path_under_for(path: &Path, fingerprint: &Fingerprint) -> PathBuf {
-    let hex = fingerprint.to_hex();
-    path.join(&hex[0..2]).join(&hex[2..4]).join(
-      format!("{}.tar", hex),
-    )
-  }
-
-  ///
-  /// Creates a Snapshot for the given paths under the given VFS.
-  ///
-  pub fn create(&self, fs: &PosixFS, paths: Vec<PathStat>) -> CpuFuture<Snapshot, String> {
-    let dest_dir = self.snapshot_path().to_owned();
-    let root = fs.root.clone();
-    let temp_path = self.next_temp_path().expect(
-      "Couldn't get the next temp path.",
-    );
-
-    fs.pool.spawn_fn(move || {
-      // Write the tar deterministically to a temporary file while fingerprinting.
-      let fingerprint = Snapshots::tar_create_fingerprinted(temp_path.as_path(), &paths, &root)?;
-
-      // Rename to the final path if it does not already exist.
-      Snapshots::finalize(
-        temp_path.as_path(),
-        Snapshots::path_under_for(&dest_dir, &fingerprint).as_path(),
-      )?;
-
-      Ok(Snapshot {
-        fingerprint: fingerprint,
-        digest: None,
-        path_stats: paths,
-      })
-    })
-  }
-
-  fn contents_for_sync(snapshot: Snapshot, path: PathBuf) -> Result<Vec<FileContent>, io::Error> {
-    let mut archive = fs::File::open(path).map(|f| tar::Archive::new(f))?;
-
-    // Zip the in-memory Snapshot to the on disk representation, validating as we go.
-    let mut files_content = Vec::new();
-    for (entry_res, path_stat) in archive.entries()?.zip(snapshot.path_stats.into_iter()) {
-      let mut entry = entry_res?;
-      if entry.header().entry_type() == tar::EntryType::file() {
-        let path = match path_stat {
-          PathStat::File { path, .. } => path,
-          PathStat::Dir { .. } => panic!("Snapshot contents changed after storage."),
-        };
-        let mut content = Vec::new();
-        io::Read::read_to_end(&mut entry, &mut content)?;
-        files_content.push(FileContent {
-          path: path,
-          content: Bytes::from(content),
-        });
-      }
-    }
-    Ok(files_content)
-  }
-
-  pub fn contents_for(
-    &self,
-    fs: &PosixFS,
-    snapshot: Snapshot,
-  ) -> CpuFuture<Vec<FileContent>, String> {
-    let archive_path = self.path_for(&snapshot.fingerprint);
-    fs.pool.spawn_fn(move || {
-      let snapshot_str = format!("{:?}", snapshot);
-      Snapshots::contents_for_sync(snapshot, archive_path).map_err(|e| {
-        format!("Failed to open Snapshot {}: {:?}", snapshot_str, e)
-      })
-    })
-  }
-}
 
 #[cfg(test)]
 mod posixfs_test {

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -437,8 +437,8 @@ mod local {
   use bytes::Bytes;
   use digest::{Digest as DigestTrait, FixedOutput};
   use hashing::{Digest, Fingerprint};
-  use lmdb::{self, Cursor, Database, DatabaseFlags, Environment, NO_OVERWRITE, RwTransaction,
-             Transaction, WriteFlags};
+  use lmdb::{self, Cursor, Database, DatabaseFlags, Environment, NO_OVERWRITE, NO_TLS,
+             RwTransaction, Transaction, WriteFlags};
   use lmdb::Error::{KeyExist, MapFull, NotFound};
   use sha2::Sha256;
   use std::collections::BinaryHeap;
@@ -467,8 +467,20 @@ mod local {
 
   impl ByteStore {
     pub fn new<P: AsRef<Path>>(path: P, pool: Arc<ResettablePool>) -> Result<ByteStore, String> {
-      // 3 DBs; one for file contents, one for directories, one for leases.
       let env = Environment::new()
+        // Without this flag, each time a read transaction is started, it eats into our transaction
+        // limit (default: 126) until that thread dies.
+        //
+        // This flag makes transactions be removed from that limit when they are dropped, rather
+        // than when their thread dies. This is important, because we perform reads from a thread
+        // pool, so our threads never die. Without this flag, all read requests will fail after the
+        // first 126.
+        //
+        // The only down-side is that you need to make sure that any individual OS thread must not
+        // try to perform multiple write transactions concurrently. Fortunately, this property
+        // holds for us.
+        .set_flags(NO_TLS)
+          // 3 DBs; one for file contents, one for directories, one for leases.
         .set_max_dbs(3)
         .set_map_size(MAX_LOCAL_STORE_SIZE_BYTES)
         .open(path.as_ref())

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -5,12 +5,19 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
 bazel_protos = { path = "bazel_protos" }
+boxfuture = { path = "../boxfuture" }
+bytes = "0.4.5"
 digest = "0.6.2"
+fs = { path = "../fs" }
+futures = "0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
+hashing = { path = "../hashing" }
+log = "0.4"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"
+tempdir = "0.3.5"
 
 [dev-dependencies]
-bytes = "0.4.5"
 mock = { path = "../testutil/mock" }
+tempdir = "0.3.5"
 testutil = { path = "../testutil" }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1,12 +1,19 @@
 extern crate bazel_protos;
-#[cfg(test)]
+extern crate boxfuture;
 extern crate bytes;
 extern crate digest;
+extern crate fs;
+extern crate futures;
 extern crate grpcio;
+extern crate hashing;
+#[macro_use]
+extern crate log;
 #[cfg(test)]
 extern crate mock;
 extern crate protobuf;
 extern crate sha2;
+#[cfg(test)]
+extern crate tempdir;
 #[cfg(test)]
 extern crate testutil;
 
@@ -36,6 +43,8 @@ pub struct ExecuteProcessRequest {
   /// No other environment variables will be set (except possibly for an empty PATH variable).
   ///
   pub env: BTreeMap<String, String>,
+
+  pub input_files: hashing::Digest,
 }
 
 ///

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -1,3 +1,5 @@
+extern crate tempdir;
+
 use std::io::Error;
 use std::path::Path;
 use std::process::Command;
@@ -11,7 +13,6 @@ pub fn run_command_locally(
   req: ExecuteProcessRequest,
   workdir: &Path,
 ) -> Result<ExecuteProcessResult, Error> {
-  println!("executing in workdir: {:?}", &workdir);
   Command::new(&req.argv[0])
     .args(&req.argv[1..])
     .current_dir(workdir)
@@ -34,6 +35,7 @@ mod tests {
   extern crate testutil;
 
   use super::{ExecuteProcessRequest, ExecuteProcessResult, run_command_locally};
+  use fs;
   use std::collections::BTreeMap;
   use std::path::PathBuf;
   use self::testutil::{owned_string_vec, as_byte_owned_vec};
@@ -45,6 +47,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
         env: BTreeMap::new(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     );
@@ -68,6 +71,7 @@ mod tests {
           &["/bin/bash", "-c", "echo -n foo ; echo >&2 -n bar ; exit 1"],
         ),
         env: BTreeMap::new(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     );
@@ -93,6 +97,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["/usr/bin/env"]),
         env: env.clone(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     );
@@ -125,6 +130,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["/usr/bin/env"]),
         env: env,
+        input_files: fs::EMPTY_DIGEST,
       }
     }
 
@@ -140,6 +146,7 @@ mod tests {
       ExecuteProcessRequest {
         argv: owned_string_vec(&["echo", "-n", "foo"]),
         env: BTreeMap::new(),
+        input_files: fs::EMPTY_DIGEST,
       },
       &PathBuf::from("/"),
     ).expect_err("Want Err");

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -2,7 +2,12 @@ use std::error::Error;
 use std::sync::Arc;
 
 use bazel_protos;
-use digest::{Digest, FixedOutput};
+use boxfuture::{BoxFuture, Boxable};
+use bytes::Bytes;
+use digest::{Digest as DigestTrait, FixedOutput};
+use fs::Store;
+use futures::{Future, future};
+use hashing::{Digest, Fingerprint};
 use grpcio;
 use protobuf::{self, Message, ProtobufEnum};
 use sha2::Sha256;
@@ -10,21 +15,36 @@ use sha2::Sha256;
 use super::{ExecuteProcessRequest, ExecuteProcessResult};
 
 pub struct CommandRunner {
-  execution_client: bazel_protos::remote_execution_grpc::ExecutionClient,
-  operations_client: bazel_protos::operations_grpc::OperationsClient,
+  execution_client: Arc<bazel_protos::remote_execution_grpc::ExecutionClient>,
+  operations_client: Arc<bazel_protos::operations_grpc::OperationsClient>,
+  store: Store,
+}
+
+#[derive(Debug, PartialEq)]
+enum ExecutionError {
+  // String is the error message.
+  Fatal(String),
+  // Digests are Files and Directories which have been reported to be missing. May be incomplete.
+  MissingFiles(Vec<Digest>),
+  // String is the operation name which can be used to poll the GetOperation gRPC API.
+  NotFinished(String),
 }
 
 impl CommandRunner {
-  pub fn new(address: &str, thread_count: usize) -> CommandRunner {
+  pub fn new(address: &str, thread_count: usize, store: Store) -> CommandRunner {
     let env = Arc::new(grpcio::Environment::new(thread_count));
     let channel = grpcio::ChannelBuilder::new(env.clone()).connect(address);
-    let execution_client =
-      bazel_protos::remote_execution_grpc::ExecutionClient::new(channel.clone());
-    let operations_client = bazel_protos::operations_grpc::OperationsClient::new(channel.clone());
+    let execution_client = Arc::new(bazel_protos::remote_execution_grpc::ExecutionClient::new(
+      channel.clone(),
+    ));
+    let operations_client = Arc::new(bazel_protos::operations_grpc::OperationsClient::new(
+      channel.clone(),
+    ));
 
     CommandRunner {
       execution_client,
       operations_client,
+      store,
     }
   }
 
@@ -32,48 +52,124 @@ impl CommandRunner {
   /// Runs a command via a gRPC service implementing the Bazel Remote Execution API
   /// (https://docs.google.com/document/d/1AaGk7fOPByEvpAbqeXIyE8HX_A3_axxNnvroblTZ_6s/edit).
   ///
+  /// If the CommandRunner has a Store, files will be uploaded to the remote CAS as needed.
+  /// Note that it does not proactively upload files to a remote CAS. This is because if we will
+  /// get a cache hit, uploading the files was wasted time and bandwidth, and if the remote CAS
+  /// already has some files, uploading them all is a waste. Instead, we look at the responses we
+  /// get back from the server, and upload the files it says it's missing.
+  ///
+  /// In the future, we may want to do some clever things like proactively upload files which the
+  /// user has changed, or files which aren't known to the local git repository, but these are
+  /// optimizations to shave off a round-trip in the future.
+  ///
   /// Loops until the server gives a response, either successful or error. Does not have any
   /// timeout: polls in a tight loop.
   ///
   pub fn run_command_remote(
     &self,
     req: ExecuteProcessRequest,
-  ) -> Result<ExecuteProcessResult, String> {
-    let execute_request = make_execute_request(&req)?;
+  ) -> BoxFuture<ExecuteProcessResult, String> {
+    let execution_client = self.execution_client.clone();
+    let execution_client2 = execution_client.clone();
+    let operations_client = self.operations_client.clone();
 
-    let initial_result = map_grpc_result(self.execution_client.execute(&execute_request))?;
+    let store = self.store.clone();
+    let execute_request_result = make_execute_request(&req);
 
-    match extract_execute_response(&initial_result)? {
-      Some(value) => {
-        return Ok(value);
+    match execute_request_result {
+      Ok((command, execute_request)) => {
+        self.upload_command(&command, execute_request.get_action().get_command_digest().into())
+          .and_then(move |_| {
+            debug!("Executing remotely request: {:?} (command: {:?})", execute_request, command);
+
+            map_grpc_result(execution_client.execute(&execute_request))
+                .map(|result| (Arc::new(execute_request), result))
+          })
+
+          // TODO: Use some better looping-frequency strategy than a tight-loop:
+          // https://github.com/pantsbuild/pants/issues/5503
+
+          // TODO: Add a timeout of some kind.
+          // https://github.com/pantsbuild/pants/issues/5504
+
+          .and_then(move |(execute_request, operation)| {
+            future::loop_fn(operation, move |operation| {
+              match extract_execute_response(operation) {
+                Ok(value) => {
+                  return future::ok(future::Loop::Break(value)).to_boxed()
+                      as BoxFuture<_, _>
+                },
+                Err(ExecutionError::Fatal(err)) => {
+                  future::err(err).to_boxed() as BoxFuture<_, _>
+                },
+                Err(ExecutionError::MissingFiles(missing_files)) => {
+                  let execute_request = execute_request.clone();
+                  let execution_client2 = execution_client2.clone();
+                  store.ensure_remote_has_recursive(missing_files)
+                      .and_then(move |()| {
+                        map_grpc_result(
+                          execution_client2.execute(
+                            &execute_request.clone()
+                          )
+                        )
+                      })
+                      .map(|operation| future::Loop::Continue(operation))
+                      .to_boxed()
+                },
+                Err(ExecutionError::NotFinished(operation_name)) => {
+                  let mut operation_request =
+                    bazel_protos::operations::GetOperationRequest::new();
+                  operation_request.set_name(operation_name);
+                  let grpc_result = map_grpc_result(
+                    operations_client.get_operation(&operation_request)
+                  );
+                  match grpc_result {
+                    Ok(operation) => {
+                      future::ok(future::Loop::Continue(operation)).to_boxed()
+                          as BoxFuture<_, _>
+                    },
+                    Err(err) => future::err(err).to_boxed() as BoxFuture<_, _>,
+                  }
+                },
+              }
+            })
+        }).to_boxed()
       }
-      None => {}
+      Err(err) => future::err(err).to_boxed(),
     }
+  }
 
-    let mut operation_request = bazel_protos::operations::GetOperationRequest::new();
-    operation_request.set_name(initial_result.get_name().to_string());
-    loop {
-      // TODO: Use some better looping-frequency strategy than a tight-loop.
-      let operation_result =
-        map_grpc_result(self.operations_client.get_operation(&operation_request))?;
-
-      let result = extract_execute_response(&operation_result)?;
-
-      match result {
-        Some(value) => {
-          break Ok(value);
-        }
-        None => {
-          continue;
-        }
-      }
-    }
+  fn upload_command(
+    &self,
+    command: &bazel_protos::remote_execution::Command,
+    command_digest: Digest,
+  ) -> BoxFuture<(), String> {
+    let store = self.store.clone();
+    let store2 = store.clone();
+    future::done(command.write_to_bytes().map_err(|e| {
+      format!("Error serializing command {:?}", e)
+    })).and_then(move |command_bytes| {
+      store.store_file_bytes(Bytes::from(command_bytes), true)
+    })
+      .map_err(|e| format!("Error saving digest to local store: {:?}", e))
+      .and_then(move |_| {
+        // TODO: Tune when we upload the command.
+        store2
+          .ensure_remote_has_recursive(vec![command_digest])
+          .map_err(|e| format!("Error uploading command {:?}", e))
+          .map(|_| ())
+      })
+      .to_boxed()
   }
 }
 
 fn make_execute_request(
   req: &ExecuteProcessRequest,
-) -> Result<bazel_protos::remote_execution::ExecuteRequest, String> {
+) -> Result<
+  (bazel_protos::remote_execution::Command,
+   bazel_protos::remote_execution::ExecuteRequest),
+  String,
+> {
   let mut command = bazel_protos::remote_execution::Command::new();
   command.set_arguments(protobuf::RepeatedField::from_vec(req.argv.clone()));
   for (ref name, ref value) in req.env.iter() {
@@ -85,35 +181,125 @@ fn make_execute_request(
 
   let mut action = bazel_protos::remote_execution::Action::new();
   action.set_command_digest(digest(&command)?);
+  action.set_input_root_digest((&req.input_files).into());
 
   let mut execute_request = bazel_protos::remote_execution::ExecuteRequest::new();
   execute_request.set_action(action);
 
-  Ok(execute_request)
+  Ok((command, execute_request))
 }
 
 fn extract_execute_response(
-  operation: &bazel_protos::operations::Operation,
-) -> Result<Option<ExecuteProcessResult>, String> {
+  mut operation: bazel_protos::operations::Operation,
+) -> Result<ExecuteProcessResult, ExecutionError> {
+  // TODO: Log less verbosely
+  debug!("Got operation response: {:?}", operation);
   if !operation.get_done() {
-    return Ok(None);
+    return Err(ExecutionError::NotFinished(operation.take_name()));
   }
   if operation.has_error() {
-    return Err(format_error(&operation.get_error()));
+    return Err(ExecutionError::Fatal(format_error(&operation.get_error())));
   }
   if !operation.has_response() {
-    return Err("Operation finished but no response supplied".to_string());
+    return Err(ExecutionError::Fatal(
+      "Operation finished but no response supplied".to_string(),
+    ));
   }
   let mut execute_response = bazel_protos::remote_execution::ExecuteResponse::new();
   execute_response
     .merge_from_bytes(operation.get_response().get_value())
-    .map_err(|e| e.description().to_string())?;
+    .map_err(|e| {
+      ExecutionError::Fatal(format!("Invalid ExecuteResponse: {:?}", e))
+    })?;
+  // TODO: Log less verbosely
+  debug!("Got (nested) execute response: {:?}", execute_response);
 
-  Ok(Some(ExecuteProcessResult {
-    stdout: execute_response.get_result().get_stdout_raw().to_vec(),
-    stderr: execute_response.get_result().get_stderr_raw().to_vec(),
-    exit_code: execute_response.get_result().get_exit_code(),
-  }))
+  match grpcio::RpcStatusCode::from(execute_response.get_status().get_code()) {
+    grpcio::RpcStatusCode::Ok => Ok(ExecuteProcessResult {
+      stdout: execute_response.get_result().get_stdout_raw().to_vec(),
+      stderr: execute_response.get_result().get_stderr_raw().to_vec(),
+      exit_code: execute_response.get_result().get_exit_code(),
+    }),
+    grpcio::RpcStatusCode::FailedPrecondition => {
+      if execute_response.get_status().get_details().len() != 1 {
+        return Err(ExecutionError::Fatal(format!(
+          "Received multiple details in FailedPrecondition ExecuteResponse's status field: {:?}",
+          execute_response.get_status().get_details()
+        )));
+      }
+      let details = execute_response.get_status().get_details().get(0).unwrap();
+      let mut precondition_failure = bazel_protos::error_details::PreconditionFailure::new();
+      if details.get_type_url() !=
+        format!(
+          "type.googleapis.com/{}",
+          precondition_failure.descriptor().full_name()
+        )
+      {
+        return Err(ExecutionError::Fatal(format!(
+          "Received FailedPrecondition, but didn't know how to resolve it: {}, \
+protobuf type {}",
+          execute_response.get_status().get_message(),
+          details.get_type_url()
+        )));
+      }
+      precondition_failure
+        .merge_from_bytes(details.get_value())
+        .map_err(|e| {
+          ExecutionError::Fatal(format!(
+            "Error deserializing FailedPrecondition proto: {:?}",
+            e
+          ))
+        })?;
+
+      let mut missing_digests = Vec::with_capacity(precondition_failure.get_violations().len());
+
+      for violation in precondition_failure.get_violations() {
+        if violation.get_field_type() != "MISSING" {
+          return Err(ExecutionError::Fatal(format!(
+            "Didn't know how to process PreconditionFailure violation: {:?}",
+            violation
+          )));
+        }
+        let parts: Vec<_> = violation.get_subject().split("/").collect();
+        if parts.len() != 3 || parts.get(0).unwrap() != &"blobs" {
+          return Err(ExecutionError::Fatal(format!(
+            "Received FailedPrecondition MISSING but didn't recognize subject {}",
+            violation.get_subject()
+          )));
+        }
+        let digest = Digest(
+          Fingerprint::from_hex_string(parts.get(1).unwrap())
+            .map_err(|e| {
+              ExecutionError::Fatal(format!(
+                "Bad digest in missing blob: {}: {}",
+                parts.get(1).unwrap(),
+                e
+              ))
+            })?,
+          parts.get(2).unwrap().parse::<usize>().map_err(|e| {
+            ExecutionError::Fatal(format!(
+              "Missing blob had bad size: {}: {}",
+              parts.get(2).unwrap(),
+              e
+            ))
+          })?,
+        );
+        missing_digests.push(digest);
+      }
+      if missing_digests.len() == 0 {
+        return Err(ExecutionError::Fatal(
+          "Error from remote execution: FailedPrecondition, but no details"
+            .to_owned(),
+        ));
+      }
+      return Err(ExecutionError::MissingFiles(missing_digests));
+    }
+    code => Err(ExecutionError::Fatal(format!(
+      "Error from remote execution: {:?}: {:?}",
+      code,
+      execute_response.get_status().get_message()
+    ))),
+  }
 }
 
 fn format_error(error: &bazel_protos::status::Status) -> String {
@@ -157,29 +343,37 @@ fn digest(message: &protobuf::Message) -> Result<bazel_protos::remote_execution:
 mod tests {
   use bazel_protos;
   use bytes::Bytes;
+  use fs;
+  use futures::Future;
+  use grpcio;
+  use hashing::{Digest, Fingerprint};
   use protobuf::{self, Message, ProtobufEnum};
   use mock;
+  use tempdir::TempDir;
   use testutil::{owned_string_vec, as_byte_owned_vec};
 
-  use super::{CommandRunner, ExecuteProcessRequest, ExecuteProcessResult};
+  use super::{CommandRunner, ExecuteProcessRequest, ExecuteProcessResult, ExecutionError,
+              extract_execute_response};
   use std::collections::BTreeMap;
   use std::iter::{self, FromIterator};
+  use std::sync::Arc;
+  use std::time::Duration;
 
   #[test]
   fn server_rejecting_execute_request_gives_error() {
     let execute_request = echo_foo_request();
 
     let mock_server = {
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          "wrong-command".to_string(),
-          super::make_execute_request(&ExecuteProcessRequest {
-            argv: owned_string_vec(&["/bin/echo", "-n", "bar"]),
-            env: BTreeMap::new(),
-          }).unwrap(),
-          vec![],
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        "wrong-command".to_string(),
+        super::make_execute_request(&ExecuteProcessRequest {
+          argv: owned_string_vec(&["/bin/echo", "-n", "bar"]),
+          env: BTreeMap::new(),
+          input_files: fs::EMPTY_DIGEST,
+        }).unwrap()
+          .1,
+        vec![],
+      ))
     };
 
     let error = run_command_remote(&mock_server.address(), execute_request).expect_err("Want Err");
@@ -196,16 +390,14 @@ mod tests {
     let mock_server = {
       let op_name = "gimme-foo".to_string();
 
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap(),
-          vec![
-            make_incomplete_operation(&op_name),
-            make_successful_operation(&op_name, "foo", "", 0),
-          ],
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&execute_request).unwrap().1,
+        vec![
+          make_incomplete_operation(&op_name),
+          make_successful_operation(&op_name, "foo", "", 0),
+        ],
+      ))
     };
 
     let result = run_command_remote(&mock_server.address(), execute_request).unwrap();
@@ -227,19 +419,17 @@ mod tests {
     let mock_server = {
       let op_name = "gimme-foo".to_string();
 
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap(),
-          Vec::from_iter(
-            iter::repeat(make_incomplete_operation(&op_name))
-              .take(10)
-              .chain(iter::once(
-                make_successful_operation(&op_name, "foo", "", 0),
-              )),
-          ),
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&execute_request).unwrap().1,
+        Vec::from_iter(
+          iter::repeat(make_incomplete_operation(&op_name))
+            .take(10)
+            .chain(iter::once(
+              make_successful_operation(&op_name, "foo", "", 0),
+            )),
+        ),
+      ))
     };
 
     let result = run_command_remote(&mock_server.address(), execute_request).unwrap();
@@ -261,32 +451,30 @@ mod tests {
     let mock_server = {
       let op_name = "gimme-foo".to_string();
 
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap(),
-          vec![
-            make_incomplete_operation(&op_name),
-            {
-              let mut op = bazel_protos::operations::Operation::new();
-              op.set_name(op_name.clone());
-              op.set_done(true);
-              op.set_response({
-                let mut response_wrapper = protobuf::well_known_types::Any::new();
-                response_wrapper.set_type_url(format!(
-                  "type.googleapis.com/{}",
-                  bazel_protos::remote_execution::ExecuteResponse::new()
-                    .descriptor()
-                    .full_name()
-                ));
-                response_wrapper.set_value(vec![0x00, 0x00, 0x00]);
-                response_wrapper
-              });
-              op
-            },
-          ],
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&execute_request).unwrap().1,
+        vec![
+          make_incomplete_operation(&op_name),
+          {
+            let mut op = bazel_protos::operations::Operation::new();
+            op.set_name(op_name.clone());
+            op.set_done(true);
+            op.set_response({
+              let mut response_wrapper = protobuf::well_known_types::Any::new();
+              response_wrapper.set_type_url(format!(
+                "type.googleapis.com/{}",
+                bazel_protos::remote_execution::ExecuteResponse::new()
+                  .descriptor()
+                  .full_name()
+              ));
+              response_wrapper.set_value(vec![0x00, 0x00, 0x00]);
+              response_wrapper
+            });
+            op
+          },
+        ],
+      ))
     };
 
     run_command_remote(&mock_server.address(), execute_request).expect_err("Want Err");
@@ -299,26 +487,24 @@ mod tests {
     let mock_server = {
       let op_name = "gimme-foo".to_string();
 
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap(),
-          vec![
-            {
-              let mut op = bazel_protos::operations::Operation::new();
-              op.set_name(op_name.to_string());
-              op.set_done(true);
-              op.set_error({
-                let mut error = bazel_protos::status::Status::new();
-                error.set_code(bazel_protos::code::Code::INTERNAL.value());
-                error.set_message("Something went wrong".to_string());
-                error
-              });
-              op
-            },
-          ],
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&execute_request).unwrap().1,
+        vec![
+          {
+            let mut op = bazel_protos::operations::Operation::new();
+            op.set_name(op_name.to_string());
+            op.set_done(true);
+            op.set_error({
+              let mut error = bazel_protos::status::Status::new();
+              error.set_code(bazel_protos::code::Code::INTERNAL.value());
+              error.set_message("Something went wrong".to_string());
+              error
+            });
+            op
+          },
+        ],
+      ))
     };
 
     let result = run_command_remote(&mock_server.address(), execute_request).expect_err("Want Err");
@@ -333,27 +519,25 @@ mod tests {
     let mock_server = {
       let op_name = "gimme-foo".to_string();
 
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap(),
-          vec![
-            make_incomplete_operation(&op_name),
-            {
-              let mut op = bazel_protos::operations::Operation::new();
-              op.set_name(op_name.to_string());
-              op.set_done(true);
-              op.set_error({
-                let mut error = bazel_protos::status::Status::new();
-                error.set_code(bazel_protos::code::Code::INTERNAL.value());
-                error.set_message("Something went wrong".to_string());
-                error
-              });
-              op
-            },
-          ],
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&execute_request).unwrap().1,
+        vec![
+          make_incomplete_operation(&op_name),
+          {
+            let mut op = bazel_protos::operations::Operation::new();
+            op.set_name(op_name.to_string());
+            op.set_done(true);
+            op.set_error({
+              let mut error = bazel_protos::status::Status::new();
+              error.set_code(bazel_protos::code::Code::INTERNAL.value());
+              error.set_message("Something went wrong".to_string());
+              error
+            });
+            op
+          },
+        ],
+      ))
     };
 
     let result = run_command_remote(&mock_server.address(), execute_request).expect_err("Want Err");
@@ -368,20 +552,18 @@ mod tests {
     let mock_server = {
       let op_name = "gimme-foo".to_string();
 
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap(),
-          vec![
-            {
-              let mut op = bazel_protos::operations::Operation::new();
-              op.set_name(op_name.to_string());
-              op.set_done(true);
-              op
-            },
-          ],
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&execute_request).unwrap().1,
+        vec![
+          {
+            let mut op = bazel_protos::operations::Operation::new();
+            op.set_name(op_name.to_string());
+            op.set_done(true);
+            op
+          },
+        ],
+      ))
     };
 
     let result = run_command_remote(&mock_server.address(), execute_request).expect_err("Want Err");
@@ -396,26 +578,140 @@ mod tests {
     let mock_server = {
       let op_name = "gimme-foo".to_string();
 
-      mock::execution_server::TestServer::new(
-        mock::execution_server::MockExecution::new(
-          op_name.clone(),
-          super::make_execute_request(&execute_request).unwrap(),
-          vec![
-            make_incomplete_operation(&op_name),
-            {
-              let mut op = bazel_protos::operations::Operation::new();
-              op.set_name(op_name.to_string());
-              op.set_done(true);
-              op
-            },
-          ],
-        ).unwrap(),
-      )
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&execute_request).unwrap().1,
+        vec![
+          make_incomplete_operation(&op_name),
+          {
+            let mut op = bazel_protos::operations::Operation::new();
+            op.set_name(op_name.to_string());
+            op.set_done(true);
+            op
+          },
+        ],
+      ))
     };
 
     let result = run_command_remote(&mock_server.address(), execute_request).expect_err("Want Err");
 
     assert_eq!(result, "Operation finished but no response supplied");
+  }
+
+  #[test]
+  fn execute_missing_file_uploads_if_known() {
+    let missing_digests = vec![
+      {
+        let mut violation = bazel_protos::error_details::PreconditionFailure_Violation::new();
+        violation.set_field_type("MISSING".to_owned());
+        violation.set_subject(format!("blobs/{}/{}", digest().0, digest().1));
+        violation
+      },
+    ];
+
+    let mock_server = {
+      let op_name = "cat".to_owned();
+
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&cat_roland_request())
+          .unwrap()
+          .1,
+        vec![
+          make_incomplete_operation(&op_name),
+          make_precondition_failure_operation(
+            missing_digests.clone()
+          ),
+          make_successful_operation("cat2", STR, "", 0),
+        ],
+      ))
+    };
+
+    let store_dir = TempDir::new("store").unwrap();
+    let cas = mock::StubCAS::new(
+      1024,
+      vec![(directory_fingerprint(), directory_bytes())]
+        .into_iter()
+        .collect(),
+    );
+    let store = fs::Store::with_remote(
+      store_dir,
+      Arc::new(fs::ResettablePool::new("test-pool-".to_owned())),
+      &cas.address(),
+      1,
+      10 * 1024 * 1024,
+      Duration::from_secs(1),
+    ).expect("Failed to make store");
+    store.store_file_bytes(str_bytes(), false).wait().expect(
+      "Saving file bytes to store",
+    );
+
+    let result = CommandRunner::new(&mock_server.address(), 1, store)
+      .run_command_remote(cat_roland_request())
+      .wait();
+    assert_eq!(
+      result,
+      Ok(ExecuteProcessResult {
+        stdout: str_bytes().to_vec(),
+        stderr: "".as_bytes().to_vec(),
+        exit_code: 0,
+      })
+    );
+    {
+      let blobs = cas.blobs.lock().unwrap();
+      assert_eq!(blobs.get(&fingerprint()), Some(&str_bytes()));
+    }
+  }
+
+  #[test]
+  fn execute_missing_file_errors_if_unknown() {
+    let missing_digests = vec![
+      {
+        let mut violation = bazel_protos::error_details::PreconditionFailure_Violation::new();
+        violation.set_field_type("MISSING".to_owned());
+        violation.set_subject(format!("blobs/{}/{}", digest().0, digest().1));
+        violation
+      },
+    ];
+
+    let mock_server = {
+      let op_name = "cat".to_owned();
+
+      mock::execution_server::TestServer::new(mock::execution_server::MockExecution::new(
+        op_name.clone(),
+        super::make_execute_request(&cat_roland_request())
+          .unwrap()
+          .1,
+        vec![
+          make_incomplete_operation(&op_name),
+          make_precondition_failure_operation(
+            missing_digests.clone()
+          ),
+        ],
+      ))
+    };
+
+    let store_dir = TempDir::new("store").unwrap();
+    let cas = mock::StubCAS::new(
+      1024,
+      vec![(directory_fingerprint(), directory_bytes())]
+        .into_iter()
+        .collect(),
+    );
+    let store = fs::Store::with_remote(
+      store_dir,
+      Arc::new(fs::ResettablePool::new("test-pool-".to_owned())),
+      &cas.address(),
+      1,
+      10 * 1024 * 1024,
+      Duration::from_secs(1),
+    ).expect("Failed to make store");
+
+    let error = CommandRunner::new(&mock_server.address(), 1, store)
+      .run_command_remote(cat_roland_request())
+      .wait()
+      .expect_err("Want error");
+    assert_contains(&error, &format!("{}", digest().0));
   }
 
   #[test]
@@ -441,7 +737,153 @@ mod tests {
   }
 
   #[test]
-  fn digest() {
+  fn extract_execute_response_success() {
+    let want_result = ExecuteProcessResult {
+      stdout: "roland".as_bytes().to_owned(),
+      stderr: "simba".as_bytes().to_owned(),
+      exit_code: 17,
+    };
+
+    let mut operation = bazel_protos::operations::Operation::new();
+    operation.set_name("cat".to_owned());
+    operation.set_done(true);
+    operation.set_response(make_any_proto(&{
+      let mut response = bazel_protos::remote_execution::ExecuteResponse::new();
+      response.set_result({
+        let mut result = bazel_protos::remote_execution::ActionResult::new();
+        result.set_exit_code(want_result.exit_code);
+        result.set_stdout_raw(Bytes::from(want_result.stdout.clone()));
+        result.set_stderr_raw(Bytes::from(want_result.stderr.clone()));
+        result
+      });
+      response
+    }));
+
+    assert_eq!(extract_execute_response(operation), Ok(want_result));
+  }
+
+  #[test]
+  fn extract_execute_response_pending() {
+    let operation_name = "cat".to_owned();
+    let mut operation = bazel_protos::operations::Operation::new();
+    operation.set_name(operation_name.clone());
+    operation.set_done(false);
+
+    assert_eq!(
+      extract_execute_response(operation),
+      Err(ExecutionError::NotFinished(operation_name))
+    );
+  }
+
+  #[test]
+  fn extract_execute_response_missing_digests() {
+    let missing_files = vec![digest(), directory_digest()];
+
+    let missing = vec![
+      {
+        let mut violation = bazel_protos::error_details::PreconditionFailure_Violation::new();
+        violation.set_field_type("MISSING".to_owned());
+        violation.set_subject(format!("blobs/{}/{}", fingerprint(), STR.len()));
+        violation
+      },
+      {
+        let mut violation = bazel_protos::error_details::PreconditionFailure_Violation::new();
+        violation.set_field_type("MISSING".to_owned());
+        violation.set_subject(format!(
+          "blobs/{}/{}",
+          directory_fingerprint(),
+          directory_bytes().len()
+        ));
+        violation
+      },
+    ];
+
+    let operation = make_precondition_failure_operation(missing);
+
+    assert_eq!(
+      extract_execute_response(operation),
+      Err(ExecutionError::MissingFiles(missing_files))
+    );
+  }
+
+  #[test]
+  fn extract_execute_response_missing_other_things() {
+    let missing = vec![
+      {
+        let mut violation = bazel_protos::error_details::PreconditionFailure_Violation::new();
+        violation.set_field_type("MISSING".to_owned());
+        violation.set_subject(format!("blobs/{}/{}", fingerprint(), STR.len()));
+        violation
+      },
+      {
+        let mut violation = bazel_protos::error_details::PreconditionFailure_Violation::new();
+        violation.set_field_type("MISSING".to_owned());
+        violation.set_subject("monkeys".to_owned());
+        violation
+      },
+    ];
+
+    let operation = make_precondition_failure_operation(missing);
+
+    match extract_execute_response(operation) {
+      Err(ExecutionError::Fatal(err)) => assert_contains(&err, "monkeys"),
+      other => assert!(false, "Want fatal error, got {:?}", other),
+    };
+  }
+
+  #[test]
+  fn extract_execute_response_other_failed_precondition() {
+    let missing = vec![
+      {
+        let mut violation = bazel_protos::error_details::PreconditionFailure_Violation::new();
+        violation.set_field_type("OUT_OF_CAPACITY".to_owned());
+        violation
+      },
+    ];
+
+    let operation = make_precondition_failure_operation(missing);
+
+    match extract_execute_response(operation) {
+      Err(ExecutionError::Fatal(err)) => assert_contains(&err, "OUT_OF_CAPACITY"),
+      other => assert!(false, "Want fatal error, got {:?}", other),
+    };
+  }
+
+  #[test]
+  fn extract_execute_response_missing_without_list() {
+    let missing = vec![];
+
+    let operation = make_precondition_failure_operation(missing);
+
+    match extract_execute_response(operation) {
+      Err(ExecutionError::Fatal(err)) => assert_contains(&err.to_lowercase(), "precondition"),
+      other => assert!(false, "Want fatal error, got {:?}", other),
+    };
+  }
+
+  #[test]
+  fn extract_execute_response_other_status() {
+    let mut operation = bazel_protos::operations::Operation::new();
+    operation.set_name("cat".to_owned());
+    operation.set_done(true);
+    operation.set_response(make_any_proto(&{
+      let mut response = bazel_protos::remote_execution::ExecuteResponse::new();
+      response.set_status({
+        let mut status = bazel_protos::status::Status::new();
+        status.set_code(grpcio::RpcStatusCode::PermissionDenied as i32);
+        status
+      });
+      response
+    }));
+
+    match extract_execute_response(operation) {
+      Err(ExecutionError::Fatal(err)) => assert_contains(&err, "PermissionDenied"),
+      other => assert!(false, "Want fatal error, got {:?}", other),
+    };
+  }
+
+  #[test]
+  fn digest_command() {
     let mut command = bazel_protos::remote_execution::Command::new();
     command.mut_arguments().push("/bin/echo".to_string());
     command.mut_arguments().push("foo".to_string());
@@ -469,6 +911,7 @@ mod tests {
     ExecuteProcessRequest {
       argv: owned_string_vec(&["/bin/echo", "-n", "foo"]),
       env: BTreeMap::new(),
+      input_files: fs::EMPTY_DIGEST,
     }
   }
 
@@ -510,10 +953,130 @@ mod tests {
     op
   }
 
+  fn make_precondition_failure_operation(
+    violations: Vec<bazel_protos::error_details::PreconditionFailure_Violation>,
+  ) -> bazel_protos::operations::Operation {
+    let mut operation = bazel_protos::operations::Operation::new();
+    operation.set_name("cat".to_owned());
+    operation.set_done(true);
+    operation.set_response(make_any_proto(&{
+      let mut response = bazel_protos::remote_execution::ExecuteResponse::new();
+      response.set_status({
+        let mut status = bazel_protos::status::Status::new();
+        status.set_code(grpcio::RpcStatusCode::FailedPrecondition as i32);
+        status.mut_details().push(make_any_proto(&{
+          let mut precondition_failure = bazel_protos::error_details::PreconditionFailure::new();
+          for violation in violations.into_iter() {
+            precondition_failure.mut_violations().push(violation);
+          }
+          precondition_failure
+        }));
+        status
+      });
+      response
+    }));
+    operation
+  }
+
   fn run_command_remote(
     address: &str,
     request: ExecuteProcessRequest,
   ) -> Result<ExecuteProcessResult, String> {
-    CommandRunner::new(address, 1).run_command_remote(request)
+    let store_dir = TempDir::new("store").unwrap();
+    let cas = mock::StubCAS::empty();
+    let store = fs::Store::with_remote(
+      store_dir,
+      Arc::new(fs::ResettablePool::new("test-pool-".to_owned())),
+      &cas.address(),
+      1,
+      10 * 1024 * 1024,
+      Duration::from_secs(1),
+    ).expect("Failed to make store");
+
+    CommandRunner::new(address, 1, store)
+      .run_command_remote(request)
+      .wait()
+  }
+
+  fn make_any_proto(message: &protobuf::Message) -> protobuf::well_known_types::Any {
+    let mut any = protobuf::well_known_types::Any::new();
+    any.set_type_url(format!(
+      "type.googleapis.com/{}",
+      message.descriptor().full_name()
+    ));
+    any.set_value(message.write_to_bytes().expect("Error serializing proto"));
+    any
+  }
+
+  fn assert_contains(haystack: &str, needle: &str) {
+    assert!(
+      haystack.contains(needle),
+      "{:?} should contain {:?}",
+      haystack,
+      needle
+    )
+  }
+
+  pub const STR: &str = "European Burmese";
+  pub const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
+  pub const DIRECTORY_HASH: &str = "63949aa823baf765eff07b946050d76e\
+c0033144c785a94d3ebd82baa931cd16";
+
+  pub fn str_bytes() -> Bytes {
+    Bytes::from(STR)
+  }
+
+  pub fn fingerprint() -> Fingerprint {
+    Fingerprint::from_hex_string(HASH).unwrap()
+  }
+
+  pub fn digest() -> Digest {
+    Digest(fingerprint(), STR.len())
+  }
+
+  pub fn directory() -> bazel_protos::remote_execution::Directory {
+    make_directory("roland")
+  }
+
+  pub fn make_directory(file_name: &str) -> bazel_protos::remote_execution::Directory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_files().push({
+      let mut file = bazel_protos::remote_execution::FileNode::new();
+      file.set_name(file_name.to_string());
+      file.set_digest({
+        let mut digest = bazel_protos::remote_execution::Digest::new();
+        digest.set_hash(HASH.to_string());
+        digest.set_size_bytes(STR.len() as i64);
+        digest
+      });
+      file.set_is_executable(false);
+      file
+    });
+    directory
+  }
+
+  pub fn directory_bytes() -> Bytes {
+    Bytes::from(directory().write_to_bytes().expect(
+      "Error serializing proto",
+    ))
+  }
+
+  pub fn directory_fingerprint() -> Fingerprint {
+    Fingerprint::from_hex_string(DIRECTORY_HASH).unwrap()
+  }
+
+  pub fn directory_digest() -> Digest {
+    Digest(
+      Fingerprint::from_hex_string(DIRECTORY_HASH).unwrap(),
+      directory_bytes().len(),
+    )
+  }
+
+  fn cat_roland_request() -> ExecuteProcessRequest {
+    ExecuteProcessRequest {
+      argv: owned_string_vec(&["/bin/cat", "roland"]),
+      env: BTreeMap::new(),
+      input_files: directory_digest(),
+    }
   }
 }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -4,5 +4,11 @@ name = "process_executor"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
+boxfuture = { path = "../boxfuture" }
 clap = "2"
-process_execution = {path = "../process_execution"}
+env_logger = "0.5.4"
+fs = { path = "../fs" }
+hashing = { path = "../hashing" }
+futures = "0.1.16"
+process_execution = { path = "../process_execution" }
+tempdir = "0.3.5"

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -1,20 +1,58 @@
+extern crate boxfuture;
 extern crate clap;
+extern crate env_logger;
+extern crate fs;
+extern crate hashing;
+extern crate futures;
 extern crate process_execution;
+extern crate tempdir;
 
 use clap::{App, AppSettings, Arg};
+use futures::future::Future;
+use hashing::{Digest, Fingerprint};
+use tempdir::TempDir;
 use std::collections::BTreeMap;
-use std::process::exit;
-
 use std::iter::Iterator;
+use std::process::exit;
+use std::sync::Arc;
+use std::time::Duration;
 
 /// A binary which takes args of format:
-///  process_executor --env=FOO=bar --env=SOME=value -- /path/to/binary --flag --otherflag
+///  process_executor --env=FOO=bar --env=SOME=value --input-digest=abc123 --input-digest-length=80
+///    -- /path/to/binary --flag --otherflag
 /// and runs /path/to/binary --flag --otherflag with FOO and SOME set.
 /// It outputs its output/err to stdout/err, and exits with its exit code.
 ///
 /// It does not perform $PATH lookup or shell expansion.
 fn main() {
+  env_logger::init();
+
   let args = App::new("process_executor")
+    .arg(
+      Arg::with_name("local-store-path")
+        .long("local-store-path")
+        .takes_value(true)
+        .required(true)
+        .help("Path to lmdb directory used for local file storage"),
+    )
+    .arg(
+      Arg::with_name("input-digest")
+        .long("input-digest")
+        .takes_value(true)
+        .required(true)
+        .help(
+          "Fingerprint (hex string) of the digest to use as the input file tree.",
+        ),
+    )
+    .arg(
+      Arg::with_name("input-digest-length")
+        .long("input-digest-length")
+        .takes_value(true)
+        .required(true)
+        .help(
+          "Length of the proto-bytes whose digest to use as the input file tree.",
+        ),
+    )
     .arg(
       Arg::with_name("server")
         .long("server")
@@ -23,6 +61,12 @@ fn main() {
           "The host:port of the gRPC server to connect to. Forces remote execution. \
 If unspecified, local execution will be performed.",
         ),
+    )
+    .arg(
+      Arg::with_name("cas-server")
+        .long("cas-server")
+        .takes_value(true)
+        .help("The host:port of the gRPC CAS server to connect to."),
     )
     .arg(
       Arg::with_name("env")
@@ -58,18 +102,56 @@ If unspecified, local execution will be performed.",
     }
     None => BTreeMap::new(),
   };
-  let server = args.value_of("server");
+  let local_store_path = args.value_of("local-store-path").unwrap();
+  let pool = Arc::new(fs::ResettablePool::new("process-executor-".to_owned()));
+  let server_arg = args.value_of("server");
+  let store = match (server_arg, args.value_of("cas-server")) {
+    (Some(_server), Some(cas_server)) => {
+      fs::Store::with_remote(
+        local_store_path,
+        pool.clone(),
+        cas_server,
+        1,
+        10 * 1024 * 1024,
+        Duration::from_secs(30),
+      )
+    }
+    (None, None) => fs::Store::local_only(local_store_path, pool.clone()),
+    _ => panic!("Must specify either both --server and --cas-server or neither."),
+  }.expect("Error making store");
 
-  let request = process_execution::ExecuteProcessRequest { argv, env };
-  let result = match server {
-    Some(addr) => {
-      process_execution::remote::CommandRunner::new(addr, 1)
+  let input_files = {
+    let fingerprint = Fingerprint::from_hex_string(args.value_of("input-digest").unwrap())
+      .expect("Bad input-digest");
+    let length = args
+      .value_of("input-digest-length")
+      .unwrap()
+      .parse::<usize>()
+      .expect("input-digest-length must be a non-negative number");
+    Digest(fingerprint, length)
+  };
+
+  let request = process_execution::ExecuteProcessRequest {
+    argv,
+    env,
+    input_files,
+  };
+
+  let result = match server_arg {
+    Some(address) => {
+      process_execution::remote::CommandRunner::new(address, 1, store)
         .run_command_remote(request)
-        .unwrap()
+        .wait()
+        .expect("Error executing remotely")
     }
     None => {
-      process_execution::local::run_command_locally(request, &std::env::current_dir().unwrap())
-        .unwrap()
+      let dir = TempDir::new("process-execution").expect("Error making temporary directory");
+      store
+        .materialize_directory(dir.path().to_owned(), request.input_files)
+        .wait()
+        .expect("Error materializing directory");
+      process_execution::local::run_command_locally(request, dir.path())
+        .expect("Error executing locally")
     }
   };
   print!("{}", String::from_utf8(result.stdout).unwrap());

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -2,13 +2,12 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std;
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use core::TypeId;
 use externs;
-use fs::{PosixFS, Snapshots, Store, safe_create_dir_all_ioerror, ResettablePool};
+use fs::{PosixFS, Store, safe_create_dir_all_ioerror, ResettablePool};
 use graph::{EntryId, Graph};
 use handles::maybe_drain_handles;
 use nodes::{Node, NodeFuture};
@@ -26,7 +25,6 @@ pub struct Core {
   pub rule_graph: RuleGraph,
   pub types: Types,
   pub pool: Arc<ResettablePool>,
-  pub snapshots: Snapshots,
   pub store: Store,
   pub vfs: PosixFS,
 }
@@ -34,7 +32,7 @@ pub struct Core {
 impl Core {
   pub fn new(
     root_subject_types: Vec<TypeId>,
-    mut tasks: Tasks,
+    tasks: Tasks,
     types: Types,
     build_root: &Path,
     ignore_patterns: Vec<String>,
@@ -59,20 +57,6 @@ impl Core {
       },
     );
 
-    // TODO: Create the Snapshots directory, and then expose it as a singleton to python.
-    //   see: https://github.com/pantsbuild/pants/issues/4397
-    let snapshots = Snapshots::new(snapshots_dir).unwrap_or_else(|e| {
-      panic!("Could not initialize Snapshot directory: {:?}", e);
-    });
-    tasks.singleton_replace(
-      externs::unsafe_call(
-        &types.construct_snapshots,
-        &vec![
-          externs::store_bytes(snapshots.snapshot_path().as_os_str().as_bytes()),
-        ],
-      ),
-      types.snapshots.clone(),
-    );
     let rule_graph = RuleGraph::new(&tasks, root_subject_types);
 
     Core {
@@ -81,7 +65,6 @@ impl Core {
       rule_graph: rule_graph,
       types: types,
       pool: pool.clone(),
-      snapshots: snapshots,
       store: store,
       // FIXME: Errors in initialization should definitely be exposed as python
       // exceptions, rather than as panics.

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -22,6 +22,8 @@ extern crate futures;
 extern crate hashing;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate log;
 extern crate ordermap;
 extern crate petgraph;
 extern crate process_execution;
@@ -532,10 +534,10 @@ pub extern "C" fn set_panic_handler() {
       panic_str.push_str(&panic_location_str);
     }
 
-    externs::log(externs::LogLevel::Critical, &panic_str);
+    error!("{}", panic_str);
 
     let panic_file_bug_str = "Please file a bug at https://github.com/pantsbuild/pants/issues.";
-    externs::log(externs::LogLevel::Critical, &panic_file_bug_str);
+    error!("{}", panic_file_bug_str);
   }));
 }
 
@@ -546,7 +548,7 @@ pub extern "C" fn garbage_collect_store(scheduler_ptr: *mut Scheduler) {
     .store
     .garbage_collect() {
     Ok(_) => {}
-    Err(err) => externs::log(externs::LogLevel::Critical, &err),
+    Err(err) => error!("{}", err),
   });
 }
 
@@ -556,7 +558,7 @@ pub extern "C" fn lease_files_in_graph(scheduler_ptr: *mut Scheduler) {
     let digests = scheduler.core.graph.all_digests();
     match scheduler.core.store.lease_all(digests.iter()) {
       Ok(_) => {}
-      Err(err) => externs::log(externs::LogLevel::Critical, &err),
+      Err(err) => error!("{}", &err),
     }
   });
 }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1,6 +1,9 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+extern crate bazel_protos;
+extern crate tempdir;
+
 use std::error::Error;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
@@ -15,7 +18,7 @@ use boxfuture::{Boxable, BoxFuture};
 use context::Context;
 use core::{Failure, Key, Noop, TypeConstraint, Value, Variants, throw};
 use externs;
-use fs::{self, Dir, File, FileContent, Link, PathGlobs, PathStat, VFS};
+use fs::{self, Dir, File, FileContent, Link, PathGlobs, PathStat, StoreFileByDigest, VFS};
 use process_execution as process_executor;
 use hashing;
 use rule_graph;
@@ -44,7 +47,7 @@ fn was_required(failure: Failure) -> Failure {
   }
 }
 
-trait GetNode {
+pub trait GetNode {
   fn get<N: Node>(&self, node: N) -> NodeFuture<N::Output>;
 }
 
@@ -66,6 +69,12 @@ impl VFS<Failure> for Context {
       externs::create_exception(msg),
       "<pants native internals>".to_string(),
     )
+  }
+}
+
+impl StoreFileByDigest<Failure> for Context {
+  fn store_by_digest(&self, file: &File) -> BoxFuture<hashing::Digest, Failure> {
+    self.get(DigestFile(file.clone()))
   }
 }
 
@@ -283,17 +292,17 @@ impl Select {
       vec![
         self
           .get_snapshot(&context)
-          .and_then(move |snapshot|
+          .and_then(
+            move |snapshot|
             // Request the file contents of the Snapshot, and then store them.
-            context.core.snapshots.contents_for(&context.core.vfs, snapshot)
-              .then(move |files_content_res| match files_content_res {
-                Ok(files_content) => Ok(Snapshot::store_files_content(&context, &files_content)),
-                Err(e) => Err(throw(&e)),
-              }))
+            snapshot.contents(context.core.store.clone()).map_err(|e| throw(&e))
+              .map(move |files_content| Snapshot::store_files_content(&context, &files_content))
+          )
           .to_boxed(),
       ]
     } else if self.product() == &context.core.types.process_result {
       let value = externs::val_for(&self.subject);
+
       let mut env: BTreeMap<String, String> = BTreeMap::new();
       let env_var_parts = externs::project_multi_strs(&value, "env");
       // TODO: Error if env_var_parts.len() % 2 != 0
@@ -303,14 +312,30 @@ impl Select {
           env_var_parts[2 * i + 1].clone(),
         );
       }
+
+      // TODO: Make this much less unwrap-happy with https://github.com/pantsbuild/pants/issues/5502
+
+      let fingerprint = externs::project_str(&value, "input_files_digest");
+      let digest_length = externs::project_str(&value, "digest_length");
+      let digest_length_as_usize = digest_length.parse::<usize>().unwrap();
+      let digest = hashing::Digest(
+        hashing::Fingerprint::from_hex_string(&fingerprint).unwrap(),
+        digest_length_as_usize,
+      );
+
       let request = process_executor::ExecuteProcessRequest {
         argv: externs::project_multi_strs(&value, "argv"),
         env: env,
+        input_files: digest,
       };
-
       let tmpdir = TempDir::new("process-execution").unwrap();
-      // TODO: Materialize the snapshot into the tmpdir when ExecuteProcessRequest has a Snapshot.
 
+      context
+        .core
+        .store
+        .materialize_directory(tmpdir.path().to_owned(), digest)
+        .wait()
+        .unwrap();
       // TODO: this should run off-thread, and asynchronously
       // TODO: request the Node that invokes the process, rather than invoke directly
       let result = process_executor::local::run_command_locally(request, tmpdir.path()).unwrap();
@@ -767,12 +792,18 @@ pub struct ProcessResult(process_executor::ExecuteProcessResult);
 impl Node for ExecuteProcess {
   type Output = ProcessResult;
 
-  fn run(self, _: Context) -> NodeFuture<ProcessResult> {
+  fn run(self, context: Context) -> NodeFuture<ProcessResult> {
     let request = self.0.clone();
 
-    let tmpdir = TempDir::new("process-execution").unwrap();
-    // TODO: Materialize the snapshot into the tmpdir when ExecuteProcessRequest has a Snapshot.
+    // TODO: Make this much less unwrap-happy with https://github.com/pantsbuild/pants/issues/5502
 
+    let tmpdir = TempDir::new("process-execution").unwrap();
+    context
+      .core
+      .store
+      .materialize_directory(tmpdir.path().to_owned(), request.input_files)
+      .wait()
+      .unwrap();
     // TODO: this should run off-thread, and asynchronously
     future::ok(ProcessResult(
       process_executor::local::run_command_locally(
@@ -825,7 +856,7 @@ impl From<ReadLink> for NodeKey {
 /// A Node that represents reading a file and fingerprinting its contents.
 ///
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DigestFile(File);
+pub struct DigestFile(pub File);
 
 impl Node for DigestFile {
   type Output = hashing::Digest;
@@ -857,31 +888,6 @@ impl Node for DigestFile {
 impl From<DigestFile> for NodeKey {
   fn from(n: DigestFile) -> Self {
     NodeKey::DigestFile(n)
-  }
-}
-
-///
-/// A Node that represents consuming the stat for some path.
-///
-/// NB: Because the `Scandir` operation gets the stats for a parent directory in a single syscall,
-/// this operation results in no data, and is simply a placeholder for `Snapshot` Nodes to use to
-/// declare a dependency on the existence/content of a particular path. This makes them more error
-/// prone, unfortunately.
-///
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Stat(PathBuf);
-
-impl Node for Stat {
-  type Output = ();
-
-  fn run(self, _: Context) -> NodeFuture<()> {
-    future::ok(()).to_boxed()
-  }
-}
-
-impl From<Stat> for NodeKey {
-  fn from(n: Stat) -> Self {
-    NodeKey::Stat(n)
   }
 }
 
@@ -934,33 +940,17 @@ pub struct Snapshot {
 
 impl Snapshot {
   fn create(context: Context, path_globs: PathGlobs) -> NodeFuture<fs::Snapshot> {
-    // Recursively expand PathGlobs into PathStats while tracking their dependencies.
+    // Recursively expand PathGlobs into PathStats.
+    // We rely on Context::expand tracking dependencies for scandirs,
+    // and fs::Snapshot::from_path_stats tracking dependencies for file digests.
     context
       .expand(path_globs)
-      .then(move |path_stats_res| match path_stats_res {
-        Ok(path_stats) => {
-          // Declare dependencies on the relevant Stats, and then create a Snapshot.
-          let stats = future::join_all(
-            path_stats
-              .iter()
-              .map(
-                |path_stat| context.get(Stat(path_stat.path().to_owned())), // for recording only
-              )
-              .collect::<Vec<_>>(),
-          );
-          // And then create a Snapshot.
-          stats
-            .and_then(move |_| {
-              context
-                .core
-                .snapshots
-                .create(&context.core.vfs, path_stats)
-                .map_err(move |e| throw(&format!("Snapshot failed: {}", e)))
-            })
-            .to_boxed()
-        }
-        Err(e) => err(throw(&format!("PathGlobs expansion failed: {:?}", e))),
+      .map_err(|e| format!("PlatGlobs expansion failed: {:?}", e))
+      .and_then(move |path_stats| {
+        fs::Snapshot::from_path_stats(context.core.store.clone(), context.clone(), path_stats)
+          .map_err(move |e| format!("Snapshot failed: {}", e))
       })
+      .map_err(|e| throw(&e))
       .to_boxed()
   }
 
@@ -985,8 +975,9 @@ impl Snapshot {
       .collect();
     externs::unsafe_call(
       &context.core.types.construct_snapshot,
-      &vec![
-        externs::store_bytes(&item.fingerprint.0),
+      &[
+        externs::store_bytes(&(item.digest.0).to_hex().as_bytes()),
+        externs::store_i32((item.digest.1 as i32)),
         externs::store_list(path_stats.iter().collect(), false),
       ],
     )
@@ -1147,7 +1138,6 @@ pub enum NodeKey {
   ExecuteProcess(ExecuteProcess),
   ReadLink(ReadLink),
   Scandir(Scandir),
-  Stat(Stat),
   Select(Select),
   Snapshot(Snapshot),
   Task(Task),
@@ -1166,7 +1156,6 @@ impl NodeKey {
       &NodeKey::ExecuteProcess(ref s) => format!("ExecuteProcess({:?}", s.0),
       &NodeKey::ReadLink(ref s) => format!("ReadLink({:?})", s.0),
       &NodeKey::Scandir(ref s) => format!("Scandir({:?})", s.0),
-      &NodeKey::Stat(ref s) => format!("Stat({:?})", s.0),
       &NodeKey::Select(ref s) => {
         format!(
           "Select({}, {})",
@@ -1198,7 +1187,6 @@ impl NodeKey {
       &NodeKey::DigestFile(..) => "DigestFile".to_string(),
       &NodeKey::ReadLink(..) => "LinkDest".to_string(),
       &NodeKey::Scandir(..) => "DirectoryListing".to_string(),
-      &NodeKey::Stat(..) => "Stat".to_string(),
     }
   }
 
@@ -1207,10 +1195,18 @@ impl NodeKey {
   ///
   pub fn fs_subject(&self) -> Option<&Path> {
     match self {
+      &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),
       &NodeKey::ReadLink(ref s) => Some((s.0).0.as_path()),
       &NodeKey::Scandir(ref s) => Some((s.0).0.as_path()),
-      &NodeKey::Stat(ref s) => Some(s.0.as_path()),
-      _ => None,
+
+      // Not FS operations:
+      // Explicitly listed so that if people add new NodeKeys they need to consider whether their
+      // NodeKey represents an FS operation, and accordingly whether they need to add it to the
+      // above list or the below list.
+      &NodeKey::ExecuteProcess { .. } |
+      &NodeKey::Select { .. } |
+      &NodeKey::Snapshot { .. } |
+      &NodeKey::Task { .. } => None,
     }
   }
 }
@@ -1223,7 +1219,6 @@ impl Node for NodeKey {
       NodeKey::DigestFile(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::ExecuteProcess(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::ReadLink(n) => n.run(context).map(|v| v.into()).to_boxed(),
-      NodeKey::Stat(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Scandir(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Select(n) => n.run(context).map(|v| v.into()).to_boxed(),
       NodeKey::Snapshot(n) => n.run(context).map(|v| v.into()).to_boxed(),

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -10,7 +10,6 @@ use futures::future::{self, Future};
 use boxfuture::{Boxable, BoxFuture};
 use context::{Context, ContextFactory, Core};
 use core::{Failure, Key, TypeConstraint, TypeId, Value};
-use externs::{self, LogLevel};
 use graph::EntryId;
 use nodes::{NodeKey, Select};
 use rule_graph;
@@ -129,10 +128,7 @@ impl Scheduler {
                   // Otherwise (if it is a success, some other type of Failure, or if we've run
                   // out of retries) recover to complete the join, which will cause the results to
                   // propagate to the user.
-                  externs::log(
-                    LogLevel::Debug,
-                    &format!("Root {} completed.", NodeKey::Select(root).format()),
-                  );
+                  debug!("Root {} completed.", NodeKey::Select(root).format());
                   Ok(other)
                 }
               }
@@ -156,10 +152,7 @@ impl Scheduler {
     request: &'e ExecutionRequest,
   ) -> Vec<(&'e Key, &'e TypeConstraint, RootResult)> {
     // Bootstrap tasks for the roots, and then wait for all of them.
-    externs::log(
-      LogLevel::Debug,
-      &format!("Launching {} roots.", request.roots.len()),
-    );
+    debug!("Launching {} roots.", request.roots.len());
 
     // Wait for all roots to complete. Failure here should be impossible, because each
     // individual Future in the join was (eventually) mapped into success.

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -86,16 +86,6 @@ impl Tasks {
     ));
   }
 
-  // TODO: Only exists in order to support the `Snapshots` singleton replacement in `context.rs`:
-  // Fix by porting isolated processes to rust:
-  //   see: https://github.com/pantsbuild/pants/issues/4397
-  pub fn singleton_replace(&mut self, value: Value, product: TypeConstraint) {
-    self.singletons.insert(product, (
-      externs::key_for(value.clone()),
-      value,
-    ));
-  }
-
   ///
   /// The following methods define the Task registration lifecycle.
   ///

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -28,25 +28,11 @@ impl MockExecution {
     name: String,
     execute_request: bazel_protos::remote_execution::ExecuteRequest,
     operation_responses: Vec<bazel_protos::operations::Operation>,
-  ) -> Result<MockExecution, String> {
-    let error = operation_responses
-      .iter()
-      .find(|o| o.get_name() != name)
-      .map(|bad| {
-        Err(format!(
-          "All operation responses must have a name matching the MockExecution's name ({}) but \
-at least one did not ({:?})",
-          name,
-          bad
-        ))
-      });
-    match error {
-      Some(x) => x,
-      None => Ok(MockExecution {
-        name: name,
-        execute_request: execute_request,
-        operation_responses: Arc::new(Mutex::new(VecDeque::from(operation_responses))),
-      }),
+  ) -> MockExecution {
+    MockExecution {
+      name: name,
+      execute_request: execute_request,
+      operation_responses: Arc::new(Mutex::new(VecDeque::from(operation_responses))),
     }
   }
 }

--- a/tests/python/pants_test/engine/examples/scheduler_inputs/src/java/simple/Broken.java
+++ b/tests/python/pants_test/engine/examples/scheduler_inputs/src/java/simple/Broken.java
@@ -1,5 +1,5 @@
 package simple;
 // Placeholder file.
-class Simple {
-
+class Broken {
+  NOT VALID JAVA!
 }

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -88,6 +88,17 @@ def process_request_from_java_sources(binary):
   env = []
   return ExecuteProcessRequest(
     argv=binary.prefix_of_command() + ('-version',),
+    env=env,
+    input_files_digest="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    digest_length=0)
+
+
+def process_request_java_args_from_java_sources(binary, sources_snapshot, out_dir):
+  env = []
+  return ExecuteProcessRequest(
+    argv=binary.prefix_of_command() + tuple(f.path for f in sources_snapshot.files),
+    input_files_digest=str(sources_snapshot.fingerprint),
+    digest_length=sources_snapshot.digest_length,
     env=env)
 
 
@@ -119,6 +130,9 @@ class SnapshottedProcessRequestTest(SchedulerTestBase, unittest.TestCase):
 
 
 class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
+
+  # TODO: Re-write this test to work with non-tar-file snapshots
+  @unittest.skip
   def test_integration_concat_with_snapshot_subjects_test(self):
     scheduler = self.mk_scheduler_in_example_fs([
       # subject to files / product of subject to files for snapshot.
@@ -157,6 +171,8 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     self.assertEqual(0, result.exit_code)
     self.assertIn('javac', result.stderr)
 
+  # TODO: Re-write this test to work with non-tar-file snapshots
+  @unittest.skip
   def test_javac_compilation_example(self):
     sources = PathGlobs.create('', include=['scheduler_inputs/src/java/simple/Simple.java'])
 
@@ -181,6 +197,48 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     self.assertIsInstance(classpath_entry, ClasspathEntry)
     self.assertTrue(os.path.exists(os.path.join(classpath_entry.path, 'simple', 'Simple.class')))
 
+  def test_javac_compilation_example_rust_success(self):
+    sources = PathGlobs.create('', include=['scheduler_inputs/src/java/simple/Simple.java'])
+
+    scheduler = self.mk_scheduler_in_example_fs([
+      ExecuteProcess.create_in(
+        product_type=ExecuteProcessRequest,
+        input_selectors=(Select(Javac), Select(Snapshot), Select(JavaOutputDir)),
+        input_conversion=process_request_java_args_from_java_sources),
+      SingletonRule(JavaOutputDir, JavaOutputDir('testing')),
+      SingletonRule(Javac, Javac()),
+    ])
+    req = scheduler.product_request(ExecuteProcessRequest, [sources])
+    request = scheduler.execution_request([ExecuteProcessResult], req)
+
+    root_entries = scheduler.execute(request).root_products
+    self.assertEquals(1, len(root_entries))
+    state = self.assertFirstEntryIsReturn(root_entries, scheduler, request)
+    execution_result = state.value
+    self.assertEqual(0, execution_result.exit_code)
+    # TODO: Test that the output snapshot is good
+
+  def test_javac_compilation_example_rust_failure(self):
+    sources = PathGlobs.create('', include=['scheduler_inputs/src/java/simple/Broken.java'])
+
+    scheduler = self.mk_scheduler_in_example_fs([
+      ExecuteProcess.create_in(
+        product_type=ExecuteProcessRequest,
+        input_selectors=(Select(Javac), Select(Snapshot), Select(JavaOutputDir)),
+        input_conversion=process_request_java_args_from_java_sources),
+      SingletonRule(JavaOutputDir, JavaOutputDir('testing')),
+      SingletonRule(Javac, Javac()),
+    ])
+    req = scheduler.product_request(ExecuteProcessRequest, [sources])
+    request = scheduler.execution_request([ExecuteProcessResult], req)
+
+    root_entries = scheduler.execute(request).root_products
+    self.assertEquals(1, len(root_entries))
+    state = self.assertFirstEntryIsReturn(root_entries, scheduler, request)
+    execution_result = state.value
+    self.assertEqual(1, execution_result.exit_code)
+    self.assertIn("NOT VALID JAVA", execution_result.stderr)
+
   def test_failed_command_propagates_throw(self):
     scheduler = self.mk_scheduler_in_example_fs([
       # subject to files / product of subject to files for snapshot.
@@ -200,6 +258,8 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     self.assertFirstEntryIsThrow(root_entries,
                                  in_msg='Running ShellFailCommand failed with non-zero exit code: 1')
 
+  # TODO: Enable a test when input/output conversions are worked out
+  @unittest.skip
   def test_failed_output_conversion_propagates_throw(self):
     scheduler = self.mk_scheduler_in_example_fs([
       # subject to files / product of subject to files for snapshot.


### PR DESCRIPTION
With two added commits:
1. Shard each LMDB 16 ways (as reviewed in https://github.com/pantsbuild/pants/pull/5538):
    Currently, we can only write files from a single thread at a time, which
    is a significant bottleneck in large repos.

    Garbage collection will be slightly slower, as we can no longer share
    one txn for all garbage collection operations, but this shouldn't be the
    end of the world. If it turns out to be a problem, we can optimise it.
2. Don't force fsync on every lmdb write transaction
    This significantly improves performance on slow or contended disks.
    
    On filesystems which preserve order of writes, on system crash this may
    lead to some transactions being rolled back. This is fine because this
    is just a write-once content-addressed cache. There is no risk of
    corruption, just compromised durability.
    
    On filesystems which don't preserve the order of writes, this may lead
    to lmdb corruption on system crash (but in no other circumstances, such
    as process crash).