### PR TITLE
Memoize stable task creation

### DIFF
--- a/src/python/pants/goal/BUILD
+++ b/src/python/pants/goal/BUILD
@@ -58,6 +58,7 @@ python_library(
   dependencies = [
     ':error',
     'src/python/pants/option',
+    'src/python/pants/util:memo',
   ],
 )
 


### PR DESCRIPTION
### Problem

After `Goal.clear()`, task subclasses created for the same superclasses and scopes will not be equal/identical to those from before `Goal.clear()`.

As part of its maintenance of the task/goal lifecycle, `pantsd` clears the goals, which currently causes the creation of multiple non-identical but otherwise equal subclasses, and that caused me some confusion on #5639 where I was attempting to use task classes as dict keys.

### Solution

Memoize creation of the stable task subclasses (similar to the strategy used in `Collection.of`).

### Result

Task classes behave as expected in #5639.