### PR TITLE
Render a warning rather than failing `list` when no targets are matched

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/listtargets.py
+++ b/src/python/pants/backend/graph_info/tasks/listtargets.py
@@ -65,7 +65,9 @@ class ListTargets(ConsoleTask):
       print_fn = lambda target: target.address.spec
 
     visited = set()
-    for target in self.determine_target_roots('list', lambda target: not target.is_synthetic):
+    for target in self.determine_target_roots('list'):
+      if target.is_synthetic:
+        continue
       result = print_fn(target)
       if result and result not in visited:
         visited.add(result)

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -12,7 +12,6 @@ from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat
 
-from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -6,11 +6,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import sys
 from abc import abstractmethod
 from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat
 
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
@@ -638,15 +640,13 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
                       .format(', '.join([repr(t) for t in target_roots])))
     return target_roots[0]
 
-  def determine_target_roots(self, goal_name, predicate=None):
+  def determine_target_roots(self, goal_name):
     """Helper for tasks that scan for default target roots.
 
     :param string goal_name: The goal name to use for any warning emissions.
-    :param callable predicate: The predicate to pass to `context.scan().targets(predicate=X)`.
     """
     if not self.context.target_roots:
-      raise TaskError('Please specify one or more explicit target '
-                      'specs (e.g. `./pants {0} ::`).'.format(goal_name))
+      print('WARNING: No targets were matched in goal `{}`.'.format(goal_name), file=sys.stderr)
 
     # For the v2 path, e.g. `./pants list` is a functional no-op. This matches the v2 mode behavior
     # of e.g. `./pants --changed-parent=HEAD list` (w/ no changes) returning an empty result.

--- a/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
@@ -30,8 +30,9 @@ class BaseListTargetsTest(ConsoleTaskTestBase):
 class ListTargetsTestEmpty(BaseListTargetsTest):
 
   def test_list_all_empty(self):
-    with self.assertRaises(TaskError):
-      self.assertEqual('', self.execute_task())
+    # NB: Also renders a warning to stderr, which is challenging to detect here but confirmed in:
+    #   tests/python/pants_test/engine/legacy/test_list_integration.py
+    self.assertEqual('', self.execute_task())
 
 
 class ListTargetsTest(BaseListTargetsTest):

--- a/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
+++ b/tests/python/pants_test/backend/graph_info/tasks/test_listtargets.py
@@ -14,7 +14,6 @@ from pants.backend.jvm.repository import Repository
 from pants.backend.jvm.scala_artifact import ScalaArtifact
 from pants.backend.jvm.targets.java_library import JavaLibrary
 from pants.backend.python.targets.python_library import PythonLibrary
-from pants.base.exceptions import TaskError
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.build_graph.target import Target
 from pants_test.tasks.task_test_base import ConsoleTaskTestBase

--- a/tests/python/pants_test/engine/legacy/test_list_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_list_integration.py
@@ -21,8 +21,8 @@ class ListIntegrationTest(PantsRunIntegrationTest):
     self.assertGreater(len(pants_run.stdout_data.strip().split()), 1)
 
   def test_list_none(self):
-    pants_run = self.do_command('list', success=False)
-    self.assertIn('Please specify one or more explicit target', pants_run.stdout_data)
+    pants_run = self.do_command('list', success=True)
+    self.assertIn('WARNING: No targets were matched in', pants_run.stderr_data)
 
   def test_list_invalid_dir(self):
     pants_run = self.do_command('list', 'abcde::', success=False)


### PR DESCRIPTION
### Problem

The `v2` engine changed the behaviour of `./pants list` (with no specs) from "list everything", to "fail with an error". But due to the deprecation/removal of the `changed` goal, this also has the effect of failing with an error for `./pants --changed=.. list` calls that result in no matched targets, which is a behaviour change from `v1`.

### Solution

Rather than raising an error, trigger a warning to stderr which naturally handles both cases by indicating that their query wasn't an error: it just didn't match anything.