### PR TITLE
Expand type constraints allowed in datatype()

### DIFF
--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -13,9 +13,6 @@ from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
 
 
-class DatatypeConstructionError(TypeError): pass
-
-
 def datatype(field_decls, superclass_name=None, **kwargs):
   """A wrapper for `namedtuple` that accounts for the type of the object in equality.
 
@@ -28,7 +25,7 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 
   :param field_decls: Iterable of field declarations.
   :return: A type object which can then be subclassed.
-  :raises: :class:`pants.util.objects.DatatypeConstructionError`
+  :raises: :class:`TypeError`
   """
   field_names = []
   fields_with_constraints = OrderedDict()
@@ -41,7 +38,7 @@ def datatype(field_decls, superclass_name=None, **kwargs):
       elif isinstance(type_spec, TypeConstraint):
         type_constraint = type_spec
       else:
-        raise DatatypeConstructionError(
+        raise TypeError(
           "type spec for field '{}' was not a type or TypeConstraint: was {!r} (type {!r})."
           .format(field_name, type_spec, type(type_spec).__name__))
       fields_with_constraints[field_name] = type_constraint

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -13,6 +13,9 @@ from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
 
 
+class DatatypeHelperConstructionError(Exception): pass
+
+
 def datatype(field_decls, superclass_name=None, **kwargs):
   """A wrapper for `namedtuple` that accounts for the type of the object in equality.
 
@@ -31,8 +34,16 @@ def datatype(field_decls, superclass_name=None, **kwargs):
   for maybe_decl in field_decls:
     # ('field_name', type)
     if isinstance(maybe_decl, tuple):
-      field_name, field_type = maybe_decl
-      fields_with_constraints[field_name] = Exactly(field_type)
+      field_name, type_spec = maybe_decl
+      if isinstance(type_spec, type):
+        type_constraint = Exactly(type_spec)
+      elif isinstance(type_spec, TypeConstraint):
+        type_constraint = type_spec
+      else:
+        raise DatatypeHelperConstructionError(
+          "type spec for field '{}' was not a type or TypeConstraint: was {!r} (type {!r})."
+          .format(field_name, type_spec, type(type_spec).__name__))
+      fields_with_constraints[field_name] = type_constraint
     else:
       # interpret it as a field name without a type to check
       field_name = maybe_decl

--- a/src/python/pants/util/objects.py
+++ b/src/python/pants/util/objects.py
@@ -13,7 +13,7 @@ from pants.util.memo import memoized
 from pants.util.meta import AbstractClass
 
 
-class DatatypeHelperConstructionError(Exception): pass
+class DatatypeConstructionError(TypeError): pass
 
 
 def datatype(field_decls, superclass_name=None, **kwargs):
@@ -28,6 +28,7 @@ def datatype(field_decls, superclass_name=None, **kwargs):
 
   :param field_decls: Iterable of field declarations.
   :return: A type object which can then be subclassed.
+  :raises: :class:`pants.util.objects.DatatypeConstructionError`
   """
   field_names = []
   fields_with_constraints = OrderedDict()
@@ -40,7 +41,7 @@ def datatype(field_decls, superclass_name=None, **kwargs):
       elif isinstance(type_spec, TypeConstraint):
         type_constraint = type_spec
       else:
-        raise DatatypeHelperConstructionError(
+        raise DatatypeConstructionError(
           "type spec for field '{}' was not a type or TypeConstraint: was {!r} (type {!r})."
           .format(field_name, type_spec, type(type_spec).__name__))
       fields_with_constraints[field_name] = type_constraint

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -14,7 +14,7 @@ from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcess
                                            create_process_rules)
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Select
-from pants.util.objects import TypeCheckError, datatype
+from pants.util.objects import Exactly, TypeCheckError, datatype
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 
 
@@ -22,10 +22,10 @@ class Concatted(datatype([('value', str)])):
   pass
 
 
-class BinaryLocation(datatype([('bin_path', str)])):
+class BinaryLocation(datatype([('bin_path', Exactly(str, unicode))])):
 
-  def __new__(cls, *args, **kwargs):
-    this_object = super(BinaryLocation, cls).__new__(cls, *args, **kwargs)
+  def __new__(cls, bin_path):
+    this_object = super(BinaryLocation, cls).__new__(cls, str(bin_path))
 
     bin_path = this_object.bin_path
 
@@ -62,11 +62,7 @@ class ShellCat(datatype([('binary_location', BinaryLocation)])):
     return (self.bin_path,) + tuple(cat_file_paths)
 
 
-class CatExecutionRequest(datatype([
-    ('shell_cat', ShellCat),
-    ('path_globs', PathGlobs),
-])):
-  pass
+class CatExecutionRequest(datatype([('shell_cat', ShellCat), ('path_globs', PathGlobs)])): pass
 
 
 @rule(ExecuteProcessRequest, [Select(CatExecutionRequest)])
@@ -99,9 +95,7 @@ def create_cat_stdout_rules():
   ]
 
 
-class JavacVersionExecutionRequest(datatype([
-    ('binary_location', BinaryLocation),
-])):
+class JavacVersionExecutionRequest(datatype([('binary_location', BinaryLocation)])):
 
   @property
   def bin_path(self):
@@ -118,8 +112,7 @@ def process_request_from_javac_version(javac_version_exe_req):
     env=tuple())
 
 
-class JavacVersionOutput(datatype([('value', str)])):
-  pass
+class JavacVersionOutput(datatype([('value', str)])): pass
 
 
 class ProcessExecutionFailure(Exception):
@@ -266,12 +259,12 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     scheduler = self.mk_scheduler_in_example_fs(create_cat_stdout_rules())
 
     cat_exe_req = CatExecutionRequest(
-      ShellCat(BinaryLocation(str('/bin/cat'))),
-      PathGlobs.create('', include=[u'fs_test/a/b/*']))
+      ShellCat(BinaryLocation('/bin/cat')),
+      PathGlobs.create('', include=['fs_test/a/b/*']))
 
     self.assertEqual(
       repr(cat_exe_req),
-      str("CatExecutionRequest(shell_cat=ShellCat(binary_location=BinaryLocation(bin_path='/bin/cat')), path_globs=PathGlobs(include=(u'fs_test/a/b/*',), exclude=()))"))
+      "CatExecutionRequest(shell_cat=ShellCat(binary_location=BinaryLocation(bin_path='/bin/cat')), path_globs=PathGlobs(include=(u'fs_test/a/b/*',), exclude=()))")
 
     results = self.execute(scheduler, Concatted, cat_exe_req)
     self.assertEqual(1, len(results))
@@ -285,7 +278,7 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
       get_javac_version_output,
     ])
 
-    request = JavacVersionExecutionRequest(BinaryLocation(str('/usr/bin/javac')))
+    request = JavacVersionExecutionRequest(BinaryLocation('/usr/bin/javac'))
 
     self.assertEqual(
       repr(request),
@@ -300,9 +293,9 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     scheduler = self.mk_scheduler_in_example_fs(create_javac_compile_rules())
 
     request = JavacCompileRequest(
-      BinaryLocation(str('/usr/bin/javac')),
+      BinaryLocation('/usr/bin/javac'),
       JavacSources(PathGlobs.create('', include=[
-        u'scheduler_inputs/src/java/simple/Simple.java',
+        'scheduler_inputs/src/java/simple/Simple.java',
       ])))
 
     self.assertEqual(
@@ -318,7 +311,7 @@ class IsolatedProcessTest(SchedulerTestBase, unittest.TestCase):
     scheduler = self.mk_scheduler_in_example_fs(create_javac_compile_rules())
 
     request = JavacCompileRequest(
-      BinaryLocation(str('/usr/bin/javac')),
+      BinaryLocation('/usr/bin/javac'),
       JavacSources(PathGlobs.create('', include=[
         'scheduler_inputs/src/java/simple/Broken.java',
       ])))

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -14,15 +14,14 @@ from pants.engine.isolated_process import (ExecuteProcessRequest, ExecuteProcess
                                            create_process_rules)
 from pants.engine.rules import RootRule, rule
 from pants.engine.selectors import Get, Select
-from pants.util.objects import Exactly, TypeCheckError, datatype
+from pants.util.objects import TypeCheckError, datatype
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
 
 
-class Concatted(datatype([('value', str)])):
-  pass
+class Concatted(datatype([('value', str)])): pass
 
 
-class BinaryLocation(datatype([('bin_path', Exactly(str, unicode))])):
+class BinaryLocation(datatype(['bin_path'])):
 
   def __new__(cls, bin_path):
     this_object = super(BinaryLocation, cls).__new__(cls, str(bin_path))

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -366,7 +366,7 @@ class TypedDatatypeTest(BaseTest):
                      "WithExplicitTypeConstraint(a_string='asdf', an_int=45)")
     self.assertEqual(
       str(some_object),
-      str("WithExplicitTypeConstraint(a_string<=str>=asdf, an_int<=int>=45)"))
+      "WithExplicitTypeConstraint(a_string<=str>=asdf, an_int<=int>=45)")
 
     some_nonneg_int = NonNegativeInt(an_int=3)
     self.assertEqual(3, some_nonneg_int.an_int)
@@ -381,7 +381,7 @@ class TypedDatatypeTest(BaseTest):
                      "CamelCaseWrapper(nonneg_int=NonNegativeInt(an_int=45))")
     self.assertEqual(
       str(wrapped_nonneg_int),
-      str("CamelCaseWrapper(nonneg_int<=NonNegativeInt>=NonNegativeInt(an_int<=int>=45))"))
+      "CamelCaseWrapper(nonneg_int<=NonNegativeInt>=NonNegativeInt(an_int<=int>=45))")
 
     mixed_type_obj = MixedTyping(value=3, name=str('asdf'))
     self.assertEqual(3, mixed_type_obj.value)

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -9,7 +9,7 @@ import copy
 import pickle
 from abc import abstractmethod
 
-from pants.util.objects import (DatatypeHelperConstructionError, Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
+from pants.util.objects import (Exactly, SubclassesOf, SuperclassesOf, TypeCheckError,
                                 TypedDatatypeInstanceConstructionError, datatype)
 from pants_test.base_test import BaseTest
 
@@ -142,25 +142,13 @@ class TypedWithMixin(datatype([('val', str)]), SomeMixin):
     return self.val
 
 
-class AnotherTypedDatatype(datatype([
-    ('string', str),
-    ('elements', list),
-])):
-  pass
+class AnotherTypedDatatype(datatype([('string', str), ('elements', list)])): pass
 
 
-class WithExplicitTypeConstraint(datatype([
-    ('a_string', str),
-    ('an_int', Exactly(int)),
-])):
-  pass
+class WithExplicitTypeConstraint(datatype([('a_string', str), ('an_int', Exactly(int))])): pass
 
 
-class MixedTyping(datatype([
-    'value',
-    ('name', str),
-])):
-  pass
+class MixedTyping(datatype(['value', ('name', str)])): pass
 
 
 class SomeBaseClass(object):
@@ -176,18 +164,15 @@ class SomeDatatypeClass(SomeBaseClass):
     return 'SomeDatatypeClass()'
 
 
-class WithSubclassTypeConstraint(datatype([('some_value', SubclassesOf(SomeBaseClass))])):
-  pass
+class WithSubclassTypeConstraint(datatype([('some_value', SubclassesOf(SomeBaseClass))])): pass
 
 
-class NonNegativeInt(datatype([
-    ('an_int', int),
-])):
+class NonNegativeInt(datatype([('an_int', int)])):
   """Example of overriding __new__() to perform deeper argument checking."""
 
-  # NB: TypedDatatype.__new__() will raise if any kwargs are provided, but
-  # subclasses are free to use kwargs as long as they don't pass them on to the
-  # TypedDatatype constructor.
+  # NB: __new__() in the class returned by datatype() will raise if any kwargs are provided, but
+  # subclasses are free to pass around kwargs as long as they don't forward them to that particular
+  # __new__() method.
   def __new__(cls, *args, **kwargs):
     # Call the superclass ctor first to ensure the type is correct.
     this_object = super(NonNegativeInt, cls).__new__(cls, *args, **kwargs)
@@ -200,10 +185,7 @@ class NonNegativeInt(datatype([
     return this_object
 
 
-class CamelCaseWrapper(datatype([
-    ('nonneg_int', NonNegativeInt),
-])):
-  pass
+class CamelCaseWrapper(datatype([('nonneg_int', NonNegativeInt)])): pass
 
 
 class ReturnsNotImplemented(object):
@@ -316,34 +298,34 @@ class TypedDatatypeTest(BaseTest):
     # If the type_name can't be converted into a suitable identifier, throw a
     # ValueError.
     with self.assertRaises(ValueError) as cm:
-      class NonStrType(datatype([int,])): pass
+      class NonStrType(datatype([int])): pass
     expected_msg = (
       "Type names and field names can only contain alphanumeric "
       "characters and underscores: \"<type 'int'>\"")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     # This raises a TypeError because it doesn't provide a required argument.
     with self.assertRaises(TypeError) as cm:
       class NoFields(datatype()): pass
     expected_msg = "datatype() takes at least 1 argument (0 given)"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(ValueError) as cm:
       class JustTypeField(datatype([str])): pass
     expected_msg = (
       "Type names and field names can only contain alphanumeric characters "
       "and underscores: \"<type 'str'>\"")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(ValueError) as cm:
       class NonStringField(datatype([3])): pass
     expected_msg = "Type names and field names cannot start with a number: '3'"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(ValueError) as cm:
       class NonStringTypeField(datatype([(32, int)])): pass
     expected_msg = "Type names and field names cannot start with a number: '32'"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(ValueError) as cm:
       class MultipleSameName(datatype([
@@ -353,7 +335,7 @@ class TypedDatatypeTest(BaseTest):
       ])):
         pass
     expected_msg = "Encountered duplicate field name: 'field_a'"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(ValueError) as cm:
       class MultipleSameNameWithType(datatype([
@@ -362,14 +344,14 @@ class TypedDatatypeTest(BaseTest):
           ])):
         pass
     expected_msg = "Encountered duplicate field name: 'field_a'"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
-    with self.assertRaises(DatatypeHelperConstructionError) as cm:
+    with self.assertRaises(TypeError) as cm:
       class InvalidTypeSpec(datatype([('a_field', 2)])): pass
     expected_msg = (
       "type spec for field 'a_field' was not a type or TypeConstraint: "
       "was 2 (type 'int').")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
   def test_instance_construction_by_repr(self):
     some_val = SomeTypedDatatype(3)
@@ -404,17 +386,17 @@ class TypedDatatypeTest(BaseTest):
     mixed_type_obj = MixedTyping(value=3, name=str('asdf'))
     self.assertEqual(3, mixed_type_obj.value)
     self.assertEqual(repr(mixed_type_obj),
-                     str("MixedTyping(value=3, name='asdf')"))
+                     "MixedTyping(value=3, name='asdf')")
     self.assertEqual(str(mixed_type_obj),
-                     str("MixedTyping(value=3, name<=str>=asdf)"))
+                     "MixedTyping(value=3, name<=str>=asdf)")
 
     subclass_constraint_obj = WithSubclassTypeConstraint(SomeDatatypeClass())
     self.assertEqual('asdf', subclass_constraint_obj.some_value.something())
     self.assertEqual(repr(subclass_constraint_obj),
-                     str("WithSubclassTypeConstraint(some_value=SomeDatatypeClass())"))
+                     "WithSubclassTypeConstraint(some_value=SomeDatatypeClass())")
     self.assertEqual(
       str(subclass_constraint_obj),
-      str("WithSubclassTypeConstraint(some_value<+SomeBaseClass>=SomeDatatypeClass())"))
+      "WithSubclassTypeConstraint(some_value<+SomeBaseClass>=SomeDatatypeClass())")
 
   def test_mixin_type_construction(self):
     obj_with_mixin = TypedWithMixin(str(' asdf '))
@@ -428,32 +410,32 @@ class TypedDatatypeTest(BaseTest):
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(something=3)
     expected_msg = "__new__() got an unexpected keyword argument 'something'"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     # not providing all the fields
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype()
     expected_msg = "__new__() takes exactly 2 arguments (1 given)"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     # unrecognized fields
     with self.assertRaises(TypeError) as cm:
       SomeTypedDatatype(3, 4)
     expected_msg = "__new__() takes exactly 2 arguments (3 given)"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypedDatatypeInstanceConstructionError) as cm:
       CamelCaseWrapper(nonneg_int=3)
     expected_msg = (
       """error: in constructor of type CamelCaseWrapper: type check error:
 field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(NonNegativeInt).""")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     # test that kwargs with keywords that aren't field names fail the same way
     with self.assertRaises(TypeError) as cm:
       CamelCaseWrapper(4, a=3)
     expected_msg = "__new__() got an unexpected keyword argument 'a'"
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
   def test_type_check_errors(self):
     # single type checking failure
@@ -462,7 +444,7 @@ field 'nonneg_int' was invalid: value 3 (with type 'int') must satisfy this type
     expected_msg = (
       """error: in constructor of type SomeTypedDatatype: type check error:
 field 'val' was invalid: value [] (with type 'list') must satisfy this type constraint: Exactly(int).""")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     # type checking failure with multiple arguments (one is correct)
     with self.assertRaises(TypeCheckError) as cm:
@@ -470,7 +452,7 @@ field 'val' was invalid: value [] (with type 'list') must satisfy this type cons
     expected_msg = (
       """error: in constructor of type AnotherTypedDatatype: type check error:
 field 'elements' was invalid: value 'should be list' (with type 'str') must satisfy this type constraint: Exactly(list).""")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     # type checking failure on both arguments
     with self.assertRaises(TypeCheckError) as cm:
@@ -479,25 +461,25 @@ field 'elements' was invalid: value 'should be list' (with type 'str') must sati
       """error: in constructor of type AnotherTypedDatatype: type check error:
 field 'string' was invalid: value 3 (with type 'int') must satisfy this type constraint: Exactly(str).
 field 'elements' was invalid: value 'should be list' (with type 'str') must satisfy this type constraint: Exactly(list).""")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       NonNegativeInt(str('asdf'))
     expected_msg = (
       """error: in constructor of type NonNegativeInt: type check error:
 field 'an_int' was invalid: value 'asdf' (with type 'str') must satisfy this type constraint: Exactly(int).""")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       NonNegativeInt(-3)
     expected_msg = (
       """error: in constructor of type NonNegativeInt: type check error:
 value is negative: -3.""")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)
 
     with self.assertRaises(TypeCheckError) as cm:
       WithSubclassTypeConstraint(3)
     expected_msg = (
       """error: in constructor of type WithSubclassTypeConstraint: type check error:
 field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
-    self.assertEqual(str(cm.exception), str(expected_msg))
+    self.assertEqual(str(cm.exception), expected_msg)

--- a/tests/python/pants_test/util/test_objects.py
+++ b/tests/python/pants_test/util/test_objects.py
@@ -494,3 +494,10 @@ field 'an_int' was invalid: value 'asdf' (with type 'str') must satisfy this typ
       """error: in constructor of type NonNegativeInt: type check error:
 value is negative: -3.""")
     self.assertEqual(str(cm.exception), str(expected_msg))
+
+    with self.assertRaises(TypeCheckError) as cm:
+      WithSubclassTypeConstraint(3)
+    expected_msg = (
+      """error: in constructor of type WithSubclassTypeConstraint: type check error:
+field 'some_value' was invalid: value 3 (with type 'int') must satisfy this type constraint: SubclassesOf(SomeBaseClass).""")
+    self.assertEqual(str(cm.exception), str(expected_msg))


### PR DESCRIPTION
### Problem

You can declare type-checked fields with an Exactly constraint on a specific type (so checking `type(x) == SomeType`), but you may want to just use e.g. anything that's a subclass of some base class or mixin.

### Solution

- Allow specifying a TypeConstraint in the tuple form of a field declaration for `datatype()`, e.g. `dataype([('val', Exactly(int))])`.

### Result

Datatype fields no longer just have to match field types exactly -- they can now just be restricted to e.g. any subclass of some given class or mixin (with e.g. `datatype([('optionable', SubclassesOf(Optionable))])`.