### PR TITLE
java_agent gets added to manifest for java_binary targets

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -432,6 +432,10 @@ class JarBuilderTask(JarTask):
       if isinstance(target, JvmBinary):
         self._add_manifest_entries(target, self._manifest)
         products_added = True
+
+      # Ensure that JavaAgent entries are added to the manifest. Either by adding all of the
+      # transitive JavaAgent deps, if recursive, or by adding the root target, if the root target
+      # is itself a JavaAgent.
       if recursive:
         agents = [t for t in target.closure() if isinstance(t, JavaAgent)]
         if len(agents) > 1:

--- a/src/python/pants/backend/jvm/tasks/jar_task.py
+++ b/src/python/pants/backend/jvm/tasks/jar_task.py
@@ -432,10 +432,7 @@ class JarBuilderTask(JarTask):
       if isinstance(target, JvmBinary):
         self._add_manifest_entries(target, self._manifest)
         products_added = True
-      elif isinstance(target, JavaAgent):
-        self._add_agent_manifest(target, self._manifest)
-        products_added = True
-      elif recursive:
+      if recursive:
         agents = [t for t in target.closure() if isinstance(t, JavaAgent)]
         if len(agents) > 1:
           raise TaskError('Only 1 agent can be added to a jar, found {} for {}:\n\t{}'
@@ -445,6 +442,9 @@ class JarBuilderTask(JarTask):
         elif agents:
           self._add_agent_manifest(agents[0], self._manifest)
           products_added = True
+      elif isinstance(target, JavaAgent):
+        self._add_agent_manifest(target, self._manifest)
+        products_added = True
 
       # In the transitive case we'll gather internal resources naturally as dependencies, but in the
       # non-transitive case we need to manually add these special (in the context of jarring)

--- a/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
+++ b/testprojects/src/java/org/pantsbuild/testproject/manifest/BUILD
@@ -21,6 +21,15 @@ jvm_binary(
   ],
 )
 
+jvm_binary(
+  name = 'manifest-with-agent',
+  main = 'org.pantsbuild.testproject.manifest.Manifest',
+  manifest_entries = {
+    'Implementation-Version' :  '4.5.6',
+  },
+  dependencies = [':agent'],
+)
+
 java_library(
   name = 'manifest-lib',
   sources = ['Manifest.java'],
@@ -31,4 +40,10 @@ jvm_app(
   dependencies = [
     ':manifest-no-source',
   ]
+)
+
+java_agent(
+  name = 'agent',
+  agent_class = 'org.pantsbuild.testproject.manifest.Agent',
+  sources = ['Agent.java'],
 )

--- a/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_binary_create_integration.py
@@ -68,6 +68,18 @@ class BinaryCreateIntegrationTest(PantsRunIntegrationTest):
       expected_output='Hello World!  Version: 4.5.6',
     )
 
+  def test_agent_dependency(self):
+    directory = "testprojects/src/java/org/pantsbuild/testproject/manifest"
+    target = "{}:manifest-with-agent".format(directory)
+    with self.temporary_workdir() as workdir:
+      pants_run = self.run_pants_with_workdir(["binary", target], workdir=workdir)
+      self.assert_success(pants_run)
+      jar = "dist/manifest-with-agent.jar"
+      with open_zip(jar, mode='r') as j:
+        with j.open("META-INF/MANIFEST.MF") as jar_entry:
+          entries = {tuple(line.strip().split(": ", 2)) for line in jar_entry.readlines() if line.strip()}
+          self.assertIn(('Agent-Class', 'org.pantsbuild.testproject.manifest.Agent'), entries)
+
   def test_deploy_excludes(self):
     jar_filename = os.path.join('dist', 'deployexcludes.jar')
     safe_delete(jar_filename)


### PR DESCRIPTION
Right now we never traverse deps, so java_agent never actually works
today. But now there's a test! :)