### PR TITLE
Update errorprone to 2.3.0 and findbugs to spotbugs 3.1.3

### DIFF
--- a/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/test_errorprone_integration.py
+++ b/contrib/errorprone/tests/python/pants_test/contrib/errorprone/tasks/test_errorprone_integration.py
@@ -19,6 +19,10 @@ class ErrorProneTest(PantsRunIntegrationTest):
       'GLOBAL': {
         'pythonpath': ["%(buildroot)s/contrib/errorprone/src/python"],
         'backend_packages': ["pants.backend.codegen", "pants.backend.jvm", "pants.contrib.errorprone"]
+      },
+      'jvm-platform': {
+        'default_platform': 'java8',
+        'platforms': {'java8': {'source': '8', 'target': '8', 'args': [] }}
       }
     }
     if config:
@@ -32,6 +36,7 @@ class ErrorProneTest(PantsRunIntegrationTest):
     cmd = ['compile', 'contrib/errorprone/tests/java/org/pantsbuild/contrib/errorprone:none']
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
+    self.assertNotIn('Exception caught:', pants_run.stderr_data)
     self.assertNotIn('warning:', pants_run.stdout_data)
     self.assertNotIn('error:', pants_run.stdout_data)
 
@@ -39,6 +44,7 @@ class ErrorProneTest(PantsRunIntegrationTest):
     cmd = ['compile', 'contrib/errorprone/tests/java/org/pantsbuild/contrib/errorprone:empty']
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
+    self.assertNotIn('Exception caught:', pants_run.stderr_data)
     self.assertNotIn('warning:', pants_run.stdout_data)
     self.assertNotIn('error:', pants_run.stdout_data)
 
@@ -46,6 +52,7 @@ class ErrorProneTest(PantsRunIntegrationTest):
     cmd = ['compile', 'contrib/errorprone/tests/java/org/pantsbuild/contrib/errorprone:warning']
     pants_run = self.run_pants(cmd)
     self.assert_success(pants_run)
+    self.assertNotIn('Exception caught:', pants_run.stderr_data)
     self.assertIn('warning: [ReferenceEquality] Comparison using reference equality instead of value equality', pants_run.stdout_data)
     self.assertIn('(see http://errorprone.info/bugpattern/ReferenceEquality)', pants_run.stdout_data)
     self.assertNotIn('error:', pants_run.stdout_data)
@@ -73,16 +80,20 @@ class ErrorProneTest(PantsRunIntegrationTest):
 
       pants_run = self.run_pants(args)
       self.assert_success(pants_run)
+      self.assertNotIn('Exception caught:', pants_run.stderr_data)
       self.assertIn('[errorprone]', pants_run.stdout_data)
       self.assertIn('No cached artifacts', pants_run.stdout_data)
       self.assertIn('1 warning', pants_run.stdout_data)
+      self.assertIn('SUCCESS', pants_run.stdout_data)
 
       pants_run = self.run_pants(args)
       self.assert_success(pants_run)
+      self.assertNotIn('Exception caught:', pants_run.stderr_data)
       self.assertIn('[errorprone]', pants_run.stdout_data)
       self.assertIn('Using cached artifacts', pants_run.stdout_data)
       self.assertNotIn('No cached artifacts', pants_run.stdout_data)
       self.assertNotIn('1 warning', pants_run.stdout_data)
+      self.assertIn('SUCCESS', pants_run.stdout_data)
 
   def test_error_does_not_get_cached(self):
     with self.temporary_cachedir() as cache:
@@ -97,12 +108,17 @@ class ErrorProneTest(PantsRunIntegrationTest):
 
       pants_run = self.run_pants(args)
       self.assert_failure(pants_run)
+      self.assertNotIn('Exception caught:', pants_run.stderr_data)
       self.assertIn('[errorprone]', pants_run.stdout_data)
       self.assertIn('No cached artifacts', pants_run.stdout_data)
       self.assertIn('1 error', pants_run.stdout_data)
+      self.assertIn('FAILURE: ErrorProne checks failed', pants_run.stdout_data)
 
       pants_run = self.run_pants(args)
+
       self.assert_failure(pants_run)
+      self.assertNotIn('Exception caught:', pants_run.stderr_data)
       self.assertIn('[errorprone]', pants_run.stdout_data)
       self.assertIn('Using cached artifacts', pants_run.stdout_data)
       self.assertIn('1 error', pants_run.stdout_data)
+      self.assertIn('FAILURE: ErrorProne checks failed', pants_run.stdout_data)

--- a/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
+++ b/contrib/findbugs/tests/python/pants_test/contrib/findbugs/tasks/test_findbugs_integration.py
@@ -23,6 +23,10 @@ class FindBugsTest(PantsRunIntegrationTest):
       'GLOBAL': {
         'pythonpath': ["%(buildroot)s/contrib/findbugs/src/python"],
         'backend_packages': ["pants.backend.codegen", "pants.backend.jvm", "pants.contrib.findbugs"]
+      },
+      'jvm-platform': {
+        'default_platform': 'java8',
+        'platforms': {'java8': {'source': '8', 'target': '8', 'args': [] }}
       }
     }
     if config:

--- a/examples/src/java/org/pantsbuild/example/annotation/processor/ExampleProcessor.java
+++ b/examples/src/java/org/pantsbuild/example/annotation/processor/ExampleProcessor.java
@@ -36,7 +36,7 @@ public class ExampleProcessor extends AbstractProcessor {
 
   private ProcessingEnvironment processingEnvironment = null;
 
-  @Override public void init(ProcessingEnvironment processingEnvironment) {
+  @Override public synchronized void init(ProcessingEnvironment processingEnvironment) {
     this.processingEnvironment = processingEnvironment;
   }
 

--- a/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java
+++ b/examples/src/java/org/pantsbuild/example/hello/greet/Greeting.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Scanner;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public final class Greeting {
   public static String greetFromFile(String filename) throws IOException {
     FileInputStream is = new FileInputStream(filename);
@@ -28,7 +30,7 @@ public final class Greeting {
   }
 
   public static String greetFromStream(InputStream is) throws IOException {
-    return greet(new Scanner(is).useDelimiter("\\Z").next());
+    return greet(new Scanner(is, UTF_8.name()).useDelimiter("\\Z").next());
   }
 
   public static String greet(String greetee) {

--- a/pants.ini
+++ b/pants.ini
@@ -159,6 +159,11 @@ antlr3_deps: ["3rdparty/python:antlr-3.1.3"]
 
 
 [compile.errorprone]
+command_line_options: [
+    # See http://errorprone.info/bugpatterns for all patterns
+    '-Xep:CatchAndPrintStackTrace:OFF',
+    '-Xep:StringSplitter:OFF',
+  ]
 exclude_patterns: [
     'contrib/errorprone/tests/java/org/pantsbuild/contrib/errorprone:error',
     'testprojects/src/java/org/pantsbuild/testproject/.*'

--- a/src/java/org/pantsbuild/tools/jar/JarBuilder.java
+++ b/src/java/org/pantsbuild/tools/jar/JarBuilder.java
@@ -381,6 +381,8 @@ public class JarBuilder implements Closeable {
   /**
    * Input stream that always ensures that a non-empty stream ends with a newline.
    */
+  // TODO: implement read(byte[], int, int) for faster multibyte reads
+  @SuppressWarnings("InputStreamSlowMultibyteRead")
   private static class NewlineAppendingInputStream extends InputStream {
     private InputStream underlyingStream;
     private int lastByteRead = -1;

--- a/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/AntJunitXmlReportListener.java
@@ -50,6 +50,7 @@ class AntJunitXmlReportListener extends RunListener {
    */
   @XmlRootElement
   @XmlAccessorType(XmlAccessType.FIELD)
+  @SuppressWarnings("JavaLangClash")
   static class Exception {
     @XmlAttribute private final String message;
     @XmlAttribute private final String type;

--- a/src/java/org/pantsbuild/tools/junit/impl/experimental/ConcurrentComputer.java
+++ b/src/java/org/pantsbuild/tools/junit/impl/experimental/ConcurrentComputer.java
@@ -56,7 +56,7 @@ public class ConcurrentComputer extends Computer {
             fService.shutdown();
             // TODO(zundel): Change long wait?
             boolean awaitResult = fService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
-            if (awaitResult != true) {
+            if (!awaitResult) {
               throw new ConcurrentTestRunnerException("Did not terminate all tests sucessfully.");
             }
             for (Future<?> testResult : testResults.keySet()) {

--- a/testprojects/maven_layout/junit_resource_collision/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/BUILD
@@ -4,7 +4,7 @@
 
 target(
   dependencies=[
-    'testprojects/maven_layout/junit_resource_collision/onedir/src/test/java',
-    'testprojects/maven_layout/junit_resource_collision/twodir/src/test/java',
+    'testprojects/maven_layout/junit_resource_collision/onedir/src/test/java:test',
+    'testprojects/maven_layout/junit_resource_collision/twodir/src/test/java:test',
   ],
 )

--- a/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/onedir/src/test/java/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
+  name='test',
   sources=[
     'org/pantsbuild/duplicates/FirstTest.java'
   ],

--- a/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
+++ b/testprojects/maven_layout/junit_resource_collision/twodir/src/test/java/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 junit_tests(
+  name='test',
   sources=[
     'org/pantsbuild/duplicates/SecondTest.java'
   ],


### PR DESCRIPTION
### Problem

Pants was on older versions of Errorprone and Findbugs (now SpotBugs) that did not run on Java 9+

### Solution

Update errorprone and findbugs so they work on Java 9 and 10.

### Result

Both are updated.  I didn't think the noise of renaming findbugs to spotbugs made sense in this change.  I also assumed it is ok that they require Java 8 as a minimum runtime even though Pants still supports Java 7. 