### PR TITLE
[coursier] use same artifact cache override as ivy

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -679,6 +679,12 @@ class CoursierResolve(CoursierMixin):
 
     self.resolve(self.context.targets(), classpath_products, sources=False, javadoc=False)
 
+  def check_artifact_cache_for(self, invalidation_check):
+    # Coursier resolution is an output dependent on the entire target set, and is not divisible
+    # by target. So we can only cache it keyed by the entire target set.
+    global_vts = VersionedTargetSet.from_versioned_targets(invalidation_check.all_vts)
+    return [global_vts]
+
 
 class CoursierResolveFingerprintStrategy(FingerprintStrategy):
 


### PR DESCRIPTION
Ivy resolve overrides check_artifact_cache_for so that it can ensure the artifact cache is only hit once. This adds that same override to coursier resolve.

Before this change, coursier resolves would check the build cache for each jar library in scope, then throw away that information. When there are hundreds of them, that can take a noticable amount of time. With this change, coursier resolve does one cache hit.