### PR TITLE
Make coursier resolve more friendly

### DIFF
--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -208,16 +208,25 @@ contents a directory tree, a giant jar, or something else.
 Toolchain
 ---------
 
+### Ivy
+
 Pants uses [Ivy](http://ant.apache.org/ivy/) to resolve `jar` dependencies. To change how Pants
 resolves these, configure `resolve.ivy`.
+
+### Coursier
 
 Starting at release `1.4.0.dev26`, Pants added an option to pick [coursier](https://github.com/coursier/coursier)
 as the JVM 3rdparty resolver, with performance improvement being the main motivation. The goal is to retire ivy
 eventually.
 
-### Example config to use coursier
+#### *Limitation*
 
-#### For Pants >= 1.7.x
+* Currently coursier only supports maven style repo resolves. [Resolving with ivy settings is still not mature](https://github.com/coursier/coursier/issues/created_by/benjyw).
+* Coursier does not do publishing.
+
+#### Example config to use coursier
+
+##### For Pants >= 1.7.x
 
     :::ini
     # This will turn on coursier and turn off ivy.
@@ -246,7 +255,7 @@ eventually.
         :::bash
         ./pants --cache-ignore --resolver-resolver=coursier resolve.coursier --report examples/tests/scala/org/pantsbuild/example/hello/welcome -ldebug
 
-#### For Pants <= 1.6.x
+##### For Pants <= 1.6.x
 
     :::ini
     # This will turn on coursier and turn off ivy.
@@ -281,9 +290,13 @@ eventually.
         '-A', 'jar,bundle,test-jar,maven-plugin,src,doc,aar'
       ]
 
+### Nailgun
+
 Pants uses [Nailgun](https://github.com/martylamb/nailgun) to speed up compiles. Nailgun is a
 JVM daemon that runs in the background. This means you don't need to start up a JVM and load
 classes for each JVM-based operation. Things go faster.
+
+### Zinc
 
 Pants uses Zinc, a dependency tracking compiler facade that supports sub-target incremental
 compilation for Java and Scala.

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -219,7 +219,7 @@ Starting at release `1.4.0.dev26`, Pants added an option to pick [coursier](http
 as the JVM 3rdparty resolver, with performance improvement being the main motivation. The goal is to retire ivy
 eventually.
 
-#### *Limitation*
+#### Limitation
 
 * Currently coursier only supports maven style repo resolves. [Resolving with ivy settings is still not mature](https://github.com/coursier/coursier/issues/created_by/benjyw).
 * Coursier does not do publishing.

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -253,7 +253,7 @@ eventually.
 * To show coursier command line invocation, use `-ldebug`
 
         :::bash
-        ./pants --cache-ignore --resolver-resolver=coursier resolve.coursier --report examples/tests/scala/org/pantsbuild/example/hello/welcome -ldebug
+        ./pants --resolver-resolver=coursier resolve.coursier --report examples/tests/scala/org/pantsbuild/example/hello/welcome -ldebug
 
 ##### For Pants <= 1.6.x
 

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -231,11 +231,12 @@ eventually. Example config to use coursier:
     jvm_options: ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
 
     [coursier]
+    repos: ['https://repo1.maven.org/maven2', 'https://dl.google.com/dl/android/maven2/']
+
     # Change the following if you choose to [build coursier jar from scratch](https://github.com/coursier/coursier/blob/master/DEVELOPMENT.md#build-with-pants)
     # or to fetch from different location.
     bootstrap_jar_url: <url>
     version: <version>
-    repos: ['https://repo1.maven.org/maven2', 'https://dl.google.com/dl/android/maven2/']
 
 ### For Pants <= 1.6.x
 

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -135,7 +135,7 @@ lives somewhere outside the workspace.
 ### Depending on a Jar
 
 The test example depends on a jar, `junit`. Instead of compiling from
-source, Pants invokes ivy to fetch such jars. To reduce the danger of
+source, Pants invokes the resolver to fetch such jars. To reduce the danger of
 version conflicts, we use the 3rdparty idiom: we keep references to
 these "third-party" jars together in `BUILD` files under the `3rdparty/`
 directory. Thus, the test has a `3rdparty` dependency:

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -211,6 +211,67 @@ Toolchain
 Pants uses [Ivy](http://ant.apache.org/ivy/) to resolve `jar` dependencies. To change how Pants
 resolves these, configure `resolve.ivy`.
 
+Starting at release `1.4.0.dev26`, Pants added an option to pick [coursier](https://github.com/coursier/coursier)
+as the JVM 3rdparty resolver, with performance improvement being the main motivation. The goal is to retire ivy
+eventually. Example config to use coursier:
+
+### For Pants >= 1.7.x
+
+    :::ini
+    # This will turn on coursier and turn off ivy.
+    [resolver]
+    resolver: coursier
+
+    [resolve.coursier]
+    # jvm option in case of large resolves
+    jvm_options: ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
+
+    [export]
+    # Same if needed for large resolves
+    jvm_options: ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
+
+    [coursier]
+    # Change the following if you choose to [build coursier jar from scratch](https://github.com/coursier/coursier/blob/master/DEVELOPMENT.md#build-with-pants)
+    # or to fetch from different location.
+    bootstrap_jar_url: <url>
+    version: <version>
+    repos: ['https://repo1.maven.org/maven2', 'https://dl.google.com/dl/android/maven2/']
+
+### For Pants <= 1.6.x
+
+    :::ini
+    # This will turn on coursier and turn off ivy.
+    [resolver]
+    resolver: coursier
+
+    [export]
+    # Same if needed for large resolves
+    jvm_options: ['-Xmx4g', '-XX:MaxMetaspaceSize=256m']
+
+    [coursier]
+    # Change the following if you choose to [build coursier jar from scratch](https://github.com/coursier/coursier/blob/master/DEVELOPMENT.md#build-with-pants)
+    # or to fetch from different location.
+    bootstrap_jar_url: <url>
+    version: <version>
+
+    fetch_options: [
+        # Specify maven repos
+        '-r', 'https://repo1.maven.org/maven2/',
+        '-r', 'https://dl.google.com/dl/android/maven2/',
+
+        # Quiet mode
+        '-q',
+
+        # Do not use default public maven repo.
+        '--no-default',
+
+        # Concurrent workers
+        '-n', '10',
+
+        # Specify the type of artifacts to fetch
+        '-A', 'jar,bundle,test-jar,maven-plugin,src,doc,aar'
+      ]
+
 Pants uses [Nailgun](https://github.com/martylamb/nailgun) to speed up compiles. Nailgun is a
 JVM daemon that runs in the background. This means you don't need to start up a JVM and load
 classes for each JVM-based operation. Things go faster.

--- a/examples/src/java/org/pantsbuild/example/README.md
+++ b/examples/src/java/org/pantsbuild/example/README.md
@@ -213,9 +213,11 @@ resolves these, configure `resolve.ivy`.
 
 Starting at release `1.4.0.dev26`, Pants added an option to pick [coursier](https://github.com/coursier/coursier)
 as the JVM 3rdparty resolver, with performance improvement being the main motivation. The goal is to retire ivy
-eventually. Example config to use coursier:
+eventually.
 
-### For Pants >= 1.7.x
+### Example config to use coursier
+
+#### For Pants >= 1.7.x
 
     :::ini
     # This will turn on coursier and turn off ivy.
@@ -238,7 +240,13 @@ eventually. Example config to use coursier:
     bootstrap_jar_url: <url>
     version: <version>
 
-### For Pants <= 1.6.x
+* To inspect the resolve result, specify `--resolver-coursier-report`
+* To show coursier command line invocation, use `-ldebug`
+
+        :::bash
+        ./pants --cache-ignore --resolver-resolver=coursier resolve.coursier --report examples/tests/scala/org/pantsbuild/example/hello/welcome -ldebug
+
+#### For Pants <= 1.6.x
 
     :::ini
     # This will turn on coursier and turn off ivy.

--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -39,7 +39,20 @@ class CoursierSubsystem(Subsystem):
     register('--repos', type=list, fingerprint=True,
              help='Maven style repos', default=['https://repo1.maven.org/maven2'])
     register('--fetch-options', type=list, fingerprint=True,
+             default=[
+               # Quiet mode, so coursier does not show resolve progress,
+               # but still prints results if --report is specified.
+               '-q',
+               # Do not use default public maven repo.
+               '--no-default',
+               # Concurrent workers
+               '-n', '8',
+             ],
              help='Additional options to pass to coursier fetch. See `coursier fetch --help`')
+    register('--artifact-types', type=list, fingerprint=True,
+             default=['jar', 'bundle', 'test-jar', 'maven-plugin', 'src', 'doc', 'aar'],
+             help='Specify the type of artifacts to fetch. See `packaging` at https://maven.apache.org/pom.html#Maven_Coordinates, '
+                  'except `src` and `doc` being coursier specific terms for sources and javadoc.')
     register('--bootstrap-jar-url', fingerprint=True,
              default='https://dl.dropboxusercontent.com/s/zwh074l9kxhqlwp/coursier-cli-1.1.0.cf365ea27a710d5f09db1f0a6feee129aa1fc417.jar?dl=0',
              help='Location to download a bootstrap version of Coursier.')

--- a/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
+++ b/src/python/pants/backend/jvm/tasks/coursier/coursier_subsystem.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 import os
 
-from pants.base.build_environment import get_buildroot
+from pants.base.build_environment import get_buildroot, get_pants_cachedir
 from pants.base.workunit import WorkUnit, WorkUnitLabel
 from pants.java.distribution.distribution import DistributionLocator
 from pants.net.http.fetcher import Fetcher
@@ -33,6 +33,11 @@ class CoursierSubsystem(Subsystem):
   @classmethod
   def register_options(cls, register):
     super(CoursierSubsystem, cls).register_options(register)
+    register('--cache-dir', type=str, fingerprint=True,
+             default=os.path.join(get_pants_cachedir(), 'coursier'),
+             help='Version paired with --bootstrap-jar-url, in order to invalidate and fetch the new version.')
+    register('--repos', type=list, fingerprint=True,
+             help='Maven style repos', default=['https://repo1.maven.org/maven2'])
     register('--fetch-options', type=list, fingerprint=True,
              help='Additional options to pass to coursier fetch. See `coursier fetch --help`')
     register('--bootstrap-jar-url', fingerprint=True,

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -58,7 +58,7 @@ class CoursierMixin(NailgunTask):
     register('--allow-global-excludes', type=bool, advanced=False, fingerprint=True, default=True,
              help='Whether global excludes are allowed.')
     register('--report', type=bool, advanced=False, default=False,
-             help='Show the resolve output. This would also force a resolve even if this task is validated.')
+             help='Show the resolve output. This would also force a resolve even if the resolve task is validated.')
 
   @staticmethod
   def _compute_jars_to_resolve_and_pin(raw_jars, artifact_set, manager):

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -57,7 +57,7 @@ class CoursierMixin(NailgunTask):
     super(CoursierMixin, cls).register_options(register)
     register('--allow-global-excludes', type=bool, advanced=False, fingerprint=True, default=True,
              help='Whether global excludes are allowed.')
-    register('--report', type=bool, advanced=False, fingerprint=True, default=False,
+    register('--report', type=bool, advanced=False, fingerprint=False, default=False,
              help='Show the resolve output.')
 
   @staticmethod
@@ -146,11 +146,11 @@ class CoursierMixin(NailgunTask):
         pants_jar_base_dir = self._prepare_workdir(pants_workdir)
         coursier_cache_dir = CoursierSubsystem.global_instance().get_options().cache_dir
 
-        # Check each individual target without context first
-        if not invalidation_check.invalid_vts:
-
+        # If a report is requested, do not proceed with loading validated result.
+        if not self.get_options().report:
+          # Check each individual target without context first
           # If the individuals are valid, check them as a VersionedTargetSet
-          if resolve_vts.valid:
+          if not invalidation_check.invalid_vts and resolve_vts.valid:
             # Load up from the results dir
             success = self._load_from_results_dir(compile_classpath, vt_set_results_dir,
                                                   coursier_cache_dir, invalidation_check, pants_jar_base_dir)

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -57,8 +57,8 @@ class CoursierMixin(NailgunTask):
     super(CoursierMixin, cls).register_options(register)
     register('--allow-global-excludes', type=bool, advanced=False, fingerprint=True, default=True,
              help='Whether global excludes are allowed.')
-    register('--report', type=bool, advanced=False, fingerprint=False, default=False,
-             help='Show the resolve output.')
+    register('--report', type=bool, advanced=False, default=False,
+             help='Show the resolve output. This would also force a resolve even if this task is validated.')
 
   @staticmethod
   def _compute_jars_to_resolve_and_pin(raw_jars, artifact_set, manager):

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -252,11 +252,13 @@ class CoursierMixin(NailgunTask):
     repos = coursier_subsystem_instance.get_options().repos
     # make [repoX, repoY] -> ['-r', repoX, '-r', repoY]
     repo_args = list(itertools.chain(*zip(['-r'] * len(repos), repos)))
+    artifact_types_arg = ['-A', ','.join(coursier_subsystem_instance.get_options().artifact_types)]
+    advanced_options = coursier_subsystem_instance.get_options().fetch_options
     common_args = ['fetch',
                    # Print the resolution tree
                    '-t',
                    '--cache', coursier_cache_path
-                   ] + repo_args + coursier_subsystem_instance.get_options().fetch_options
+                   ] + repo_args + artifact_types_arg + advanced_options
 
     coursier_work_temp_dir = os.path.join(pants_workdir, 'tmp')
     safe_mkdir(coursier_work_temp_dir)

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -140,7 +140,8 @@ class CoursierMixin(NailgunTask):
         resolve_vts = VersionedTargetSet.from_versioned_targets(invalidation_check.all_vts)
 
         vt_set_results_dir = self._prepare_vts_results_dir(pants_workdir, resolve_vts)
-        coursier_cache_dir, pants_jar_base_dir = self._prepare_workdir(pants_workdir)
+        coursier_cache_dir = self.get_options().cache_dir
+        pants_jar_base_dir = self._prepare_workdir(pants_workdir)
 
         # Check each individual target without context first
         if not invalidation_check.invalid_vts:
@@ -187,15 +188,11 @@ class CoursierMixin(NailgunTask):
   def _prepare_workdir(self, pants_workdir):
     """
     Given pants workdir, prepare the location in pants workdir to store all the symlinks
-    and coursier cache dir.
+    to coursier cache dir.
     """
-    coursier_cache_dir = os.path.join(self.get_options().pants_bootstrapdir, 'coursier')
     pants_jar_base_dir = os.path.join(pants_workdir, 'coursier', 'cache')
-
-    # Only pants_jar_path_base needs to be touched whereas coursier_cache_path will
-    # be managed by coursier
     safe_mkdir(pants_jar_base_dir)
-    return coursier_cache_dir, pants_jar_base_dir
+    return pants_jar_base_dir
 
   def _get_result_from_coursier(self, jars_to_resolve, global_excludes, pinned_coords, pants_workdir,
                                 coursier_cache_path, sources, javadoc):

--- a/tests/python/pants_test/backend/jvm/tasks/BUILD
+++ b/tests/python/pants_test/backend/jvm/tasks/BUILD
@@ -296,6 +296,16 @@ python_tests(
 )
 
 python_tests(
+  name = 'coursier_resolve_integration',
+  sources = ['test_coursier_integration.py'],
+  dependencies = [
+    'src/python/pants/util:contextutil',
+    'tests/python/pants_test:int-test',
+  ],
+  tags = {'integration'},
+)
+
+python_tests(
   name = 'ivy_resolve_integration',
   sources = ['test_ivy_resolve_integration.py'],
   dependencies = [

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_integration.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class CouriserIntegrationTest(PantsRunIntegrationTest):
+  def test_coursier_show_report(self):
+    pants_run = self.run_pants(["--resolver-resolver=coursier",
+                                "--resolve-coursier-report",
+                                "resolve",
+                                "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"])
+    self.assert_success(pants_run)
+    # Coursier report looks like this:
+    #    Result:
+    #  ├─ org.scala-lang:scala-library:2.11.11
+    #  ├─ junit:junit:4.12
+    #  │  └─ org.hamcrest:hamcrest-core:1.3
+    #  └─ org.scalatest:scalatest_2.11:3.0.0
+    #     ├─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+    #     ├─ org.scala-lang:scala-reflect:2.11.8
+    #     │  └─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+    #     ├─ org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4
+    #     │  └─ org.scala-lang:scala-library:2.11.6 -> 2.11.11
+    #     ├─ org.scala-lang.modules:scala-xml_2.11:1.0.5
+    #     │  └─ org.scala-lang:scala-library:2.11.7 -> 2.11.11
+    #     └─ org.scalactic:scalactic_2.11:3.0.0
+    #        ├─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+    #        └─ org.scala-lang:scala-reflect:2.11.8
+    #           └─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.11/1.0.5/scala-xml_2.11-1.0.5.jar
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scalatest/scalatest_2.11/3.0.0/scalatest_2.11-3.0.0.jar
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar
+    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.11/3.0.0/scalactic_2.11-3.0.0.jar
+    self.assertIn('Result:', pants_run.stdout_data)
+    self.assertIn('junit:junit:4.12', pants_run.stdout_data)

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_integration.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
@@ -10,38 +10,43 @@ from pants_test.pants_run_integration_test import PantsRunIntegrationTest
 
 class CouriserIntegrationTest(PantsRunIntegrationTest):
   def test_coursier_show_report(self):
-    pants_run = self.run_pants(["--resolver-resolver=coursier",
-                                "--resolve-coursier-report",
-                                "resolve",
-                                "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"])
-    self.assert_success(pants_run)
-    # Coursier report looks like this:
-    #    Result:
-    #  ├─ org.scala-lang:scala-library:2.11.11
-    #  ├─ junit:junit:4.12
-    #  │  └─ org.hamcrest:hamcrest-core:1.3
-    #  └─ org.scalatest:scalatest_2.11:3.0.0
-    #     ├─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
-    #     ├─ org.scala-lang:scala-reflect:2.11.8
-    #     │  └─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
-    #     ├─ org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4
-    #     │  └─ org.scala-lang:scala-library:2.11.6 -> 2.11.11
-    #     ├─ org.scala-lang.modules:scala-xml_2.11:1.0.5
-    #     │  └─ org.scala-lang:scala-library:2.11.7 -> 2.11.11
-    #     └─ org.scalactic:scalactic_2.11:3.0.0
-    #        ├─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
-    #        └─ org.scala-lang:scala-reflect:2.11.8
-    #           └─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.11/1.0.5/scala-xml_2.11-1.0.5.jar
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scalatest/scalatest_2.11/3.0.0/scalatest_2.11-3.0.0.jar
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar
-    #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.11/3.0.0/scalactic_2.11-3.0.0.jar
-    self.assertIn('Result:', pants_run.stdout_data)
-    self.assertIn('junit:junit:4.12', pants_run.stdout_data)
+    with self.temporary_workdir() as workdir:
+      # Run the coursier report twice in a row with the same workdir to check that
+      # --report forces a resolve even though the task is validated.
+      for _ in range(2):
+        pants_run = self.run_pants_with_workdir(command=["--resolver-resolver=coursier",
+                                                         "--resolve-coursier-report",
+                                                         "resolve",
+                                                         "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"],
+                                                workdir=workdir)
+        self.assert_success(pants_run)
+        # Coursier report looks like this:
+        #    Result:
+        #  ├─ org.scala-lang:scala-library:2.11.11
+        #  ├─ junit:junit:4.12
+        #  │  └─ org.hamcrest:hamcrest-core:1.3
+        #  └─ org.scalatest:scalatest_2.11:3.0.0
+        #     ├─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+        #     ├─ org.scala-lang:scala-reflect:2.11.8
+        #     │  └─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+        #     ├─ org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4
+        #     │  └─ org.scala-lang:scala-library:2.11.6 -> 2.11.11
+        #     ├─ org.scala-lang.modules:scala-xml_2.11:1.0.5
+        #     │  └─ org.scala-lang:scala-library:2.11.7 -> 2.11.11
+        #     └─ org.scalactic:scalactic_2.11:3.0.0
+        #        ├─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+        #        └─ org.scala-lang:scala-reflect:2.11.8
+        #           └─ org.scala-lang:scala-library:2.11.8 -> 2.11.11
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.11/1.0.5/scala-xml_2.11-1.0.5.jar
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.8/scala-reflect-2.11.8.jar
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scalatest/scalatest_2.11/3.0.0/scalatest_2.11-3.0.0.jar
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.11/scala-library-2.11.11.jar
+        #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.11/3.0.0/scalactic_2.11-3.0.0.jar
+        self.assertIn('Result:', pants_run.stdout_data)
+        self.assertIn('junit:junit:4.12', pants_run.stdout_data)
 
   def test_coursier_no_report(self):
     pants_run = self.run_pants(["--resolver-resolver=coursier",

--- a/tests/python/pants_test/backend/jvm/tasks/test_coursier_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_coursier_integration.py
@@ -42,3 +42,10 @@ class CouriserIntegrationTest(PantsRunIntegrationTest):
     #  /Users/me/.cache/pants/coursier/https/repo1.maven.org/maven2/org/scalactic/scalactic_2.11/3.0.0/scalactic_2.11-3.0.0.jar
     self.assertIn('Result:', pants_run.stdout_data)
     self.assertIn('junit:junit:4.12', pants_run.stdout_data)
+
+  def test_coursier_no_report(self):
+    pants_run = self.run_pants(["--resolver-resolver=coursier",
+                                "resolve",
+                                "examples/tests/scala/org/pantsbuild/example/hello/welcome:welcome"])
+    self.assert_success(pants_run)
+    self.assertNotIn('Result:', pants_run.stdout_data)


### PR DESCRIPTION
Address points from #5382

* Extract the following coursier options and assign sensible defaults
  * artifact types
  * cache dir
  * fetch options
  * repos
* Add `--report` flag to show coursier output
* Add documentation