### PR TITLE
Add python_app support

### DIFF
--- a/examples/src/python/example/hello/main/BUILD
+++ b/examples/src/python/example/hello/main/BUILD
@@ -9,3 +9,14 @@ python_binary(
   ],
   source='main.py',
 )
+
+# An "app" is a binary plus other loose files bundled together in
+# an archive (e.g.: tar.gz, zip). In this example, the archive includes
+# both `main.pex` and `BUILD`.
+python_app(
+  name='hello-app',
+  binary=':main',
+  bundles=[
+    bundle(fileset=globs('BUILD')),
+  ],
+)

--- a/src/python/pants/backend/jvm/tasks/bundle_create.py
+++ b/src/python/pants/backend/jvm/tasks/bundle_create.py
@@ -41,7 +41,6 @@ class BundleCreate(BundleMixin, JvmBinaryTask):
                   "directory, the root will only contain a synthetic jar with its manifest's "
                   "Class-Path set to those jars. This option is also defined in jvm_app target. "
                   "Precedence is CLI option > target option > pants.ini option.")
-    cls.register_common_options(register)
 
   @classmethod
   def implementation_version(cls):

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -36,7 +36,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 def build_file_aliases():
   return BuildFileAliases(
     targets={
-      PythonApp.alias():PythonApp,
+      PythonApp.alias(): PythonApp,
       PythonBinary.alias(): PythonBinary,
       PythonLibrary.alias(): PythonLibrary,
       PythonTests.alias(): PythonTests,

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -9,6 +9,7 @@ from pants.backend.python.pants_requirement import PantsRequirement
 from pants.backend.python.python_artifact import PythonArtifact
 from pants.backend.python.python_requirement import PythonRequirement
 from pants.backend.python.python_requirements import PythonRequirements
+from pants.backend.python.targets.python_app import PythonApp
 from pants.backend.python.targets.python_binary import PythonBinary
 from pants.backend.python.targets.python_distribution import PythonDistribution
 from pants.backend.python.targets.python_library import PythonLibrary
@@ -20,6 +21,7 @@ from pants.backend.python.tasks.gather_sources import GatherSources
 from pants.backend.python.tasks.pytest_prep import PytestPrep
 from pants.backend.python.tasks.pytest_run import PytestRun
 from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
+from pants.backend.python.tasks.python_bundle import PythonBundle
 from pants.backend.python.tasks.python_isort import IsortPythonTask
 from pants.backend.python.tasks.python_repl import PythonRepl
 from pants.backend.python.tasks.python_run import PythonRun
@@ -34,6 +36,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 def build_file_aliases():
   return BuildFileAliases(
     targets={
+      PythonApp.alias():PythonApp,
       PythonBinary.alias(): PythonBinary,
       PythonLibrary.alias(): PythonLibrary,
       PythonTests.alias(): PythonTests,
@@ -65,6 +68,7 @@ def register_goals():
   task(name='setup-py', action=SetupPy).install()
   task(name='py', action=PythonBinaryCreate).install('binary')
   task(name='isort', action=IsortPythonTask).install('fmt')
+  task(name='py', action=PythonBundle).install('bundle')
 
 
 def rules():

--- a/src/python/pants/backend/python/targets/BUILD
+++ b/src/python/pants/backend/python/targets/BUILD
@@ -3,6 +3,7 @@
 
 python_library(
   sources = [
+    'python_app.py',
     'python_binary.py',
     'python_distribution.py',
     'python_library.py',

--- a/src/python/pants/backend/python/targets/python_app.py
+++ b/src/python/pants/backend/python/targets/python_app.py
@@ -1,0 +1,23 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.python.targets.python_binary import PythonBinary
+from pants.build_graph.app_base import AppBase
+
+
+class PythonApp(AppBase):
+  @classmethod
+  def alias(cls):
+    return 'python_app'
+
+  @classmethod
+  def binary_target_type(cls):
+    return PythonBinary
+
+  @staticmethod
+  def is_python_app(target):
+    return isinstance(target, PythonApp)

--- a/src/python/pants/backend/python/tasks/python_bundle.py
+++ b/src/python/pants/backend/python/tasks/python_bundle.py
@@ -9,6 +9,7 @@ import os
 
 from pants.backend.python.targets.python_app import PythonApp
 from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
 from pants.build_graph.bundle_mixin import BundleMixin
 from pants.fs import archive
 from pants.task.task import Task
@@ -90,6 +91,10 @@ class PythonBundle(BundleMixin, Task):
 
   def _get_binary_path(self, target):
     pex_archives = self.context.products.get(self._PEX_ARCHIVES)
+    paths = []
     for basedir, filenames in pex_archives.get(target.binary).items():
       for filename in filenames:
-        return os.path.join(basedir, filename)
+        paths.append(os.path.join(basedir, filename))
+    if len(paths) != 1:
+      raise TaskError('Expected one binary but found: {}'.format(', '.join(sorted(paths))))
+    return paths[0]

--- a/src/python/pants/backend/python/tasks/python_bundle.py
+++ b/src/python/pants/backend/python/tasks/python_bundle.py
@@ -23,11 +23,6 @@ class PythonBundle(BundleMixin, Task):
   _PEX_ARCHIVES = 'pex_archives'
 
   @classmethod
-  def register_options(cls, register):
-    super(PythonBundle, cls).register_options(register)
-    cls.register_common_options(register)
-
-  @classmethod
   def product_types(cls):
     return [cls._DEPLOYABLE_ARCHIVES]
 

--- a/src/python/pants/backend/python/tasks/python_bundle.py
+++ b/src/python/pants/backend/python/tasks/python_bundle.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.backend.python.targets.python_app import PythonApp
+from pants.base.build_environment import get_buildroot
+from pants.build_graph.bundle_mixin import BundleMixin
+from pants.fs import archive
+from pants.task.task import Task
+from pants.util.dirutil import safe_mkdir
+
+
+class PythonBundle(BundleMixin, Task):
+  """Create an archive bundle of PythonApp targets."""
+
+  _DEPLOYABLE_ARCHIVES = 'deployable_archives'
+  _PEX_ARCHIVES = 'pex_archives'
+
+  @classmethod
+  def register_options(cls, register):
+    super(PythonBundle, cls).register_options(register)
+    cls.register_common_options(register)
+
+  @classmethod
+  def product_types(cls):
+    return [cls._DEPLOYABLE_ARCHIVES]
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(PythonBundle, cls).prepare(options, round_manager)
+    round_manager.require_data(cls._PEX_ARCHIVES)
+
+  @staticmethod
+  def _get_archive_path(vt, archive_format):
+    ext = archive.archive_extensions.get(archive_format, archive_format)
+    filename = '{}.{}'.format(vt.target.id, ext)
+    return os.path.join(vt.results_dir, filename) if archive_format else ''
+
+  @property
+  def create_target_dirs(self):
+    return True
+
+  def __init__(self, *args, **kwargs):
+    super(PythonBundle, self).__init__(*args, **kwargs)
+    self._outdir = self.get_options().pants_distdir
+
+  def execute(self):
+    targets_to_bundle = self.context.targets(PythonApp.is_python_app)
+
+    with self.invalidated(targets_to_bundle, invalidate_dependents=True) as invalidation_check:
+      bundle_archive_product = self.context.products.get(self._DEPLOYABLE_ARCHIVES)
+
+      for vt in invalidation_check.all_vts:
+        bundle_dir = self.get_bundle_dir(vt.target.id, vt.results_dir)
+        archive_format = self.resolved_option(self.get_options(), vt.target, 'archive')
+        archiver = archive.archiver(archive_format) if archive_format else None
+        archive_path = self._get_archive_path(vt, archive_format)
+
+        if not vt.valid:  # Only recreate the bundle/archive if it's changed
+          self._bundle(vt.target, bundle_dir)
+          if archiver:
+            archiver.create(bundle_dir, vt.results_dir, vt.target.id)
+            self.context.log.info(
+              'created archive {}'.format(os.path.relpath(archive_path, get_buildroot())))
+
+        if archiver:
+          bundle_archive_product.add(
+            vt.target, os.path.dirname(archive_path)).append(os.path.basename(archive_path))
+
+        if vt.target in self.context.target_roots:  # Always publish bundle/archive in dist
+          self.publish_results(self.get_options().pants_distdir,
+                               False,
+                               vt,
+                               bundle_dir,
+                               archive_path,
+                               vt.target.id,
+                               archive_format)
+
+  def _bundle(self, target, bundle_dir):
+    self.context.log.debug('creating {}'.format(os.path.relpath(bundle_dir, get_buildroot())))
+    safe_mkdir(bundle_dir, clean=True)
+    binary_path = self._get_binary_path(target)
+    os.symlink(binary_path, os.path.join(bundle_dir, os.path.basename(binary_path)))
+    self.symlink_bundles(target, bundle_dir)
+
+  def _get_binary_path(self, target):
+    pex_archives = self.context.products.get(self._PEX_ARCHIVES)
+    for basedir, filenames in pex_archives.get(target.binary).items():
+      for filename in filenames:
+        return os.path.join(basedir, filename)

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -60,6 +60,7 @@ class LegacySymbolTable(SymbolTable):
 
     self._table['junit_tests'] = JunitTestsAdaptor
     self._table['jvm_app'] = AppAdaptor
+    self._table['python_app'] = AppAdaptor
     self._table['python_tests'] = PythonTestsAdaptor
     self._table['python_binary'] = PythonTargetAdaptor
     self._table['remote_sources'] = RemoteSourcesAdaptor

--- a/src/python/pants/build_graph/bundle_mixin.py
+++ b/src/python/pants/build_graph/bundle_mixin.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os.path
+
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TargetDefinitionException
+from pants.build_graph.app_base import AppBase
+from pants.fs import archive
+from pants.util.dirutil import absolute_symlink, safe_mkdir, safe_mkdir_for
+from pants.util.fileutil import atomic_copy
+
+
+class BundleMixin(object):
+
+  @staticmethod
+  def register_common_options(register):
+    register('--archive', choices=list(archive.TYPE_NAMES),
+             fingerprint=True,
+             help='Create an archive of this type from the bundle. '
+                  'This option is also defined in app target. '
+                  'Precedence is CLI option > target option > pants.ini option.')
+    # `target.id` ensures global uniqueness, this flag is provided primarily for
+    # backward compatibility.
+    register('--use-basename-prefix', advanced=True, type=bool,
+             help='Use target basename to prefix bundle folder or archive; otherwise a unique '
+                  'identifier derived from target will be used.')
+
+  @staticmethod
+  def get_bundle_dir(name, results_dir):
+    return os.path.join(results_dir, '{}-bundle'.format(name))
+
+  # TODO (Benjy): The following CLI > target > config logic
+  # should be implemented in the options system.
+  # https://github.com/pantsbuild/pants/issues/3538
+  @staticmethod
+  def resolved_option(options, target, key):
+    """Get value for option "key".
+
+    Resolution precedence is CLI option > target option > pants.ini option.
+
+    :param options: Options returned by `task.get_option()`
+    :param target: Target
+    :param key: Key to get using the resolution precedence
+    """
+    option_value = options.get(key)
+    if not isinstance(target, AppBase) or options.is_flagged(key):
+      return option_value
+    v = target.payload.get_field_value(key, None)
+    return option_value if v is None else v
+
+  def symlink_bundles(self, app, bundle_dir):
+    """For each bundle in the given app, symlinks relevant matched paths.
+
+    Validates that at least one path was matched by a bundle.
+    """
+    for bundle_counter, bundle in enumerate(app.bundles):
+      count = 0
+      for path, relpath in bundle.filemap.items():
+        bundle_path = os.path.join(bundle_dir, relpath)
+        count += 1
+        if os.path.exists(bundle_path):
+          continue
+
+        if os.path.isfile(path):
+          safe_mkdir(os.path.dirname(bundle_path))
+          os.symlink(path, bundle_path)
+        elif os.path.isdir(path):
+          safe_mkdir(bundle_path)
+
+      if count == 0:
+        raise TargetDefinitionException(app.target,
+                                        'Bundle index {} of "bundles" field '
+                                        'does not match any files.'.format(bundle_counter))
+
+  def publish_results(self, dist_dir, use_basename_prefix, vt, bundle_dir, archivepath, id, archive_ext):
+    """Publish a copy of the bundle and archive from the results dir in dist."""
+    # TODO (from mateor) move distdir management somewhere more general purpose.
+    name = vt.target.basename if use_basename_prefix else id
+    bundle_copy = os.path.join(dist_dir, '{}-bundle'.format(name))
+    absolute_symlink(bundle_dir, bundle_copy)
+    self.context.log.info(
+      'created bundle copy {}'.format(os.path.relpath(bundle_copy, get_buildroot())))
+
+    if archivepath:
+      ext = archive.archive_extensions.get(archive_ext, archive_ext)
+      archive_copy = os.path.join(dist_dir,'{}.{}'.format(name, ext))
+      safe_mkdir_for(archive_copy)  # Ensure parent dir exists
+      atomic_copy(archivepath, archive_copy)
+      self.context.log.info(
+        'created archive copy {}'.format(os.path.relpath(archive_copy, get_buildroot())))

--- a/src/python/pants/build_graph/bundle_mixin.py
+++ b/src/python/pants/build_graph/bundle_mixin.py
@@ -19,6 +19,11 @@ class BundleMixin(object):
 
   @staticmethod
   def register_common_options(register):
+    """Register options common to all bundles.
+
+    Bundle tasks must call this method from their `register_options` even if they do not
+    specify additional options.
+    """
     register('--archive', choices=list(archive.TYPE_NAMES),
              fingerprint=True,
              help='Create an archive of this type from the bundle. '

--- a/src/python/pants/build_graph/bundle_mixin.py
+++ b/src/python/pants/build_graph/bundle_mixin.py
@@ -11,19 +11,17 @@ from pants.base.build_environment import get_buildroot
 from pants.base.exceptions import TargetDefinitionException
 from pants.build_graph.app_base import AppBase
 from pants.fs import archive
+from pants.task.task import TaskBase
 from pants.util.dirutil import absolute_symlink, safe_mkdir, safe_mkdir_for
 from pants.util.fileutil import atomic_copy
 
 
-class BundleMixin(object):
+class BundleMixin(TaskBase):
 
-  @staticmethod
-  def register_common_options(register):
-    """Register options common to all bundles.
-
-    Bundle tasks must call this method from their `register_options` even if they do not
-    specify additional options.
-    """
+  @classmethod
+  def register_options(cls, register):
+    """Register options common to all bundle tasks."""
+    super(BundleMixin, cls).register_options(register)
     register('--archive', choices=list(archive.TYPE_NAMES),
              fingerprint=True,
              help='Create an archive of this type from the bundle. '

--- a/src/python/pants/engine/legacy/BUILD
+++ b/src/python/pants/engine/legacy/BUILD
@@ -54,7 +54,6 @@ python_library(
   dependencies=[
     '3rdparty/python/twitter/commons:twitter.common.collections',
     ':structs',
-    'src/python/pants/backend/jvm/targets:jvm',
     'src/python/pants/base:exceptions',
     'src/python/pants/base:parse_context',
     'src/python/pants/build_graph',

--- a/src/python/pants/engine/legacy/graph.py
+++ b/src/python/pants/engine/legacy/graph.py
@@ -11,13 +11,12 @@ from contextlib import contextmanager
 
 from twitter.common.collections import OrderedSet
 
-from pants.backend.jvm.targets.jvm_app import JvmApp
 from pants.base.exceptions import TargetDefinitionException
 from pants.base.parse_context import ParseContext
 from pants.base.specs import SingleAddress, Specs
 from pants.build_graph.address import Address
 from pants.build_graph.address_lookup_error import AddressLookupError
-from pants.build_graph.app_base import Bundle
+from pants.build_graph.app_base import AppBase, Bundle
 from pants.build_graph.build_graph import BuildGraph
 from pants.build_graph.remote_sources import RemoteSources
 from pants.engine.addressable import BuildFileAddresses
@@ -153,7 +152,7 @@ class LegacyBuildGraph(BuildGraph):
       kwargs.pop('dependencies')
 
       # Instantiate.
-      if target_cls is JvmApp:
+      if issubclass(target_cls, AppBase):
         return self._instantiate_app(target_cls, kwargs)
       elif target_cls is RemoteSources:
         return self._instantiate_remote_sources(kwargs)


### PR DESCRIPTION
Pants supports the "app" concept - a binary + other loose files - but currently only has the `jvm_app` implementation. Here we add `python_app` which is given a `python_binary` and `bundles` to include in an archive. This enables users to easily create a pex along with other files needed in production and create a deployable archive.