### PR TITLE
[pantsd] Don't initialize a scheduler for pantsd lifecycle checks.

### DIFF
--- a/src/python/pants/bin/remote_pants_runner.py
+++ b/src/python/pants/bin/remote_pants_runner.py
@@ -16,7 +16,6 @@ from pants.java.nailgun_client import NailgunClient
 from pants.java.nailgun_protocol import NailgunProtocol
 from pants.pantsd.pants_daemon import PantsDaemon
 from pants.util.collections import combined_dict
-from pants.util.memo import memoized_property
 
 
 logger = logging.getLogger(__name__)
@@ -52,10 +51,6 @@ class RemotePantsRunner(object):
     self._stdin = stdin or sys.stdin
     self._stdout = stdout or sys.stdout
     self._stderr = stderr or sys.stderr
-
-  @memoized_property
-  def pantsd(self):
-    return PantsDaemon.Factory.create(bootstrap_options=self._bootstrap_options)
 
   @contextmanager
   def _trapped_signals(self, client):
@@ -113,9 +108,12 @@ class RemotePantsRunner(object):
     # Exit.
     self._exiter.exit(result)
 
+  def _maybe_launch_pantsd(self):
+    return PantsDaemon.Factory.maybe_launch(bootstrap_options=self._bootstrap_options)
+
   def run(self, args=None):
     self._setup_logging()
-    port = self.pantsd.maybe_launch()
+    port = self._maybe_launch_pantsd()
 
     logger.debug('connecting to pailgun on port {}'.format(port))
     try:

--- a/src/python/pants/core_tasks/pantsd_kill.py
+++ b/src/python/pants/core_tasks/pantsd_kill.py
@@ -16,6 +16,6 @@ class PantsDaemonKill(Task):
 
   def execute(self):
     try:
-      PantsDaemon.Factory.create(self.context.options).terminate()
+      PantsDaemon.Factory.create(self.context.options, full_init=False).terminate()
     except ProcessManager.NonResponsiveProcess as e:
       raise TaskError('failure while terminating pantsd: {}'.format(e))

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -96,7 +96,11 @@ class PantsDaemon(FingerprintedProcessManager):
     def create(cls, bootstrap_options=None, full_init=True):
       """
       :param Options bootstrap_options: The bootstrap options, if available.
-      :param bool full_init: Whether or not to fully initialize the engine.
+      :param bool full_init: Whether or not to fully initialize an engine et al for the purposes
+                             of spawning a new daemon. `full_init=False` is intended primarily
+                             for lightweight lifecycle checks (since there is a ~1s overhead to
+                             initialize the engine). See the impl of `maybe_launch` for an example
+                             of the intended usage.
       """
       bootstrap_options = bootstrap_options or cls._parse_bootstrap_options()
       bootstrap_options_values = bootstrap_options.for_global_scope()

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -257,7 +257,7 @@ class ProcessManager(ProcessMetadataManager):
     return self._process_name
 
   @memoized_property
-  def process_lock(self):
+  def lifecycle_lock(self):
     """An identity-keyed inter-process lock for safeguarding lifecycle and other operations."""
     safe_mkdir(self._metadata_base_dir)
     return OwnerPrintingInterProcessFileLock(

--- a/src/python/pants/process/lock.py
+++ b/src/python/pants/process/lock.py
@@ -36,6 +36,7 @@ class OwnerPrintingInterProcessFileLock(InterProcessLock):
     )
 
   def acquire(self, message_fn=print_to_stderr, **kwargs):
+    logger.debug('acquiring lock: {!r}'.format(self))
     super(OwnerPrintingInterProcessFileLock, self).acquire(blocking=False)
     if not self.acquired:
       try:
@@ -59,6 +60,7 @@ class OwnerPrintingInterProcessFileLock(InterProcessLock):
     return self.acquired
 
   def release(self):
+    logger.debug('releasing lock: {!r}'.format(self))
     if self.acquired:
       safe_delete(self.message_path)
     return super(OwnerPrintingInterProcessFileLock, self).release()


### PR DESCRIPTION
good for a ~40% speedup in lifecycle overhead for a 25 no-op run test case:

before:

```
[omerta pants (master)]$ ./pants -q clean-all; time (for i in $(seq 1 25); do PANTS_ENABLE_PANTSD=True ./pants >/dev/null 2>&1; done)
real    0m59.543s
user    0m23.667s
sys     0m12.274s
```

after:
```
[omerta pants (kwlzn/5433)]$ ./pants -q clean-all; time (for i in $(seq 1 25); do PANTS_ENABLE_PANTSD=True ./pants >/dev/null 2>&1; done)
real    0m42.530s
user    0m14.582s
sys     0m8.409s
```

`clean-all`/`kill-pantsd` with and without the daemon is also snappier as well.

Fixes #5433 