### PR TITLE
[pantsd] Don't compute TargetRoots twice.

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -73,13 +73,14 @@ class DaemonPantsRunner(ProcessManager):
   N.B. this class is primarily used by the PailgunService in pantsd.
   """
 
-  def __init__(self, socket, exiter, args, env, graph_helper, fork_lock, preceding_graph_size,
-               deferred_exception=None):
+  def __init__(self, socket, exiter, args, env, target_roots, graph_helper, fork_lock,
+               preceding_graph_size, deferred_exception=None):
     """
     :param socket socket: A connected socket capable of speaking the nailgun protocol.
     :param Exiter exiter: The Exiter instance for this run.
     :param list args: The arguments (i.e. sys.argv) for this run.
     :param dict env: The environment (i.e. os.environ) for this run.
+    :param TargetRoots target_roots: The `TargetRoots` for this run.
     :param LegacyGraphHelper graph_helper: The LegacyGraphHelper instance to use for BuildGraph
                                            construction. In the event of an exception, this will be
                                            None.
@@ -93,6 +94,7 @@ class DaemonPantsRunner(ProcessManager):
     self._exiter = exiter
     self._args = args
     self._env = env
+    self._target_roots = target_roots
     self._graph_helper = graph_helper
     self._fork_lock = fork_lock
     self._preceding_graph_size = preceding_graph_size
@@ -238,7 +240,13 @@ class DaemonPantsRunner(ProcessManager):
         self._raise_deferred_exc()
 
         # Otherwise, conduct a normal run.
-        runner = LocalPantsRunner(self._exiter, self._args, self._env, self._graph_helper)
+        runner = LocalPantsRunner(
+          self._exiter,
+          self._args,
+          self._env,
+          target_roots=self._target_roots,
+          daemon_build_graph=self._graph_helper
+        )
         runner.set_start_time(self._maybe_get_client_start_time_from_env(self._env))
         runner.set_preceding_graph_size(self._preceding_graph_size)
         runner.run()

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -18,17 +18,20 @@ from pants.util.contextutil import hard_exit_handler, maybe_profiled
 class LocalPantsRunner(object):
   """Handles a single pants invocation running in the process-local context."""
 
-  def __init__(self, exiter, args, env, daemon_build_graph=None, options_bootstrapper=None):
+  def __init__(self, exiter, args, env, target_roots=None, daemon_build_graph=None,
+               options_bootstrapper=None):
     """
     :param Exiter exiter: The Exiter instance to use for this run.
     :param list args: The arguments (e.g. sys.argv) for this run.
     :param dict env: The environment (e.g. os.environ) for this run.
+    :param TargetRoots target_roots: The `TargetRoots` for this run.
     :param BuildGraph daemon_build_graph: A BuildGraph instance for graph reuse (optional).
     :param OptionsBootstrapper options_bootstrapper: An optional existing OptionsBootstrapper.
     """
     self._exiter = exiter
     self._args = args
     self._env = env
+    self._target_roots = target_roots
     self._daemon_build_graph = daemon_build_graph
     self._options_bootstrapper = options_bootstrapper
     self._preceding_graph_size = -1
@@ -87,6 +90,7 @@ class LocalPantsRunner(object):
                                        build_config,
                                        run_tracker,
                                        reporting,
+                                       self._target_roots,
                                        self._daemon_build_graph,
                                        self._exiter).setup()
 

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -85,6 +85,7 @@ class PailgunService(PantsService):
         exiter,
         arguments,
         environment,
+        target_roots,
         graph_helper,
         self.fork_lock,
         preceding_graph_size,


### PR DESCRIPTION
good for a couple of seconds in this synthetic benchmark, potentially more:

```
[omerta pants (master)]$ pkill -f "pantsd \["
[omerta pants (master)]$ time PANTS_ENABLE_PANTSD=True ./pants --changed-parent=HEAD~100 --changed-include-dependees=transitive list > a 

real    0m24.249s
user    0m1.071s
sys     0m0.736s
```

vs

```
[omerta pants (kwlzn/2_chaaaanged)]$ pkill -f "pantsd \["
[omerta pants (kwlzn/2_chaaaanged)]$ time PANTS_ENABLE_PANTSD=True ./pants --changed-parent=HEAD~100 --changed-include-dependees=transitive list > b


real    0m22.667s
user    0m1.080s
sys     0m0.668s
```