### PR TITLE
Batch execution of address Specs and remove SelectTransitive

### DIFF
--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.base.target_roots import ChangedTargetRoots, LiteralTargetRoots
-from pants.engine.build_files import BuildFileAddresses, create_graph_rules
+from pants.engine.build_files import BuildFileAddresses, Specs, create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.isolated_process import create_process_rules
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
@@ -84,7 +84,7 @@ class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'symbol_ta
     if type(target_roots) is ChangedTargetRoots:
       subjects = [BuildFileAddresses(target_roots.addresses)]
     elif type(target_roots) is LiteralTargetRoots:
-      subjects = target_roots.specs
+      subjects = [Specs(tuple(target_roots.specs))]
     else:
       raise ValueError('Unexpected TargetRoots type: `{}`.'.format(target_roots))
     request = self.scheduler.execution_request([TransitiveHydratedTargets], subjects)

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -79,7 +79,6 @@ python_library(
   name='mapper',
   sources=['mapper.py'],
   dependencies=[
-    '3rdparty/python:pathspec',
     ':objects',
     ':parser',
     'src/python/pants/build_graph',

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -70,6 +70,8 @@ python_library(
     ':struct',
     'src/python/pants/base:project_tree',
     'src/python/pants/build_graph',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:objects',
   ]
 )
 

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -16,7 +16,7 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import (AddressableDescriptor, BuildFileAddresses, Collection,
-                                      Exactly, TypeConstraintError)
+                                      TypeConstraintError)
 from pants.engine.fs import FilesContent, PathGlobs, Snapshot
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
@@ -76,7 +76,6 @@ def parse_address_family(address_mapper, path, build_files):
   if not files_content:
     raise ResolveError('Directory "{}" does not contain build files.'.format(path))
   address_maps = []
-  paths = (f.path for f in files_content)
   for filecontent_product in files_content:
     address_maps.append(AddressMap.parse(filecontent_product.path,
                                          filecontent_product.content,

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -319,19 +319,18 @@ def transitive_hydrated_targets(transitive_hydrated_targets):
   when multiple TransitiveHydratedTargets objects are being constructed for multiple
   roots, their structure will be shared.
   """
-  result = []
-  visited = set()
+  closure = set()
   to_visit = deque(transitive_hydrated_targets)
 
   while to_visit:
     tht = to_visit.popleft()
-    if tht.root in visited:
+    if tht.root in closure:
       continue
-    visited.add(tht.root)
-    result.append(tht.root)
+    closure.add(tht.root)
     to_visit.extend(tht.dependencies)
 
-  return TransitiveHydratedTargets(tuple(tht.root for tht in transitive_hydrated_targets), result)
+  return TransitiveHydratedTargets(tuple(tht.root for tht in transitive_hydrated_targets), closure)
+
 
 @rule(TransitiveHydratedTarget, [Select(HydratedTarget),
                                  SelectDependencies(TransitiveHydratedTarget,

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -21,9 +21,9 @@ from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.addressable import BuildFileAddresses, Collection
+from pants.engine.build_files import Specs
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, SourcesField, TargetAdaptor
-from pants.engine.mapper import ResolveError
 from pants.engine.rules import TaskRule, rule
 from pants.engine.selectors import Select, SelectDependencies, SelectProjection
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper
@@ -57,9 +57,6 @@ class LegacyBuildGraph(BuildGraph):
   This implementation is backed by a Scheduler that is able to resolve TransitiveHydratedTargets.
   """
 
-  class InvalidCommandLineSpecError(AddressLookupError):
-    """Raised when command line spec is not a valid directory"""
-
   @classmethod
   def create(cls, scheduler, symbol_table):
     """Construct a graph given a Scheduler, Engine, and a SymbolTable class."""
@@ -80,7 +77,7 @@ class LegacyBuildGraph(BuildGraph):
     """Returns a new BuildGraph instance of the same type and with the same __init__ params."""
     return LegacyBuildGraph(self._scheduler, self._target_types)
 
-  def _index(self, roots):
+  def _index(self, hydrated_targets):
     """Index from the given roots into the storage provided by the base class.
 
     This is an additive operation: any existing connections involving these nodes are preserved.
@@ -89,14 +86,12 @@ class LegacyBuildGraph(BuildGraph):
     new_targets = list()
 
     # Index the ProductGraph.
-    for product in roots:
-      # We have a successful TransitiveHydratedTargets value (for a particular input Spec).
-      for hydrated_target in product.dependencies:
-        target_adaptor = hydrated_target.adaptor
-        address = target_adaptor.address
-        all_addresses.add(address)
-        if address not in self._target_by_address:
-          new_targets.append(self._index_target(target_adaptor))
+    for hydrated_target in hydrated_targets:
+      target_adaptor = hydrated_target.adaptor
+      address = target_adaptor.address
+      all_addresses.add(address)
+      if address not in self._target_by_address:
+        new_targets.append(self._index_target(target_adaptor))
 
     # Once the declared dependencies of all targets are indexed, inject their
     # additional "traversable_(dependency_)?specs".
@@ -209,12 +204,8 @@ class LegacyBuildGraph(BuildGraph):
     addresses = set(addresses) - set(self._target_by_address.keys())
     if not addresses:
       return
-    matched = set(self._inject_specs([SingleAddress(a.spec_path, a.target_name) for a in addresses]))
-    missing = addresses - matched
-    if missing:
-      # TODO: When SingleAddress resolution converted from projection of a directory
-      # and name to a match for PathGlobs, we lost our useful AddressLookupError formatting.
-      raise AddressLookupError('Addresses were not matched: {}'.format(missing))
+    for _ in self._inject_specs([SingleAddress(a.spec_path, a.target_name) for a in addresses]):
+      pass
 
   def inject_roots_closure(self, target_roots, fail_fast=None):
     if type(target_roots) is ChangedTargetRoots:
@@ -240,9 +231,6 @@ class LegacyBuildGraph(BuildGraph):
   def _resolve_context(self):
     try:
       yield
-    except ResolveError as e:
-      # NB: ResolveError means that a target was not found, which is a common user facing error.
-      raise AddressLookupError(str(e))
     except Exception as e:
       raise AddressLookupError(
         'Build graph construction failed: {} {}'.format(type(e).__name__, str(e))
@@ -251,16 +239,15 @@ class LegacyBuildGraph(BuildGraph):
   def _inject_addresses(self, subjects):
     """Injects targets into the graph for each of the given `Address` objects, and then yields them.
 
-    TODO: See #4533 about unifying "collection of literal Addresses" with the `Spec` types, which
-    would avoid the need for the independent `_inject_addresses` and `_inject_specs` codepaths.
+    TODO: See #5606 about undoing the split between `_inject_addresses` and `_inject_specs`.
     """
     logger.debug('Injecting addresses to %s: %s', self, subjects)
     with self._resolve_context():
       addresses = tuple(subjects)
-      hydrated_targets = self._scheduler.product_request(TransitiveHydratedTargets,
-                                                         [BuildFileAddresses(addresses)])
+      thts, = self._scheduler.product_request(TransitiveHydratedTargets,
+                                              [BuildFileAddresses(addresses)])
 
-    self._index(hydrated_targets)
+    self._index(thts.closure)
 
     yielded_addresses = set()
     for address in subjects:
@@ -275,20 +262,14 @@ class LegacyBuildGraph(BuildGraph):
     """
     logger.debug('Injecting specs to %s: %s', self, subjects)
     with self._resolve_context():
-      product_results = self._scheduler.products_request([TransitiveHydratedTargets, BuildFileAddresses],
-                                                         subjects)
+      specs = tuple(subjects)
+      thts, = self._scheduler.product_request(TransitiveHydratedTargets,
+                                              [Specs(specs)])
 
-    self._index(product_results[TransitiveHydratedTargets])
+    self._index(thts.closure)
 
-    yielded_addresses = set()
-    for subject, product in zip(subjects, product_results[BuildFileAddresses]):
-      if not product.dependencies:
-        raise self.InvalidCommandLineSpecError(
-          'Spec {} does not match any targets.'.format(subject))
-      for address in product.dependencies:
-        if address not in yielded_addresses:
-          yielded_addresses.add(address)
-          yield address
+    for hydrated_target in thts.roots:
+      yield hydrated_target.address
 
 
 class HydratedTarget(datatype('HydratedTarget', ['address', 'adaptor', 'dependencies'])):
@@ -318,8 +299,8 @@ class TransitiveHydratedTarget(datatype('TransitiveHydratedTarget', ['root', 'de
   """A recursive structure wrapping a HydratedTarget root and TransitiveHydratedTarget deps."""
 
 
-class TransitiveHydratedTargets(Collection.of(HydratedTarget)):
-  """A transitive set of HydratedTarget objects, flattened and de-duped."""
+class TransitiveHydratedTargets(datatype('TransitiveHydratedTargets', ['roots', 'closure'])):
+  """A set of HydratedTarget roots, and their transitive, flattened, de-duped closure."""
 
 
 class HydratedTargets(Collection.of(HydratedTarget)):
@@ -337,9 +318,6 @@ def transitive_hydrated_targets(transitive_hydrated_targets):
   and flatten here. The engine memoizes the computation of TransitiveHydratedTarget, so
   when multiple TransitiveHydratedTargets objects are being constructed for multiple
   roots, their structure will be shared.
-
-  TODO: Further work would be to create exactly one `Collection.of(Spec)` root that also
-  dedupes.
   """
   result = []
   visited = set()
@@ -353,7 +331,7 @@ def transitive_hydrated_targets(transitive_hydrated_targets):
     result.append(tht.root)
     to_visit.extend(tht.dependencies)
 
-  return TransitiveHydratedTargets(result)
+  return TransitiveHydratedTargets(tuple(tht.root for tht in transitive_hydrated_targets), result)
 
 @rule(TransitiveHydratedTarget, [Select(HydratedTarget),
                                  SelectDependencies(TransitiveHydratedTarget,

--- a/src/python/pants/engine/mapper.py
+++ b/src/python/pants/engine/mapper.py
@@ -8,9 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import re
 from collections import OrderedDict
 
-from pathspec import PathSpec
-from pathspec.patterns.gitwildmatch import GitWildMatchPattern
-
 from pants.build_graph.address import BuildFileAddress
 from pants.engine.objects import Serializable
 from pants.util.memo import memoized_property
@@ -184,8 +181,8 @@ class AddressMapper(object):
     :param list exclude_target_regexps: A list of regular expressions for excluding targets.
     """
     self.parser = parser
-    self.build_patterns = build_patterns or (b'BUILD', b'BUILD.*')
-    self.build_ignore_patterns = PathSpec.from_lines(GitWildMatchPattern, build_ignore_patterns or [])
+    self.build_patterns = tuple(build_patterns or [b'BUILD', b'BUILD.*'])
+    self.build_ignore_patterns = tuple(build_ignore_patterns or [])
     self._exclude_target_regexps = exclude_target_regexps or []
     self.exclude_patterns = [re.compile(pattern) for pattern in self._exclude_target_regexps]
     self.subproject_roots = subproject_roots or []

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -162,7 +162,6 @@ void tasks_task_begin(Tasks*, Function, TypeConstraint);
 void tasks_add_select(Tasks*, TypeConstraint);
 void tasks_add_select_variant(Tasks*, TypeConstraint, Buffer);
 void tasks_add_select_dependencies(Tasks*, TypeConstraint, TypeConstraint, Buffer, TypeIdBuffer);
-void tasks_add_select_transitive(Tasks*, TypeConstraint, TypeConstraint, Buffer, TypeIdBuffer);
 void tasks_add_select_projection(Tasks*, TypeConstraint, TypeId, Buffer, TypeConstraint);
 void tasks_task_end(Tasks*);
 void tasks_singleton_add(Tasks*, Value, TypeConstraint);

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -20,7 +20,7 @@ from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcess
 from pants.engine.native import Function, TypeConstraint, TypeId
 from pants.engine.nodes import Return, State, Throw
 from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
-from pants.engine.selectors import (Select, SelectDependencies, SelectProjection, SelectTransitive,
+from pants.engine.selectors import (Select, SelectDependencies, SelectProjection,
                                     SelectVariant, constraint_for)
 from pants.engine.struct import HasProducts, Variants
 from pants.util.contextutil import temporary_file_path
@@ -208,12 +208,6 @@ class WrappedNativeScheduler(object):
                                                        self._to_constraint(selector.dep_product),
                                                        self._to_utf8_buf(selector.field),
                                                        self._to_ids_buf(selector.field_types))
-      elif selector_type is SelectTransitive:
-        self._native.lib.tasks_add_select_transitive(self._tasks,
-                                                     product_constraint,
-                                                     self._to_constraint(selector.dep_product),
-                                                     self._to_utf8_buf(selector.field),
-                                                     self._to_ids_buf(selector.field_types))
       elif selector_type is SelectProjection:
         self._native.lib.tasks_add_select_projection(self._tasks,
                                                      self._to_constraint(selector.product),

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -20,8 +20,8 @@ from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcess
 from pants.engine.native import Function, TypeConstraint, TypeId
 from pants.engine.nodes import Return, State, Throw
 from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
-from pants.engine.selectors import (Select, SelectDependencies, SelectProjection,
-                                    SelectVariant, constraint_for)
+from pants.engine.selectors import (Select, SelectDependencies, SelectProjection, SelectVariant,
+                                    constraint_for)
 from pants.engine.struct import HasProducts, Variants
 from pants.util.contextutil import temporary_file_path
 from pants.util.objects import datatype

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -127,26 +127,6 @@ class SelectDependencies(datatype('Dependencies', ['product', 'dep_product', 'fi
                                      field_types_portion)
 
 
-class SelectTransitive(datatype('Transitive', ['product', 'dep_product', 'field', 'field_types']),
-                       Selector):
-  """A variation of `SelectDependencies` that is used to recursively request a product.
-
-  One use case is to eagerly walk the entire graph.
-
-  It first selects for dep_product then recursively requests products with the `product` type, expanding each by its
-  `field`.
-
-  Requires that both the dep_product and product have the same field `field` that contains the same `field_types`.
-  """
-
-  DEFAULT_FIELD = 'dependencies'
-
-  optional = False
-
-  def __new__(cls, product, dep_product, field=DEFAULT_FIELD, field_types=tuple()):
-    return super(SelectTransitive, cls).__new__(cls, product, dep_product, field, field_types)
-
-
 class SelectProjection(datatype('Projection', ['product', 'projected_subject', 'field', 'input_product']), Selector):
   """Selects a field of the given Subject to produce a Subject, Product dependency from.
 

--- a/src/python/pants/scm/change_calculator.py
+++ b/src/python/pants/scm/change_calculator.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from pants.base.build_environment import get_scm
 from pants.base.specs import DescendantAddresses
 from pants.build_graph.address import Address
-from pants.engine.build_files import HydratedStructs
+from pants.engine.build_files import HydratedStructs, Specs
 from pants.engine.legacy.graph import target_types_from_symbol_table
 from pants.engine.legacy.source_mapper import EngineSourceMapper
 from pants.goal.workspace import ScmWorkspace
@@ -147,9 +147,10 @@ class EngineChangeCalculator(ChangeCalculator):
     # For dependee finding, we need to parse all build files to collect all structs. But we
     # don't need to fully hydrate targets (ie, expand their source globs), and so we use
     # the `HydratedStructs` product. See #4535 for more info.
+    specs = (DescendantAddresses(''),)
     adaptor_iter = (t
                     for targets in self._scheduler.product_request(HydratedStructs,
-                                                                   [DescendantAddresses('')])
+                                                                   [Specs(specs)])
                     for t in targets.dependencies)
     graph = _DependentGraph.from_iterable(target_types_from_symbol_table(self._symbol_table),
                                           adaptor_iter)

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -363,24 +363,6 @@ pub extern "C" fn tasks_add_select_dependencies(
 }
 
 #[no_mangle]
-pub extern "C" fn tasks_add_select_transitive(
-  tasks_ptr: *mut Tasks,
-  product: TypeConstraint,
-  dep_product: TypeConstraint,
-  field: Buffer,
-  field_types: TypeIdBuffer,
-) {
-  with_tasks(tasks_ptr, |tasks| {
-    tasks.add_select_transitive(
-      product,
-      dep_product,
-      field.to_string().expect("field to be a string"),
-      field_types.to_vec(),
-    );
-  })
-}
-
-#[no_mangle]
 pub extern "C" fn tasks_add_select_projection(
   tasks_ptr: *mut Tasks,
   product: TypeConstraint,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -5,13 +5,12 @@ extern crate bazel_protos;
 extern crate tempdir;
 
 use std::error::Error;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use futures::future::{self, Future};
-use ordermap::OrderMap;
 use tempdir::TempDir;
 
 use boxfuture::{BoxFuture, Boxable};
@@ -521,162 +520,6 @@ impl SelectDependencies {
   }
 }
 
-///
-/// A node that selects for the dep_product type, then recursively selects for the product type of
-/// the result. Both the product and the dep_product must have the same "field" and the types of
-/// products in that field must match the field type.
-///
-/// A node that recursively selects the dependencies of requested type and merge them.
-///
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct SelectTransitive {
-  pub subject: Key,
-  pub variants: Variants,
-  pub selector: selectors::SelectTransitive,
-  dep_product_entries: rule_graph::Entries,
-  product_entries: rule_graph::Entries,
-}
-
-impl SelectTransitive {
-  fn new(
-    selector: selectors::SelectTransitive,
-    subject: Key,
-    variants: Variants,
-    edges: &rule_graph::RuleEdges,
-  ) -> SelectTransitive {
-    let dep_p_entries = edges.entries_for(&rule_graph::SelectKey::NestedSelect(
-      Selector::SelectTransitive(selector.clone()),
-      selectors::Select::without_variant(selector.clone().dep_product),
-    ));
-    let p_entries = edges.entries_for(&rule_graph::SelectKey::ProjectedMultipleNestedSelect(
-      Selector::SelectTransitive(selector.clone()),
-      selector.field_types.clone(),
-      selectors::Select::without_variant(selector.clone().product),
-    ));
-
-    SelectTransitive {
-      subject: subject,
-      variants: variants,
-      selector: selector.clone(),
-      dep_product_entries: dep_p_entries,
-      product_entries: p_entries,
-    }
-  }
-
-  ///
-  /// Process single subject.
-  ///
-  /// Return tuple of:
-  /// (processed subject_key, product output, dependencies to be processed in future iterations).
-  ///
-  fn expand_transitive(
-    &self,
-    context: &Context,
-    subject_key: Key,
-  ) -> NodeFuture<(Key, Value, Vec<Value>)> {
-    let field_name = self.selector.field.to_owned();
-    Select {
-      selector: selectors::Select::without_variant(self.selector.product),
-      subject: subject_key,
-      variants: self.variants.clone(),
-      // NB: We're filtering out all of the entries for field types other than
-      //     subject_key's since none of them will match.
-      entries: self
-        .product_entries
-        .clone()
-        .into_iter()
-        .filter(|e| e.matches_subject_type(subject_key.type_id().clone()))
-        .collect(),
-    }.run(context.clone())
-      .map(move |product| {
-        let deps = externs::project_multi(&product, &field_name);
-        (subject_key, product, deps)
-      })
-      .to_boxed()
-  }
-}
-
-///
-/// Track states when processing `SelectTransitive` iteratively.
-///
-#[derive(Debug)]
-struct TransitiveExpansion {
-  // Subjects to be processed.
-  todo: HashSet<Key>,
-
-  // Mapping from processed subject `Key` to its product.
-  // Products will be collected at the end of iterations.
-  outputs: OrderMap<Key, Value>,
-}
-
-impl SelectTransitive {
-  fn run(self, context: Context) -> NodeFuture<Value> {
-    // Select the product holding the dependency list.
-    Select {
-      selector: selectors::Select::without_variant(self.selector.dep_product),
-      subject: self.subject.clone(),
-      variants: self.variants.clone(),
-      entries: self.dep_product_entries.clone(),
-    }.run(context.clone())
-      .then(move |dep_product_res| {
-        match dep_product_res {
-          Ok(dep_product) => {
-            let subject_keys = externs::project_multi(&dep_product, &self.selector.field)
-              .into_iter()
-              .map(|subject| externs::key_for(subject))
-              .collect();
-
-            let init = TransitiveExpansion {
-              todo: subject_keys,
-              outputs: OrderMap::default(),
-            };
-
-            future::loop_fn(init, move |mut expansion| {
-              let round = future::join_all({
-                expansion
-                  .todo
-                  .drain()
-                  .map(|subject_key| self.expand_transitive(&context, subject_key))
-                  .collect::<Vec<_>>()
-              });
-
-              round.map(move |finished_items| {
-                let mut todo_candidates = Vec::new();
-                for (subject_key, product, more_deps) in finished_items.into_iter() {
-                  expansion.outputs.insert(subject_key, product);
-                  todo_candidates.extend(more_deps);
-                }
-
-                // NB enclose with {} to limit the borrowing scope.
-                {
-                  let outputs = &expansion.outputs;
-                  expansion.todo.extend(
-                    todo_candidates
-                      .into_iter()
-                      .map(|dep| externs::key_for(dep))
-                      .filter(|dep_key| !outputs.contains_key(dep_key))
-                      .collect::<Vec<_>>(),
-                  );
-                }
-
-                if expansion.todo.is_empty() {
-                  future::Loop::Break(expansion)
-                } else {
-                  future::Loop::Continue(expansion)
-                }
-              })
-            }).map(|expansion| {
-              externs::store_list(expansion.outputs.values().collect::<Vec<_>>(), false)
-            })
-              .to_boxed()
-          }
-          Err(failure) => err(failure),
-        }
-      })
-      .to_boxed()
-  }
-}
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SelectProjection {
   subject: Key,
@@ -737,7 +580,7 @@ impl SelectProjection {
               selector: selectors::Select::without_variant(self.selector.product),
               subject: externs::key_for(projected_subject),
               variants: self.variants.clone(),
-              // NB: Unlike SelectDependencies and SelectTransitive, we don't need to filter by
+              // NB: Unlike SelectDependencies , we don't need to filter by
               // subject here, because there is only one projected type.
               entries: self.projected_entries.clone(),
             }.run(context.clone())
@@ -1059,10 +902,6 @@ impl Task {
         SelectDependencies::new(s, self.subject.clone(), self.variants.clone(), edges)
           .run(context.clone())
       }
-      Selector::SelectTransitive(s) => {
-        SelectTransitive::new(s, self.subject.clone(), self.variants.clone(), edges)
-          .run(context.clone())
-      }
       Selector::SelectProjection(s) => {
         SelectProjection::new(s, self.subject.clone(), self.variants.clone(), edges)
           .run(context.clone())
@@ -1131,7 +970,7 @@ impl NodeKey {
       ),
       &NodeKey::Task(ref s) => format!(
         "Task({}, {}, {})",
-        externs::key_to_str(&s.task.func.0),
+        externs::project_str(&externs::val_for(&s.task.func.0), "__name__"),
         keystr(&s.subject),
         typstr(&s.product)
       ),

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -8,7 +8,7 @@ use std::io;
 
 use core::{Function, Key, TypeConstraint, TypeId, Value, ANY_TYPE};
 use externs;
-use selectors::{Select, SelectDependencies, SelectTransitive, Selector};
+use selectors::{Select, SelectDependencies, Selector};
 use tasks::{Task, Tasks};
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug)]
@@ -358,12 +358,6 @@ impl<'t> GraphMaker<'t> {
                 ref dep_product,
                 ref field_types,
                 ..
-              })
-              | &Selector::SelectTransitive(SelectTransitive {
-                ref product,
-                ref dep_product,
-                ref field_types,
-                ..
               }) => {
                 let initial_selector = *dep_product;
                 let initial_rules_or_literals = rhs_for_select(
@@ -683,22 +677,6 @@ pub fn selector_str(selector: &Selector) -> String {
     &Selector::SelectDependencies(ref s) => format!(
       "{}({}, {}, {}field_types=({},))",
       "SelectDependencies",
-      type_constraint_str(s.product),
-      type_constraint_str(s.dep_product),
-      if s.field == "dependencies" {
-        "".to_string()
-      } else {
-        format!("'{}', ", s.field)
-      },
-      s.field_types
-        .iter()
-        .map(|&f| type_str(f))
-        .collect::<Vec<String>>()
-        .join(", ")
-    ),
-    &Selector::SelectTransitive(ref s) => format!(
-      "{}({}, {}, {}field_types=({},))",
-      "SelectTransitive",
       type_constraint_str(s.product),
       type_constraint_str(s.dep_product),
       if s.field == "dependencies" {

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -27,14 +27,6 @@ pub struct SelectDependencies {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct SelectTransitive {
-  pub product: TypeConstraint,
-  pub dep_product: TypeConstraint,
-  pub field: Field,
-  pub field_types: Vec<TypeId>,
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SelectProjection {
   pub product: TypeConstraint,
   // TODO: This should in theory be a TypeConstraint, but because the `project` operation
@@ -49,6 +41,5 @@ pub struct SelectProjection {
 pub enum Selector {
   Select(Select),
   SelectDependencies(SelectDependencies),
-  SelectTransitive(SelectTransitive),
   SelectProjection(SelectProjection),
 }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 
 use core::{Field, Function, Key, TypeConstraint, TypeId, Value, FNV};
 use externs;
-use selectors::{Select, SelectDependencies, SelectProjection, SelectTransitive, Selector};
+use selectors::{Select, SelectDependencies, SelectProjection, Selector};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
@@ -114,21 +114,6 @@ impl Tasks {
     field_types: Vec<TypeId>,
   ) {
     self.clause(Selector::SelectDependencies(SelectDependencies {
-      product: product,
-      dep_product: dep_product,
-      field: field,
-      field_types: field_types,
-    }));
-  }
-
-  pub fn add_select_transitive(
-    &mut self,
-    product: TypeConstraint,
-    dep_product: TypeConstraint,
-    field: Field,
-    field_types: Vec<TypeId>,
-  ) {
-    self.clause(Selector::SelectTransitive(SelectTransitive {
       product: product,
       dep_product: dep_product,
       field: field,

--- a/tests/python/pants_test/build_graph/test_build_graph_integration.py
+++ b/tests/python/pants_test/build_graph/test_build_graph_integration.py
@@ -18,7 +18,7 @@ class BuildGraphIntegrationTest(PantsRunIntegrationTest):
       with self.file_renamed(os.path.join(prefix, 'cycle2'), 'TEST_BUILD', 'BUILD'):
         pants_run = self.run_pants(['compile', os.path.join(prefix, 'cycle1')])
         self.assert_failure(pants_run)
-        self.assertIn('Cycle detected', pants_run.stderr_data)
+        self.assertIn('cycle', pants_run.stderr_data)
 
   def test_banned_module_import(self):
     self.banned_import('testprojects/src/python/build_file_imports_module')

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -151,6 +151,7 @@ python_tests(
     ':scheduler_test_base',
     ':util',
     'src/python/pants/build_graph',
+    'src/python/pants/engine:build_files',
     'src/python/pants/engine:mapper',
     'src/python/pants/engine:struct',
     'src/python/pants/util:dirutil',
@@ -191,6 +192,7 @@ python_tests(
   coverage=['pants.engine.nodes', 'pants.engine.scheduler'],
   dependencies=[
     ':util',
+    'src/python/pants/base:cmd_line_spec_parser',
     'src/python/pants/build_graph',
     'src/python/pants/engine:scheduler',
     'tests/python/pants_test/engine/examples:planners',

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -102,8 +102,7 @@ class GraphTargetScanFailureTests(GraphTestBase):
       with self.graph_helper() as graph_helper:
         self.create_graph_from_specs(graph_helper, ['build-support/bin::'])
 
-    self.assertIn('Path "build-support/bin" contains no BUILD files',
-                  str(cm.exception))
+    self.assertIn('does not match any targets.', str(cm.exception))
 
   def test_inject_bad_dir(self):
     with self.assertRaises(AddressLookupError) as cm:

--- a/tests/python/pants_test/engine/legacy/test_list_integration.py
+++ b/tests/python/pants_test/engine/legacy/test_list_integration.py
@@ -26,7 +26,7 @@ class ListIntegrationTest(PantsRunIntegrationTest):
 
   def test_list_invalid_dir(self):
     pants_run = self.do_command('list', 'abcde::', success=False)
-    self.assertIn('ResolveError', pants_run.stderr_data)
+    self.assertIn('AddressLookupError', pants_run.stderr_data)
 
   def test_list_nested_function_scopes(self):
     pants_run = self.do_command('list',

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -122,7 +122,7 @@ class EngineTraceTest(unittest.TestCase, SchedulerTestBase):
     self.assert_equal_with_printing(dedent('''
       Received unexpected Throw state(s):
       Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
-        Computing Task(<function nested_raise at 0xEEEEEEEEE>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
+        Computing Task(nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
           Throw(An exception for B)
             Traceback (most recent call last):
               File LOCATION-INFO, in call
@@ -152,8 +152,8 @@ class EngineTraceTest(unittest.TestCase, SchedulerTestBase):
     self.assert_equal_with_printing(dedent('''
       Received unexpected Throw state(s):
       Computing Select(<pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
-        Computing Task(<class 'pants_test.engine.test_engine.A'>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
-          Computing Task(<function nested_raise at 0xEEEEEEEEE>, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C)
+        Computing Task(A, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =A)
+          Computing Task(nested_raise, <pants_test.engine.test_engine.B object at 0xEEEEEEEEE>, =C)
             Throw(An exception for B)
               Traceback (most recent call last):
                 File LOCATION-INFO, in call

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses, Collection
-from pants.engine.build_files import UnhydratedStruct, create_graph_rules
+from pants.engine.build_files import Specs, UnhydratedStruct, create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError,
                                  DuplicateNameError, UnaddressableObjectError)
@@ -167,18 +167,8 @@ class AddressMapperTest(unittest.TestCase, SchedulerTestBase):
                              type_alias='target')
 
   def resolve(self, spec):
-    request = self.scheduler.execution_request([UnhydratedStructs], [spec])
-    result = self.scheduler.execute(request)
-    if result.error:
-      raise result.error
-
-    # Expect a single root.
-    if len(result.root_products) != 1:
-      raise Exception('Wrong number of result products: {}'.format(result.root_products))
-    state = result.root_products[0][1]
-    if type(state) is Throw:
-      raise Exception(state.exc)
-    return state.value.dependencies
+    uhs, = self.scheduler.product_request(UnhydratedStructs, [Specs(tuple([spec]))])
+    return uhs.dependencies
 
   def resolve_multi(self, spec):
     return {uhs.address: uhs.struct for uhs in self.resolve(spec)}

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -17,7 +17,6 @@ from pants.engine.build_files import Specs, UnhydratedStruct, create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError,
                                  DuplicateNameError, UnaddressableObjectError)
-from pants.engine.nodes import Throw
 from pants.engine.parser import SymbolTable
 from pants.engine.rules import TaskRule
 from pants.engine.selectors import SelectDependencies

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -14,7 +14,7 @@ from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import AddressMapper
 from pants.engine.rules import RootRule, RuleIndex, SingletonRule, TaskRule
 from pants.engine.scheduler import WrappedNativeScheduler
-from pants.engine.selectors import Select, SelectDependencies, SelectProjection, SelectTransitive
+from pants.engine.selectors import Select, SelectDependencies, SelectProjection
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.examples.planners import Goal
 from pants_test.engine.util import (TargetTable, assert_equal_with_printing,
@@ -470,28 +470,6 @@ class RuleGraphMakerTest(unittest.TestCase):
                          "Select(A) for SubA" -> {"(A, (,), noop) of SubA"}
                        // internal entries
                          "(A, (,), noop) of SubA" -> {}
-                     }""").strip(),
-      subgraph)
-
-  def test_select_transitive_with_separate_types_for_subselectors(self):
-    rules = [
-      TaskRule(Exactly(A), [SelectTransitive(B, C, field_types=(D,))], noop),
-      TaskRule(B, [Select(D)], noop),
-      TaskRule(C, [Select(SubA)], noop)
-    ]
-
-    subgraph = self.create_subgraph(A, rules, SubA())
-
-    self.assert_equal_with_printing(dedent("""
-                     digraph {
-                       // root subject types: SubA
-                       // root entries
-                         "Select(A) for SubA" [color=blue]
-                         "Select(A) for SubA" -> {"(A, (SelectTransitive(B, C, field_types=(D,)),), noop) of SubA"}
-                       // internal entries
-                         "(A, (SelectTransitive(B, C, field_types=(D,)),), noop) of SubA" -> {"(C, (Select(SubA),), noop) of SubA" "(B, (Select(D),), noop) of D"}
-                         "(B, (Select(D),), noop) of D" -> {"SubjectIsProduct(D)"}
-                         "(C, (Select(SubA),), noop) of SubA" -> {"SubjectIsProduct(SubA)"}
                      }""").strip(),
       subgraph)
 

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -303,8 +303,8 @@ class RuleGraphMakerTest(unittest.TestCase):
       else:
         pass
 
-    self.assertEquals(41, len(all_rules))
-    self.assertEquals(78, len(root_rule_lines)) # 2 lines per entry
+    self.assertEquals(20, len(all_rules))
+    self.assertEquals(36, len(root_rule_lines)) # 2 lines per entry
 
   def test_smallest_full_test_multiple_root_subject_types(self):
     rules = [

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -270,7 +270,7 @@ class SchedulerTraceTest(unittest.TestCase):
 
     assert_equal_with_printing(self, dedent('''
                      Computing Select(<pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, =A)
-                       Computing Task(<function nested_raise at 0xEEEEEEEEE>, <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, =A)
+                       Computing Task(nested_raise, <pants_test.engine.test_scheduler.B object at 0xEEEEEEEEE>, =A)
                          Throw(An exception for B)
                            Traceback (most recent call last):
                              File LOCATION-INFO, in call

--- a/tests/python/pants_test/option/util/fakes.py
+++ b/tests/python/pants_test/option/util/fakes.py
@@ -93,7 +93,7 @@ def create_options(options, passthru_args=None, fingerprintable_options=None):
     def for_scope(self, scope):
       # TODO(John Sirois): Some users pass in A dict of scope -> _FakeOptionValues instead of a
       # dict of scope -> (dict of option name -> value).  Clean up these usages and kill this
-      # accomodation.
+      # accommodation.
       options_for_this_scope = options.get(scope) or {}
       if isinstance(options_for_this_scope, _FakeOptionValues):
         options_for_this_scope = options_for_this_scope.option_values


### PR DESCRIPTION
### Problem

While chasing performance in one area for #4349 we added `SelectTransitive`. This decreased performance in another significant area: executions involving multiple transitive roots can't structure-share at all when expanding dependencies, leading to many redundant walks (#4533). 

Additionally, usability regressed in a few ways: the product `Graph` could not implement cycle detection for dependencies expanded via `SelectTransitive` (#4358), and in the case of a missing or broken dependency, the referring context was lost (#4515). 

### Solution

* Remove usage of `SelectTransitive` for `TransitiveHydratedTargets` to reintroduce structure sharing and improve usability (fixes #4358 and fixes #4515).
* Replace `@rule`s that operate on single-`Spec`s with batch forms that operate on a `Specs` collection (fixes #4533).

### Result

Cycles should be detected much earlier with:
```
Exception message: Build graph construction failed: ExecutionError Received unexpected Throw state(s):
Computing Select(Collection(dependencies=(SingleAddress(directory=u'testprojects/src/java/org/pantsbuild/testproject/cycle1', name=u'cycle1'),)), =TransitiveHydratedTargets)
  Computing Task(transitive_hydrated_targets, Collection(dependencies=(SingleAddress(directory=u'testprojects/src/java/org/pantsbuild/testproject/cycle1', name=u'cycle1'),)), =TransitiveHydratedTargets)
    Computing Task(transitive_hydrated_target, testprojects/src/java/org/pantsbuild/testproject/cycle1:cycle1, =TransitiveHydratedTarget)
      Computing Task(transitive_hydrated_target, testprojects/src/java/org/pantsbuild/testproject/cycle2:cycle2, =TransitiveHydratedTarget)
        Throw(No source of required dependency: Dep graph contained a cycle.)
          Traceback (no traceback):
            <pants native internals>
          Exception: No source of required dependency: Dep graph contained a cycle.
```
_(more polish needed here: re-opened #3695 to clean up `trace`)_

And time taken is proportional to the total number of matched targets, rather than to the sum of the closure sizes of the roots:
```
# before:
$ time ./pants --target-spec-file=targets.txt list | wc -l
    1500

real	0m15.297s
user	0m14.603s
sys	0m1.625s

# after:
$ time ./pants --target-spec-file=targets.txt list | wc -l
    1500

real	0m5.989s
user	0m5.261s
sys	0m1.310s
```

Runtimes for things like `./pants list ::` are unaffected, although memory usage increases by about 5%, likely due to the branchier resulting `Graph`.