### PR TITLE
[junit-runner] cache localhost lookups to ease OSX/JDK DNS issues

### DIFF
--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -44,6 +44,24 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 class AntJunitXmlReportListener extends RunListener {
 
+  // NB: Cache the localhost name as a workaround for an issue where localhost resolution on OSX
+  // may take seconds.
+  // See: https://bugs.openjdk.java.net/browse/JDK-8170910
+  private static String localHostName = null;
+
+  private static String getLocalHostName() {
+    if (localHostName == null) {
+      String hostName;
+      try {
+        hostName = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        hostName = "localhost";
+      }
+      localHostName = hostName;
+    }
+    return localHostName;
+  }
+
   /**
    * A JAXB bean describing a test case exception.  These may indicate either an assertion failure
    * or an uncaught test exception.
@@ -235,11 +253,7 @@ class AntJunitXmlReportListener extends RunListener {
     TestSuite(Description test) {
       name = test.getClassName();
       testClass = test.getTestClass();
-      try {
-        hostname = InetAddress.getLocalHost().getHostName();
-      } catch (UnknownHostException e) {
-        hostname = "localhost";
-      }
+      hostname = getLocalHostName();
     }
 
     public int getErrors() {


### PR DESCRIPTION
### Problem

OSX's DNS service's handling of localhost names changed, I think with 10.12, in a way that combined with JDK releases after a particular point release of 1.8 causes looking up localhost's name to take on the order of seconds for some folks. https://bugs.openjdk.java.net/browse/JDK-8170910

### Solution
This patch memoizes the localhost lookup used by the xml listener of Pants' junit runner so that it won't be re-looked up per test suite entry.

As a workaround for the problem, OSX users can add an additional name in their `/etc/hosts` file for 127.0.0.1, eg

```
127.0.0.1       localhost My-MacBook-Pro
```