### PR TITLE
Upgrade virtualenv.

### DIFF
--- a/build-support/virtualenv
+++ b/build-support/virtualenv
@@ -3,7 +3,7 @@
 
 set -e
 
-VIRTUALENV_VERSION=15.1.0
+VIRTUALENV_VERSION=15.2.0
 VIRTUALENV_PACKAGE_LOCATION=${VIRTUALENV_PACKAGE_LOCATION:-https://pypi.io/packages/source/v/virtualenv}
 
 if [[ $GIT_HOOK == 1 ]] ; then


### PR DESCRIPTION
This is a good thing in its own right, more modern pip, setuptools,
wheel for bootstrapping pants and running release steps, but its also a
naive attempt to fix pip install errors on OSX in ci.

Release notes here: https://pypi.python.org/pypi/virtualenv/15.2.0