### PR TITLE
Use pre-compiled rustfmt instead of compiling it ourselves

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -92,6 +92,7 @@ function ensure_native_build_prerequisites() {
   # Make sure rust is pinned at the correct version.
   # We sincerely hope that no one ever runs `rustup override set` in a subdirectory of the working directory.
   "${CARGO_HOME}/bin/rustup" override set "${RUST_TOOLCHAIN}" >&2
+  "${CARGO_HOME}/bin/rustup" component add rustfmt-preview >&2
 
   # Sometimes fetching a large git repo dependency can take more than 10 minutes.
   # This times out on travis, because nothing is printed to stdout/stderr in that time.
@@ -108,7 +109,6 @@ function ensure_native_build_prerequisites() {
   "${CARGO_HOME}/bin/cargo" ensure-installed --package=cargo-ensure-installed --version=0.1.0 >&2
   "${CARGO_HOME}/bin/cargo" ensure-installed --package=protobuf --version=1.4.2 >&2
   "${CARGO_HOME}/bin/cargo" ensure-installed --package=grpcio-compiler --version=0.2.0 >&2
-  "${CARGO_HOME}/bin/cargo" ensure-installed --package=rustfmt --version=0.9.0 >&2
 
   local download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
   local readonly cmakeroot="$("${download_binary}" "binaries.pantsbuild.org" "cmake" "3.9.5" "cmake.tar.gz")" || die "Failed to fetch cmake"

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -8,7 +8,7 @@ extern crate futures;
 extern crate hashing;
 extern crate protobuf;
 
-use boxfuture::{Boxable, BoxFuture};
+use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use clap::{App, Arg, SubCommand};
 use fs::{ResettablePool, Snapshot, Store, StoreFileByDigest, VFS};
@@ -162,19 +162,17 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
   let pool = Arc::new(ResettablePool::new("fsutil-pool-".to_string()));
   let (store, store_has_remote) = {
     let (store_result, store_has_remote) = match top_match.value_of("server-address") {
-      Some(cas_address) => {
-        (
-          Store::with_remote(
-            store_dir,
-            pool.clone(),
-            cas_address,
-            1,
-            10 * 1024 * 1024,
-            Duration::from_secs(30),
-          ),
-          true,
-        )
-      }
+      Some(cas_address) => (
+        Store::with_remote(
+          store_dir,
+          pool.clone(),
+          cas_address,
+          1,
+          10 * 1024 * 1024,
+          Duration::from_secs(30),
+        ),
+        true,
+      ),
       None => (Store::local_only(store_dir, pool.clone()), false),
     };
     let store = store_result.map_err(|e| {
@@ -247,7 +245,6 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
               ).into(),
             ),
           }
-
         }
         (_, _) => unimplemented!(),
       }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 mod snapshot;
-pub use snapshot::{EMPTY_DIGEST, Snapshot, StoreFileByDigest};
+pub use snapshot::{Snapshot, StoreFileByDigest, EMPTY_DIGEST};
 mod store;
 pub use store::Store;
 mod pool;
@@ -47,8 +47,7 @@ use glob::Pattern;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ordermap::OrderMap;
 
-use boxfuture::{Boxable, BoxFuture};
-
+use boxfuture::{BoxFuture, Boxable};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Stat {
@@ -827,13 +826,12 @@ fn safe_create_dir_all(path: &Path) -> Result<(), String> {
   })
 }
 
-
 #[cfg(test)]
 mod posixfs_test {
   extern crate tempdir;
   extern crate testutil;
 
-  use super::{Dir, File, Link, PosixFS, Stat, ResettablePool};
+  use super::{Dir, File, Link, PosixFS, ResettablePool, Stat};
   use futures::Future;
   use self::testutil::make_file;
   use std;

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -4,7 +4,7 @@
 extern crate tempdir;
 
 use bazel_protos;
-use boxfuture::{Boxable, BoxFuture};
+use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use futures::Future;
 use futures::future::join_all;
@@ -288,18 +288,14 @@ fn paths_of_child_dir(paths: Vec<PathStat>) -> Vec<PathStat> {
         return None;
       }
       Some(match s {
-        PathStat::File { path, stat } => {
-          PathStat::File {
-            path: path.iter().skip(1).collect(),
-            stat: stat,
-          }
-        }
-        PathStat::Dir { path, stat } => {
-          PathStat::Dir {
-            path: path.iter().skip(1).collect(),
-            stat: stat,
-          }
-        }
+        PathStat::File { path, stat } => PathStat::File {
+          path: path.iter().skip(1).collect(),
+          stat: stat,
+        },
+        PathStat::Dir { path, stat } => PathStat::Dir {
+          path: path.iter().skip(1).collect(),
+          stat: stat,
+        },
       })
     })
     .collect()
@@ -313,8 +309,8 @@ fn osstring_as_utf8(path: OsString) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-  extern crate testutil;
   extern crate tempdir;
+  extern crate testutil;
 
   use boxfuture::{BoxFuture, Boxable};
   use bytes::Bytes;

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -136,7 +136,7 @@ impl<W: Write> Write for WriterHasher<W> {
 
 #[cfg(test)]
 mod fingerprint_tests {
-  use super::{Digest, Fingerprint, bazel_protos};
+  use super::{bazel_protos, Digest, Fingerprint};
 
   #[test]
   fn from_bytes_unsafe() {

--- a/src/rust/engine/process_execution/bazel_protos/src/verification.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/verification.rs
@@ -82,7 +82,7 @@ mod canonical_directory_tests {
   const DIRECTORY_HASH: &str = "63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16";
   const DIRECTORY_SIZE: i64 = 80;
   const OTHER_DIRECTORY_HASH: &str = "e3b0c44298fc1c149afbf4c8996fb924\
-27ae41e4649b934ca495991b7852b855";
+                                      27ae41e4649b934ca495991b7852b855";
   const OTHER_DIRECTORY_SIZE: i64 = 0;
 
   #[test]

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -29,16 +29,15 @@ pub fn run_command_locally(
     })
 }
 
-
 #[cfg(test)]
 mod tests {
   extern crate testutil;
 
-  use super::{ExecuteProcessRequest, ExecuteProcessResult, run_command_locally};
+  use super::{run_command_locally, ExecuteProcessRequest, ExecuteProcessResult};
   use fs;
   use std::collections::BTreeMap;
   use std::path::PathBuf;
-  use self::testutil::{owned_string_vec, as_byte_owned_vec};
+  use self::testutil::{as_byte_owned_vec, owned_string_vec};
 
   #[test]
   #[cfg(unix)]

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -6,7 +6,7 @@ use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
 use digest::{Digest as DigestTrait, FixedOutput};
 use fs::Store;
-use futures::{Future, future};
+use futures::{future, Future};
 use hashing::{Digest, Fingerprint};
 use grpcio;
 use protobuf::{self, Message, ProtobufEnum};
@@ -237,7 +237,7 @@ fn extract_execute_response(
       {
         return Err(ExecutionError::Fatal(format!(
           "Received FailedPrecondition, but didn't know how to resolve it: {}, \
-protobuf type {}",
+           protobuf type {}",
           execute_response.get_status().get_message(),
           details.get_type_url()
         )));
@@ -350,10 +350,10 @@ mod tests {
   use protobuf::{self, Message, ProtobufEnum};
   use mock;
   use tempdir::TempDir;
-  use testutil::{owned_string_vec, as_byte_owned_vec};
+  use testutil::{as_byte_owned_vec, owned_string_vec};
 
-  use super::{CommandRunner, ExecuteProcessRequest, ExecuteProcessResult, ExecutionError,
-              extract_execute_response};
+  use super::{extract_execute_response, CommandRunner, ExecuteProcessRequest,
+              ExecuteProcessResult, ExecutionError};
   use std::collections::BTreeMap;
   use std::iter::{self, FromIterator};
   use std::sync::Arc;
@@ -1020,7 +1020,7 @@ mod tests {
   pub const STR: &str = "European Burmese";
   pub const HASH: &str = "693d8db7b05e99c6b7a7c0616456039d89c555029026936248085193559a0b5d";
   pub const DIRECTORY_HASH: &str = "63949aa823baf765eff07b946050d76e\
-c0033144c785a94d3ebd82baa931cd16";
+                                    c0033144c785a94d3ebd82baa931cd16";
 
   pub fn str_bytes() -> Bytes {
     Bytes::from(STR)

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -2,8 +2,8 @@ extern crate boxfuture;
 extern crate clap;
 extern crate env_logger;
 extern crate fs;
-extern crate hashing;
 extern crate futures;
+extern crate hashing;
 extern crate process_execution;
 extern crate tempdir;
 
@@ -59,7 +59,7 @@ fn main() {
         .takes_value(true)
         .help(
           "The host:port of the gRPC server to connect to. Forces remote execution. \
-If unspecified, local execution will be performed.",
+           If unspecified, local execution will be performed.",
         ),
     )
     .arg(

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use core::TypeId;
 use externs;
-use fs::{PosixFS, Store, safe_create_dir_all_ioerror, ResettablePool};
+use fs::{safe_create_dir_all_ioerror, PosixFS, ResettablePool, Store};
 use graph::{EntryId, Graph};
 use handles::maybe_drain_handles;
 use nodes::{Node, NodeFuture};
@@ -49,13 +49,9 @@ impl Core {
     };
 
     let store = safe_create_dir_all_ioerror(&store_path)
-        .map_err(|e| format!("{:?}", e))
-        .and_then(|()| Store::local_only(store_path, pool.clone()))
-        .unwrap_or_else(
-      |e| {
-        panic!("Could not initialize Store directory {:?}", e)
-      },
-    );
+      .map_err(|e| format!("{:?}", e))
+      .and_then(|()| Store::local_only(store_path, pool.clone()))
+      .unwrap_or_else(|e| panic!("Could not initialize Store directory {:?}", e));
 
     let rule_graph = RuleGraph::new(&tasks, root_subject_types);
 

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -8,7 +8,7 @@ use std::{fmt, hash};
 use std::ops::Drop;
 
 use externs;
-use handles::{Handle, enqueue_drop_handle};
+use handles::{enqueue_drop_handle, Handle};
 
 pub type FNV = hash::BuildHasherDefault<FnvHasher>;
 

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -14,7 +14,6 @@ use handles::Handle;
 use interning::Interns;
 use log;
 
-
 pub fn eval(python: &str) -> Result<Value, Failure> {
   with_externs(|e| {
     (e.eval)(e.context, python.as_ptr(), python.len() as u64)
@@ -358,7 +357,10 @@ impl From<PyResult> for Result<Value, Failure> {
 impl From<Result<(), String>> for PyResult {
   fn from(res: Result<(), String>) -> Self {
     match res {
-      Ok(()) => PyResult { is_throw: false, value: eval("None").unwrap() },
+      Ok(()) => PyResult {
+        is_throw: false,
+        value: eval("None").unwrap(),
+      },
       Err(msg) => PyResult {
         is_throw: true,
         value: create_exception(&msg),

--- a/src/rust/engine/src/graph.rs
+++ b/src/rust/engine/src/graph.rs
@@ -15,10 +15,9 @@ use futures::future::{self, Future};
 use externs;
 use boxfuture::{BoxFuture, Boxable};
 use context::ContextFactory;
-use core::{Failure, FNV, Noop};
+use core::{Failure, Noop, FNV};
 use hashing;
 use nodes::{DigestFile, Node, NodeFuture, NodeKey, NodeResult, TryInto};
-
 
 // 2^32 Nodes ought to be more than enough for anyone!
 pub type EntryId = NodeIndex<u32>;

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::hash;
 
-use core::{FNV, Key, Value};
+use core::{Key, Value, FNV};
 use externs;
 
 ///

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -39,14 +39,13 @@ use std::os::raw;
 use std::panic;
 use std::path::{Path, PathBuf};
 
-
 use context::Core;
 use core::{Failure, Function, Key, TypeConstraint, TypeId, Value};
-use externs::{Buffer, BufferBuffer, CloneValExtern, DropHandlesExtern, CreateExceptionExtern,
-              ExternContext, Externs, TypeToStrExtern, CallExtern, EvalExtern, LogExtern,
-              IdentifyExtern, ProjectExtern, ProjectMultiExtern, ProjectIgnoringTypeExtern,
-              PyResult, SatisfiedByExtern, StoreI32Extern, SatisfiedByTypeExtern, StoreListExtern,
-              StoreBytesExtern, TypeIdBuffer, EqualsExtern, ValToStrExtern};
+use externs::{Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern,
+              DropHandlesExtern, EqualsExtern, EvalExtern, ExternContext, Externs, IdentifyExtern,
+              LogExtern, ProjectExtern, ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult,
+              SatisfiedByExtern, SatisfiedByTypeExtern, StoreBytesExtern, StoreI32Extern,
+              StoreListExtern, TypeIdBuffer, TypeToStrExtern, ValToStrExtern};
 use rule_graph::{GraphMaker, RuleGraph};
 use scheduler::{ExecutionRequest, RootResult, Scheduler};
 use tasks::Tasks;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -14,9 +14,9 @@ use futures::future::{self, Future};
 use ordermap::OrderMap;
 use tempdir::TempDir;
 
-use boxfuture::{Boxable, BoxFuture};
+use boxfuture::{BoxFuture, Boxable};
 use context::Context;
-use core::{Failure, Key, Noop, TypeConstraint, Value, Variants, throw};
+use core::{throw, Failure, Key, Noop, TypeConstraint, Value, Variants};
 use externs;
 use fs::{self, Dir, File, FileContent, Link, PathGlobs, PathStat, StoreFileByDigest, VFS};
 use process_execution as process_executor;
@@ -24,7 +24,6 @@ use hashing;
 use rule_graph;
 use selectors::{self, Selector};
 use tasks;
-
 
 pub type NodeFuture<T> = BoxFuture<T, Failure>;
 

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -1,13 +1,12 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 use std::collections::{hash_map, HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 use std::fmt;
 use std::io;
 
-use core::{ANY_TYPE, Function, Key, TypeConstraint, TypeId, Value};
+use core::{Function, Key, TypeConstraint, TypeId, Value, ANY_TYPE};
 use externs;
 use selectors::{Select, SelectDependencies, SelectTransitive, Selector};
 use tasks::{Task, Tasks};
@@ -121,7 +120,6 @@ impl Entry {
       &Entry::Root(ref root) => root.subject_type,
       &Entry::SubjectIsProduct { subject_type, .. } => subject_type,
       _ => panic!("has no subject type"),
-
     }
   }
 
@@ -133,7 +131,6 @@ impl Entry {
     }
   }
 }
-
 
 ///
 /// A key for the Selects used from a rule. Rules are only picked up by Select selectors. These keys
@@ -298,7 +295,6 @@ impl<'t> GraphMaker<'t> {
     mut rule_dependency_edges: RuleDependencyEdges,
     mut unfulfillable_rules: UnfulfillableRuleMap,
   ) -> RuleGraph {
-
     let mut rules_to_traverse: VecDeque<Entry> = VecDeque::new();
     rules_to_traverse.push_back(Entry::from(beginning_rule));
     while let Some(entry) = rules_to_traverse.pop_front() {
@@ -476,7 +472,6 @@ impl<'t> GraphMaker<'t> {
                   );
                   was_unfulfillable = true;
                   continue;
-
                 }
                 add_rules_to_graph(
                   &mut rules_to_traverse,
@@ -572,7 +567,7 @@ impl<'t> GraphMaker<'t> {
             if !rule_graph.rule_dependency_edges.contains_key(inner) {
               panic!(
                 "All referenced dependencies should have entries in the graph, but {:?} had {:?}, \
-                  which is missing!",
+                 which is missing!",
                 root_rule,
                 d
               )
@@ -623,7 +618,6 @@ impl<'t> GraphMaker<'t> {
   }
 }
 
-
 ///
 /// A graph containing rules mapping rules to their dependencies taking into account subject types.
 ///
@@ -665,7 +659,6 @@ fn function_str(func: &Function) -> String {
   let as_val = to_val_from_func(func);
   val_name(&as_val)
 }
-
 
 pub fn type_str(type_id: TypeId) -> String {
   if type_id == ANY_TYPE {
@@ -721,11 +714,12 @@ pub fn selector_str(selector: &Selector) -> String {
       )
     }
     &Selector::SelectProjection(ref s) => {
-      format!("SelectProjection({}, {}, '{}', {})",
-                                                  type_constraint_str(s.product),
-                                                  type_str(s.projected_subject),
-                                                  s.field,
-                                                  type_constraint_str(s.input_product),
+      format!(
+      "SelectProjection({}, {}, '{}', {})",
+      type_constraint_str(s.product),
+      type_str(s.projected_subject),
+      s.field,
+      type_constraint_str(s.input_product),
     )
     }
   }
@@ -899,7 +893,6 @@ impl RuleGraph {
       return write!(f, "}}");
     }
 
-
     let mut root_subject_type_strs = self
       .root_subject_types
       .iter()
@@ -934,7 +927,6 @@ impl RuleGraph {
     root_rule_strs.sort();
     write!(f, "{}\n", root_rule_strs.join("\n"))?;
 
-
     write!(f, "  // internal entries\n")?;
     let mut internal_rule_strs = self
       .rule_dependency_edges
@@ -963,7 +955,6 @@ pub struct RuleEdges {
   dependencies: Entries,
   dependencies_by_select_key: HashMap<SelectKey, Entries>,
 }
-
 
 impl RuleEdges {
   pub fn new() -> RuleEdges {

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use futures::future::{self, Future};
 
-use boxfuture::{Boxable, BoxFuture};
+use boxfuture::{BoxFuture, Boxable};
 use context::{Context, ContextFactory, Core};
 use core::{Failure, Key, TypeConstraint, TypeId, Value};
 use graph::EntryId;

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -3,10 +3,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use core::{Field, Function, FNV, Key, TypeConstraint, TypeId, Value};
+use core::{Field, Function, Key, TypeConstraint, TypeId, Value, FNV};
 use externs;
-use selectors::{Selector, Select, SelectDependencies, SelectProjection, SelectTransitive};
-
+use selectors::{Select, SelectDependencies, SelectProjection, SelectTransitive, Selector};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
@@ -75,9 +74,7 @@ impl Tasks {
     if let Some(&(_, ref existing_value)) = self.singletons.get(&product) {
       panic!(
         "More than one singleton rule was installed for the product {:?}: {:?} vs {:?}",
-        product,
-        existing_value,
-        value,
+        product, existing_value, value,
       );
     }
     self.singletons.insert(product, (


### PR DESCRIPTION
This saves several minutes from a clean build.

Unfortunately, the more-stable formatter has changed, so we get to re-format our code again. On the plus side, the new formatter fixes a lot of issues I have with it...