### PR TITLE
Only create native engine resource when needed.

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -593,6 +593,11 @@ class Native(object):
     lib_name = '{}.so'.format(NATIVE_ENGINE_MODULE)
     lib_path = os.path.join(safe_mkdtemp(), lib_name)
     with closing(pkg_resources.resource_stream(__name__, lib_name)) as input_fp:
+      # NB: The header stripping code here must be coordinated with header insertion code in
+      #     build-support/bin/native/bootstrap.sh
+      engine_version = input_fp.readline().strip()
+      repo_version = input_fp.readline().strip()
+      logger.debug('using {} built at {}'.format(engine_version, repo_version))
       with open(lib_path, 'wb') as output_fp:
         output_fp.write(input_fp.read())
     return lib_path


### PR DESCRIPTION
Previously, although the engine was only built when needed, the resource
embedded in the `pantsbuild.pants` wheel was always replaced on every
`./pants` run. When using the daemon, this led to un-necessary
invalidation work on every run. On my machine, this change dropped
~500ms from warm `./pants --enable-pantsd list ::` runs.

A metadata header is now added to the native engine resource containing
its version to allow for ~robust replacement only when needed as well as
some additional sanity check logging of the native engine provenance.
With debug logging turned on, we now can read:
```
DEBUG] using engine_version: 992db34178f6647a7961ec3fadc9f0bb1f2d9747 built at repo_version: release_1.6.0.dev1-13-g39324e46d-dirty
DEBUG] loading native engine python module from: /tmp/tmpkMBxLs
```