### PR TITLE
eagerly fetch stderr in remote process execution

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -54,6 +54,6 @@ pub struct ExecuteProcessRequest {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExecuteProcessResult {
   pub stdout: Bytes,
-  pub stderr: Vec<u8>,
+  pub stderr: Bytes,
   pub exit_code: i32,
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -25,7 +25,7 @@ pub fn run_command_locally(
     .output()
     .map(|output| ExecuteProcessResult {
       stdout: Bytes::from(output.stdout),
-      stderr: output.stderr,
+      stderr: Bytes::from(output.stderr),
       exit_code: output.status.code().unwrap(),
     })
 }
@@ -38,7 +38,7 @@ mod tests {
   use fs;
   use std::collections::BTreeMap;
   use std::path::PathBuf;
-  use self::testutil::{as_byte_owned_vec, as_bytes, owned_string_vec};
+  use self::testutil::{as_bytes, owned_string_vec};
 
   #[test]
   #[cfg(unix)]
@@ -56,7 +56,7 @@ mod tests {
       result.unwrap(),
       ExecuteProcessResult {
         stdout: as_bytes("foo"),
-        stderr: as_byte_owned_vec(""),
+        stderr: as_bytes(""),
         exit_code: 0,
       }
     )
@@ -78,7 +78,7 @@ mod tests {
       result.unwrap(),
       ExecuteProcessResult {
         stdout: as_bytes("foo"),
-        stderr: as_byte_owned_vec("bar"),
+        stderr: as_bytes("bar"),
         exit_code: 1,
       }
     )

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -320,7 +320,7 @@ impl CommandRunner {
 
   fn extract_stdout(
     &self,
-    execute_response: &bazel_protos::remote_execution::ExecuteResponse
+    execute_response: &bazel_protos::remote_execution::ExecuteResponse,
   ) -> BoxFuture<Bytes, ExecutionError> {
     let stdout = if execute_response.get_result().has_stdout_digest() {
       let stdout_digest = execute_response.get_result().get_stdout_digest().into();
@@ -352,7 +352,7 @@ impl CommandRunner {
 
   fn extract_stderr(
     &self,
-    execute_response: &bazel_protos::remote_execution::ExecuteResponse
+    execute_response: &bazel_protos::remote_execution::ExecuteResponse,
   ) -> BoxFuture<Bytes, ExecutionError> {
     let stderr = if execute_response.get_result().has_stderr_digest() {
       let stderr_digest = execute_response.get_result().get_stderr_digest().into();
@@ -1055,7 +1055,12 @@ mod tests {
           super::make_execute_request(&execute_request).unwrap().1,
           vec![
             make_incomplete_operation(&op_name),
-            make_successful_operation(&op_name, StdoutType::Raw("foo".to_owned()), "", 0),
+            make_successful_operation(
+              &op_name,
+              StdoutType::Raw("foo".to_owned()),
+              StderrType::Raw("".to_owned()),
+              0,
+            ),
           ],
         ))
       };
@@ -1078,7 +1083,12 @@ mod tests {
             make_incomplete_operation(&op_name),
             make_incomplete_operation(&op_name),
             make_incomplete_operation(&op_name),
-            make_successful_operation(&op_name, StdoutType::Raw("foo".to_owned()), "", 0),
+            make_successful_operation(
+              &op_name,
+              StdoutType::Raw("foo".to_owned()),
+              StderrType::Raw("".to_owned()),
+              0,
+            ),
           ],
         ))
       };

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -522,34 +522,37 @@ mod tests {
   fn extract_response_with_digest_stdout() {
     let op_name = "gimme-foo".to_string();
     let testdata = TestData::roland();
+    let testdata_empty = TestData::empty();
     assert_eq!(
       extract_execute_response(make_successful_operation(
         &op_name,
         StdoutType::Digest(testdata.digest()),
-        "",
+        StderrType::Raw(testdata_empty.string()),
         0,
       )),
       Ok(ExecuteProcessResult {
-        stdout: as_bytes("foo"),
-        stderr: as_bytes(""),
+        stdout: testdata.bytes(),
+        stderr: testdata_empty.bytes(),
         exit_code: 0,
-    }),
+      })
     );
   }
 
   #[test]
   fn extract_response_with_digest_stderr() {
     let op_name = "gimme-foo".to_string();
+    let testdata = TestData::roland();
+    let testdata_empty = TestData::empty();
     assert_eq!(
       extract_execute_response(make_successful_operation(
         &op_name,
-        StdoutType::Raw("foo".to_owned()),
-        StderrType::Digest(digest()),
+        StdoutType::Raw(testdata_empty.string()),
+        StderrType::Digest(testdata.digest()),
         0,
       )),
       Ok(ExecuteProcessResult {
-        stdout: as_bytes("foo"),
-        stderr: str_bytes(),
+        stdout: testdata_empty.bytes(),
+        stderr: testdata.bytes(),
         exit_code: 0,
       })
     );
@@ -761,7 +764,12 @@ mod tests {
           make_precondition_failure_operation(vec![
             missing_preconditionfailure_violation(&roland.digest()),
           ]),
-          make_successful_operation("cat2", StdoutType::Raw(roland.string()), StderrType::Raw("".to_owned()), 0),
+          make_successful_operation(
+            "cat2",
+            StdoutType::Raw(roland.string()),
+            StderrType::Raw("".to_owned()),
+            0,
+          ),
         ],
       ))
     };

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -146,6 +146,6 @@ fn main() {
     }
   };
   print!("{}", String::from_utf8(result.stdout.to_vec()).unwrap());
-  eprint!("{}", String::from_utf8(result.stderr).unwrap());
+  eprint!("{}", String::from_utf8(result.stderr.to_vec()).unwrap());
   exit(result.exit_code);
 }


### PR DESCRIPTION
### Problem

As defined in #5511 - Right now when remote execution finishes, we just return whether it was successful, and any inline stdout/stderr.

Instead, we should fetch stderr if it's not inline, and populate those fields.

### Solution

- fetch stderr and populate using digest/raw
- extract stdout and stderr into functions
- add test for stderr
