### PR TITLE
Run `lint` in commit hooks

### DIFF
--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -18,8 +18,9 @@ $(git rev-parse --verify master > /dev/null 2>&1)
 if [[ $? -eq 0 ]]; then
   echo "* Checking imports" && ./build-support/bin/isort.sh || \
     die "To fix import sort order, run \`./build-support/bin/isort.sh -f\`"
+  echo "* Checking lint" && ./pants -q --changed-parent=master lint || exit 1
 else
   # When travis builds a tag, it does so in a shallow clone without master fetched, which
   # fails in pants changed.
-  echo "* Skipping import check in partial working copy."
+  echo "* Skipping import/lint checks in partial working copy."
 fi


### PR DESCRIPTION
### Problem

The third travis shard runs `./pants lint`, and frequently fails with trivial errors like unused imports.

### Solution

Add `./pants --changed-parent=master lint` to the pre-commit hooks.