### PR TITLE
Update junit-runner to 1.0.24 and use junit-runner-annotations 0.0.21 in tests

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/junit.py
+++ b/src/python/pants/backend/jvm/subsystems/junit.py
@@ -21,7 +21,7 @@ class JUnit(JvmToolMixin, InjectablesMixin, Subsystem):
   RUNNER_MAIN = 'org.pantsbuild.tools.junit.ConsoleRunner'
 
   LIBRARY_JAR = JarDependency(org='junit', name='junit', rev=LIBRARY_REV)
-  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.23')
+  _RUNNER_JAR = JarDependency(org='org.pantsbuild', name='junit-runner', rev='1.0.24')
 
   @classmethod
   def register_options(cls, register):
@@ -43,6 +43,8 @@ class JUnit(JvmToolMixin, InjectablesMixin, Subsystem):
                           # @Before, as well as other annotations, but there is also the Assert
                           # class and some subset of the @Rules, @Theories and @RunWith APIs.
                           custom_rules=[
+                            Shader.exclude_package('com.sun.xml', recursive=True),
+                            Shader.exclude_package('javax.xml.bind', recursive=True),
                             Shader.exclude_package('junit.framework', recursive=True),
                             Shader.exclude_package('org.junit', recursive=True),
                             Shader.exclude_package('org.hamcrest', recursive=True),

--- a/src/python/pants/java/junit/junit_xml_parser.py
+++ b/src/python/pants/java/junit/junit_xml_parser.py
@@ -100,20 +100,20 @@ class RegistryOfTests(object):
 class ParseError(Exception):
   """Indicates an error parsing a junit xml report file."""
 
-  def __init__(self, junit_xml_path, cause):
+  def __init__(self, xml_path, cause):
     super(ParseError, self).__init__('Error parsing test result file {}: {}'
-                                     .format(junit_xml_path, cause))
-    self._junit_xml_path = junit_xml_path
+                                     .format(xml_path, cause))
+    self._xml_path = xml_path
     self._cause = cause
 
   @property
-  def junit_xml_path(self):
+  def xml_path(self):
     """Return the path of the file the parse error was encountered in.
 
     :return: The path of the file the parse error was encountered in.
     :rtype: string
     """
-    return self._junit_xml_path
+    return self._xml_path
 
   @property
   def cause(self):

--- a/testprojects/tests/java/org/pantsbuild/testproject/parallel/BUILD
+++ b/testprojects/tests/java/org/pantsbuild/testproject/parallel/BUILD
@@ -48,6 +48,6 @@ junit_tests(name='annotated-serial',
 jar_library(
   name='junit-runner-annotations',
   jars=[
-    jar(org='org.pantsbuild', name='junit-runner-annotations', rev='0.0.11'),
+    jar(org='org.pantsbuild', name='junit-runner-annotations', rev='0.0.21'),
   ],
 )

--- a/tests/python/pants_test/java/junit/test_junit_xml_parser.py
+++ b/tests/python/pants_test/java/junit/test_junit_xml_parser.py
@@ -166,7 +166,7 @@ class TestParseFailedTargets(unittest.TestCase):
         fp.write('<invalid></xml>')
       with self.assertRaises(ParseError) as exc:
         parse_failed_targets(registry, junit_xml_dir, self._raise_handler)
-      self.assertEqual(junit_xml_file, exc.exception.junit_xml_path)
+      self.assertEqual(junit_xml_file, exc.exception.xml_path)
       self.assertIsInstance(exc.exception.cause, XmlParser.XmlError)
 
   def test_parse_failed_targets_error_continue(self):
@@ -190,6 +190,6 @@ class TestParseFailedTargets(unittest.TestCase):
       collect_handler = self.CollectHandler()
       failed_targets = parse_failed_targets(registry, junit_xml_dir, collect_handler)
       self.assertEqual(2, len(collect_handler.errors))
-      self.assertEqual({bad_file1, bad_file2}, {e.junit_xml_path for e in collect_handler.errors})
+      self.assertEqual({bad_file1, bad_file2}, {e.xml_path for e in collect_handler.errors})
 
       self.assertEqual({None: {JUnitTest('org.pantsbuild.Error', 'testError')}}, failed_targets)


### PR DESCRIPTION
### Problem

Updating master to use the latest version of the junit-runner

### Solution

Update the version of junit-runner to 1.0.24.

Main changes included in the update are

https://github.com/pantsbuild/pants/pull/5667 Add explicit JAXB dependencies in the junit-runner so it works in Java 9+ without --add-modules=java.xml.bind
https://github.com/pantsbuild/pants/pull/5660 [junit-runner] cache localhost lookups to ease OSX/JDK DNS issues
https://github.com/pantsbuild/pants/pull/5614 Memoize org.scalatest.Suite class loading

### Result

Tests are passing.  The new junit-runner jar includes jaxb jars which required some changes to the shading excludes of the junit-runner shaded jar.  