### PR TITLE
Document howto set go version

### DIFF
--- a/contrib/go/README.md
+++ b/contrib/go/README.md
@@ -17,6 +17,9 @@ pants_version: 1.0.0
 plugins: [
     'pantsbuild.pants.contrib.go==%(pants_version)s',
   ]
+
+[go-distribution]
+version: 1.10
 ```
 
 On your next run of `./pants` the plugin will be installed and you'll find these new goals:


### PR DESCRIPTION
While setting up a new repo with Go support, one of the first questions
was how to set the Go version. Here we update the docs with how to set
the Go version.