### PR TITLE
Dedupe parsed Gets

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -57,14 +57,14 @@ def rule(output_type, input_selectors):
                          'got: {}'.format(name))
       return resolved
 
-    gets = []
+    gets = OrderedSet()
     for node in ast.iter_child_nodes(module_ast):
       if isinstance(node, ast.FunctionDef) and node.name == func.__name__:
         rule_visitor = _RuleVisitor()
         rule_visitor.visit(node)
-        gets.extend(Get(resolve_type(p), resolve_type(s)) for p, s in rule_visitor.gets)
+        gets.update(Get(resolve_type(p), resolve_type(s)) for p, s in rule_visitor.gets)
 
-    func._rule = TaskRule(output_type, input_selectors, func, input_gets=gets)
+    func._rule = TaskRule(output_type, input_selectors, func, input_gets=list(gets))
     return func
   return wrapper
 

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -11,15 +11,16 @@ from textwrap import dedent
 
 from pants.build_graph.address import Address
 from pants.engine.nodes import Return
-from pants.engine.rules import RootRule, TaskRule
-from pants.engine.selectors import Select
+from pants.engine.rules import RootRule, TaskRule, rule
+from pants.engine.selectors import Get, Select
+from pants.util.objects import datatype
 from pants_test.engine.examples.planners import Classpath, setup_json_scheduler
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 from pants_test.engine.util import (assert_equal_with_printing, init_native,
                                     remove_locations_from_traceback)
 
 
-class EngineTest(unittest.TestCase):
+class EngineExamplesTest(unittest.TestCase):
 
   _native = init_native()
 
@@ -72,12 +73,34 @@ def nested_raise(x):
   fn_raises(x)
 
 
-class EngineTraceTest(unittest.TestCase, SchedulerTestBase):
+class Fib(datatype('Fib', 'val')): pass
+
+
+@rule(Fib, [Select(int)])
+def fib(n):
+  if n < 2:
+    yield Fib(n)
+  x, y = yield Get(Fib, int(n-2)), Get(Fib, int(n-1))
+  yield Fib(x.val + y.val)
+
+
+class EngineTest(unittest.TestCase, SchedulerTestBase):
 
   assert_equal_with_printing = assert_equal_with_printing
 
   def scheduler(self, rules, include_trace_on_error):
     return self.mk_scheduler(rules=rules, include_trace_on_error=include_trace_on_error)
+
+  def test_recursive_multi_get(self):
+    # Tests that a rule that "uses itself" multiple times per invoke works.
+    rules = [
+      fib,
+      RootRule(int),
+    ]
+
+    fib_10, = self.mk_scheduler(rules=rules).product_request(Fib, subjects=[10])
+
+    self.assertEqual(55, fib_10.val)
 
   def test_no_include_trace_error_raises_boring_error(self):
     rules = [


### PR DESCRIPTION
### Problem

Rules containing two `Get`s for the same product/subject pair experience a panic during RuleGraph construction time.

### Solution

Dedupe `Get` requests.