### PR TITLE
Remove SelectProjection

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -235,12 +235,11 @@ def addresses_from_address_families(address_mapper, specs):
     matched = False
     for af in address_families:
       for a in af.addressables.keys():
-        if a in included:
-          continue
         if not exclude_address(a) and (predicate is None or predicate(a)):
           matched = True
-          addresses.append(a)
-          included.add(a)
+          if a not in included:
+            addresses.append(a)
+            included.add(a)
     return matched
 
   for spec in specs.dependencies:

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -178,7 +178,7 @@ class RuleIndex(datatype('RuleIndex', ['rules', 'roots'])):
       # TODO: The heterogenity here has some confusing implications here:
       # see https://github.com/pantsbuild/pants/issues/4005
       for kind in rule.output_constraint.types:
-        # NB Ensure that interior types from SelectDependencies / SelectProjections work by
+        # NB Ensure that interior types from SelectDependencies work by
         # indexing on the list of types in the constraint.
         add_task(kind, rule)
       add_task(rule.output_constraint, rule)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -21,8 +21,7 @@ from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcess
 from pants.engine.native import Function, TypeConstraint, TypeId
 from pants.engine.nodes import Return, State, Throw
 from pants.engine.rules import RuleIndex, SingletonRule, TaskRule
-from pants.engine.selectors import (Select, SelectDependencies, SelectProjection, SelectVariant,
-                                    constraint_for)
+from pants.engine.selectors import Select, SelectDependencies, SelectVariant, constraint_for
 from pants.engine.struct import HasProducts, Variants
 from pants.util.contextutil import temporary_file_path
 from pants.util.objects import datatype
@@ -209,12 +208,6 @@ class WrappedNativeScheduler(object):
                                                        self._to_constraint(selector.dep_product),
                                                        self._to_utf8_buf(selector.field),
                                                        self._to_ids_buf(selector.field_types))
-      elif selector_type is SelectProjection:
-        self._native.lib.tasks_add_select_projection(self._tasks,
-                                                     self._to_constraint(selector.product),
-                                                     TypeId(self._to_id(selector.projected_subject)),
-                                                     self._to_utf8_buf(selector.field),
-                                                     self._to_constraint(selector.input_product))
       else:
         raise ValueError('Unrecognized Selector type: {}'.format(selector))
     for get in rule.input_gets:

--- a/src/python/pants/engine/selectors.py
+++ b/src/python/pants/engine/selectors.py
@@ -174,36 +174,3 @@ class SelectDependencies(datatype('Dependencies', ['product', 'dep_product', 'fi
                                      type_or_constraint_repr(self.dep_product),
                                      field_name_portion,
                                      field_types_portion)
-
-
-class SelectProjection(datatype('Projection', ['product', 'projected_subject', 'field', 'input_product']), Selector):
-  """Selects a field of the given Subject to produce a Subject, Product dependency from.
-
-  Projecting an input allows for deduplication in the graph, where multiple Subjects
-  resolve to a single backing Subject instead.
-
-  For convenience, if a single field is requested and it is of the requested type, the field value
-  is projected directly rather than attempting to use it to construct the projected type.
-  """
-  optional = False
-
-  def __new__(cls, product, projected_subject, field, input_product):
-    if not isinstance(field, six.string_types):
-      raise ValueError('Expected `field` to be a string, but was: {!r}'.format(field))
-    return super(SelectProjection, cls).__new__(cls, product, projected_subject, field, input_product)
-
-  @property
-  def input_product_selector(self):
-    return Select(self.input_product)
-
-  @property
-  def projected_product_selector(self):
-    return Select(self.product)
-
-  def __repr__(self):
-    return '{}({}, {}, {}, {})'.format(type(self).__name__,
-                                       type_or_constraint_repr(self.product),
-                                       self.projected_subject.__name__,
-                                       repr(self.field),
-                                       getattr(
-                                         self.input_product, '__name__', repr(self.input_product)))

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -74,18 +74,6 @@ pub fn store_i32(val: i32) -> Value {
   with_externs(|e| (e.store_i32)(e.context, val))
 }
 
-pub fn project(value: &Value, field: &str, type_id: &TypeId) -> Value {
-  with_externs(|e| {
-    (e.project)(
-      e.context,
-      value,
-      field.as_ptr(),
-      field.len() as u64,
-      type_id,
-    )
-  })
-}
-
 pub fn project_ignoring_type(value: &Value, field: &str) -> Value {
   with_externs(|e| (e.project_ignoring_type)(e.context, value, field.as_ptr(), field.len() as u64))
 }
@@ -103,13 +91,7 @@ pub fn project_multi_strs(item: &Value, field: &str) -> Vec<String> {
 
 pub fn project_str(value: &Value, field: &str) -> String {
   let name_val = with_externs(|e| {
-    (e.project)(
-      e.context,
-      value,
-      field.as_ptr(),
-      field.len() as u64,
-      &e.py_str_type,
-    )
+    (e.project_ignoring_type)(e.context, value, field.as_ptr(), field.len() as u64)
   });
   val_to_str(&name_val)
 }
@@ -248,7 +230,6 @@ pub struct Externs {
   pub store_list: StoreListExtern,
   pub store_bytes: StoreBytesExtern,
   pub store_i32: StoreI32Extern,
-  pub project: ProjectExtern,
   pub project_ignoring_type: ProjectIgnoringTypeExtern,
   pub project_multi: ProjectMultiExtern,
   pub type_to_str: TypeToStrExtern,
@@ -286,14 +267,6 @@ pub type StoreListExtern =
 pub type StoreBytesExtern = extern "C" fn(*const ExternContext, *const u8, u64) -> Value;
 
 pub type StoreI32Extern = extern "C" fn(*const ExternContext, i32) -> Value;
-
-pub type ProjectExtern = extern "C" fn(
-  *const ExternContext,
-  *const Value,
-  field_name_ptr: *const u8,
-  field_name_len: u64,
-  *const TypeId,
-) -> Value;
 
 #[repr(C)]
 #[derive(Debug)]

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -43,10 +43,10 @@ use context::Core;
 use core::{Failure, Function, Key, TypeConstraint, TypeId, Value};
 use externs::{Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionExtern,
               DropHandlesExtern, EqualsExtern, EvalExtern, ExternContext, Externs,
-              GeneratorSendExtern, IdentifyExtern, LogExtern, ProjectExtern,
-              ProjectIgnoringTypeExtern, ProjectMultiExtern, PyResult, SatisfiedByExtern,
-              SatisfiedByTypeExtern, StoreBytesExtern, StoreI32Extern, StoreListExtern,
-              TypeIdBuffer, TypeToStrExtern, ValToStrExtern};
+              GeneratorSendExtern, IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern,
+              ProjectMultiExtern, PyResult, SatisfiedByExtern, SatisfiedByTypeExtern,
+              StoreBytesExtern, StoreI32Extern, StoreListExtern, TypeIdBuffer, TypeToStrExtern,
+              ValToStrExtern};
 use rule_graph::{GraphMaker, RuleGraph};
 use scheduler::{ExecutionRequest, RootResult, Scheduler};
 use tasks::Tasks;
@@ -137,7 +137,6 @@ pub extern "C" fn externs_set(
   store_list: StoreListExtern,
   store_bytes: StoreBytesExtern,
   store_i32: StoreI32Extern,
-  project: ProjectExtern,
   project_ignoring_type: ProjectIgnoringTypeExtern,
   project_multi: ProjectMultiExtern,
   create_exception: CreateExceptionExtern,
@@ -161,7 +160,6 @@ pub extern "C" fn externs_set(
     store_list,
     store_bytes,
     store_i32,
-    project,
     project_ignoring_type,
     project_multi,
     create_exception,
@@ -370,24 +368,6 @@ pub extern "C" fn tasks_add_select_dependencies(
       dep_product,
       field.to_string().expect("field to be a string"),
       field_types.to_vec(),
-    );
-  })
-}
-
-#[no_mangle]
-pub extern "C" fn tasks_add_select_projection(
-  tasks_ptr: *mut Tasks,
-  product: TypeConstraint,
-  projected_subject: TypeId,
-  field: Buffer,
-  input_product: TypeConstraint,
-) {
-  with_tasks(tasks_ptr, |tasks| {
-    tasks.add_select_projection(
-      product,
-      projected_subject,
-      field.to_string().expect("field to be a string"),
-      input_product,
     );
   })
 }

--- a/src/rust/engine/src/selectors.rs
+++ b/src/rust/engine/src/selectors.rs
@@ -33,19 +33,7 @@ pub struct SelectDependencies {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct SelectProjection {
-  pub product: TypeConstraint,
-  // TODO: This should in theory be a TypeConstraint, but because the `project` operation
-  // needs to construct an instance of the type if the result doesn't match, we use
-  // a concrete type here.
-  pub projected_subject: TypeId,
-  pub field: Field,
-  pub input_product: TypeConstraint,
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Selector {
   Select(Select),
   SelectDependencies(SelectDependencies),
-  SelectProjection(SelectProjection),
 }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 
 use core::{Field, Function, Key, TypeConstraint, TypeId, Value, FNV};
 use externs;
-use selectors::{Get, Select, SelectDependencies, SelectProjection, Selector};
+use selectors::{Get, Select, SelectDependencies, Selector};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Task {
@@ -132,21 +132,6 @@ impl Tasks {
       dep_product: dep_product,
       field: field,
       field_types: field_types,
-    }));
-  }
-
-  pub fn add_select_projection(
-    &mut self,
-    product: TypeConstraint,
-    projected_subject: TypeId,
-    field: Field,
-    input_product: TypeConstraint,
-  ) {
-    self.clause(Selector::SelectProjection(SelectProjection {
-      product: product,
-      projected_subject: projected_subject,
-      field: field,
-      input_product: input_product,
     }));
   }
 

--- a/tests/python/pants_test/engine/test_selectors.py
+++ b/tests/python/pants_test/engine/test_selectors.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-from pants.engine.selectors import Select, SelectDependencies, SelectProjection, SelectVariant
+from pants.engine.selectors import Select, SelectDependencies, SelectVariant
 
 
 class AClass(object):
@@ -30,10 +30,6 @@ class SelectorsTest(unittest.TestCase):
                      SelectDependencies(AClass, AClass, field='some_field', field_types=(AClass,)))
     self.assert_repr("SelectDependencies(AClass, AClass)",
                      SelectDependencies(AClass, AClass))
-
-  def test_projection_repr(self):
-    self.assert_repr("SelectProjection(AClass, AClass, u'field', AClass)",
-                     SelectProjection(AClass, AClass, 'field', AClass))
 
   def assert_repr(self, expected, selector):
     self.assertEqual(expected, repr(selector))


### PR DESCRIPTION
`SelectProjection` is entirely superseded by the new `@rule` coroutine syntax from #5580.