### PR TITLE
Add interpreter identity check for non-blacklisted interpreters

### DIFF
--- a/src/python/pants/backend/python/tasks/pex_build_util.py
+++ b/src/python/pants/backend/python/tasks/pex_build_util.py
@@ -165,9 +165,10 @@ def dump_requirements(builder, interpreter, reqs, log, platforms=None):
   """
   deduped_reqs = OrderedSet(reqs)
   find_links = OrderedSet()
+  blacklist = PythonSetup.global_instance().resolver_blacklist
   for req in deduped_reqs:
     log.debug('  Dumping requirement: {}'.format(req))
-    if not req.key in PythonSetup.global_instance().resolver_blacklist:
+    if not (req.key in blacklist and interpreter.identity.matches(blacklist[req.key])):
       builder.add_requirement(req.requirement)
     if req.repository:
       find_links.add(req.repository)

--- a/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
+++ b/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/BUILD
@@ -16,3 +16,19 @@ python_requirement_library(
     python_requirement('jupyter'),
   ]
 )
+
+# Test non-blacklisted backport usage.
+python_binary(
+  name='test_py2',
+  source='import_futures.py',
+  dependencies=[
+    ':futures_reqlib'
+  ]
+)
+
+python_requirement_library(
+  name='futures_reqlib',
+  requirements=[
+    python_requirement('futures'),
+  ]
+)

--- a/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/import_futures.py
+++ b/testprojects/src/python/interpreter_selection/resolver_blacklist_testing/import_futures.py
@@ -1,0 +1,2 @@
+from concurrent.futures import *
+print('Successful.')

--- a/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_python_run_integration.py
@@ -203,6 +203,11 @@ class PythonRunIntegrationTest(PantsRunIntegrationTest):
         config=pants_ini_config
       )
       self.assert_success(pants_run_36)
+      pants_run_27 = self.run_pants(
+        command=['clean-all', 'run', '{}:test_py2'.format(os.path.join(self.testproject,'resolver_blacklist_testing'))],
+        config=pants_ini_config
+      )
+      self.assert_success(pants_run_27)
     finally:
       if os.path.exists(pex):
         os.remove(pex)


### PR DESCRIPTION
### Problem

The pex resolver blacklist checking in the Pants codebase is too loose and only checks that a requirement name is present in the blacklist before excluding it from the pex builder object. Requirements blacklisted by pants.ini do not get their requirement strings plumbed though to PEX-INFO of product pexes, and these pex files cannot import the dependencies they need.

### Solution

Check for interpreter identity matches before excluding from the pex builder object in addition to the requirement name check.

### Result

Pex files that use a non-blacklisted interpreter for a particular requirement will not have that requirement excluded from PEX-INFO metadata, hence making it importable in the scripts packaged by the pex file.