### PR TITLE
Introduce Resettable

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "mock 0.0.1",
  "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "resettable 0.0.1",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
@@ -646,6 +647,10 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "resettable"
+version = "0.0.1"
 
 [[package]]
 name = "same-file"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "process_execution",
   "process_execution/bazel_protos",
   "process_executor",
+  "resettable",
   "testutil",
   "testutil/mock",
 ]
@@ -53,6 +54,7 @@ default-members = [
   "process_execution",
   "process_execution/bazel_protos",
   "process_executor",
+  "resettable",
   "testutil",
   "testutil/mock",
 ]

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -22,6 +22,7 @@ lmdb = "0.7.2"
 log = "0.4"
 ordermap = "0.2.8"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
+resettable = { path = "../resettable" }
 sha2 = "0.6.0"
 tempdir = "0.3.5"
 

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -612,7 +612,7 @@ fn main() {
     Some(address) => fs::Store::with_remote(
       &store_path,
       pool,
-      address,
+      address.to_owned(),
       1,
       4 * 1024 * 1024,
       std::time::Duration::from_secs(5 * 60),

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -166,7 +166,7 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
         Store::with_remote(
           store_dir,
           pool.clone(),
-          cas_address,
+          cas_address.to_owned(),
           1,
           10 * 1024 * 1024,
           Duration::from_secs(30),

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -30,6 +30,7 @@ extern crate log;
 extern crate mock;
 extern crate ordermap;
 extern crate protobuf;
+extern crate resettable;
 extern crate sha2;
 extern crate tempdir;
 #[cfg(test)]

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -795,7 +795,7 @@ mod tests {
     let store = fs::Store::with_remote(
       store_dir,
       Arc::new(fs::ResettablePool::new("test-pool-".to_owned())),
-      &cas.address(),
+      cas.address(),
       1,
       10 * 1024 * 1024,
       Duration::from_secs(1),
@@ -848,7 +848,7 @@ mod tests {
     let store = fs::Store::with_remote(
       store_dir,
       Arc::new(fs::ResettablePool::new("test-pool-".to_owned())),
-      &cas.address(),
+      cas.address(),
       1,
       10 * 1024 * 1024,
       Duration::from_secs(1),
@@ -1192,7 +1192,7 @@ mod tests {
     let store = fs::Store::with_remote(
       store_dir,
       Arc::new(fs::ResettablePool::new("test-pool-".to_owned())),
-      &cas.address(),
+      cas.address(),
       1,
       10 * 1024 * 1024,
       Duration::from_secs(1),

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -104,7 +104,7 @@ fn main() {
     (Some(_server), Some(cas_server)) => fs::Store::with_remote(
       local_store_path,
       pool.clone(),
-      cas_server,
+      cas_server.to_owned(),
       1,
       10 * 1024 * 1024,
       Duration::from_secs(30),

--- a/src/rust/engine/resettable/Cargo.toml
+++ b/src/rust/engine/resettable/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "resettable"
+version = "0.0.1"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+
+[dependencies]

--- a/src/rust/engine/resettable/src/lib.rs
+++ b/src/rust/engine/resettable/src/lib.rs
@@ -1,0 +1,56 @@
+use std::sync::{Arc, RwLock};
+
+///
+/// Resettable is a lazily computed value which can be reset, so that it can be lazily computed
+/// again next time it is needed.
+///
+/// This is useful because we fork without execing a lot in the engine, and before doing so, we need
+/// to reset any references which hide background threads, so that forked processes don't inherit
+/// pointers to threads from the parent process which will not exist in the forked process.
+///
+#[derive(Clone)]
+pub struct Resettable<T> {
+  val: Arc<RwLock<Option<T>>>,
+  make: Arc<Fn() -> T>,
+}
+
+unsafe impl<T> Send for Resettable<T> {}
+unsafe impl<T> Sync for Resettable<T> {}
+
+impl<T> Resettable<T>
+where
+  T: Clone + Send + Sync,
+{
+  // Sadly there is no way to accept an Fn() -> T because it's not Sized, so we need to accept an
+  // Arc of one. This is not at all ergonomic, but at some point "impl trait" will come along and
+  // allow us to remove this monstrosity.
+  pub fn new(make: Arc<Fn() -> T>) -> Resettable<T> {
+    Resettable {
+      val: Arc::new(RwLock::new(None)),
+      make: make,
+    }
+  }
+
+  pub fn get(&self) -> T {
+    {
+      if let Some(ref val) = *self.val.read().unwrap() {
+        return val.clone();
+      }
+    }
+    {
+      let mut maybe_val = self.val.write().unwrap();
+      {
+        if let Some(ref val) = *maybe_val {
+          return val.clone();
+        }
+      }
+      let val = (self.make)();
+      *maybe_val = Some(val.clone());
+      val
+    }
+  }
+
+  pub fn reset(&self) {
+    *self.val.write().unwrap() = None
+  }
+}

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -72,7 +72,7 @@ impl Core {
 
   pub fn pre_fork(&self) {
     self.pool.reset();
-    self.store.reset_lmdb_connections();
+    self.store.reset_prefork();
   }
 }
 


### PR DESCRIPTION
Because we fork without execing a lot, we often need to reset things
that have references to background threads. This provides a handy
wrapper for doing so.

Right now, our uses of grpcio::Environment aren't fork-safe. This fixes that.

If this looks good, I will also apply it to the
process_execution::remote::CommandRunner.

I can also apply it to the ResettablePool which we already have, for
re-use (it would add an additional Arc clone per CpuPool operation, but
this is probably fine because the CpuPool operations are already by
definition somewhat heavyweight).