### PR TITLE
Bump coursier version to 1.1.0.cf365ea27a710d5f09db1f0a6feee129aa1fc417

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -36,14 +36,14 @@ class CoursierSubsystem(Subsystem):
     register('--fetch-options', type=list, fingerprint=True,
              help='Additional options to pass to coursier fetch. See `coursier fetch --help`')
     register('--bootstrap-jar-url', fingerprint=True,
-             default='https://dl.dropboxusercontent.com/s/t8zz2nupqkv2sfv/coursier-cli-1.0.2.e943c8069180d22f352878949f9522ad91d89026.jar?dl=0',
+             default='https://dl.dropboxusercontent.com/s/zwh074l9kxhqlwp/coursier-cli-1.1.0.cf365ea27a710d5f09db1f0a6feee129aa1fc417.jar?dl=0',
              help='Location to download a bootstrap version of Coursier.')
     # TODO(wisechengyi): currently using a custom url for fast iteration.
     # Once the coursier builds are stable, move the logic to binary_util. https://github.com/pantsbuild/pants/issues/5381
     # Ths sha in the version corresponds to the sha in the PR https://github.com/coursier/coursier/pull/774
     # The jar is built by following https://github.com/coursier/coursier/blob/master/DEVELOPMENT.md#build-with-pants
     register('--version', type=str, fingerprint=True,
-             default='1.0.2.e943c8069180d22f352878949f9522ad91d89026',
+             default='1.1.0.cf365ea27a710d5f09db1f0a6feee129aa1fc417',
              help='Version paired with --bootstrap-jar-url, in order to invalidate and fetch the new version.')
     register('--bootstrap-fetch-timeout-secs', type=int, advanced=True, default=10,
              help='Timeout the fetch if the connection is idle for longer than this value.')


### PR DESCRIPTION
Corresponding to https://github.com/coursier/coursier/commit/cf365ea27a710d5f09db1f0a6feee129aa1fc417