### PR TITLE
Rename and simplify store_list

### DIFF
--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -54,16 +54,8 @@ pub fn satisfied_by_type(constraint: &TypeConstraint, cls: &TypeId) -> bool {
   with_externs(|e| (e.satisfied_by_type)(e.context, interns.get(&constraint.0), cls))
 }
 
-pub fn store_list(values: Vec<&Value>, merge: bool) -> Value {
-  with_externs(|e| {
-    let values_clone: Vec<*const Value> = values.into_iter().map(|v| v as *const Value).collect();
-    (e.store_list)(
-      e.context,
-      values_clone.as_ptr(),
-      values_clone.len() as u64,
-      merge,
-    )
-  })
+pub fn store_tuple(values: &[Value]) -> Value {
+  with_externs(|e| (e.store_tuple)(e.context, values.as_ptr(), values.len() as u64))
 }
 
 pub fn store_bytes(bytes: &[u8]) -> Value {
@@ -227,7 +219,7 @@ pub struct Externs {
   pub drop_handles: DropHandlesExtern,
   pub satisfied_by: SatisfiedByExtern,
   pub satisfied_by_type: SatisfiedByTypeExtern,
-  pub store_list: StoreListExtern,
+  pub store_tuple: StoreTupleExtern,
   pub store_bytes: StoreBytesExtern,
   pub store_i32: StoreI32Extern,
   pub project_ignoring_type: ProjectIgnoringTypeExtern,
@@ -245,10 +237,8 @@ unsafe impl Send for Externs {}
 
 pub type LogExtern = extern "C" fn(*const ExternContext, u8, str_ptr: *const u8, str_len: u64);
 
-// TODO: Type alias used to avoid rustfmt breaking itself by rendering a 101 character line.
-pub type SatisfedBool = bool;
 pub type SatisfiedByExtern =
-  extern "C" fn(*const ExternContext, *const Value, *const Value) -> SatisfedBool;
+  extern "C" fn(*const ExternContext, *const Value, *const Value) -> bool;
 
 pub type SatisfiedByTypeExtern =
   extern "C" fn(*const ExternContext, *const Value, *const TypeId) -> bool;
@@ -261,8 +251,7 @@ pub type CloneValExtern = extern "C" fn(*const ExternContext, *const Value) -> V
 
 pub type DropHandlesExtern = extern "C" fn(*const ExternContext, *const Handle, u64);
 
-pub type StoreListExtern =
-  extern "C" fn(*const ExternContext, *const *const Value, u64, bool) -> Value;
+pub type StoreTupleExtern = extern "C" fn(*const ExternContext, *const Value, u64) -> Value;
 
 pub type StoreBytesExtern = extern "C" fn(*const ExternContext, *const u8, u64) -> Value;
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -45,7 +45,7 @@ use externs::{Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionE
               DropHandlesExtern, EqualsExtern, EvalExtern, ExternContext, Externs,
               GeneratorSendExtern, IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern,
               ProjectMultiExtern, PyResult, SatisfiedByExtern, SatisfiedByTypeExtern,
-              StoreBytesExtern, StoreI32Extern, StoreListExtern, TypeIdBuffer, TypeToStrExtern,
+              StoreBytesExtern, StoreI32Extern, StoreTupleExtern, TypeIdBuffer, TypeToStrExtern,
               ValToStrExtern};
 use rule_graph::{GraphMaker, RuleGraph};
 use scheduler::{ExecutionRequest, RootResult, Scheduler};
@@ -134,7 +134,7 @@ pub extern "C" fn externs_set(
   val_to_str: ValToStrExtern,
   satisfied_by: SatisfiedByExtern,
   satisfied_by_type: SatisfiedByTypeExtern,
-  store_list: StoreListExtern,
+  store_tuple: StoreTupleExtern,
   store_bytes: StoreBytesExtern,
   store_i32: StoreI32Extern,
   project_ignoring_type: ProjectIgnoringTypeExtern,
@@ -157,7 +157,7 @@ pub extern "C" fn externs_set(
     val_to_str,
     satisfied_by,
     satisfied_by_type,
-    store_list,
+    store_tuple,
     store_bytes,
     store_i32,
     project_ignoring_type,
@@ -456,7 +456,7 @@ pub extern "C" fn execution_request_destroy(ptr: *mut ExecutionRequest) {
 pub extern "C" fn validator_run(scheduler_ptr: *mut Scheduler) -> Value {
   with_scheduler(scheduler_ptr, |scheduler| {
     match scheduler.core.rule_graph.validate() {
-      Result::Ok(_) => externs::store_list(vec![], false),
+      Result::Ok(_) => externs::store_tuple(&[]),
       Result::Err(msg) => externs::create_exception(&msg),
     }
   })

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -492,7 +492,7 @@ impl SelectDependencies {
               .then(move |dep_values_res| {
                 // Finally, store the resulting values.
                 match dep_values_res {
-                  Ok(dep_values) => Ok(externs::store_list(dep_values.iter().collect(), false)),
+                  Ok(dep_values) => Ok(externs::store_tuple(&dep_values)),
                   Err(failure) => Err(was_required(failure)),
                 }
               })
@@ -736,7 +736,7 @@ impl Snapshot {
       &[
         externs::store_bytes(&(item.digest.0).to_hex().as_bytes()),
         externs::store_i32(item.digest.1 as i32),
-        externs::store_list(path_stats.iter().collect(), false),
+        externs::store_tuple(&path_stats),
       ],
     )
   }
@@ -784,7 +784,7 @@ impl Snapshot {
       .collect();
     externs::unsafe_call(
       &context.core.types.construct_files_content,
-      &[externs::store_list(entries.iter().collect(), false)],
+      &[externs::store_tuple(&entries)],
     )
   }
 }
@@ -894,7 +894,7 @@ impl Task {
             .map(|vs| future::Loop::Continue(vs.into_iter().next().unwrap()))
             .to_boxed(),
           externs::GeneratorResponse::GetMulti(gets) => Self::gen_get(&context, entry, gets)
-            .map(|vs| future::Loop::Continue(externs::store_list(vs.iter().collect(), false)))
+            .map(|vs| future::Loop::Continue(externs::store_tuple(&vs)))
             .to_boxed(),
           externs::GeneratorResponse::Break(val) => future::ok(future::Loop::Break(val)).to_boxed(),
         }


### PR DESCRIPTION
### Problem

1. `store_list` creates tuples rather than lists
2. It has an unused `merge` parameter (from when we used to use `store_list` to flatten lists).
3. It requires more allocations than are strictly necessary because it takes a `Vec` and then copies it to change its shape.

### Solution

Rename to `store_tuple`, remove the `merge` parameter, and change the signature to taking a `&[Value]`, which allows for use of arrays on the stack, as well as direct usage of `Vec<Value>`, which we have in most (all?) cases.

### Result

Fewer allocations, simpler API.