### PR TITLE
A utility to aggregate s3 access logs.

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -4,7 +4,7 @@
 # see/edit requirements.txt in this directory to change deps.
 python_requirements()
 
-# Only used by tests so we lift this library out of the requirements.txt
+# Only used by tests, so we lift this library out of the requirements.txt
 # file used to bootstrap pants itself.
 python_requirement_library(
   name='antlr-3.1.3',
@@ -14,6 +14,15 @@ python_requirement_library(
     # repository arg can be removed.
     python_requirement('antlr_python_runtime==3.1.3',
                        repository='http://www.antlr3.org/download/Python/')
+  ]
+)
+
+# Only used by a maintenance tool, so we lift this library out of the requirements.txt
+# file used to bootstrap pants itself.
+python_requirement_library(
+  name='s3logparse',
+  requirements=[
+    python_requirement('s3-log-parse==0.1.1')
   ]
 )
 

--- a/src/python/pants/util/BUILD
+++ b/src/python/pants/util/BUILD
@@ -118,6 +118,22 @@ python_library(
 )
 
 python_library(
+  name = 's3_log_aggregator',
+  sources = ['s3_log_aggregator.py'],
+  dependencies = [
+    '3rdparty/python:s3logparse'
+  ]
+)
+
+python_binary(
+  name = 's3_log_aggregator_bin',
+  entry_point = 'pants.util.s3_log_aggregator',
+  dependencies = [
+    ':s3_log_aggregator'
+  ]
+)
+
+python_library(
   name = 'socket',
   sources = ['socket.py']
 )

--- a/src/python/pants/util/s3_log_aggregator.py
+++ b/src/python/pants/util/s3_log_aggregator.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from s3logparse.s3logparse import parse_log_lines
+
+import os
+import sys
+from collections import defaultdict
+
+
+class S3LogAccumulator(object):
+  """Aggregates total downloaded bytes per file from S3 logs.
+
+  Helps us track which binaries our S3 bandwidth costs are being spent on.
+
+  To run, first download S3 access logs. For example, to download all logs for 4/2018,
+  you can use something like:
+
+  aws s3 sync s3://logs.pantsbuild.org/binaries/ /tmp/s3logs --exclude "*" --include "2018-04-*"
+
+  Then run this binary on the downloaded logs:
+
+  ./pants run src/python/pants/util/:s3_log_aggregator_bin -- /tmp/s3logs
+  """
+
+  def __init__(self):
+    self._file_to_size = defaultdict(int)
+    self._file_to_count = defaultdict(int)
+
+  def accumulate(self, logdir):
+    for filename in os.listdir(logdir):
+      with open(os.path.join(logdir, filename)) as fp:
+        for log_entry in parse_log_lines(fp.readlines()):
+          self._file_to_size[log_entry.s3_key] += log_entry.bytes_sent
+          self._file_to_count[log_entry.s3_key] += 1
+
+  def get_by_size(self):
+    return sorted([(path, self._file_to_count[path], size)
+                   for (path, size) in self._file_to_size.items()],
+                  key=lambda x: x[2], reverse=True)
+
+  def get_by_size_prettyprinted(self):
+    return [(path, count, self.prettyprint_bytes(size))
+            for (path, count, size) in self.get_by_size()]
+
+  @staticmethod
+  def prettyprint_bytes(x):
+    for unit in ['B', 'KB', 'MB', 'GB']:
+      if abs(x) < 1024.0:
+        return '{:3.1f}{}'.format(x, unit)
+      x /= 1024.0
+    return '{:.1f}TB'.format(x)
+
+
+if __name__ == '__main__':
+  accumulator = S3LogAccumulator()
+  for logdir in sys.argv[1:]:
+    accumulator.accumulate(logdir)
+
+  for path, count, total_bytes in accumulator.get_by_size_prettyprinted():
+    print('{} {} {}'.format(total_bytes, count, path))

--- a/src/python/pants/util/s3_log_aggregator.py
+++ b/src/python/pants/util/s3_log_aggregator.py
@@ -40,6 +40,7 @@ class S3LogAccumulator(object):
 
   ./pants run src/python/pants/util/:s3_log_aggregator_bin -- /tmp/s3logs
   """
+
   def __init__(self):
     self._path_to_measure = defaultdict(Measure)
     self._ip_to_measure = defaultdict(Measure)


### PR DESCRIPTION
Helps us track which binaries our S3 bandwidth costs are being spent on.

Currently produces:

```
936.9GB 3452 bin/clang/linux/x86_64/6.0.0/clang.tar.gz
785.9GB 3401 bin/gcc/linux/x86_64/7.3.0/gcc.tar.gz
537.2GB 6987 bin/go/linux/x86_64/1.7.3/go.tar.gz
292.0GB 6891 bin/protobuf/linux/x86_64/3.4.1/protoc
195.9GB 6981 bin/cmake/linux/x86_64/3.9.5/cmake.tar.gz
187.8GB 5029 bin/thrift/linux/x86_64/0.9.2/thrift
183.1GB 5553 bin/watchman/linux/x86_64/4.9.0-pants1/watchman
123.8GB 3322 bin/binutils/linux/x86_64/2.30/binutils.tar.gz
113.9GB 1359 bin/go/linux/x86_64/1.8.3/go.tar.gz
59.8GB 3454 bin/protoc/linux/x86_64/2.4.1/protoc
42.2GB 551 bin/go/mac/10.10/1.7.3/go.tar.gz
28.8GB 634 bin/thrift/linux/x86_64/0.10.0/thrift
19.8GB 1520 bin/node/linux/x86_64/v6.9.1/node.tar.gz
...
```