### PR TITLE
Handle `native_engine.so` resources without headers.

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -194,7 +194,7 @@ function bootstrap_native_code() {
   #     the Native.binary method in src/python/pants/engine/native.py.
   if [[
     ! -f "${NATIVE_ENGINE_RESOURCE}" ||
-    "$(head -1 "${NATIVE_ENGINE_RESOURCE}")" != "${engine_version_header}"
+    "$(head -1 "${NATIVE_ENGINE_RESOURCE}" | tr '\0' '\n')" != "${engine_version_header}"
   ]]
   then
     cat "${target_binary_metadata}" "${target_binary}" > "${NATIVE_ENGINE_RESOURCE}"


### PR DESCRIPTION
Previously, although bootstrapping worked fine when a `native_engine.so`
resource file was present without headers (switching from an old branch
to a newer one), reading the 1st line from the headerless resource
emitted the following warning to stderr:
  warning: command substitution: ignored null byte in input

Tighten up the script to handle these cases more gracefully by scrubbing
null bytes.