### PR TITLE
add --frozen-lockfile option as default for yarn install

### DIFF
--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -47,7 +47,7 @@ class PackageManager(object):
     :param production_only: True to only install production dependencies, i.e.
       ignore devDependencies.
     :param force: True to force re-download dependencies.
-    :param frozen_lockfile: True to disallow automatically update lock files.
+    :param frozen_lockfile: True to disallow automatic update of lock files.
     :rtype: list of strings
     """
     raise NotImplementedError
@@ -88,7 +88,7 @@ class PackageManager(object):
     :param production_only: True to only install production dependencies, i.e.
       ignore devDependencies.
     :param force: True to force re-download dependencies.
-    :param frozen_lockfile: True to disallow automatically update lock files.
+    :param frozen_lockfile: True to disallow automatic update of lock files.
     :param node_paths: A list of path that should be included in $PATH when
       running installation.
     """
@@ -211,7 +211,7 @@ class PackageManagerNpm(PackageManager):
       return_args.append('--production')
     if force:
       return_args.append('--force')
-    if frozen_lockfile is not None:
+    if frozen_lockfile:
       LOG.warning('{} does not support frozen lockfile option. Ignored.'.format(self.name))
     return return_args
 

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -47,7 +47,7 @@ class PackageManager(object):
     :param production_only: True to only install production dependencies, i.e.
       ignore devDependencies.
     :param force: True to force re-download dependencies.
-    :param frozen_lockfile: True to disallow True to disallow automatically update lock files.
+    :param frozen_lockfile: True to disallow automatically update lock files.
     :rtype: list of strings
     """
     raise NotImplementedError
@@ -211,7 +211,7 @@ class PackageManagerNpm(PackageManager):
       return_args.append('--production')
     if force:
       return_args.append('--force')
-    if frozen_lockfile:
+    if frozen_lockfile is not None:
       LOG.warning('{} does not support frozen lockfile option. Ignored.'.format(self.name))
     return return_args
 

--- a/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
+++ b/contrib/node/src/python/pants/contrib/node/subsystems/package_managers.py
@@ -40,13 +40,14 @@ class PackageManager(object):
     self.name = name
     self.tool_installations = tool_installations
 
-  def _get_installation_args(self, install_optional, production_only, force):
+  def _get_installation_args(self, install_optional, production_only, force, frozen_lockfile):
     """Returns command line args for installing package.
 
     :param install_optional: True to request install optional dependencies.
     :param production_only: True to only install production dependencies, i.e.
       ignore devDependencies.
     :param force: True to force re-download dependencies.
+    :param frozen_lockfile: True to disallow True to disallow automatically update lock files.
     :rtype: list of strings
     """
     raise NotImplementedError
@@ -79,6 +80,7 @@ class PackageManager(object):
     install_optional=False,
     production_only=False,
     force=False,
+    frozen_lockfile=True,
     node_paths=None):
     """Returns a command that when executed will install node package.
 
@@ -86,13 +88,15 @@ class PackageManager(object):
     :param production_only: True to only install production dependencies, i.e.
       ignore devDependencies.
     :param force: True to force re-download dependencies.
+    :param frozen_lockfile: True to disallow automatically update lock files.
     :param node_paths: A list of path that should be included in $PATH when
       running installation.
     """
     args=self._get_installation_args(
       install_optional=install_optional,
       production_only=production_only,
-      force=force)
+      force=force,
+      frozen_lockfile=frozen_lockfile)
     return self.run_command(args=args, node_paths=node_paths)
 
   def run_script(self, script_name, script_args=None, node_paths=None):
@@ -153,7 +157,7 @@ class PackageManagerYarnpkg(PackageManager):
   def _get_run_script_args(self):
     return ['run']
 
-  def _get_installation_args(self, install_optional, production_only, force):
+  def _get_installation_args(self, install_optional, production_only, force, frozen_lockfile):
     return_args = ['--non-interactive']
     if not install_optional:
       return_args.append('--ignore-optional')
@@ -161,6 +165,8 @@ class PackageManagerYarnpkg(PackageManager):
       return_args.append('--production=true')
     if force:
       return_args.append('--force')
+    if frozen_lockfile:
+      return_args.append('--frozen-lockfile')
     return return_args
 
   def _get_add_package_args(self, package, type_option, version_option):
@@ -174,7 +180,7 @@ class PackageManagerYarnpkg(PackageManager):
       PackageInstallationTypeOption.NO_SAVE: None,
     }.get(type_option)
     if package_type_option is None:
-      logging.warning('{} does not support {} packages, ignored.'.format(self.name, type_option))
+      LOG.warning('{} does not support {} packages, ignored.'.format(self.name, type_option))
     elif package_type_option:  # Skip over '' entries
       return_args.append(package_type_option)
     package_version_option = {
@@ -197,7 +203,7 @@ class PackageManagerNpm(PackageManager):
   def _get_run_script_args(self):
     return ['run-script']
 
-  def _get_installation_args(self, install_optional, production_only, force):
+  def _get_installation_args(self, install_optional, production_only, force, frozen_lockfile):
     return_args = ['install']
     if not install_optional:
       return_args.append('--no-optional')
@@ -205,6 +211,8 @@ class PackageManagerNpm(PackageManager):
       return_args.append('--production')
     if force:
       return_args.append('--force')
+    if frozen_lockfile:
+      LOG.warning('{} does not support frozen lockfile option. Ignored.'.format(self.name))
     return return_args
 
   def _get_add_package_args(self, package, type_option, version_option):
@@ -218,7 +226,7 @@ class PackageManagerNpm(PackageManager):
       PackageInstallationTypeOption.NO_SAVE: '--no-save',
     }.get(type_option)
     if package_type_option is None:
-      logging.warning('{} does not support {} packages, ignored.'.format(self.name, type_option))
+      LOG.warning('{} does not support {} packages, ignored.'.format(self.name, type_option))
     elif package_type_option:  # Skip over '' entries
       return_args.append(package_type_option)
     package_version_option = {

--- a/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/subsystems/test_package_managers.py
@@ -43,18 +43,22 @@ class TestYarnpkg(unittest.TestCase):
 
   def test_install_module_options_off(self, mock_command_gen):
     self.yarnpkg.install_module(
-      install_optional=False, production_only=False, force=False)
+      install_optional=False, production_only=False, force=False, frozen_lockfile=True)
     mock_command_gen.assert_called_once_with(
-      [fake_install], 'yarnpkg',
-      args=['--non-interactive', '--ignore-optional'], node_paths=None
+      [fake_install],
+      'yarnpkg',
+      args=['--non-interactive', '--ignore-optional', '--frozen-lockfile'],
+      node_paths=None
     )
 
   def test_install_module_options_on(self, mock_command_gen):
     self.yarnpkg.install_module(
-      install_optional=True, production_only=True, force=True)
+      install_optional=True, production_only=True, force=True, frozen_lockfile=True)
     mock_command_gen.assert_called_once_with(
-      [fake_install], 'yarnpkg',
-      args=['--non-interactive', '--production=true', '--force'], node_paths=None
+      [fake_install],
+      'yarnpkg',
+      args=['--non-interactive', '--production=true', '--force', '--frozen-lockfile'],
+      node_paths=None
     )
 
   def test_add_package_default(self, mock_command_gen):

--- a/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
+++ b/contrib/node/tests/python/pants_test/contrib/node/tasks/test_node_resolve.py
@@ -287,10 +287,10 @@ class NodeResolveTest(TaskTestBase):
     self._test_resolve_optional_install_helper(
       install_optional=False,
       package_manager='yarnpkg',
-      expected_params=['--non-interactive', '--ignore-optional'])
+      expected_params=['--non-interactive', '--ignore-optional', '--frozen-lockfile'])
 
   def test_resolve_optional_install_yarn(self):
     self._test_resolve_optional_install_helper(
       install_optional=True,
       package_manager='yarnpkg',
-      expected_params=['--non-interactive'])
+      expected_params=['--non-interactive', '--frozen-lockfile'])


### PR DESCRIPTION
### Problem
documentation from yarn:
```
yarn install --frozen-lockfile
Don’t generate a yarn.lock lockfile and fail if an update is needed.
```
Adding this option and turn it on by default in essence force all node_modules that uses `yarn` as package manager to have an up-to-date `yarn.lock`.   Since the default for `npm` and `yarn` is to update the lock file when a newer semver matched dependency is published, it can leads to surprises that the actual installed codes does not match checked in lock files.

### Solution

Add `--frozen-lockfile` errors out when lock files needed to be updated.  Unfortunately, there is no such option for `npm`.

### Result

Installation of `node_module` targets with `yarn` is more strict.