### PR TITLE
Resolve for current platform only if resolving a local python dist with native extensions

### DIFF
--- a/examples/src/python/example/python_distribution/hello/fasthello/BUILD
+++ b/examples/src/python/example/python_distribution/hello/fasthello/BUILD
@@ -19,5 +19,6 @@ python_binary(
   source='main.py',
   dependencies=[
     ':fasthello',
-  ]
+  ],
+  platforms=['current']
 )

--- a/pants-plugins/src/python/internal_backend/sitegen/tasks/BUILD
+++ b/pants-plugins/src/python/internal_backend/sitegen/tasks/BUILD
@@ -16,5 +16,7 @@ python_library(
     'pants-plugins/3rdparty/python:beautifulsoup4',
     'src/python/pants/base:exceptions',
     'src/python/pants/task',
+    'src/python/pants/backend/python/subsystems',
+    'src/python/pants/backend/python/tasks'
   ]
 )

--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -64,4 +64,4 @@ class PythonDistribution(Target):
 
   @property
   def has_native_sources(self):
-    return any(src.endswith(('.c', '.cpp', '.cc')) for src in self.sources_relative_to_target_base())
+    return self.has_sources(extension=('.c', '.cpp', '.cc'))

--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -61,3 +61,7 @@ class PythonDistribution(Target):
         PythonIdentity.parse_requirement(req)
       except ValueError as e:
         raise TargetDefinitionException(self, str(e))
+
+    @property
+    def has_native_sources(self):
+      return any(src.endswith(('.c', '.cpp')) for src in self.sources_relative_to_target_base())

--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -62,6 +62,6 @@ class PythonDistribution(Target):
       except ValueError as e:
         raise TargetDefinitionException(self, str(e))
 
-    @property
-    def has_native_sources(self):
-      return any(src.endswith(('.c', '.cpp')) for src in self.sources_relative_to_target_base())
+  @property
+  def has_native_sources(self):
+    return any(src.endswith(('.c', '.cpp', '.cc')) for src in self.sources_relative_to_target_base())

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -46,6 +46,10 @@ def has_python_requirements(tgt):
   return isinstance(tgt, PythonRequirementLibrary)
 
 
+def is_python_binary(tgt):
+  return isinstance(tgt, PythonBinary)
+
+
 def _create_source_dumper(builder, tgt):
   if type(tgt) == Files:
     # Loose `Files` as opposed to `Resources` or `PythonTarget`s have no (implied) package structure

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -85,7 +85,7 @@ def build_for_current_platform_only_check(tgts):
   Performs a check of whether the current target closure has native sources and if so, ensures that
   Pants is only targeting the current platform.
 
-  :context_tgts_func function: The target filtering function of the current task context.
+  :param tgts: a list of :class:`Target` objects.
   :return: a boolean value indicating whether the current target closure has native sources.
   """
   if tgt_closure_has_native_sources(filter(is_local_python_dist, tgts)):

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -51,8 +51,8 @@ def is_python_binary(tgt):
 
 
 def tgt_closure_has_native_sources(tgts):
-    """Determine if any target in the current target closure has native (c or cpp) sources."""
-    return any(tgt.has_native_sources for tgt in tgts)
+  """Determine if any target in the current target closure has native (c or cpp) sources."""
+  return any(tgt.has_native_sources for tgt in tgts)
 
 
 def tgt_closure_platforms(tgts):
@@ -80,7 +80,7 @@ def tgt_closure_platforms(tgts):
   return tgts_by_platforms
 
 
-def build_for_current_platform_only_check(context_tgts_func):
+def build_for_current_platform_only_check(tgts):
   """
   Performs a check of whether the current target closure has native sources and if so, ensures that
   Pants is only targeting the current platform.
@@ -88,8 +88,8 @@ def build_for_current_platform_only_check(context_tgts_func):
   :context_tgts_func function: The target filtering function of the current task context.
   :return: a boolean value indicating whether the current target closure has native sources.
   """
-  if tgt_closure_has_native_sources(context_tgts_func(is_local_python_dist)):
-    platforms = tgt_closure_platforms(context_tgts_func(is_python_binary))
+  if tgt_closure_has_native_sources(filter(is_local_python_dist, tgts)):
+    platforms = tgt_closure_platforms(filter(is_python_binary, tgts))
     if len(platforms.keys()) > 1 or not 'current' in platforms.keys():
       raise IncompatiblePlatformsError('The target set contains one or more targets that depend on '
         'native code. Please ensure that the platform arguments in all relevant targets and build '

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -18,7 +18,7 @@ from pants.backend.python.targets.python_library import PythonLibrary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.targets.python_tests import PythonTests
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import TaskError
+from pants.base.exceptions import IncompatiblePlatformsError, TaskError
 from pants.build_graph.files import Files
 from pants.python.python_repos import PythonRepos
 
@@ -48,6 +48,55 @@ def has_python_requirements(tgt):
 
 def is_python_binary(tgt):
   return isinstance(tgt, PythonBinary)
+
+
+def tgt_closure_has_native_sources(tgts):
+    """Determine if any target in the current target closure has native (c or cpp) sources."""
+    return any(tgt.has_native_sources for tgt in tgts)
+
+
+def tgt_closure_platforms(tgts):
+  """
+  Aggregates a dict that maps a platform string to a list of targets that specify the platform.
+  If no targets have platforms arguments, return a dict containing platforms inherited from
+  the PythonSetup object.
+
+  :param tgts: a list of :class:`Target` objects.
+  :returns: a dict mapping a platform string to a list of targets that specify the platform.
+  """
+  tgts_by_platforms = {}
+  for tgt in tgts:
+    if tgt.platforms:
+      for platform in tgt.platforms:
+        if platform in tgts_by_platforms:
+          tgts_by_platforms[platform].append(tgt)
+        else:
+          tgts_by_platforms[platform] = [tgt]
+  # If no targets specify platforms, inherit the default platforms.
+  if not tgts_by_platforms:
+    for platform in PythonSetup.global_instance().platforms:
+      tgts_by_platforms[platform] = ['(No target) Platform inherited from either the '
+                                     '--platforms option or a pants.ini file.']
+  return tgts_by_platforms
+
+
+def build_for_current_platform_only_check(context_tgts_func):
+  """
+  Performs a check of whether the current target closure has native sources and if so, ensures that
+  Pants is only targeting the current platform.
+
+  :context_tgts_func function: The target filtering function of the current task context.
+  :return: a boolean value indicating whether the current target closure has native sources.
+  """
+  if tgt_closure_has_native_sources(context_tgts_func(is_local_python_dist)):
+    platforms = tgt_closure_platforms(context_tgts_func(is_python_binary))
+    if len(platforms.keys()) > 1 or not 'current' in platforms.keys():
+      raise IncompatiblePlatformsError('The target set contains one or more targets that depend on '
+        'native code. Please ensure that the platform arguments in all relevant targets and build '
+        'options are compatible with the current platform. Found targets for platforms: {}'
+        .format(str(platforms)))
+    return True
+  return False
 
 
 def _create_source_dumper(builder, tgt):

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -128,7 +128,10 @@ class PythonBinaryCreate(Task):
       # Dump everything into the builder's chroot.
       for tgt in source_tgts:
         dump_sources(builder, tgt, self.context.log)
-      dump_requirement_libs(builder, interpreter, req_tgts, self.context.log, binary_tgt.platforms)
+      # We need to ensure that we are resolving for only the current platform if we are
+      # including local python dist targets that have native extensions.
+      platforms = ['current'] if self.tgt_closure_has_native_sources() else binary_tgt.platforms
+      dump_requirement_libs(builder, interpreter, req_tgts, self.context.log, platforms)
 
       # Build the .pex file.
       pex_path = os.path.join(results_dir, '{}.pex'.format(binary_tgt.name))

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -13,11 +13,12 @@ from pex.pex_info import PexInfo
 
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-from pants.backend.python.tasks.pex_build_util import (dump_requirement_libs, dump_sources,
+from pants.backend.python.tasks.pex_build_util import (build_for_current_platform_only_check,
+                                                       dump_requirement_libs, dump_sources,
                                                        has_python_requirements, has_python_sources,
                                                        has_resources, is_python_target)
 from pants.base.build_environment import get_buildroot
-from pants.base.exceptions import IncompatiblePlatformsError, TaskError
+from pants.base.exceptions import TaskError
 from pants.build_graph.target_scopes import Scopes
 from pants.task.task import Task
 from pants.util.contextutil import temporary_dir
@@ -130,13 +131,7 @@ class PythonBinaryCreate(Task):
         dump_sources(builder, tgt, self.context.log)
       # We need to ensure that we are resolving for only the current platform if we are
       # including local python dist targets that have native extensions.
-      if self.tgt_closure_has_native_sources():
-        platforms = self.tgt_closure_platforms()
-        if platforms != ['current']:
-          raise IncompatiblePlatformsError('The target set contains one or more targets that depend on '
-            'native code. Please ensure that the platform arguments in all relevant '
-            'targets are compatible with the current platform. Found platforms: {}'
-            .format(str(platforms)))
+      build_for_current_platform_only_check(self.context.targets)
       dump_requirement_libs(builder, interpreter, req_tgts, self.context.log, binary_tgt.platforms)
 
       # Build the .pex file.

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -129,9 +129,10 @@ class PythonBinaryCreate(Task):
       # Dump everything into the builder's chroot.
       for tgt in source_tgts:
         dump_sources(builder, tgt, self.context.log)
+        import pdb;pdb.set_trace()
       # We need to ensure that we are resolving for only the current platform if we are
       # including local python dist targets that have native extensions.
-      build_for_current_platform_only_check(self.context.targets)
+      build_for_current_platform_only_check(self.context.targets())
       dump_requirement_libs(builder, interpreter, req_tgts, self.context.log, binary_tgt.platforms)
 
       # Build the .pex file.

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -132,7 +132,7 @@ class PythonBinaryCreate(Task):
       # including local python dist targets that have native extensions.
       if self.tgt_closure_has_native_sources():
         platforms = self.tgt_closure_platforms()
-        if set(platforms) != set(['current']):
+        if platforms != ['current']:
           raise IncompatiblePlatformsError('The target set contains one or more targets that depend on '
             'native code. Please ensure that the platform arguments in all relevant '
             'targets are compatible with the current platform. Found platforms: {}'

--- a/src/python/pants/backend/python/tasks/python_binary_create.py
+++ b/src/python/pants/backend/python/tasks/python_binary_create.py
@@ -129,7 +129,6 @@ class PythonBinaryCreate(Task):
       # Dump everything into the builder's chroot.
       for tgt in source_tgts:
         dump_sources(builder, tgt, self.context.log)
-        import pdb;pdb.set_trace()
       # We need to ensure that we are resolving for only the current platform if we are
       # including local python dist targets that have native extensions.
       build_for_current_platform_only_check(self.context.targets())

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -57,7 +57,7 @@ class ResolveRequirementsTaskBase(Task):
       maybe_platforms = None
       if self.tgt_closure_has_native_sources():
         platforms = self.tgt_closure_platforms()
-        if set(platforms) != set(['current']):
+        if platforms != ['current']:
           raise IncompatiblePlatformsError('The target set contains one or more targets that depend on '
             'native code. Please ensure that the platform arguments in all relevant '
             'targets are compatible with the current platform. Found platforms: {}'

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -16,7 +16,6 @@ from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
 from pants.backend.python.tasks.pex_build_util import (build_for_current_platform_only_check,
                                                        dump_requirement_libs, dump_requirements)
-from pants.base.exceptions import IncompatiblePlatformsError
 from pants.base.hash_utils import hash_all
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task
@@ -55,7 +54,8 @@ class ResolveRequirementsTaskBase(Task):
 
       # We need to ensure that we are resolving for only the current platform if we are
       # including local python dist targets that have native extensions.
-      maybe_platforms = ['current'] if build_for_current_platform_only_check else None
+      tgts = self.context.targets()
+      maybe_platforms = ['current'] if build_for_current_platform_only_check(tgts) else None
 
       path = os.path.realpath(os.path.join(self.workdir, str(interpreter.identity), target_set_id))
       # Note that we check for the existence of the directory, instead of for invalid_vts,

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -14,7 +14,8 @@ from pex.pex_builder import PEXBuilder
 
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-from pants.backend.python.tasks.pex_build_util import dump_requirement_libs, dump_requirements
+from pants.backend.python.tasks.pex_build_util import (build_for_current_platform_only_check,
+                                                       dump_requirement_libs, dump_requirements)
 from pants.base.exceptions import IncompatiblePlatformsError
 from pants.base.hash_utils import hash_all
 from pants.invalidation.cache_manager import VersionedTargetSet
@@ -54,15 +55,7 @@ class ResolveRequirementsTaskBase(Task):
 
       # We need to ensure that we are resolving for only the current platform if we are
       # including local python dist targets that have native extensions.
-      maybe_platforms = None
-      if self.tgt_closure_has_native_sources():
-        platforms = self.tgt_closure_platforms()
-        if platforms != ['current']:
-          raise IncompatiblePlatformsError('The target set contains one or more targets that depend on '
-            'native code. Please ensure that the platform arguments in all relevant '
-            'targets are compatible with the current platform. Found platforms: {}'
-            .format(str(platforms)))
-        maybe_platforms = ['current']
+      maybe_platforms = ['current'] if build_for_current_platform_only_check else None
 
       path = os.path.realpath(os.path.join(self.workdir, str(interpreter.identity), target_set_id))
       # Note that we check for the existence of the directory, instead of for invalid_vts,

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -14,8 +14,7 @@ from pex.pex_builder import PEXBuilder
 
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-from pants.backend.python.tasks.pex_build_util import (dump_requirement_libs, dump_requirements,
-                                                       is_python_binary)
+from pants.backend.python.tasks.pex_build_util import dump_requirement_libs, dump_requirements
 from pants.base.exceptions import IncompatiblePlatformsError
 from pants.base.hash_utils import hash_all
 from pants.invalidation.cache_manager import VersionedTargetSet

--- a/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
+++ b/src/python/pants/backend/python/tasks/resolve_requirements_task_base.py
@@ -14,8 +14,7 @@ from pex.pex_builder import PEXBuilder
 
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.targets.python_requirement_library import PythonRequirementLibrary
-from pants.backend.python.tasks.pex_build_util import (dump_requirement_libs, dump_requirements,
-                                                       is_local_python_dist)
+from pants.backend.python.tasks.pex_build_util import dump_requirement_libs, dump_requirements
 from pants.base.hash_utils import hash_all
 from pants.invalidation.cache_manager import VersionedTargetSet
 from pants.task.task import Task
@@ -34,12 +33,6 @@ class ResolveRequirementsTaskBase(Task):
   def prepare(cls, options, round_manager):
     round_manager.require_data(PythonInterpreter)
     round_manager.optional_product(PythonRequirementLibrary)  # For local dists.
-
-  @staticmethod
-  def tgt_closure_has_native_sources():
-    local_dist_tgts = self.context.targets(is_local_python_dist)
-    if local_dist_tgts:
-      return any(tgt.has_native_sources for tgt in local_dist_tgts)
 
   def resolve_requirements(self, interpreter, req_libs):
     """Requirements resolution for PEX files.
@@ -60,7 +53,7 @@ class ResolveRequirementsTaskBase(Task):
 
       # We need to ensure that we are resolving for only the current platform if we are
       # including local python dist targets that have native extensions.
-      maybe_platforms = ['current'] if self.tgt_closure_has_native_sources else None
+      maybe_platforms = ['current'] if self.tgt_closure_has_native_sources() else None
 
       path = os.path.realpath(os.path.join(self.workdir, str(interpreter.identity), target_set_id))
       # Note that we check for the existence of the directory, instead of for invalid_vts,

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -59,3 +59,7 @@ class BuildConfigurationError(Exception):
 
 class BackendConfigurationError(BuildConfigurationError):
   """Indicates a plugin backend with a missing or malformed register module."""
+
+
+class IncompatiblePlatformsError(Exception):
+  """Indicates that target platforms are incompatible with a target that contains native code."""

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat
 
+from pants.backend.python.tasks.pex_build_util import is_local_python_dist
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files
@@ -650,6 +651,11 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     # For the v2 path, e.g. `./pants list` is a functional no-op. This matches the v2 mode behavior
     # of e.g. `./pants --changed-parent=HEAD list` (w/ no changes) returning an empty result.
     return self.context.target_roots
+
+  def tgt_closure_has_native_sources(self):
+    """Determine if any target in the current target closure has native (c or cpp) sources."""
+    local_dist_tgts = self.context.targets(is_local_python_dist)
+    return any(tgt.has_native_sources for tgt in local_dist_tgts)
 
 
 class Task(TaskBase):

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -653,20 +653,6 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     # of e.g. `./pants --changed-parent=HEAD list` (w/ no changes) returning an empty result.
     return self.context.target_roots
 
-  def tgt_closure_has_native_sources(self):
-    """Determine if any target in the current target closure has native (c or cpp) sources."""
-    local_dist_tgts = self.context.targets(is_local_python_dist)
-    return any(tgt.has_native_sources for tgt in local_dist_tgts)
-
-  def tgt_closure_platforms(self):
-    """Returns a list of all platform constraints in the target set of the current context."""
-    platforms = []
-    for tgt in self.context.targets(is_python_binary):
-      if tgt.platforms:
-        platforms += tgt.platforms
-    # If no targets specify platforms, inherit the default platforms.
-    return list(set(platforms)) or PythonSetup.global_instance().platforms
-
 
 class Task(TaskBase):
   """An executable task.

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -12,8 +12,6 @@ from contextlib import contextmanager
 from hashlib import sha1
 from itertools import repeat
 
-from pants.backend.python.subsystems.python_setup import PythonSetup
-from pants.backend.python.tasks.pex_build_util import is_local_python_dist, is_python_binary
 from pants.base.exceptions import TaskError
 from pants.base.worker_pool import Work
 from pants.cache.artifact_cache import UnreadableArtifact, call_insert, call_use_cached_files

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -664,10 +664,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
     for tgt in self.context.targets(is_python_binary):
       if tgt.platforms:
         platforms += tgt.platforms
-    if not platforms:
-      # If no targets specify platforms, inherit the default platforms.
-      platforms = PythonSetup.global_instance().platforms
-    return platforms
+    # If no targets specify platforms, inherit the default platforms.
+    return list(set(platforms)) or PythonSetup.global_instance().platforms
 
 
 class Task(TaskBase):

--- a/testprojects/src/python/python_distribution/fasthello_with_install_requires/BUILD
+++ b/testprojects/src/python/python_distribution/fasthello_with_install_requires/BUILD
@@ -17,7 +17,8 @@ python_binary(
   source='main.py',
   dependencies=[
     ':fasthello',
-  ]
+  ],
+  platforms=['current']
 )
 
 python_binary(
@@ -26,7 +27,8 @@ python_binary(
   dependencies=[
     ':fasthello',
     ':pycountry'
-  ]
+  ],
+  platforms=['current']
 )
 
 python_requirement_library(


### PR DESCRIPTION
### Problem

If a pants.ini file specifies default platforms that include more than just the current platform, local python dist targets will fail to resolve during the resolve requirements task because they are built locally for the current platform. Furthermore, the resolve requirements task does not plumb binary target platform arguments through to the pex resolver at resolve time, so we need a mechanism to check if there are native sources (from a python dist) in play, and pass only the `"current"` platform to the pex resolver if this is the case.

### Solution

Check if a python_dist target is in play during the requirements resolution task and whether any of these targets contain native (c or cpp) sources. If they do, set the `platforms` parameter of the pex resolver to contain only `"current"`.

### Result

Pants projects that have pants.ini files which specify multiple default platforms can now build local python dist targets for the current platform only.