### PR TITLE
[pytest runner] re-add --options flag as a shlexed list of strings

### DIFF
--- a/src/python/pants/backend/python/tasks/pytest_run.py
+++ b/src/python/pants/backend/python/tasks/pytest_run.py
@@ -35,6 +35,7 @@ from pants.util.dirutil import mergetree, safe_mkdir, safe_mkdir_for
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.objects import datatype
 from pants.util.process_handler import SubprocessProcessHandler
+from pants.util.strutil import safe_shlex_split
 from pants.util.xml_parser import XmlParser
 
 
@@ -109,7 +110,7 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
                   "emitted to that file (prefix). Note that tests may run in a different cwd, so "
                   "it's best to use an absolute path to make it easy to find the subprocess "
                   "profiles later.")
-
+    register('--options', type=list, fingerprint=True, help='Pass these options to pytest.')
     register('--coverage', fingerprint=True,
              help='Emit coverage information for specified packages or directories (absolute or '
                   'relative to the build root).  The special value "auto" indicates that Pants '
@@ -683,6 +684,9 @@ class PytestRun(PartitionedTestRunnerTaskMixin, Task):
       if self.get_options().colors:
         args.extend(['--color', 'yes'])
 
+      if self.get_options().options:
+        for opt in self.get_options().options:
+          args.extend(safe_shlex_split(opt))
       args.extend(self.get_passthru_args())
 
       args.extend(test_args)

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run.py
@@ -777,3 +777,21 @@ class PytestTest(PytestTestBase):
       assert_test_not_run('test_three')
       assert_test_run('test_four')
       assert_test_not_run('test_five')
+
+  def test_passthrough_added_after_options(self):
+    with self.marking_tests() as (target, assert_test_run, assert_test_not_run):
+      self.run_tests([target], '-m', 'purple or red', options=['-k', 'two'])
+      assert_test_not_run('test_one')
+      assert_test_run('test_two')
+      assert_test_not_run('test_three')
+      assert_test_not_run('test_four')
+      assert_test_not_run('test_five')
+
+  def test_options_shlexed(self):
+    with self.marking_tests() as (target, assert_test_run, assert_test_not_run):
+      self.run_tests([target], options=["-m 'purple or red'"])
+      assert_test_not_run('test_one')
+      assert_test_run('test_two')
+      assert_test_not_run('test_three')
+      assert_test_run('test_four')
+      assert_test_not_run('test_five')


### PR DESCRIPTION
### Problem

`--options` was removed from pytest when cleaning up some issues with passthrough args (https://github.com/pantsbuild/pants/pull/5594/). This made it more difficult to pass arbitrary args for pytest runs for automated use cases or to have options set in `pants.ini`. It makes it more difficult because now those options must be collated and appended to the end of the command in all cases. If the command construction code splits up how different flags are populated, it can be difficult to ensure that a particular flag's contents always ends up at the end.

### Solution

Bring back the options flag, but only shlex it and not the passthrough args.
