### PR TITLE
Add explicit JAXB dependencies in the junit-runner so it works in Java 9+ without --add-modules=java.xml.bind

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -30,6 +30,26 @@ jar_library(name='jansi',
               jar('org.fusesource.jansi', 'jansi', '1.11'),
             ])
 
+jar_library(name='javax-activation',
+            jars=[
+              jar('com.sun.activation', 'javax.activation', '1.2.0'),
+            ])
+
+jar_library(name='jaxb-api',
+            jars=[
+              jar('javax.xml.bind', 'jaxb-api', '2.3.0'),
+            ])
+
+jar_library(name='jaxb-core',
+            jars=[
+              jar('com.sun.xml.bind', 'jaxb-core', '2.3.0'),
+            ])
+
+jar_library(name='jaxb-impl',
+            jars=[
+              jar('com.sun.xml.bind', 'jaxb-impl', '2.3.0'),
+            ])
+
 jar_library(name='jsr305',
             jars=[
               jar('com.google.code.findbugs', 'jsr305', '3.0.2'),

--- a/3rdparty/jvm/org/mockito/BUILD
+++ b/3rdparty/jvm/org/mockito/BUILD
@@ -4,6 +4,6 @@
 jar_library(
   name='mockito-core',
   jars=[
-    jar(org='org.mockito', name='mockito-core', rev='2.7.21'),
+    jar(org='org.mockito', name='mockito-core', rev='2.17.0'),
   ],
 )

--- a/src/java/org/pantsbuild/tools/junit/BUILD
+++ b/src/java/org/pantsbuild/tools/junit/BUILD
@@ -14,6 +14,10 @@ java_library(
   dependencies=[
     '3rdparty:args4j',
     '3rdparty:guava',
+    '3rdparty:javax-activation',
+    '3rdparty:jaxb-api',
+    '3rdparty:jaxb-core',
+    '3rdparty:jaxb-impl',
     '3rdparty:junit',
     '3rdparty/jvm/commons-io:commons-io',
     'src/java/org/pantsbuild/args4j',


### PR DESCRIPTION
### Problem

In Java 9 and 10 they have removed default access for the JAXB classes from the JDK.  In order to use them you need to add `--add-modules=java.xml.bind` to the java invocation of the junit-testrunner

### Solution

Add explicit dependencies for the JAXB jars

### Result

The junit-testrunner can run under Java 9 and Java 10 with no additional command line flags.