### PR TITLE
Add support for merging Snapshots

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -97,14 +97,14 @@ pub enum PathStat {
 }
 
 impl PathStat {
-  fn dir(path: PathBuf, stat: Dir) -> PathStat {
+  pub fn dir(path: PathBuf, stat: Dir) -> PathStat {
     PathStat::Dir {
       path: path,
       stat: stat,
     }
   }
 
-  fn file(path: PathBuf, stat: File) -> PathStat {
+  pub fn file(path: PathBuf, stat: File) -> PathStat {
     PathStat::File {
       path: path,
       stat: stat,


### PR DESCRIPTION
### Problem

As described in #5707: we need a way to merge `Snapshot` objects (although we have not yet decided how to expose them to `@rule`s.)

### Solution

Add `Snapshot::merge`.

### Result

Fixes #5707.