### PR TITLE
Introduce a backdoor around PYTHONPATH scrubbing in pytest runs.

### DIFF
--- a/examples/src/python/example/README.md
+++ b/examples/src/python/example/README.md
@@ -151,6 +151,27 @@ Use `test` to run the tests. This uses `pytest`:
                    SUCCESS
     $
 
+Debugging Tests
+---------------
+Pants scrubs the environment's `PYTHONPATH` when running tests, to ensure a hermetic, repeatable test run.
+
+However some Python debuggers require you to add the debugger's code to the `PYTHONPATH`.
+To do so, set `PANTS_PYTEST_RUN_EXTRA_PYTHONPATH` in the environment in which you run Pants.
+
+So, for example, to use PyCharm's interactive debugger:
+ 
+- Find the [pycharm-debug.egg](https://www.jetbrains.com/help/pycharm/remote-debugging.html) 
+  in your PyCharm installation.
+- Set the environment variable to point to it:  
+  `PANTS_PYTEST_RUN_EXTRA_PYTHONPATH=/path/to/pycharm-debug.egg`.
+- Start the debug server in PyCharm (this assumes you have previously set it up to listen on port 5000).
+- Set a breakpoint in your code by adding this line where you wish to break:    
+  `import pydevd;pydevd.settrace('localhost', port=5000, stdoutToServer=True, stderrToServer=True)`
+- Run your `./pants test` command.
+
+When your code hits the breakpoint, you'll enter an interactive debugging session in PyCharm!
+
+
 Handling `python_requirement`
 -----------------------------
 

--- a/examples/src/python/example/README.md
+++ b/examples/src/python/example/README.md
@@ -156,14 +156,18 @@ Debugging Tests
 Pants scrubs the environment's `PYTHONPATH` when running tests, to ensure a hermetic, repeatable test run.
 
 However some Python debuggers require you to add the debugger's code to the `PYTHONPATH`.
-To do so, set `PANTS_PYTEST_RUN_EXTRA_PYTHONPATH` in the environment in which you run Pants.
+To do so, set the `extra_pythonpath` option on the `test.pytest` scope.
+
+You can do so with the `--test-pytest-extra-pythonpath` flag, but it may be more convenient to 
+set this permanently in your personal environment using the `PANTS_TEST_PYTEST_EXTRA_PYTHONPATH` 
+environment variable.
 
 So, for example, to use PyCharm's interactive debugger:
  
 - Find the [pycharm-debug.egg](https://www.jetbrains.com/help/pycharm/remote-debugging.html) 
   in your PyCharm installation.
 - Set the environment variable to point to it:  
-  `PANTS_PYTEST_RUN_EXTRA_PYTHONPATH=/path/to/pycharm-debug.egg`.
+  `PANTS_TEST_PYTEST_EXTRA_PYTHONPATH=/path/to/pycharm-debug.egg`.
 - Start the debug server in PyCharm (this assumes you have previously set it up to listen on port 5000).
 - Set a breakpoint in your code by adding this line where you wish to break:    
   `import pydevd;pydevd.settrace('localhost', port=5000, stdoutToServer=True, stderrToServer=True)`

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -127,8 +127,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
 
     register('--extra-pythonpath', type=list, fingerprint=True, advanced=True,
              help='Add these entries to the PYTHONPATH when running the tests. '
-                  'Useful for attaching to debuggers in test code.'
-                  '')
+                  'Useful for attaching to debuggers in test code.')
 
   @classmethod
   def supports_passthru_args(cls):

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -478,6 +478,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         yield pytest_binary, [conftest] + coverage_args, get_pytest_rootdir
 
   def _do_run_tests_with_args(self, pex, args):
+    python_path_backdoor = 'PANTS_PYTEST_RUN_EXTRA_PYTHONPATH'
     try:
       env = dict(os.environ)
 
@@ -488,7 +489,8 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
         self.context.log.warn('scrubbed PYTHONPATH={} from py.test environment'.format(pythonpath))
       # But allow this back door for users who do want to force something onto the test pythonpath,
       # e.g., modules required during a debugging session.
-      env['PYTHONPATH'] = env.get('PANTS_PYTEST_RUN_EXTRA_PYTHONPATH')
+      if python_path_backdoor in env:
+        env['PYTHONPATH'] = env.get(python_path_backdoor)
 
       # The pytest runner we use accepts a --pdb argument that will launch an interactive pdb
       # session on any test failure.  In order to support use of this pass-through flag we must

--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -486,6 +486,9 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
       pythonpath = env.pop('PYTHONPATH', None)
       if pythonpath:
         self.context.log.warn('scrubbed PYTHONPATH={} from py.test environment'.format(pythonpath))
+      # But allow this back door for users who do want to force something onto the test pythonpath,
+      # e.g., modules required during a debugging session.
+      env['PYTHONPATH'] = env.get('PANTS_PYTEST_RUN_EXTRA_PYTHONPATH')
 
       # The pytest runner we use accepts a --pdb argument that will launch an interactive pdb
       # session on any test failure.  In order to support use of this pass-through flag we must


### PR DESCRIPTION
This allows a user who knows what they're doing to, e.g., use external debuggers to step into test code. E.g., PyCharm's graphical debugger requires `pycharm-debug.egg` to be on the PYTHONPATH.