### PR TITLE
Add configurable timeouts for reading/writing to remote cache

### DIFF
--- a/src/python/pants/cache/cache_setup.py
+++ b/src/python/pants/cache/cache_setup.py
@@ -74,6 +74,10 @@ class CacheSetup(Subsystem):
                   'a RESTful cache, a path of a filesystem cache, or a pipe-separated list of '
                   'alternate caches to choose from. This list is also used as input to '
                   'the resolver. When resolver is \'none\' list is used as is.')
+    register('--read-timeout', advanced=True, type=float, default=4.0,
+             help='The read timeout for any remote caches in use, in seconds.')
+    register('--write-timeout', advanced=True, type=float, default=4.0,
+             help='The write timeout for any remote caches in use, in seconds.')
     register('--compression-level', advanced=True, type=int, default=5,
              help='The gzip compression level (0-9) for created artifacts.')
     register('--dereference-symlinks', type=bool, default=True, fingerprint=True,
@@ -288,7 +292,13 @@ class CacheFactory(object):
           ['{}/{}'.format(url.rstrip('/'), self._cache_dirname) for url in urls]
         )
         local_cache = local_cache or TempLocalArtifactCache(artifact_root, compression)
-        return RESTfulArtifactCache(artifact_root, best_url_selector, local_cache)
+        return RESTfulArtifactCache(
+          artifact_root,
+          best_url_selector,
+          local_cache,
+          read_timeout=self._options.read_timeout,
+          write_timeout=self._options.write_timeout,
+        )
 
     local_cache = create_local_cache(spec.local) if spec.local else None
     remote_cache = create_remote_cache(spec.remote, local_cache) if spec.remote else None

--- a/src/python/pants/cache/restful_artifact_cache.py
+++ b/src/python/pants/cache/restful_artifact_cache.py
@@ -38,7 +38,7 @@ class RESTfulArtifactCache(ArtifactCache):
 
   READ_SIZE_BYTES = 4 * 1024 * 1024
 
-  def __init__(self, artifact_root, best_url_selector, local):
+  def __init__(self, artifact_root, best_url_selector, local, read_timeout=4.0, write_timeout=4.0):
     """
     :param string artifact_root: The path under which cacheable products will be read/written.
     :param BestUrlSelector best_url_selector: Url selector that supports fail-over. Each returned
@@ -49,7 +49,8 @@ class RESTfulArtifactCache(ArtifactCache):
     super(RESTfulArtifactCache, self).__init__(artifact_root)
 
     self.best_url_selector = best_url_selector
-    self._timeout_secs = 4.0
+    self._read_timeout_secs = read_timeout
+    self._write_timeout_secs = write_timeout
     self._localcache = local
 
   def try_insert(self, cache_key, paths):
@@ -77,7 +78,7 @@ class RESTfulArtifactCache(ArtifactCache):
           target=_log_if_no_response,
           args=(
             60,
-            "Still downloading artifacts (either they're very large or the connection to the cache is slow)",
+            "\nStill downloading artifacts (either they're very large or the connection to the cache is slow)",
             queue.get,
           )
         ).start()
@@ -107,13 +108,13 @@ class RESTfulArtifactCache(ArtifactCache):
       logger.debug('Sending {0} request to {1}'.format(method, url))
       try:
         if 'PUT' == method:
-          response = session.put(url, data=body, timeout=self._timeout_secs)
+          response = session.put(url, data=body, timeout=self._write_timeout_secs)
         elif 'GET' == method:
-          response = session.get(url, timeout=self._timeout_secs, stream=True)
+          response = session.get(url, timeout=self._read_timeout_secs, stream=True)
         elif 'HEAD' == method:
-          response = session.head(url, timeout=self._timeout_secs)
+          response = session.head(url, timeout=self._read_timeout_secs)
         elif 'DELETE' == method:
-          response = session.delete(url, timeout=self._timeout_secs)
+          response = session.delete(url, timeout=self._write_timeout_secs)
         else:
           raise ValueError('Unknown request method {0}'.format(method))
       except RequestException as e:


### PR DESCRIPTION
### Problem

On busy networks or with sufficiently high concurrency and large artifacts, write timeouts were possible at the (hardcoded) 4 seconds.

### Solution

Differentiate between reads and writes, and make both artifact cache timeouts configurable.