### PR TITLE
Merge TargetRoots subclasses

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from abc import abstractmethod
 
 from pants.util.meta import AbstractClass
-from pants.util.objects import datatype
+from pants.util.objects import Collection, datatype
 
 
 class Spec(AbstractClass):
@@ -58,3 +58,7 @@ class AscendantAddresses(datatype('AscendantAddresses', ['directory']), Spec):
 
   def to_spec_string(self):
     return '{}^'.format(self.directory)
+
+
+class Specs(Collection.of(Spec)):
+  """A collection of Spec subclasses."""

--- a/src/python/pants/base/target_roots.py
+++ b/src/python/pants/base/target_roots.py
@@ -12,17 +12,5 @@ class InvalidSpecConstraint(Exception):
   """Raised when invalid constraints are given via target specs and arguments like --changed*."""
 
 
-class TargetRoots(object):
+class TargetRoots(datatype('TargetRoots', ['specs'])):
   """Determines the target roots for a given pants run."""
-
-
-class ChangedTargetRoots(datatype('ChangedTargetRoots', ['addresses']), TargetRoots):
-  """Target roots that have been altered by `--changed` functionality.
-
-  Contains a list of `Address`es rather than `Spec`s, because all inputs have already been
-  resolved, and are known to exist.
-  """
-
-
-class LiteralTargetRoots(datatype('LiteralTargetRoots', ['specs']), TargetRoots):
-  """User defined target roots, as pants.base.specs.Spec objects."""

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -10,8 +10,9 @@ from collections import namedtuple
 
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.file_system_project_tree import FileSystemProjectTree
+from pants.base.specs import Specs
 from pants.base.target_roots import ChangedTargetRoots, LiteralTargetRoots
-from pants.engine.build_files import BuildFileAddresses, Specs, create_graph_rules
+from pants.engine.build_files import BuildFileAddresses, create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.isolated_process import create_process_rules
 from pants.engine.legacy.address_mapper import LegacyAddressMapper

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -11,8 +11,7 @@ from collections import namedtuple
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.base.specs import Specs
-from pants.base.target_roots import ChangedTargetRoots, LiteralTargetRoots
-from pants.engine.build_files import BuildFileAddresses, create_graph_rules
+from pants.engine.build_files import create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.isolated_process import create_process_rules
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
@@ -82,12 +81,7 @@ class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'symbol_ta
     :param TargetRoots target_roots: The targets root of the request.
     """
     logger.debug('warming target_roots for: %r', target_roots)
-    if type(target_roots) is ChangedTargetRoots:
-      subjects = [BuildFileAddresses(target_roots.addresses)]
-    elif type(target_roots) is LiteralTargetRoots:
-      subjects = [Specs(tuple(target_roots.specs))]
-    else:
-      raise ValueError('Unexpected TargetRoots type: `{}`.'.format(target_roots))
+    subjects = [Specs(tuple(target_roots.specs))]
     request = self.scheduler.execution_request([TransitiveHydratedTargets], subjects)
     result = self.scheduler.execute(request)
     if result.error:

--- a/src/python/pants/build_graph/mutable_build_graph.py
+++ b/src/python/pants/build_graph/mutable_build_graph.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 import traceback
 
-from pants.base.target_roots import ChangedTargetRoots, LiteralTargetRoots
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_graph import BuildGraph
@@ -101,17 +100,10 @@ class MutableBuildGraph(BuildGraph):
                                        .format(message=e, spec=target_address.spec))
 
   def inject_roots_closure(self, target_roots, fail_fast=None):
-    if type(target_roots) is ChangedTargetRoots:
-      for address in target_roots.addresses:
-        self.inject_address_closure(address)
-        yield address
-    elif type(target_roots) is LiteralTargetRoots:
-      for address in self._address_mapper.scan_specs(target_roots.specs,
-                                                     fail_fast=fail_fast):
-        self.inject_address_closure(address)
-        yield address
-    else:
-      raise ValueError('Unrecognized TargetRoots type: `{}`.'.format(target_roots))
+    for address in self._address_mapper.scan_specs(target_roots.specs,
+                                                    fail_fast=fail_fast):
+      self.inject_address_closure(address)
+      yield address
 
   def inject_specs_closure(self, specs, fail_fast=None):
     for address in self._address_mapper.scan_specs(specs,

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import collections
 import inspect
-import sys
 from abc import abstractmethod
 from functools import update_wrapper
 
@@ -15,9 +14,8 @@ import six
 
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Resolvable, Serializable
-from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
-from pants.util.objects import Collection, datatype
+from pants.util.objects import Collection
 
 
 Addresses = Collection.of(Address)

--- a/src/python/pants/engine/addressable.py
+++ b/src/python/pants/engine/addressable.py
@@ -17,29 +17,7 @@ from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.objects import Resolvable, Serializable
 from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
-from pants.util.objects import datatype
-
-
-class Collection(object):
-  """
-  Singleton Collection Type. The ambition is to gain native support for flattening,
-  so methods like <pants.engine.fs.merge_files> won't have to be defined separately.
-  Related to: https://github.com/pantsbuild/pants/issues/3169
-  """
-
-  @classmethod
-  @memoized
-  def of(cls, *element_types):
-    union = '|'.join(element_type.__name__ for element_type in element_types)
-    type_name = b'{}.of({})'.format(cls.__name__, union)
-    supertypes = (cls, datatype('Collection', ['dependencies']))
-    properties = {'element_types': element_types}
-    collection_of_type = type(type_name, supertypes, properties)
-
-    # Expose the custom class type at the module level to be pickle compatible.
-    setattr(sys.modules[cls.__module__], type_name, collection_of_type)
-
-    return collection_of_type
+from pants.util.objects import Collection, datatype
 
 
 Addresses = Collection.of(Address)

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -12,7 +12,7 @@ import six
 
 from pants.base.project_tree import Dir
 from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAddresses,
-                              SingleAddress, Spec)
+                              SingleAddress, Spec, Specs)
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import AddressableDescriptor, BuildFileAddresses, TypeConstraintError
@@ -45,10 +45,6 @@ class BuildFiles(datatype('BuildFiles', ['files_content'])):
 
 class BuildFileGlobs(datatype('BuildFilesGlobs', ['path_globs'])):
   """A wrapper around PathGlobs that are known to match a build file pattern."""
-
-
-class Specs(Collection.of(Spec)):
-  """A collection of Spec subclasses."""
 
 
 @rule(BuildFiles,

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -12,7 +12,7 @@ import six
 
 from pants.base.project_tree import Dir
 from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAddresses,
-                              SingleAddress, Spec, Specs)
+                              SingleAddress, Specs)
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import AddressableDescriptor, BuildFileAddresses, TypeConstraintError

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -15,8 +15,7 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
                               SingleAddress, Spec)
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
-from pants.engine.addressable import (AddressableDescriptor, BuildFileAddresses, Collection,
-                                      TypeConstraintError)
+from pants.engine.addressable import AddressableDescriptor, BuildFileAddresses, TypeConstraintError
 from pants.engine.fs import FilesContent, PathGlobs, Snapshot
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
@@ -24,7 +23,7 @@ from pants.engine.rules import RootRule, SingletonRule, TaskRule, rule
 from pants.engine.selectors import Select, SelectDependencies, SelectProjection
 from pants.engine.struct import Struct
 from pants.util.dirutil import fast_relpath_optional
-from pants.util.objects import datatype
+from pants.util.objects import Collection, datatype
 
 
 class ResolvedTypeMismatchError(ResolveError):

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -9,10 +9,9 @@ from binascii import hexlify
 from os.path import join
 
 from pants.base.project_tree import Dir, File
-from pants.engine.addressable import Collection
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Select
-from pants.util.objects import datatype
+from pants.util.objects import Collection, datatype
 
 
 class FileContent(datatype('FileContent', ['path', 'content'])):

--- a/src/python/pants/engine/legacy/address_mapper.py
+++ b/src/python/pants/engine/legacy/address_mapper.py
@@ -9,11 +9,11 @@ import logging
 import os
 
 from pants.base.build_file import BuildFile
-from pants.base.specs import DescendantAddresses, SiblingAddresses
+from pants.base.specs import DescendantAddresses, SiblingAddresses, Specs
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.address_mapper import AddressMapper
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import BuildFilesCollection, Specs
+from pants.engine.build_files import BuildFilesCollection
 from pants.engine.mapper import ResolveError
 from pants.engine.nodes import Throw
 from pants.util.dirutil import fast_relpath

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -14,14 +14,13 @@ from twitter.common.collections import OrderedSet
 from pants.backend.jvm.targets.jvm_app import Bundle, JvmApp
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.parse_context import ParseContext
-from pants.base.specs import SingleAddress
+from pants.base.specs import SingleAddress, Specs
 from pants.base.target_roots import ChangedTargetRoots, LiteralTargetRoots
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import Specs
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, SourcesField, TargetAdaptor
 from pants.engine.rules import TaskRule, rule

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -20,7 +20,7 @@ from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
-from pants.engine.addressable import BuildFileAddresses, Collection
+from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import Specs
 from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.legacy.structs import BundleAdaptor, BundlesField, SourcesField, TargetAdaptor
@@ -28,7 +28,7 @@ from pants.engine.rules import TaskRule, rule
 from pants.engine.selectors import Select, SelectDependencies, SelectProjection
 from pants.source.wrapped_globs import EagerFilesetWithSpec, FilesetRelPathWrapper
 from pants.util.dirutil import fast_relpath
-from pants.util.objects import datatype
+from pants.util.objects import Collection, datatype
 
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -15,7 +15,6 @@ from pants.backend.jvm.targets.jvm_app import Bundle, JvmApp
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.parse_context import ParseContext
 from pants.base.specs import SingleAddress, Specs
-from pants.base.target_roots import ChangedTargetRoots, LiteralTargetRoots
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.build_graph.build_graph import BuildGraph
@@ -207,14 +206,8 @@ class LegacyBuildGraph(BuildGraph):
       pass
 
   def inject_roots_closure(self, target_roots, fail_fast=None):
-    if type(target_roots) is ChangedTargetRoots:
-      for address in self._inject_addresses(target_roots.addresses):
-        yield address
-    elif type(target_roots) is LiteralTargetRoots:
-      for address in self._inject_specs(target_roots.specs):
-        yield address
-    else:
-      raise ValueError('Unrecognized TargetRoots type: `{}`.'.format(target_roots))
+    for address in self._inject_specs(target_roots.specs):
+      yield address
 
   def inject_specs_closure(self, specs, fail_fast=None):
     # Request loading of these specs.

--- a/src/python/pants/engine/legacy/source_mapper.py
+++ b/src/python/pants/engine/legacy/source_mapper.py
@@ -9,10 +9,9 @@ import os
 
 import six
 
-from pants.base.specs import AscendantAddresses, SingleAddress
+from pants.base.specs import AscendantAddresses, SingleAddress, Specs
 from pants.build_graph.address import parse_spec
 from pants.build_graph.source_mapper import SourceMapper
-from pants.engine.build_files import Specs
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.legacy.graph import HydratedTargets
 from pants.source.filespec import any_matches_filespec

--- a/src/python/pants/init/target_roots_calculator.py
+++ b/src/python/pants/init/target_roots_calculator.py
@@ -11,7 +11,8 @@ from twitter.common.collections import OrderedSet
 
 from pants.base.build_environment import get_buildroot
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
-from pants.base.target_roots import ChangedTargetRoots, LiteralTargetRoots
+from pants.base.specs import SingleAddress
+from pants.base.target_roots import TargetRoots
 from pants.scm.subsystems.changed import ChangedRequest
 
 
@@ -64,6 +65,6 @@ class TargetRootsCalculator(object):
       # alternate target roots.
       changed_addresses = change_calculator.changed_target_addresses(changed_request)
       logger.debug('changed addresses: %s', changed_addresses)
-      return ChangedTargetRoots(tuple(changed_addresses))
+      return TargetRoots(tuple(SingleAddress(a.spec_path, a.target_name) for a in changed_addresses))
 
-    return LiteralTargetRoots(spec_roots)
+    return TargetRoots(spec_roots)

--- a/src/python/pants/scm/change_calculator.py
+++ b/src/python/pants/scm/change_calculator.py
@@ -11,9 +11,8 @@ from abc import abstractmethod
 from collections import defaultdict
 
 from pants.base.build_environment import get_scm
-from pants.base.specs import DescendantAddresses
+from pants.base.specs import DescendantAddresses, Specs
 from pants.build_graph.address import Address
-from pants.engine.build_files import Specs
 from pants.engine.legacy.graph import TransitiveHydratedTargets, target_types_from_symbol_table
 from pants.engine.legacy.source_mapper import EngineSourceMapper
 from pants.goal.workspace import ScmWorkspace

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -83,6 +83,9 @@ python_library(
 python_library(
   name = 'objects',
   sources = ['objects.py'],
+  dependencies = [
+    ':memo',
+  ],
 )
 
 python_library(

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -10,10 +10,10 @@ import unittest
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
+from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress, Specs
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import Specs, UnhydratedStruct, create_graph_rules
+from pants.engine.build_files import UnhydratedStruct, create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError,
                                  DuplicateNameError, UnaddressableObjectError)

--- a/tests/python/pants_test/engine/test_mapper.py
+++ b/tests/python/pants_test/engine/test_mapper.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 
 from pants.base.specs import DescendantAddresses, SiblingAddresses, SingleAddress
 from pants.build_graph.address import Address
-from pants.engine.addressable import BuildFileAddresses, Collection
+from pants.engine.addressable import BuildFileAddresses
 from pants.engine.build_files import Specs, UnhydratedStruct, create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import (AddressFamily, AddressMap, AddressMapper, DifferingFamiliesError,
@@ -22,6 +22,7 @@ from pants.engine.rules import TaskRule
 from pants.engine.selectors import SelectDependencies
 from pants.engine.struct import Struct
 from pants.util.dirutil import safe_open
+from pants.util.objects import Collection
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.engine.util import Target, TargetTable

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -10,9 +10,9 @@ import unittest
 from textwrap import dedent
 
 from pants.base.cmd_line_spec_parser import CmdLineSpecParser
+from pants.base.specs import Specs
 from pants.build_graph.address import Address
 from pants.engine.addressable import BuildFileAddresses
-from pants.engine.build_files import Specs
 from pants.engine.nodes import Return, Throw
 from pants.engine.rules import RootRule, TaskRule
 from pants.engine.selectors import Select, SelectVariant


### PR DESCRIPTION
### Problem

At one point it was necessary for performance purposes (due to #4533) to differentiate between `ChangedTargetRoots` (containing `Address` objects) and `LiteralTargetRoots` containing parsed specs... but with #4533 fixed, the split is no longer necessary.

### Solution

Lift the `Collection` helper to `pants.objects.Collection` to allow for reuse, relocate `Specs` next to types that it holds, and merge the two `TargetRoots` subclasses.