### PR TITLE
Fix some errorprone warnings and remove duplicates from findbugs targets

### DIFF
--- a/contrib/errorprone/tests/java/org/pantsbuild/contrib/errorprone/ReferenceEqualityWarning.java
+++ b/contrib/errorprone/tests/java/org/pantsbuild/contrib/errorprone/ReferenceEqualityWarning.java
@@ -5,8 +5,8 @@ package org.pantsbuild.contrib.errorprone;
 
 public class ReferenceEqualityWarning {
   public static void main(String[] args) {
-    if ("one" == "two") {
-      System.out.println("one equals two?");
+    if (args[0] == "one") {
+      System.out.println("You should use equals() instead");
     }
   }
 }

--- a/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/findbugs.py
+++ b/contrib/findbugs/src/python/pants/contrib/findbugs/tasks/findbugs.py
@@ -107,6 +107,8 @@ class FindBugs(NailgunTask):
     else:
       targets = filter(self._is_findbugs_target, self.context.target_roots)
 
+    targets = list(set(targets))
+
     bug_counts = { 'error': 0, 'high': 0, 'normal': 0, 'low': 0 }
     target_count = 0
     with self.invalidated(targets, invalidate_dependents=True) as invalidation_check:

--- a/examples/src/java/org/pantsbuild/example/wire/temperatureservice/WireTemperatureExample.java
+++ b/examples/src/java/org/pantsbuild/example/wire/temperatureservice/WireTemperatureExample.java
@@ -13,11 +13,11 @@ import org.pantsbuild.example.temperature.TemperatureService;
  */
 class WireTemperatureExample implements TemperatureService {
 
-  public Temperature getTemperature(TemperatureRequest request) {
+  @Override public Temperature getTemperature(TemperatureRequest request) {
     return new Temperature.Builder().unit("celsius").number(19L).build();
   }
 
-  public Temperature predictTemperature(TemperatureRequest request) {
+  @Override public Temperature predictTemperature(TemperatureRequest request) {
     return new Temperature.Builder().unit("fahrenheit").number(82L).build();
   }
 

--- a/src/java/org/pantsbuild/tools/junit/impl/ConcurrentRunnerScheduler.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/ConcurrentRunnerScheduler.java
@@ -3,16 +3,14 @@
 
 package org.pantsbuild.tools.junit.impl;
 
-import java.util.LinkedList;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-
-import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import org.junit.runners.model.RunnerScheduler;
 import org.pantsbuild.junit.annotations.TestParallel;
 import org.pantsbuild.junit.annotations.TestSerial;
@@ -44,7 +42,7 @@ public class ConcurrentRunnerScheduler implements RunnerScheduler {
         .setNameFormat("concurrent-junit-runner-%d")
         .build();
     executor = Executors.newFixedThreadPool(numThreads, threadFactory);
-    serialTasks = new LinkedList<Runnable>();
+    serialTasks = new ArrayDeque<Runnable>();
   }
 
   @Override

--- a/src/java/org/pantsbuild/tools/junit/impl/SpecSet.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/SpecSet.java
@@ -10,7 +10,7 @@ class SpecSet {
   private final Concurrency defaultConcurrency;
 
   public SpecSet(Collection<Spec> allSpecs, Concurrency defaultConcurrency) {
-    this.specs = new LinkedHashSet(allSpecs);
+    this.specs = new LinkedHashSet<Spec>(allSpecs);
     this.defaultConcurrency = defaultConcurrency;
   }
 

--- a/src/java/org/pantsbuild/tools/junit/impl/Util.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/Util.java
@@ -110,7 +110,7 @@ final class Util {
       return vanillaDisplayName;
     }
 
-    StringBuffer sb = new StringBuffer(className.length() + methodName.length() + 1);
+    StringBuilder sb = new StringBuilder(className.length() + methodName.length() + 1);
     sb.append(className);
     sb.append("#");
     sb.append(methodName);

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BadnamesSteps.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/BadnamesSteps.java
@@ -5,8 +5,8 @@ package org.pantsbuild.testproject.cucumber;
 
 import java.lang.Exception;
 import java.lang.RuntimeException;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.LinkedList;
 
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
@@ -23,8 +23,8 @@ public class BadnamesSteps {
   private List<String> theListOfStrings;
 
   @Before public void before() {
-    theStrings = new LinkedList<String>();
-    theListOfStrings = new LinkedList<String>();
+    theStrings = new ArrayList<String>();
+    theListOfStrings = new ArrayList<String>();
   }
 
   @After public void after() {

--- a/testprojects/tests/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
+++ b/testprojects/tests/java/org/pantsbuild/testproject/cucumber/DemoSteps.java
@@ -3,8 +3,8 @@
 
 package org.pantsbuild.testproject.cucumber;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.LinkedList;
 
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
@@ -22,9 +22,9 @@ public class DemoSteps {
   private List<String> cart;
 
   @Before public void before() {
-    fruits = new LinkedList<String>();
-    veggies = new LinkedList<String>();
-    cart = new LinkedList<String>();
+    fruits = new ArrayList<String>();
+    veggies = new ArrayList<String>();
+    cart = new ArrayList<String>();
   }
 
   @After public void after() {

--- a/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
+++ b/tests/java/org/pantsbuild/tools/junit/impl/SpecParserTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SpecParserTest {
   private static final String DUMMY_CLASS_NAME =
@@ -31,7 +32,7 @@ public class SpecParserTest {
     new SpecParser(new ArrayList<String>());
   }
 
-  @Test public void testParserClass() throws Exception {
+  @Test public void testParserClass() {
     SpecParser parser = new SpecParser(ImmutableList.of(DUMMY_CLASS_NAME));
     Collection<Spec> specs = parser.parse();
     Spec spec = Iterables.getOnlyElement(specs);
@@ -40,7 +41,7 @@ public class SpecParserTest {
     assertEquals(0, spec.getMethods().size());
   }
 
-  @Test public void testParserMethod() throws Exception {
+  @Test public void testParserMethod() {
     String specString = DUMMY_CLASS_NAME + "#" + DUMMY_METHOD_NAME;
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     Collection<Spec> specs = parser.parse();
@@ -50,11 +51,12 @@ public class SpecParserTest {
     assertThat(spec.getMethods(), contains(DUMMY_METHOD_NAME));
   }
 
-  @Test public void testMethodDupsClass() throws Exception {
+  @Test public void testMethodDupsClass() {
     String specString = DUMMY_CLASS_NAME + "#" + DUMMY_METHOD_NAME;
-    SpecParser parser = new SpecParser(ImmutableList.of(DUMMY_CLASS_NAME, specString));
+    SpecParser parser = new SpecParser(ImmutableList.of(specString, DUMMY_CLASS_NAME));
     try {
       parser.parse();
+      fail("Expected SpecException");
     } catch (SpecException expected) {
       assertThat(expected.getMessage(),
           containsString("Request for entire class already requesting individual methods"));
@@ -66,6 +68,7 @@ public class SpecParserTest {
     SpecParser parser = new SpecParser(ImmutableList.of(DUMMY_CLASS_NAME, specString));
     try {
       parser.parse();
+      fail("Expected SpecException");
     } catch (SpecException expected) {
       assertThat(expected.getMessage(),
           containsString("Expected only one # in spec"));
@@ -77,6 +80,7 @@ public class SpecParserTest {
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     try {
       parser.parse();
+      fail("Expected SpecException");
     } catch (SpecException expected) {
       assertThat(expected.getMessage(),
           containsString("Class org.foo.bar.Baz not found"));
@@ -88,13 +92,14 @@ public class SpecParserTest {
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     try {
       parser.parse();
+      fail("Expected SpecException");
     } catch (SpecException expected) {
       assertThat(expected.getMessage(),
           containsString("Method doesNotExist not found in class"));
     }
   }
 
-  private void assertNoSpecs(String className) throws Exception {
+  private void assertNoSpecs(String className) {
     String specString = "org.pantsbuild.tools.junit.lib." + className;
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     Collection<Spec> specs = parser.parse();
@@ -106,7 +111,7 @@ public class SpecParserTest {
    * and interfaces it finds, but if they get passed down to the BlockJUnit4Runner, the runner
    * will throw an InitializationError
    */
-  @Test public void testNotATestClassSpec() throws Exception {
+  @Test public void testNotATestClassSpec() {
     assertNoSpecs("NotATestAbstractClass");
     assertNoSpecs("NotATestInterface");
     assertNoSpecs("NotATestNonzeroArgConstructor");
@@ -115,14 +120,14 @@ public class SpecParserTest {
     assertNoSpecs("NotATestPrivateClass");
   }
 
-  @Test public void testNotATestMethodSpec() throws Exception {
+  @Test public void testNotATestMethodSpec() {
     String specString = "org.pantsbuild.tools.junit.lib.NotATestInterface#natif1";
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     Collection<Spec> specs = parser.parse();
     assertTrue(specs.isEmpty());
   }
 
-  @Test public void testJUnit3() throws Exception {
+  @Test public void testJUnit3() {
     String specString = "org.pantsbuild.tools.junit.lib.MockJUnit3Test";
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     Collection<Spec> specs = parser.parse();
@@ -130,7 +135,7 @@ public class SpecParserTest {
     assertEquals(MockJUnit3Test.class, spec.getSpecClass());
   }
 
-  @Test public void testRunWith() throws Exception {
+  @Test public void testRunWith() {
     String specString = "org.pantsbuild.tools.junit.lib.MockRunWithTest";
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     Collection<Spec> specs = parser.parse();
@@ -138,7 +143,7 @@ public class SpecParserTest {
     assertEquals(MockRunWithTest.class, spec.getSpecClass());
   }
 
-  @Test public void testScalaTest() throws Exception {
+  @Test public void testScalaTest() {
     String specString = "org.pantsbuild.tools.junit.lib.MockScalaTest";
     SpecParser parser = new SpecParser(ImmutableList.of(specString));
     Collection<Spec> specs = parser.parse();

--- a/tests/java/org/pantsbuild/tools/runner/PantsRunnerTest.java
+++ b/tests/java/org/pantsbuild/tools/runner/PantsRunnerTest.java
@@ -152,17 +152,12 @@ public class PantsRunnerTest {
   private static void assertExceptionWasThrown(Class<? extends Exception> exceptionClass,
                                                String exceptionMessage,
                                                URL[] classpath, String[] args) {
-    boolean failed = true;
     try {
       runRunner(classpath, args);
-      failed = false;
+      fail("Expected " + exceptionClass);
     } catch (Exception e) {
       assertEquals(exceptionClass, e.getClass());
       assertEquals(exceptionMessage, e.getMessage());
-    }
-
-    if (!failed) {
-      fail();
     }
   }
 


### PR DESCRIPTION
### Problem

The latest errorprone has more warnings than the current version Pants is running on.   We also potentially run findbugs on the same target twice.  

### Solution

This cleans up new warnings from errorprone 2.2.0 and removes duplicates from the findbugs targets.

### Result

It will reduce the amount of changes in code when we update to errorprone 2.2.0