### PR TITLE
expand dependencies on ':' to be the default target for the directory

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -5,11 +5,15 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import logging
 import os
 from collections import namedtuple
 
 from pants.util.dirutil import longest_dir_prefix
 from pants.util.strutil import strip_prefix
+
+
+logger = logging.getLogger(__name__)
 
 
 # @ is reserved for configuring variant, see `addressable.parse_variants`
@@ -79,6 +83,9 @@ def parse_spec(spec, relative_to=None, subproject_roots=None):
     spec_path, target_name = spec_parts
     if not spec_path and not subproject and relative_to:
       spec_path = relative_to
+      if not target_name:
+        target_name = os.path.basename(spec_path)
+        logger.debug("':' expanded to ':{}' in {}".format(target_name, spec_path))
     spec_path = prefix_subproject(normalize_absolute_refs(spec_path))
 
   return spec_path, target_name

--- a/tests/python/pants_test/build_graph/test_address.py
+++ b/tests/python/pants_test/build_graph/test_address.py
@@ -75,6 +75,7 @@ class ParseSpecTest(unittest.TestCase):
 
   def test_parse_bad_spec_bad_name(self):
     self.do_test_bad_target_name('a:')
+    self.do_test_bad_target_name('a/b:')
     self.do_test_bad_target_name('a::')
     self.do_test_bad_target_name('//')
 
@@ -159,6 +160,7 @@ class AddressTest(BaseAddressTest):
     self.assert_address('', 'target', Address.parse('//:target', relative_to='a/b'))
     self.assert_address('', 'target', Address.parse(':target'))
     self.assert_address('a/b', 'target', Address.parse(':target', relative_to='a/b'))
+    self.assert_address('a/b', 'b', Address.parse(':', relative_to='a/b'))
 
 
 class BuildFileAddressTest(BaseAddressTest):


### PR DESCRIPTION
### Problem

You can refer to another target with `name='a'` in the same BUILD file with the shorthand `':a'`. Targets that do not provide a name (and are therefore given the default name) must be referred to with the fully spelled-out default name. A target with the default name in directory `src/scala` could be referred to with `':scala'` in the same BUILD file, but if someone tries to search the BUILD file for `name='scala'`, they won't find it, and it's not clear that `':scala'` refers to the target with the default name, so it might no be easy to understand where that target is coming from.

### Solution

- A dependency on `':'` resolves to the default target name for that directory (so in `src/scala/BUILD`, `':'` would refer to the target `src/scala:scala`). This works if the target with the default name explicitly declares e.g. `name='scala'` too. Only `':'` is allowed -- any target spec with a path, such as `a/b:`, will still raise an error when parsed.. 

### Result

`some/code/BUILD`:
```python
# default target name 'code' assigned to this target
python_library(
  sources=['main.py'],
)

python_library(
  name='other',
  sources=['other.py'],
  dependencies=[
    ':', # expanded to ':code'
  ],
)
```