### PR TITLE
Fix shader to not shade .class files under META-INF directory

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/shader.py
+++ b/src/python/pants/backend/jvm/subsystems/shader.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 import re
 from collections import namedtuple
@@ -18,6 +19,9 @@ from pants.java.jar.jar_dependency import JarDependency
 from pants.subsystem.subsystem import Subsystem, SubsystemError
 from pants.util.contextutil import temporary_file
 from pants.util.memo import memoized_method
+
+
+logger = logging.getLogger(__name__)
 
 
 class UnaryRule(namedtuple('UnaryRule', ['name', 'pattern'])):
@@ -308,7 +312,7 @@ class Shader(object):
   def _potential_package_path(path):
     # TODO(John Sirois): Implement a full valid java package name check, `-` just happens to get
     # the common non-package cases like META-INF/...
-    return path.endswith('.class') or path.endswith('.java') and '-' not in path
+    return (path.endswith('.class') or path.endswith('.java')) and '-' not in path
 
   @classmethod
   def _iter_dir_packages(cls, path):
@@ -435,6 +439,7 @@ class Shader(object):
     :rtype: :class:`pants.java.executor.Executor.Runner`
     """
     with self.temporary_rules_file(rules) as rules_file:
+      logger.debug('Running jarjar with rules:\n{}'.format(' '.join(rule.render() for rule in rules)))
       yield self._executor.runner(classpath=self._jarjar_classpath,
                                   main='org.pantsbuild.jarjar.Main',
                                   jvm_options=jvm_options,

--- a/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
+++ b/tests/python/pants_test/backend/jvm/subsystems/test_shader.py
@@ -65,6 +65,16 @@ class ShaderTest(unittest.TestCase):
     self.assertEqual(Shader.exclude_package(), rules[2])
     self.assertIn(Shader.exclude_package('javax.annotation'), rules[3:])
 
+  def test_assemble_classes_in_meta_inf(self):
+    input_jar = self.populate_input_jar('org/pantsbuild/tools/fake/Main.class',
+                                        'META-INF/versions/9/javax/xml/bind/ModuleInfo.class')
+
+    rules = self.shader.assemble_binary_rules('org.pantsbuild.tools.fake.Main', input_jar)
+
+    self.assertEqual(Shader.exclude_package('org.pantsbuild.tools.fake'), rules[0])
+    self.assertIn(Shader.exclude_package('javax.annotation'), rules[1:])
+    self.assertNotIn(Shading.create_relocate('META-INF.versions.9.javax.xml.bind.*'), rules[1:])
+
   def test_runner_command(self):
     input_jar = self.populate_input_jar('main.class', 'com/google/common/base/Function.class')
     custom_rules = [Shader.exclude_package('log4j', recursive=True)]


### PR DESCRIPTION
### Problem

If a jar contained a class file under META-INF than the shader would try to relocate it.

### Solution

Fix the conditional in `_potential_package_path` to exclude class files in META-INF

### Result

The shader no longer tries to shade class files under META-INF