### PR TITLE
Disable google java format by default

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -224,6 +224,9 @@ skip: True
 config: %(buildroot)s/build-support/scalastyle/scalastyle_config.xml
 excludes: %(buildroot)s/build-support/scalastyle/excludes.txt
 
+[fmt.google-java-format]
+skip: True
+
 [fmt.scalafmt]
 skip: True
 


### PR DESCRIPTION
See issue at #5622 and the original PR that was failing to build at #5614

### Problem

CI is running a formatter prior to linting, and the formatter causes the linting (and the build) to fail.

### Solution

Disable the linter by default, much like scalafmt and scalafix are disabled by default.

### Result

The build (#5614) went green!