### PR TITLE
Extract reusable test data

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "grpcio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashing 0.0.1",
  "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "testutil 0.0.1",
 ]
 
 [[package]]
@@ -650,7 +651,12 @@ dependencies = [
 name = "testutil"
 version = "0.0.1"
 dependencies = [
+ "bazel_protos 0.0.1",
  "bytes 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashing 0.0.1",
+ "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -32,6 +32,8 @@ extern crate ordermap;
 extern crate protobuf;
 extern crate sha2;
 extern crate tempdir;
+#[cfg(test)]
+extern crate testutil;
 
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;

--- a/src/rust/engine/testutil/Cargo.toml
+++ b/src/rust/engine/testutil/Cargo.toml
@@ -4,4 +4,9 @@ name = "testutil"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
+bazel_protos = { path = "../process_execution/bazel_protos" }
 bytes = "0.4.5"
+digest = "0.6.2"
+hashing = { path = "../hashing" }
+protobuf = { version = "1.4.1", features = ["with-bytes"] }
+sha2 = "0.6.0"

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -10,3 +10,4 @@ futures = "0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
+testutil = { path = ".." }

--- a/src/rust/engine/testutil/mock/src/lib.rs
+++ b/src/rust/engine/testutil/mock/src/lib.rs
@@ -4,6 +4,7 @@ extern crate futures;
 extern crate grpcio;
 extern crate hashing;
 extern crate protobuf;
+extern crate testutil;
 
 mod cas;
 pub use cas::StubCAS;

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -81,7 +81,6 @@ impl TestDirectory {
   // Directory structure:
   //
   // /cats/roland
-  // /treats
   pub fn nested() -> TestDirectory {
     let mut directory = bazel_protos::remote_execution::Directory::new();
     directory.mut_directories().push({

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -1,0 +1,182 @@
+use bazel_protos;
+use bytes;
+use digest::FixedOutput;
+use hashing;
+use protobuf::Message;
+use sha2::{self, Digest};
+
+pub struct TestData {
+  string: String,
+}
+
+impl TestData {
+  pub fn empty() -> TestData {
+    TestData::new("")
+  }
+
+  pub fn roland() -> TestData {
+    TestData::new("European Burmese")
+  }
+
+  pub fn catnip() -> TestData {
+    TestData::new("catnip")
+  }
+
+  pub fn fourty_chars() -> TestData {
+    TestData::new(
+      "0123456789012345678901234567890123456789\
+       0123456789012345678901234567890123456789",
+    )
+  }
+
+  pub fn new(s: &str) -> TestData {
+    TestData {
+      string: s.to_owned(),
+    }
+  }
+
+  pub fn bytes(&self) -> bytes::Bytes {
+    bytes::Bytes::from(self.string.as_str())
+  }
+
+  pub fn fingerprint(&self) -> hashing::Fingerprint {
+    hash(&self.bytes())
+  }
+
+  pub fn digest(&self) -> hashing::Digest {
+    hashing::Digest(self.fingerprint(), self.string.len())
+  }
+
+  pub fn string(&self) -> String {
+    self.string.clone()
+  }
+}
+
+pub struct TestDirectory {
+  directory: bazel_protos::remote_execution::Directory,
+}
+
+impl TestDirectory {
+  pub fn empty() -> TestDirectory {
+    TestDirectory {
+      directory: bazel_protos::remote_execution::Directory::new(),
+    }
+  }
+
+  // Directory structure:
+  //
+  // /roland
+  pub fn containing_roland() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_files().push({
+      let mut file = bazel_protos::remote_execution::FileNode::new();
+      file.set_name("roland".to_owned());
+      file.set_digest((&TestData::roland().digest()).into());
+      file.set_is_executable(false);
+      file
+    });
+    TestDirectory { directory }
+  }
+
+  // Directory structure:
+  //
+  // /cats/roland
+  // /treats
+  pub fn nested() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_directories().push({
+      let mut subdir = bazel_protos::remote_execution::DirectoryNode::new();
+      subdir.set_name("cats".to_string());
+      subdir.set_digest((&TestDirectory::containing_roland().digest()).into());
+      subdir
+    });
+    TestDirectory { directory }
+  }
+
+  // Directory structure:
+  //
+  // /dnalor
+  pub fn containing_dnalor() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_files().push({
+      let mut file = bazel_protos::remote_execution::FileNode::new();
+      file.set_name("dnalor".to_owned());
+      file.set_digest((&TestData::roland().digest()).into());
+      file.set_is_executable(false);
+      file
+    });
+    TestDirectory { directory }
+  }
+
+  // Directory structure:
+  //
+  // /cats/roland
+  // /treats
+  pub fn recursive() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_directories().push({
+      let mut subdir = bazel_protos::remote_execution::DirectoryNode::new();
+      subdir.set_name("cats".to_string());
+      subdir.set_digest((&TestDirectory::containing_roland().digest()).into());
+      subdir
+    });
+    directory.mut_files().push({
+      let mut file = bazel_protos::remote_execution::FileNode::new();
+      file.set_name("treats".to_string());
+      file.set_digest((&TestData::catnip().digest()).into());
+      file.set_is_executable(false);
+      file
+    });
+    TestDirectory { directory }
+  }
+
+  // Directory structure:
+  //
+  // /feed (executable)
+  // /food
+  pub fn with_mixed_executable_files() -> TestDirectory {
+    let mut directory = bazel_protos::remote_execution::Directory::new();
+    directory.mut_files().push({
+      let mut file = bazel_protos::remote_execution::FileNode::new();
+      file.set_name("feed".to_string());
+      file.set_digest((&TestData::catnip().digest()).into());
+      file.set_is_executable(true);
+      file
+    });
+    directory.mut_files().push({
+      let mut file = bazel_protos::remote_execution::FileNode::new();
+      file.set_name("food".to_string());
+      file.set_digest((&TestData::catnip().digest()).into());
+      file.set_is_executable(false);
+      file
+    });
+    TestDirectory { directory }
+  }
+
+  pub fn directory(&self) -> bazel_protos::remote_execution::Directory {
+    self.directory.clone()
+  }
+
+  pub fn bytes(&self) -> bytes::Bytes {
+    bytes::Bytes::from(
+      self
+        .directory
+        .write_to_bytes()
+        .expect("Error serializing proto"),
+    )
+  }
+
+  pub fn fingerprint(&self) -> hashing::Fingerprint {
+    hash(&self.bytes())
+  }
+
+  pub fn digest(&self) -> hashing::Digest {
+    hashing::Digest(self.fingerprint(), self.bytes().len())
+  }
+}
+
+fn hash(bytes: &bytes::Bytes) -> hashing::Fingerprint {
+  let mut hasher = sha2::Sha256::default();
+  hasher.input(bytes);
+  hashing::Fingerprint::from_bytes_unsafe(hasher.fixed_result().as_slice())
+}

--- a/src/rust/engine/testutil/src/file.rs
+++ b/src/rust/engine/testutil/src/file.rs
@@ -1,0 +1,35 @@
+use bytes;
+use std;
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+pub fn list_dir(path: &Path) -> Vec<String> {
+  let mut v: Vec<_> = std::fs::read_dir(path)
+    .expect(&format!("Listing dir {:?}", path))
+    .map(|entry| {
+      entry
+        .expect("Error reading entry")
+        .file_name()
+        .to_string_lossy()
+        .to_string()
+    })
+    .collect();
+  v.sort();
+  v
+}
+
+pub fn contents(path: &Path) -> bytes::Bytes {
+  let mut contents = Vec::new();
+  std::fs::File::open(path)
+    .and_then(|mut f| f.read_to_end(&mut contents))
+    .expect("Error reading file");
+  bytes::Bytes::from(contents)
+}
+
+pub fn is_executable(path: &Path) -> bool {
+  std::fs::metadata(path)
+    .expect("Getting file metadata")
+    .permissions()
+    .mode() & 0o100 == 0o100
+}

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -1,9 +1,17 @@
+extern crate bazel_protos;
 extern crate bytes;
+extern crate digest;
+extern crate hashing;
+extern crate protobuf;
+extern crate sha2;
 
+use bytes::Bytes;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use bytes::Bytes;
+
+pub mod data;
+pub mod file;
 
 pub fn owned_string_vec(args: &[&str]) -> Vec<String> {
   args.into_iter().map(|s| s.to_string()).collect()


### PR DESCRIPTION
Rather than having implicit relationships between bytes/Directories and
their digests, make them explicit.

Reduce re-creating the same things.