### PR TITLE
Fix matching for duplicated Specs

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -235,11 +235,12 @@ def addresses_from_address_families(address_mapper, specs):
     matched = False
     for af in address_families:
       for a in af.addressables.keys():
+        if a in included:
+          continue
         if not exclude_address(a) and (predicate is None or predicate(a)):
           matched = True
-          if a not in included:
-            addresses.append(a)
-            included.add(a)
+          addresses.append(a)
+          included.add(a)
     return matched
 
   for spec in specs.dependencies:

--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -235,12 +235,11 @@ def addresses_from_address_families(address_mapper, specs):
     matched = False
     for af in address_families:
       for a in af.addressables.keys():
-        if a in included:
-          continue
         if not exclude_address(a) and (predicate is None or predicate(a)):
           matched = True
-          addresses.append(a)
-          included.add(a)
+          if a not in included:
+            addresses.append(a)
+            included.add(a)
     return matched
 
   for spec in specs.dependencies:


### PR DESCRIPTION
### Problem

If a `Specs` object contains multiple `Spec` objects matching a single address, the second instance will fail to match. This is easy to do by just listing the same `Spec` twice (and which can be defended against by deduping), but it's also possible to hit by matching both `SingleAddress('a', 'a')` and `DescendantAddresses('')` in the same call.

### Solution

I encountered this bug while testing #5672, and fixed it there. This PR reverts that fix and reapplies it (in order to make it cherry-pickable), and adds a test to cover it.