### PR TITLE
Use absolute path to check_rust_formatting

### DIFF
--- a/build-support/bin/pre-commit.sh
+++ b/build-support/bin/pre-commit.sh
@@ -12,12 +12,12 @@ fi
 echo "* Checking packages" && ./build-support/bin/check_packages.sh || exit 1
 echo "* Checking headers" && ./build-support/bin/check_header.sh || exit 1
 echo "* Checking for banned imports" && ./build-support/bin/check_banned_imports.sh || exit 1
-echo "* Checking formatting of rust files" && ./build-support/bin/check_rust_formatting.sh || exit 1
+echo "* Checking formatting of rust files" && "$(pwd)/build-support/bin/check_rust_formatting.sh" || exit 1
 
 $(git rev-parse --verify master > /dev/null 2>&1)
 if [[ $? -eq 0 ]]; then
   echo "* Checking imports" && ./build-support/bin/isort.sh || \
-    die "To fix import sort order, run \`./build-support/bin/isort.sh -f\`"
+    die "To fix import sort order, run \`\"$(pwd)/build-support/bin/isort.sh\" -f\`"
   echo "* Checking lint" && ./pants -q --changed-parent=master lint || exit 1
 else
   # When travis builds a tag, it does so in a shallow clone without master fetched, which


### PR DESCRIPTION
The script outputs its own path as a suggestion to run, which is incorrect if you're not in the repo root.