### PR TITLE
Fix `PytestRun` passthru arg handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - ANDROID_SDK_INSTALL_LOCATION="${HOME}/opt/android-sdk-install"
     - ANDROID_HOME="$ANDROID_SDK_INSTALL_LOCATION/android-sdk-linux"
-    # Show the 3 slowest tests per py.test invocation
-    - PYTEST_PASSTHRU_ARGS="--duration=3"
+    - PYTEST_PASSTHRU_ARGS="-v --duration=3"
 
 before_cache:
   # Ensure permissions to do the below removals, which happen with or without caching enabled.

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ env:
     - PANTS_CONFIG_FILES="${TRAVIS_BUILD_DIR}/pants.travis-ci.ini"
     - ANDROID_SDK_INSTALL_LOCATION="${HOME}/opt/android-sdk-install"
     - ANDROID_HOME="$ANDROID_SDK_INSTALL_LOCATION/android-sdk-linux"
+    # Show the 3 slowest tests per py.test invocation
+    - PYTEST_PASSTHRU_ARGS="--duration=3"
 
 before_cache:
   # Ensure permissions to do the below removals, which happen with or without caching enabled.

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -185,7 +185,7 @@ if [[ "${skip_internal_backends:-false}" == "false" ]]; then
   start_travis_section "BackendTests" "Running internal backend python tests"
   (
     ./pants.pex ${PANTS_ARGS[@]} test.pytest \
-    pants-plugins/tests/python::
+    pants-plugins/tests/python:: -- ${PYTEST_PASSTHRU_ARGS}
   ) || die "Internal backend python test failure"
   end_travis_section
 fi
@@ -198,7 +198,7 @@ if [[ "${skip_python:-false}" == "false" ]]; then
   (
     ./pants.pex --tag='-integration' ${PANTS_ARGS[@]} test.pytest --chroot \
       --test-pytest-test-shard=${python_unit_shard} \
-      tests/python::
+      tests/python:: -- ${PYTEST_PASSTHRU_ARGS}
   ) || die "Core python test failure"
   end_travis_section
 fi
@@ -212,7 +212,7 @@ if [[ "${skip_contrib:-false}" == "false" ]]; then
     ./pants.pex ${PANTS_ARGS[@]} --exclude-target-regexp='.*/testprojects/.*' \
     --build-ignore=$SKIP_ANDROID_PATTERN test.pytest \
     --test-pytest-test-shard=${python_contrib_shard} \
-    contrib:: \
+    contrib:: -- ${PYTEST_PASSTHRU_ARGS}
   ) || die "Contrib python test failure"
   end_travis_section
 fi
@@ -237,7 +237,7 @@ if [[ "${skip_integration:-false}" == "false" ]]; then
   (
     ./pants.pex ${PANTS_ARGS[@]} --tag='+integration' test.pytest \
       --test-pytest-test-shard=${python_intg_shard} \
-      tests/python::
+      tests/python:: -- ${PYTEST_PASSTHRU_ARGS}
   ) || die "Pants Integration test failure"
   end_travis_section
 fi

--- a/pants.travis-ci.ini
+++ b/pants.travis-ci.ini
@@ -11,7 +11,5 @@ use_nailgun: False
 worker_count: 4
 
 [test.pytest]
-options: ['--duration=3']
-
 # Increase isolation. This is the direction that all tests will head in soon via #4586.
 fast: false

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -35,7 +35,6 @@ from pants.util.dirutil import mergetree, safe_mkdir, safe_mkdir_for
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.objects import datatype
 from pants.util.process_handler import SubprocessProcessHandler
-from pants.util.strutil import safe_shlex_split
 from pants.util.xml_parser import XmlParser
 
 
@@ -111,7 +110,12 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                   "it's best to use an absolute path to make it easy to find the subprocess "
                   "profiles later.")
 
-    register('--options', type=list, fingerprint=True, help='Pass these options to pytest.')
+    register('--options', type=list, fingerprint=True,
+             removal_version='1.7.0.dev0',
+             removal_hint='You can supply py.test options using the generic pass through the args '
+                          'facility. At the end of the pants command line, add `-- <py.test pass'
+                          'through args>`.',
+             help='Pass these options to pytest.')
 
     register('--coverage', fingerprint=True,
              help='Emit coverage information for specified packages or directories (absolute or '
@@ -676,8 +680,10 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         args.extend(['-s'])
       if self.get_options().colors:
         args.extend(['--color', 'yes'])
-      for options in self.get_options().options + self.get_passthru_args():
-        args.extend(safe_shlex_split(options))
+
+      args.extend(self.get_options().options)
+      args.extend(self.get_passthru_args())
+
       args.extend(test_args)
       args.extend(sources_map.keys())
 

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -20,9 +20,10 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
   def test_pytest_run_timeout_succeeds(self):
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
-                                '--test-pytest-options=-k within_timeout',
                                 '--timeout-default=2',
-                                'testprojects/tests/python/pants/timeout:exceeds_timeout'])
+                                'testprojects/tests/python/pants/timeout:exceeds_timeout',
+                                '--',
+                                '-kwithin_timeout'])
     self.assert_success(pants_run)
 
   def test_pytest_run_conftest_succeeds(self):
@@ -35,11 +36,12 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     start = time.time()
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
-                                '--test-pytest-coverage=auto',
-                                '--test-pytest-options=-k exceeds_timeout',
-                                '--test-pytest-timeout-default=1',
-                                '--cache-test-pytest-ignore',
-                                'testprojects/tests/python/pants/timeout:exceeds_timeout'])
+                                '--coverage=auto',
+                                '--timeout-default=1',
+                                '--cache-ignore',
+                                'testprojects/tests/python/pants/timeout:exceeds_timeout',
+                                '--',
+                                '-kexceeds_timeout'])
     end = time.time()
     self.assert_failure(pants_run)
 
@@ -56,10 +58,10 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     start = time.time()
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
-                                '--test-pytest-timeout-terminate-wait=2',
-                                '--test-pytest-timeout-default=1',
-                                '--test-pytest-coverage=auto',
-                                '--cache-test-pytest-ignore',
+                                '--timeout-terminate-wait=2',
+                                '--timeout-default=1',
+                                '--coverage=auto',
+                                '--cache-ignore',
                                 'testprojects/tests/python/pants/timeout:ignores_terminate'])
     end = time.time()
     self.assert_failure(pants_run)
@@ -81,7 +83,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     with temporary_dir(cleanup=False) as coverage_dir:
       pants_run = self.run_pants(['clean-all',
                                   'test.pytest',
-                                  '--test-pytest-coverage=pants',
+                                  '--coverage=pants',
                                   '--test-pytest-coverage-output-dir={}'.format(coverage_dir),
                                   'testprojects/tests/python/pants/constants_only'])
       self.assert_success(pants_run)


### PR DESCRIPTION
Previously passthru arguments were shlex-split even though they were
already presented in list form via `--options` and the passthru args
facility. Add a unit test to confirm passthru args are not over-split
and deprecate `--options` in favor of the standard passthru args
facility.