### PR TITLE
Move From impls from hashing to bazel_protos

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
  "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -313,7 +314,6 @@ dependencies = [
 name = "hashing"
 version = "0.0.1"
 dependencies = [
- "bazel_protos 0.0.1",
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
-bazel_protos = { path = "../process_execution/bazel_protos" }
 digest = "0.6.2"
 hex = "0.3.1"
 sha2 = "0.6.0"

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-extern crate bazel_protos;
 extern crate digest;
 extern crate hex;
 extern crate sha2;
@@ -79,24 +78,6 @@ impl AsRef<[u8]> for Fingerprint {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Digest(pub Fingerprint, pub usize);
 
-impl<'a> From<&'a Digest> for bazel_protos::remote_execution::Digest {
-  fn from(d: &Digest) -> Self {
-    let mut digest = bazel_protos::remote_execution::Digest::new();
-    digest.set_hash(d.0.to_hex());
-    digest.set_size_bytes(d.1 as i64);
-    digest
-  }
-}
-
-impl<'a> From<&'a bazel_protos::remote_execution::Digest> for Digest {
-  fn from(d: &bazel_protos::remote_execution::Digest) -> Self {
-    Digest(
-      Fingerprint::from_hex_string(d.get_hash()).expect("Bad fingerprint in Digest"),
-      d.get_size_bytes() as usize,
-    )
-  }
-}
-
 ///
 /// A Write instance that fingerprints all data that passes through it.
 ///
@@ -136,7 +117,7 @@ impl<W: Write> Write for WriterHasher<W> {
 
 #[cfg(test)]
 mod fingerprint_tests {
-  use super::{bazel_protos, Digest, Fingerprint};
+  use super::Fingerprint;
 
   #[test]
   fn from_bytes_unsafe() {
@@ -203,36 +184,5 @@ mod fingerprint_tests {
       Fingerprint::from_hex_string(hex).unwrap().to_hex(),
       hex.to_lowercase()
     )
-  }
-
-  #[test]
-  fn from_our_digest() {
-    let our_digest = &Digest(
-      Fingerprint::from_hex_string(
-        "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
-      ).unwrap(),
-      10,
-    );
-    let converted: bazel_protos::remote_execution::Digest = our_digest.into();
-    let mut want = bazel_protos::remote_execution::Digest::new();
-    want.set_hash("0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff".to_owned());
-    want.set_size_bytes(10);
-    assert_eq!(converted, want);
-  }
-
-  #[test]
-  fn from_bazel_digest() {
-    let mut bazel_digest = bazel_protos::remote_execution::Digest::new();
-    bazel_digest
-      .set_hash("0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff".to_owned());
-    bazel_digest.set_size_bytes(10);
-    let converted: Digest = (&bazel_digest).into();
-    let want = Digest(
-      Fingerprint::from_hex_string(
-        "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
-      ).unwrap(),
-      10,
-    );
-    assert_eq!(converted, want);
   }
 }

--- a/src/rust/engine/process_execution/bazel_protos/.gitignore
+++ b/src/rust/engine/process_execution/bazel_protos/.gitignore
@@ -1,3 +1,4 @@
 src/*.rs
+!src/conversions.rs
 !src/lib.rs
 !src/verification.rs

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -7,4 +7,5 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 bytes = "0.4.5"
 futures = "0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
+hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
@@ -1,0 +1,55 @@
+use hashing;
+
+impl<'a> From<&'a hashing::Digest> for super::remote_execution::Digest {
+  fn from(d: &hashing::Digest) -> Self {
+    let mut digest = super::remote_execution::Digest::new();
+    digest.set_hash(d.0.to_hex());
+    digest.set_size_bytes(d.1 as i64);
+    digest
+  }
+}
+
+impl<'a> From<&'a super::remote_execution::Digest> for hashing::Digest {
+  fn from(d: &super::remote_execution::Digest) -> Self {
+    hashing::Digest(
+      hashing::Fingerprint::from_hex_string(d.get_hash()).expect("Bad fingerprint in Digest"),
+      d.get_size_bytes() as usize,
+    )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use hashing;
+
+  #[test]
+  fn from_our_digest() {
+    let our_digest = &hashing::Digest(
+      hashing::Fingerprint::from_hex_string(
+        "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
+      ).unwrap(),
+      10,
+    );
+    let converted: super::super::remote_execution::Digest = our_digest.into();
+    let mut want = super::super::remote_execution::Digest::new();
+    want.set_hash("0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff".to_owned());
+    want.set_size_bytes(10);
+    assert_eq!(converted, want);
+  }
+
+  #[test]
+  fn from_bazel_digest() {
+    let mut bazel_digest = super::super::remote_execution::Digest::new();
+    bazel_digest
+      .set_hash("0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff".to_owned());
+    bazel_digest.set_size_bytes(10);
+    let converted: hashing::Digest = (&bazel_digest).into();
+    let want = hashing::Digest(
+      hashing::Fingerprint::from_hex_string(
+        "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
+      ).unwrap(),
+      10,
+    );
+    assert_eq!(converted, want);
+  }
+}

--- a/src/rust/engine/process_execution/bazel_protos/src/lib.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate bytes;
 extern crate futures;
 extern crate grpcio;
+extern crate hashing;
 extern crate protobuf;
 
 pub mod bytestream;
@@ -14,5 +15,6 @@ pub mod remote_execution;
 pub mod remote_execution_grpc;
 pub mod status;
 
+mod conversions;
 mod verification;
 pub use verification::verify_directory_canonical;


### PR DESCRIPTION
hashing should be a nice quick/easy/small thing to compile, which
shouldn't rely on protocol buffer compilation because it just has a
couple of value types in.

bazel_protos already needs to depend on protocol buffer compilation.