### PR TITLE
@rules as coroutines

### DIFF
--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -182,6 +182,7 @@ python_library(
   sources=['native.py'],
   dependencies=[
     ':native_engine_shared_library',
+    ':selectors',
     '3rdparty/python:cffi',
     '3rdparty/python:setuptools',
     'src/python/pants/binaries:binary_util',

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -1,10 +1,157 @@
-# The New Engine
+# The (New) Engine
 
-## Scheduling
+## API
 
-In the current RoundEngine, work is scheduled and then later performed via the `Task` interface. In
-the new engine execution occurs via simple functions, with inputs selected via an input
-selection clause made up of `Selector` objects (described later).
+The end user API for the engine is based on the registration of `@rules`, which are functions
+or coroutines with statically declared inputs and outputs. A Pants (plugin) developer can write
+and install additional `@rule`s to extend the functionality of Pants.
+
+The set of installed `@rule`s is statically checked as a closed world: this compilation step occurs
+on startup, and identifies all unreachable or unsatisfiable rules before execution begins. This
+allows most composition errors to be detected immediately, and also provides for easy introspection
+of the build. To inspect the set of rules that are installed and which product types can be
+computed, you can pass the `--native-engine-visualize-to=$dir` flag, which will write out a graph
+of reachable `@rules`.
+
+Once the engine is instantiated with a valid set of `@rules`, a caller can synchronously request
+computation of any of the product types provided by those `@rules` by calling:
+
+```python
+# Request a ThingINeed (a `Product`) for the thing_i_have (a `Subject`).
+thing_i_need, = scheduler.product_request(ThingINeed, [thing_i_have])
+```
+
+The engine then takes care of concurrently executing all dependencies of the matched `@rules` to
+produce the requested value.
+
+### Products and Subjects
+
+The return value of an `@rule` for a particular `Subject` is known as a `Product`. At some level, you
+can think of (`subject_value`, `product_type`) as a "key" that uniquely identifies a particular
+Product value. The engine executes your `@rules` in order to (recursively) compute a Product of the
+requested type for a given Subject.
+
+This recursive type search leads to a very loosely coupled (and yet still statically checked) form
+of dependency injection.
+
+#### Example
+
+As a very simple example, you might register the following `@rule` that can compute a `String`
+Product given a single `Int` input.
+
+```python
+@rule(StringType, [Select(IntType)])
+def int_to_str(an_int):
+  return '{}'.format(an_int)
+```
+
+The first argument to the `@rule` decorator is the Product (ie, return) type for the @rule. The
+second argument is a list of `Selectors` that declare the types of the input arguments to the
+`@rule`. In this case, because the Product type is `StringType` and there is one `Selector`
+(`Select(IntType)`), this `@rule` represents a conversion from `IntType` to `StrType`, with no
+other inputs.
+
+When the engine statically checks whether it can use this `@rule` to create a string for a
+Subject, it will first see whether there are any ways to get an IntType for that Subject. If
+the subject is already of `type(subject) == IntType`, then the @rule will be satisfiable without
+any other depenencies. On the other hand, if the type _doesn't_ match, the engine doesn't give up:
+it will next look for any other registered @rules that can compute an IntType Product for the
+Subject (and so on, recursively.)
+
+In practical use, using basic types like `StringType` or `IntType` does not provide enough
+information to disambiguate between various types of data: So declaring small `datatype`
+definitions to provide a unique and descriptive type is strongly recommended:
+
+```python
+class FormattedInt(datatype('FormattedInt', ['content'])): pass
+
+@rule(FormattedInt, [Select(IntType)])
+def int_to_str(an_int):
+  return FormattedInt('{}'.format(an_int))
+```
+
+### Selectors and Gets
+
+As demonstrated above, the `Selector` classes select `@rule` inputs in the context of a particular
+`Subject` (and its `Variants`: discussed below). But it is frequently necessary to "change" the
+subject and request products for subjects other than the one that the `@rule` is running for.
+
+In cases where this is necessary, `@rule`s may be written as coroutines (ie, using the python
+`yield` statement) that yield "`Get` requests" that request products for other subjects. Just like
+`@rule` parameter Selectors, `Get` requests instatiated in the body of an `@rule` are statically
+checked to be satisfiable in the set of installed `@rules`.
+
+#### Example
+
+For example, you could declare an `@rule` that requests FileContent for each entry in a Files list,
+and then concatentates that content into a (typed) string:
+
+```python
+@rule(ConcattedFiles, [Select(Files)])
+def concat(files):
+  file_content_list = yield [Get(FileContent, File(f)) for f in files]
+  yield ConcattedFiles(''.join(fc.content for fc in file_content_list))
+```
+
+This @rule declares that: "for any Subject for which we can compute `Files`, we can also compute
+`ConcattedFiles`". Each yielded `Get` request results in FileContent for a different File Subject
+from the Files list.
+
+### Variants
+
+Certain @rules will also need parameters provided by their dependents in order to tailor their output
+Products to their consumers.  For example, a javac `@rule` might need to know the version of the java
+platform for a given dependent binary target (say Java 9), or an ivy @rule might need to identify a
+globally consistent ivy resolve for a test target.  To allow for this the engine introduces the
+concept of `Variants`, which are passed recursively from dependents to dependencies.
+
+If a Rule uses a `SelectVariants` Selector to indicate that a variant is required, consumers can use
+a `@[type]=[name]` address syntax extension to pass a variant that matches a particular configuration
+for a `@rule`. A dependency declared as `src/java/com/example/lib:lib` specifies no particular variant, but
+`src/java/com/example/lib:lib@java=java8` asks for the configured variant of the lib named "java8".
+
+Additionally, it is possible to specify the "default" variants for an Address by installing an @rule
+function that can provide `Variants(default=..)`. Since the purpose of variants is to collect
+information from dependents, only default variant values which have not been set by a dependent
+will be used.
+
+## Internal API
+
+Internally, the engine uses end user `@rules` to create private `Node` objects and
+build a `Graph` of futures that links them to their dependency Nodes. A Node represents a unique
+computation and the data for a Node implicitly acts as its own key/identity.
+
+To compute a value for a Node, the engine uses the `Node.run` method starting from requested
+roots. If a Node needs more inputs, it requests them via `Context.get`, which will declare a
+dependency, and memoize the computation represented by the requested `Node`.
+
+The initial Nodes are [launched by the engine](https://github.com/pantsbuild/pants/blob/16d43a06ba3751e22fdc7f69f009faeb59a33930/src/rust/engine/src/scheduler.rs#L116-L126),
+but the rest of execution is driven by Nodes recursively calling `Context.get` to request their
+dependencies.
+
+## Execution
+
+The engine executes work concurrently wherever possible; to help visualize executions, a visualization
+tool is provided that, after executing a `Graph`, generates a `dot` file that can be rendered using
+Graphviz:
+
+```console
+$ mkdir viz
+$ ./pants --native-engine-visualize-to=viz list some/example/directory:
+$ ls viz
+run.0.dot
+```
+
+## Native Engine
+
+The native engine is integrated into the pants codebase via `native.py` in
+this directory along with `build-support/bin/native/bootstrap.sh` which ensures a
+pants native engine library is built and available for linking. The glue is the
+sha1 hash of the native engine source code used as its version by the `Native`
+class. This hash is maintained by `build-support/bin/native/bootstrap.sh` and
+output to the `native_engine_version` file in this directory. Any modification
+to this resource file's location will need adjustments in
+`build-support/bin/native/bootstrap.sh` to ensure the linking continues to work.
 
 ## History
 
@@ -28,134 +175,3 @@ in the context of scala and mixed scala & java builds.  Twitter spiked on a proj
 a target-level scheduling system scoped to just the jvm compilation tasks.  This bore fruit and
 served as further impetus to get a "tuple-engine" designed and constructed to bring the benefits
 seen in the jvm compilers to the wider pants world of tasks.
-
-### API
-
-#### End User API
-
-The end user API for the engine is based on the registration of `Rules`, which are made up of:
-
-1. a `Product` or return type of a function,
-2. a list of dependency `Selectors` which match inputs to the function,
-3. the function itself.
-
-A `Rule` fully declares the inputs and outputs for its function: there is no imperative API for
-requesting additional inputs during execution of a function. While a tight constraint,
-this has the advantage of forcing decomposition of work into functions which are loosely
-coupled by only the types of their inputs and outputs, and which are naturally isolated, cacheable,
-and parallelizable.
-
-A function is guaranteed to execute only when all of its inputs are ready for use. The Scheduler
-considers executing a Rule when it determines that it needs to produce the declared
-output `Product` type of that function for a particular `Subject`. But the Scheduler will only
-actually run a Rule if it is able to (recursively) find sources for each of the
-function's inputs.
-
-See below for more information on `Products`, `Subjects`, and `Selectors`.
-
-#### Internal API
-
-Internally, the `Scheduler` uses end user `Rules` to create private `Node` objects and
-build a `Graph` of futures that links them to their dependency Nodes. A Node represents a unique
-computation and the data for a Node implicitly acts as its own key/identity.
-
-To compute a value for a Node, the Scheduler uses the `Node.run` method starting from requested
-roots. If a Node needs more inputs, it requests them via `Context.get`, which will declare a
-dependency, and memoize the computation represented by the `Node`.
-
-The initial Nodes are [launched by the scheduler](https://github.com/pantsbuild/pants/blob/16d43a06ba3751e22fdc7f69f009faeb59a33930/src/rust/engine/src/scheduler.rs#L116-L126),
-but the rest of the scheduling is driven by Nodes recursively calling `Context.get` to request
-dependencies.
-
-### Products and Subjects
-
-A `Product` is a strongly typed value specific to a particular `Subject`. End user Rules execute
-in order to (recursively) compute a Product for a Subject: as a very simple example, one might
-register the following Rule that can compute a `String` Product given a single `Int` input
-by calling the `str` function:
-
-    @rule(StringType, [Select(IntType)])
-    def int_to_str(an_int):
-      return str(an_int)
-
-When the Scheduler wants to decide whether it can use this Rule to create a string for a
-Subject, it will first see whether there are any ways to get an IntType for that Subject. If
-the subject is already of `type(subject) == IntType`, then the Rule will be able to
-execute immediately. On the other hand, if the type _doesn't_ match, the Scheduler doesn't give up:
-it will next look for any other registered Rules that can compute an IntType Product for the
-Subject (and so on, recursively.)
-
-This recursive type search leads to some very interesting (and, admittedly, somewhat "magical")
-properties. If there is any path through the Rule graph that allows for conversion
-from one type to another, it will be found and executed.
-
-### Selectors
-
-As demonstrated above, the `Selector` classes select function inputs in the context of a particular
-`Subject` (and its `Variants`: discussed below). For example, it might select a `Product` for the given
-Subject (`Select`), or for other Subject(s) selected from fields of a Product (`SelectDependencies`,
-`SelectProjection`).
-
-One very important thing to keep in mind is that Selectors like `SelectDependencies` and `SelectProjection`
-"change" the Subject within a particular subgraph. For example, `SelectDependencies`
-results in new subgraphs for each Subject in a list of values that was computed for some original Subject.
-Concretely, a Rule could use SelectDependencies to select FileContent for each entry in a Files list,
-and then concatentate that content into a string:
-
-    @rule(StringType, [SelectDependencies(FileContent, Files)])
-    def concat(file_content_list):
-      return ''.join(fc.content for fc in file_content_list)
-
-This Rule declares that: "for any Subject for which we can compute a 'Files' object, we can also
-compute a StringType". Each subgraph will contain an attempt to get FileContent for a different
-File Subject from the Files list.
-
-In practical use, using `StringType` or `IntType` directly would probably not provide enough information
-to disambiguate between various types of data: So declaring small `datatype` definitions to provide
-a unique and descriptive type is strongly recommended:
-
-    class ConcattedFiles(datatype('ConcattedFiles', ['content'])):
-      pass
-
-### Variants
-
-Certain Rules will also need parameters provided by their dependents in order to tailor their output
-Products to their consumers.  For example, a javac planner might need to know
-the version of the java platform for a given dependent binary target (say Java 6), or an ivy Rule
-might need to identify a globally consistent ivy resolve for a test target.  To allow for this the
-engine introduces the concept of `variants`, which are passed recursively from dependents to
-dependencies.
-
-If a Rule uses a `SelectVariants` Selector to indicate that a variant is required, consumers can use
-a `@[type]=[name]` address syntax extension to pass a variant that matches a particular configuration
-for a Rule. A dependency declared as `src/java/com/example/lib:lib` specifies no particular variant, but
-`src/java/com/example/lib:lib@java=java8` asks for the configured variant of the lib named "java8".
-
-Additionally, it is possible to specify the "default" variants for an Address by installing a Rule
-function that can provide `Variants(default=..)`. Again, since the purpose of variants is to collect
-information from dependents, only default variant values which have not been set by a dependent
-will be used.
-
-## Execution
-
-The Scheduler executes work concurrently wherever possible; to help visualize executions, a visualization
-tool is provided that, after executing a `ProductGraph`, generates a `dot` file that can be rendered using
-Graphviz:
-
-```console
-$ mkdir viz
-$ ./pants --native-engine-visualize-to=viz list some/example/directory:
-$ ls viz
-run.0.dot
-```
-
-## Native Engine
-
-The native engine is integrated into the pants codebase via `native.py` in
-this directory along with `build-support/bin/native/bootstrap.sh` which ensures a
-pants native engine library is built and available for linking. The glue is the
-sha1 hash of the native engine source code used as its version by the `Native`
-class. This hash is maintained by `build-support/bin/native/bootstrap.sh` and
-output to the `native_engine_version` file in this directory. Any modification
-to this resource file's location will need adjustments in
-`build-support/bin/native/bootstrap.sh` to ensure the linking continues to work.

--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -13,7 +13,6 @@ from pants.base.specs import DescendantAddresses, SiblingAddresses, Specs
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.address_mapper import AddressMapper
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import BuildFilesCollection
 from pants.engine.mapper import ResolveError
 from pants.engine.nodes import Throw
 from pants.util.dirutil import fast_relpath
@@ -33,14 +32,10 @@ class LegacyAddressMapper(AddressMapper):
     self._build_root = build_root
 
   def scan_build_files(self, base_path):
-    specs = (DescendantAddresses(base_path),)
-    build_files_collection, = self._scheduler.product_request(BuildFilesCollection, [Specs(specs)])
+    build_file_addresses = self._internal_scan_specs([DescendantAddresses(base_path)],
+                                                     missing_is_fatal=False)
 
-    build_files_set = set()
-    for build_files in build_files_collection.dependencies:
-      build_files_set.update(f.path for f in build_files.files_content.dependencies)
-
-    return build_files_set
+    return {bfa.rel_path for bfa in build_file_addresses}
 
   @staticmethod
   def any_is_declaring_file(address, file_paths):

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -23,7 +23,7 @@ from pants.engine.addressable import BuildFileAddresses
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, SourcesField, TargetAdaptor
 from pants.engine.rules import TaskRule, rule
-from pants.engine.selectors import Select, SelectDependencies, SelectProjection
+from pants.engine.selectors import Get, Select, SelectDependencies
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper
 from pants.util.dirutil import fast_relpath
 from pants.util.objects import Collection, datatype
@@ -299,18 +299,19 @@ class HydratedTargets(Collection.of(HydratedTarget)):
   """An intransitive set of HydratedTarget objects."""
 
 
-@rule(TransitiveHydratedTargets, [SelectDependencies(TransitiveHydratedTarget,
-                                                     BuildFileAddresses,
-                                                     field_types=(Address,),
-                                                     field='addresses')])
-def transitive_hydrated_targets(transitive_hydrated_targets):
-  """Kicks off recursion on expansion of TransitiveHydratedTarget objects.
+@rule(TransitiveHydratedTargets, [Select(BuildFileAddresses)])
+def transitive_hydrated_targets(build_file_addresses):
+  """Given BuildFileAddresses, kicks off recursion on expansion of TransitiveHydratedTargets.
 
   The TransitiveHydratedTarget struct represents a structure-shared graph, which we walk
   and flatten here. The engine memoizes the computation of TransitiveHydratedTarget, so
   when multiple TransitiveHydratedTargets objects are being constructed for multiple
   roots, their structure will be shared.
   """
+
+  transitive_hydrated_targets = yield [Get(TransitiveHydratedTarget, Address, a)
+                                       for a in build_file_addresses.addresses]
+
   closure = set()
   to_visit = deque(transitive_hydrated_targets)
 
@@ -321,25 +322,20 @@ def transitive_hydrated_targets(transitive_hydrated_targets):
     closure.add(tht.root)
     to_visit.extend(tht.dependencies)
 
-  return TransitiveHydratedTargets(tuple(tht.root for tht in transitive_hydrated_targets), closure)
+  yield TransitiveHydratedTargets(tuple(tht.root for tht in transitive_hydrated_targets), closure)
 
 
-@rule(TransitiveHydratedTarget, [Select(HydratedTarget),
-                                 SelectDependencies(TransitiveHydratedTarget,
-                                                    HydratedTarget,
-                                                    field_types=(Address,),
-                                                    field='addresses')])
-def transitive_hydrated_target(root, dependencies):
-  return TransitiveHydratedTarget(root, dependencies)
+@rule(TransitiveHydratedTarget, [Select(HydratedTarget)])
+def transitive_hydrated_target(root):
+  dependencies = yield [Get(TransitiveHydratedTarget, Address, d) for d in root.dependencies]
+  yield TransitiveHydratedTarget(root, dependencies)
 
 
-@rule(HydratedTargets, [SelectDependencies(HydratedTarget,
-                                           BuildFileAddresses,
-                                           field_types=(Address,),
-                                           field='addresses')])
-def hydrated_targets(targets):
-  """Requests HydratedTarget instances."""
-  return HydratedTargets(targets)
+@rule(HydratedTargets, [Select(BuildFileAddresses)])
+def hydrated_targets(build_file_addresses):
+  """Requests HydratedTarget instances for BuildFileAddresses."""
+  targets = yield [Get(HydratedTarget, Address, a) for a in build_file_addresses.addresses]
+  yield HydratedTargets(targets)
 
 
 class HydratedField(datatype('HydratedField', ['name', 'value'])):
@@ -372,22 +368,22 @@ def _eager_fileset_with_spec(spec_path, filespec, snapshot, include_dirs=False):
                               files_hash=snapshot.fingerprint)
 
 
-@rule(HydratedField,
-      [Select(SourcesField),
-       SelectProjection(Snapshot, PathGlobs, 'path_globs', SourcesField)])
-def hydrate_sources(sources_field, snapshot):
-  """Given a SourcesField and a Snapshot for its path_globs, create an EagerFilesetWithSpec."""
+@rule(HydratedField, [Select(SourcesField)])
+def hydrate_sources(sources_field):
+  """Given a SourcesField, request a Snapshot for its path_globs and create an EagerFilesetWithSpec."""
+
+  snapshot = yield Get(Snapshot, PathGlobs, sources_field.path_globs)
   fileset_with_spec = _eager_fileset_with_spec(sources_field.address.spec_path,
                                                sources_field.filespecs,
                                                snapshot)
-  return HydratedField(sources_field.arg, fileset_with_spec)
+  yield HydratedField(sources_field.arg, fileset_with_spec)
 
 
-@rule(HydratedField,
-      [Select(BundlesField),
-       SelectDependencies(Snapshot, BundlesField, 'path_globs_list', field_types=(PathGlobs,))])
-def hydrate_bundles(bundles_field, snapshot_list):
-  """Given a BundlesField and a Snapshot for each of its filesets create a list of BundleAdaptors."""
+@rule(HydratedField, [Select(BundlesField)])
+def hydrate_bundles(bundles_field):
+  """Given a BundlesField, request Snapshots for each of its filesets and create BundleAdaptors."""
+  snapshot_list = yield [Get(Snapshot, PathGlobs, pg) for pg in bundles_field.path_globs_list]
+
   bundles = []
   zipped = zip(bundles_field.bundles,
                bundles_field.filespecs_list,
@@ -403,7 +399,7 @@ def hydrate_bundles(bundles_field, snapshot_list):
                                                  snapshot,
                                                  include_dirs=True)
     bundles.append(BundleAdaptor(**kwargs))
-  return HydratedField('bundles', bundles)
+  yield HydratedField('bundles', bundles)
 
 
 def create_legacy_graph_tasks(symbol_table):

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -168,6 +168,7 @@ Value externs_val_for(Key);
 
 Tasks* tasks_create(void);
 void tasks_task_begin(Tasks*, Function, TypeConstraint);
+void tasks_add_get(Tasks*, TypeConstraint, TypeId);
 void tasks_add_select(Tasks*, TypeConstraint);
 void tasks_add_select_variant(Tasks*, TypeConstraint, Buffer);
 void tasks_add_select_dependencies(Tasks*, TypeConstraint, TypeConstraint, Buffer, TypeIdBuffer);

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -17,6 +17,7 @@ import cffi
 import pkg_resources
 import six
 
+from pants.engine.selectors import Get, constraint_for
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_mkdir, safe_mkdtemp
 from pants.util.memo import memoized_property
@@ -84,6 +85,12 @@ typedef struct {
 } PyResult;
 
 typedef struct {
+  uint8_t      tag;
+  ValueBuffer  values;
+  ValueBuffer  constraints;
+} PyGeneratorResponse;
+
+typedef struct {
   int64_t   hash_;
   Value     value;
   TypeId    type_id;
@@ -92,25 +99,26 @@ typedef struct {
 typedef void ExternContext;
 
 // On the rust side the integration is defined in externs.rs
-typedef void             (*extern_ptr_log)(ExternContext*, uint8_t, uint8_t*, uint64_t);
-typedef uint8_t          extern_log_level;
-typedef Ident            (*extern_ptr_identify)(ExternContext*, Value*);
-typedef _Bool            (*extern_ptr_equals)(ExternContext*, Value*, Value*);
-typedef Value            (*extern_ptr_clone_val)(ExternContext*, Value*);
-typedef void             (*extern_ptr_drop_handles)(ExternContext*, Handle*, uint64_t);
-typedef Buffer           (*extern_ptr_type_to_str)(ExternContext*, TypeId);
-typedef Buffer           (*extern_ptr_val_to_str)(ExternContext*, Value*);
-typedef _Bool            (*extern_ptr_satisfied_by)(ExternContext*, Value*, Value*);
-typedef _Bool            (*extern_ptr_satisfied_by_type)(ExternContext*, Value*, TypeId*);
-typedef Value            (*extern_ptr_store_list)(ExternContext*, Value**, uint64_t, _Bool);
-typedef Value            (*extern_ptr_store_bytes)(ExternContext*, uint8_t*, uint64_t);
-typedef Value            (*extern_ptr_store_i32)(ExternContext*, int32_t);
-typedef Value            (*extern_ptr_project)(ExternContext*, Value*, uint8_t*, uint64_t, TypeId*);
-typedef ValueBuffer      (*extern_ptr_project_multi)(ExternContext*, Value*, uint8_t*, uint64_t);
-typedef Value            (*extern_ptr_project_ignoring_type)(ExternContext*, Value*, uint8_t*, uint64_t);
-typedef Value            (*extern_ptr_create_exception)(ExternContext*, uint8_t*, uint64_t);
-typedef PyResult         (*extern_ptr_call)(ExternContext*, Value*, Value*, uint64_t);
-typedef PyResult         (*extern_ptr_eval)(ExternContext*, uint8_t*, uint64_t);
+typedef void                (*extern_ptr_log)(ExternContext*, uint8_t, uint8_t*, uint64_t);
+typedef uint8_t             extern_log_level;
+typedef Ident               (*extern_ptr_identify)(ExternContext*, Value*);
+typedef _Bool               (*extern_ptr_equals)(ExternContext*, Value*, Value*);
+typedef Value               (*extern_ptr_clone_val)(ExternContext*, Value*);
+typedef void                (*extern_ptr_drop_handles)(ExternContext*, Handle*, uint64_t);
+typedef Buffer              (*extern_ptr_type_to_str)(ExternContext*, TypeId);
+typedef Buffer              (*extern_ptr_val_to_str)(ExternContext*, Value*);
+typedef _Bool               (*extern_ptr_satisfied_by)(ExternContext*, Value*, Value*);
+typedef _Bool               (*extern_ptr_satisfied_by_type)(ExternContext*, Value*, TypeId*);
+typedef Value               (*extern_ptr_store_list)(ExternContext*, Value**, uint64_t, _Bool);
+typedef Value               (*extern_ptr_store_bytes)(ExternContext*, uint8_t*, uint64_t);
+typedef Value               (*extern_ptr_store_i32)(ExternContext*, int32_t);
+typedef Value               (*extern_ptr_project)(ExternContext*, Value*, uint8_t*, uint64_t, TypeId*);
+typedef ValueBuffer         (*extern_ptr_project_multi)(ExternContext*, Value*, uint8_t*, uint64_t);
+typedef Value               (*extern_ptr_project_ignoring_type)(ExternContext*, Value*, uint8_t*, uint64_t);
+typedef Value               (*extern_ptr_create_exception)(ExternContext*, uint8_t*, uint64_t);
+typedef PyResult            (*extern_ptr_call)(ExternContext*, Value*, Value*, uint64_t);
+typedef PyGeneratorResponse (*extern_ptr_generator_send)(ExternContext*, Value*, Value*);
+typedef PyResult            (*extern_ptr_eval)(ExternContext*, uint8_t*, uint64_t);
 
 typedef void Tasks;
 typedef void Scheduler;
@@ -136,6 +144,7 @@ void externs_set(ExternContext*,
                  extern_ptr_log,
                  extern_log_level,
                  extern_ptr_call,
+                 extern_ptr_generator_send,
                  extern_ptr_eval,
                  extern_ptr_identify,
                  extern_ptr_equals,
@@ -189,6 +198,7 @@ Scheduler* scheduler_create(Tasks*,
                             TypeConstraint,
                             TypeConstraint,
                             TypeConstraint,
+                            TypeConstraint,
                             TypeId,
                             TypeId,
                             Buffer,
@@ -226,24 +236,25 @@ void garbage_collect_store(Scheduler*);
 
 CFFI_EXTERNS = '''
 extern "Python" {
-  void             extern_log(ExternContext*, uint8_t, uint8_t*, uint64_t);
-  PyResult         extern_call(ExternContext*, Value*, Value*, uint64_t);
-  PyResult         extern_eval(ExternContext*, uint8_t*, uint64_t);
-  Ident            extern_identify(ExternContext*, Value*);
-  _Bool            extern_equals(ExternContext*, Value*, Value*);
-  Value            extern_clone_val(ExternContext*, Value*);
-  void             extern_drop_handles(ExternContext*, Handle*, uint64_t);
-  Buffer           extern_type_to_str(ExternContext*, TypeId);
-  Buffer           extern_val_to_str(ExternContext*, Value*);
-  _Bool            extern_satisfied_by(ExternContext*, Value*, Value*);
-  _Bool            extern_satisfied_by_type(ExternContext*, Value*, TypeId*);
-  Value            extern_store_list(ExternContext*, Value**, uint64_t, _Bool);
-  Value            extern_store_bytes(ExternContext*, uint8_t*, uint64_t);
-  Value            extern_store_i32(ExternContext*, int32_t);
-  Value            extern_project(ExternContext*, Value*, uint8_t*, uint64_t, TypeId*);
-  Value            extern_project_ignoring_type(ExternContext*, Value*, uint8_t*, uint64_t);
-  ValueBuffer      extern_project_multi(ExternContext*, Value*, uint8_t*, uint64_t);
-  Value            extern_create_exception(ExternContext*, uint8_t*, uint64_t);
+  void                extern_log(ExternContext*, uint8_t, uint8_t*, uint64_t);
+  PyResult            extern_call(ExternContext*, Value*, Value*, uint64_t);
+  PyGeneratorResponse extern_generator_send(ExternContext*, Value*, Value*);
+  PyResult            extern_eval(ExternContext*, uint8_t*, uint64_t);
+  Ident               extern_identify(ExternContext*, Value*);
+  _Bool               extern_equals(ExternContext*, Value*, Value*);
+  Value               extern_clone_val(ExternContext*, Value*);
+  void                extern_drop_handles(ExternContext*, Handle*, uint64_t);
+  Buffer              extern_type_to_str(ExternContext*, TypeId);
+  Buffer              extern_val_to_str(ExternContext*, Value*);
+  _Bool               extern_satisfied_by(ExternContext*, Value*, Value*);
+  _Bool               extern_satisfied_by_type(ExternContext*, Value*, TypeId*);
+  Value               extern_store_list(ExternContext*, Value**, uint64_t, _Bool);
+  Value               extern_store_bytes(ExternContext*, uint8_t*, uint64_t);
+  Value               extern_store_i32(ExternContext*, int32_t);
+  Value               extern_project(ExternContext*, Value*, uint8_t*, uint64_t, TypeId*);
+  Value               extern_project_ignoring_type(ExternContext*, Value*, uint8_t*, uint64_t);
+  ValueBuffer         extern_project_multi(ExternContext*, Value*, uint8_t*, uint64_t);
+  Value               extern_create_exception(ExternContext*, uint8_t*, uint64_t);
 }
 '''
 
@@ -460,6 +471,41 @@ def _initialize_externs(ffi):
     return c.to_value(Exception(msg))
 
   @ffi.def_extern()
+  def extern_generator_send(context_handle, func, arg):
+    """Given a generator, send it the given value and return a response."""
+    c = ffi.from_handle(context_handle)
+    try:
+      res = c.from_value(func).send(c.from_value(arg))
+      if isinstance(res, Get):
+        # Get.
+        values = [res.subject]
+        constraints = [constraint_for(res.product)]
+        tag = 2
+      elif type(res) in (tuple, list):
+        # GetMulti.
+        values = [g.subject for g in res]
+        constraints = [constraint_for(g.product) for g in res]
+        tag = 3
+      else:
+        # Break.
+        values = [res]
+        constraints = []
+        tag = 0
+    except Exception as e:
+      # Throw.
+      val = e
+      val._formatted_exc = traceback.format_exc()
+      values = [val]
+      constraints = []
+      tag = 1
+
+    return (
+        tag,
+        c.vals_buf([c.to_value(v) for v in values]),
+        c.vals_buf([c.to_value(v) for v in constraints])
+      )
+
+  @ffi.def_extern()
   def extern_call(context_handle, func, args_ptr, args_len):
     """Given a callable, call it."""
     c = ffi.from_handle(context_handle)
@@ -637,6 +683,7 @@ class Native(object):
                            self.ffi_lib.extern_log,
                            logger.getEffectiveLevel(),
                            self.ffi_lib.extern_call,
+                           self.ffi_lib.extern_generator_send,
                            self.ffi_lib.extern_eval,
                            self.ffi_lib.extern_identify,
                            self.ffi_lib.extern_equals,
@@ -710,7 +757,8 @@ class Native(object):
                     constraint_file,
                     constraint_link,
                     constraint_process_request,
-                    constraint_process_result):
+                    constraint_process_result,
+                    constraint_generator):
     """Create and return an ExternContext and native Scheduler."""
 
     def func(constraint):
@@ -743,6 +791,7 @@ class Native(object):
         tc(constraint_link),
         tc(constraint_process_request),
         tc(constraint_process_result),
+        tc(constraint_generator),
         # Types.
         TypeId(self.context.to_id(six.text_type)),
         TypeId(self.context.to_id(six.binary_type)),

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -9,6 +9,7 @@ import logging
 import os
 import time
 from collections import defaultdict
+from types import GeneratorType
 
 from pants.base.exceptions import TaskError
 from pants.base.project_tree import Dir, File, Link
@@ -111,6 +112,7 @@ class WrappedNativeScheduler(object):
       constraint_for(Link),
       constraint_for(ExecuteProcessRequest),
       constraint_for(ExecuteProcessResult),
+      constraint_for(GeneratorType),
     )
 
   def _root_type_ids(self):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -191,10 +191,9 @@ class WrappedNativeScheduler(object):
 
   def _register_task(self, output_constraint, rule):
     """Register the given TaskRule with the native scheduler."""
-    input_selects = rule.input_selectors
     func = rule.func
     self._native.lib.tasks_task_begin(self._tasks, Function(self._to_key(func)), output_constraint)
-    for selector in input_selects:
+    for selector in rule.input_selectors:
       selector_type = type(selector)
       product_constraint = self._to_constraint(selector.product)
       if selector_type is Select:
@@ -218,6 +217,10 @@ class WrappedNativeScheduler(object):
                                                      self._to_constraint(selector.input_product))
       else:
         raise ValueError('Unrecognized Selector type: {}'.format(selector))
+    for get in rule.input_gets:
+      self._native.lib.tasks_add_get(self._tasks,
+                                     self._to_constraint(get.product),
+                                     TypeId(self._to_id(get.subject)))
     self._native.lib.tasks_task_end(self._tasks)
 
   def visualize_graph_to_file(self, execution_request, filename):

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -32,11 +32,30 @@ def constraint_for(type_or_constraint):
     raise TypeError("Expected a type or constraint: got: {}".format(type_or_constraint))
 
 
+class Get(datatype('Get', ['product', 'subject'])):
+  """TODO: Experimental synchronous generator API.
+
+  May be called equivalently as either:
+    # verbose form: Get(product_type, subject_type, subject)
+    # shorthand form: Get(product_type, subject_type(subject))
+  """
+
+  def __new__(cls, *args):
+    if len(args) == 2:
+      product, subject = args
+    elif len(args) == 3:
+      product, _, subject = args
+    else:
+      raise Exception('Expected either two or three arguments to {}; got {}.'.format(
+          Get.__name__, args))
+    return super(Get, cls).__new__(cls, product, subject)
+
+
 class Selector(AbstractClass):
-  # The type constraint for the product type for this selector.
 
   @property
   def type_constraint(self):
+    """The type constraint for the product type for this selector."""
     return constraint_for(self.product)
 
   @abstractproperty

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -54,17 +54,17 @@ class Get(datatype('Get', ['product', 'subject'])):
     if len(call_node.args) == 2:
       product_type, subject_constructor = call_node.args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_constructor, ast.Call):
-        raise Exception('Two arg form of {} expected (product_type, subject_type(subject)), but '
+        raise ValueError('Two arg form of {} expected (product_type, subject_type(subject)), but '
                         'got: ({})'.format(Get.__name__, render_args()))
       return (product_type.id, subject_constructor.func.id)
     elif len(call_node.args) == 3:
       product_type, subject_type, _ = call_node.args
       if not isinstance(product_type, ast.Name) or not isinstance(subject_type, ast.Name):
-        raise Exception('Three arg form of {} expected (product_type, subject_type, subject), but '
+        raise ValueError('Three arg form of {} expected (product_type, subject_type, subject), but '
                         'got: ({})'.format(Get.__name__, render_args()))
       return (product_type.id, subject_type.id)
     else:
-      raise Exception('Invalid {}; expected either two or three args, but '
+      raise ValueError('Invalid {}; expected either two or three args, but '
                       'got: ({})'.format(Get.__name__, render_args()))
 
   def __new__(cls, *args):

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import ast
 from abc import abstractproperty
 
 import six
@@ -33,21 +34,50 @@ def constraint_for(type_or_constraint):
 
 
 class Get(datatype('Get', ['product', 'subject'])):
-  """TODO: Experimental synchronous generator API.
+  """Experimental synchronous generator API.
 
   May be called equivalently as either:
     # verbose form: Get(product_type, subject_type, subject)
     # shorthand form: Get(product_type, subject_type(subject))
   """
 
+  @staticmethod
+  def extract_constraints(call_node):
+    """Parses a `Get(..)` call in one of its two legal forms to return its type constraints.
+
+    :param call_node: An `ast.Call` node representing a call to `Get(..)`.
+    :return: A tuple of product type id and subject type id.
+    """
+    def render_args():
+      return ', '.join(a.id for a in call_node.args)
+
+    if len(call_node.args) == 2:
+      product_type, subject_constructor = call_node.args
+      if not isinstance(product_type, ast.Name) or not isinstance(subject_constructor, ast.Call):
+        raise Exception('Two arg form of {} expected (product_type, subject_type(subject)), but '
+                        'got: ({})'.format(Get.__name__, render_args()))
+      return (product_type.id, subject_constructor.func.id)
+    elif len(call_node.args) == 3:
+      product_type, subject_type, _ = call_node.args
+      if not isinstance(product_type, ast.Name) or not isinstance(subject_type, ast.Name):
+        raise Exception('Three arg form of {} expected (product_type, subject_type, subject), but '
+                        'got: ({})'.format(Get.__name__, render_args()))
+      return (product_type.id, subject_type.id)
+    else:
+      raise Exception('Invalid {}; expected either two or three args, but '
+                      'got: ({})'.format(Get.__name__, render_args()))
+
   def __new__(cls, *args):
     if len(args) == 2:
       product, subject = args
     elif len(args) == 3:
-      product, _, subject = args
+      product, subject_type, subject = args
+      if type(subject) is not subject_type:
+        raise TypeError('Declared type did not match actual type for {}({}).'.format(
+          Get.__name__, ', '.join(str(a) for a in args)))
     else:
       raise Exception('Expected either two or three arguments to {}; got {}.'.format(
-          Get.__name__, args))
+        Get.__name__, args))
     return super(Get, cls).__new__(cls, product, subject)
 
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -697,19 +697,14 @@ pub trait VFS<E: Send + Sync + 'static>: Clone + Send + Sync + 'static {
 
         // If there were any new PathGlobs, continue the expansion.
         if expansion.todo.is_empty() {
-          future::Loop::Break(expansion)
+          future::Loop::Break(expansion.outputs)
         } else {
           future::Loop::Continue(expansion)
         }
       })
-    }).map(|expansion| {
-      assert!(
-        expansion.todo.is_empty(),
-        "Loop shouldn't have exited with work to do: {:?}",
-        expansion.todo,
-      );
+    }).map(|expansion_outputs| {
       // Finally, capture the resulting PathStats from the expansion.
-      expansion.outputs.into_iter().map(|(k, _)| k).collect()
+      expansion_outputs.into_iter().map(|(k, _)| k).collect()
     })
       .to_boxed()
   }

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -146,6 +146,33 @@ pub fn call(func: &Value, args: &[Value]) -> Result<Value, Failure> {
   with_externs(|e| (e.call)(e.context, func, args.as_ptr(), args.len() as u64)).into()
 }
 
+pub fn generator_send(generator: &Value, arg: &Value) -> Result<GeneratorResponse, Failure> {
+  let response = with_externs(|e| (e.generator_send)(e.context, generator, arg));
+  match response.res_type {
+    PyGeneratorResponseType::Break => Ok(GeneratorResponse::Break(response.values.unwrap_one())),
+    PyGeneratorResponseType::Throw => Err(PyResult::failure_from(response.values.unwrap_one())),
+    PyGeneratorResponseType::Get => {
+      let mut interns = INTERNS.write().unwrap();
+      let constraint = TypeConstraint(interns.insert(response.constraints.unwrap_one()));
+      Ok(GeneratorResponse::Get(Get(
+        constraint,
+        interns.insert(response.values.unwrap_one()),
+      )))
+    }
+    PyGeneratorResponseType::GetMulti => {
+      let mut interns = INTERNS.write().unwrap();
+      let continues = response
+        .constraints
+        .to_vec()
+        .into_iter()
+        .zip(response.values.to_vec().into_iter())
+        .map(|(c, v)| Get(TypeConstraint(interns.insert(c)), interns.insert(v)))
+        .collect();
+      Ok(GeneratorResponse::GetMulti(continues))
+    }
+  }
+}
+
 ///
 /// NB: Panics on failure. Only recommended for use with built-in functions, such as
 /// those configured in types::Types.
@@ -206,83 +233,34 @@ where
 pub type ExternContext = raw::c_void;
 
 pub struct Externs {
-  context: *const ExternContext,
-  log: LogExtern,
-  log_level: u8,
-  call: CallExtern,
-  eval: EvalExtern,
-  identify: IdentifyExtern,
-  equals: EqualsExtern,
-  clone_val: CloneValExtern,
-  drop_handles: DropHandlesExtern,
-  satisfied_by: SatisfiedByExtern,
-  satisfied_by_type: SatisfiedByTypeExtern,
-  store_list: StoreListExtern,
-  store_bytes: StoreBytesExtern,
-  store_i32: StoreI32Extern,
-  project: ProjectExtern,
-  project_ignoring_type: ProjectIgnoringTypeExtern,
-  project_multi: ProjectMultiExtern,
-  type_to_str: TypeToStrExtern,
-  val_to_str: ValToStrExtern,
-  create_exception: CreateExceptionExtern,
+  pub context: *const ExternContext,
+  pub log_level: u8,
+  pub log: LogExtern,
+  pub call: CallExtern,
+  pub generator_send: GeneratorSendExtern,
+  pub eval: EvalExtern,
+  pub identify: IdentifyExtern,
+  pub equals: EqualsExtern,
+  pub clone_val: CloneValExtern,
+  pub drop_handles: DropHandlesExtern,
+  pub satisfied_by: SatisfiedByExtern,
+  pub satisfied_by_type: SatisfiedByTypeExtern,
+  pub store_list: StoreListExtern,
+  pub store_bytes: StoreBytesExtern,
+  pub store_i32: StoreI32Extern,
+  pub project: ProjectExtern,
+  pub project_ignoring_type: ProjectIgnoringTypeExtern,
+  pub project_multi: ProjectMultiExtern,
+  pub type_to_str: TypeToStrExtern,
+  pub val_to_str: ValToStrExtern,
+  pub create_exception: CreateExceptionExtern,
   // TODO: This type is also declared on `types::Types`.
-  py_str_type: TypeId,
+  pub py_str_type: TypeId,
 }
 
 // The pointer to the context is safe for sharing between threads.
 unsafe impl Sync for Externs {}
 unsafe impl Send for Externs {}
-
-impl Externs {
-  pub fn new(
-    ext_context: *const ExternContext,
-    log: LogExtern,
-    log_level: u8,
-    call: CallExtern,
-    eval: EvalExtern,
-    identify: IdentifyExtern,
-    equals: EqualsExtern,
-    clone_val: CloneValExtern,
-    drop_handles: DropHandlesExtern,
-    type_to_str: TypeToStrExtern,
-    val_to_str: ValToStrExtern,
-    satisfied_by: SatisfiedByExtern,
-    satisfied_by_type: SatisfiedByTypeExtern,
-    store_list: StoreListExtern,
-    store_bytes: StoreBytesExtern,
-    store_i32: StoreI32Extern,
-    project: ProjectExtern,
-    project_ignoring_type: ProjectIgnoringTypeExtern,
-    project_multi: ProjectMultiExtern,
-    create_exception: CreateExceptionExtern,
-    py_str_type: TypeId,
-  ) -> Externs {
-    Externs {
-      context: ext_context,
-      log: log,
-      log_level: log_level,
-      call: call,
-      eval: eval,
-      identify: identify,
-      equals: equals,
-      clone_val: clone_val,
-      drop_handles: drop_handles,
-      satisfied_by: satisfied_by,
-      satisfied_by_type: satisfied_by_type,
-      store_list: store_list,
-      store_bytes: store_bytes,
-      store_i32: store_i32,
-      project: project,
-      project_ignoring_type: project_ignoring_type,
-      project_multi: project_multi,
-      type_to_str: type_to_str,
-      val_to_str: val_to_str,
-      create_exception: create_exception,
-      py_str_type: py_str_type,
-    }
-  }
-}
 
 pub type LogExtern = extern "C" fn(*const ExternContext, u8, str_ptr: *const u8, str_len: u64);
 
@@ -324,11 +302,17 @@ pub struct PyResult {
   value: Value,
 }
 
+impl PyResult {
+  fn failure_from(v: Value) -> Failure {
+    let traceback = project_str(&v, "_formatted_exc");
+    Failure::Throw(v, traceback)
+  }
+}
+
 impl From<PyResult> for Result<Value, Failure> {
   fn from(result: PyResult) -> Self {
     if result.is_throw {
-      let traceback = project_str(&result.value, "_formatted_exc");
-      Err(Failure::Throw(result.value, traceback))
+      Err(PyResult::failure_from(result.value))
     } else {
       Ok(result.value)
     }
@@ -350,6 +334,32 @@ impl From<Result<(), String>> for PyResult {
   }
 }
 
+// Only constructed from the python side.
+#[allow(dead_code)]
+#[repr(u8)]
+pub enum PyGeneratorResponseType {
+  Break = 0,
+  Throw = 1,
+  Get = 2,
+  GetMulti = 3,
+}
+
+#[repr(C)]
+pub struct PyGeneratorResponse {
+  res_type: PyGeneratorResponseType,
+  values: ValueBuffer,
+  constraints: ValueBuffer,
+}
+
+#[derive(Debug)]
+pub struct Get(pub TypeConstraint, pub Key);
+
+pub enum GeneratorResponse {
+  Break(Value),
+  Get(Get),
+  GetMulti(Vec<Get>),
+}
+
 // The result of an `identify` call, including the __hash__ of a Value and its TypeId.
 #[repr(C)]
 pub struct Ident {
@@ -358,7 +368,13 @@ pub struct Ident {
   pub type_id: TypeId,
 }
 
-// Points to an array containing a series of values allocated by Python.
+///
+/// Points to an array containing a series of values allocated by Python.
+///
+/// TODO: An interesting optimization might be possible where we avoid actually
+/// allocating the values array for values_len == 1, and instead store the Value in
+/// the `handle_` field.
+///
 #[repr(C)]
 pub struct ValueBuffer {
   values_ptr: *mut Value,
@@ -373,6 +389,20 @@ impl ValueBuffer {
       self.values_ptr,
       self.values_len as usize,
       |value_vec| unsafe { value_vec.iter().map(|v| v.clone_without_handle()).collect() },
+    )
+  }
+
+  /// Asserts that the ValueBuffer contains one value, and returns it.
+  pub fn unwrap_one(&self) -> Value {
+    assert!(
+      self.values_len == 1,
+      "ValueBuffer contained more than one value: {}",
+      self.values_len
+    );
+    with_vec(
+      self.values_ptr,
+      self.values_len as usize,
+      |value_vec| unsafe { value_vec.iter().next().unwrap().clone_without_handle() },
     )
   }
 }
@@ -466,6 +496,9 @@ pub type CreateExceptionExtern =
 
 pub type CallExtern =
   extern "C" fn(*const ExternContext, *const Value, *const Value, u64) -> PyResult;
+
+pub type GeneratorSendExtern =
+  extern "C" fn(*const ExternContext, *const Value, *const Value) -> PyGeneratorResponse;
 
 pub type EvalExtern =
   extern "C" fn(*const ExternContext, python_ptr: *const u8, python_len: u64) -> PyResult;

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -329,6 +329,13 @@ pub extern "C" fn tasks_task_begin(
 }
 
 #[no_mangle]
+pub extern "C" fn tasks_add_get(tasks_ptr: *mut Tasks, product: TypeConstraint, subject: TypeId) {
+  with_tasks(tasks_ptr, |tasks| {
+    tasks.add_get(product, subject);
+  })
+}
+
+#[no_mangle]
 pub extern "C" fn tasks_add_select(tasks_ptr: *mut Tasks, product: TypeConstraint) {
   with_tasks(tasks_ptr, |tasks| {
     tasks.add_select(product, None);

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -4,6 +4,12 @@
 use core::{Field, TypeConstraint, TypeId};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Get {
+  pub product: TypeConstraint,
+  pub subject: TypeId,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Select {
   pub product: TypeConstraint,
   pub variant_key: Option<String>,

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -5,12 +5,13 @@ use std::collections::{HashMap, HashSet};
 
 use core::{Field, Function, Key, TypeConstraint, TypeId, Value, FNV};
 use externs;
-use selectors::{Select, SelectDependencies, SelectProjection, Selector};
+use selectors::{Get, Select, SelectDependencies, SelectProjection, Selector};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
   pub product: TypeConstraint,
   pub clause: Vec<Selector>,
+  pub gets: Vec<Get>,
   pub func: Function,
   pub cacheable: bool,
 }
@@ -95,8 +96,21 @@ impl Tasks {
       cacheable: true,
       product: product,
       clause: Vec::new(),
+      gets: Vec::new(),
       func: func,
     });
+  }
+
+  pub fn add_get(&mut self, product: TypeConstraint, subject: TypeId) {
+    self
+      .preparing
+      .as_mut()
+      .expect("Must `begin()` a task creation before adding gets!")
+      .gets
+      .push(Get {
+        product: product,
+        subject: subject,
+      });
   }
 
   pub fn add_select(&mut self, product: TypeConstraint, variant_key: Option<String>) {
@@ -163,6 +177,7 @@ impl Tasks {
       tasks,
     );
     task.clause.shrink_to_fit();
+    task.gets.shrink_to_fit();
     tasks.push(task);
   }
 }

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -22,6 +22,7 @@ pub struct Types {
   pub link: TypeConstraint,
   pub process_request: TypeConstraint,
   pub process_result: TypeConstraint,
+  pub generator: TypeConstraint,
   pub string: TypeId,
   pub bytes: TypeId,
 }

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -106,10 +106,10 @@ class SourceRoots(datatype('SourceRoots', ['srcroots'])):
   """Placeholder for the SourceRoot subsystem."""
 
 
+@printing_func
 @rule(Address,
       [Select(JVMPackageName),
        SelectDependencies(AddressFamily, Snapshot, field='dir_stats', field_types=(Dir,))])
-@printing_func
 def select_package_address(jvm_package_name, address_families):
   """Return the Address from the given AddressFamilies which provides the given package."""
   addresses = [address for address_family in address_families
@@ -123,8 +123,8 @@ def select_package_address(jvm_package_name, address_families):
   return addresses[0].to_address()
 
 
-@rule(PathGlobs, [Select(JVMPackageName), Select(SourceRoots)])
 @printing_func
+@rule(PathGlobs, [Select(JVMPackageName), Select(SourceRoots)])
 def calculate_package_search_path(jvm_package_name, source_roots):
   """Return PathGlobs to match directories where the given JVMPackageName might exist."""
   rel_package_dir = jvm_package_name.name.replace('.', os_sep)
@@ -132,9 +132,9 @@ def calculate_package_search_path(jvm_package_name, source_roots):
   return PathGlobs.create('', include=specs)
 
 
+@printing_func
 @rule(ImportedJVMPackages,
       [SelectProjection(FilesContent, PathGlobs, 'path_globs', ScalaInferredDepsSources)])
-@printing_func
 def extract_scala_imports(source_files_content):
   """A toy example of dependency inference. Would usually be a compiler plugin."""
   packages = set()
@@ -147,10 +147,10 @@ def extract_scala_imports(source_files_content):
   return ImportedJVMPackages([JVMPackageName(p) for p in packages])
 
 
+@printing_func
 @rule(ScalaSources,
       [Select(ScalaInferredDepsSources),
        SelectDependencies(Address, ImportedJVMPackages, field_types=(JVMPackageName,))])
-@printing_func
 def reify_scala_sources(sources, dependency_addresses):
   """Given a ScalaInferredDepsSources object and its inferred dependencies, create ScalaSources."""
   kwargs = sources._asdict()
@@ -214,8 +214,8 @@ class ManagedJar(Struct):
     super(ManagedJar, self).__init__(org=org, name=name, **kwargs)
 
 
-@rule(Jar, [Select(ManagedJar), SelectVariant(ManagedResolve, 'resolve')])
 @printing_func
+@rule(Jar, [Select(ManagedJar), SelectVariant(ManagedResolve, 'resolve')])
 def select_rev(managed_jar, managed_resolve):
   (org, name) = (managed_jar.org, managed_jar.name)
   rev = managed_resolve.revs.get('{}#{}'.format(org, name), None)
@@ -224,14 +224,14 @@ def select_rev(managed_jar, managed_resolve):
   return Jar(org=managed_jar.org, name=managed_jar.name, rev=rev)
 
 
-@rule(Classpath, [Select(Jar)])
 @printing_func
+@rule(Classpath, [Select(Jar)])
 def ivy_resolve(jars):
   return Classpath(creator='ivy_resolve')
 
 
-@rule(Classpath, [Select(ResourceSources)])
 @printing_func
+@rule(Classpath, [Select(ResourceSources)])
 def isolate_resources(resources):
   """Copies resources into a private directory, and provides them as a Classpath entry."""
   return Classpath(creator='isolate_resources')
@@ -287,8 +287,8 @@ class BuildPropertiesConfiguration(Struct):
   pass
 
 
-@rule(Classpath, [Select(BuildPropertiesConfiguration)])
 @printing_func
+@rule(Classpath, [Select(BuildPropertiesConfiguration)])
 def write_name_file(name):
   """Write a file containing the name of this target in the CWD."""
   return Classpath(creator='write_name_file')
@@ -339,18 +339,18 @@ def gen_scrooge_thrift(sources, config, scrooge_classpath):
     return ScalaSources(files=['Fake.scala'], dependencies=config.dependencies)
 
 
+@printing_func
 @rule(Classpath,
       [Select(JavaSources),
        SelectDependencies(Classpath, JavaSources, field_types=(Address, Jar))])
-@printing_func
 def javac(sources, classpath):
   return Classpath(creator='javac')
 
 
+@printing_func
 @rule(Classpath,
       [Select(ScalaSources),
        SelectDependencies(Classpath, ScalaSources, field_types=(Address, Jar))])
-@printing_func
 def scalac(sources, classpath):
   return Classpath(creator='scalac')
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -303,8 +303,8 @@ class RuleGraphMakerTest(unittest.TestCase):
       else:
         pass
 
-    self.assertTrue(10 < len(all_rules))
-    self.assertTrue(30 < len(root_rule_lines)) # 2 lines per entry
+    self.assertTrue(6 < len(all_rules))
+    self.assertTrue(12 < len(root_rule_lines)) # 2 lines per entry
 
   def test_smallest_full_test_multiple_root_subject_types(self):
     rules = [

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import re
+from types import GeneratorType
 
 from pants.binaries.binary_util import BinaryUtilPrivate
 from pants.engine.addressable import SubclassesOf, addressable_list
@@ -13,9 +14,70 @@ from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
 from pants.engine.rules import RuleIndex
 from pants.engine.scheduler import WrappedNativeScheduler
+from pants.engine.selectors import Get
 from pants.engine.struct import HasProducts, Struct
 from pants_test.option.util.fakes import create_options_for_optionables
 from pants_test.subsystem.subsystem_util import init_subsystem
+
+
+def run_rule(rule, *args):
+  """A test helper function that runs an @rule with a set of arguments and Get providers.
+
+  An @rule named `my_rule` that takes one argument and makes no `Get` requests can be invoked
+  like so (although you could also just invoke it directly):
+  ```
+  return_value = run_rule(my_rule, arg1)
+  ```
+
+  In the case of an @rule that makes Get requests, things get more interesting: an extra argument
+  is required that represents a dict mapping (product, subject) type pairs to one argument functions
+  that take a subject value and return a product value.
+
+  So in the case of an @rule named `my_co_rule` that takes one argument and makes Get requests
+  for product and subject types (Listing, Dir), the invoke might look like:
+  ```
+  return_value = run_rule(my_co_rule, arg1, {(Listing, Dir): lambda x: Listing(..)})
+  ```
+
+  :returns: The return value of the completed @rule.
+  """
+
+  task_rule = getattr(rule, '_rule', None)
+  if task_rule is None:
+    raise TypeError('Expected to receive a decorated `@rule`; got: {}'.format(rule))
+
+  gets_len = len(task_rule.input_gets)
+
+  if len(args) != len(task_rule.input_selectors) + (1 if gets_len else 0):
+    raise ValueError('Rule expected to receive arguments of the form: {}; got: {}'.format(
+      task_rule.input_selectors, args))
+
+  args, get_providers = (args[:-1], args[-1]) if gets_len > 0 else (args, {})
+  if gets_len != len(get_providers):
+    raise ValueError('Rule expected to receive Get providers for {}; got: {}'.format(
+      task_rule.input_gets, get_providers))
+
+  res = rule(*args)
+  if not isinstance(res, GeneratorType):
+    return res
+
+  def get(product, subject):
+    provider = get_providers.get((product, type(subject)))
+    if provider is None:
+      raise AssertionError('Rule requested: Get{}, which cannot be satisfied.'.format(
+        (product, type(subject), subject)))
+    return provider(subject)
+
+  rule_coroutine = res
+  rule_input = None
+  while True:
+    res = rule_coroutine.send(rule_input)
+    if isinstance(res, Get):
+      rule_input = get(res.product, res.subject)
+    elif type(res) in (tuple, list):
+      rule_input = [get(g.product, g.subject) for g in res]
+    else:
+      return res
 
 
 def init_native():


### PR DESCRIPTION
### Problem

The "complex" `Selector` types used to select `@rule` inputs for subjects other than the current subject of an `@rule` have proven to be entirely too complicated. Additionally, their lack of flexibility meant that we needed to introduce many intermediate types to provide links between `@rules` in cases where imperative logic was needed for filtering or conditionals.

The only remaining motivating factor for these complex selectors was that they allow for closed-world compilation of the `@rule` graph, which avoids the need for error checking in rule bodies and provides for easier composition of sets of `@rules`.

### Solution

After experimenting with using coroutines (ie: functions containing `yield` statements that receive a result on their left hand side), it became clear both that:

1. Coroutines were universally easier to understand than the Selector DSL
2. The dependency requests made by coroutines could still easily be statically checked via a small amount of runtime introspection.

And so, this change removes all usage of `SelectProjection` and most usage of `SelectDependencies` in favor of `@rule` coroutines. It does not yet remove the implementation of those `Selectors` (although doing so will shed a massive amount of complexity from the codebase).

### Result

`@rules` are still statically checked, but are now much easier to write. Performance is unaffected.