### PR TITLE
Plumb requirement blacklist through to the pex resolver

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -14,7 +14,7 @@ packaging==16.8
 pathspec==0.5.0
 parameterized==0.6.1
 pep8==1.6.2
-pex==1.3.1
+pex==1.3.2
 psutil==4.3.0
 pyflakes==1.1.0
 Pygments==1.4

--- a/src/python/pants/backend/python/subsystems/python_setup.py
+++ b/src/python/pants/backend/python/subsystems/python_setup.py
@@ -64,6 +64,17 @@ class PythonSetup(Subsystem):
              help='A list of paths to search for python interpreters. Note that if a PEX_PYTHON_PATH '
               'variable is defined in a pexrc file, those interpreter paths will take precedence over ' 
               'this option.')
+    register('--resolver-blacklist', advanced=True, type=dict, default={},
+             metavar='<blacklist>',
+             help='A blacklist dict (str->str) that maps package name to an interpreter '
+              'constraint. If a package name is in the blacklist and its interpreter '
+              'constraint matches the target interpreter, skip the requirement. This is needed '
+              'to ensure that universal requirement resolves for a target interpreter version do '
+              'not error out on interpreter specific requirements such as backport libs like '
+              '`functools32`. For example, a valid blacklist is {"functools32": "CPython>3"}. '
+              'NOTE: this keyword is a temporary fix and will be reverted per: '
+              'https://github.com/pantsbuild/pants/issues/5696. The long term '
+              'solution is tracked by: https://github.com/pantsbuild/pex/issues/456.')
 
   @property
   def interpreter_constraints(self):
@@ -108,6 +119,10 @@ class PythonSetup(Subsystem):
   @property
   def resolver_allow_prereleases(self):
     return self.get_options().resolver_allow_prereleases
+
+  @property
+  def resolver_blacklist(self):
+    return self.get_options().resolver_blacklist
 
   @property
   def artifact_cache_dir(self):

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -162,7 +162,8 @@ def dump_requirements(builder, interpreter, reqs, log, platforms=None):
   find_links = OrderedSet()
   for req in deduped_reqs:
     log.debug('  Dumping requirement: {}'.format(req))
-    builder.add_requirement(req.requirement)
+    if not req.key in PythonSetup.global_instance().resolver_blacklist:
+      builder.add_requirement(req.requirement)
     if req.repository:
       find_links.add(req.repository)
 
@@ -209,6 +210,7 @@ def _resolve_multi(interpreter, requirements, platforms, find_links):
       context=python_repos.get_network_context(),
       cache=requirements_cache_dir,
       cache_ttl=python_setup.resolver_cache_ttl,
-      allow_prereleases=python_setup.resolver_allow_prereleases)
+      allow_prereleases=python_setup.resolver_allow_prereleases,
+      pkg_blacklist=python_setup.resolver_blacklist)
 
   return distributions

--- a/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
@@ -1,0 +1,18 @@
+python_binary(
+  name='test_bin',
+  source='main.py',
+  compatibility=['CPython>3'],
+  dependencies=[
+    ':reqlib'
+  ]
+)
+
+# Without blacklisting, pex resolver will error out
+# on a transitive requirement of jupyter (functools32)
+# when resolving for Python 3.
+python_requirement_library(
+	name='reqlib',
+	requirements=[
+		python_requirement('jupyter')
+	]
+)

--- a/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
@@ -11,8 +11,8 @@ python_binary(
 # on a transitive requirement of jupyter (functools32)
 # when resolving for Python 3.
 python_requirement_library(
-	name='reqlib',
-	requirements=[
-		python_requirement('jupyter')
-	]
+  name='reqlib',
+  requirements=[
+    python_requirement('jupyter'),
+  ]
 )

--- a/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/main.py
+++ b/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/main.py
@@ -1,0 +1,3 @@
+import jupyter
+print(jupyter)
+print('Successful.')

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -184,3 +184,25 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
                '--quiet']
     pants_run = self.run_pants(command=command)
     return pants_run.stdout_data.rstrip().split('\n')[-1]
+
+  def test_pex_resolver_blacklist_integration(self):
+    py3 = '3'
+    if self.skip_if_no_python(py3):
+      return
+    pex = os.path.join(os.getcwd(), 'dist', 'test_bin.pex')
+    try:
+      pants_ini_config = {'python-setup': {'resolver_blacklist': {"functools32": "CPython>3"}}}
+      # clean-all to ensure that Pants resolves requirements for each run.
+      pants_binary_36 = self.run_pants(
+        command=['clean-all', 'binary', '{}:test_bin'.format(os.path.join(self.testproject,'resolver_blacklist_testing'))],
+        config=pants_ini_config
+      )
+      self.assert_success(pants_binary_36)
+      pants_run_36 = self.run_pants(
+        command=['clean-all', 'run', '{}:test_bin'.format(os.path.join(self.testproject,'resolver_blacklist_testing'))],
+        config=pants_ini_config
+      )
+      self.assert_success(pants_run_36)
+    finally:
+      if os.path.exists(pex):
+        os.remove(pex)


### PR DESCRIPTION
### Problem

The pex resolver errors on PEP508 environment markers when resolving for an incompatible interpreter. A common use case for such markers is to ensure backport libraries are installed for universal wheels. Pex has a workaround in place but needs Pants to do some plumbing with a new config var for it to take full effect in a Pants project.

### Solution

Add a `resolver-blacklist` option for python-setup. Do not add requirements to the requirements pex if its name (key) shows up in the set of keys of the blacklist dictionary.

### Result

Users can now define a blacklist dictionary in pants.ini to ignore problematic requirements during the pex resolver step. An example of a valid blacklist
```
[python-setup]
# functools32 is a backport from 3 to 2 and will error out on Python 3 resolves.
resolver_blacklist: {"functools32": "CPython>3"}
```

https://github.com/pantsbuild/pants/issues/5696 tracks the removal of these changes and 
https://github.com/pantsbuild/pex/issues/456 tracks the long term solution in the pex codebase.