### PR TITLE
Add Javac compile option as an alternative to Zinc

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -200,6 +200,26 @@ no_warning_args: [
     '-S-nowarn',
   ]
 
+[compile.javac]
+args: [
+    '-encoding', 'UTF-8',
+    '-J-Xmx2g',
+  ]
+
+# javac -help -X will show the complete list
+warning_args: [
+    '-Xlint:deprecation',
+    '-Xlint:empty',
+    '-Xlint:finally',
+    '-Xlint:overrides',
+    '-Xlint:static',
+    '-Xlint:unchecked',
+    '-Xlint:try',
+  ]
+no_warning_args: [
+    '-Xlint:none',
+  ]
+
 [node-distribution]
 eslint_setupdir: %(pants_supportdir)s/eslint
 eslint_config: %(pants_supportdir)s/eslint/.eslintrc

--- a/src/python/pants/backend/jvm/register.py
+++ b/src/python/pants/backend/jvm/register.py
@@ -47,6 +47,7 @@ from pants.backend.jvm.tasks.jar_create import JarCreate
 from pants.backend.jvm.tasks.jar_publish import JarPublish
 from pants.backend.jvm.tasks.javadoc_gen import JavadocGen
 from pants.backend.jvm.tasks.junit_run import JUnitRun
+from pants.backend.jvm.tasks.jvm_compile.javac.javac_compile import JavacCompile
 from pants.backend.jvm.tasks.jvm_compile.jvm_classpath_publisher import RuntimeClasspathPublisher
 from pants.backend.jvm.tasks.jvm_compile.zinc.zinc_compile import ZincCompile
 from pants.backend.jvm.tasks.jvm_dependency_check import JvmDependencyCheck
@@ -158,6 +159,7 @@ def register_goals():
 
   # Compile
   task(name='zinc', action=ZincCompile).install('compile')
+  task(name='javac', action=JavacCompile).install('compile')
 
   # Dependency resolution.
   task(name='ivy', action=IvyResolve).install('resolve', first=True)

--- a/src/python/pants/backend/jvm/subsystems/BUILD
+++ b/src/python/pants/backend/jvm/subsystems/BUILD
@@ -131,6 +131,14 @@ python_library(
 )
 
 python_library(
+  name='compile_subsystem',
+  sources=['compile_subsystem.py'],
+  dependencies=[
+    'src/python/pants/subsystem',
+  ],
+)
+
+python_library(
   name='resolve_subsystem',
   sources=['resolve_subsystem.py'],
   dependencies=[

--- a/src/python/pants/backend/jvm/subsystems/compile_subsystem.py
+++ b/src/python/pants/backend/jvm/subsystems/compile_subsystem.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+
+from pants.subsystem.subsystem import Subsystem
+
+
+logger = logging.getLogger(__name__)
+
+
+class JvmCompileSubsystem(Subsystem):
+  """Used to keep track of global jvm compiler option
+
+  :API: public
+  """
+  options_scope = 'compiler'
+
+  @classmethod
+  def register_options(cls, register):
+    super(JvmCompileSubsystem, cls).register_options(register)
+    register('--compiler', choices=['zinc', 'javac'], default='zinc', help='Java compiler implementation to use.')

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/BUILD
@@ -8,6 +8,7 @@ target(
     ':analysis_parser',
     ':analysis_tools',
     ':anonymizer',
+    ':javac',
     ':jvm_classpath_publisher',
     ':jvm_compile',
     ':zinc',
@@ -102,6 +103,31 @@ python_library(
 )
 
 python_library(
+  name = 'javac',
+  sources = globs('javac/*.py'),
+  dependencies = [
+    '3rdparty/python/twitter/commons:twitter.common.collections',
+    '3rdparty/python:six',
+    ':analysis',
+    ':analysis_parser',
+    ':analysis_tools',
+    ':jvm_compile',
+    'src/python/pants/backend/jvm/subsystems:compile_subsystem',
+    'src/python/pants/backend/jvm/subsystems:java',
+    'src/python/pants/backend/jvm/subsystems:shader',
+    'src/python/pants/backend/jvm/targets:java',
+    'src/python/pants/base:exceptions',
+    'src/python/pants/base:hash_utils',
+    'src/python/pants/base:workunit',
+    'src/python/pants/java/distribution',
+    'src/python/pants/option',
+    'src/python/pants/util:contextutil',
+    'src/python/pants/util:dirutil',
+    'src/python/pants/util:memo',
+  ],
+)
+
+python_library(
   name = 'zinc',
   sources = globs('zinc/*.py'),
   dependencies = [
@@ -112,6 +138,7 @@ python_library(
     '3rdparty/python/twitter/commons:twitter.common.collections',
     '3rdparty/python:six',
     'src/python/pants/java/jar',
+    'src/python/pants/backend/jvm/subsystems:compile_subsystem',
     'src/python/pants/backend/jvm/subsystems:java',
     'src/python/pants/backend/jvm/subsystems:scala_platform',
     'src/python/pants/backend/jvm/subsystems:shader',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/analysis_tools.py
@@ -5,10 +5,14 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 import shutil
 
 from pants.util.contextutil import temporary_dir
+
+
+logger = logging.getLogger(__name__)
 
 
 class AnalysisTools(object):
@@ -27,6 +31,9 @@ class AnalysisTools(object):
     self.localize_mappings = {v:k for k, v in self.rebase_mappings.items()}
 
   def relativize(self, src_analysis, relativized_analysis):
+    if not os.path.isfile(src_analysis):
+      logger.debug("AnalysisTools: src_analysis file {} does not exist, skipping relativize".format(src_analysis))
+      return
     with temporary_dir() as tmp_analysis_dir:
       tmp_analysis_file = os.path.join(tmp_analysis_dir, 'analysis.relativized')
 
@@ -43,6 +50,9 @@ class AnalysisTools(object):
       shutil.move(tmp_analysis_file, relativized_analysis)
 
   def localize(self, src_analysis, localized_analysis):
+    if not os.path.isfile(src_analysis):
+      logger.debug("AnalysisTools: src_analysis file {} does not exist, skipping localize".format(src_analysis))
+      return
     with temporary_dir() as tmp_analysis_dir:
       tmp_analysis_file = os.path.join(tmp_analysis_dir, 'analysis')
 

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_analysis.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_analysis.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.backend.jvm.tasks.jvm_compile.analysis import Analysis
+
+
+class JavacAnalysis(Analysis):
+
+  def write(self, outfile):
+    pass

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_analysis_parser.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_analysis_parser.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+
+class JavacAnalysisParser(object):
+
+  def parse(self, infile):
+    pass
+
+  def parse_products(self, infile, classes_dir):
+    pass
+
+  def parse_deps(self, infile):
+    pass
+
+  def rebase(self, infile, outfile, pants_home_from, pants_home_to, java_home=None):
+    pass
+
+  def rebase_from_path(self, infile_path, outfile_path, rebase_mappings, java_home=None):
+    pass
+
+  def parse_deps_from_path(self, infile_path):
+    pass

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -1,0 +1,196 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+import os
+
+from pants.backend.jvm import argfile
+from pants.backend.jvm.subsystems.compile_subsystem import JvmCompileSubsystem
+from pants.backend.jvm.subsystems.java import Java
+from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
+from pants.backend.jvm.targets.annotation_processor import AnnotationProcessor
+from pants.backend.jvm.targets.javac_plugin import JavacPlugin
+from pants.backend.jvm.targets.jvm_target import JvmTarget
+from pants.backend.jvm.tasks.jvm_compile.analysis_tools import AnalysisTools
+from pants.backend.jvm.tasks.jvm_compile.javac.javac_analysis import JavacAnalysis
+from pants.backend.jvm.tasks.jvm_compile.javac.javac_analysis_parser import JavacAnalysisParser
+from pants.backend.jvm.tasks.jvm_compile.jvm_compile import JvmCompile
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnit, WorkUnitLabel
+from pants.java.distribution.distribution import DistributionLocator
+from pants.util.dirutil import safe_open
+from pants.util.process_handler import subprocess
+
+
+# Well known metadata file to register javac plugins.
+_JAVAC_PLUGIN_INFO_FILE = 'META-INF/services/com.sun.source.util.Plugin'
+
+# Well known metadata file to register annotation processors with a java 1.6+ compiler.
+_PROCESSOR_INFO_FILE = 'META-INF/services/javax.annotation.processing.Processor'
+
+
+logger = logging.getLogger(__name__)
+
+
+class JavacCompile(JvmCompile):
+  """Compile Java code using Javac."""
+
+  _name = 'java'
+
+  @staticmethod
+  def _write_javac_plugin_info(resources_dir, javac_plugin_target):
+    javac_plugin_info_file = os.path.join(resources_dir, _JAVAC_PLUGIN_INFO_FILE)
+    with safe_open(javac_plugin_info_file, 'w') as f:
+      f.write(javac_plugin_target.classname)
+
+  @classmethod
+  def compiler_plugin_types(cls):
+    """A tuple of target types which are compiler plugins."""
+    return (AnnotationProcessor, JavacPlugin)
+
+  @classmethod
+  def get_args_default(cls, bootstrap_option_values):
+    return ('-encoding', 'UTF-8')
+
+  @classmethod
+  def get_warning_args_default(cls):
+    return ('-deprecation', '-Xlint:all', '-Xlint:-serial', '-Xlint:-path')
+
+  @classmethod
+  def get_no_warning_args_default(cls):
+    return ('-nowarn', '-Xlint:none', )
+
+  @classmethod
+  def get_fatal_warnings_enabled_args_default(cls):
+    return ('-Werror')
+
+  @classmethod
+  def get_fatal_warnings_disabled_args_default(cls):
+    return ()
+
+  @classmethod
+  def register_options(cls, register):
+    super(JavacCompile, cls).register_options(register)
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(JavacCompile, cls).subsystem_dependencies() + (JvmCompileSubsystem,)
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(JavacCompile, cls).prepare(options, round_manager)
+
+  @classmethod
+  def product_types(cls):
+    return ['runtime_classpath']
+
+  def __init__(self, *args, **kwargs):
+    super(JavacCompile, self).__init__(*args, **kwargs)
+    self.set_distribution(jdk=True)
+
+  def select(self, target):
+    if not isinstance(target, JvmTarget):
+      return False
+    return target.has_sources('.java')
+
+  def select_source(self, source_file_path):
+    return source_file_path.endswith('.java')
+
+  def validate_analysis(self, path):
+    pass
+
+  def create_analysis_tools(self):
+    return AnalysisTools(self.dist.real_home, JavacAnalysisParser(), JavacAnalysis,
+                         get_buildroot(), self.get_options().pants_workdir)
+
+  def javac_classpath(self):
+    # Note that if this classpath is empty then Javac will automatically use the javac from
+    # the JDK it was invoked with.
+    return Java.global_javac_classpath(self.context.products)
+
+  def write_extra_resources(self, compile_context):
+    """Override write_extra_resources to produce plugin and annotation processor files."""
+    target = compile_context.target
+    if isinstance(target, JavacPlugin):
+      self._write_javac_plugin_info(compile_context.classes_dir, target)
+    elif isinstance(target, AnnotationProcessor) and target.processors:
+      processor_info_file = os.path.join(compile_context.classes_dir, _PROCESSOR_INFO_FILE)
+      self._write_processor_info(processor_info_file, target.processors)
+
+  def _write_processor_info(self, processor_info_file, processors):
+    with safe_open(processor_info_file, 'w') as f:
+      for processor in processors:
+        f.write('{}\n'.format(processor.strip()))
+
+  def execute(self):
+    if JvmCompileSubsystem.global_instance().get_options().compiler == 'javac':
+      return super(JavacCompile, self).execute()
+
+  def compile(self, args, classpath, sources, classes_output_dir, upstream_analysis, analysis_file,
+              log_file, zinc_args_file, settings, fatal_warnings, zinc_file_manager,
+              javac_plugin_map, scalac_plugin_map):
+    try:
+      distribution = JvmPlatform.preferred_jvm_distribution([settings], strict=True)
+    except DistributionLocator.Error:
+      distribution = JvmPlatform.preferred_jvm_distribution([settings], strict=False)
+
+    javac_cmd = ['{}/bin/javac'.format(distribution.real_home)]
+
+    javac_cmd.extend([
+      '-classpath', ':'.join(classpath),
+    ])
+
+    if settings.args:
+      settings_args = settings.args
+      if any('$JAVA_HOME' in a for a in settings.args):
+        logger.debug('Substituting "$JAVA_HOME" with "{}" in jvm-platform args.'
+                     .format(distribution.home))
+        settings_args = (a.replace('$JAVA_HOME', distribution.home) for a in settings.args)
+      javac_cmd.extend(settings_args)
+
+    javac_cmd.extend([
+      '-d', classes_output_dir,
+      # TODO: support -release
+      '-source', str(settings.source_level),
+      '-target', str(settings.target_level),
+    ])
+
+    javac_cmd.extend(self._javac_plugin_args(javac_plugin_map))
+
+    javac_cmd.extend(args)
+
+    if fatal_warnings:
+      javac_cmd.extend(self.get_options().fatal_warnings_enabled_args)
+    else:
+      javac_cmd.extend(self.get_options().fatal_warnings_disabled_args)
+
+    with argfile.safe_args(sources, self.get_options()) as batched_sources:
+      javac_cmd.extend(batched_sources)
+
+      with self.context.new_workunit(name='javac',
+                                     cmd=' '.join(javac_cmd),
+                                     labels=[WorkUnitLabel.COMPILER]) as workunit:
+        self.context.log.debug('Executing {}'.format(' '.join(javac_cmd)))
+        p = subprocess.Popen(javac_cmd, stdout=workunit.output('stdout'), stderr=workunit.output('stderr'))
+        return_code = p.wait()
+        workunit.set_outcome(WorkUnit.FAILURE if return_code else WorkUnit.SUCCESS)
+        if return_code:
+          raise TaskError('javac exited with return code {rc}'.format(rc=return_code))
+
+  @classmethod
+  def _javac_plugin_args(cls, javac_plugin_map):
+    ret = []
+    for plugin, args in javac_plugin_map.items():
+      for arg in args:
+        if ' ' in arg:
+          # Note: Args are separated by spaces, and there is no way to escape embedded spaces, as
+          # javac's Main does a simple split on these strings.
+          raise TaskError('javac plugin args must not contain spaces '
+                          '(arg {} for plugin {})'.format(arg, plugin))
+      ret.append('-Xplugin:{} {}'.format(plugin, ' '.join(args)))
+    return ret

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -14,6 +14,7 @@ from contextlib import closing
 from hashlib import sha1
 from xml.etree import ElementTree
 
+from pants.backend.jvm.subsystems.compile_subsystem import JvmCompileSubsystem
 from pants.backend.jvm.subsystems.java import Java
 from pants.backend.jvm.subsystems.jvm_platform import JvmPlatform
 from pants.backend.jvm.subsystems.scala_platform import ScalaPlatform
@@ -179,7 +180,7 @@ class BaseZincCompile(JvmCompile):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(BaseZincCompile, cls).subsystem_dependencies() + (Zinc.Factory,)
+    return super(BaseZincCompile, cls).subsystem_dependencies() + (Zinc.Factory, JvmCompileSubsystem,)
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -262,6 +263,10 @@ class BaseZincCompile(JvmCompile):
       hasher.update(os.path.relpath(jar_path, self.get_options().pants_workdir))
     key = hasher.hexdigest()[:12]
     return os.path.join(self.get_options().pants_bootstrapdir, 'zinc', key)
+
+  def execute(self):
+    if JvmCompileSubsystem.global_instance().get_options().compiler == 'zinc':
+      return super(BaseZincCompile, self).execute()
 
   def compile(self, args, classpath, sources, classes_output_dir, upstream_analysis, analysis_file,
               log_file, zinc_args_file, settings, fatal_warnings, zinc_file_manager,


### PR DESCRIPTION
### Problem

Zinc doesn't run on Java 9 or Java 10.

### Solution

Provide the option to use Javac for java compilation instead of Zinc. 

### Result

This is first pass which is meant for discussion.   I haven't updated tests or documentation, mainly just want to get feedback on what is there, and if the general pattern of using the subsystem is how we want to go. 

It should be noted that there is no code analysis with Javac so any tasks that use analysis won't work.

To test it on the branch you need to add

```
[compiler]
compiler: javac
``` 

to pants.ini