### PR TITLE
Remodel of node subsystem

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
@@ -2,12 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
-  sources=[
-    'command.py',
-    'node_distribution.py',
-    'package_managers.py',
-    'yarnpkg_distribution.py',
-  ],
   dependencies=[
     'src/python/pants/base:deprecated',
     'src/python/pants/binaries:binary_util',

--- a/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/BUILD
@@ -2,6 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_library(
+  sources=[
+    'command.py',
+    'node_distribution.py',
+    'package_managers.py',
+    'yarnpkg_distribution.py',
+  ],
   dependencies=[
     'src/python/pants/base:deprecated',
     'src/python/pants/binaries:binary_util',

--- a/contrib/node/src/python/pants/contrib/node/subsystems/command.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/command.py
@@ -9,6 +9,7 @@ import logging
 import os
 from collections import namedtuple
 
+from pants.util.contextutil import get_joined_path
 from pants.util.process_handler import subprocess
 
 
@@ -39,7 +40,7 @@ class Command(namedtuple('Command', ['executable', 'args', 'extra_paths'])):
     """
     kwargs = kwargs.copy()
     env = kwargs.pop('env', os.environ).copy()
-    env['PATH'] = os.path.pathsep.join(self.extra_paths + [env.get('PATH', '')])
+    env['PATH'] = get_joined_path(self.extra_paths, env=env, prepend=True)
     return env, kwargs
 
   def run(self, **kwargs):

--- a/contrib/node/src/python/pants/contrib/node/subsystems/command.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/command.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,

--- a/contrib/node/src/python/pants/contrib/node/subsystems/command.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/command.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+import os
+from collections import namedtuple
+
+from pants.util.process_handler import subprocess
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(namedtuple('Command', ['executable', 'args', 'extra_paths'])):
+  """Describes a command to be run using a Node distribution."""
+
+  @property
+  def cmd(self):
+    """The command line that will be executed when this command is spawned.
+
+    :returns: The full command line used to spawn this command as a list of strings.
+    :rtype: list
+    """
+    return [self.executable] + (self.args or [])
+
+  def _prepare_env(self, kwargs):
+    """Returns a modifed copy of kwargs['env'], and a copy of kwargs with 'env' removed.
+
+    If there is no 'env' field in the kwargs, os.environ.copy() is used.
+    env['PATH'] is set/modified to contain the Node distribution's bin directory at the front.
+
+    :param kwargs: The original kwargs.
+    :returns: An (env, kwargs) tuple containing the modified env and kwargs copies.
+    :rtype: (dict, dict)
+    """
+    kwargs = kwargs.copy()
+    env = kwargs.pop('env', os.environ).copy()
+    env['PATH'] = os.path.pathsep.join(self.extra_paths + [env.get('PATH', '')])
+    return env, kwargs
+
+  def run(self, **kwargs):
+    """Runs this command.
+
+    :param kwargs: Any extra keyword arguments to pass along to `subprocess.Popen`.
+    :returns: A handle to the running command.
+    :rtype: :class:`subprocess.Popen`
+    """
+    env, kwargs = self._prepare_env(kwargs)
+    logger.debug('Running command {}'.format(self.cmd))
+    return subprocess.Popen(self.cmd, env=env, **kwargs)
+
+  def check_output(self, **kwargs):
+    """Runs this command returning its captured stdout.
+
+    :param kwargs: Any extra keyword arguments to pass along to `subprocess.Popen`.
+    :returns: The captured standard output stream of the command.
+    :rtype: string
+    :raises: :class:`subprocess.CalledProcessError` if the command fails.
+    """
+    env, kwargs = self._prepare_env(kwargs)
+    return subprocess.check_output(self.cmd, env=env, **kwargs)
+
+  def __str__(self):
+    return ' '.join(self.cmd)
+
+
+def command_gen(tool_installations, tool_executable, args=None, node_paths=None):
+  """Generate a Command object with requires tools installed and paths setup.
+
+  :param list tool_installations: A list of functions to install required tools.  Those functions
+    should take no parameter and return an installation path to be included in the runtime path.
+  :param tool_executable: Name of the tool to be executed.
+  :param list args: A list of arguments to be passed to the executable
+  :param list node_paths: A list of path to node_modules.  node_modules/.bin will be appended
+    to the run time path.
+  :rtype: class: `Command`
+  """
+  node_module_bin_dir = 'node_modules/.bin'
+  extra_paths = []
+  for t in tool_installations:
+    # Calling tool_installation[i]() triggers installation if tool is not installed
+    extra_paths.append(t())
+  if node_paths:
+    for node_path in node_paths:
+      if not node_path.endswith(node_module_bin_dir):
+        node_path = os.path.join(node_path, node_module_bin_dir)
+      extra_paths.append(node_path)
+  return Command(executable=tool_executable, args=args, extra_paths=extra_paths)

--- a/contrib/node/src/python/pants/contrib/node/subsystems/command.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/command.py
@@ -16,6 +16,7 @@ from pants.util.process_handler import subprocess
 logger = logging.getLogger(__name__)
 
 
+# TODO: Consider generalizing this into pants.util.
 class Command(namedtuple('Command', ['executable', 'args', 'extra_paths'])):
   """Describes a command to be run using a Node distribution."""
 
@@ -70,7 +71,7 @@ class Command(namedtuple('Command', ['executable', 'args', 'extra_paths'])):
 
 
 def command_gen(tool_installations, tool_executable, args=None, node_paths=None):
-  """Generate a Command object with requires tools installed and paths setup.
+  """Generate a Command object with required tools installed and paths set up.
 
   :param list tool_installations: A list of functions to install required tools.  Those functions
     should take no parameter and return an installation path to be included in the runtime path.

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -46,11 +46,6 @@ class NodeDistribution(NativeTool):
   @classmethod
   def register_options(cls, register):
     super(NodeDistribution, cls).register_options(register)
-    register('--supportdir', advanced=True, default='bin/node',
-             removal_version='1.8.0.dev0', removal_hint='No longer supported.',
-             help='Find the Node distributions under this dir.  Used as part of the path to '
-                  'lookup the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-
     register('--package-manager', advanced=True, default='npm', fingerprint=True,
              choices=VALID_PACKAGE_MANAGERS,
              help='Default package manager config for repo. Should be one of {}'.format(

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -9,7 +9,6 @@ import filecmp
 import logging
 import os
 import shutil
-from collections import namedtuple
 
 from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
@@ -17,8 +16,11 @@ from pants.binaries.binary_tool import NativeTool
 from pants.option.custom_types import dir_option, file_option
 from pants.util.dirutil import safe_mkdir, safe_rmtree
 from pants.util.memo import memoized_method, memoized_property
-from pants.util.process_handler import subprocess
 
+
+from pants.contrib.node.subsystems.command import command_gen
+from pants.contrib.node.subsystems.package_managers import (
+  PACKAGE_MANAGER_NPM, PACKAGE_MANAGER_YARNPKG, PackageManagerNpm, PackageManagerYarnpkg)
 from pants.contrib.node.subsystems.yarnpkg_distribution import YarnpkgDistribution
 
 
@@ -44,13 +46,9 @@ class NodeDistribution(NativeTool):
   def register_options(cls, register):
     super(NodeDistribution, cls).register_options(register)
     register('--supportdir', advanced=True, default='bin/node',
-             removal_version='1.7.0.dev0', removal_hint='No longer supported.',
+             removal_version='1.8.0.dev0', removal_hint='No longer supported.',
              help='Find the Node distributions under this dir.  Used as part of the path to '
                   'lookup the distribution with --binary-util-baseurls and --pants-bootstrapdir')
-    register('--yarnpkg-version', advanced=True, default='v0.19.1', fingerprint=True,
-             removal_version='1.7.0.dev0',
-             removal_hint='Use --version in scope yarnpkg-distribution',
-             help='Yarnpkg version to use.')
 
     register('--package-manager', advanced=True, default='npm', fingerprint=True,
              choices=NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys(),
@@ -66,19 +64,25 @@ class NodeDistribution(NativeTool):
     register('--eslint-version', default='4.15.0', fingerprint=True,
              help='Use this ESLint version.')
 
-  PACKAGE_MANAGER_NPM = 'npm'
-  PACKAGE_MANAGER_YARNPKG = 'yarnpkg'
-  VALID_PACKAGE_MANAGER_LIST = {
-    'npm': PACKAGE_MANAGER_NPM,
-    'yarn': PACKAGE_MANAGER_YARNPKG
-  }
+  @memoized_method
+  def _get_package_managers(self):
+    npm = PackageManagerNpm([self._install_node])
+    yarnpkg = PackageManagerYarnpkg([self._install_node, self._install_yarnpkg])
+    return {
+      PACKAGE_MANAGER_NPM: npm,
+      PACKAGE_MANAGER_YARNPKG: yarnpkg,
+      'yarn': yarnpkg,  # Allow yarn to be used as an alias for yarnpkg
+    }
 
-  @classmethod
-  def validate_package_manager(cls, package_manager):
-    if package_manager not in cls.VALID_PACKAGE_MANAGER_LIST.keys():
-      raise TaskError('Unknown package manager: %s' % package_manager)
-    package_manager = cls.VALID_PACKAGE_MANAGER_LIST[package_manager]
-    return package_manager
+  def get_package_manager(self, package_manager=None):
+    package_manager = package_manager or self.get_options().package_manager
+    package_manager_obj = self._get_package_managers().get(package_manager)
+    if not package_manager_obj:
+      raise TaskError(
+        'Unknown package manager: {}.\nValid values are {}.'.format(
+          package_manager, NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys()
+      ))
+    return package_manager_obj
 
   @memoized_method
   def version(self, context=None):
@@ -115,16 +119,8 @@ class NodeDistribution(NativeTool):
   def eslint_ignore(self):
     return self.get_options().eslint_ignore
 
-  @memoized_property
-  def package_manager(self):
-    return self.validate_package_manager(self.get_options().package_manager)
-
-  @memoized_property
-  def yarnpkg_version(self):
-    return self._normalize_version(self.get_options().yarnpkg_version)
-
   @memoized_method
-  def install_node(self):
+  def _install_node(self):
     """Install the Node distribution from pants support binaries.
 
     :returns: The Node distribution bin path.
@@ -138,90 +134,15 @@ class NodeDistribution(NativeTool):
     return node_bin_path
 
   @memoized_method
-  def install_yarnpkg(self, context=None):
+  def _install_yarnpkg(self):
     """Install the Yarnpkg distribution from pants support binaries.
 
-    :param context: The context for this call. Remove this param in 1.7.0.dev0.
     :returns: The Yarnpkg distribution bin path.
     :rtype: string
     """
-    yarnpkg_package_path = YarnpkgDistribution.scoped_instance(self).select(context=context)
+    yarnpkg_package_path = YarnpkgDistribution.scoped_instance(self).select()
     yarnpkg_bin_path = os.path.join(yarnpkg_package_path, 'dist', 'bin')
     return yarnpkg_bin_path
-
-  class Command(namedtuple('Command', ['executable', 'args', 'extra_paths'])):
-    """Describes a command to be run using a Node distribution."""
-
-    @property
-    def cmd(self):
-      """The command line that will be executed when this command is spawned.
-
-      :returns: The full command line used to spawn this command as a list of strings.
-      :rtype: list
-      """
-      return [self.executable] + (self.args or [])
-
-    def _prepare_env(self, kwargs):
-      """Returns a modifed copy of kwargs['env'], and a copy of kwargs with 'env' removed.
-
-      If there is no 'env' field in the kwargs, os.environ.copy() is used.
-      env['PATH'] is set/modified to contain the Node distribution's bin directory at the front.
-
-      :param kwargs: The original kwargs.
-      :returns: An (env, kwargs) tuple containing the modified env and kwargs copies.
-      :rtype: (dict, dict)
-      """
-      kwargs = kwargs.copy()
-      env = kwargs.pop('env', os.environ).copy()
-      env['PATH'] = os.path.pathsep.join(self.extra_paths + [env.get('PATH', '')])
-      return env, kwargs
-
-    def run(self, **kwargs):
-      """Runs this command.
-
-      :param kwargs: Any extra keyword arguments to pass along to `subprocess.Popen`.
-      :returns: A handle to the running command.
-      :rtype: :class:`subprocess.Popen`
-      """
-      env, kwargs = self._prepare_env(kwargs)
-      logger.debug('Running command {}'.format(self.cmd))
-      return subprocess.Popen(self.cmd, env=env, **kwargs)
-
-    def check_output(self, **kwargs):
-      """Runs this command returning its captured stdout.
-
-      :param kwargs: Any extra keyword arguments to pass along to `subprocess.Popen`.
-      :returns: The captured standard output stream of the command.
-      :rtype: string
-      :raises: :class:`subprocess.CalledProcessError` if the command fails.
-      """
-      env, kwargs = self._prepare_env(kwargs)
-      return subprocess.check_output(self.cmd, env=env, **kwargs)
-
-    def __str__(self):
-      return ' '.join(self.cmd)
-
-  def _command_gen(self, tool_installations, tool_executable, args=None, node_paths=None):
-    """Generate a Command object with requires tools installed and paths setup.
-
-    :param list tool_installations: A list of functions to install required tools.  Those functions
-      should take no parameter and return an installation path to be included in the runtime path.
-    :param tool_executable: Name of the tool to be executed.
-    :param list args: A list of arguments to be passed to the executable
-    :param list node_paths: A list of path to node_modules.  node_modules/.bin will be appended
-      to the run time path.
-    :rtype: class: `NodeDistribution.Command`
-    """
-    node_module_bin_dir = 'node_modules/.bin'
-    extra_paths = []
-    for t in tool_installations:
-      extra_paths.append(t())
-    if node_paths:
-      for node_path in node_paths:
-        if not node_path.endswith(node_module_bin_dir):
-          node_path = os.path.join(node_path, node_module_bin_dir)
-        extra_paths.append(node_path)
-    return self.Command(executable=tool_executable, args=args, extra_paths=extra_paths)
 
   def node_command(self, args=None, node_paths=None):
     """Creates a command that can run `node`, passing the given args to it.
@@ -233,32 +154,7 @@ class NodeDistribution(NativeTool):
     """
     # NB: We explicitly allow no args for the `node` command unlike the `npm` command since running
     # `node` with no arguments is useful, it launches a REPL.
-    return self._command_gen([self.install_node], 'node', args=args, node_paths=node_paths)
-
-  def npm_command(self, args, node_paths=None):
-    """Creates a command that can run `npm`, passing the given args to it.
-
-    :param list args: A list of arguments to pass to `npm`.
-    :param list node_paths: An optional list of paths to node_modules.
-    :returns: An `npm` command that can be run later.
-    :rtype: :class:`NodeDistribution.Command`
-    """
-    return self._command_gen([self.install_node], 'npm', args=args, node_paths=node_paths)
-
-  def yarnpkg_command(self, args, node_paths=None, context=None):
-    """Creates a command that can run `yarnpkg`, passing the given args to it.
-
-    :param list args: A list of arguments to pass to `yarnpkg`.
-    :param list node_paths: An optional list of paths to node_modules.
-    :param context: The context for this call. Remove this param in 1.7.0.dev0.
-    :returns: An `yarnpkg` command that can be run later.
-    :rtype: :class:`NodeDistribution.Command`
-    """
-    # TODO: In 1.7.0.dev0, remove this helper func and use self._install_yarnpkg directly.
-    def install_yarnpkg():
-      return self.install_yarnpkg(context=context)
-    return self._command_gen(
-      [self.install_node, install_yarnpkg], 'yarnpkg', args=args, node_paths=node_paths)
+    return command_gen([self._install_node], 'node', args=args, node_paths=node_paths)
 
   def _configure_eslinter(self, bootstrapped_support_path):
     logger.debug('Copying {setupdir} to bootstrapped dir: {support_path}'

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -17,11 +17,13 @@ from pants.option.custom_types import dir_option, file_option
 from pants.util.dirutil import safe_mkdir, safe_rmtree
 from pants.util.memo import memoized_method, memoized_property
 
-
 from pants.contrib.node.subsystems.command import command_gen
-from pants.contrib.node.subsystems.package_managers import (
-  PACKAGE_MANAGER_NPM, PACKAGE_MANAGER_YARNPKG, PACKAGE_MANAGER_YARNPKG_ALIAS, VALID_PACKAGE_MANAGERS,
-  PackageManagerNpm, PackageManagerYarnpkg)
+from pants.contrib.node.subsystems.package_managers import (PACKAGE_MANAGER_NPM,
+                                                            PACKAGE_MANAGER_YARNPKG,
+                                                            PACKAGE_MANAGER_YARNPKG_ALIAS,
+                                                            VALID_PACKAGE_MANAGERS,
+                                                            PackageManagerNpm,
+                                                            PackageManagerYarnpkg)
 from pants.contrib.node.subsystems.yarnpkg_distribution import YarnpkgDistribution
 
 

--- a/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/node_distribution.py
@@ -20,7 +20,8 @@ from pants.util.memo import memoized_method, memoized_property
 
 from pants.contrib.node.subsystems.command import command_gen
 from pants.contrib.node.subsystems.package_managers import (
-  PACKAGE_MANAGER_NPM, PACKAGE_MANAGER_YARNPKG, PackageManagerNpm, PackageManagerYarnpkg)
+  PACKAGE_MANAGER_NPM, PACKAGE_MANAGER_YARNPKG, PACKAGE_MANAGER_YARNPKG_ALIAS, VALID_PACKAGE_MANAGERS,
+  PackageManagerNpm, PackageManagerYarnpkg)
 from pants.contrib.node.subsystems.yarnpkg_distribution import YarnpkgDistribution
 
 
@@ -51,9 +52,9 @@ class NodeDistribution(NativeTool):
                   'lookup the distribution with --binary-util-baseurls and --pants-bootstrapdir')
 
     register('--package-manager', advanced=True, default='npm', fingerprint=True,
-             choices=NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys(),
+             choices=VALID_PACKAGE_MANAGERS,
              help='Default package manager config for repo. Should be one of {}'.format(
-               NodeDistribution.VALID_PACKAGE_MANAGER_LIST.keys()))
+               VALID_PACKAGE_MANAGERS))
     register('--eslint-setupdir', advanced=True, type=dir_option, fingerprint=True,
              help='Find the package.json and yarn.lock under this dir '
                   'for installing eslint and plugins.')
@@ -71,7 +72,7 @@ class NodeDistribution(NativeTool):
     return {
       PACKAGE_MANAGER_NPM: npm,
       PACKAGE_MANAGER_YARNPKG: yarnpkg,
-      'yarn': yarnpkg,  # Allow yarn to be used as an alias for yarnpkg
+      PACKAGE_MANAGER_YARNPKG_ALIAS: yarnpkg,  # Allow yarn to be used as an alias for yarnpkg
     }
 
   def get_package_manager(self, package_manager=None):

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -177,6 +177,7 @@ class PackageManagerYarnpkg(PackageManager):
         '{} does not support install with {} version, ignored'.format(self.name, version_option))
     else:
       return_args.append(package_version_option)
+    raise RuntimeError(' '.join(return_args))
     return return_args
 
 
@@ -221,4 +222,5 @@ class PackageManagerNpm(PackageManager):
         '{} does not support install with {} version, ignored.'.format(self.name, version_option))
     else:
       return_args.append(package_version_option)
+    raise RuntimeError(' '.join(return_args))
     return return_args

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -135,6 +135,18 @@ class PackageManager(object):
       node_paths=node_paths,
     )
 
+  def run_cli(self, cli, args=None, node_paths=None):
+    cli_args = [cli]
+    if args:
+      cli_args.append('--')
+      cli_args.extend(args)
+    return command_gen(
+      self.tool_installations,
+      self.name,
+      args=cli_args,
+      node_paths = node_paths
+    )
+
 
 class PackageManagerYarnpkg(PackageManager):
 
@@ -177,7 +189,6 @@ class PackageManagerYarnpkg(PackageManager):
         '{} does not support install with {} version, ignored'.format(self.name, version_option))
     else:
       return_args.append(package_version_option)
-    raise RuntimeError(' '.join(return_args))
     return return_args
 
 
@@ -222,5 +233,7 @@ class PackageManagerNpm(PackageManager):
         '{} does not support install with {} version, ignored.'.format(self.name, version_option))
     else:
       return_args.append(package_version_option)
-    raise RuntimeError(' '.join(return_args))
     return return_args
+
+  def run_cli(self, cli, args=None, node_paths=None):
+    raise RuntimeError('npm does not support run cli directly.  Please use Yarn instead.')

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -65,6 +65,15 @@ class PackageManager(object):
     """
     raise NotImplementedError()
 
+  def run_command(self, args=None, node_paths=None):
+    """Returns a command that when executed will run an arbitury command via package manager."""
+    return command_gen(
+      self.tool_installations,
+      self.name,
+      args=args,
+      node_paths=node_paths
+    )
+
   def install_module(
     self,
     install_optional=False,
@@ -80,15 +89,11 @@ class PackageManager(object):
     :param node_paths: A list of path that should be included in $PATH when
       running installation.
     """
-    return command_gen(
-      self.tool_installations,
-      self.name,
-      args=self._get_installation_args(
-        install_optional=install_optional,
-        production_only=production_only,
-        force=force),
-      node_paths=node_paths
-    )
+    args=self._get_installation_args(
+      install_optional=install_optional,
+      production_only=production_only,
+      force=force)
+    return self.run_command(args=args, node_paths=node_paths)
 
   def run_script(self, script_name, script_args=None, node_paths=None):
     """Returns a command to execute a package.json script.
@@ -104,12 +109,7 @@ class PackageManager(object):
     if script_args:
       package_manager_args.append('--')
       package_manager_args.extend(script_args)
-    return command_gen(
-      self.tool_installations,
-      self.name,
-      args=package_manager_args,
-      node_paths=node_paths
-    )
+    return self.run_command(args=package_manager_args, node_paths=node_paths)
 
   def add_package(
     self,
@@ -125,27 +125,19 @@ class PackageManager(object):
     :param node_paths: A list of path that should be included in $PATH when
       running the script.
     """
-    return command_gen(
-      self.tool_installations,
-      self.name,
-      args=self._get_add_package_args(
-        package,
-        type_option=type_option,
-        version_option=version_option),
-      node_paths=node_paths,
-    )
+    args=self._get_add_package_args(
+      package,
+      type_option=type_option,
+      version_option=version_option)
+    return self.run_command(args=args, node_paths=node_paths)
 
   def run_cli(self, cli, args=None, node_paths=None):
+    """Returns a command that when executed will run an installed cli via package manager."""
     cli_args = [cli]
     if args:
       cli_args.append('--')
       cli_args.extend(args)
-    return command_gen(
-      self.tool_installations,
-      self.name,
-      args=cli_args,
-      node_paths = node_paths
-    )
+    return self.run_command(args=args, node_paths=node_paths)
 
 
 class PackageManagerYarnpkg(PackageManager):

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -13,7 +13,9 @@ from pants.contrib.node.subsystems.command import command_gen
 LOG = logging.getLogger(__name__)
 
 PACKAGE_MANAGER_NPM = 'npm'
-PACKAGE_MANAGER_YARNPKG = 'yarnpkg' 
+PACKAGE_MANAGER_YARNPKG = 'yarnpkg'
+PACKAGE_MANAGER_YARNPKG_ALIAS = 'yarn'
+VALID_PACKAGE_MANAGERS = [PACKAGE_MANAGER_NPM, PACKAGE_MANAGER_YARNPKG, PACKAGE_MANAGER_YARNPKG_ALIAS]
 
 
 # TODO: Change to enum type when migrated to Python 3.4+

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -104,6 +104,7 @@ class PackageManager(object):
     :param node_paths: A list of path that should be included in $PATH when
       running the script.
     """
+    # TODO: consider add a pants.util function to manipulate command line.
     package_manager_args = self._get_run_script_args()
     package_manager_args.append(script_name)
     if script_args:

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -137,7 +137,7 @@ class PackageManager(object):
     if args:
       cli_args.append('--')
       cli_args.extend(args)
-    return self.run_command(args=args, node_paths=node_paths)
+    return self.run_command(args=cli_args, node_paths=node_paths)
 
 
 class PackageManagerYarnpkg(PackageManager):
@@ -170,7 +170,7 @@ class PackageManagerYarnpkg(PackageManager):
     }.get(type_option)
     if package_type_option is None:
       logging.warning('{} does not support {} packages, ignored.'.format(self.name, type_option))
-    else:
+    elif package_type_option:  # Skip over '' entries
       return_args.append(package_type_option)
     package_version_option = {
       PackageInstallationVersionOption.EXACT: '--exact',
@@ -179,7 +179,7 @@ class PackageManagerYarnpkg(PackageManager):
     if package_version_option is None:
       LOG.warning(
         '{} does not support install with {} version, ignored'.format(self.name, version_option))
-    else:
+    elif package_version_option: # Skip over '' entries
       return_args.append(package_version_option)
     return return_args
 
@@ -211,10 +211,10 @@ class PackageManagerNpm(PackageManager):
       PackageInstallationTypeOption.OPTIONAL: '--save-optional',
       PackageInstallationTypeOption.BUNDLE: '--save-bundle',
       PackageInstallationTypeOption.NO_SAVE: '--no-save',
-    }
+    }.get(type_option)
     if package_type_option is None:
       logging.warning('{} does not support {} packages, ignored.'.format(self.name, type_option))
-    else:
+    elif package_type_option:  # Skip over '' entries
       return_args.append(package_type_option)
     package_version_option = {
       PackageInstallationVersionOption.EXACT: '--save-exact',
@@ -223,7 +223,7 @@ class PackageManagerNpm(PackageManager):
     if package_version_option is None:
       LOG.warning(
         '{} does not support install with {} version, ignored.'.format(self.name, version_option))
-    else:
+    elif package_version_option:  # Skip over '' entries
       return_args.append(package_version_option)
     return return_args
 

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -124,6 +124,10 @@ class PackageManager(object):
       https://url/to.tgz
     :param node_paths: A list of path that should be included in $PATH when
       running the script.
+    :param type_option: A value from PackageInstallationTypeOption that indicates the type
+      of package to be installed. Default to 'prod', which is a production dependency.
+    :param version_option: A value from PackageInstallationVersionOption that indicates how
+      to match version. Default to None, which uses package manager default.
     """
     args=self._get_add_package_args(
       package,

--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
@@ -59,8 +59,8 @@ class NpmResolver(Subsystem, NodeResolverBase):
         workunit_name=target.address.reference(),
         workunit_labels=[WorkUnitLabel.COMPILER])
       if result != 0:
-          raise TaskError('Failed to resolve dependencies for {}:\n\t{} failed with exit code {}'
-                          .format(target.address.reference(), command, result))
+        raise TaskError('Failed to resolve dependencies for {}:\n\t{} failed with exit code {}'
+                        .format(target.address.reference(), command, result))
 
   @staticmethod
   def _emit_package_descriptor(node_task, target, results_dir, node_paths):

--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
@@ -13,7 +13,8 @@ from pants.base.workunit import WorkUnitLabel
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import pushd
 
-from pants.contrib.node.subsystems.package_managers import PACKAGE_MANAGER_NPM, PACKAGE_MANAGER_YARNPKG
+from pants.contrib.node.subsystems.package_managers import (PACKAGE_MANAGER_NPM,
+                                                            PACKAGE_MANAGER_YARNPKG)
 from pants.contrib.node.subsystems.resolvers.node_resolver_base import NodeResolverBase
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.tasks.node_resolve import NodeResolve

--- a/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/resolvers/npm_resolver.py
@@ -13,6 +13,7 @@ from pants.base.workunit import WorkUnitLabel
 from pants.subsystem.subsystem import Subsystem
 from pants.util.contextutil import pushd
 
+from pants.contrib.node.subsystems.package_managers import PACKAGE_MANAGER_NPM, PACKAGE_MANAGER_YARNPKG
 from pants.contrib.node.subsystems.resolvers.node_resolver_base import NodeResolverBase
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.tasks.node_resolve import NodeResolve
@@ -35,9 +36,9 @@ class NpmResolver(Subsystem, NodeResolverBase):
       if not os.path.exists('package.json'):
         raise TaskError(
           'Cannot find package.json. Did you forget to put it in target sources?')
-      package_manager = node_task.get_package_manager_for_target(target=target)
-      install_optional = self.get_options().install_optional
-      if package_manager == node_task.node_distribution.PACKAGE_MANAGER_NPM:
+      # TODO: remove/remodel the following section when node_module dependency is fleshed out.
+      package_manager = node_task.get_package_manager(target=target).name
+      if package_manager == PACKAGE_MANAGER_NPM:
         if os.path.exists('npm-shrinkwrap.json'):
           node_task.context.log.info('Found npm-shrinkwrap.json, will not inject package.json')
         else:
@@ -47,30 +48,18 @@ class NpmResolver(Subsystem, NodeResolverBase):
             'including node_remote_module and other node dependencies. However, this is '
             'not fully supported.')
           self._emit_package_descriptor(node_task, target, results_dir, node_paths)
-        # TODO: expose npm command options via node subsystems.
-        args = ['install']
-        if not install_optional:
-          args.append('--no-optional')
-        result, npm_install = node_task.execute_npm(args,
-                                                    workunit_name=target.address.reference(),
-                                                    workunit_labels=[WorkUnitLabel.COMPILER])
-        if result != 0:
-          raise TaskError('Failed to resolve dependencies for {}:\n\t{} failed with exit code {}'
-                          .format(target.address.reference(), npm_install, result))
-      elif package_manager == node_task.node_distribution.PACKAGE_MANAGER_YARNPKG:
+      elif package_manager == PACKAGE_MANAGER_YARNPKG:
         if not os.path.exists('yarn.lock'):
           raise TaskError(
             'Cannot find yarn.lock. Did you forget to put it in target sources?')
-        args = []
-        if not install_optional:
-          args.append('--ignore-optional')
-        returncode, yarnpkg_command = node_task.execute_yarnpkg(
-          args,
-          workunit_name=target.address.reference(),
-          workunit_labels=[WorkUnitLabel.COMPILER])
-        if returncode != 0:
+
+      result, command = node_task.install_module(
+        target=target, install_optional=self.get_options().install_optional,
+        workunit_name=target.address.reference(),
+        workunit_labels=[WorkUnitLabel.COMPILER])
+      if result != 0:
           raise TaskError('Failed to resolve dependencies for {}:\n\t{} failed with exit code {}'
-                          .format(target.address.reference(), yarnpkg_command, returncode))
+                          .format(target.address.reference(), command, result))
 
   @staticmethod
   def _emit_package_descriptor(node_task, target, results_dir, node_paths):

--- a/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
@@ -7,9 +7,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import logging
 
-from pants.base.deprecated import deprecated_conditional
 from pants.binaries.binary_tool import NativeTool
-from pants.util.memo import memoized_method
 
 
 logger = logging.getLogger(__name__)

--- a/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/yarnpkg_distribution.py
@@ -22,19 +22,3 @@ class YarnpkgDistribution(NativeTool):
   name = 'yarnpkg'
   default_version = 'v0.19.1'
   archive_type = 'tgz'
-
-  replaces_scope = 'node-distribution'
-  replaces_name = 'yarnpkg_version'
-
-  @memoized_method
-  def version(self, context=None):
-    # The versions reported by node and embedded in distribution package names are 'vX.Y.Z'.
-    # TODO: After the deprecation cycle is over we'll expect the values of the version option
-    # to already include the 'v' prefix, so there will be no need to normalize, and we can
-    # delete this entire method override.
-    version = super(YarnpkgDistribution, self).version(context)
-    deprecated_conditional(
-      lambda: not version.startswith('v'), entity_description='', removal_version='1.7.0.dev0',
-      hint_message='value of --version in scope {} must be of the form '
-                   'vX.Y.Z'.format(self.options_scope))
-    return version if version.startswith('v') else 'v' + version

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -16,10 +16,11 @@ from pants.task.lint_task_mixin import LintTaskMixin
 from pants.util.contextutil import pushd
 from pants.util.memo import memoized_method
 
+from pants.contrib.node.subsystems.command import command_gen
+from pants.contrib.node.subsystems.package_managers import (PACKAGE_MANAGER_YARNPKG,
+                                                            PackageInstallationVersionOption)
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.tasks.node_task import NodeTask
-from pants.contrib.node.subsystems.command import command_gen
-from pants.contrib.node.subsystems.package_managers import PACKAGE_MANAGER_YARNPKG, PackageInstallationVersionOption
 
 
 class JavascriptStyleBase(NodeTask):

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -18,6 +18,8 @@ from pants.util.memo import memoized_method
 
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.tasks.node_task import NodeTask
+from pants.contrib.node.subsystems.command import command_gen
+from pants.contrib.node.subsystems.package_managers import PackageInstallationVersionOption
 
 
 class JavascriptStyleBase(NodeTask):
@@ -78,13 +80,14 @@ class JavascriptStyleBase(NodeTask):
     with pushd(bootstrap_dir):
       eslint_version = self.node_distribution.eslint_version
       eslint = 'eslint@{}'.format(eslint_version)
-      result, yarn_add_command = self.execute_yarnpkg(
-        args=['add', eslint],
+      result, add_command = self.add_package(
+        package=eslint,
+        version_option=PackageInstallationVersionOption.EXACT,
         workunit_name=self.INSTALL_JAVASCRIPTSTYLE_TARGET_NAME,
         workunit_labels=[WorkUnitLabel.PREP])
       if result != 0:
         raise TaskError('Failed to install eslint\n'
-                        '\t{} failed with exit code {}'.format(yarn_add_command, result))
+                        '\t{} failed with exit code {}'.format(add_command, result))
     return bootstrap_dir
 
   @memoized_method
@@ -94,13 +97,12 @@ class JavascriptStyleBase(NodeTask):
     :rtype: string
     """
     with pushd(bootstrap_dir):
-      result, yarn_install_command = self.execute_yarnpkg(
-        args=['install'],
+      result, install_command = self.install_module(
         workunit_name=self.INSTALL_JAVASCRIPTSTYLE_TARGET_NAME,
         workunit_labels=[WorkUnitLabel.PREP])
       if result != 0:
         raise TaskError('Failed to install ESLint\n'
-                        '\t{} failed with exit code {}'.format(yarn_install_command, result))
+                        '\t{} failed with exit code {}'.format(install_command, result))
 
     self.context.log.debug('Successfully installed ESLint to {}'.format(bootstrap_dir))
     return bootstrap_dir
@@ -114,7 +116,7 @@ class JavascriptStyleBase(NodeTask):
 
   def _run_javascriptstyle(self, target, bootstrap_dir, files, config=None, ignore_path=None,
                            other_args=None):
-    args = ['eslint', '--']
+    args = ['--']
     if config:
       args.extend(['--config', config])
     else:
@@ -135,12 +137,13 @@ class JavascriptStyleBase(NodeTask):
       args.extend(other_args)
     args.extend(files)
     with pushd(bootstrap_dir):
-      result, yarn_run_command = self.execute_yarnpkg(
-        args=args,
+      command = command_gen([], 'eslint', args=args, node_paths=[bootstrap_dir])
+      result, run_command = self._execute_command(
+        command,
         workunit_name=target.address.reference(),
         workunit_labels=[WorkUnitLabel.PREP])
-      self.context.log.debug('Javascript style command: {}'.format(yarn_run_command))
-    return (result, yarn_run_command)
+      self.context.log.debug('Javascript style command: {}'.format(run_command))
+    return (result, run_command)
 
   def execute(self):
     targets = self.get_lintable_node_targets(self.get_targets())

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -16,7 +16,6 @@ from pants.task.lint_task_mixin import LintTaskMixin
 from pants.util.contextutil import pushd
 from pants.util.memo import memoized_method
 
-from pants.contrib.node.subsystems.command import command_gen
 from pants.contrib.node.subsystems.package_managers import (PACKAGE_MANAGER_YARNPKG,
                                                             PackageInstallationVersionOption)
 from pants.contrib.node.targets.node_module import NodeModule

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -140,13 +140,7 @@ class JavascriptStyleBase(NodeTask):
       args.extend(other_args)
     args.extend(files)
     with pushd(bootstrap_dir):
-      command = command_gen([], 'eslint', args=args, node_paths=[bootstrap_dir])
-      result, run_command = self._execute_command(
-        command,
-        workunit_name=target.address.reference(),
-        workunit_labels=[WorkUnitLabel.PREP])
-      self.context.log.debug('Javascript style command: {}'.format(run_command))
-    return (result, run_command)
+      return self.run_cli('eslint', args=args)
 
   def execute(self):
     targets = self.get_lintable_node_targets(self.get_targets())

--- a/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/javascript_style.py
@@ -19,7 +19,7 @@ from pants.util.memo import memoized_method
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.tasks.node_task import NodeTask
 from pants.contrib.node.subsystems.command import command_gen
-from pants.contrib.node.subsystems.package_managers import PackageInstallationVersionOption
+from pants.contrib.node.subsystems.package_managers import PACKAGE_MANAGER_YARNPKG, PackageInstallationVersionOption
 
 
 class JavascriptStyleBase(NodeTask):
@@ -80,8 +80,10 @@ class JavascriptStyleBase(NodeTask):
     with pushd(bootstrap_dir):
       eslint_version = self.node_distribution.eslint_version
       eslint = 'eslint@{}'.format(eslint_version)
+      self.context.log.debug('Installing {}...'.format(eslint))
       result, add_command = self.add_package(
         package=eslint,
+        package_manager=self.node_distribution.get_package_manager(package_manager=PACKAGE_MANAGER_YARNPKG),
         version_option=PackageInstallationVersionOption.EXACT,
         workunit_name=self.INSTALL_JAVASCRIPTSTYLE_TARGET_NAME,
         workunit_labels=[WorkUnitLabel.PREP])
@@ -98,6 +100,7 @@ class JavascriptStyleBase(NodeTask):
     """
     with pushd(bootstrap_dir):
       result, install_command = self.install_module(
+        package_manager=self.node_distribution.get_package_manager(package_manager=PACKAGE_MANAGER_YARNPKG),
         workunit_name=self.INSTALL_JAVASCRIPTSTYLE_TARGET_NAME,
         workunit_labels=[WorkUnitLabel.PREP])
       if result != 0:
@@ -116,7 +119,7 @@ class JavascriptStyleBase(NodeTask):
 
   def _run_javascriptstyle(self, target, bootstrap_dir, files, config=None, ignore_path=None,
                            other_args=None):
-    args = ['--']
+    args = []
     if config:
       args.extend(['--config', config])
     else:

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_build.py
@@ -43,22 +43,13 @@ class NodeBuild(NodeTask):
     if target.payload.build_script:
       self.context.log.info('Running node build {} for {} at {}\n'.format(
         target.payload.build_script, target_address, node_installed_path))
-      package_manager = self.get_package_manager_for_target(target)
-      if package_manager == self.node_distribution.PACKAGE_MANAGER_NPM:
-        result, build_command = self.execute_npm(
-          ['run-script', target.payload.build_script],
-          node_paths=node_paths,
-          workunit_name=target_address,
-          workunit_labels=[WorkUnitLabel.COMPILER])
-      elif package_manager == self.node_distribution.PACKAGE_MANAGER_YARNPKG:
-        result, build_command = self.execute_yarnpkg(
-          ['run', target.payload.build_script],
-          node_paths=node_paths,
-          workunit_name=target_address,
-          workunit_labels=[WorkUnitLabel.COMPILER]
-          )
-      else:
-        raise TaskError('Unknown node package manager {}'.format(package_manager))
+      result, build_command = self.run_script(
+        target.payload.build_script,
+        target=target,
+        node_paths=node_paths,
+        workunit_name=target_address,
+        workunit_labels=[WorkUnitLabel.COMPILER]
+      )
       # Make sure script run is successful.
       if result != 0:
         raise TaskError(

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_repl.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_repl.py
@@ -65,7 +65,7 @@ class NodeRepl(ReplTaskMixin, NodeTask):
 
       with pushd(temp_dir):
         result, command = self.install_module(
-          package_manager=self.node_distribution.get_package_manager(package_manage=PACKAGE_MANAGER_NPM),
+          package_manager=self.node_distribution.get_package_manager(package_manager=PACKAGE_MANAGER_NPM),
           workunit_name=self.SYNTHETIC_NODE_TARGET_NAME)
         if result != 0:
           raise TaskError('npm install of synthetic REPL module failed:\n'

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_repl.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_repl.py
@@ -12,6 +12,7 @@ from pants.base.exceptions import TaskError
 from pants.task.repl_task_mixin import ReplTaskMixin
 from pants.util.contextutil import pushd, temporary_dir
 
+from pants.contrib.node.subsystems.package_managers import PACKAGE_MANAGER_NPM
 from pants.contrib.node.tasks.node_paths import NodePaths
 from pants.contrib.node.tasks.node_task import NodeTask
 
@@ -63,12 +64,12 @@ class NodeRepl(ReplTaskMixin, NodeTask):
         args=args, node_paths=node_paths.all_node_paths if node_paths else None)
 
       with pushd(temp_dir):
-        # TODO: Expose npm command options via node subsystems.
-        result, npm_install = self.execute_npm(['install', '--no-optional'],
-                                               workunit_name=self.SYNTHETIC_NODE_TARGET_NAME)
+        result, command = self.install_module(
+          package_manager=self.node_distribution.get_package_manager(package_manage=PACKAGE_MANAGER_NPM),
+          workunit_name=self.SYNTHETIC_NODE_TARGET_NAME)
         if result != 0:
           raise TaskError('npm install of synthetic REPL module failed:\n'
-                          '\t{} failed with exit code {}'.format(npm_install, result))
+                          '\t{} failed with exit code {}'.format(command, result))
 
         repl_session = node_repl.run()
         repl_session.wait()

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_run.py
@@ -31,30 +31,14 @@ class NodeRun(NodeTask):
 
     if self.is_node_module(target):
       node_paths = self.context.products.get_data(NodePaths)
-      node_path = node_paths.node_path(target)
-      package_manager = self.get_package_manager_for_target(target=target)
-      if package_manager == self.node_distribution.PACKAGE_MANAGER_NPM:
-        args = ['run-script', self.get_options().script_name, '--'] + self.get_passthru_args()
-
-        with pushd(node_path):
-          result, npm_run = self.execute_npm(
-            args,
-            node_paths=node_paths.all_node_paths,
-            workunit_name=target.address.reference(),
-            workunit_labels=[WorkUnitLabel.RUN])
-          if result != 0:
-            raise TaskError('npm run script failed:\n'
-                            '\t{} failed with exit code {}'.format(npm_run, result))
-      elif package_manager == self.node_distribution.PACKAGE_MANAGER_YARNPKG:
-        args = ['run', self.get_options().script_name, '--'] + self.get_passthru_args()
-        with pushd(node_path):
-          returncode, yarnpkg_run_command = self.execute_yarnpkg(
-            args=args,
-            node_paths=node_paths.all_node_paths,
-            workunit_name=target.address.reference(),
-            workunit_labels=[WorkUnitLabel.RUN])
-          if returncode != 0:
-            raise TaskError('yarnpkg run script failed:\n'
-                            '\t{} failed with exit code {}'.format(yarnpkg_run_command, returncode))
-      else:
-        raise RuntimeError('Unknown package manager: {}'.format(package_manager))
+      with pushd(node_paths.node_path(target)):
+        result, command = self.run_script(
+          self.get_options().script_name,
+          target=target,
+          script_args=self.get_passthru_args(),
+          node_paths=node_paths.all_node_paths,
+          workunit_name=target.address.reference(),
+          workunit_labels=[WorkUnitLabel.RUN])
+        if result != 0:
+          raise TaskError('Run script failed:\n'
+                          '\t{} failed with exit code {}'.format(command, result))

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -53,13 +53,14 @@ class NodeTask(Task):
     """Returns `True` if given target is a `NodeBundle`."""
     return isinstance(target, NodeBundle)
 
-  def get_package_manager_for_target(self, target):
-    """Returns package manager string for target argument or global config."""
-    package_manager = target.payload.get_field('package_manager').value
-    package_manager = self.node_distribution.validate_package_manager(
-      package_manager=package_manager
-    ) if package_manager else self.node_distribution.package_manager
-    return package_manager
+  def get_package_manager(self, target=None):
+    """Returns package manager for target argument or global config."""
+    package_manager = None
+    if target:
+      target_package_manager_field = target.payload.get_field('package_manager')
+      if target_package_manager_field:
+        package_manager = target_package_manager_field.value
+    return self.node_distribution.get_package_manager(package_manager=package_manager)
 
   def execute_node(self, args, workunit_name, workunit_labels=None, node_paths=None):
     """Executes node passing the given args.
@@ -77,40 +78,46 @@ class NodeTask(Task):
                                  workunit_name=workunit_name,
                                  workunit_labels=workunit_labels)
 
-  def execute_npm(self, args, workunit_name, workunit_labels=None, node_paths=None):
-    """Executes npm passing the given args.
+  def add_package(
+    self, target=None, package_manager=None, 
+    package=None, type_option=None, version_option=None,
+    node_paths=None, workunit_name=None, workunit_labels=None):
+    """Add an additional package using requested package_manager."""
+    package_manager = package_manager or self.get_package_manager(target=target)
+    command = package_manager.add_package(
+      package,
+      type_option=type_option,
+      version_option=version_option,
+    )
+    return self._execute_command(
+      command, workunit_name=workunit_name, workunit_labels=workunit_labels)
 
-    :param list args: The command line args to pass to `npm`.
-    :param string workunit_name: A name for the execution's work unit; defaults to 'npm'.
-    :param list workunit_labels: Any extra :class:`pants.base.workunit.WorkUnitLabel`s to apply.
-    :param list node_paths: A list of node module paths to be included.
-    :returns: A tuple of (returncode, command).
-    :rtype: A tuple of (int,
-            :class:`pants.contrib.node.subsystems.node_distribution.NodeDistribution.Command`)
-    """
+  def install_module(
+    self, target=None, package_manager=None, 
+    install_optional=False, production_only=False, force=False, 
+    node_paths=None, workunit_name=None, workunit_labels=None):
+    """Installs node module using requested package_manager."""
+    package_manager = package_manager or self.get_package_manager(target=target)
+    command = package_manager.install_module(
+      install_optional=install_optional,
+      force=force,
+      production_only=production_only,
+      node_paths=node_paths,
+    )
+    return self._execute_command(
+      command, workunit_name=workunit_name, workunit_labels=workunit_labels)
 
-    npm_command = self.node_distribution.npm_command(args=args, node_paths=node_paths)
-    return self._execute_command(npm_command,
-                                 workunit_name=workunit_name,
-                                 workunit_labels=workunit_labels)
-
-  def execute_yarnpkg(self, args, workunit_name, workunit_labels=None, node_paths=None):
-    """Executes npm passing the given args.
-
-    :param list args: The command line args to pass to `yarnpkg`.
-    :param string workunit_name: A name for the execution's work unit; defaults to 'yarnpkg'.
-    :param list workunit_labels: Any extra :class:`pants.base.workunit.WorkUnitLabel`s to apply.
-    :param list node_paths: A list of node module paths to be included.
-    :returns: A tuple of (returncode, command).
-    :rtype: A tuple of (int,
-            :class:`pants.contrib.node.subsystems.node_distribution.NodeDistribution.Command`)
-    """
-
-    yarnpkg_command = self.node_distribution.yarnpkg_command(args=args, node_paths=node_paths,
-                                                             context=self.context)
-    return self._execute_command(yarnpkg_command,
-                                 workunit_name=workunit_name,
-                                 workunit_labels=workunit_labels)
+  def run_script(
+    self, script_name, target=None, package_manager=None, script_args=None, node_paths=None,
+    workunit_name=None, workunit_labels=None):
+    package_manager = package_manager or self.get_package_manager(target=target)
+    command = package_manager.run_script(
+      script_name,
+      script_args=script_args,
+      node_paths=node_paths,
+    )
+    return self._execute_command(
+      command, workunit_name=workunit_name, workunit_labels=workunit_labels)
 
   def _execute_command(self, command, workunit_name, workunit_labels=None):
     """Executes a node or npm command via self._run_node_distribution_command.

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -10,6 +10,7 @@ from pants.task.task import Task
 from pants.util.memo import memoized_property
 
 from pants.contrib.node.subsystems.node_distribution import NodeDistribution
+from pants.contrib.node.subsystems.package_managers import PACKAGE_MANAGER_YARNPKG
 from pants.contrib.node.targets.node_bundle import NodeBundle
 from pants.contrib.node.targets.node_module import NodeModule
 from pants.contrib.node.targets.node_package import NodePackage
@@ -118,6 +119,14 @@ class NodeTask(Task):
     )
     return self._execute_command(
       command, workunit_name=workunit_name, workunit_labels=workunit_labels)
+
+  def run_cli(self, cli, args=None, node_paths=None, workunit_name=None, workunit_labels=None):
+    package_manager = self.node_distribution.get_package_manager(
+      package_manager=PACKAGE_MANAGER_YARNPKG)
+    command = package_manager.run_cli(cli, args=args, node_paths=node_paths)
+    return self._execute_command(
+      command, workunit_name=workunit_name, workunit_labels=workunit_labels)
+
 
   def _execute_command(self, command, workunit_name, workunit_labels=None):
     """Executes a node or npm command via self._run_node_distribution_command.

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -128,7 +128,6 @@ class NodeTask(Task):
     return self._execute_command(
       command, workunit_name=workunit_name, workunit_labels=workunit_labels)
 
-
   def _execute_command(self, command, workunit_name=None, workunit_labels=None):
     """Executes a node or npm command via self._run_node_distribution_command.
 

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_task.py
@@ -89,6 +89,7 @@ class NodeTask(Task):
       package,
       type_option=type_option,
       version_option=version_option,
+      node_paths=node_paths,
     )
     return self._execute_command(
       command, workunit_name=workunit_name, workunit_labels=workunit_labels)
@@ -128,7 +129,7 @@ class NodeTask(Task):
       command, workunit_name=workunit_name, workunit_labels=workunit_labels)
 
 
-  def _execute_command(self, command, workunit_name, workunit_labels=None):
+  def _execute_command(self, command, workunit_name=None, workunit_labels=None):
     """Executes a node or npm command via self._run_node_distribution_command.
 
     :param NodeDistribution.Command command: The command to run.

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -67,6 +67,7 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
       self.context.log.debug(
         'Testing node module (first dependency): {}'.format(node_module))
       with pushd(node_paths.node_path(node_module)):
+        self._currently_executing_test_targets = [target]
         result, test_command = self.run_script(
           target.script_name,
           target=target,

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -72,8 +72,8 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
           target=target,
           script_args=self.get_passthru_args(),
           node_paths=node_paths.all_node_paths,
-            workunit_name=target.address.reference(),
-            workunit_labels=[WorkUnitLabel.TEST])
+          workunit_name=target.address.reference(),
+          workunit_labels=[WorkUnitLabel.TEST])
         if result != 0:
           raise TaskError('test script failed:\n'
                           '\t{} failed with exit code {}'.format(test_command, result))

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -70,6 +70,7 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
         self._currently_executing_test_targets = [target]
         result, test_command = self.run_script(
           target.script_name,
+          package_manager=self.get_package_manager(target=node_module),
           target=target,
           script_args=self.get_passthru_args(),
           node_paths=node_paths.all_node_paths,

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -38,7 +38,7 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
   def _run_node_distribution_command(self, command, workunit):
     """Overrides NodeTask._run_node_distribution_command.
 
-    This is what execute_npm ultimately uses to run the NodeDistribution.Command.
+    This is what ultimately used to run the Command.
     It must return the return code of the process. The base implementation just calls
     command.run immediately. We override here to invoke TestRunnerTaskMixin._spawn_and_wait,
     which ultimately invokes _spawn, which finally calls command.run.
@@ -63,38 +63,20 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
     node_paths = self.context.products.get_data(NodePaths)
 
     for target in targets:
-      node_path = node_paths.node_path(target.dependencies[0])
-
+      node_module = target.dependencies[0]
       self.context.log.debug(
-        'Testing node module (first dependency): {}'.format(target.dependencies[0]))
-
-      package_manager = self.get_package_manager_for_target(target=target.dependencies[0])
-      if package_manager == self.node_distribution.PACKAGE_MANAGER_NPM:
-        args = ['run-script', target.script_name, '--'] + self.get_passthru_args()
-
-        with pushd(node_path):
-          self._currently_executing_test_targets = [target]
-          result, npm_test_command = self.execute_npm(
-            args,
-            node_paths=node_paths.all_node_paths,
+        'Testing node module (first dependency): {}'.format(node_module))
+      with pushd(node_paths.node_path(node_module)):
+        result, test_command = self.run_script(
+          target.script_name,
+          target=target,
+          script_args=self.get_passthru_args(),
+          node_paths=node_paths.all_node_paths,
             workunit_name=target.address.reference(),
             workunit_labels=[WorkUnitLabel.TEST])
-          if result != 0:
-            raise TaskError('npm test script failed:\n'
-                            '\t{} failed with exit code {}'.format(npm_test_command, result))
-      elif package_manager == self.node_distribution.PACKAGE_MANAGER_YARNPKG:
-        args = ['run', target.script_name, '--'] + self.get_passthru_args()
-        with pushd(node_path):
-          self._currently_executing_test_targets = [target]
-          result, npm_test_command = self.execute_yarnpkg(
-            args=args,
-            node_paths=node_paths.all_node_paths,
-            workunit_name=target.address.reference(),
-            workunit_labels=[WorkUnitLabel.TEST])
-          if result != 0:
-            raise TaskError('npm test script failed:\n'
-                            '\t{} failed with exit code {}'.format(npm_test_command, result))
-
+        if result != 0:
+          raise TaskError('test script failed:\n'
+                          '\t{} failed with exit code {}'.format(test_command, result))
     self._currently_executing_test_targets = []
 
   def _spawn(self, command, workunit):

--- a/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
+++ b/contrib/node/src/python/pants/contrib/node/tasks/node_test.py
@@ -38,7 +38,7 @@ class NodeTest(TestRunnerTaskMixin, NodeTask):
   def _run_node_distribution_command(self, command, workunit):
     """Overrides NodeTask._run_node_distribution_command.
 
-    This is what ultimately used to run the Command.
+    This is what is ultimately used to run the Command.
     It must return the return code of the process. The base implementation just calls
     command.run immediately. We override here to invoke TestRunnerTaskMixin._spawn_and_wait,
     which ultimately invokes _spawn, which finally calls command.run.

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/BUILD
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/BUILD
@@ -11,3 +11,13 @@ python_tests(
     'tests/python/pants_test/subsystem:subsystem_utils',
   ]
 )
+
+python_tests(
+  name='package_managers',
+  sources=['test_package_managers.py'],
+  dependencies=[
+    '3rdparty/python:mock',
+    'contrib/node/src/python/pants/contrib/node/subsystems',
+    'tests/python/pants_test:base_test',
+  ]
+)

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_node_distribution.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_node_distribution.py
@@ -41,26 +41,30 @@ class NodeDistributionTest(unittest.TestCase):
                 'output:\n{}'.format(out))
 
   def test_npm(self):
-    npm_version_flag = self.distribution.npm_command(args=['--version'])
+    npm_version_flag = self.distribution.get_package_manager('npm').run_command(
+      args=['--version'])
     raw_version = npm_version_flag.check_output().strip()
 
-    npm_version_cmd = self.distribution.npm_command(args=['version', '--json'])
+    npm_version_cmd = self.distribution.get_package_manager('npm').run_command(
+      args=['version', '--json'])
     versions_json = npm_version_cmd.check_output()
     versions = json.loads(versions_json)
 
     self.assertEqual(raw_version, versions['npm'])
 
   def test_yarnpkg(self):
-    yarnpkg_version_command = self.distribution.yarnpkg_command(args=['--version'])
+    yarnpkg_version_command = self.distribution.get_package_manager('yarn').run_command(
+      args=['--version'])
     yarnpkg_version = yarnpkg_version_command.check_output().strip()
-    yarnpkg_versions_command = self.distribution.yarnpkg_command(args=['versions', '--json'])
+    yarnpkg_versions_command = self.distribution.get_package_manager('yarn').run_command(
+      args=['versions', '--json'])
     yarnpkg_versions = json.loads(yarnpkg_versions_command.check_output())
     self.assertEqual(yarnpkg_version, yarnpkg_versions['data']['yarn'])
 
   def test_node_command_path_injection(self):
-    node_bin_path = self.distribution.install_node()
     node_path_cmd = self.distribution.node_command(
       args=['--eval', 'console.log(process.env["PATH"])'])
+    node_bin_path = self.distribution._install_node()
 
     # Test the case in which we do not pass in env,
     # which should fall back to env=os.environ.copy()
@@ -68,9 +72,9 @@ class NodeDistributionTest(unittest.TestCase):
     self.assertEqual(node_bin_path, injected_paths[0])
 
   def test_node_command_path_injection_with_overrided_path(self):
-    node_bin_path = self.distribution.install_node()
     node_path_cmd = self.distribution.node_command(
       args=['--eval', 'console.log(process.env["PATH"])'])
+    node_bin_path = self.distribution._install_node()
     injected_paths = node_path_cmd.check_output(
       env={'PATH': '/test/path'}
     ).strip().split(os.pathsep)
@@ -78,9 +82,9 @@ class NodeDistributionTest(unittest.TestCase):
     self.assertListEqual([node_bin_path, '/test/path'], injected_paths)
 
   def test_node_command_path_injection_with_empty_path(self):
-    node_bin_path = self.distribution.install_node()
     node_path_cmd = self.distribution.node_command(
       args=['--eval', 'console.log(process.env["PATH"])'])
+    node_bin_path = self.distribution._install_node()
     injected_paths = node_path_cmd.check_output(
       env={'PATH': ''}
     ).strip().split(os.pathsep)

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
@@ -2,6 +2,9 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
 import mock
 import unittest
 

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
@@ -5,12 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import mock
 import unittest
 
-from pants.contrib.node.subsystems.package_managers import (
-  PackageInstallationTypeOption, PackageInstallationVersionOption,
-  PackageManagerNpm, PackageManagerYarnpkg)
+import mock
+
+from pants.contrib.node.subsystems.package_managers import (PackageInstallationTypeOption,
+                                                            PackageInstallationVersionOption,
+                                                            PackageManagerNpm,
+                                                            PackageManagerYarnpkg)
 
 
 def fake_install():

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
@@ -1,0 +1,176 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import mock
+import unittest
+
+from pants.contrib.node.subsystems.package_managers import (
+  PackageInstallationTypeOption, PackageInstallationVersionOption,
+  PackageManagerNpm, PackageManagerYarnpkg)
+
+
+def fake_install():
+  return 'fake_install_dir'
+
+
+@mock.patch('pants.contrib.node.subsystems.package_managers.command_gen')
+class TestYarnpkg(unittest.TestCase):
+
+  def setUp(self):
+    self.yarnpkg = PackageManagerYarnpkg([fake_install])
+  
+  def test_run_cli(self, mock_command_gen):
+    fake_cli = 'fake_cli'
+    args = ['arg1', 'arg2']
+
+    self.yarnpkg.run_cli(fake_cli, args=args)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'yarnpkg', args=([fake_cli, '--'] + args), node_paths=None)
+
+  def test_run_script(self, mock_command_gen):
+    script_name = 'script_name'
+    script_args = ['arg1', 'arg2']
+    self.yarnpkg.run_script(script_name, script_args=script_args)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'yarnpkg',
+      args=(['run', script_name, '--'] + script_args), node_paths=None)
+
+  def test_install_module_options_off(self, mock_command_gen):
+    self.yarnpkg.install_module(
+      install_optional=False, production_only=False, force=False)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'yarnpkg',
+      args=['--non-interactive', '--ignore-optional'], node_paths=None
+    )
+
+  def test_install_module_options_on(self, mock_command_gen):
+    self.yarnpkg.install_module(
+      install_optional=True, production_only=True, force=True)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'yarnpkg',
+      args=['--non-interactive', '--production=true', '--force'], node_paths=None
+    )
+
+  def test_add_package_default(self, mock_command_gen):
+    package_name = 'package_name'
+    self.yarnpkg.add_package(package_name)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'yarnpkg',
+      args=['add', package_name],
+      node_paths=None
+    )
+
+  def test_add_package_other_options(self, mock_command_gen):
+    package_name = 'package_name'
+    for type_option, expected_args in {
+      PackageInstallationTypeOption.DEV: ['--dev'],
+      PackageInstallationTypeOption.PEER: ['--peer'],
+      PackageInstallationTypeOption.OPTIONAL: ['--optional'],
+      PackageInstallationTypeOption.BUNDLE: [],
+      PackageInstallationTypeOption.NO_SAVE: [],
+    }.items():
+      self.yarnpkg.add_package(
+        package_name,
+        type_option=type_option,
+      )
+      mock_command_gen.assert_called_once_with(
+        [fake_install], 'yarnpkg',
+        args=['add', package_name] + expected_args,
+        node_paths=None
+      )
+      mock_command_gen.reset_mock()
+    for version_option, expected_args in {
+      PackageInstallationVersionOption.EXACT: ['--exact'],
+      PackageInstallationVersionOption.TILDE: ['--tilde'],
+    }.items():
+      self.yarnpkg.add_package(
+        package_name,
+        version_option=version_option,
+      )
+      mock_command_gen.assert_called_once_with(
+        [fake_install], 'yarnpkg',
+        args=['add', package_name] + expected_args,
+        node_paths=None
+      )
+      mock_command_gen.reset_mock()
+
+
+@mock.patch('pants.contrib.node.subsystems.package_managers.command_gen')
+class TestNpm(unittest.TestCase):
+
+  def setUp(self):
+    self.npm = PackageManagerNpm([fake_install])
+  
+  def test_run_cli(self, mock_command_gen):
+    fake_cli = 'fake_cli'
+    args = ['arg1', 'arg2']
+
+    self.assertRaises(RuntimeError, self.npm.run_cli, fake_cli, args=args)
+
+  def test_run_script(self, mock_command_gen):
+    script_name = 'script_name'
+    script_args = ['arg1', 'arg2']
+    self.npm.run_script(script_name, script_args=script_args)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'npm',
+      args=(['run-script', script_name, '--'] + script_args), node_paths=None)
+
+  def test_install_module_options_off(self, mock_command_gen):
+    self.npm.install_module(
+      install_optional=False, production_only=False, force=False)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'npm',
+      args=['install', '--no-optional'], node_paths=None
+    )
+
+  def test_install_module_options_on(self, mock_command_gen):
+    self.npm.install_module(
+      install_optional=True, production_only=True, force=True)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'npm',
+      args=['install', '--production', '--force'], node_paths=None
+    )
+
+  def test_add_package_default(self, mock_command_gen):
+    package_name = 'package_name'
+    self.npm.add_package(package_name)
+    mock_command_gen.assert_called_once_with(
+      [fake_install], 'npm',
+      args=['install', package_name, '--save-prod'],
+      node_paths=None
+    )
+
+  def test_add_package_other_options(self, mock_command_gen):
+    package_name = 'package_name'
+    for type_option, expected_args in {
+      PackageInstallationTypeOption.DEV: ['--save-dev'],
+      PackageInstallationTypeOption.PEER: [],
+      PackageInstallationTypeOption.OPTIONAL: ['--save-optional'],
+      PackageInstallationTypeOption.BUNDLE: ['--save-bundle'],
+      PackageInstallationTypeOption.NO_SAVE: ['--no-save'],
+    }.items():
+      self.npm.add_package(
+        package_name,
+        type_option=type_option,
+      )
+      mock_command_gen.assert_called_once_with(
+        [fake_install], 'npm',
+        args=['install', package_name] + expected_args,
+        node_paths=None
+      )
+      mock_command_gen.reset_mock()
+    for version_option, expected_args in {
+      PackageInstallationVersionOption.EXACT: ['--save-exact'],
+      PackageInstallationVersionOption.TILDE: [],
+    }.items():
+      self.npm.add_package(
+        package_name,
+        version_option=version_option,
+      )
+      mock_command_gen.assert_called_once_with(
+        [fake_install], 'npm',
+        args=['install', package_name, '--save-prod'] + expected_args,
+        node_paths=None
+      )
+      mock_command_gen.reset_mock()

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
@@ -263,17 +263,13 @@ class NodeResolveTest(TaskTestBase):
     })
     task = self.create_task(context)
 
-    method_to_mock = {
-      'npm': 'execute_npm',
-      'yarn': 'execute_yarnpkg'
-    }[package_manager]
-    with mock.patch.object(task, method_to_mock) as exec_call:
-      exec_call.return_value = (0, None)
+    package_manager_obj = task.get_package_manager(target=target)
+    with mock.patch.object(package_manager_obj, 'run_command') as exec_call:
+      exec_call.return_value.run.return_value.wait.return_value = 0
       task.execute()
       exec_call.assert_called_once_with(
-        expected_params,
-        workunit_labels=mock.ANY,
-        workunit_name=mock.ANY)
+        args=expected_params,
+        node_paths=None)
 
   def test_resolve_default_no_optional_install_npm(self):
     self._test_resolve_optional_install_helper(
@@ -290,11 +286,11 @@ class NodeResolveTest(TaskTestBase):
   def test_resolve_default_no_optional_install_yarn(self):
     self._test_resolve_optional_install_helper(
       install_optional=False,
-      package_manager='yarn',
-      expected_params=['--ignore-optional'])
+      package_manager='yarnpkg',
+      expected_params=['--non-interactive', '--ignore-optional'])
 
   def test_resolve_optional_install_yarn(self):
     self._test_resolve_optional_install_helper(
       install_optional=True,
-      package_manager='yarn',
-      expected_params=[])
+      package_manager='yarnpkg',
+      expected_params=['--non-interactive'])

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_task.py
@@ -115,7 +115,10 @@ class NodeTaskTest(TaskTestBase):
       with open(os.path.join(chroot, 'package.json'), 'wb') as fp:
         json.dump(package, fp)
       with pushd(chroot):
-        returncode, _ = task.execute_npm(['run-script', 'proof'], workunit_name='test')
+        returncode, _ = task.run_script(
+          'proof',
+          package_manager=task.node_distribution.get_package_manager(package_manager='npm'),
+          workunit_name='test')
 
       self.assertEqual(0, returncode)
       self.assertTrue(os.path.exists(proof))
@@ -137,7 +140,10 @@ class NodeTaskTest(TaskTestBase):
       with open(os.path.join(chroot, 'package.json'), 'wb') as fp:
         json.dump(package, fp)
       with pushd(chroot):
-        returncode, _ = task.execute_yarnpkg(['run', 'proof'], workunit_name='test')
+        returncode, _ = task.run_script(
+          'proof',
+          package_manager=task.node_distribution.get_package_manager(package_manager='yarnpkg'),
+          workunit_name='test')
 
       self.assertEqual(0, returncode)
       self.assertTrue(os.path.exists(proof))


### PR DESCRIPTION
### Problem
There are two package managers that are currently supported by Pants, npm and yarn.  The codes to invoke those two package manager are scattered in various task and usually invokes a pattern of codes looks like:

  * get the package manager defined at target level;
  * if not defined, use subsystem default package manager;
  * if package manager is npm, generate npm command line;
  * otherwise if package manager is yarn, generate yarn command line;
  * run the generated command in task context.

### Solution

Remodel node subsystem code to provide better package manager support.  PackageManagers are used to remove package manager selection logic from task level.  It also isolates npm/yarn specific codes into separate classes that is easier to understand. 

Minimal work has go into eslint javascript style task.  Further remodeling will be required.
### Result

There should be no end user impact, while the codes should be more readable and easier to add future package manager related functionalities.  It should also be easier to add more tools for node if necessary.
