### PR TITLE
Misc rust fixups

### DIFF
--- a/build-support/bin/ci.sh
+++ b/build-support/bin/ci.sh
@@ -222,7 +222,7 @@ if [[ "${skip_rust_tests:-false}" == "false" ]]; then
     fi
 
     activate_pants_venv
-    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test "${MODE_FLAG}" --all --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" -- "${test_threads_flag}"
+    RUST_BACKTRACE=1 PANTS_SRCPATH="${REPO_ROOT}/src/python" ensure_cffi_sources=1 run_cargo test --all --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" -- "${test_threads_flag}"
   ) || die "Pants rust test failure"
   end_travis_section
 fi

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -17,7 +17,7 @@ use pool::ResettablePool;
 // This is the maximum size any particular local LMDB store file is allowed to grow to.
 // It doesn't reflect space allocated on disk, or RAM allocated (it may be reflected in VIRT but
 // not RSS). There is no practical upper bound on this number, so we set it ridiculously high.
-const MAX_LOCAL_STORE_SIZE_BYTES: usize = 1024 * 1024 * 1024 * 1024;
+const MAX_LOCAL_STORE_SIZE_BYTES: usize = 1024 * 1024 * 1024 * 1024 / 10;
 
 // This is the target number of bytes which should be present in all combined LMDB store files
 // after garbage collection. We almost certainly want to make this configurable.

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -148,7 +148,7 @@ impl CommandRunner {
 
                         let backoff_period = min(
                       CommandRunner::BACKOFF_MAX_WAIT_MILLIS,
-                      ((1 + iter_num) * CommandRunner::BACKOFF_INCR_WAIT_MILLIS));
+                      (1 + iter_num) * CommandRunner::BACKOFF_INCR_WAIT_MILLIS);
 
                         let grpc_result = map_grpc_result(
                     operations_client.get_operation(&operation_request));
@@ -580,7 +580,7 @@ mod tests {
   }
 
   #[test]
-  fn successful_execution_after_ten_getoperations() {
+  fn successful_execution_after_four_getoperations() {
     let execute_request = echo_foo_request();
 
     let mock_server = {
@@ -591,7 +591,7 @@ mod tests {
         super::make_execute_request(&execute_request).unwrap().1,
         Vec::from_iter(
           iter::repeat(make_incomplete_operation(&op_name))
-            .take(10)
+            .take(4)
             .chain(iter::once(make_successful_operation(
               &op_name,
               StdoutType::Raw("foo".to_owned()),
@@ -1065,7 +1065,7 @@ mod tests {
         ))
       };
       let start_time = SystemTime::now();
-      let result = run_command_remote(&mock_server.address(), execute_request).unwrap();
+      run_command_remote(&mock_server.address(), execute_request).unwrap();
       assert!(start_time.elapsed().unwrap() >= Duration::from_millis(500));
     }
   }
@@ -1093,7 +1093,7 @@ mod tests {
         ))
       };
       let start_time = SystemTime::now();
-      let result = run_command_remote(&mock_server.address(), execute_request).unwrap();
+      run_command_remote(&mock_server.address(), execute_request).unwrap();
       assert!(start_time.elapsed().unwrap() >= Duration::from_millis(3000));
     }
   }


### PR DESCRIPTION
Reduce MAX_LOCAL_STORE_SIZE_BYTES because when tests run with more than
one thread we sometimes exhaust virtual memory.

Remove unnecessary parens.

Drop successful_execution_after_ten_getoperations down to 4 operations,
beacuse we now sleep between them, so the test is now super slow.

Don't assign unread values to unused variables.