### PR TITLE
Robustify `SetupPyIntegrationTest`.

### DIFF
--- a/tests/python/pants_test/backend/python/BUILD
+++ b/tests/python/pants_test/backend/python/BUILD
@@ -46,10 +46,19 @@ python_tests(
   name='integration',
   sources=globs('*_integration.py'),
   dependencies=[
+    ':pants_requirement_integration_test_base',
+    'src/python/pants/base:build_environment',
+  ],
+  tags={'integration'},
+)
+
+python_library(
+  name='pants_requirement_integration_test_base',
+  sources=['pants_requirement_integration_test_base.py'],
+  dependencies=[
     'src/python/pants/base:build_environment',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test:int-test',
-  ],
-  tags={'integration'},
+  ]
 )

--- a/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
+++ b/tests/python/pants_test/backend/python/pants_requirement_integration_test_base.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import shutil
+import uuid
+from contextlib import contextmanager
+
+from pants.base.build_environment import get_buildroot, pants_version
+from pants.util.contextutil import temporary_dir
+from pants.util.dirutil import safe_walk
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class PantsRequirementIntegrationTestBase(PantsRunIntegrationTest):
+  @contextmanager
+  def _unstable_pants_version(self):
+    stable_version = pants_version()
+    unstable_version = b'{}+{}'.format(stable_version, uuid.uuid4().hex)
+    version_dir = os.path.join(get_buildroot(), 'src/python/pants')
+
+    with self.file_renamed(version_dir, 'VERSION', 'VERSION.orig'):
+      with open(os.path.join(version_dir, 'VERSION'), 'wb') as fp:
+        fp.write(unstable_version)
+
+      pants_run = self.run_pants(['--version'])
+      self.assert_success(pants_run)
+      self.assertEqual(unstable_version, pants_run.stdout_data.strip())
+
+      yield
+
+  def _iter_wheels(self, path):
+    for root, _, files in safe_walk(path):
+      for f in files:
+        if f.endswith('.whl'):
+          yield os.path.join(root, f)
+
+  @contextmanager
+  def create_unstable_pants_distribution(self):
+    with self._unstable_pants_version():
+      with temporary_dir() as dist_dir:
+        create_pants_dist_cmd = ['--pants-distdir={}'.format(dist_dir),
+                                 'setup-py',
+                                 '--run=bdist_wheel',
+                                 'src/python/pants:pants-packaged']
+        pants_run = self.run_pants(create_pants_dist_cmd)
+        self.assert_success(pants_run)
+
+        # Create a flat wheel repo from the results of setup-py above.
+        with temporary_dir() as repo:
+          for wheel in self._iter_wheels(dist_dir):
+            shutil.copy(wheel, os.path.join(repo, os.path.basename(wheel)))
+
+          yield repo

--- a/tests/python/pants_test/backend/python/tasks/BUILD
+++ b/tests/python/pants_test/backend/python/tasks/BUILD
@@ -53,10 +53,11 @@ python_tests(
   name='integration',
   sources=globs('*_integration.py'),
   dependencies=[
+    '3rdparty/python:pex',
     'src/python/pants/util:contextutil',
     'src/python/pants/util:process_handler',
+    'tests/python/pants_test/backend/python:pants_requirement_integration_test_base',
     'tests/python/pants_test:int-test',
-    '3rdparty/python:pex',
   ],
   tags={'integration'},
   timeout=2400

--- a/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_setup_py_integration.py
@@ -8,10 +8,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import re
 import tarfile
 
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants_test.backend.python.pants_requirement_integration_test_base import \
+  PantsRequirementIntegrationTestBase
 
 
-class SetupPyIntegrationTest(PantsRunIntegrationTest):
+class SetupPyIntegrationTest(PantsRequirementIntegrationTestBase):
 
   def assert_sdist(self, pants_run, key, files):
     sdist_path = 'dist/{}-0.0.1.tar.gz'.format(key)
@@ -142,19 +143,19 @@ class SetupPyIntegrationTest(PantsRunIntegrationTest):
 
     self.maxDiff = None
 
-    command = [
-      'setup-py',
-      'testprojects/pants-plugins/src/python/test_pants_plugin',
-    ]
-    pants_run = self.run_pants(command=command)
-    self.assert_success(pants_run)
+    with self.create_unstable_pants_distribution() as repo:
+      command = ['--python-repos-repos={}'.format(repo),
+                 'setup-py',
+                 'testprojects/pants-plugins/src/python/test_pants_plugin']
+      pants_run = self.run_pants(command=command)
+      self.assert_success(pants_run)
 
-    self.assert_sdist(pants_run, 'test_pants_plugin', [
-      'test_pants_plugin/',
-      'test_pants_plugin/__init__.py',
-      'test_pants_plugin/pants_infra_tests.py',
-      'test_pants_plugin/register.py',
-      'test_pants_plugin/subsystems/',
-      'test_pants_plugin/subsystems/__init__.py',
-      'test_pants_plugin/subsystems/pants_test_infra.py',
-    ])
+      self.assert_sdist(pants_run, 'test_pants_plugin', [
+        'test_pants_plugin/',
+        'test_pants_plugin/__init__.py',
+        'test_pants_plugin/pants_infra_tests.py',
+        'test_pants_plugin/register.py',
+        'test_pants_plugin/subsystems/',
+        'test_pants_plugin/subsystems/__init__.py',
+        'test_pants_plugin/subsystems/pants_test_infra.py',
+      ])

--- a/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
+++ b/tests/python/pants_test/backend/python/test_pants_requirement_integration.py
@@ -6,17 +6,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import shutil
-import uuid
-from contextlib import contextmanager
 
-from pants.base.build_environment import get_buildroot, pants_version
-from pants.util.contextutil import temporary_dir
-from pants.util.dirutil import safe_walk
-from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+from pants.base.build_environment import get_buildroot
+from pants_test.backend.python.pants_requirement_integration_test_base import \
+  PantsRequirementIntegrationTestBase
 
 
-class PantsRequirementIntegrationTest(PantsRunIntegrationTest):
+class PantsRequirementIntegrationTest(PantsRequirementIntegrationTestBase):
   """A pants plugin should be able to depend on a pants_requirement() alone to
   declare its dependencies on pants modules. This plugin, when added to the
   pythonpath and backend_packages, should be able to declare new BUILD file
@@ -36,46 +32,6 @@ class PantsRequirementIntegrationTest(PantsRunIntegrationTest):
     ]
     command = pre_cmd_args + cmd
     return self.run_pants(command=command)
-
-  @contextmanager
-  def unstable_pants_version(self):
-    stable_version = pants_version()
-    unstable_version = b'{}+{}'.format(stable_version, uuid.uuid4().hex)
-    version_dir = os.path.join(get_buildroot(), 'src/python/pants')
-
-    with self.file_renamed(version_dir, 'VERSION', 'VERSION.orig'):
-      with open(os.path.join(version_dir, 'VERSION'), 'wb') as fp:
-        fp.write(unstable_version)
-
-      pants_run = self.run_pants(['--version'])
-      self.assert_success(pants_run)
-      self.assertEqual(unstable_version, pants_run.stdout_data.strip())
-
-      yield
-
-  def iter_wheels(self, path):
-    for root, _, files in safe_walk(path):
-      for f in files:
-        if f.endswith('.whl'):
-          yield os.path.join(root, f)
-
-  @contextmanager
-  def create_unstable_pants_distribution(self):
-    with self.unstable_pants_version():
-      with temporary_dir() as dist_dir:
-        create_pants_dist_cmd = ['--pants-distdir={}'.format(dist_dir),
-                                 'setup-py',
-                                 '--run=bdist_wheel',
-                                 'src/python/pants:pants-packaged']
-        pants_run = self.run_pants(create_pants_dist_cmd)
-        self.assert_success(pants_run)
-
-        # Create a flat wheel repo from the results of setup-py above.
-        with temporary_dir() as repo:
-          for wheel in self.iter_wheels(dist_dir):
-            shutil.copy(wheel, os.path.join(repo, os.path.basename(wheel)))
-
-          yield repo
 
   def test_pants_requirement(self):
     self.maxDiff = None


### PR DESCRIPTION
Previously, when the pants `VERSION` was bumped and before publishing
the `test_setup_py_unregistered_pants_plugin` test would fail to resolve
`pantsbuild.pants` at the new version on pypi. Update the test to use a
custom-produced `pantsbuild.pants` distribution and share this logic
with `PantsRequirementIntegrationTest`.

Similar to #5519 / #5520