### PR TITLE
Some streamlining of the artifact cache code.

### DIFF
--- a/src/python/pants/cache/artifact_cache.py
+++ b/src/python/pants/cache/artifact_cache.py
@@ -67,14 +67,6 @@ class ArtifactCache(object):
     """
     self.artifact_root = artifact_root
 
-  def prune(self):
-    """Prune stale cache files
-
-    Remove old unused cache files
-    :return:
-    """
-    pass
-
   def insert(self, cache_key, paths, overwrite=False):
     """Cache the output of a build.
 
@@ -132,6 +124,8 @@ class ArtifactCache(object):
     differently, as these are unexpected, unlike normal cache misses.
 
     :param CacheKey cache_key: A CacheKey object.
+    :param str results_dir: The path to the expected destination of the artifact extraction: will
+      be cleared before extraction.
     """
     pass
 

--- a/src/python/pants/cache/local_artifact_cache.py
+++ b/src/python/pants/cache/local_artifact_cache.py
@@ -13,34 +13,35 @@ from pants.cache.artifact import TarballArtifact
 from pants.cache.artifact_cache import ArtifactCache, UnreadableArtifact
 from pants.util.contextutil import temporary_file
 from pants.util.dirutil import (safe_delete, safe_mkdir, safe_mkdir_for,
-                                safe_rm_oldest_items_in_dir, safe_rmtree)
+                                safe_rm_oldest_items_in_dir)
 
 
 logger = logging.getLogger(__name__)
 
 
-class BaseLocalArtifactCache(ArtifactCache):
+class LocalArtifactCacheBase(ArtifactCache):
 
   def __init__(self, artifact_root, compression, permissions=None, dereference=True):
     """
     :param str artifact_root: The path under which cacheable products will be read/written.
     :param int compression: The gzip compression level for created artifacts.
                             Valid values are 0-9.
-    :param str permissions: File permissions to use when creating artifact files.
+    :param int permissions: File permissions to use when creating artifact files.
     :param bool dereference: Dereference symlinks when creating the cache tarball.
     """
-    super(BaseLocalArtifactCache, self).__init__(artifact_root)
+    super(LocalArtifactCacheBase, self).__init__(artifact_root)
     self._compression = compression
     self._cache_root = None
     self._permissions = permissions
     self._dereference = dereference
 
   def _artifact(self, path):
-    return TarballArtifact(self.artifact_root, path, self._compression, dereference=self._dereference)
+    return TarballArtifact(self.artifact_root, path, self._compression,
+                           dereference=self._dereference)
 
   @contextmanager
   def _tmpfile(self, cache_key, use):
-    """Allocate tempfile on same device as cache with a suffix chosen to prevent collisions"""
+    """Allocate tempfile on same device as cache, with a suffix chosen to prevent collisions."""
     with temporary_file(suffix=cache_key.id + use, root_dir=self._cache_root,
                         permissions=self._permissions) as tmpfile:
       yield tmpfile
@@ -65,18 +66,31 @@ class BaseLocalArtifactCache(ArtifactCache):
         tmp.write(chunk)
       tmp.close()
       tarball = self._store_tarball(cache_key, tmp.name)
-      artifact = self._artifact(tarball)
+      return self.extract_artifact_from_tarball(tarball, results_dir)
 
-      # NOTE(mateo): The two clean=True args passed in this method are likely safe, since the cache will by
-      # definition be dealing with unique results_dir, as opposed to the stable vt.results_dir (aka 'current').
-      # But if by chance it's passed the stable results_dir, safe_makedir(clean=True) will silently convert it
-      # from a symlink to a real dir and cause mysterious 'Operation not permitted' errors until the workdir is cleaned.
-      if results_dir is not None:
-        safe_mkdir(results_dir, clean=True)
+  def extract_artifact_from_tarball(self, tarball, results_dir=None):
+    """Extract an artifact from a given tarball.
 
+    :param tarball: Path to the tarball to extract.
+    :param results_dir: The path to the expected destination of the artifact extraction: will
+      be cleared both before extraction, and after a failure to extract.
+    :return: True iff the extraction succeeded.
+    :rtype: bool
+    """
+    # NOTE(mateo): The two clean=True args passed in this method are likely safe, since the cache
+    # will by definition be dealing with unique results_dir, as opposed to the stable
+    # vt.results_dir (aka 'current').  But if by chance it's passed the stable results_dir,
+    # safe_makedir(clean=True) will silently convert it from a symlink to a real dir and cause
+    # mysterious 'Operation not permitted' errors until the workdir is cleaned.
+    artifact = self._artifact(tarball)
+    if artifact.exists():
       try:
+        if results_dir is not None:
+          safe_mkdir(results_dir, clean=True)
         artifact.extract()
-      except Exception:
+        return True
+      except Exception as e:
+        logger.warn('Error while reading {0} from local artifact cache: {1}'.format(tarball, e))
         # Do our best to clean up after a failed artifact extraction. If a results_dir has been
         # specified, it is "expected" to represent the output destination of the extracted
         # artifact, and so removing it should clear any partially extracted state.
@@ -84,15 +98,14 @@ class BaseLocalArtifactCache(ArtifactCache):
           safe_mkdir(results_dir, clean=True)
         safe_delete(tarball)
         raise
-
-      return True
+    return False
 
   def _store_tarball(self, cache_key, src):
     """Given a src path to an artifact tarball, store it and return stored artifact's path."""
     pass
 
 
-class LocalArtifactCache(BaseLocalArtifactCache):
+class LocalArtifactCache(LocalArtifactCacheBase):
   """An artifact cache that stores the artifacts in local files."""
 
   def __init__(self, artifact_root, cache_root, compression, max_entries_per_target=None,
@@ -101,7 +114,8 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     :param str artifact_root: The path under which cacheable products will be read/written.
     :param str cache_root: The locally cached files are stored under this directory.
     :param int compression: The gzip compression level for created artifacts (1-9 or false-y).
-    :param int max_entries_per_target: The maximum number of old cache files to leave behind on a cache miss.
+    :param int max_entries_per_target: The maximum number of old cache files to leave behind on a
+      cache miss.
     :param str permissions: File permissions to use when creating artifact files.
     :param bool dereference: Dereference symlinks when creating the cache tarball.
     """
@@ -115,7 +129,7 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     self._max_entries_per_target = max_entries_per_target
     safe_mkdir(self._cache_root)
 
-  def prune(self, root):
+  def _prune(self, root):
     """Prune stale cache files
 
     If the option --cache-target-max-entry is greater than zero, then prune will remove all but n
@@ -135,21 +149,11 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     return self._artifact(self._cache_file_for_key(cache_key))
 
   def use_cached_files(self, cache_key, results_dir=None):
-    tarfile = self._cache_file_for_key(cache_key)
+    tarball = self._cache_file_for_key(cache_key)
     try:
-      artifact = self._artifact_for(cache_key)
-      if artifact.exists():
-        if results_dir is not None:
-          safe_rmtree(results_dir)
-        artifact.extract()
-        return True
-    except Exception as e:
-      # TODO(davidt): Consider being more granular in what is caught.
-      logger.warn('Error while reading {0} from local artifact cache: {1}'.format(tarfile, e))
-      safe_delete(tarfile)
+      return self.extract_artifact_from_tarball(tarball, results_dir)
+    except Exception as e:  # TODO: Consider being more granular in what is caught.
       return UnreadableArtifact(cache_key, e)
-
-    return False
 
   def try_insert(self, cache_key, paths):
     with self.insert_paths(cache_key, paths):
@@ -164,7 +168,7 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     os.rename(src, dest)
     if self._permissions:
       os.chmod(dest, self._permissions)
-    self.prune(os.path.dirname(dest))  # Remove old cache files.
+    self._prune(os.path.dirname(dest))  # Remove old cache files.
     return dest
 
   def _cache_file_for_key(self, cache_key):
@@ -173,7 +177,7 @@ class LocalArtifactCache(BaseLocalArtifactCache):
     return os.path.join(self._cache_root, cache_key.id, cache_key.hash) + '.tgz'
 
 
-class TempLocalArtifactCache(BaseLocalArtifactCache):
+class TempLocalArtifactCache(LocalArtifactCacheBase):
   """A local cache that does not actually store any files between calls.
 
   This implementation does not have a backing _cache_root, and never

--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -44,7 +44,7 @@ class RESTfulArtifactCache(ArtifactCache):
     :param BestUrlSelector best_url_selector: Url selector that supports fail-over. Each returned
       url represents prefix for some RESTful service. We must be able to PUT and GET to any path
       under this base.
-    :param BaseLocalArtifactCache local: local cache instance for storing and creating artifacts
+    :param LocalArtifactCacheBase local: local cache instance for storing and creating artifacts
     """
     super(RESTfulArtifactCache, self).__init__(artifact_root)
 
@@ -77,11 +77,12 @@ class RESTfulArtifactCache(ArtifactCache):
           target=_log_if_no_response,
           args=(
             60,
-            "Still downloading artifacts (either they're very large or the connection to the cache is slow)",
+            "Still downloading artifacts (either they're very large "
+            "or the connection to the cache is slow)",
             queue.get,
           )
         ).start()
-        # Delegate storage and extraction to local cache
+        # Delegate storage and extraction to local cache.
         byte_iter = response.iter_content(self.READ_SIZE_BYTES)
         res = self._localcache.store_and_use_artifact(cache_key, byte_iter, results_dir)
         queue.put(None)

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -59,12 +59,12 @@ def environment_as(**kwargs):
   new_environment = kwargs
   old_environment = {}
 
-  def setenv(key, val):
-    if val is not None:
-      os.environ[key] = val
+  def setenv(k, v):
+    if v is not None:
+      os.environ[k] = v
     else:
-      if key in os.environ:
-        del os.environ[key]
+      if k in os.environ:
+        del os.environ[k]
 
   for key, val in new_environment.items():
     old_environment[key] = os.environ.get(key)
@@ -146,7 +146,8 @@ def signal_handler_as(sig, handler):
 
 
 @contextmanager
-def temporary_dir(root_dir=None, cleanup=True, suffix=str(), permissions=None, prefix=tempfile.template):
+def temporary_dir(root_dir=None, cleanup=True, suffix='', permissions=None,
+                  prefix=tempfile.template):
   """
     A with-context that creates a temporary directory.
 
@@ -155,7 +156,10 @@ def temporary_dir(root_dir=None, cleanup=True, suffix=str(), permissions=None, p
     You may specify the following keyword args:
     :param string root_dir: The parent directory to create the temporary directory.
     :param bool cleanup: Whether or not to clean up the temporary directory.
+    :param str suffix: Optional suffix for the file's name.
+                       Does not add a dot between the file name and the suffix.
     :param int permissions: If provided, sets the directory permissions to this mode.
+    :param str prefix: Optional prefix template for the path.
   """
   path = tempfile.mkdtemp(dir=root_dir, suffix=suffix, prefix=prefix)
 
@@ -178,6 +182,9 @@ def temporary_file_path(root_dir=None, cleanup=True, suffix='', permissions=None
     You may specify the following keyword args:
     :param str root_dir: The parent directory to create the temporary file.
     :param bool cleanup: Whether or not to clean up the temporary file.
+    :param str suffix: Optional suffix for the file's name.
+                       Does not add a dot between the file name and the suffix.
+    :param int permissions: Set the file to have these permissions.
   """
   with temporary_file(root_dir, cleanup=cleanup, suffix=suffix, permissions=permissions) as fd:
     fd.close()
@@ -192,12 +199,9 @@ def temporary_file(root_dir=None, cleanup=True, suffix='', permissions=None):
     You may specify the following keyword args:
     :param str root_dir: The parent directory to create the temporary file.
     :param bool cleanup: Whether or not to clean up the temporary file.
-    :param str suffix: If suffix is specified, the file name will end with that suffix.
-                       Otherwise there will be no suffix.
-                       mkstemp() does not put a dot between the file name and the suffix;
-                       if you need one, put it at the beginning of suffix.
-                       See :py:class:`tempfile.NamedTemporaryFile`.
-    :param int permissions: If provided, sets the file to use these permissions.
+    :param str suffix: Optional suffix for the file's name.
+                       Does not add a dot between the file name and the suffix.
+    :param int permissions: Set the file to have these permissions.
   """
   with tempfile.NamedTemporaryFile(suffix=suffix, dir=root_dir, delete=False) as fd:
     try:
@@ -215,6 +219,7 @@ def safe_file(path, suffix=None, cleanup=True):
 
   This is useful for doing work on a file but only changing its state on success.
 
+  :param str path: The file to copy.
   :param str suffix: Use this suffix to create the copy. Otherwise use a random string.
   :param bool cleanup: Whether or not to clean up the copy.
   """
@@ -262,9 +267,9 @@ def open_zip(path_or_file, *args, **kwargs):
   """
   if not path_or_file:
     raise InvalidZipPath('Invalid zip location: {}'.format(path_or_file))
-  allowZip64 = kwargs.pop('allowZip64', True)
+  allow_zip64 = kwargs.pop(b'allowZip64', True)
   try:
-    zf = zipfile.ZipFile(path_or_file, *args, allowZip64=allowZip64, **kwargs)
+    zf = zipfile.ZipFile(path_or_file, *args, allowZip64=allow_zip64, **kwargs)
   except zipfile.BadZipfile as bze:
     # Use the realpath in order to follow symlinks back to the problem source file.
     raise zipfile.BadZipfile("Bad Zipfile {0}: {1}".format(os.path.realpath(path_or_file), bze))

--- a/tests/python/pants_test/cache/test_artifact_cache.py
+++ b/tests/python/pants_test/cache/test_artifact_cache.py
@@ -106,7 +106,7 @@ class TestArtifactCache(unittest.TestCase):
       self.assertFalse(artifact_cache.has(key))
 
   def test_local_backed_remote_cache(self):
-    """make sure that the combined cache finds what it should and that it backfills"""
+    """make sure that the combined cache finds what it should and that it backfills."""
     with self.setup_server() as server:
       with self.setup_local_cache() as local:
         tmp = TempLocalArtifactCache(local.artifact_root, 0)


### PR DESCRIPTION
The previous code had two very similar code blocks for extracting tarballs, clearing results_dir and handling errors.  

These blocks differed in unessential but confusing ways (e.g., one used `safe_mkdir(results_dir, clean=True)` to clear out the results_dir, and the other used `safe_rmtree` - but since you could get either code path depending on whether the remote cache hit, this can't be a meaningful difference).  Also, one block failed to clean up results_dir on extraction error, while the other did. 

This change unifies those blocks into a single method, called in the two places that use it.  This method is scrupulous about cleaning up on error.