### PR TITLE
Expand engine readme

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -107,9 +107,9 @@ function ensure_native_build_prerequisites() {
   if [[ ! -x "${CARGO_HOME}/bin/cargo-ensure-installed" ]]; then
     "${CARGO_HOME}/bin/cargo" install cargo-ensure-installed >&2
   fi
-  "${CARGO_HOME}/bin/cargo" ensure-installed --package=cargo-ensure-installed --version=0.1.0 >&2
+  "${CARGO_HOME}/bin/cargo" ensure-installed --package=cargo-ensure-installed --version=0.2.1 >&2
   "${CARGO_HOME}/bin/cargo" ensure-installed --package=protobuf --version=1.4.2 >&2
-  "${CARGO_HOME}/bin/cargo" ensure-installed --package=grpcio-compiler --version=0.2.0 >&2
+  "${CARGO_HOME}/bin/cargo" ensure-installed --package=grpcio-compiler --version=0.2.0 --git-url=https://github.com/illicitonion/grpc-rs.git --git-rev=1147866fda52ca1b53de8d80272a68e3b7bd8b93 >&2
 
   local download_binary="${REPO_ROOT}/build-support/bin/download_binary.sh"
   local -r cmakeroot="$("${download_binary}" "binaries.pantsbuild.org" "cmake" "3.9.5" "cmake.tar.gz")" || die "Failed to fetch cmake"

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -164,6 +164,18 @@ The initial Nodes are [launched by the engine](https://github.com/pantsbuild/pan
 but the rest of execution is driven by Nodes recursively calling `Context.get` to request their
 dependencies.
 
+### Registering Rules
+
+Currently, it is only possible to load rules into the pants scheduler in two ways: by importing and using them in `src/python/pants/bin/engine_initializer.py`, or by adding them to the list returned by a `rules()` method defined in `src/python/backend/<backend_name>/register.py`. Plugins cannot add new rules yet. Unit tests, however, can mix in `SchedulerTestBase` from `tests/python/pants_test/engine/scheduler_test_base.py` to generate and execute a scheduler from a given set of rules.
+
+In general, there are three types of rules you can define:
+
+1. an `@rule`, which has a single product type and selects its inputs as described above.
+2. a `SingletonRule`, which matches a product type with a value so the type can then be `Select`ed in an `@rule`.
+3. a `RootRule`, which declares a type that can be used as a *subject*, which means it can be provided as an input to a `product_request()` or a `Get` statement.
+
+This interface is being actively developed at this time and this documentation may be out of date.
+
 ## Execution
 
 The engine executes work concurrently wherever possible; to help visualize executions, a visualization

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -105,6 +105,9 @@ constructor will create your object, then raise an error if
 of a *subclass* of a field's declared type will **fail** this type check in the
 constructor!
 
+Please see [Datatypes in Depth](#datatypes-in-depth) for further discussion on
+using `datatype` objects with the v2 engine.
+
 ### Selectors and Gets
 
 As demonstrated above, the `Selector` classes select `@rule` inputs in the context of a particular
@@ -222,3 +225,108 @@ in the context of scala and mixed scala & java builds.  Twitter spiked on a proj
 a target-level scheduling system scoped to just the jvm compilation tasks.  This bore fruit and
 served as further impetus to get a "tuple-engine" designed and constructed to bring the benefits
 seen in the jvm compilers to the wider pants world of tasks.
+
+## Datatypes in Depth
+
+`datatype` objects can be used to colocate multiple dependencies of an
+`@rule`. For example, to compile C code, you typically require both source code
+and a C compiler:
+
+``` python
+class CCompileRequest(datatype(['c_compiler', 'c_sources'])):
+  pass
+
+class CObjectFiles(datatype(['files_snapshot'])):
+  pass
+
+# The engine ensures this is the only way to get from
+# CCompileRequest -> CObjectFiles.
+@rule(CObjectFiles, [Select(CCompileRequest)])
+def compile_c_sources(c_compile_request):
+  c_compiler, c_sources = c_compile_request
+  compiled_object_files = c_compiler.compile(c_sources)
+  return CObjectFiles(compiled_object_files)
+```
+
+Encoding different stages of a build process into different `datatype`
+subclasses which have all the information they need and no more makes it easier
+to add functionality to the build by consuming and/or producing types from a
+concise shared set of `datatype` definitions. For example:
+
+``` python
+# "Vendoring" refers to checking a source or binary copy of a 3rdparty
+# library into source control. In this case, we assume the snapshot contains
+# _only_ binary object files for the current platform.
+class VendoredLibrary(datatype(['files_snapshot'])):
+  pass
+
+@rule(CObjectFiles, [Select(VendoredLibrary)])
+def get_vendored_object_files(vendored_library):
+  return CObjectFiles(vendored_library.files_snapshot)
+```
+
+We have added the ability to depend on checked-in binary object files with an
+extremely small amount of code, because we can assume that `VendoredLibrary` is
+constructed with a snapshot containing only object files, so we can ensure that
+the `CObjectFiles` we construct also upholds that guarantee. The key to making
+that assumption possible is encoding assumptions about our objects into specific
+types, and letting the engine invoke the correct sequence of rules.
+
+### Encoding Assumptions into Types
+
+Passing around an instance of a primitive type such as `str` or `int` can
+sometimes require significant mental overhead to keep track of assumptions that
+the code makes about the object's value. If the `str` needs to be formatted a
+specific way or the `int` must be within a certain range, using those types
+directly can require repeated validation of the object wherever it's used, for
+example to avoid injection attacks from user-provided strings, or attempting to
+read a negative number of bytes from a file. Outside of the variable name, with
+a `str` object there is no context about what validation or transformations have
+been performed on the object or how it will be used.
+
+One way to keep track of assumptions made about an object's value is to make a
+wrapper type for that object, and then control the ways that instances of the
+wrapper type can be created. One way to implement this is to override the
+wrapper type's constructor and raise an exception if the object's value is
+invalid. Declaring a typed field for a `datatype` takes this approach, but it
+can be extended for arbitrary types of input validation:
+
+``` python
+# Declare a datatype with a single field 'int_value',
+# which must be an int when the datatype is constructed.
+class NonNegativeInt(datatype([('int_value', int)])):
+  def __new__(cls, *args, **kwargs):
+    # Call the superclass constructor first to check the type of `int_value`.
+    this_object = super(NonNegativeInt, cls).__new__(cls, *args, **kwargs)
+
+    if this_object.int_value < 0:
+      raise cls.make_type_error("value is negative: {!r}"
+                                .format(this_object.int_value))
+
+    return this_object
+```
+
+`make_type_error()` creates an exception object which can be raised in a
+`datatype`'s constructor to note a type checking failure, and automatically
+includes the type name in the error message. However, any other exception type
+can be raised as well.
+
+For `NonNegativeInt`, the input is extremely simple (we're not calling any
+methods on the `int`), and the validation is extremely straightforward (can be
+expressed in a single `if`). These characteristics make it natural to declare a
+specific type for the field in the call to `datatype()` and to ensure validity
+with a check in the `__new__()` method. Using type checking in this way makes
+types like `NonNegativeInt` usable in many different scenarios without
+additional boilerplate for the user.
+
+`VendoredLibrary` and `CObjectFile` are the opposite: a synchronous scan of
+every file in a `VendoredLibrary`'s `files_snapshot` to verify that they are all
+indeed object files for the correct platform every time we construct one would
+be difficult to justify, because the inputs are much more complex to construct,
+and the result much more difficult to validate. In this case, making simple,
+focused `datatype` definitions makes it easier to correctly consume, manipulate,
+and produce them to form a common set of `@rule` definitions. The engine ensures
+that there is at most one sequence of rules transforming type A to type B, and
+makes this feasible by automatically linking together the rules to convert type
+A to type B. Making a set of rules maximally composable implicitly helps to
+ensure correctness by reusing logic as much as possible.

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -52,7 +52,7 @@ def int_to_str(an_int):
 ```
 
 The first argument to the `@rule` decorator is the Product (ie, return) type for the `@rule`. The
-second argument is a list of `Selectors` that declare the types of the input arguments to the
+second argument is a list of `Selector`s that declare the types of the input arguments to the
 `@rule`. In this case, because the Product type is `StringType` and there is one `Selector`
 (`Select(IntType)`), this `@rule` represents a conversion from `IntType` to `StrType`, with no
 other inputs.
@@ -62,10 +62,12 @@ Subject, it will first see whether there are any ways to get an IntType for that
 the subject is already of `type(subject) == IntType`, then the `@rule` will be satisfiable without
 any other dependencies. On the other hand, if the type _doesn't_ match, the engine doesn't give up:
 it will next look for any other registered `@rule`s that can compute an IntType Product for the
-Subject (and so on, recursively.)
+Subject (and so on, recursively).
+
+### Datatypes
 
 In practical use, using basic types like `StringType` or `IntType` does not provide enough
-information to disambiguate between various types of data: So declaring small `datatype`
+information to disambiguate between various types of data. So declaring small `datatype`
 definitions to provide a unique and descriptive type is strongly recommended:
 
 ```python

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -76,7 +76,34 @@ class FormattedInt(datatype(['content'])): pass
 @rule(FormattedInt, [Select(IntType)])
 def int_to_str(an_int):
   return FormattedInt('{}'.format(an_int))
+
+# Field values can be specified with positional and/or keyword arguments in the constructor:
+x = FormattedInt('a string')
+x = FormattedInt(content='a string')
+
+# Field values can be accessed after construction by name or index:
+print(x.content)    # 'a string'
+print(x[0])         # 'a string'
+
+# The object is also a tuple, and can be destructured:
+some_content, = x
+print(some_content) # 'a string'
+
+# datatype objects can be easily inspected:
+print(x)            # 'FormattedInt(content=a string)'
 ```
+
+#### Types of Fields
+
+`datatype()` accepts a list of *field declarations*, and returns a type which can
+be subclassed. A *field declaration* can just be a string (e.g. `'field_name'`),
+which is then used as the field name, as with `FormattedInt` above. A field can
+also be declared with a tuple of two elements: the field name string, and a type
+for the field (e.g. `('field_name', FieldType)`). If the tuple form is used, the
+constructor will create your object, then raise an error if
+`type(self.field_name) != FieldType`. Note that this means providing an instance
+of a *subclass* of a field's declared type will **fail** this type check in the
+constructor!
 
 ### Selectors and Gets
 

--- a/src/python/pants/engine/README.md
+++ b/src/python/pants/engine/README.md
@@ -174,15 +174,34 @@ dependencies.
 
 ### Registering Rules
 
-Currently, it is only possible to load rules into the pants scheduler in two ways: by importing and using them in `src/python/pants/bin/engine_initializer.py`, or by adding them to the list returned by a `rules()` method defined in `src/python/backend/<backend_name>/register.py`. Plugins cannot add new rules yet. Unit tests, however, can mix in `SchedulerTestBase` from `tests/python/pants_test/engine/scheduler_test_base.py` to generate and execute a scheduler from a given set of rules.
+Currently, it is only possible to load rules into the pants scheduler in two ways: by importing and
+using them in `src/python/pants/bin/engine_initializer.py`, or by adding them to the list returned
+by a `rules()` method defined in `src/python/backend/<backend_name>/register.py`. Plugins cannot add
+new rules yet. Unit tests, however, can mix in `SchedulerTestBase` from
+`tests/python/pants_test/engine/scheduler_test_base.py` to generate and execute a scheduler from a
+given set of rules.
 
 In general, there are three types of rules you can define:
 
 1. an `@rule`, which has a single product type and selects its inputs as described above.
-2. a `SingletonRule`, which matches a product type with a value so the type can then be `Select`ed in an `@rule`.
-3. a `RootRule`, which declares a type that can be used as a *subject*, which means it can be provided as an input to a `product_request()` or a `Get` statement.
+2. a `SingletonRule`, which matches a product type with a value so the type can then be `Select`ed
+   in an `@rule`.
+3. a `RootRule`, which declares a type that can be used as a *subject*, which means it can be
+   provided as an input to a `product_request()`.
 
-This interface is being actively developed at this time and this documentation may be out of date.
+In more depth, a `RootRule` for some type is required when no other rule provides that type (i.e. it
+is not provided with a `SingletonRule` or as the product of any `@rule`). In the absence of a
+`RootRule`, any subject type involved in a request "at runtime" (i.e. via `product_request()`),
+would show up as an an unused or impossible path in the rule graph. Another potential name for
+`RootRule` might be `ParamRule`, or something similar, as it can be thought of as saying that the
+type represents a sort of "public API entrypoint" via a `product_request()`.
+
+Note that `Get` requests do not require a `RootRule`, as their requests are statically verified when
+the `@rule` definition is parsed, so we know before runtime that they might be requested.
+
+This interface is being actively developed at this time and this documentation may be out of
+date. Please feel free to file an issue or pull request if you notice any outdated or incorrect
+information in this document!
 
 ## Execution
 

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -56,8 +56,8 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 
   class DataType(namedtuple_cls):
     @classmethod
-    def make_type_error(cls, msg):
-      return TypeCheckError(cls.__name__, msg)
+    def make_type_error(cls, msg, *args, **kwargs):
+      return TypeCheckError(cls.__name__, msg, *args, **kwargs)
 
     def __new__(cls, *args, **kwargs):
       this_object = super(DataType, cls).__new__(cls, *args, **kwargs)

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -109,6 +109,11 @@ def datatype(field_decls, superclass_name=None, **kwargs):
         raise ValueError('Got unexpected field names: %r' % kwds.keys())
       return result
 
+    # TODO(cosmicexplorer): would we want to expose a self.as_tuple() method so we can tuple assign?
+    # class A(datatype(['field'])): pass
+    # x = A(field='asdf')
+    # field_value, = x.as_tuple()
+    # print(field_value) # => 'asdf'
     def __getnewargs__(self):
       '''Return self as a plain tuple.  Used by copy and pickle.'''
       return tuple(self._super_iter())


### PR DESCRIPTION
### Problem

It's not clear how to make rule definitions available to the scheduler, and there's no discussion of the type checking added to `datatype()` fields in #5723.

### Solution

- Add a section on datatype fields, typing, and how they interact with the engine.
- Add a section on making rules available to the scheduler in and out of unit tests.
- Add a section describing types of rules after discussion on this PR.