### PR TITLE
Save noop time on codegen

### DIFF
--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -341,7 +341,7 @@ class CoursierMixin(NailgunTask):
 
     with self.context.new_workunit(name='coursier', labels=[WorkUnitLabel.TOOL]) as workunit:
       return_code = self.runjava(
-        classpath=[coursier_jar],
+        classpath=['/Users/yic/workspace/coursier_dev/dist/coursier-cli.jar'],
         main='coursier.cli.Coursier',
         args=cmd_args,
         jvm_options=self.get_options().jvm_options,

--- a/src/python/pants/backend/jvm/tasks/coursier_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/coursier_resolve.py
@@ -341,7 +341,7 @@ class CoursierMixin(NailgunTask):
 
     with self.context.new_workunit(name='coursier', labels=[WorkUnitLabel.TOOL]) as workunit:
       return_code = self.runjava(
-        classpath=['/Users/yic/workspace/coursier_dev/dist/coursier-cli.jar'],
+        classpath=[coursier_jar],
         main='coursier.cli.Coursier',
         args=cmd_args,
         jvm_options=self.get_options().jvm_options,

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -203,7 +203,11 @@ class SimpleCodegenTask(Task):
     return synthetic_address
 
   def execute(self):
-    with self.invalidated(self.codegen_targets(),
+    codegen_targets = self.codegen_targets()
+    if not codegen_targets:
+      return
+
+    with self.invalidated(codegen_targets,
                           invalidate_dependents=True,
                           topological_order=True,
                           fingerprint_strategy=self.get_fingerprint_strategy()) as invalidation_check:


### PR DESCRIPTION
### Before
```
$ for i in `seq 1 5`; do ./pants --time compile 2>&1 | grep 'Critical Path' -A 20 | grep main:gen; done
0.706 main:gen
0.603 main:gen
0.652 main:gen
0.601 main:gen
0.667 main:gen
```

### After
```
$ for i in `seq 1 5`; do ./pants --time compile 2>&1 | grep 'Critical Path' -A 20 | grep main:gen; done
0.168 main:gen
0.156 main:gen
0.163 main:gen
0.163 main:gen
0.157 main:gen
```