### PR TITLE
Bump Scala versions

### DIFF
--- a/src/python/pants/backend/jvm/subsystems/scala_platform.py
+++ b/src/python/pants/backend/jvm/subsystems/scala_platform.py
@@ -25,7 +25,7 @@ major_version_info = namedtuple('major_version_info', ['full_version'])
 scala_build_info = {
   '2.10': major_version_info(full_version='2.10.6'),
   '2.11': major_version_info(full_version='2.11.11'),
-  '2.12': major_version_info(full_version='2.12.2'),
+  '2.12': major_version_info(full_version='2.12.4'),
 }
 
 


### PR DESCRIPTION
### Problem

The default scala build toolchain is out-of-date and insecure(!). See https://nvd.nist.gov/vuln/detail/CVE-2017-15288 for details.

### Solution

Bumped version numbers.