### PR TITLE
brfs: FUSE filesystem exposing the Store and remote CAS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -416,9 +416,7 @@ matrix:
       script:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
     - os: osx
-      # We request the oldest image we can (corresponding to OSX 10.10) for maximum compatibility.
-      # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
-      osx_image: xcode6.4
+      osx_image: xcode9.3
       language: generic
       env:
         - SHARD="Rust tests OSX"

--- a/.travis.yml
+++ b/.travis.yml
@@ -417,7 +417,7 @@ matrix:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
     - os: osx
       # Fuse actually works on this image. It hangs on many others.
-      osx_image: xcode8.1
+      osx_image: xcode8.3
       language: generic
       env:
         - SHARD="Rust tests OSX"

--- a/.travis.yml
+++ b/.travis.yml
@@ -416,13 +416,13 @@ matrix:
       script:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
     - os: osx
+      # Fuse actually works on this image. It hangs on many others.
       osx_image: xcode8.1
       language: generic
       env:
         - SHARD="Rust tests OSX"
       before_install:
-        - brew tap caskroom/cask
-        - brew update && brew cask install osxfuse
+        - brew tap caskroom/cask && brew update && brew cask install osxfuse
       script:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -416,7 +416,7 @@ matrix:
       script:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode8.1
       language: generic
       env:
         - SHARD="Rust tests OSX"

--- a/.travis.yml
+++ b/.travis.yml
@@ -412,7 +412,7 @@ matrix:
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf
       env:
-        - SHARD="Rust tests"
+        - SHARD="Rust Tests Linux"
       script:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
     - os: osx
@@ -420,7 +420,7 @@ matrix:
       osx_image: xcode8.3
       language: generic
       env:
-        - SHARD="Rust tests OSX"
+        - SHARD="Rust Tests OSX"
       before_install:
         - brew tap caskroom/cask && brew update && brew cask install osxfuse
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -407,7 +407,7 @@ matrix:
           packages:
             - cmake
       before_install:
-        - sudo apt-get install -y pkg-config fuse
+        - sudo apt-get install -y pkg-config fuse libfuse-dev
         - sudo modprobe fuse
         - sudo chmod 666 /dev/fuse
         - sudo chown root:$USER /etc/fuse.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -420,6 +420,9 @@ matrix:
       language: generic
       env:
         - SHARD="Rust tests OSX"
+      before_install:
+        - brew tap caskroom/cask
+        - brew update && brew cask install osxfuse
       script:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -415,6 +415,15 @@ matrix:
         - SHARD="Rust tests"
       script:
         - ./build-support/bin/ci.sh -bcfjklmnprtx
+    - os: osx
+      # We request the oldest image we can (corresponding to OSX 10.10) for maximum compatibility.
+      # See: https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+      osx_image: xcode6.4
+      language: generic
+      env:
+        - SHARD="Rust tests OSX"
+      script:
+        - ./build-support/bin/ci.sh -bcfjklmnprtx
 
 deploy:
   # See: https://docs.travis-ci.com/user/deployment/s3/

--- a/.travis.yml
+++ b/.travis.yml
@@ -399,12 +399,18 @@ matrix:
     # Rust tests
     - os: linux
       dist: trusty
+      sudo: required
       language: python
       python: "2.7.13"
       addons:
         apt:
           packages:
             - cmake
+      before_install:
+        - sudo apt-get install -y pkg-config fuse
+        - sudo modprobe fuse
+        - sudo chmod 666 /dev/fuse
+        - sudo chown root:$USER /etc/fuse.conf
       env:
         - SHARD="Rust tests"
       script:

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -214,7 +214,7 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
     source "${REPO_ROOT}/build-support/pants_venv"
     source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
     activate_pants_venv
-    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --all --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml"
+    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --manifest-path="${REPO_ROOT}/src/rust/engine/fs/brfs/Cargo.toml" -- --test-threads=1 --nocapture
   ) || die "Pants rust test failure"
   end_travis_section
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -214,8 +214,7 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
     source "${REPO_ROOT}/build-support/pants_venv"
     source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
     activate_pants_venv
-    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test --no-run "${MODE_FLAG}" --manifest-path="${REPO_ROOT}/src/rust/engine/fs/brfs/Cargo.toml"
-    RUST_LOG=debug RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --manifest-path="${REPO_ROOT}/src/rust/engine/fs/brfs/Cargo.toml" -- --test-threads=1 --nocapture
+    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --all --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml"
   ) || die "Pants rust test failure"
   end_travis_section
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -213,8 +213,16 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
   (
     source "${REPO_ROOT}/build-support/pants_venv"
     source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
+
+    test_threads_flag=""
+    if [[ "$(uname)" == "Darwin" ]]; then
+      # The osx travis environment has a low file descriptors ulimit, so we avoid running too many
+      # tests in parallel.
+      test_threads_flag="--test-threads=2"
+    fi
+
     activate_pants_venv
-    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --all --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml"
+    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --all --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" -- "${test_threads_flag}"
   ) || die "Pants rust test failure"
   end_travis_section
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -214,6 +214,7 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
     source "${REPO_ROOT}/build-support/pants_venv"
     source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
     activate_pants_venv
+    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test --no-run "${MODE_FLAG}" --manifest-path="${REPO_ROOT}/src/rust/engine/fs/brfs/Cargo.toml"
     RUST_LOG=debug RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --manifest-path="${REPO_ROOT}/src/rust/engine/fs/brfs/Cargo.toml" -- --test-threads=1 --nocapture
   ) || die "Pants rust test failure"
   end_travis_section

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -214,7 +214,7 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
     source "${REPO_ROOT}/build-support/pants_venv"
     source "${REPO_ROOT}/build-support/bin/native/bootstrap.sh"
     activate_pants_venv
-    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --manifest-path="${REPO_ROOT}/src/rust/engine/fs/brfs/Cargo.toml" -- --test-threads=1 --nocapture
+    RUST_LOG=debug RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --manifest-path="${REPO_ROOT}/src/rust/engine/fs/brfs/Cargo.toml" -- --test-threads=1 --nocapture
   ) || die "Pants rust test failure"
   end_travis_section
 fi

--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -218,7 +218,7 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
       # The osx travis environment has a low file descriptors ulimit, so we avoid running too many
       # tests in parallel.
-      test_threads_flag="--test-threads=2"
+      test_threads_flag="--test-threads=1"
     fi
 
     activate_pants_venv

--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -153,7 +153,7 @@ function _wait_noisily() {
 function _build_native_code() {
   # Builds the native code, and echos the path of the built binary.
 
-  ensure_cffi_sources=1 run_cargo build ${MODE_FLAG} --manifest-path ${NATIVE_ROOT}/Cargo.toml || die
+  ensure_cffi_sources=1 run_cargo build ${MODE_FLAG} --manifest-path ${NATIVE_ROOT}/Cargo.toml -p engine || die
   echo "${NATIVE_ROOT}/target/${MODE}/libengine.${LIB_EXTENSION}"
 }
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -61,6 +61,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brfs"
+version = "0.0.1"
+dependencies = [
+ "bazel_protos 0.0.1",
+ "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs 0.0.1",
+ "fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "testutil 0.0.1",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "byte-tools"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +191,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +271,18 @@ dependencies = [
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuse"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures"
@@ -668,12 +711,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-scoped"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -779,11 +837,13 @@ dependencies = [
 "checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f0628f04f7c26ebccf40d7fc2c1cf92236c05ec88cf2132641cc956812312f0f"
+"checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum fuse 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
 "checksum futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0bab5b5e94f5c31fc764ba5dd9ad16568aae5d4825538c01d6bca680c9bf94a7"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
@@ -829,7 +889,9 @@ dependencies = [
 "checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
+"checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -23,6 +23,7 @@ cc = "1.0"
 members = [
   "boxfuture",
   "fs",
+  "fs/brfs",
   "fs/fs_util",
   "hashing",
   "process_execution",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -18,11 +18,14 @@ crate-type = ["cdylib"]
 cc = "1.0"
 
 [workspace]
+# These are the packages which are built/tested when the --all flag is passed to cargo.
+#
 # We need to explicitly list these, because otherwise the standalone tools
-# (e.g. fs_util) won't be included.
-default-members = [
+# (e.g. fs_util) won't be included when we build/test things.
+members = [
   "boxfuture",
   "fs",
+  "fs/brfs",
   "fs/fs_util",
   "hashing",
   "process_execution",
@@ -32,10 +35,17 @@ default-members = [
   "testutil/mock",
 ]
 
-members = [
+# These are the packages which are built/tested when no special selector flags are passed to cargo.
+#
+# This is the set of packages which are expected to work on any arbitrary system that checks out the code.
+# It should be exactly equivalent to members, except without any packages that require more system
+# configuration than we're comfortable doing in our bootstrap scripts.
+#
+# In particular, it does not contain the fs/brfs package, which will not compile without a fuse installation.
+# On Ubuntu, that means installing libfuse-dev. On OSX, that means installing OSXFUSE.
+default-members = [
   "boxfuture",
   "fs",
-  "fs/brfs",
   "fs/fs_util",
   "hashing",
   "process_execution",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -23,6 +23,7 @@ cc = "1.0"
 # We need to explicitly list these, because otherwise the standalone tools
 # (e.g. fs_util) won't be included when we build/test things.
 members = [
+  ".",
   "boxfuture",
   "fs",
   "fs/brfs",
@@ -44,6 +45,7 @@ members = [
 # In particular, it does not contain the fs/brfs package, which will not compile without a fuse installation.
 # On Ubuntu, that means installing libfuse-dev. On OSX, that means installing OSXFUSE.
 default-members = [
+  ".",
   "boxfuture",
   "fs",
   "fs/fs_util",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -20,6 +20,18 @@ cc = "1.0"
 [workspace]
 # We need to explicitly list these, because otherwise the standalone tools
 # (e.g. fs_util) won't be included.
+default-members = [
+  "boxfuture",
+  "fs",
+  "fs/fs_util",
+  "hashing",
+  "process_execution",
+  "process_execution/bazel_protos",
+  "process_executor",
+  "testutil",
+  "testutil/mock",
+]
+
 members = [
   "boxfuture",
   "fs",

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "brfs"
+version = "0.0.1"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+
+[dependencies]
+bazel_protos = { path = "../../process_execution/bazel_protos" }
+clap = "2"
+env_logger = "0.5.4"
+errno = "0.2.3"
+fs = { path = ".." }
+fuse = "0.3.1"
+futures = "0.1.16"
+hashing = { path = "../../hashing" }
+libc = "0.2.39"
+log = "0.4.1"
+protobuf = { version = "1.4.1", features = ["with-bytes"] }
+time = "0.1.39"
+
+[dev-dependencies]
+bytes = "0.4.5"
+tempdir = "0.3.5"
+testutil = { path = "../../testutil" }

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -922,7 +922,7 @@ mod syscall_tests {
       let fd = libc::open(path_to_cstring(&path).as_ptr(), 0);
       assert!(fd > 0, "Bad fd {}", fd);
       let mut buf = make_buffer(test_bytes.len());
-      let read_bytes = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.capacity());
+      let read_bytes = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len());
       assert_eq!(test_bytes.len() as isize, read_bytes);
       assert_eq!(0, libc::close(fd));
       assert_eq!(test_bytes.string(), String::from_utf8(buf).unwrap());

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -52,11 +52,11 @@ pub fn digest_from_filepath(str: &str) -> Result<Digest, String> {
   let mut parts = str.split("-");
   let fingerprint_str = parts
     .next()
-    .ok_or_else(|| format!("Invalid digest: {}", str))?;
+    .ok_or_else(|| format!("Invalid digest: {} wasn't of form fingerprint-size", str))?;
   let fingerprint = Fingerprint::from_hex_string(fingerprint_str)?;
   let size_bytes = parts
     .next()
-    .ok_or_else(|| format!("Invalid digest: {}", str))?
+    .ok_or_else(|| format!("Invalid digest: {} wasn't of form fingerprint-size", str))?
     .parse::<usize>()
     .map_err(|err| format!("Invalid digest; size {} not a number: {}", str, err))?;
   Ok(Digest(fingerprint, size_bytes))
@@ -381,14 +381,14 @@ impl fuse::Filesystem for BuildResultFS {
               .ok_or(libc::ENOENT)
           }),
         Err(err) => {
-          warn!("Invalid digest: {:?}", err);
+          warn!("Invalid digest for file in digest root: {}", err);
           Err(libc::ENOENT)
         }
       },
       (DIRECTORY_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
         Ok(digest) => self.dir_attr_for(digest),
         Err(err) => {
-          warn!("Invalid digest: {:?}", err);
+          warn!("Invalid digest for directroy in directory root: {}", err);
           Err(libc::ENOENT)
         }
       },

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -914,19 +914,22 @@ mod syscall_tests {
 
     let _fs = mount(mount_dir.path(), store).expect("Mounting");
 
+    let path = mount_dir
+      .path()
+      .join("digest")
+      .join(digest_to_filepath(&test_bytes.digest()));
+
+    let mut buf = make_buffer(test_bytes.len());
+
     unsafe {
-      let path = mount_dir
-        .path()
-        .join("digest")
-        .join(digest_to_filepath(&test_bytes.digest()));
       let fd = libc::open(path_to_cstring(&path).as_ptr(), 0);
       assert!(fd > 0, "Bad fd {}", fd);
-      let mut buf = make_buffer(test_bytes.len());
       let read_bytes = libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len());
       assert_eq!(test_bytes.len() as isize, read_bytes);
       assert_eq!(0, libc::close(fd));
-      assert_eq!(test_bytes.string(), String::from_utf8(buf).unwrap());
     }
+
+    assert_eq!(test_bytes.string(), String::from_utf8(buf).unwrap());
   }
 
   fn path_to_cstring(path: &Path) -> CString {

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -583,8 +583,6 @@ pub fn mount<'a, P: AsRef<Path>>(
 }
 
 fn main() {
-  env_logger::init();
-
   let default_store_path = std::env::home_dir()
     .expect("Couldn't find homedir")
     .join(".cache")
@@ -668,7 +666,6 @@ mod test {
   use super::mount;
   use self::testutil::{file, data::{TestData, TestDirectory}};
 
-  /*
   #[test]
   fn missing_digest() {
     let store_dir = TempDir::new("store").unwrap();
@@ -686,11 +683,9 @@ mod test {
       .join(digest_to_filepath(&TestData::roland().digest()))
       .exists());
   }
-  */
 
   #[test]
   fn read_file_by_digest() {
-    env_logger::init();
     let store_dir = TempDir::new("store").unwrap();
     let mount_dir = TempDir::new("mount").unwrap();
 
@@ -715,7 +710,6 @@ mod test {
     assert!(file::is_executable(&file_path));
   }
 
-  /*
   #[test]
   fn list_directory() {
     let store_dir = TempDir::new("store").unwrap();
@@ -896,7 +890,6 @@ mod test {
     assert!(file::is_executable(&virtual_dir.join("feed")));
     assert!(!file::is_executable(&virtual_dir.join("food")));
   }
-  */
 
   fn digest_to_filepath(digest: &hashing::Digest) -> String {
     format!("{}-{}", digest.0, digest.1)

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -485,11 +485,10 @@ impl fuse::Filesystem for BuildResultFS {
         let result: Result<(), ()> = self
           .store
           .load_file_bytes_with(digest, move |bytes| {
+            let begin = std::cmp::min(offset as usize, bytes.len());
+            let end = std::cmp::min(offset as usize + size as usize, bytes.len());
             let mut reply = reply.lock().unwrap();
-            reply
-              .take()
-              .unwrap()
-              .data(&bytes.slice(offset as usize, offset as usize + size as usize));
+            reply.take().unwrap().data(&bytes.slice(begin, end));
           })
           .map(|v| match v {
             Some(_) => {}
@@ -632,16 +631,12 @@ fn main() {
 
 #[cfg(target_os = "macos")]
 fn unmount(mount_path: &str) -> i32 {
-  unsafe {
-    libc::unmount(CString::new(mount_path).unwrap().as_ptr(), 0)
-  }
+  unsafe { libc::unmount(CString::new(mount_path).unwrap().as_ptr(), 0) }
 }
 
 #[cfg(target_os = "linux")]
 fn unmount(mount_path: &str) -> i32 {
-  unsafe {
-    libc::umount(CString::new(mount_path).unwrap().as_ptr())
-  }
+  unsafe { libc::umount(CString::new(mount_path).unwrap().as_ptr()) }
 }
 
 #[cfg(test)]

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -1,0 +1,890 @@
+extern crate bazel_protos;
+extern crate clap;
+extern crate env_logger;
+extern crate errno;
+extern crate fs;
+extern crate fuse;
+extern crate futures;
+extern crate hashing;
+extern crate libc;
+#[macro_use]
+extern crate log;
+extern crate protobuf;
+extern crate time;
+
+use futures::future::Future;
+use hashing::{Digest, Fingerprint};
+use std::collections::HashMap;
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::ffi::{CString, OsStr, OsString};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+const TTL: time::Timespec = time::Timespec { sec: 0, nsec: 0 };
+
+const CREATE_TIME: time::Timespec = time::Timespec { sec: 1, nsec: 0 };
+
+fn dir_attr_for(inode: Inode) -> fuse::FileAttr {
+  attr_for(inode, 0, fuse::FileType::Directory, 0x555)
+}
+
+fn attr_for(inode: Inode, size: u64, kind: fuse::FileType, perm: u16) -> fuse::FileAttr {
+  fuse::FileAttr {
+    ino: inode,
+    size: size,
+    // TODO: Find out whether blocks is actaully important
+    blocks: 0,
+    atime: CREATE_TIME,
+    mtime: CREATE_TIME,
+    ctime: CREATE_TIME,
+    crtime: CREATE_TIME,
+    kind: kind,
+    perm: perm,
+    nlink: 1,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    flags: 0,
+  }
+}
+
+pub fn digest_from_filepath(str: &str) -> Result<Digest, String> {
+  let mut parts = str.split("-");
+  let fingerprint_str = parts
+    .next()
+    .ok_or_else(|| format!("Invalid digest: {}", str))?;
+  let fingerprint = Fingerprint::from_hex_string(fingerprint_str)?;
+  let size_bytes = parts
+    .next()
+    .ok_or_else(|| format!("Invalid digest: {}", str))?
+    .parse::<usize>()
+    .map_err(|err| format!("Invalid digest; size {} not a number: {}", str, err))?;
+  Ok(Digest(fingerprint, size_bytes))
+}
+
+type Inode = u64;
+
+const ROOT: Inode = 1;
+const DIGEST_ROOT: Inode = 2;
+const DIRECTORY_ROOT: Inode = 3;
+
+#[derive(Clone, Copy, Debug)]
+enum EntryType {
+  File,
+  Directory,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct InodeDetails {
+  digest: Digest,
+  entry_type: EntryType,
+  is_executable: bool,
+}
+
+#[derive(Debug)]
+struct ReaddirEntry {
+  inode: Inode,
+  kind: fuse::FileType,
+  name: OsString,
+}
+
+enum Node {
+  Directory(bazel_protos::remote_execution::DirectoryNode),
+  File(bazel_protos::remote_execution::FileNode),
+}
+
+struct BuildResultFS {
+  store: fs::Store,
+  inode_digest_cache: HashMap<Inode, InodeDetails>,
+  digest_inode_cache: HashMap<Digest, (Inode, Inode)>,
+  directory_inode_cache: HashMap<Digest, Inode>,
+  next_inode: Inode,
+}
+
+impl BuildResultFS {
+  pub fn new(store: fs::Store) -> BuildResultFS {
+    BuildResultFS {
+      store: store,
+      inode_digest_cache: HashMap::new(),
+      digest_inode_cache: HashMap::new(),
+      directory_inode_cache: HashMap::new(),
+      next_inode: 4,
+    }
+  }
+}
+
+impl BuildResultFS {
+  pub fn node_for_digest(
+    &mut self,
+    directory: &bazel_protos::remote_execution::Directory,
+    filename: &str,
+  ) -> Option<Node> {
+    for file in directory.get_files() {
+      if file.get_name() == filename {
+        return Some(Node::File(file.clone()));
+      }
+    }
+    for child in directory.get_directories() {
+      if child.get_name() == filename {
+        return Some(Node::Directory(child.clone()));
+      }
+    }
+    None
+  }
+
+  // TODO: Unify with inode_for_directory
+  pub fn inode_for_file(
+    &mut self,
+    digest: Digest,
+    is_executable: bool,
+  ) -> Result<Option<Inode>, String> {
+    match self.digest_inode_cache.entry(digest) {
+      Occupied(entry) => {
+        let (executable_inode, non_executable_inode) = *entry.get();
+        Ok(Some(if is_executable {
+          executable_inode
+        } else {
+          non_executable_inode
+        }))
+      }
+      Vacant(entry) => match self.store.load_file_bytes_with(digest, |_| ()).wait() {
+        Ok(Some(())) => {
+          let executable_inode = self.next_inode;
+          self.next_inode += 1;
+          let non_executable_inode = self.next_inode;
+          self.next_inode += 1;
+          entry.insert((executable_inode, non_executable_inode));
+          self.inode_digest_cache.insert(
+            executable_inode,
+            InodeDetails {
+              digest: digest,
+              entry_type: EntryType::File,
+              is_executable: true,
+            },
+          );
+          self.inode_digest_cache.insert(
+            non_executable_inode,
+            InodeDetails {
+              digest: digest,
+              entry_type: EntryType::File,
+              is_executable: false,
+            },
+          );
+          Ok(Some(if is_executable {
+            executable_inode
+          } else {
+            non_executable_inode
+          }))
+        }
+        Ok(None) => Ok(None),
+        Err(err) => Err(err),
+      },
+    }
+  }
+
+  pub fn inode_for_directory(&mut self, digest: Digest) -> Result<Option<Inode>, String> {
+    match self.directory_inode_cache.entry(digest) {
+      Occupied(entry) => Ok(Some(*entry.get())),
+      Vacant(entry) => match self.store.load_directory(digest).wait() {
+        Ok(Some(_)) => {
+          let inode = self.next_inode;
+          self.next_inode += 1;
+          entry.insert(inode);
+          self.inode_digest_cache.insert(
+            inode,
+            InodeDetails {
+              digest: digest,
+              entry_type: EntryType::Directory,
+              is_executable: true,
+            },
+          );
+          Ok(Some(inode))
+        }
+        Ok(None) => Ok(None),
+        Err(err) => Err(err),
+      },
+    }
+  }
+
+  pub fn file_attr_for(&mut self, inode: Inode) -> Option<fuse::FileAttr> {
+    self.inode_digest_cache.get(&inode).map(|f| {
+      attr_for(
+        inode,
+        f.digest.1 as u64,
+        fuse::FileType::RegularFile,
+        if f.is_executable { 0o555 } else { 0o444 },
+      )
+    })
+  }
+
+  pub fn dir_attr_for(&mut self, digest: Digest) -> Result<fuse::FileAttr, i32> {
+    match self.directory_inode_cache.entry(digest) {
+      Vacant(entry) => match self.store.load_directory(digest).wait() {
+        Ok(Some(_)) => {
+          let inode = self.next_inode;
+          self.next_inode += 1;
+          entry.insert(inode);
+          self.inode_digest_cache.insert(
+            inode,
+            InodeDetails {
+              digest: digest,
+              entry_type: EntryType::Directory,
+              is_executable: true,
+            },
+          );
+          Ok(dir_attr_for(inode))
+        }
+        Ok(None) => Err(libc::ENOENT),
+        Err(err) => {
+          error!("Error loading directory {:?}: {}", digest, err);
+          Err(libc::EINVAL)
+        }
+      },
+      Occupied(entry) => Ok(dir_attr_for(*entry.get())),
+    }
+  }
+
+  pub fn readdir_entries(&mut self, inode: Inode) -> Result<Vec<ReaddirEntry>, i32> {
+    match inode {
+      ROOT => Ok(vec![
+        ReaddirEntry {
+          inode: ROOT,
+          kind: fuse::FileType::Directory,
+          name: OsString::from("."),
+        },
+        ReaddirEntry {
+          inode: ROOT,
+          kind: fuse::FileType::Directory,
+          name: OsString::from(".."),
+        },
+        ReaddirEntry {
+          inode: DIGEST_ROOT,
+          kind: fuse::FileType::Directory,
+          name: OsString::from("digest"),
+        },
+        ReaddirEntry {
+          inode: DIRECTORY_ROOT,
+          kind: fuse::FileType::Directory,
+          name: OsString::from("directory"),
+        },
+      ]),
+      // Skip digest contents because enumerating them takes forever.
+      // Subdirectories will still work, they just won't show up in a readdir.
+      DIGEST_ROOT | DIRECTORY_ROOT => Ok(vec![]),
+      inode => {
+        match self.inode_digest_cache.get(&inode) {
+          Some(&InodeDetails {
+            digest,
+            entry_type: EntryType::Directory,
+            ..
+          }) => {
+            let maybe_directory = self.store.load_directory(digest).wait();
+
+            match maybe_directory {
+              Ok(Some(directory)) => {
+                let mut entries = vec![
+                  ReaddirEntry {
+                    inode: inode,
+                    kind: fuse::FileType::Directory,
+                    name: OsString::from("."),
+                  },
+                  ReaddirEntry {
+                    inode: DIRECTORY_ROOT,
+                    kind: fuse::FileType::Directory,
+                    name: OsString::from(".."),
+                  },
+                ];
+
+                // TODO: Unify codepath with for files
+                for child in directory.get_directories() {
+                  let child_digest = child.get_digest().into();
+                  let maybe_child_inode = self.inode_for_directory(child_digest);
+                  match maybe_child_inode {
+                    Ok(Some(child_inode)) => {
+                      entries.push(ReaddirEntry {
+                        inode: child_inode,
+                        kind: fuse::FileType::Directory,
+                        name: OsString::from(child.get_name()),
+                      });
+                    }
+                    Ok(None) => {
+                      return Err(libc::ENOENT);
+                    }
+                    Err(err) => {
+                      error!("Error reading child directory {:?}: {}", child_digest, err);
+                      return Err(libc::EINVAL);
+                    }
+                  }
+                }
+
+                for file in directory.get_files() {
+                  let child_digest = file.get_digest().into();
+                  let maybe_child_inode =
+                    self.inode_for_file(child_digest, file.get_is_executable());
+                  match maybe_child_inode {
+                    Ok(Some(child_inode)) => {
+                      entries.push(ReaddirEntry {
+                        inode: child_inode,
+                        kind: fuse::FileType::RegularFile,
+                        name: OsString::from(file.get_name()),
+                      });
+                    }
+                    Ok(None) => {
+                      return Err(libc::ENOENT);
+                    }
+                    Err(err) => {
+                      error!("Error reading child file {:?}: {}", child_digest, err);
+                      return Err(libc::EINVAL);
+                    }
+                  }
+                }
+
+                Ok(entries)
+              }
+              Ok(None) => {
+                return Err(libc::ENOENT);
+              }
+              Err(err) => {
+                error!("Error loading directory {:?}: {}", digest, err);
+                return Err(libc::EINVAL);
+              }
+            }
+          }
+          _ => return Err(libc::ENOENT),
+        }
+      }
+    }
+  }
+}
+
+// inodes:
+//  1: /
+//  2: /digest
+//  3: /directory
+//  ... created on demand and cached for the lifetime of the program.
+impl fuse::Filesystem for BuildResultFS {
+  // Used to answer stat calls
+  fn lookup(&mut self, _req: &fuse::Request, parent: Inode, name: &OsStr, reply: fuse::ReplyEntry) {
+    let r = match (parent, name.to_str()) {
+      (ROOT, Some("digest")) => Ok(dir_attr_for(DIGEST_ROOT)),
+      (ROOT, Some("directory")) => Ok(dir_attr_for(DIRECTORY_ROOT)),
+      (DIGEST_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
+        Ok(digest) => self
+          .inode_for_file(digest, true)
+          .map_err(|err| {
+            error!("Error loading file by digest {}: {}", digest_str, err);
+            libc::EINVAL
+          })
+          .and_then(|maybe_inode| {
+            maybe_inode
+              .and_then(|inode| self.file_attr_for(inode))
+              .ok_or(libc::ENOENT)
+          }),
+        Err(err) => {
+          warn!("Invalid digest: {:?}", err);
+          Err(libc::ENOENT)
+        }
+      },
+      (DIRECTORY_ROOT, Some(digest_str)) => match digest_from_filepath(digest_str) {
+        Ok(digest) => self.dir_attr_for(digest),
+        Err(err) => {
+          warn!("Invalid digest: {:?}", err);
+          Err(libc::ENOENT)
+        }
+      },
+      (parent, Some(filename)) => {
+        let maybe_cache_entry = self
+          .inode_digest_cache
+          .get(&parent)
+          .map(|entry| entry.clone())
+          .ok_or(libc::ENOENT);
+        maybe_cache_entry
+          .and_then(|cache_entry| {
+            let parent_digest = cache_entry.digest.clone();
+            self
+              .store
+              .load_directory(parent_digest)
+              .wait()
+              .map_err(|err| {
+                error!("Error reading directory {:?}: {}", parent_digest, err);
+                libc::EINVAL
+              })?
+              .and_then(|directory| self.node_for_digest(&directory, filename))
+              .ok_or(libc::ENOENT)
+          })
+          .and_then(|node| match node {
+            Node::Directory(directory_node) => {
+              let digest = directory_node.get_digest().into();
+              self.dir_attr_for(digest)
+            }
+            Node::File(file_node) => {
+              let digest = file_node.get_digest().into();
+              self
+                .inode_for_file(digest, file_node.get_is_executable())
+                .map_err(|err| {
+                  error!("Error loading file by digest {}: {}", filename, err);
+                  libc::EINVAL
+                })
+                .and_then(|maybe_inode| {
+                  maybe_inode
+                    .and_then(|inode| self.file_attr_for(inode))
+                    .ok_or(libc::ENOENT)
+                })
+            }
+          })
+      }
+      _ => Err(libc::ENOENT),
+    };
+    match r {
+      Ok(r) => reply.entry(&TTL, &r, 1),
+      Err(err) => reply.error(err),
+    }
+  }
+
+  fn getattr(&mut self, _req: &fuse::Request, inode: Inode, reply: fuse::ReplyAttr) {
+    match inode {
+      ROOT => reply.attr(&TTL, &dir_attr_for(ROOT)),
+      DIGEST_ROOT => reply.attr(&TTL, &dir_attr_for(DIGEST_ROOT)),
+      DIRECTORY_ROOT => reply.attr(&TTL, &dir_attr_for(DIRECTORY_ROOT)),
+      _ => match self.inode_digest_cache.get(&inode) {
+        Some(&InodeDetails {
+          entry_type: EntryType::File,
+          ..
+        }) => match self.file_attr_for(inode) {
+          Some(file_attr) => reply.attr(&TTL, &file_attr),
+          None => reply.error(libc::ENOENT),
+        },
+        Some(&InodeDetails {
+          entry_type: EntryType::Directory,
+          ..
+        }) => reply.attr(&TTL, &dir_attr_for(inode)),
+        _ => reply.error(libc::ENOENT),
+      },
+    }
+  }
+
+  // TODO: Find out whether fh is ever passed if open isn't explicitly implemented (and whether offset is ever negative)
+  fn read(
+    &mut self,
+    _req: &fuse::Request,
+    inode: Inode,
+    _fh: u64,
+    offset: i64,
+    size: u32,
+    reply: fuse::ReplyData,
+  ) {
+    match self.inode_digest_cache.get(&inode) {
+      Some(&InodeDetails {
+        digest,
+        entry_type: EntryType::File,
+        ..
+      }) => {
+        let reply = Arc::new(Mutex::new(Some(reply)));
+        let reply2 = reply.clone();
+        // TODO: Drive futures async from a pool and queue somewhere.
+        let result: Result<(), ()> = self
+          .store
+          .load_file_bytes_with(digest, move |bytes| {
+            let mut reply = reply.lock().unwrap();
+            reply
+              .take()
+              .unwrap()
+              .data(&bytes.slice(offset as usize, offset as usize + size as usize));
+          })
+          .map(|v| match v {
+            Some(_) => {}
+            None => {
+              let maybe_reply = reply2.lock().unwrap().take();
+              if let Some(reply) = maybe_reply {
+                reply.error(libc::ENOENT);
+              }
+            }
+          })
+          .or_else(|err| {
+            error!("Error loading bytes for {:?}: {}", digest, err);
+            let maybe_reply = reply2.lock().unwrap().take();
+            if let Some(reply) = maybe_reply {
+              reply.error(libc::EINVAL);
+            }
+            Ok(())
+          })
+          .wait();
+        result.expect("Error from read future which should have been handled in the future ");
+      }
+      _ => reply.error(libc::ENOENT),
+    }
+  }
+
+  fn readdir(
+    &mut self,
+    _req: &fuse::Request,
+    inode: Inode,
+    // TODO: Find out whether fh is ever passed if open isn't explicitly implemented (and whether offset is ever negative)
+    _fh: u64,
+    offset: i64,
+    mut reply: fuse::ReplyDirectory,
+  ) {
+    match self.readdir_entries(inode) {
+      Ok(entries) => {
+        // 0 is a magic offset which means no offset, whereas a non-zero offset means start
+        // _after_ that entry. Inconsistency is fun.
+        let to_skip = if offset == 0 { 0 } else { offset + 1 } as usize;
+        let mut i = offset;
+        for entry in entries.into_iter().skip(to_skip) {
+          if reply.add(entry.inode, i, entry.kind, entry.name) {
+            // Buffer is full, don't add more entries.
+            break;
+          }
+          i += 1;
+        }
+        reply.ok();
+      }
+      Err(err) => reply.error(err),
+    }
+  }
+
+  // If this isn't implemented, OSX will try to manipulate ._ files to manage xattrs out of band, which adds both overhead and logspam.
+  fn listxattr(
+    &mut self,
+    _req: &fuse::Request,
+    _inode: Inode,
+    _size: u32,
+    reply: fuse::ReplyXattr,
+  ) {
+    reply.size(0);
+  }
+}
+
+pub fn mount<'a, P: AsRef<Path>>(
+  mount_path: P,
+  store: fs::Store,
+) -> std::io::Result<fuse::BackgroundSession<'a>> {
+  // TODO: Work out how to disable caching in the filesystem
+  let options = ["-o", "ro", "-o", "fsname=brfs", "-o", "noapplexattr"]
+    .iter()
+    .map(|o| o.as_ref())
+    .collect::<Vec<&OsStr>>();
+
+  unsafe { fuse::spawn_mount(BuildResultFS::new(store), &mount_path, &options) }
+}
+
+fn main() {
+  env_logger::init();
+
+  let default_store_path = std::env::home_dir()
+    .expect("Couldn't find homedir")
+    .join(".cache")
+    .join("pants")
+    .join("lmdb_store");
+
+  let args = clap::App::new("brfs")
+    .arg(
+      clap::Arg::with_name("local-store-path")
+        .takes_value(true)
+        .long("local-store-path")
+        .default_value_os(default_store_path.as_ref())
+        .required(false),
+    )
+    .arg(
+      clap::Arg::with_name("server-address")
+        .takes_value(true)
+        .long("server-address")
+        .required(false),
+    )
+    .arg(
+      clap::Arg::with_name("mount-path")
+        .required(true)
+        .takes_value(true),
+    )
+    .get_matches();
+
+  let mount_path = args.value_of("mount-path").unwrap();
+  let store_path = args.value_of("local-store-path").unwrap();
+
+  // Unmount whatever happens to be mounted there already.
+  // This is handy for development, but should probably be removed :)
+  unsafe {
+    let unmount_return = libc::unmount(CString::new(mount_path).unwrap().as_ptr(), 0);
+    if unmount_return != 0 {
+      match errno::errno() {
+        errno::Errno(22) => {
+          debug!("unmount failed, continuing because error code suggests directory was not mounted")
+        }
+        v => panic!("Error unmounting: {:?}", v),
+      }
+    }
+  }
+
+  let pool = Arc::new(fs::ResettablePool::new("brfs-".to_owned()));
+  let store = match args.value_of("server-address") {
+    Some(address) => fs::Store::with_remote(
+      &store_path,
+      pool,
+      address,
+      1,
+      4 * 1024 * 1024,
+      std::time::Duration::from_secs(5 * 60),
+    ),
+    None => fs::Store::local_only(&store_path, pool),
+  }.expect("Error making store");
+
+  let _fs = mount(mount_path, store).expect("Error mounting");
+  loop {}
+}
+
+#[cfg(test)]
+mod test {
+  extern crate tempdir;
+  extern crate testutil;
+
+  use fs;
+  use futures::future::Future;
+  use hashing;
+  use self::tempdir::TempDir;
+  use std::sync::Arc;
+  use super::mount;
+  use self::testutil::{file, data::{TestData, TestDirectory}};
+
+  #[test]
+  fn missing_digest() {
+    let store_dir = TempDir::new("store").unwrap();
+    let mount_dir = TempDir::new("mount").unwrap();
+
+    let store = fs::Store::local_only(
+      store_dir.path(),
+      Arc::new(fs::ResettablePool::new("test-pool-".to_string())),
+    ).expect("Error creating local store");
+
+    let _fs = mount(mount_dir.path(), store).expect("Mounting");
+    assert!(!&mount_dir
+      .path()
+      .join("digest")
+      .join(digest_to_filepath(&TestData::roland().digest()))
+      .exists());
+  }
+
+  #[test]
+  fn read_file_by_digest() {
+    let store_dir = TempDir::new("store").unwrap();
+    let mount_dir = TempDir::new("mount").unwrap();
+
+    let store = fs::Store::local_only(
+      store_dir.path(),
+      Arc::new(fs::ResettablePool::new("test-pool-".to_string())),
+    ).expect("Error creating local store");
+
+    let test_bytes = TestData::roland();
+
+    store
+      .store_file_bytes(test_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+
+    let _fs = mount(mount_dir.path(), store).expect("Mounting");
+    let file_path = mount_dir
+      .path()
+      .join("digest")
+      .join(digest_to_filepath(&test_bytes.digest()));
+    assert_eq!(test_bytes.bytes(), file::contents(&file_path));
+    assert!(file::is_executable(&file_path));
+  }
+
+  #[test]
+  fn list_directory() {
+    let store_dir = TempDir::new("store").unwrap();
+    let mount_dir = TempDir::new("mount").unwrap();
+
+    let store = fs::Store::local_only(
+      store_dir.path(),
+      Arc::new(fs::ResettablePool::new("test-pool-".to_string())),
+    ).expect("Error creating local store");
+
+    let test_bytes = TestData::roland();
+    let test_directory = TestDirectory::containing_roland();
+
+    store
+      .store_file_bytes(test_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+    store
+      .record_directory(&test_directory.directory(), false)
+      .wait()
+      .expect("Storing directory");
+
+    let _fs = mount(mount_dir.path(), store).expect("Mounting");
+    let virtual_dir = mount_dir
+      .path()
+      .join("directory")
+      .join(digest_to_filepath(&test_directory.digest()));
+    assert_eq!(vec!["roland"], file::list_dir(&virtual_dir));
+  }
+
+  #[test]
+  fn read_file_from_directory() {
+    let store_dir = TempDir::new("store").unwrap();
+    let mount_dir = TempDir::new("mount").unwrap();
+
+    let store = fs::Store::local_only(
+      store_dir.path(),
+      Arc::new(fs::ResettablePool::new("test-pool-".to_string())),
+    ).expect("Error creating local store");
+
+    let test_bytes = TestData::roland();
+    let test_directory = TestDirectory::containing_roland();
+
+    store
+      .store_file_bytes(test_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+    store
+      .record_directory(&test_directory.directory(), false)
+      .wait()
+      .expect("Storing directory");
+
+    let _fs = mount(mount_dir.path(), store).expect("Mounting");
+    let roland = mount_dir
+      .path()
+      .join("directory")
+      .join(digest_to_filepath(&test_directory.digest()))
+      .join("roland");
+    assert_eq!(test_bytes.bytes(), file::contents(&roland));
+    assert!(!file::is_executable(&roland));
+  }
+
+  #[test]
+  fn list_recursive_directory() {
+    let store_dir = TempDir::new("store").unwrap();
+    let mount_dir = TempDir::new("mount").unwrap();
+
+    let store = fs::Store::local_only(
+      store_dir.path(),
+      Arc::new(fs::ResettablePool::new("test-pool-".to_string())),
+    ).expect("Error creating local store");
+
+    let test_bytes = TestData::roland();
+    let treat_bytes = TestData::catnip();
+    let test_directory = TestDirectory::containing_roland();
+    let recursive_directory = TestDirectory::recursive();
+
+    store
+      .store_file_bytes(test_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+    store
+      .store_file_bytes(treat_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+    store
+      .record_directory(&test_directory.directory(), false)
+      .wait()
+      .expect("Storing directory");
+    store
+      .record_directory(&recursive_directory.directory(), false)
+      .wait()
+      .expect("Storing directory");
+
+    let _fs = mount(mount_dir.path(), store).expect("Mounting");
+    let virtual_dir = mount_dir
+      .path()
+      .join("directory")
+      .join(digest_to_filepath(&recursive_directory.digest()));
+    assert_eq!(vec!["cats", "treats"], file::list_dir(&virtual_dir));
+    assert_eq!(vec!["roland"], file::list_dir(&virtual_dir.join("cats")));
+  }
+
+  #[test]
+  fn read_file_from_recursive_directory() {
+    let store_dir = TempDir::new("store").unwrap();
+    let mount_dir = TempDir::new("mount").unwrap();
+
+    let store = fs::Store::local_only(
+      store_dir.path(),
+      Arc::new(fs::ResettablePool::new("test-pool-".to_string())),
+    ).expect("Error creating local store");
+
+    let test_bytes = TestData::roland();
+    let treat_bytes = TestData::catnip();
+    let test_directory = TestDirectory::containing_roland();
+    let recursive_directory = TestDirectory::recursive();
+
+    store
+      .store_file_bytes(test_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+    store
+      .store_file_bytes(treat_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+    store
+      .record_directory(&test_directory.directory(), false)
+      .wait()
+      .expect("Storing directory");
+    store
+      .record_directory(&recursive_directory.directory(), false)
+      .wait()
+      .expect("Storing directory");
+
+    let _fs = mount(mount_dir.path(), store).expect("Mounting");
+    let virtual_dir = mount_dir
+      .path()
+      .join("directory")
+      .join(digest_to_filepath(&recursive_directory.digest()));
+    let treats = virtual_dir.join("treats");
+    assert_eq!(treat_bytes.bytes(), file::contents(&treats));
+    assert!(!file::is_executable(&treats));
+
+    let roland = virtual_dir.join("cats").join("roland");
+    assert_eq!(test_bytes.bytes(), file::contents(&roland));
+    assert!(!file::is_executable(&roland));
+  }
+
+  #[test]
+  fn files_are_correctly_executable() {
+    let store_dir = TempDir::new("store").unwrap();
+    let mount_dir = TempDir::new("mount").unwrap();
+
+    let store = fs::Store::local_only(
+      store_dir.path(),
+      Arc::new(fs::ResettablePool::new("test-pool-".to_string())),
+    ).expect("Error creating local store");
+
+    let treat_bytes = TestData::catnip();
+    let directory = TestDirectory::with_mixed_executable_files();
+
+    store
+      .store_file_bytes(treat_bytes.bytes(), false)
+      .wait()
+      .expect("Storing bytes");
+    store
+      .record_directory(&directory.directory(), false)
+      .wait()
+      .expect("Storing directory");
+
+    let _fs = mount(mount_dir.path(), store).expect("Mounting");
+    let virtual_dir = mount_dir
+      .path()
+      .join("directory")
+      .join(digest_to_filepath(&directory.digest()));
+    assert_eq!(vec!["feed", "food"], file::list_dir(&virtual_dir));
+    assert!(file::is_executable(&virtual_dir.join("feed")));
+    assert!(!file::is_executable(&virtual_dir.join("food")));
+  }
+
+  fn digest_to_filepath(digest: &hashing::Digest) -> String {
+    format!("{}-{}", digest.0, digest.1)
+  }
+
+  // TODO: Write a bunch of syscall-y tests. Example syscalls:
+  //    unsafe {
+  //        let fd = libc::open(CString::new("/Users/dwagnerhall/tmp/cats/pets/roland").unwrap().as_ptr(), 0);
+  //        println ! ("DWH: fd: {}", fd);
+  //        let mut buf: Vec < u8> = Vec::with_capacity(7);
+  //        buf.resize(7, 0);
+  //        println !("DWH: {}", libc::read(fd, buf.as_mut_ptr() as * mut libc::c_void, buf.capacity()));
+  //        libc::close(fd);
+  //        println ! ("DWH: {:?}", buf);
+  //        println ! ("DWH: ({})", String::from_utf8(buf).unwrap());
+  //    }
+
+  // /usr/local/include/fuse/fuse_lowlevel.h
+}

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -657,7 +657,6 @@ mod test {
   extern crate tempdir;
   extern crate testutil;
 
-  use env_logger;
   use fs;
   use futures::future::Future;
   use hashing;

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -640,7 +640,7 @@ fn unmount(mount_path: &str) -> i32 {
 #[cfg(target_os = "linux")]
 fn unmount(mount_path: &str) -> i32 {
   unsafe {
-    libc::umount(CString::new(mount_path).unwrap().as_ptr(), 0)
+    libc::umount(CString::new(mount_path).unwrap().as_ptr())
   }
 }
 

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -575,7 +575,11 @@ pub fn mount<'a, P: AsRef<Path>>(
     .map(|o| o.as_ref())
     .collect::<Vec<&OsStr>>();
 
-  unsafe { fuse::spawn_mount(BuildResultFS::new(store), &mount_path, &options) }
+  debug!("About to spawn_mount with options {:?}", options);
+
+  let fs = unsafe { fuse::spawn_mount(BuildResultFS::new(store), &mount_path, &options) };
+  debug!("Did spawn mount");
+  fs
 }
 
 fn main() {
@@ -655,6 +659,7 @@ mod test {
   extern crate tempdir;
   extern crate testutil;
 
+  use env_logger;
   use fs;
   use futures::future::Future;
   use hashing;
@@ -663,6 +668,7 @@ mod test {
   use super::mount;
   use self::testutil::{file, data::{TestData, TestDirectory}};
 
+  /*
   #[test]
   fn missing_digest() {
     let store_dir = TempDir::new("store").unwrap();
@@ -680,9 +686,11 @@ mod test {
       .join(digest_to_filepath(&TestData::roland().digest()))
       .exists());
   }
+  */
 
   #[test]
   fn read_file_by_digest() {
+    env_logger::init();
     let store_dir = TempDir::new("store").unwrap();
     let mount_dir = TempDir::new("mount").unwrap();
 
@@ -707,6 +715,7 @@ mod test {
     assert!(file::is_executable(&file_path));
   }
 
+  /*
   #[test]
   fn list_directory() {
     let store_dir = TempDir::new("store").unwrap();
@@ -887,6 +896,7 @@ mod test {
     assert!(file::is_executable(&virtual_dir.join("feed")));
     assert!(!file::is_executable(&virtual_dir.join("food")));
   }
+  */
 
   fn digest_to_filepath(digest: &hashing::Digest) -> String {
     format!("{}-{}", digest.0, digest.1)

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -50,6 +50,10 @@ impl TestData {
   pub fn string(&self) -> String {
     self.string.clone()
   }
+
+  pub fn len(&self) -> usize {
+    self.string.len()
+  }
 }
 
 pub struct TestDirectory {


### PR DESCRIPTION
Exposes
======
 * `${mount_point}/digest` - contains a file named sha256-length for each
   file digest. Does not show anything in response to `readdir`, but
   opening any particular file (of a known digest) will work.
 * `${mount_point}/directory` - contains a directory named sha256-length
   for each directory digest. Does not show anything in response to
   `readdir`, but `readdir` on any particular directory (of a known
   digest) will work.

Caveats
======
 * Not at all performance optimised. In particular, all filesystem
   operations happen single-threaded, including performing expensive I/O
   operations like fetching from a remote CAS or reading from LMDB.
   The underlying implementation is Futures-based, and the expensive
   operations are easily parallelisable, it just hasn't been done yet :)

This uses the low-level https://github.com/zargony/rust-fuse which
requires manual inode management.

There is also a higher-level https://github.com/wfraser/fuse-mt which I
discovered after putting this together, but which I'm consciously not
using. Its benefits would be:
 1. It operates on paths rather than inodes. This would be pretty
    convenient, as the inode cache in this implementation is a little
    annoying.
 2. It runs some operations in parallel by not having every function
    take a &mut self. I haven't looked at how parallel it ends up being.
 3. Its readdir API avoids needing to think about pagination. I ended up
    coincidentally re-inventing their API here :)

But its big drawback is that functions are required to return values
(e.g. from read) rather than call callbacks, which means that it's hard
for us to take advantage of our Futurey implementation in Store, as
we'd need to block in every call.

Both projects have talked about wanting to support Futures as a more
first-class concept at some point in a nebulous future, but neither has
a concrete plan for doing so.

Changes to our Cargo workspace
=========================
This excludes brfs from default workspace packages.
This is because not everyone has fuse installed, and we want things to
work out of the box.

To run all tests, including brfs, run `cargo test --all`. CI does this.
To run all tests, excluding brfs, run `cargo test`.
To run just the fs package's tests, run `cargo test -p fs`.