### PR TITLE
mypy: make the task more like a "lint" task

### DIFF
--- a/contrib/mypy/src/python/pants/contrib/mypy/register.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/register.py
@@ -11,4 +11,4 @@ from pants.contrib.mypy.tasks.mypy_task import MypyTask
 
 
 def register_goals():
-  task(name='mypy', action=MypyTask).install('mypy')
+  task(name='mypy', action=MypyTask).install('lint')

--- a/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
+++ b/contrib/mypy/src/python/pants/contrib/mypy/tasks/mypy_task.py
@@ -19,6 +19,7 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TaskError
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.python.python_repos import PythonRepos
+from pants.task.lint_task_mixin import LintTaskMixin
 from pants.util.contextutil import temporary_file_path
 from pants.util.memo import memoized_property
 from pants.util.process_handler import subprocess
@@ -27,7 +28,7 @@ from pex.pex import PEX
 from pex.pex_info import PexInfo
 
 
-class MypyTask(ResolveRequirementsTaskBase):
+class MypyTask(LintTaskMixin, ResolveRequirementsTaskBase):
   """Invoke the mypy static type analyzer for Python."""
 
   _PYTHON_SOURCE_EXTENSION = '.py'
@@ -38,17 +39,25 @@ class MypyTask(ResolveRequirementsTaskBase):
     round_manager.require_data(PythonInterpreter)
 
   @classmethod
+  def subsystem_dependencies(cls):
+    return super(MypyTask, cls).subsystem_dependencies() + (PythonRepos, PythonSetup)
+
+  @classmethod
   def register_options(cls, register):
-    register('--mypy-version', default='0.550', help='The version of mypy to use.')
-    register('--config-file', default=None,
+    super(MypyTask, cls).register_options(register)
+    register('--mypy-version', default='0.580', fingerprint=True,
+             help='The version of mypy to use.')
+    register('--config-file', default=None, fingerprint=True,
              help='Path mypy configuration file, relative to buildroot.')
+    register('--search-source-roots', type=bool, default=True, fingerprint=True, advanced=True,
+             help='Add source roots for targets to the MYPYPATH.')
 
   @classmethod
   def supports_passthru_args(cls):
     return True
 
   def find_py3_interpreter(self):
-    interpreters = self._interpreter_cache.setup(filters=['>=3'])
+    interpreters = self._interpreter_cache.setup(filters=['>=3.4'])
     return min(interpreters) if interpreters else None
 
   @staticmethod
@@ -62,9 +71,9 @@ class MypyTask(ResolveRequirementsTaskBase):
 
   def _calculate_python_sources(self, targets):
     """Generate a set of source files from the given targets."""
-    python_eval_targets = filter(self.is_non_synthetic_python_target, targets)
+    lintable_python_targets = filter(self.is_non_synthetic_python_target, targets)
     sources = set()
-    for target in python_eval_targets:
+    for target in lintable_python_targets:
       sources.update(
         source for source in target.sources_relative_to_buildroot()
         if os.path.splitext(source)[1] == self._PYTHON_SOURCE_EXTENSION
@@ -101,20 +110,20 @@ class MypyTask(ResolveRequirementsTaskBase):
     pex = WrappedPEX(PEX(path, py3_interpreter), py3_interpreter)
     return pex.run(mypy_args, **kwargs)
 
-  def execute(self):
+  def _lint(self, targets):
     py3_interpreter = self.find_py3_interpreter()
     if not py3_interpreter:
-      raise TaskError('Unable to find a Python 3.x interpreter (required for mypy).')
+      raise TaskError('Unable to find a compatible Python 3.x interpreter (v3.4 or higher is required for mypy).')
 
-    sources = self._calculate_python_sources(self.context.target_roots)
+    sources = self._calculate_python_sources(targets)
     if not sources:
       self.context.log.debug('No Python sources to check.')
       return
 
     # Determine interpreter used by the sources so we can tell mypy.
-    interpreter_for_targets = self._interpreter_cache.select_interpreter_for_targets(self.context.target_roots)
+    interpreter_for_targets = self._interpreter_cache.select_interpreter_for_targets(targets)
     if not interpreter_for_targets:
-      raise TaskError('No Python interpreter compatible with specified sources.')
+      raise TaskError('Unable to find a Python interpreter compatible with the specified sources.')
 
     with temporary_file_path() as sources_list_path:
       with open(sources_list_path, 'w') as f:
@@ -123,19 +132,23 @@ class MypyTask(ResolveRequirementsTaskBase):
 
       # Construct the mypy command line.
       cmd = ['--python-version={}'.format(interpreter_for_targets.identity.python)]
+
       if self.get_options().config_file:
-        cmd.append('--config-file={}'.format(os.path.join(get_buildroot(),
-                                                          self.get_options().config_file)))
+        config_file_path = os.path.join(get_buildroot(), self.get_options().config_file)
+        cmd.append('--config-file={}'.format(config_file_path))
+
       cmd.extend(self.get_passthru_args())
       cmd.append('@{}'.format(sources_list_path))
       self.context.log.debug('mypy command: {}'.format(' '.join(cmd)))
 
       # Collect source roots for the targets being checked.
-      source_roots = self._collect_source_roots()
+      env = {}
+      if self.get_options().search_source_roots:
+        source_roots = self._collect_source_roots()
+        mypy_path = os.pathsep.join([os.path.join(get_buildroot(), root) for root in source_roots])
+        env['MYPYPATH'] = mypy_path
+        self.context.log.debug('setting MYPYPATH to {}'.format(mypy_path))
 
-      mypy_path = os.pathsep.join([os.path.join(get_buildroot(), root) for root in source_roots])
-
-      # Execute mypy.
       with self.context.new_workunit(
         name='check',
         labels=[WorkUnitLabel.TOOL, WorkUnitLabel.RUN],
@@ -143,6 +156,16 @@ class MypyTask(ResolveRequirementsTaskBase):
                                       colors=self.get_options().colors),
         cmd=' '.join(cmd)) as workunit:
         returncode = self._run_mypy(py3_interpreter, cmd,
-          env={'MYPYPATH': mypy_path}, stdout=workunit.output('stdout'), stderr=subprocess.STDOUT)
+                                    env=env, stdout=workunit.output('stdout'), stderr=subprocess.STDOUT)
         if returncode != 0:
           raise TaskError('mypy failed: code={}'.format(returncode))
+
+  def execute(self):
+    if self.get_options().skip:
+      self.context.log.debug('mypy disabled')
+      return
+
+    python_targets = self.get_targets(self.is_non_synthetic_python_target)
+    with self.invalidated(python_targets) as invalidation_check:
+      targets = [vt.target for vt in invalidation_check.invalid_vts]
+      self._lint(targets)

--- a/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
+++ b/contrib/mypy/tests/python/pants_test/contrib/mypy/tasks/test_mypy_integration.py
@@ -11,7 +11,9 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 class MypyIntegrationTest(PantsRunIntegrationTest):
   def test_mypy(self):
     cmd = [
-      'mypy',
+      'lint.mypy',
+      '--no-lint-mypy-skip',
+      '--no-lint-mypy-transitive',
       'contrib/mypy/tests/python/pants_test/contrib/mypy::',
       '--',
       '--follow-imports=silent'
@@ -24,5 +26,4 @@ class MypyIntegrationTest(PantsRunIntegrationTest):
       # Python 3.x was not found. Test whether mypy task fails for that reason.
       with self.pants_results(cmd) as pants_run:
         self.assert_failure(pants_run)
-        self.assertIn('Unable to find a Python 3.x interpreter (required for mypy)',
-                      pants_run.stdout_data)
+        self.assertIn('Unable to find a Python 3.x interpreter', pants_run.stdout_data)

--- a/pants.ini
+++ b/pants.ini
@@ -206,6 +206,9 @@ configuration: %(pants_supportdir)s/checkstyle/coding_style.xml
 [lint.google-java-format]
 skip: True
 
+[lint.mypy]
+skip: True
+
 [lint.python-eval]
 # After we fix the cycles from the engine refactor we should re-enable this.
 # https://github.com/pantsbuild/pants/issues/4601


### PR DESCRIPTION
Changes:

- Use mypy v0.580 (which reqiures Python v3.4 or higher).
- Install mypy under the `lint` goal.
- Use the lint-related skip and transitive options.
- Allow disabling adding source roots to MYPYPATH.
- Use artifact caching to cache success.

This PR updates the mypy plugin to make it more like a regular lint task.

Open questions:

1. Should the fingerprint take the contents of the mypy config file into account?
2. What about pass-through parameters?
