### PR TITLE
Disable lint for Python 3 targets

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -14,12 +14,11 @@ from pants.base.exceptions import TaskError
 from pants.option.custom_types import file_option
 from pants.task.lint_task_mixin import LintTaskMixin
 from pants.task.task import Task
+from pex.interpreter import PythonInterpreter
 
 from pants.contrib.python.checks.tasks.checkstyle.common import CheckSyntaxError, Nit, PythonFile
 from pants.contrib.python.checks.tasks.checkstyle.file_excluder import FileExcluder
 from pants.contrib.python.checks.tasks.checkstyle.register_plugins import register_plugins
-
-from pex.interpreter import PythonInterpreter
 
 
 _NOQA_LINE_SEARCH = re.compile(r'# noqa\b').search
@@ -56,6 +55,10 @@ class PythonCheckStyleTask(LintTaskMixin, Task):
   @classmethod
   def subsystem_dependencies(cls):
     return super(Task, cls).subsystem_dependencies() + cls._subsystems
+
+  @classmethod
+  def prepare(cls, options, round_manager):
+    round_manager.require_data(PythonInterpreter)
 
   @classmethod
   def register_options(cls, register):
@@ -173,8 +176,8 @@ class PythonCheckStyleTask(LintTaskMixin, Task):
     # If we are linting for Python 3, skip lint altogether. 
     # Long-term Python 3 linting solution tracked by:
     # https://github.com/pantsbuild/pants/issues/5764
-    intepreter = self.context.products.get_data(PythonInterpreter)
-    if intepreter and intepreter.version > (3, 0 ,0):
+    interpreter = self.context.products.get_data(PythonInterpreter)
+    if interpreter and intepreter.version > (3, 0 ,0):
       self.context.log.info('Linting is currently disabled for Python 3 targets.\n '
                             'See https://github.com/pantsbuild/pants/issues/5764 for '
                             'long-term solution tracking.')

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -178,7 +178,7 @@ class PythonCheckStyleTask(LintTaskMixin, Task):
       self.context.log.info('Linting is currently disabled for Python 3 targets.\n '
                             'See https://github.com/pantsbuild/pants/issues/5764 for '
                             'long-term solution tracking.')
-      return 0
+      return
 
     with self.invalidated(self.get_targets(self._is_checked)) as invalidation_check:
       sources = self.calculate_sources([vt.target for vt in invalidation_check.invalid_vts])

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -177,7 +177,7 @@ class PythonCheckStyleTask(LintTaskMixin, Task):
     # Long-term Python 3 linting solution tracked by:
     # https://github.com/pantsbuild/pants/issues/5764
     interpreter = self.context.products.get_data(PythonInterpreter)
-    if interpreter and intepreter.version > (3, 0 ,0):
+    if interpreter and interpreter.version > (3, 0 ,0):
       self.context.log.info('Linting is currently disabled for Python 3 targets.\n '
                             'See https://github.com/pantsbuild/pants/issues/5764 for '
                             'long-term solution tracking.')

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -177,6 +177,8 @@ class PythonCheckStyleTask(LintTaskMixin, Task):
     # Long-term Python 3 linting solution tracked by:
     # https://github.com/pantsbuild/pants/issues/5764
     interpreter = self.context.products.get_data(PythonInterpreter)
+    # Check interpreter is not 'None' for test cases that do not
+    # run the python interpreter selection task.
     if interpreter and interpreter.version > (3, 0 ,0):
       self.context.log.info('Linting is currently disabled for Python 3 targets.\n '
                             'See https://github.com/pantsbuild/pants/issues/5764 for '

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/plugin_test_base.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/plugin_test_base.py
@@ -15,6 +15,8 @@ from pants_test.option.util.fakes import create_options
 from pants.contrib.python.checks.tasks.checkstyle.common import Nit, PythonFile
 
 
+# TODO: Refactor this test suite to leverage the ConsoleTaskTestBase class
+# for proper integration testing (i.e. any test that runs task.execute()).
 class CheckstylePluginTestBase(unittest.TestCase):
   plugin_type = None   # Subclasses must override.
 


### PR DESCRIPTION
### Problem

`./pants lint` fails on targets containing source code that utilizes Python 2-incompatible syntax.

### Solution

Disable lint when targeting Python 3. Track long-term solution with https://github.com/pantsbuild/pants/issues/5764.

### Result

Python 3 targets utilizing Python 3-specific syntax will be able to pass lint.