### PR TITLE
Fix a broken 3rdparty example.

### DIFF
--- a/3rdparty/jvm/com/google/auto/value/BUILD
+++ b/3rdparty/jvm/com/google/auto/value/BUILD
@@ -1,6 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# DOCSTART: This target is included in documentation.
 jar_library(
   jars=[
     jar(org='com.google.auto.value', name='auto-value', rev='1.1'),
@@ -8,3 +9,4 @@ jar_library(
   # Is used as an annotation processor.
   scope='compile',
 )
+# DOCEND

--- a/examples/src/java/org/pantsbuild/example/3rdparty_jvm.md
+++ b/examples/src/java/org/pantsbuild/example/3rdparty_jvm.md
@@ -21,7 +21,7 @@ may make sense to organize them in multiple subdirectories, say by category or b
 In the appropriate `BUILD` file, you create a <a pantsref="bdict_jar_library">`jar_library`</a>
 referencing the <a pantsref="bdict_jar">`jar`</a>s you want:
 
-!inc[start-at=junit&end-before=scalatest](../../../../../../3rdparty/BUILD)
+!inc[start-after=DOCSTART&end-before=DOCEND](../../../../../../3rdparty/jvm/com/google/auto/value/BUILD)
 
 Here, the <a pantsref="bdict_jar_library">`jar_library`</a>'s name
 defines a target address that other build targets can refer to. The
@@ -37,12 +37,13 @@ statements in your Java code.
 
 For example, your `BUILD` file might have
 
-!inc[start-after=junit_tests&end-before=src/java](../../../../../tests/java/org/pantsbuild/example/hello/greet/BUILD)
+!inc[start-after=DOCSTART&end-before=DOCEND](../../../../../src/java/org/pantsbuild/example/autovalue/BUILD)
 
 And your Java code might have:
 
     :::java
-    import org.junit.Test;
+    import com.google.auto.value.AutoValue;
+
 
 "Round Trip" Dependencies
 -------------------------

--- a/examples/src/java/org/pantsbuild/example/autovalue/BUILD
+++ b/examples/src/java/org/pantsbuild/example/autovalue/BUILD
@@ -8,9 +8,10 @@ jvm_binary(
   ],
 )
 
+# DOCSTART: This target is included in documentation.
 java_library(name='autovalue-lib',
-  sources = globs('*'),
   dependencies = [
     '3rdparty/jvm/com/google/auto/value',
   ],
 )
+# DOCEND


### PR DESCRIPTION
Fix an example that was using a broken include, and use explicit comments to ensure it doesn't break again.