### PR TITLE
Uniform handling of subsystem discovery

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coverage/manager.py
+++ b/src/python/pants/backend/jvm/tasks/coverage/manager.py
@@ -12,7 +12,6 @@ from pants.backend.jvm.tasks.coverage.cobertura import Cobertura
 from pants.backend.jvm.tasks.coverage.engine import NoCoverage
 from pants.backend.jvm.tasks.coverage.jacoco import Jacoco
 from pants.subsystem.subsystem import Subsystem
-from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.dirutil import safe_mkdir
 from pants.util.strutil import safe_shlex_split
 
@@ -55,7 +54,7 @@ class CodeCoverageSettings(object):
                log=task.context.log)
 
 
-class CodeCoverage(Subsystem, SubsystemClientMixin):
+class CodeCoverage(Subsystem):
   """Manages setup and construction of JVM code coverage engines.
   """
   options_scope = 'coverage'

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -214,10 +214,7 @@ class GoalRunner(object):
 
   @classmethod
   def subsystems(cls):
-    """Subsystems used outside of any task.
-
-    TODO: Should these simply be dependencies of the GlobalOptions optionable?
-    """
+    """Subsystems used outside of any task."""
     return {
       SourceRootConfig,
       Reporting,

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -214,7 +214,10 @@ class GoalRunner(object):
 
   @classmethod
   def subsystems(cls):
-    """Subsystems used outside of any task."""
+    """Subsystems used outside of any task.
+
+    TODO: Should these simply be dependencies of the GlobalOptions optionable?
+    """
     return {
       SourceRootConfig,
       Reporting,

--- a/src/python/pants/core_tasks/bash_completion.py
+++ b/src/python/pants/core_tasks/bash_completion.py
@@ -15,7 +15,6 @@ from pants.base.generator import Generator
 from pants.goal.goal import Goal
 from pants.help.help_info_extracter import HelpInfoExtracter
 from pants.option.arg_splitter import GLOBAL_SCOPE
-from pants.option.scope import ScopeInfo
 from pants.task.console_task import ConsoleTask
 from pants.task.task import TaskBase
 

--- a/src/python/pants/core_tasks/bash_completion.py
+++ b/src/python/pants/core_tasks/bash_completion.py
@@ -23,17 +23,17 @@ from pants.task.task import TaskBase
 class BashCompletion(ConsoleTask):
   """Generate a Bash shell script that teaches Bash how to autocomplete pants command lines."""
 
-  def get_all_cmd_line_scopes(self):
+  @staticmethod
+  def _get_all_cmd_line_scopes():
     """Return all scopes that may be explicitly specified on the cmd line, in no particular order.
 
     Note that this includes only task scope, and not, say, subsystem scopes,
     as those aren't specifiable on the cmd line.
     """
-    all_scopes = set([''])
+    all_scopes ={GLOBAL_SCOPE}
     for goal in Goal.all():
-      for scope_info in goal.known_scope_infos():
-        if scope_info.category == ScopeInfo.TASK:
-          all_scopes.add(scope_info.scope)
+      for task in goal.task_types():
+        all_scopes.add(task.get_scope_info().scope)
     return all_scopes
 
   def get_autocomplete_options_by_scope(self):
@@ -74,14 +74,14 @@ class BashCompletion(ConsoleTask):
   def console_output(self, targets):
     if targets:
       raise TaskError('This task does not accept any target addresses.')
-    cmd_line_scopes = sorted(self.get_all_cmd_line_scopes())
+    cmd_line_scopes = sorted(self._get_all_cmd_line_scopes())
     autocomplete_options_by_scope = self.get_autocomplete_options_by_scope()
 
-    def bash_scope_key(scope):
-      if scope == GLOBAL_SCOPE:
+    def bash_scope_key(sc):
+      if sc == GLOBAL_SCOPE:
         return '__pants_global_options'
       else:
-        return '__pants_options_for_{}'.format(scope.replace('-', '_').replace('.', '_'))
+        return '__pants_options_for_{}'.format(sc.replace('-', '_').replace('.', '_'))
 
     options_text_lines = []
     for scope in cmd_line_scopes:

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -94,7 +94,6 @@ class OptionsInitializer(object):
 
     # Gather the optionables that are not scoped to any other.  All known scopes are reachable
     # via these optionables' known_scope_infos() methods.
-    # TODO: Rename methods to 'global_subsystems'.
     top_level_optionables = ({GlobalOptionsRegistrar} |
                              GoalRunner.subsystems() |
                              build_configuration.subsystems() |

--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -11,12 +11,13 @@ from collections import namedtuple
 
 from twitter.common.collections import OrderedSet
 
-from pants.option.scope import ScopeInfo
+from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION, ScopeInfo
 from pants.util.meta import AbstractClass
 
 
-GLOBAL_SCOPE = ''
-GLOBAL_SCOPE_CONFIG_SECTION = 'GLOBAL'
+# TODO: Switch all clients to reference pants.option.scope directly.
+GLOBAL_SCOPE = GLOBAL_SCOPE
+GLOBAL_SCOPE_CONFIG_SECTION = GLOBAL_SCOPE_CONFIG_SECTION
 
 
 class ArgSplitterError(Exception):

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -15,9 +15,10 @@ from pants.option.arg_splitter import GLOBAL_SCOPE
 from pants.option.custom_types import dir_option
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
+from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 
 
-class GlobalOptionsRegistrar(Optionable):
+class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
   options_scope = GLOBAL_SCOPE
   options_scope_category = ScopeInfo.GLOBAL
   options_subsumed_scopes = [

--- a/src/python/pants/option/optionable.py
+++ b/src/python/pants/option/optionable.py
@@ -50,6 +50,14 @@ class Optionable(AbstractClass):
     return ScopeInfo(cls.options_scope, cls.options_scope_category, cls)
 
   @classmethod
+  def known_scope_infos(cls):
+    """Yields ScopeInfo for all known scopes for this optionable, in no particular order.
+
+    Specific Optionable subtypes may override to provide information about other optionables.
+    """
+    yield cls.get_scope_info()
+
+  @classmethod
   def get_description(cls):
     # First line of docstring.
     return '' if cls.__doc__ is None else cls.__doc__.partition('\n')[0].strip()

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -22,16 +22,6 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
   SUBSYSTEM = 'SUBSYSTEM'
   INTERMEDIATE = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.
 
-  def scoped_to(self, client_scope):
-    """The Optionable described by this scope, when scoped to the Optionable with client_scope."""
-    if client_scope == GLOBAL_SCOPE:
-      return self
-    return ScopeInfo('{0}.{1}'.format(self.scope, client_scope), self.category, self.optionable_cls)
-
-  def is_scoped(self):
-    """Whether this ScopeInfo represents a subsystem scoped to some other optionable."""
-    return self.category == self.SUBSYSTEM and '.' in self.scope
-
   @property
   def description(self):
     return self._optionable_cls_attr('get_description', lambda: '')()

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -8,6 +8,10 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from collections import namedtuple
 
 
+GLOBAL_SCOPE = ''
+GLOBAL_SCOPE_CONFIG_SECTION = 'GLOBAL'
+
+
 class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls'])):
   """Information about a scope."""
 
@@ -17,6 +21,12 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
   TASK = 'TASK'
   SUBSYSTEM = 'SUBSYSTEM'
   INTERMEDIATE = 'INTERMEDIATE'  # Scope added automatically to fill out the scope hierarchy.
+
+  def scoped_to(self, client_scope):
+    """The Optionable described by this scope, when scoped to the Optionable with client_scope."""
+    if client_scope == GLOBAL_SCOPE:
+      return self
+    return ScopeInfo('{0}.{1}'.format(self.scope, client_scope), self.category, self.optionable_cls)
 
   @property
   def description(self):

--- a/src/python/pants/option/scope.py
+++ b/src/python/pants/option/scope.py
@@ -28,6 +28,10 @@ class ScopeInfo(namedtuple('_ScopeInfo', ['scope', 'category', 'optionable_cls']
       return self
     return ScopeInfo('{0}.{1}'.format(self.scope, client_scope), self.category, self.optionable_cls)
 
+  def is_scoped(self):
+    """Whether this ScopeInfo represents a subsystem scoped to some other optionable."""
+    return self.category == self.SUBSYSTEM and '.' in self.scope
+
   @property
   def description(self):
     return self._optionable_cls_attr('get_description', lambda: '')()

--- a/src/python/pants/subsystem/BUILD
+++ b/src/python/pants/subsystem/BUILD
@@ -4,6 +4,6 @@
 python_library(
   dependencies = [
     '3rdparty/python/twitter/commons:twitter.common.collections',
-    'src/python/pants/option'
+    'src/python/pants/option',
   ],
 )

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -97,11 +97,12 @@ class SubsystemClientMixin(object):
       if scope_info not in known_scope_infos:
         known_scope_infos.add(scope_info)
         for dep in scope_info.optionable_cls.subsystem_dependencies_iter():
-          if dep.is_global():
-            scoped_to = GLOBAL_SCOPE
-          else:
-            scoped_to = scope
-          collect_scope_infos(dep.subsystem_cls, scoped_to)
+          # A subsystem always exists at its global scope (for the purpose of options
+          # registration and specification), even if in practice we only use it scoped to
+          # some other scope.
+          collect_scope_infos(dep.subsystem_cls, GLOBAL_SCOPE)
+          if not dep.is_global():
+            collect_scope_infos(dep.subsystem_cls, scope)
 
       optionables_path.remove(scope_info.optionable_cls)
 

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -59,24 +59,12 @@ class SubsystemClientMixin(object):
 
   @classmethod
   def subsystem_dependencies_iter(cls):
+    """Iterate over the direct subsystem dependencies of this Optionable."""
     for dep in cls.subsystem_dependencies():
       if isinstance(dep, SubsystemDependency):
         yield dep
       else:
         yield SubsystemDependency(dep, GLOBAL_SCOPE)
-
-  # @classmethod
-  # def known_scope_infos(cls):
-  #   """Yields ScopeInfo for all known scopes for this optionable, in no particular order."""
-  #   # The optionable's own scope.
-  #   yield cls.get_scope_info()
-  #   # The scopes of any scoped subsystems it uses.
-  #   for dep in cls.subsystem_dependencies_iter():
-  #     for si in dep.subsystem_cls.known_scope_infos():
-  #       if si.is_scoped() or not dep.is_global():
-  #         yield si.scoped_to(dep.scope)
-  #       else:
-  #         yield si
 
   class CycleException(Exception):
     """Thrown when a circular subsystem dependency is detected."""

--- a/src/python/pants/subsystem/subsystem_client_mixin.py
+++ b/src/python/pants/subsystem/subsystem_client_mixin.py
@@ -32,7 +32,13 @@ class SubsystemDependency(namedtuple('_SubsystemDependency', ('subsystem_cls', '
 
 
 class SubsystemClientMixin(object):
-  """A mixin for declaring dependencies on subsystems."""
+  """A mixin for declaring dependencies on subsystems.
+
+  Must be mixed in to an Optionable.
+
+  TODO(benjy): Do we need this mixin? Can we put these methods directly on Optionable?
+               Are there Optionables that must not use subsystems?
+  """
 
   @classmethod
   def subsystem_dependencies(cls):
@@ -58,3 +64,14 @@ class SubsystemClientMixin(object):
         yield dep
       else:
         yield SubsystemDependency(dep, GLOBAL_SCOPE)
+
+  @classmethod
+  def known_scope_infos(cls):
+    """Yields ScopeInfo for all known scopes for this optionable, in no particular order."""
+    # The optionable's own scope.
+    yield cls.get_scope_info()
+    # The scopes of any scoped subsystems it uses.
+    for dep in cls.subsystem_dependencies_iter():
+      if not dep.is_global():
+        for si in dep.subsystem_cls.known_scope_infos():
+          yield si.scoped_to(dep.scope)

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -102,16 +102,6 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     return []
 
   @classmethod
-  def known_scope_infos(cls):
-    """Yields ScopeInfo for all known scopes for this task, in no particular order."""
-    # The task's own scope.
-    yield cls.get_scope_info()
-    # The scopes of any task-specific subsystems it uses.
-    for dep in cls.subsystem_dependencies_iter():
-      if not dep.is_global():
-        yield dep.subsystem_cls.get_scope_info(subscope=dep.scope)
-
-  @classmethod
   def supports_passthru_args(cls):
     """Subclasses may override to indicate that they can use passthru args.
 

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -284,13 +284,12 @@ class BaseTest(unittest.TestCase):
     """
     # Many tests use source root functionality via the SourceRootConfig.global_instance().
     # (typically accessed via Target.target_base), so we always set it up, for convenience.
-    optionables = {SourceRootConfig}
-
     for_subsystems = for_subsystems or ()
     for subsystem in for_subsystems:
       if subsystem.options_scope is None:
         raise TaskError('You must set a scope on your subsystem type before using it in tests.')
-      optionables.add(subsystem)
+
+    optionables = {SourceRootConfig} | self._build_configuration.subsystems() | for_subsystems
 
     for_task_types = for_task_types or ()
     for task_type in for_task_types:
@@ -307,9 +306,10 @@ class BaseTest(unittest.TestCase):
         optionables.add(type(subclass_name, (task_type.goal_options_registrar_cls, ),
                              {b'options_scope': task_type.options_scope}))
 
-      optionables.update(Subsystem.closure(
-        set([dep.subsystem_cls for dep in task_type.subsystem_dependencies_iter()]) |
-            self._build_configuration.subsystems()))
+    # Now expand to all deps.
+    all_optionables = set()
+    for optionable in optionables:
+      all_optionables.update(si.optionable_cls for si in optionable.known_scope_infos())
 
     # Now default the option values and override with any caller-specified values.
     # TODO(benjy): Get rid of the options arg, and require tests to call set_options.
@@ -319,7 +319,7 @@ class BaseTest(unittest.TestCase):
       scoped_opts.update(opts)
 
     fake_options = create_options_for_optionables(
-      optionables, options=options, **kwargs)
+      all_optionables, options=options, **kwargs)
 
     Subsystem.reset(reset_options=True)
     Subsystem.set_options(fake_options)

--- a/tests/python/pants_test/base_test.py
+++ b/tests/python/pants_test/base_test.py
@@ -284,7 +284,7 @@ class BaseTest(unittest.TestCase):
     """
     # Many tests use source root functionality via the SourceRootConfig.global_instance().
     # (typically accessed via Target.target_base), so we always set it up, for convenience.
-    for_subsystems = for_subsystems or ()
+    for_subsystems = set(for_subsystems or ())
     for subsystem in for_subsystems:
       if subsystem.options_scope is None:
         raise TaskError('You must set a scope on your subsystem type before using it in tests.')

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -43,10 +43,12 @@ def init_subsystems(subsystem_types, options=None):
                   subsystem_type.options_scope) and/or the scopes of instances of the
                   subsystems they transitively depend on.
   """
+  optionables = set()
   for s in subsystem_types:
     if not Subsystem.is_subsystem_type(s):
       raise TypeError('{} is not a subclass of `Subsystem`'.format(s))
-  optionables = Subsystem.closure(subsystem_types)
+    for si in s.known_scope_infos():
+      optionables.update(si.optionable_cls)
   if options:
     allowed_scopes = {o.options_scope for o in optionables}
     for scope in options.keys():

--- a/tests/python/pants_test/subsystem/subsystem_util.py
+++ b/tests/python/pants_test/subsystem/subsystem_util.py
@@ -48,7 +48,7 @@ def init_subsystems(subsystem_types, options=None):
     if not Subsystem.is_subsystem_type(s):
       raise TypeError('{} is not a subclass of `Subsystem`'.format(s))
     for si in s.known_scope_infos():
-      optionables.update(si.optionable_cls)
+      optionables.add(si.optionable_cls)
   if options:
     allowed_scopes = {o.options_scope for o in optionables}
     for scope in options.keys():

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -131,6 +131,27 @@ class SubsystemTest(unittest.TestCase):
       with self.assertRaises(Subsystem.CycleException):
         Subsystem.closure((root,))
 
+  def test_scoping(self):
+    class SubsystemC(Subsystem):
+      options_scope = 'c'
+
+    class SubsystemB(Subsystem):
+      options_scope = 'b'
+
+      @classmethod
+      def subsystem_dependencies(cls):
+        return (SubsystemC.scoped(cls),)
+
+    class SubsystemA(Subsystem):
+       options_scope = 'a'
+
+       @classmethod
+       def subsystem_dependencies(cls):
+         return (SubsystemB.scoped(cls),)
+
+    expected_known_scope_infos_c = []
+    self.assertListEqual(expected_known_scope_infos_c, SubsystemC.known_scope_infos())
+
   def test_uninitialized_global(self):
     Subsystem.reset()
     with self.assertRaisesRegexp(Subsystem.UninitializedSubsystemError,

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -8,7 +8,9 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import unittest
 
 from pants.option.optionable import Optionable
+from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem import Subsystem
+from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 
 
 class DummySubsystem(Subsystem):
@@ -38,6 +40,11 @@ class ScopedDependentSubsystem(Subsystem):
     )
 
 
+def si(scope, subsystem_cls):
+  """Shorthand helper."""
+  return ScopeInfo(scope, ScopeInfo.SUBSYSTEM, subsystem_cls)
+
+
 class SubsystemTest(unittest.TestCase):
   def setUp(self):
     DummySubsystem._options = DummyOptions()
@@ -60,12 +67,13 @@ class SubsystemTest(unittest.TestCase):
     with self.assertRaises(NotImplementedError):
       NoScopeSubsystem.global_instance()
 
-  def test_closure_simple(self):
-    self.assertEqual({DummySubsystem}, Subsystem.closure((DummySubsystem,)))
-    self.assertEqual({DummySubsystem, ScopedDependentSubsystem},
-                     Subsystem.closure((ScopedDependentSubsystem,)))
+  def test_scoping_simple(self):
+    self.assertEqual({si('dummy', DummySubsystem)}, DummySubsystem.known_scope_infos())
+    self.assertEqual({si('scoped-dependent-subsystem', ScopedDependentSubsystem),
+                      si('dummy.scoped-dependent-subsystem', DummySubsystem)},
+                     ScopedDependentSubsystem.known_scope_infos())
 
-  def test_closure_tree(self):
+  def test_scoping_tree(self):
     class SubsystemB(Subsystem):
       options_scope = 'b'
 
@@ -76,13 +84,10 @@ class SubsystemTest(unittest.TestCase):
       def subsystem_dependencies(cls):
         return (DummySubsystem, SubsystemB)
 
-    self.assertEqual({DummySubsystem, SubsystemA, SubsystemB}, Subsystem.closure((SubsystemA,)))
-    self.assertEqual({DummySubsystem, SubsystemA, SubsystemB},
-                     Subsystem.closure((SubsystemA, SubsystemB)))
-    self.assertEqual({DummySubsystem, SubsystemA, SubsystemB},
-                     Subsystem.closure((DummySubsystem, SubsystemA, SubsystemB)))
+    self.assertEqual({si('dummy', DummySubsystem), si('a', SubsystemA), si('b', SubsystemB)},
+                     SubsystemA.known_scope_infos())
 
-  def test_closure_graph(self):
+  def test_scoping_graph(self):
     class SubsystemB(Subsystem):
       options_scope = 'b'
 
@@ -97,15 +102,13 @@ class SubsystemTest(unittest.TestCase):
       def subsystem_dependencies(cls):
         return (DummySubsystem, SubsystemB)
 
-    self.assertEqual({DummySubsystem, SubsystemB}, Subsystem.closure((SubsystemB,)))
+    self.assertEqual({si('dummy', DummySubsystem), si('b', SubsystemB)},
+                     SubsystemB.known_scope_infos())
 
-    self.assertEqual({DummySubsystem, SubsystemA, SubsystemB}, Subsystem.closure((SubsystemA,)))
-    self.assertEqual({DummySubsystem, SubsystemA, SubsystemB},
-                     Subsystem.closure((SubsystemA, SubsystemB)))
-    self.assertEqual({DummySubsystem, SubsystemA, SubsystemB},
-                     Subsystem.closure((DummySubsystem, SubsystemA, SubsystemB)))
+    self.assertEqual({si('dummy', DummySubsystem), si('a', SubsystemA), si('b', SubsystemB)},
+                     SubsystemA.known_scope_infos())
 
-  def test_closure_cycle(self):
+  def test_option_class_cycle(self):
     class SubsystemC(Subsystem):
       options_scope = 'c'
 
@@ -118,7 +121,8 @@ class SubsystemTest(unittest.TestCase):
 
       @classmethod
       def subsystem_dependencies(cls):
-        return (SubsystemC,)
+        # Ensure that we detect cycles via scoped deps as well as global deps.
+        return (SubsystemC.scoped(cls),)
 
     class SubsystemA(Subsystem):
       options_scope = 'a'
@@ -128,10 +132,31 @@ class SubsystemTest(unittest.TestCase):
         return (SubsystemB,)
 
     for root in SubsystemA, SubsystemB, SubsystemC:
-      with self.assertRaises(Subsystem.CycleException):
-        Subsystem.closure((root,))
+      with self.assertRaises(SubsystemClientMixin.CycleException):
+        root.known_scope_infos()
 
-  def test_scoping(self):
+  def test_scoping_complex(self):
+    """
+    Subsystem dep structure is (-s-> = scoped dep, -g-> = global dep):
+
+    D -s-> E
+    |
+    + -s->
+          \
+    A -s-> B -s-> C
+           |
+           + -g-> E
+    """
+    class SubsystemE(Subsystem):
+      options_scope = 'e'
+
+    class SubsystemD(Subsystem):
+      options_scope = 'd'
+
+      @classmethod
+      def subsystem_dependencies(cls):
+        return (SubsystemE.scoped(cls), SubsystemB.scoped(cls))
+
     class SubsystemC(Subsystem):
       options_scope = 'c'
 
@@ -140,7 +165,7 @@ class SubsystemTest(unittest.TestCase):
 
       @classmethod
       def subsystem_dependencies(cls):
-        return (SubsystemC.scoped(cls),)
+        return (SubsystemE, SubsystemC.scoped(cls))
 
     class SubsystemA(Subsystem):
        options_scope = 'a'
@@ -149,8 +174,23 @@ class SubsystemTest(unittest.TestCase):
        def subsystem_dependencies(cls):
          return (SubsystemB.scoped(cls),)
 
-    expected_known_scope_infos_c = []
-    self.assertListEqual(expected_known_scope_infos_c, SubsystemC.known_scope_infos())
+    expected_known_scope_infos_c = {si('c', SubsystemC)}
+    self.assertSetEqual(expected_known_scope_infos_c, set(SubsystemC.known_scope_infos()))
+
+    expected_known_scope_infos_b = {si('b', SubsystemB), si('e', SubsystemE), si('c.b', SubsystemC)}
+    self.assertSetEqual(expected_known_scope_infos_b, set(SubsystemB.known_scope_infos()))
+
+    expected_known_scope_infos_a = {
+      si('a', SubsystemA), si('e', SubsystemE), si('b.a', SubsystemB), si('c.b.a', SubsystemC)
+    }
+    self.assertSetEqual(expected_known_scope_infos_a, set(SubsystemA.known_scope_infos()))
+
+    expected_known_scope_infos_d = {
+      si('d', SubsystemD), si('e.d', SubsystemE), si('b.d', SubsystemB), si('c.b.d', SubsystemC),
+      si('e', SubsystemE)
+    }
+    self.assertSetEqual(expected_known_scope_infos_d, set(SubsystemD.known_scope_infos()))
+
 
   def test_uninitialized_global(self):
     Subsystem.reset()

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -168,11 +168,11 @@ class SubsystemTest(unittest.TestCase):
         return (SubsystemE, SubsystemC.scoped(cls))
 
     class SubsystemA(Subsystem):
-       options_scope = 'a'
+      options_scope = 'a'
 
-       @classmethod
-       def subsystem_dependencies(cls):
-         return (SubsystemB.scoped(cls),)
+      @classmethod
+      def subsystem_dependencies(cls):
+        return (SubsystemB.scoped(cls),)
 
     expected_known_scope_infos_c = {si('c', SubsystemC)}
     self.assertSetEqual(expected_known_scope_infos_c, set(SubsystemC.known_scope_infos()))
@@ -190,7 +190,6 @@ class SubsystemTest(unittest.TestCase):
       si('e', SubsystemE)
     }
     self.assertSetEqual(expected_known_scope_infos_d, set(SubsystemD.known_scope_infos()))
-
 
   def test_uninitialized_global(self):
     Subsystem.reset()

--- a/tests/python/pants_test/subsystem/test_subsystem.py
+++ b/tests/python/pants_test/subsystem/test_subsystem.py
@@ -70,6 +70,7 @@ class SubsystemTest(unittest.TestCase):
   def test_scoping_simple(self):
     self.assertEqual({si('dummy', DummySubsystem)}, DummySubsystem.known_scope_infos())
     self.assertEqual({si('scoped-dependent-subsystem', ScopedDependentSubsystem),
+                      si('dummy', DummySubsystem),
                       si('dummy.scoped-dependent-subsystem', DummySubsystem)},
                      ScopedDependentSubsystem.known_scope_infos())
 
@@ -177,17 +178,19 @@ class SubsystemTest(unittest.TestCase):
     expected_known_scope_infos_c = {si('c', SubsystemC)}
     self.assertSetEqual(expected_known_scope_infos_c, set(SubsystemC.known_scope_infos()))
 
-    expected_known_scope_infos_b = {si('b', SubsystemB), si('e', SubsystemE), si('c.b', SubsystemC)}
+    expected_known_scope_infos_b = {si('b', SubsystemB), si('e', SubsystemE),
+                                    si('c', SubsystemC), si('c.b', SubsystemC)}
     self.assertSetEqual(expected_known_scope_infos_b, set(SubsystemB.known_scope_infos()))
 
     expected_known_scope_infos_a = {
-      si('a', SubsystemA), si('e', SubsystemE), si('b.a', SubsystemB), si('c.b.a', SubsystemC)
+      si('a', SubsystemA), si('e', SubsystemE), si('b', SubsystemB), si('b.a', SubsystemB),
+      si('c', SubsystemC), si('c.b', SubsystemC), si('c.b.a', SubsystemC)
     }
     self.assertSetEqual(expected_known_scope_infos_a, set(SubsystemA.known_scope_infos()))
 
     expected_known_scope_infos_d = {
-      si('d', SubsystemD), si('e.d', SubsystemE), si('b.d', SubsystemB), si('c.b.d', SubsystemC),
-      si('e', SubsystemE)
+      si('d', SubsystemD), si('e.d', SubsystemE), si('b', SubsystemB), si('b.d', SubsystemB),
+      si('c', SubsystemC), si('c.b', SubsystemC), si('c.b.d', SubsystemC), si('e', SubsystemE)
     }
     self.assertSetEqual(expected_known_scope_infos_d, set(SubsystemD.known_scope_infos()))
 


### PR DESCRIPTION
Previously we had two related/overlapping ways to discover all subsystems that require initialization. We had `Subsystem.closure()` for discovering the unscoped subsystem types, and then `known_scope_infos()` for discovering the possible scopes they can be found in. 

Options initialization required a somewhat delicate dance involving separate treatment for different kind of `Optionable`s (tasks, subsystems, global options). And yet, due to the naive implementation of `known_scope_infos()`, the init sequence still didn't support cases like "a subsystem scoped to a subsystem scoped to a task".

This change re-implements `known_scope_infos()` using a similar algorithm to the one used by `Subsystem.closure()`, and removes the latter (since `ScopeInfo` includes the type of the `Optionable` at each scope anyway).  This new implementation is no longer naive, and can handle elaborate cases. Handling the different kinds of `Optionable` in the initialization sequence is now uniform - since they all define `known_scope_infos()`. 