### PR TITLE
Deprecate BinaryUtil as public API.

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -14,11 +14,13 @@ from collections import namedtuple
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 from pants.binaries.binary_tool import NativeTool
-from pants.contrib.node.subsystems.yarnpkg_distribution import YarnpkgDistribution
 from pants.option.custom_types import dir_option, file_option
 from pants.util.dirutil import safe_mkdir, safe_rmtree
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.process_handler import subprocess
+
+from pants.contrib.node.subsystems.yarnpkg_distribution import YarnpkgDistribution
+
 
 logger = logging.getLogger(__name__)
 

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import filecmp
 import logging
 import os
 import shutil
@@ -12,16 +13,12 @@ from collections import namedtuple
 
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
-from pants.base.hash_utils import hash_file
 from pants.binaries.binary_tool import NativeTool
-from pants.binaries.binary_util import BinaryUtil
+from pants.contrib.node.subsystems.yarnpkg_distribution import YarnpkgDistribution
 from pants.option.custom_types import dir_option, file_option
 from pants.util.dirutil import safe_mkdir, safe_rmtree
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.process_handler import subprocess
-
-from pants.contrib.node.subsystems.yarnpkg_distribution import YarnpkgDistribution
-
 
 logger = logging.getLogger(__name__)
 
@@ -269,6 +266,8 @@ class NodeDistribution(NativeTool):
     shutil.copytree(self.eslint_setupdir, bootstrapped_support_path)
     return True
 
+  _eslint_required_files = ['yarn.lock', 'package.json']
+
   def eslint_supportdir(self, task_workdir):
     """ Returns the path where the ESLint is bootstrapped.
     
@@ -285,18 +284,21 @@ class NodeDistribution(NativeTool):
     # clean up the directory so that Pants can install a pre-defined eslint version later on.
     # Otherwise, if there is no configurations changes, rely on the cache.
     # If there is a config change detected, use the new configuration.
-    configured = False
     if self.eslint_setupdir:
-      configured = self._binary_util.is_bin_valid(self.eslint_setupdir,
-                                           [BinaryUtil.BinaryFileSpec('package.json'),
-                                            BinaryUtil.BinaryFileSpec('yarn.lock')])
+      configured = all(os.path.exists(os.path.join(self.eslint_setupdir, f))
+                       for f in self._eslint_required_files)
+    else:
+      configured = False
     if not configured:
       safe_mkdir(bootstrapped_support_path, clean=True)
     else:
-      binary_file_specs = [
-        BinaryUtil.BinaryFileSpec(f, hash_file(os.path.join(self.eslint_setupdir, f)))
-        for f in ['yarn.lock', 'package.json']]
-      installed = self._binary_util.is_bin_valid(bootstrapped_support_path, binary_file_specs)
+      try:
+        installed = all(filecmp.cmp(
+          os.path.join(self.eslint_setupdir, f), os.path.join(bootstrapped_support_path, f))
+        for f in self._eslint_required_files)
+      except OSError:
+        installed = False
+
       if not installed:
         self._configure_eslinter(bootstrapped_support_path)
     return bootstrapped_support_path, configured

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -12,7 +12,7 @@ from pants.base.cmd_line_spec_parser import CmdLineSpecParser
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.bin.engine_initializer import EngineInitializer
 from pants.bin.repro import Reproducer
-from pants.binaries.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtilPrivate
 from pants.build_graph.build_file_parser import BuildFileParser
 from pants.engine.native import Native
 from pants.engine.round_engine import RoundEngine
@@ -233,7 +233,7 @@ class GoalRunner(object):
       Reproducer,
       RunTracker,
       Changed,
-      BinaryUtil.Factory,
+      BinaryUtilPrivate.Factory,
       Subprocess.Factory
     }
 

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 
-from pants.binaries.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtilPrivate
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
 
@@ -46,7 +46,7 @@ class BinaryToolBase(Subsystem):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(BinaryToolBase, cls).subsystem_dependencies() + (BinaryUtil.Factory,)
+    return super(BinaryToolBase, cls).subsystem_dependencies() + (BinaryUtilPrivate.Factory,)
 
   @classmethod
   def register_options(cls, register):
@@ -105,7 +105,7 @@ class BinaryToolBase(Subsystem):
 
   @memoized_property
   def _binary_util(self):
-    return BinaryUtil.Factory.create()
+    return BinaryUtilPrivate.Factory.create()
 
   @classmethod
   def get_support_dir(cls):

--- a/src/python/pants/binaries/binary_util.py
+++ b/src/python/pants/binaries/binary_util.py
@@ -22,6 +22,7 @@ from pants.util.contextutil import temporary_file
 from pants.util.dirutil import chmod_plus_x, safe_concurrent_creation, safe_open
 from pants.util.osutil import get_os_id
 
+
 _DEFAULT_PATH_BY_ID = {
   ('linux', 'x86_64'): ('linux', 'x86_64'),
   ('linux', 'amd64'): ('linux', 'x86_64'),

--- a/src/python/pants/binaries/thrift_binary.py
+++ b/src/python/pants/binaries/thrift_binary.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 from pants.base.deprecated import deprecated
-from pants.binaries.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtilPrivate
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_property
 
@@ -25,7 +25,8 @@ class ThriftBinary(object):
 
     @classmethod
     def subsystem_dependencies(cls):
-      return super(ThriftBinary.Factory, cls).subsystem_dependencies() + (BinaryUtil.Factory,)
+      return (super(ThriftBinary.Factory, cls).subsystem_dependencies() +
+              (BinaryUtilPrivate.Factory,))
 
     @classmethod
     def register_options(cls, register):
@@ -48,7 +49,7 @@ class ThriftBinary(object):
       """
       # NB: create is an instance method to allow the user to choose global or scoped.
       # Its not unreasonable to imagine python and jvm stacks using different versions.
-      binary_util = BinaryUtil.Factory.create()
+      binary_util = BinaryUtilPrivate.Factory.create()
       options = self.get_options()
       return ThriftBinary(binary_util, options.supportdir, options.version)
 

--- a/src/python/pants/pantsd/watchman_launcher.py
+++ b/src/python/pants/pantsd/watchman_launcher.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 
-from pants.binaries.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtilPrivate
 from pants.pantsd.watchman import Watchman
 from pants.util.memo import testable_memoized_property
 
@@ -20,7 +20,7 @@ class WatchmanLauncher(object):
     """
     :param Options bootstrap_options: The bootstrap options bag.
     """
-    binary_util = BinaryUtil(
+    binary_util = BinaryUtilPrivate(
       bootstrap_options.binaries_baseurls,
       bootstrap_options.binaries_fetch_timeout_secs,
       bootstrap_options.pants_bootstrapdir,

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import re
 
-from pants.binaries.binary_util import BinaryUtil
+from pants.binaries.binary_util import BinaryUtilPrivate
 from pants.engine.addressable import SubclassesOf, addressable_list
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
@@ -20,7 +20,7 @@ from pants_test.subsystem.subsystem_util import init_subsystem
 
 def init_native():
   """Initialize and return a `Native` instance."""
-  init_subsystem(BinaryUtil.Factory)
+  init_subsystem(BinaryUtilPrivate.Factory)
   opts = create_options_for_optionables([])
   return Native.create(opts.for_global_scope())
 


### PR DESCRIPTION
Clients shouldn't use it directly, because we want to be able to discover which binary tools are "registered" for use via `BinaryToolBase` subclass subsystems.

This change also gets rid of a heavy-handed mechanism for checking if two files have the same content. The old code was convoluted and hard to reason about, and included degrees of freedom (such as setting the hasher) that weren't used in practice. It also contained a bug (it used a `hashlib.sha1()`, which is mutable, as a default value for a method arg). 

The replacement logic uses the built-in `filecmp` module. This is much more straightforward, and likely faster, than computing two hashes and comparing them.  