### PR TITLE
Ban testprojects/pants-plugins from TestProjectsIntegrationTest

### DIFF
--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -94,7 +94,9 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
 
     simply_skip = [
       # Already tested at pants_test.backend.jvm.targets.test_jar_dependency_integration.JarDependencyIntegrationTest
-      'testprojects/3rdparty/org/pantsbuild/testprojects:testprojects'
+      'testprojects/3rdparty/org/pantsbuild/testprojects:testprojects',
+      # Already tested in 'PantsRequirementIntegrationTest' and 'SetupPyIntegrationTest'.
+      'testprojects/pants-plugins/*',
     ]
 
     targets_to_exclude = (known_failing_targets + negative_test_targets + need_java_8 +


### PR DESCRIPTION
### Problem

These tests were previously stabilized by running against private publishes in #5610 and #5520. But because they were still covered by `TestProjectsIntegrationTest` (outside the context of the private publish), they failed there instead.

### Solution

Ban them from `TestProjectsIntegrationTest`.