### PR TITLE
Copy locally build .whl files to dist dir when 'binary' goal is invoked.

### DIFF
--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -17,6 +17,7 @@ from pants.backend.python.targets.python_tests import PythonTests
 from pants.backend.python.tasks.build_local_python_distributions import \
   BuildLocalPythonDistributions
 from pants.backend.python.tasks.gather_sources import GatherSources
+from pants.backend.python.tasks.local_python_distribution_artifact import LocalPythonDistributionArtifact
 from pants.backend.python.tasks.pytest_prep import PytestPrep
 from pants.backend.python.tasks.pytest_run import PytestRun
 from pants.backend.python.tasks.python_binary_create import PythonBinaryCreate
@@ -64,4 +65,5 @@ def register_goals():
   task(name='py', action=PythonRepl).install('repl')
   task(name='setup-py', action=SetupPy).install()
   task(name='py', action=PythonBinaryCreate).install('binary')
+  task(name='py-local-wheels', action=LocalPythonDistributionArtifact).install('binary')
   task(name='isort', action=IsortPythonTask).install('fmt')

--- a/src/python/pants/backend/python/tasks/local_python_distribution_artifact.py
+++ b/src/python/pants/backend/python/tasks/local_python_distribution_artifact.py
@@ -1,0 +1,43 @@
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+from pants.backend.python.tasks.pex_build_util import is_local_python_dist
+from pants.base.build_environment import get_buildroot
+from pants.task.task import Task
+from pants.util.dirutil import safe_mkdir
+from pants.util.fileutil import atomic_copy
+
+
+class LocalPythonDistributionArtifact(Task):
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    super(LocalPythonDistributionArtifact, cls).prepare(options, round_manager)
+    round_manager.require_data('local_wheels')
+
+  def __init__(self, *args, **kwargs):
+    super(LocalPythonDistributionArtifact, self).__init__(*args, **kwargs)
+    self.dist_dir = self.get_options().pants_distdir
+
+  def execute(self):
+    dist_targets = self.context.targets(is_local_python_dist)
+
+    for t in dist_targets:
+      # Copy generated wheel files to dist folder
+      safe_mkdir(self.dist_dir)  # Make sure dist dir is present.
+      local_wheels_product = self.context.products.get('local_wheels')
+      if not local_wheels_product:
+        continue
+      target_local_wheels = local_wheels_product.get(t)
+      if not target_local_wheels:
+        continue
+      for output_dir, base_names in target_local_wheels.items():
+        for base_name in base_names:
+          wheel_output = os.path.join(output_dir, base_name)
+          self.context.log.debug('found local built wheels {}'.format(wheel_output))
+          # Create a copy for wheel in dist dir..
+          wheel_copy = os.path.join(self.dist_dir, base_name)
+          atomic_copy(wheel_output, wheel_copy)
+          self.context.log.info(
+            'created wheel {}'.format(os.path.relpath(wheel_copy, get_buildroot())))


### PR DESCRIPTION
### Problem

build_local_python_distributions generates a wheel artifact, but users can not access it from dist folder.

### Solution

copy the generated wheel to dist folder when 'binary' goal is invoked.

### Result

locally generated wheel artifacts exists in dist folder.