### PR TITLE
Improve support for intrinsic tasks

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -9,8 +9,7 @@ from binascii import hexlify
 from os.path import join
 
 from pants.base.project_tree import Dir, File
-from pants.engine.rules import RootRule, rule
-from pants.engine.selectors import Select
+from pants.engine.rules import RootRule
 from pants.util.objects import Collection, datatype
 
 
@@ -102,20 +101,8 @@ EMPTY_SNAPSHOT = Snapshot(
 )
 
 
-@rule(Snapshot, [Select(PathGlobs)])
-def snapshot_noop(*args):
-  raise Exception('This task is replaced intrinsically, and should never run.')
-
-
-@rule(FilesContent, [Select(Snapshot)])
-def files_content_noop(*args):
-  raise Exception('This task is replaced intrinsically, and should never run.')
-
-
 def create_fs_rules():
   """Creates rules that consume the intrinsic filesystem types."""
   return [
-    files_content_noop,
-    snapshot_noop,
     RootRule(PathGlobs),
   ]

--- a/src/python/pants/engine/isolated_process.py
+++ b/src/python/pants/engine/isolated_process.py
@@ -8,8 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import logging
 
 from pants.engine.fs import EMPTY_SNAPSHOT
-from pants.engine.rules import RootRule, rule
-from pants.engine.selectors import Select
+from pants.engine.rules import RootRule
 from pants.util.objects import datatype
 
 
@@ -61,9 +60,6 @@ class ExecuteProcessResult(datatype(['stdout', 'stderr', 'exit_code'])):
 
 def create_process_rules():
   """Intrinsically replaced on the rust side."""
-  return [execute_process_noop, RootRule(ExecuteProcessRequest)]
-
-
-@rule(ExecuteProcessResult, [Select(ExecuteProcessRequest)])
-def execute_process_noop(*args):
-  raise Exception('This task is replaced intrinsically, and should never run.')
+  return [
+      RootRule(ExecuteProcessRequest),
+    ]

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -216,35 +216,37 @@ pub extern "C" fn scheduler_create(
   let ignore_patterns = ignore_patterns_buf
     .to_strings()
     .unwrap_or_else(|e| panic!("Failed to decode ignore patterns as UTF8: {:?}", e));
-  let tasks = with_tasks(tasks_ptr, |tasks| tasks.clone());
+  let types = Types {
+    construct_snapshot: construct_snapshot,
+    construct_file_content: construct_file_content,
+    construct_files_content: construct_files_content,
+    construct_path_stat: construct_path_stat,
+    construct_dir: construct_dir,
+    construct_file: construct_file,
+    construct_link: construct_link,
+    construct_process_result: construct_process_result,
+    address: type_address,
+    has_products: type_has_products,
+    has_variants: type_has_variants,
+    path_globs: type_path_globs,
+    snapshot: type_snapshot,
+    files_content: type_files_content,
+    dir: type_dir,
+    file: type_file,
+    link: type_link,
+    process_request: type_process_request,
+    process_result: type_process_result,
+    generator: type_generator,
+    string: type_string,
+    bytes: type_bytes,
+  };
+  let mut tasks = with_tasks(tasks_ptr, |tasks| tasks.clone());
+  tasks.intrinsics_set(&types);
   // Allocate on the heap via `Box` and return a raw pointer to the boxed value.
   Box::into_raw(Box::new(Scheduler::new(Core::new(
     root_type_ids.clone(),
     tasks,
-    Types {
-      construct_snapshot: construct_snapshot,
-      construct_file_content: construct_file_content,
-      construct_files_content: construct_files_content,
-      construct_path_stat: construct_path_stat,
-      construct_dir: construct_dir,
-      construct_file: construct_file,
-      construct_link: construct_link,
-      construct_process_result: construct_process_result,
-      address: type_address,
-      has_products: type_has_products,
-      has_variants: type_has_variants,
-      path_globs: type_path_globs,
-      snapshot: type_snapshot,
-      files_content: type_files_content,
-      dir: type_dir,
-      file: type_file,
-      link: type_link,
-      process_request: type_process_request,
-      process_result: type_process_result,
-      generator: type_generator,
-      string: type_string,
-      bytes: type_bytes,
-    },
+    types,
     build_root_buf.to_os_string().as_ref(),
     ignore_patterns,
     work_dir_buf.to_os_string().as_ref(),

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -616,11 +616,11 @@ impl<'t> GraphMaker<'t> {
     subject_type: &TypeId,
     product_type: &TypeConstraint,
   ) -> Option<RootEntry> {
-    self
-      .tasks
-      .gen_tasks(product_type)
-      .and_then(|tasks| if !tasks.is_empty() { Some(tasks) } else { None })
-      .map(|_| RootEntry {
+    let candidates = rhs(&self.tasks, subject_type.clone(), product_type);
+    if candidates.is_empty() {
+      None
+    } else {
+      Some(RootEntry {
         subject_type: subject_type.clone(),
         clause: vec![
           Selector::Select(Select {
@@ -630,6 +630,7 @@ impl<'t> GraphMaker<'t> {
         ],
         gets: vec![],
       })
+    }
   }
 }
 

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -9,7 +9,7 @@ use std::io;
 use core::{Function, Key, TypeConstraint, TypeId, Value, ANY_TYPE};
 use externs;
 use selectors::{Get, Select, SelectDependencies, Selector};
-use tasks::{Task, Tasks};
+use tasks::{Intrinsic, Task, Tasks};
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug)]
 pub enum Entry {
@@ -29,7 +29,7 @@ pub enum Entry {
   Unreachable {
     // NB: unreachable is an error type, it might be better to name it error, but currently
     //     unreachable is the only error entry type.
-    rule: Task,
+    task_rule: Task,
     reason: Diagnostic,
   },
 }
@@ -63,9 +63,15 @@ impl From<RootEntry> for Entry {
 }
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug)]
+pub enum Rule {
+  Intrinsic(Intrinsic),
+  Task(Task),
+}
+
+#[derive(Eq, Hash, PartialEq, Clone, Debug)]
 pub struct InnerEntry {
   subject_type: TypeId,
-  rule: Task,
+  rule: Rule,
 }
 
 impl From<InnerEntry> for Entry {
@@ -75,22 +81,15 @@ impl From<InnerEntry> for Entry {
 }
 
 impl Entry {
-  fn new_inner(subject_type: TypeId, rule: &Task) -> Entry {
-    Entry::InnerEntry(InnerEntry {
-      subject_type: subject_type,
-      rule: rule.clone(),
-    })
-  }
-
   fn new_subject_is_product(subject_type: TypeId) -> Entry {
     Entry::SubjectIsProduct {
       subject_type: subject_type,
     }
   }
 
-  fn new_unreachable(rule: &Task) -> Entry {
+  fn new_unreachable(task_rule: &Task) -> Entry {
     Entry::Unreachable {
-      rule: rule.clone(),
+      task_rule: task_rule.clone(),
       reason: Diagnostic {
         subject_type: ANY_TYPE,
         reason: "".to_string(),
@@ -134,11 +133,14 @@ impl Entry {
     }
   }
 
-  fn rule(&self) -> &Task {
+  fn task_rule(&self) -> Option<&Task> {
     match self {
-      &Entry::InnerEntry(ref inner) => &inner.rule,
-      &Entry::Unreachable { ref rule, .. } => rule,
-      _ => panic!("no rule"),
+      &Entry::InnerEntry(InnerEntry {
+        rule: Rule::Task(ref task_rule),
+        ..
+      }) => Some(task_rule),
+      &Entry::Unreachable { ref task_rule, .. } => Some(task_rule),
+      _ => None,
     }
   }
 }
@@ -273,11 +275,18 @@ impl<'t> GraphMaker<'t> {
   ) {
     let rules_in_graph: HashSet<_> = full_dependency_edges
       .keys()
-      .map(|f| f.rule.clone())
+      .filter_map(|entry| match entry {
+        &InnerEntry {
+          rule: Rule::Task(ref task_rule),
+          ..
+        } => Some(task_rule.clone()),
+        _ => None,
+      })
       .collect();
     let unfulfillable_discovered_during_construction: HashSet<_> = full_unfulfillable_rules
       .keys()
-      .map(|f| f.rule().clone())
+      .filter_map(|f| f.task_rule())
+      .cloned()
       .collect();
     let unreachable_rules: HashSet<_> = self
       .tasks
@@ -309,12 +318,13 @@ impl<'t> GraphMaker<'t> {
     let mut rules_to_traverse: VecDeque<Entry> = VecDeque::new();
     rules_to_traverse.push_back(Entry::from(beginning_rule));
     while let Some(entry) = rules_to_traverse.pop_front() {
+      // TODO: Drop both of these methods, and just noop for irrelevant entries in the match.
       if entry.can_be_dependency() && !entry.can_have_dependencies() {
         continue;
       }
       if !entry.can_have_dependencies() {
         panic!(
-          "Cannot determine dependencies of entry not of type CanHaveDependencies: {:?}",
+          "Cannot determine deps of entry that can be neither a dependency or dependent: {:?}",
           entry
         )
       }
@@ -329,11 +339,12 @@ impl<'t> GraphMaker<'t> {
       let mut was_unfulfillable = false;
       match entry {
         Entry::InnerEntry(InnerEntry {
-          rule: Task {
-            ref clause,
-            ref gets,
-            ..
-          },
+          rule:
+            Rule::Task(Task {
+              ref clause,
+              ref gets,
+              ..
+            }),
           ..
         })
         | Entry::Root(RootEntry {
@@ -481,8 +492,37 @@ impl<'t> GraphMaker<'t> {
             }
           }
         }
+        Entry::InnerEntry(InnerEntry {
+          rule: Rule::Intrinsic(Intrinsic { ref input, .. }),
+          ref subject_type,
+        }) => {
+          let rules_or_literals_for_selector = rhs(&self.tasks, subject_type.clone(), input);
+          if rules_or_literals_for_selector.is_empty() {
+            mark_unfulfillable(
+              &mut unfulfillable_rules,
+              &entry,
+              subject_type.clone(),
+              format!(
+                "no rule was available to compute {} for {}",
+                type_constraint_str(input.clone()),
+                type_str(subject_type.clone())
+              ),
+            );
+            was_unfulfillable = true;
+          } else {
+            add_rules_to_graph(
+              &mut rules_to_traverse,
+              &mut rule_dependency_edges,
+              &mut unfulfillable_rules,
+              &mut root_rule_dependency_edges,
+              &entry,
+              SelectKey::JustSelect(Select::without_variant(*input)),
+              rules_or_literals_for_selector,
+            );
+          }
+        }
         _ => panic!(
-          "Entry type that cannot dependencies was not filtered out {:?}",
+          "Entry type that cannot have dependencies was not filtered out {:?}",
           entry
         ),
       }
@@ -682,10 +722,19 @@ fn get_str(get: &Get) -> String {
 
 fn entry_str(entry: &Entry) -> String {
   match entry {
-    &Entry::InnerEntry(ref inner) => format!(
-      "{} of {}",
-      task_display(&inner.rule),
-      type_str(inner.subject_type)
+    &Entry::InnerEntry(InnerEntry {
+      rule: Rule::Task(ref task_rule),
+      subject_type,
+    }) => format!("{} of {}", task_display(task_rule), type_str(subject_type)),
+    &Entry::InnerEntry(InnerEntry {
+      rule: Rule::Intrinsic(ref intrinsic),
+      subject_type,
+    }) => format!(
+      "({}, ({},), {:?}) for {}",
+      type_constraint_str(intrinsic.product),
+      type_constraint_str(intrinsic.input),
+      intrinsic.kind,
+      type_str(subject_type)
     ),
     &Entry::Root(ref root) => format!(
       "{} for {}",
@@ -706,9 +755,9 @@ fn entry_str(entry: &Entry) -> String {
       type_constraint_str(product)
     ),
     &Entry::Unreachable {
-      ref rule,
+      ref task_rule,
       ref reason,
-    } => format!("Unreachable({}, {:?})", task_display(rule), reason),
+    } => format!("Unreachable({}, {:?})", task_display(task_rule), reason),
   }
 }
 
@@ -745,9 +794,7 @@ fn task_display(task: &Task) -> String {
 
 impl RuleGraph {
   pub fn new(tasks: &Tasks, root_subject_types: Vec<TypeId>) -> RuleGraph {
-    let maker = GraphMaker::new(tasks, root_subject_types);
-
-    maker.full_graph()
+    GraphMaker::new(tasks, root_subject_types).full_graph()
   }
 
   pub fn find_root_edges(&self, subject_type: TypeId, selector: Selector) -> Option<RuleEdges> {
@@ -760,9 +807,9 @@ impl RuleGraph {
     self.root_dependencies.get(&root).map(|e| e.clone())
   }
 
-  pub fn task_for_inner(&self, entry: &Entry) -> Task {
+  pub fn rule_for_inner<'a>(&self, entry: &'a Entry) -> &'a Rule {
     if let &Entry::InnerEntry(ref inner) = entry {
-      inner.rule.clone()
+      &inner.rule
     } else {
       panic!("not an inner entry! {:?}", entry)
     }
@@ -784,31 +831,34 @@ impl RuleGraph {
   }
 
   pub fn validate(&self) -> Result<(), String> {
-    if self.has_errors() {
-      Result::Err(self.build_error_msg())
-    } else {
-      Result::Ok(())
-    }
-  }
-
-  fn build_error_msg(&self) -> String {
     // TODO the rule display is really unfriendly right now. Next up should be to improve it.
     let mut collated_errors: HashMap<Task, HashMap<String, HashSet<TypeId>>> = HashMap::new();
 
     let used_rules: HashSet<_> = self
       .rule_dependency_edges
       .keys()
-      .map(|entry| &entry.rule)
+      .filter_map(|entry| match entry {
+        &InnerEntry {
+          rule: Rule::Task(ref task_rule),
+          ..
+        } => Some(task_rule),
+        _ => None,
+      })
       .collect();
+
     for (rule_entry, diagnostics) in &self.unfulfillable_rules {
       match rule_entry {
-        &Entry::InnerEntry(InnerEntry { ref rule, .. }) | &Entry::Unreachable { ref rule, .. } => {
-          if used_rules.contains(&rule) {
+        &Entry::InnerEntry(InnerEntry {
+          rule: Rule::Task(ref task_rule),
+          ..
+        })
+        | &Entry::Unreachable { ref task_rule, .. } => {
+          if used_rules.contains(&task_rule) {
             continue;
           }
           for d in diagnostics {
             let msg_to_type = collated_errors
-              .entry(rule.clone())
+              .entry(task_rule.clone())
               .or_insert(HashMap::new());
             let subject_set = msg_to_type
               .entry(d.reason.clone())
@@ -820,31 +870,18 @@ impl RuleGraph {
                 // So we ignore entries that do not have rules.
       }
     }
+
+    if collated_errors.is_empty() {
+      return Ok(());
+    }
+
     let mut msgs: Vec<String> = collated_errors
       .into_iter()
       .map(|(ref rule, ref subject_types_by_reasons)| format_msgs(rule, subject_types_by_reasons))
       .collect();
     msgs.sort();
 
-    format!("Rules with errors: {}\n  {}", msgs.len(), msgs.join("\n  ")).to_string()
-  }
-
-  fn has_errors(&self) -> bool {
-    let used_rules: HashSet<_> = self
-      .rule_dependency_edges
-      .keys()
-      .map(|entry| &entry.rule)
-      .collect();
-    self
-      .unfulfillable_rules
-      .iter()
-      .any(|(&ref entry, &ref diagnostics)| match entry {
-        &Entry::InnerEntry(ref inner) => {
-          !used_rules.contains(&inner.rule) && !diagnostics.is_empty()
-        }
-        &Entry::Unreachable { .. } => true,
-        _ => false,
-      })
+    Err(format!("Rules with errors: {}\n  {}", msgs.len(), msgs.join("\n  ")).to_string())
   }
 
   pub fn visualize(&self, f: &mut io::Write) -> io::Result<()> {
@@ -1033,13 +1070,22 @@ fn rhs(tasks: &Tasks, subject_type: TypeId, product_type: &TypeConstraint) -> En
   } else if let Some(&(ref key, _)) = tasks.gen_singleton(product_type) {
     vec![Entry::new_singleton(key.clone(), product_type.clone())]
   } else {
-    match tasks.gen_tasks(product_type) {
-      Some(ref matching_tasks) => matching_tasks
-        .iter()
-        .map(|t| Entry::new_inner(subject_type, t))
-        .collect(),
-      None => vec![],
+    let mut entries = Vec::new();
+    if let Some(matching_intrinsic) = tasks.gen_intrinsic(product_type) {
+      entries.push(Entry::InnerEntry(InnerEntry {
+        subject_type: subject_type,
+        rule: Rule::Intrinsic(matching_intrinsic.clone()),
+      }));
     }
+    if let Some(matching_tasks) = tasks.gen_tasks(product_type) {
+      entries.extend(matching_tasks.iter().map(|task_rule| {
+        Entry::InnerEntry(InnerEntry {
+          subject_type: subject_type,
+          rule: Rule::Task(task_rule.clone()),
+        })
+      }));
+    }
+    entries
   }
 }
 

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -90,6 +90,11 @@ impl Tasks {
         product: types.files_content,
         input: types.snapshot,
       },
+      Intrinsic {
+        kind: IntrinsicKind::ProcessExecution,
+        product: types.process_result,
+        input: types.process_request,
+      },
     ].into_iter()
       .map(|i| (i.product.clone(), i))
       .collect();
@@ -205,4 +210,5 @@ pub struct Intrinsic {
 pub enum IntrinsicKind {
   Snapshot,
   FilesContent,
+  ProcessExecution,
 }

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -196,9 +196,6 @@ impl Tasks {
   }
 }
 
-// TODO: This definition of `Intrinsic` is broken. Like `Tasks`, Intrinsics may have zero or more
-// input type requirements. As an example, `Snapshot` should have zero inputs, but currently it
-// "depends on" the subgraph that instantiates its PathGlobs object.
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
 pub struct Intrinsic {
   pub kind: IntrinsicKind,

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -58,6 +58,7 @@ impl Tasks {
       .singletons
       .keys()
       .chain(self.tasks.keys())
+      .chain(self.intrinsics.keys())
       .cloned()
       .collect::<HashSet<_>>()
   }

--- a/tests/python/pants_test/engine/test_isolated_process.py
+++ b/tests/python/pants_test/engine/test_isolated_process.py
@@ -77,12 +77,7 @@ def cat_files_process_request_input_snapshot(cat_exe_req):
 
 @rule(Concatted, [Select(CatExecutionRequest)])
 def cat_files_process_result_concatted(cat_exe_req):
-  # FIXME(cosmicexplorer): we should only have to run Get once here. this: yield
-  # Get(ExecuteProcessResult, CatExecutionRequest, cat_exe_req) fails because
-  # ExecuteProcessRequest is a RootRule (which shouldn't be true), but there's
-  # probably some work required in isolated_process.py to fix this (see #5718).
-  cat_proc_req = yield Get(ExecuteProcessRequest, CatExecutionRequest, cat_exe_req)
-  cat_process_result = yield Get(ExecuteProcessResult, ExecuteProcessRequest, cat_proc_req)
+  cat_process_result = yield Get(ExecuteProcessResult, CatExecutionRequest, cat_exe_req)
   yield Concatted(str(cat_process_result.stdout))
 
 


### PR DESCRIPTION
### Problem

#5718 describes a case which resulted in an attempt to lift the wrong input type for a process execution, and #5784 demonstrates a case where intrinsic types can't be used as root subject types.

Both of these are caused by a fragile/hacky implementation of intrinsics that the `RuleGraph` was (mostly) not aware of.

### Solution

Made `Intrinsic` a `RuleGraph::Entry` type, and then cleaned up the product requests made by intrinsics so that they will always select the input type before executing.

### Result

Fixes #5718, unblocks testing of #5784, and lays cleaner groundwork for addition of further `Intrinsic` tasks.