### PR TITLE
Allow arbitrary directories to be Snapshotted

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -49,6 +49,10 @@ class PathGlobs(datatype(['include', 'exclude'])):
                      tuple(join(relative_to, f) for f in exclude))
 
 
+class PathGlobsAndRoot(datatype([('path_globs', PathGlobs), ('root', str)])):
+  pass
+
+
 class DirectoryDigest(datatype([('fingerprint', str), ('serialized_bytes_length', int)])):
   """A DirectoryDigest is an opaque handle to a set of files known about by the engine.
 

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -221,6 +221,8 @@ void graph_trace(Scheduler*, ExecutionRequest*, char*);
 
 PyResult  execution_add_root_select(Scheduler*, ExecutionRequest*, Key, TypeConstraint);
 
+PyResult capture_snapshot(Scheduler*, char*, Value);
+
 Value validator_run(Scheduler*);
 
 void rule_graph_visualize(Scheduler*, TypeIdBuffer, char*);

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -221,7 +221,7 @@ void graph_trace(Scheduler*, ExecutionRequest*, char*);
 
 PyResult  execution_add_root_select(Scheduler*, ExecutionRequest*, Key, TypeConstraint);
 
-PyResult capture_snapshot(Scheduler*, char*, Value);
+PyResult capture_snapshots(Scheduler*, Value);
 
 Value validator_run(Scheduler*);
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -158,6 +158,13 @@ class Scheduler(object):
   def _from_value(self, val):
     return self._native.context.from_value(val)
 
+  def _raise_or_return(self, pyresult):
+    value = self._from_value(pyresult.value)
+    if pyresult.is_throw:
+      raise value
+    else:
+      return value
+
   def _to_id(self, typ):
     return self._native.context.to_id(typ)
 
@@ -279,8 +286,7 @@ class Scheduler(object):
                                                      execution_request,
                                                      self._to_key(subject),
                                                      self._to_constraint(product))
-    if res.is_throw:
-      raise self._from_value(res.value)
+    self._raise_or_return(res)
 
   def visualize_to_dir(self):
     return self._native.visualize_to_dir
@@ -310,12 +316,12 @@ class Scheduler(object):
     return roots
 
   def capture_snapshot(self, root_path, path_globs):
-    result = self._native.lib.capture_snapshot(self._scheduler, root_path, self._to_value(path_globs))
-    value = self._from_value(result.value)
-    if result.is_throw:
-      raise value
-    else:
-      return value
+    result = self._native.lib.capture_snapshot(
+      self._scheduler,
+      root_path,
+      self._to_value(path_globs),
+    )
+    return self._raise_or_return(result)
 
   def lease_files_in_graph(self):
     self._native.lib.lease_files_in_graph(self._scheduler)

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -309,6 +309,14 @@ class Scheduler(object):
       self._native.lib.nodes_destroy(raw_roots)
     return roots
 
+  def capture_snapshot(self, root_path, path_globs):
+    result = self._native.lib.capture_snapshot(self._scheduler, root_path, self._to_value(path_globs))
+    value = self._from_value(result.value)
+    if result.is_throw:
+      raise value
+    else:
+      return value
+
   def lease_files_in_graph(self):
     self._native.lib.lease_files_in_graph(self._scheduler)
 
@@ -480,6 +488,9 @@ class SchedulerSession(object):
     :returns: A list of the requested products, with length match len(subjects).
     """
     return self.products_request([product], subjects)[product]
+
+  def capture_snapshot(self, root_path, path_globs):
+    return self._scheduler.capture_snapshot(root_path, path_globs)
 
   def lease_files_in_graph(self):
     self._scheduler.lease_files_in_graph()

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -317,6 +317,14 @@ class Scheduler(object):
     return roots
 
   def capture_snapshots(self, path_globs_and_roots):
+    """Synchronously captures Snapshots for each matching PathGlobs rooted at a its root directory.
+
+    This is a blocking operation, and should be avoided where possible.
+
+    :param path_globs_and_roots tuple<PathGlobsAndRoot>: The PathGlobs to capture, and the root
+           directory relative to which each should be captured.
+    :returns: A tuple of Snapshots.
+    """
     result = self._native.lib.capture_snapshots(
       self._scheduler,
       self._to_value(_PathGlobsAndRootCollection(path_globs_and_roots)),
@@ -499,6 +507,14 @@ class SchedulerSession(object):
     return self.products_request([product], subjects)[product]
 
   def capture_snapshots(self, path_globs_and_roots):
+    """Synchronously captures Snapshots for each matching PathGlobs rooted at a its root directory.
+
+    This is a blocking operation, and should be avoided where possible.
+
+    :param path_globs_and_roots tuple<PathGlobsAndRoot>: The PathGlobs to capture, and the root
+           directory relative to which each should be captured.
+    :returns: A tuple of Snapshots.
+    """
     return self._scheduler.capture_snapshots(path_globs_and_roots)
 
   def lease_files_in_graph(self):

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -371,30 +371,8 @@ impl PosixFS {
     pool: Arc<ResettablePool>,
     ignore_patterns: Vec<String>,
   ) -> Result<PosixFS, String> {
-    let ignore = create_ignore(&ignore_patterns).map_err(|e| {
-      format!(
-        "Could not parse build ignore inputs {:?}: {:?}",
-        ignore_patterns, e
-      )
-    })?;
-    Ok(PosixFS {
-      root: Self::canonicalize(root)?,
-      pool: pool,
-      ignore: ignore,
-    })
-  }
-
-  pub fn clone_with_root<P: AsRef<Path>>(&self, root: P) -> Result<PosixFS, String> {
-    Ok(PosixFS {
-      root: Self::canonicalize(root)?,
-      pool: self.pool.clone(),
-      ignore: self.ignore.clone(),
-    })
-  }
-
-  fn canonicalize<P: AsRef<Path>>(path: P) -> Result<Dir, String> {
-    let path: &Path = path.as_ref();
-    path
+    let root: &Path = root.as_ref();
+    let canonical_root = root
       .canonicalize()
       .and_then(|canonical| {
         canonical.metadata().and_then(|metadata| {
@@ -408,7 +386,19 @@ impl PosixFS {
           }
         })
       })
-      .map_err(|e| format!("Could not canonicalize root {:?}: {:?}", path, e))
+      .map_err(|e| format!("Could not canonicalize root {:?}: {:?}", root, e))?;
+
+    let ignore = create_ignore(&ignore_patterns).map_err(|e| {
+      format!(
+        "Could not parse build ignore inputs {:?}: {:?}",
+        ignore_patterns, e
+      )
+    })?;
+    Ok(PosixFS {
+      root: canonical_root,
+      pool: pool,
+      ignore: ignore,
+    })
   }
 
   fn scandir_sync(root: PathBuf, dir_relative_to_root: Dir) -> Result<Vec<Stat>, io::Error> {

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -281,18 +281,24 @@ impl From<PyResult> for Result<Value, Failure> {
   }
 }
 
-impl From<Result<(), String>> for PyResult {
-  fn from(res: Result<(), String>) -> Self {
+impl From<Result<Value, String>> for PyResult {
+  fn from(res: Result<Value, String>) -> Self {
     match res {
-      Ok(()) => PyResult {
+      Ok(v) => PyResult {
         is_throw: false,
-        value: eval("None").unwrap(),
+        value: v,
       },
       Err(msg) => PyResult {
         is_throw: true,
         value: create_exception(&msg),
       },
     }
+  }
+}
+
+impl From<Result<(), String>> for PyResult {
+  fn from(res: Result<(), String>) -> Self {
+    PyResult::from(res.map(|()| eval("None").unwrap()))
   }
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -37,6 +37,7 @@ use std::mem;
 use std::os::raw;
 use std::panic;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use context::Core;
 use core::{Failure, Function, Key, TypeConstraint, TypeId, Value};
@@ -46,6 +47,8 @@ use externs::{Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionE
               ProjectMultiExtern, PyResult, SatisfiedByExtern, SatisfiedByTypeExtern,
               StoreBytesExtern, StoreI64Extern, StoreTupleExtern, TypeIdBuffer, TypeToStrExtern,
               ValToStrExtern};
+use fs::VFS;
+use futures::Future;
 use rule_graph::{GraphMaker, RuleGraph};
 use scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
 use tasks::Tasks;
@@ -565,6 +568,48 @@ pub extern "C" fn lease_files_in_graph(scheduler_ptr: *mut Scheduler) {
       Err(err) => error!("{}", &err),
     }
   });
+}
+
+#[no_mangle]
+pub extern "C" fn capture_snapshot(
+  scheduler_ptr: *mut Scheduler,
+  raw_root_path: *const raw::c_char,
+  path_globs_value: Value,
+) -> PyResult {
+  let root_path = unsafe { CStr::from_ptr(raw_root_path).to_string_lossy().into_owned() };
+  with_scheduler(scheduler_ptr, |scheduler| {
+    capture_snapshot_inner(scheduler, root_path, path_globs_value).into()
+  })
+}
+
+fn capture_snapshot_inner(
+  scheduler: &Scheduler,
+  root_path: String,
+  path_globs_value: Value,
+) -> Result<Value, String> {
+  // Note that we don't use a Context here, and don't cache any intermediate steps, we just place
+  // the resultant Snapshot into the store and return it. This is important, because we're reading
+  // things from arbitrary filepaths which we don't want to cache in the graph, as we don't watch
+  // them for changes.
+  // We assume that this Snapshot is of an immutable piece of the filesystem.
+
+  let posix_fs = Arc::new(scheduler.core.vfs.clone_with_root(&root_path)?);
+  let path_globs = nodes::Snapshot::lift_path_globs(&path_globs_value)?;
+  let store = scheduler.core.store.clone();
+
+  let snapshot = posix_fs
+    .expand(path_globs)
+    .map_err(|err| format!("Error expanding globs: {:?}", err))
+    .and_then(|path_stats| {
+      fs::Snapshot::from_path_stats(
+        scheduler.core.store.clone(),
+        fs::OneOffStoreFileByDigest::new(store, posix_fs),
+        path_stats,
+      )
+    })
+    .wait()?;
+
+  Ok(nodes::Snapshot::store_snapshot(&scheduler.core, &snapshot))
 }
 
 fn graph_full(scheduler: &Scheduler, subject_types: Vec<TypeId>) -> RuleGraph {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -380,7 +380,6 @@ impl Select {
             ..
           }) => {
             let context = context.clone();
-            let context2 = context.clone();
             self
               .execute_process(&context, &entry)
               .map(move |result| {
@@ -390,7 +389,7 @@ impl Select {
                     externs::store_bytes(&result.0.stdout),
                     externs::store_bytes(&result.0.stderr),
                     externs::store_i64(result.0.exit_code as i64),
-                    Snapshot::store_directory(&context2, &result.0.output_directory),
+                    Snapshot::store_directory(&context.core, &result.0.output_directory),
                   ],
                 )
               })

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -11,7 +11,7 @@ use futures::future::{self, Future};
 use boxfuture::{BoxFuture, Boxable};
 use context::{Context, ContextFactory, Core};
 use core::{Failure, Key, TypeConstraint, TypeId, Value};
-use fs::{self, VFS};
+use fs::{self, PosixFS, VFS};
 use graph::EntryId;
 use nodes::{NodeKey, Select};
 use rule_graph;
@@ -231,7 +231,11 @@ impl Scheduler {
     // them for changes.
     // We assume that this Snapshot is of an immutable piece of the filesystem.
 
-    let posix_fs = Arc::new(try_future!(self.core.vfs.clone_with_root(root_path)));
+    let posix_fs = Arc::new(try_future!(PosixFS::new(
+      root_path,
+      self.core.fs_pool.clone(),
+      vec![]
+    )));
     let store = self.core.store.clone();
 
     posix_fs

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -11,7 +11,8 @@ import unittest
 from contextlib import contextmanager
 
 from pants.base.project_tree import Dir, Link
-from pants.engine.fs import DirectoryDigest, FilesContent, PathGlobs, Snapshot, create_fs_rules
+from pants.engine.fs import (EMPTY_DIRECTORY_DIGEST, DirectoryDigest, FilesContent, PathGlobs,
+                             PathGlobsAndRoot, Snapshot, create_fs_rules)
 from pants.util.contextutil import temporary_dir
 from pants.util.meta import AbstractClass
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
@@ -267,20 +268,43 @@ class FSTest(unittest.TestCase, SchedulerTestBase, AbstractClass):
         f.write("European Burmese")
       scheduler = self.mk_scheduler(rules=create_fs_rules())
       globs = PathGlobs(("*",), ())
-      snapshot = scheduler.capture_snapshot(temp_dir, globs)
-      self.assertEquals([file.path for file in snapshot.files], ["roland"])
-      self.assertEquals(
-        snapshot.directory_digest,
-        DirectoryDigest(
-          str("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
-          80
-        )
-      )
+      snapshot = scheduler.capture_snapshots((PathGlobsAndRoot(globs, temp_dir),))[0]
+      self.assert_snapshot_equals(snapshot, ["roland"], DirectoryDigest(
+        str("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
+        80
+      ))
+
+  def test_multiple_snapshots_from_outside_buildroot(self):
+    with temporary_dir() as temp_dir:
+      with open(os.path.join(temp_dir, "roland"), "w") as f:
+        f.write("European Burmese")
+      with open(os.path.join(temp_dir, "susannah"), "w") as f:
+        f.write("I don't know")
+      scheduler = self.mk_scheduler(rules=create_fs_rules())
+      snapshots = scheduler.capture_snapshots((
+        PathGlobsAndRoot(PathGlobs(("roland",), ()), temp_dir),
+        PathGlobsAndRoot(PathGlobs(("susannah",), ()), temp_dir),
+        PathGlobsAndRoot(PathGlobs(("doesnotexist",), ()), temp_dir),
+      ))
+      self.assertEquals(3, len(snapshots))
+      self.assert_snapshot_equals(snapshots[0], ["roland"], DirectoryDigest(
+        str("63949aa823baf765eff07b946050d76ec0033144c785a94d3ebd82baa931cd16"),
+        80
+      ))
+      self.assert_snapshot_equals(snapshots[1], ["susannah"], DirectoryDigest(
+        str("d3539cfc21eb4bab328ca9173144a8e932c515b1b9e26695454eeedbc5a95f6f"),
+        82
+      ))
+      self.assert_snapshot_equals(snapshots[2], [], EMPTY_DIRECTORY_DIGEST)
 
   def test_snapshot_from_outside_buildroot_failure(self):
     with temporary_dir() as temp_dir:
       scheduler = self.mk_scheduler(rules=create_fs_rules())
       globs = PathGlobs(("*",), ())
       with self.assertRaises(Exception) as cm:
-        scheduler.capture_snapshot(str(os.path.join(temp_dir, "doesnotexist")), globs)
+        scheduler.capture_snapshots((PathGlobsAndRoot(globs, str(os.path.join(temp_dir, "doesnotexist"))),))
       self.assertIn("doesnotexist", str(cm.exception))
+
+  def assert_snapshot_equals(self, snapshot, files, directory_digest):
+    self.assertEquals([file.path for file in snapshot.files], files)
+    self.assertEquals(snapshot.directory_digest, directory_digest)


### PR DESCRIPTION
We don't cache anything intermediate here, we just dump the Snapshot
into the Store and return it.

This is intended to be a short-term transition path to allow BinaryUtils
to be consumed in the v2 engine.