### PR TITLE
Repair PyPI user checking in release scripts.

### DIFF
--- a/src/python/pants/releases/BUILD
+++ b/src/python/pants/releases/BUILD
@@ -13,6 +13,7 @@ python_binary(
   name = 'packages',
   source = 'packages.py',
   dependencies = [
+    '3rdparty/python:beautifulsoup4',
     'src/python/pants/util:process_handler',
   ],
 )

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -62,7 +62,7 @@ class Package(object):
       for item
       in parser.find_all(html_node_type, class_=html_node_class)
     ]
-    return [owner.lower() for owner in owners]
+    return set(owner.lower() for owner in owners)
 
 
 core_packages = set([

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -11,9 +11,9 @@ import sys
 import urllib2
 from ConfigParser import ConfigParser
 
-from pants.util.process_handler import subprocess
-
 from bs4 import BeautifulSoup
+
+from pants.util.process_handler import subprocess
 
 
 COLOR_BLUE = "\x1b[34m"

--- a/src/python/pants/releases/packages.py
+++ b/src/python/pants/releases/packages.py
@@ -10,7 +10,10 @@ import os
 import sys
 import urllib2
 from ConfigParser import ConfigParser
+
 from pants.util.process_handler import subprocess
+
+from bs4 import BeautifulSoup
 
 
 COLOR_BLUE = "\x1b[34m"
@@ -47,18 +50,19 @@ class Package(object):
     j = json.load(f)
     return j["info"]["version"]
 
-  def owners(self):
+  def owners(self,
+             html_node_type='a',
+             html_node_class='sidebar-section__user-gravatar',
+             html_node_attr='aria-label'):
     url = "https://pypi.python.org/pypi/{}/{}".format(self.name, self.latest_version())
-    f = urllib2.urlopen(url)
-    return_next_line = False
-    for line in f.readlines():
-      line = line.decode("utf-8")
-      if return_next_line:
-        owners = line.strip().replace("<span>", "").replace("</span>", "").split(", ")
-        return set(owner.lower() for owner in owners)
-      elif "Package Index Owner:" in line:
-        return_next_line = True
-    raise ValueError("Didn't find package owners in HTML output from {}".format(url))
+    url_content = urllib2.urlopen(url).read()
+    parser = BeautifulSoup(url_content, 'html.parser')
+    owners = [
+      item.attrs[html_node_attr]
+      for item
+      in parser.find_all(html_node_type, class_=html_node_class)
+    ]
+    return [owner.lower() for owner in owners]
 
 
 core_packages = set([


### PR DESCRIPTION
PyPI recently switched over to the new "Warehouse" implementation which broke our release scripts that currently rely on HTML parsing.

before:

```
[omerta pants (master)]$ git rev-parse HEAD; ./build-support/bin/release.sh -o
6a1ac80462820b9746fed311ff868f02e615683b
Owners of pantsbuild.pants:
Traceback (most recent call last):
  File "/Users/kwilson/dev/pants/.pants.d/run/py/CPython-2.7.14/d5e26e10a466d987cfaead3ea238dd3959d1cc92/.bootstrap/_pex/pex.py", line 367, in execute
    self._wrap_coverage(self._wrap_profiling, self._execute)
  File "/Users/kwilson/dev/pants/.pants.d/run/py/CPython-2.7.14/d5e26e10a466d987cfaead3ea238dd3959d1cc92/.bootstrap/_pex/pex.py", line 293, in _wrap_coverage
    runner(*args)
  File "/Users/kwilson/dev/pants/.pants.d/run/py/CPython-2.7.14/d5e26e10a466d987cfaead3ea238dd3959d1cc92/.bootstrap/_pex/pex.py", line 325, in _wrap_profiling
    runner(*args)
  File "/Users/kwilson/dev/pants/.pants.d/run/py/CPython-2.7.14/d5e26e10a466d987cfaead3ea238dd3959d1cc92/.bootstrap/_pex/pex.py", line 410, in _execute
    return self.execute_entry(self._pex_info.entry_point)
  File "/Users/kwilson/dev/pants/.pants.d/run/py/CPython-2.7.14/d5e26e10a466d987cfaead3ea238dd3959d1cc92/.bootstrap/_pex/pex.py", line 468, in execute_entry
    return runner(entry_point)
  File "/Users/kwilson/dev/pants/.pants.d/run/py/CPython-2.7.14/d5e26e10a466d987cfaead3ea238dd3959d1cc92/.bootstrap/_pex/pex.py", line 473, in execute_module
    runpy.run_module(module_name, run_name='__main__')
  File "/opt/twitter_mde/package/eepython27/2b9f44c3673ea5b18e3c12bf36c35ef93e3d03a547f10d19f45d7097b09a85a1/lib/python2.7/runpy.py", line 192, in run_module
    fname, loader, pkg_name)
  File "/opt/twitter_mde/package/eepython27/2b9f44c3673ea5b18e3c12bf36c35ef93e3d03a547f10d19f45d7097b09a85a1/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/kwilson/dev/pants/.pants.d/pyprep/sources/11e7e1652cb2d9176b129ad84bd11143d8be921b/pants/releases/packages.py", line 132, in <module>
    for owner in sorted(package.owners()):
  File "/Users/kwilson/dev/pants/.pants.d/pyprep/sources/11e7e1652cb2d9176b129ad84bd11143d8be921b/pants/releases/packages.py", line 61, in owners
    raise ValueError("Didn't find package owners in HTML output from {}".format(url))
ValueError: Didn't find package owners in HTML output from https://pypi.python.org/pypi/pantsbuild.pants/1.5.0

FAILURE: /opt/twitter_mde/package/eepython27/2b9f44c3673ea5b18e3c12bf36c35ef93e3d03a547f10d19f45d7097b09a85a1/bin/python2.7 pants.releases.packages list-owners ... exited non-zero (1)


FAILURE
```

after:
```
[omerta pants (kwlzn/pypi_user_checking)]$ ./build-support/bin/release.sh -o
Owners of pantsbuild.pants:
benjyw
illicitonion
ity
john.sirois
kwlzn
mateor
stuhood
wisechengyi
...
```