### PR TITLE
Bump ordermap to indexmap 1

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -165,7 +165,6 @@ dependencies = [
  "hashing 0.0.1",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,12 +231,12 @@ dependencies = [
  "hashing 0.0.1",
  "hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mock 0.0.1",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -400,6 +399,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,11 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "ordermap"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ordermap"
@@ -865,6 +864,7 @@ dependencies = [
 "checksum hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "459d3cf58137bb02ad4adeef5036377ff59f066dbb82517b7192e3a5462a2abc"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum ignore 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bb2f0238094bd1b41800fb6eb9b16fdd5e9832ed6053ed91409f0cd5bf28dcfd"
+"checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "23d53b4c7394338044c3b9c8c5b2caaf7b40ae049ecd321578ebdc2e13738cd1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -880,7 +880,6 @@ dependencies = [
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3c2bd9b9d21e48e956b763c9f37134dc62d9e95da6edb3f672cacb6caf3cd3"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
-"checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -67,7 +67,6 @@ futures = "0.1.16"
 hashing = { path = "hashing" }
 lazy_static = "0.2.2"
 log = "0.4"
-ordermap = "0.2.8"
 petgraph = "0.4.5"
 process_execution = { path = "process_execution" }
 tempdir = "0.3.5"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -16,11 +16,11 @@ grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../hashing" }
 hex = "0.3.1"
 ignore = "0.3.1"
+indexmap = "1"
 itertools = "0.7.2"
 lazy_static = "0.2.2"
 lmdb = "0.7.2"
 log = "0.4"
-ordermap = "0.2.8"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 sha2 = "0.6.0"
 tempdir = "0.3.5"

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -20,6 +20,7 @@ extern crate grpcio;
 extern crate hashing;
 extern crate hex;
 extern crate ignore;
+extern crate indexmap;
 extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
@@ -28,7 +29,6 @@ extern crate lmdb;
 extern crate log;
 #[cfg(test)]
 extern crate mock;
-extern crate ordermap;
 extern crate protobuf;
 extern crate sha2;
 extern crate tempdir;
@@ -47,7 +47,7 @@ use bytes::Bytes;
 use futures::future::{self, Future};
 use glob::Pattern;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 
 use boxfuture::{BoxFuture, Boxable};
 
@@ -333,7 +333,7 @@ struct PathGlobsExpansion<T: Sized> {
   // Globs that have already been expanded.
   completed: HashSet<PathGlob>,
   // Unique Paths that have been matched, in order.
-  outputs: OrderMap<PathStat, ()>,
+  outputs: IndexMap<PathStat, ()>,
 }
 
 fn create_ignore(patterns: &[String]) -> Result<Gitignore, ignore::Error> {
@@ -674,7 +674,7 @@ pub trait VFS<E: Send + Sync + 'static>: Clone + Send + Sync + 'static {
       todo: path_globs.include,
       exclude: path_globs.exclude,
       completed: HashSet::default(),
-      outputs: OrderMap::default(),
+      outputs: IndexMap::default(),
     };
     future::loop_fn(init, |mut expansion| {
       // Request the expansion of all outstanding PathGlobs as a batch.

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -26,7 +26,6 @@ extern crate hashing;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate ordermap;
 extern crate petgraph;
 extern crate process_execution;
 extern crate tempdir;


### PR DESCRIPTION
The crate was renamed when it stabilised. But stable is good :)

This also removes the unused `extern crate ordermap` from engine.