### PR TITLE
Skip commit hooks during publishing

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -342,6 +342,9 @@ restrict_push_urls: [
     'git@github.com:pantsbuild/pants.git',
     'https://github.com/pantsbuild/pants.git'
   ]
+# The commithooks on this repository cause a deadlock while acquiring the workspace lock
+# if a commit is made from within pants: skip them.
+verify_commit: False
 
 
 [python-setup]

--- a/src/python/pants/scm/git.py
+++ b/src/python/pants/scm/git.py
@@ -237,8 +237,11 @@ class Git(Scm):
                      raise_type=Scm.LocalException)
     self.push('refs/tags/' + name)
 
-  def commit(self, message):
-    self._check_call(['commit', '--all', '--message=' + message], raise_type=Scm.LocalException)
+  def commit(self, message, verify=True):
+    cmd = ['commit', '--all', '--message=' + message]
+    if not verify:
+      cmd.append('--no-verify')
+    self._check_call(cmd, raise_type=Scm.LocalException)
 
   def add(self, *paths):
     self._check_call(['add'] + list(paths), raise_type=Scm.LocalException)

--- a/src/python/pants/scm/scm.py
+++ b/src/python/pants/scm/scm.py
@@ -133,7 +133,7 @@ class Scm(AbstractClass):
     """
 
   @abstractmethod
-  def commit(self, message):
+  def commit(self, message, verify=True):
     """Commits all the changes for tracked files in the local workspace.
 
     Subclasses should raise LocalException if there is a problem making the commit.

--- a/src/python/pants/task/scm_publish_mixin.py
+++ b/src/python/pants/task/scm_publish_mixin.py
@@ -158,7 +158,7 @@ class ScmPublishMixin(object):
              help='Allow pushes only from one of these branches.')
     register('--restrict-push-urls', advanced=True, type=list,
              help='Allow pushes to only one of these urls.')
-    register('--verify-commit', advanced=True, type=bool, default=False,
+    register('--verify-commit', advanced=True, type=bool, default=True,
              help='Whether or not to "verify" commits made using SCM publishing. For git, this '
                   'means running commit hooks.')
 

--- a/src/python/pants/task/scm_publish_mixin.py
+++ b/src/python/pants/task/scm_publish_mixin.py
@@ -205,7 +205,8 @@ class ScmPublishMixin(object):
   def commit_pushdb(self, coordinates, postscript=None):
     """Commit changes to the pushdb with a message containing the provided coordinates."""
     self.scm.commit('pants build committing publish data for push of {coordinates}'
-                    '{postscript}'.format(coordinates=coordinates, postscript=postscript or ''))
+                    '{postscript}'.format(coordinates=coordinates, postscript=postscript or ''),
+                    verify=False)
 
   def publish_pushdb_changes_to_remote_scm(self, pushdb_file, coordinate, tag_name, tag_message,
                                            postscript=None):

--- a/src/python/pants/task/scm_publish_mixin.py
+++ b/src/python/pants/task/scm_publish_mixin.py
@@ -158,6 +158,9 @@ class ScmPublishMixin(object):
              help='Allow pushes only from one of these branches.')
     register('--restrict-push-urls', advanced=True, type=list,
              help='Allow pushes to only one of these urls.')
+    register('--verify-commit', advanced=True, type=bool, default=False,
+             help='Whether or not to "verify" commits made using SCM publishing. For git, this '
+                  'means running commit hooks.')
 
   @property
   def restrict_push_branches(self):
@@ -206,7 +209,7 @@ class ScmPublishMixin(object):
     """Commit changes to the pushdb with a message containing the provided coordinates."""
     self.scm.commit('pants build committing publish data for push of {coordinates}'
                     '{postscript}'.format(coordinates=coordinates, postscript=postscript or ''),
-                    verify=False)
+                    verify=self.get_options().verify_commit)
 
   def publish_pushdb_changes_to_remote_scm(self, pushdb_file, coordinate, tag_name, tag_message,
                                            postscript=None):


### PR DESCRIPTION
### Problem

In the pants repo, commit-hooks cause pants to deadlock on itself by linting and then failing to acquire the pantsbuild workdir lock.

### Solution

Add an option to skip commit hooks during publishing.