### PR TITLE
Ensure test goal implicitly targets current platform when using python_dist targets

### DIFF
--- a/src/python/pants/backend/python/targets/python_distribution.py
+++ b/src/python/pants/backend/python/targets/python_distribution.py
@@ -65,3 +65,7 @@ class PythonDistribution(Target):
   @property
   def has_native_sources(self):
     return self.has_sources(extension=('.c', '.cpp', '.cc'))
+
+  @property
+  def platforms(self):
+    return ['current']

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -74,8 +74,7 @@ def tgt_closure_platforms(tgts):
         else:
           tgts_by_platforms[platform] = [tgt]
 
-  for tgt in tgts:
-    insert_or_append_tgt_by_platform(tgt)
+  map(insert_or_append_tgt_by_platform, tgts)
   # If no targets specify platforms, inherit the default platforms.
   if not tgts_by_platforms:
     for platform in PythonSetup.global_instance().platforms:

--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -64,21 +64,18 @@ def tgt_closure_platforms(tgts):
   :param tgts: a list of :class:`Target` objects.
   :returns: a dict mapping a platform string to a list of targets that specify the platform.
   """
-
-  def insert_or_append_tgt_by_platform(platform, tgt, tgt_dict):
-    if platform in tgt_dict:
-      tgt_dict[platform].append(tgt)
-    else:
-      tgt_dict[platform] = [tgt]
-
   tgts_by_platforms = {}
+
+  def insert_or_append_tgt_by_platform(tgt):
+    if tgt.platforms:
+      for platform in tgt.platforms:
+        if platform in tgts_by_platforms:
+          tgts_by_platforms[platform].append(tgt)
+        else:
+          tgts_by_platforms[platform] = [tgt]
+
   for tgt in tgts:
-    if is_local_python_dist(tgt):
-      insert_or_append_tgt_by_platform('current', tgt, tgts_by_platforms)
-    else:
-      if tgt.platforms:
-        for platform in tgt.platforms:
-          insert_or_append_tgt_by_platform(platform, tgt, tgts_by_platforms)
+    insert_or_append_tgt_by_platform(tgt)
   # If no targets specify platforms, inherit the default platforms.
   if not tgts_by_platforms:
     for platform in PythonSetup.global_instance().platforms:

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
+import sys
 
 from pants.base.build_environment import get_buildroot
 from pants.util.process_handler import subprocess
@@ -129,10 +130,14 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
         os.remove(pex)
 
   def test_pants_tests_local_dists_for_current_platform_only(self):
-    # Cannot use 'platforms': ['current', 'linux-x86_64'] for testing because the test goal
+    if 'linux' in sys.platform:
+      platform_string = 'linux-x86_64'
+    else:
+      platform_string = 'macosx-10.12-x86_64'
+    # Use a platform-specific string for testing because the test goal
     # requires the coverage package and the pex resolver raises an Untranslatable error when
-    # attempting to translate the coverage sdist for linux platforms.
-    pants_ini_config = {'python-setup': {'platforms': ['macosx-10.12-x86_64']}}
+    # attempting to translate the coverage sdist for incompatible platforms.
+    pants_ini_config = {'python-setup': {'platforms': [platform_string]}}
     # Clean all to rebuild requirements pex.
     command=['clean-all', 'test', '{}:fasthello'.format(self.fasthello_tests)]
     pants_run = self.run_pants(command=command, config=pants_ini_config)

--- a/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_distribution_integration.py
@@ -127,3 +127,13 @@ class PythonDistributionIntegrationTest(PantsRunIntegrationTest):
       if os.path.exists(pex):
         # Cleanup
         os.remove(pex)
+
+  def test_pants_tests_local_dists_for_current_platform_only(self):
+    # Cannot use 'platforms': ['current', 'linux-x86_64'] for testing because the test goal
+    # requires the coverage package and the pex resolver raises an Untranslatable error when
+    # attempting to translate the coverage sdist for linux platforms.
+    pants_ini_config = {'python-setup': {'platforms': ['macosx-10.12-x86_64']}}
+    # Clean all to rebuild requirements pex.
+    command=['clean-all', 'test', '{}:fasthello'.format(self.fasthello_tests)]
+    pants_run = self.run_pants(command=command, config=pants_ini_config)
+    self.assert_success(pants_run)


### PR DESCRIPTION
### Problem

https://github.com/pantsbuild/pants/pull/5618 introduced safety checks to ensure that targets depending on `python_dist` targets build for the current platform only. However, test targets do not have a platform parameter, and we need to extend this check to ensure that `./pants test` runs do not inherit incompatible default platform constraints and only build for `'current'` only.

### Solution

Give the `python_dist` target a hard-coded platform constraint so that `python_tests` implicitly targets the current platform when testing APIs from a `python_dist` target.

### Result

Users can now depend on the `python_dist` target in `python_tests` targets when pants.ini specifies multiple platforms.