### PR TITLE
Per-run metrics for target roots, transitive target counts.

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -265,6 +265,7 @@ class GoalRunner(object):
     should_kill_nailguns = self._kill_nailguns
 
     try:
+      self._context.set_target_count_in_runtracker()
       result = self._execute_engine()
       self._context.set_resulting_graph_size_in_runtracker()
       if result:

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -265,8 +265,9 @@ class GoalRunner(object):
     should_kill_nailguns = self._kill_nailguns
 
     try:
-      self._context.set_target_count_in_runtracker()
+      self._context.set_target_root_count_in_runtracker()
       result = self._execute_engine()
+      self._context.set_affected_target_count_in_runtracker()
       self._context.set_resulting_graph_size_in_runtracker()
       if result:
         self._run_tracker.set_root_outcome(WorkUnit.FAILURE)

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -267,8 +267,8 @@ class GoalRunner(object):
     try:
       with self._context.executing():
         result = self._execute_engine()
-      if result:
-        self._run_tracker.set_root_outcome(WorkUnit.FAILURE)
+        if result:
+          self._run_tracker.set_root_outcome(WorkUnit.FAILURE)
     except KeyboardInterrupt:
       self._run_tracker.set_root_outcome(WorkUnit.FAILURE)
       # On ctrl-c we always kill nailguns, otherwise they might keep running

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -265,10 +265,8 @@ class GoalRunner(object):
     should_kill_nailguns = self._kill_nailguns
 
     try:
-      self._context.set_target_root_count_in_runtracker()
-      result = self._execute_engine()
-      self._context.set_affected_target_count_in_runtracker()
-      self._context.set_resulting_graph_size_in_runtracker()
+      with self._context.executing():
+        result = self._execute_engine()
       if result:
         self._run_tracker.set_root_outcome(WorkUnit.FAILURE)
     except KeyboardInterrupt:

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -125,6 +125,11 @@ class BuildGraph(AbstractClass):
   def __len__(self):
     return len(self._target_by_address)
 
+  def target_file_count(self):
+    """Returns a count of source files owned by all Targets in the BuildGraph."""
+    # TODO: Move this file counting into the `ProductGraph`.
+    return sum(t.sources_count() for t in self.targets())
+
   @abstractmethod
   def clone_new(self):
     """Returns a new BuildGraph instance of the same type and with the same __init__ params."""

--- a/src/python/pants/build_graph/build_graph.py
+++ b/src/python/pants/build_graph/build_graph.py
@@ -51,7 +51,6 @@ class BuildGraph(AbstractClass):
       super(BuildGraph.ManualSyntheticTargetError, self).__init__(
           'Found a manually-defined target at synthetic address {}'.format(addr.spec))
 
-
   class NoDepPredicateWalk(object):
     """This is a utility class to aid in graph traversals that don't have predicates on dependency edges."""
 
@@ -80,7 +79,6 @@ class BuildGraph(AbstractClass):
     def dep_predicate(self, target, dep, level):
       return True
 
-
   class DepthAgnosticWalk(NoDepPredicateWalk):
     """This is a utility class to aid in graph traversals that don't care about the depth."""
 
@@ -90,7 +88,6 @@ class BuildGraph(AbstractClass):
 
     def dep_predicate(self, target, dep, level):
       return self._dep_predicate(target, dep)
-
 
   class DepthAwareWalk(NoDepPredicateWalk):
     """This is a utility class to aid in graph traversals that care about the depth."""
@@ -124,6 +121,9 @@ class BuildGraph(AbstractClass):
 
   def __init__(self):
     self.reset()
+
+  def __len__(self):
+    return len(self._target_by_address)
 
   @abstractmethod
   def clone_new(self):

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -547,6 +547,10 @@ class Target(AbstractTarget):
     """
     return self._sources_field.sources
 
+  def sources_count(self):
+    """Returns the count of source files owned by the target."""
+    return len(self._sources_field.sources)
+
   @property
   def derived_from(self):
     """Returns the target this target was derived from.

--- a/src/python/pants/build_graph/target.py
+++ b/src/python/pants/build_graph/target.py
@@ -549,7 +549,7 @@ class Target(AbstractTarget):
 
   def sources_count(self):
     """Returns the count of source files owned by the target."""
-    return len(self._sources_field.sources)
+    return len(self._sources_field.sources.files)
 
   @property
   def derived_from(self):

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -155,6 +155,14 @@ class Context(object):
     ident = Target.identify(self.targets())
     return 'Context(id:{}, targets:{})'.format(ident, self.targets())
 
+  def set_target_count_in_runtracker(self):
+    """Sets the affected target count in the run tracker's daemon stats object."""
+    # N.B. `self._target_roots` is always an expanded list of `Target` objects as
+    # provided by `GoalRunner`.
+    target_count = len(self._target_roots)
+    self.run_tracker.pantsd_stats.set_target_root_size(target_count)
+    return target_count
+
   def set_resulting_graph_size_in_runtracker(self):
     """Sets the resulting graph size in the run tracker's daemon stats object."""
     node_count = self._scheduler.graph_len()

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -155,7 +155,15 @@ class Context(object):
     ident = Target.identify(self.targets())
     return 'Context(id:{}, targets:{})'.format(ident, self.targets())
 
-  def set_target_root_count_in_runtracker(self):
+  @contextmanager
+  def executing(self):
+    """A contextmanager that sets metrics in the context of a (v1) engine execution."""
+    self._set_target_root_count_in_runtracker()
+    yield
+    self._set_affected_target_count_in_runtracker()
+    self._set_resulting_graph_size_in_runtracker()
+
+  def _set_target_root_count_in_runtracker(self):
     """Sets the target root count in the run tracker's daemon stats object."""
     # N.B. `self._target_roots` is always an expanded list of `Target` objects as
     # provided by `GoalRunner`.
@@ -163,13 +171,13 @@ class Context(object):
     self.run_tracker.pantsd_stats.set_target_root_size(target_count)
     return target_count
 
-  def set_affected_target_count_in_runtracker(self):
+  def _set_affected_target_count_in_runtracker(self):
     """Sets the realized target count in the run tracker's daemon stats object."""
     target_count = len(self.build_graph)
     self.run_tracker.pantsd_stats.set_affected_targets_size(target_count)
     return target_count
 
-  def set_resulting_graph_size_in_runtracker(self):
+  def _set_resulting_graph_size_in_runtracker(self):
     """Sets the resulting graph size in the run tracker's daemon stats object."""
     node_count = self._scheduler.graph_len()
     self.run_tracker.pantsd_stats.set_resulting_graph_size(node_count)

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -161,6 +161,7 @@ class Context(object):
     self._set_target_root_count_in_runtracker()
     yield
     self._set_affected_target_count_in_runtracker()
+    self._set_affected_target_files_count_in_runtracker()
     self._set_resulting_graph_size_in_runtracker()
 
   def _set_target_root_count_in_runtracker(self):
@@ -176,6 +177,13 @@ class Context(object):
     target_count = len(self.build_graph)
     self.run_tracker.pantsd_stats.set_affected_targets_size(target_count)
     return target_count
+
+  def _set_affected_target_files_count_in_runtracker(self):
+    """Sets the realized target file count in the run tracker's daemon stats object."""
+    # TODO: Move this file counting into the `ProductGraph`.
+    target_file_count = self.build_graph.target_file_count()
+    self.run_tracker.pantsd_stats.set_affected_targets_file_count(target_file_count)
+    return target_file_count
 
   def _set_resulting_graph_size_in_runtracker(self):
     """Sets the resulting graph size in the run tracker's daemon stats object."""

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -155,12 +155,18 @@ class Context(object):
     ident = Target.identify(self.targets())
     return 'Context(id:{}, targets:{})'.format(ident, self.targets())
 
-  def set_target_count_in_runtracker(self):
-    """Sets the affected target count in the run tracker's daemon stats object."""
+  def set_target_root_count_in_runtracker(self):
+    """Sets the target root count in the run tracker's daemon stats object."""
     # N.B. `self._target_roots` is always an expanded list of `Target` objects as
     # provided by `GoalRunner`.
     target_count = len(self._target_roots)
     self.run_tracker.pantsd_stats.set_target_root_size(target_count)
+    return target_count
+
+  def set_affected_target_count_in_runtracker(self):
+    """Sets the realized target count in the run tracker's daemon stats object."""
+    target_count = len(self.build_graph)
+    self.run_tracker.pantsd_stats.set_affected_targets_size(target_count)
     return target_count
 
   def set_resulting_graph_size_in_runtracker(self):

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -13,12 +13,16 @@ class PantsDaemonStats(object):
     self.preceding_graph_size = None
     self.resulting_graph_size = None
     self.target_root_size = 0
+    self.affected_targets_size = 0
 
   def set_preceding_graph_size(self, size):
     self.preceding_graph_size = size
 
   def set_target_root_size(self, size):
     self.target_root_size = size
+
+  def set_affected_targets_size(self, size):
+    self.affected_targets_size = size
 
   def set_resulting_graph_size(self, size):
     self.resulting_graph_size = size
@@ -27,5 +31,6 @@ class PantsDaemonStats(object):
     return {
       'preceding_graph_size': self.preceding_graph_size,
       'target_root_size': self.target_root_size,
+      'affected_targets_size': self.affected_targets_size,
       'resulting_graph_size': self.resulting_graph_size,
     }

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -11,9 +11,10 @@ class PantsDaemonStats(object):
 
   def __init__(self):
     self.preceding_graph_size = None
-    self.resulting_graph_size = None
     self.target_root_size = 0
     self.affected_targets_size = 0
+    self.affected_targets_file_count = 0
+    self.resulting_graph_size = None
 
   def set_preceding_graph_size(self, size):
     self.preceding_graph_size = size
@@ -24,6 +25,9 @@ class PantsDaemonStats(object):
   def set_affected_targets_size(self, size):
     self.affected_targets_size = size
 
+  def set_affected_targets_file_count(self, count):
+    self.affected_targets_file_count = count
+
   def set_resulting_graph_size(self, size):
     self.resulting_graph_size = size
 
@@ -32,5 +36,6 @@ class PantsDaemonStats(object):
       'preceding_graph_size': self.preceding_graph_size,
       'target_root_size': self.target_root_size,
       'affected_targets_size': self.affected_targets_size,
+      'affected_targets_file_count': self.affected_targets_file_count,
       'resulting_graph_size': self.resulting_graph_size,
     }

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -12,9 +12,13 @@ class PantsDaemonStats(object):
   def __init__(self):
     self.preceding_graph_size = None
     self.resulting_graph_size = None
+    self.target_root_size = 0
 
   def set_preceding_graph_size(self, size):
     self.preceding_graph_size = size
+
+  def set_target_root_size(self, size):
+    self.target_root_size = size
 
   def set_resulting_graph_size(self, size):
     self.resulting_graph_size = size
@@ -22,5 +26,6 @@ class PantsDaemonStats(object):
   def get_all(self):
     return {
       'preceding_graph_size': self.preceding_graph_size,
+      'target_root_size': self.target_root_size,
       'resulting_graph_size': self.resulting_graph_size,
     }

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -49,9 +49,6 @@ class FilesetWithSpec(AbstractClass):
     self.filespec = filespec
     self._validate_globs_in_filespec(filespec, rel_root)
 
-  def __len__(self):
-    return len(self.files)
-
   def _validate_globs_in_filespec(self, filespec, rel_root):
     for glob in filespec['globs']:
       if not glob.startswith(rel_root):

--- a/src/python/pants/source/wrapped_globs.py
+++ b/src/python/pants/source/wrapped_globs.py
@@ -49,6 +49,9 @@ class FilesetWithSpec(AbstractClass):
     self.filespec = filespec
     self._validate_globs_in_filespec(filespec, rel_root)
 
+  def __len__(self):
+    return len(self.files)
+
   def _validate_globs_in_filespec(self, filespec, rel_root):
     for glob in filespec['globs']:
       if not glob.startswith(rel_root):


### PR DESCRIPTION
This should help ensure a more stable sizing metric for runs.

```
[omerta pants (kwlzn/more_metrics)]$ PANTS_ENABLE_PANTSD=True ./pants -q list 3rdparty/python:psutil 3rdparty/python:requests --run-tracker-stats-local-json-file=test.json | wc -l ; cat test.json | json.tool | grep -A5 pantsd_stats

       2
    "pantsd_stats": {
        "affected_targets_size": 2,
        "preceding_graph_size": 0,
        "resulting_graph_size": 27,
        "target_root_size": 2
    },
[omerta pants (kwlzn/more_metrics)]$ PANTS_ENABLE_PANTSD=True ./pants -q list : --run-tracker-stats-local-json-file=test.json | wc -l ; cat test.json | json.tool | grep -A5 pantsd_stats

       8
    "pantsd_stats": {
        "affected_targets_size": 15,
        "preceding_graph_size": 5,
        "resulting_graph_size": 99,
        "target_root_size": 8
    },
[omerta pants (kwlzn/more_metrics)]$ PANTS_ENABLE_PANTSD=True ./pants -q list :: --run-tracker-stats-local-json-file=test.json | wc -l ; cat test.json | json.tool | grep -A5 pantsd_stats

    1558
    "pantsd_stats": {
        "affected_targets_size": 1562,
        "preceding_graph_size": 19,
        "resulting_graph_size": 15256,
        "target_root_size": 1558
    },
[omerta pants (kwlzn/more_metrics)]$ PANTS_ENABLE_PANTSD=True ./pants -q list : --run-tracker-stats-local-json-file=test.json | wc -l ; cat test.json | json.tool | grep -A5 pantsd_stats

       8
    "pantsd_stats": {
        "affected_targets_size": 15,
        "preceding_graph_size": 5086,
        "resulting_graph_size": 5166,
        "target_root_size": 8
    },
[omerta pants (kwlzn/more_metrics)]$ ./pants -q list : --run-tracker-stats-local-json-file=test.json | wc -l ; cat test.json | json.tool | grep -A5 pantsd_stats

       8
    "pantsd_stats": {
        "affected_targets_size": 15,
        "preceding_graph_size": -1,
        "resulting_graph_size": 95,
        "target_root_size": 8
    },
[omerta pants (kwlzn/more_metrics)]$ ./pants -q list :: --run-tracker-stats-local-json-file=test.json | wc -l ; cat test.json | json.tool | grep -A5 pantsd_stats

    1558
    "pantsd_stats": {
        "affected_targets_size": 1562,
        "preceding_graph_size": -1,
        "resulting_graph_size": 15254,
        "target_root_size": 1558
    },
```