### PR TITLE
Cleanup `unused_parens` warning for cast.

### DIFF
--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -726,7 +726,7 @@ impl Snapshot {
       &context.core.types.construct_snapshot,
       &[
         externs::store_bytes(&(item.digest.0).to_hex().as_bytes()),
-        externs::store_i32((item.digest.1 as i32)),
+        externs::store_i32(item.digest.1 as i32),
         externs::store_list(path_stats.iter().collect(), false),
       ],
     )


### PR DESCRIPTION
The warning looked like so:
```
   Compiling process_execution v0.0.1 (file:///home/jsirois/dev/pantsbuild/jsirois-pants/src/rust/engine/process_execution)
warning: unnecessary parentheses around function argument
   --> src/nodes.rs:729:28
    |
729 |         externs::store_i32((item.digest.1 as i32)),
    |                            ^^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
    |
    = note: #[warn(unused_parens)] on by default
```