### PR TITLE
Update to rust 1.26

### DIFF
--- a/build-support/bin/native/bootstrap.sh
+++ b/build-support/bin/native/bootstrap.sh
@@ -45,7 +45,7 @@ esac
 readonly CACHE_ROOT=${XDG_CACHE_HOME:-$HOME/.cache}/pants
 readonly NATIVE_ENGINE_CACHE_DIR=${CACHE_ROOT}/bin/native-engine
 
-readonly RUST_TOOLCHAIN="1.25.0"
+readonly RUST_TOOLCHAIN="1.26.0"
 
 function calculate_current_hash() {
   # Cached and unstaged files, with ignored files excluded.

--- a/src/rust/engine/boxfuture/src/lib.rs
+++ b/src/rust/engine/boxfuture/src/lib.rs
@@ -30,12 +30,12 @@ where
 ///
 #[macro_export]
 macro_rules! try_future {
-( $x:expr) => {
-    {
-        match $x {
-            Ok(value) => {value}
-            Err(error) => {return future::err(error).to_boxed();}
-        }
+  ($x:expr) => {{
+    match $x {
+      Ok(value) => value,
+      Err(error) => {
+        return future::err(error).to_boxed();
+      }
     }
-};
+  }};
 }

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -643,13 +643,13 @@ mod test {
   extern crate tempdir;
   extern crate testutil;
 
+  use self::tempdir::TempDir;
+  use self::testutil::{file, data::{TestData, TestDirectory}};
+  use super::mount;
   use fs;
   use futures::future::Future;
   use hashing;
-  use self::tempdir::TempDir;
   use std::sync::Arc;
-  use super::mount;
-  use self::testutil::{file, data::{TestData, TestDirectory}};
 
   #[test]
   fn missing_digest() {
@@ -888,16 +888,16 @@ mod syscall_tests {
   extern crate tempdir;
   extern crate testutil;
 
+  use self::tempdir::TempDir;
+  use self::testutil::data::TestData;
+  use super::mount;
+  use super::test::digest_to_filepath;
   use fs;
   use futures::Future;
   use libc;
-  use std::sync::Arc;
-  use super::mount;
-  use super::test::digest_to_filepath;
-  use self::tempdir::TempDir;
-  use self::testutil::data::TestData;
   use std::ffi::CString;
   use std::path::Path;
+  use std::sync::Arc;
 
   #[test]
   fn read_file_by_digest_exact_bytes() {

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -37,13 +37,13 @@ extern crate tempdir;
 #[cfg(test)]
 extern crate testutil;
 
+use std::cmp::min;
 use std::collections::HashSet;
+use std::io::{self, Read};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, fs};
-use std::io::{self, Read};
-use std::cmp::min;
 
 use bytes::Bytes;
 use futures::future::{self, Future};
@@ -123,12 +123,9 @@ impl PathStat {
 
 lazy_static! {
   static ref PARENT_DIR: &'static str = "..";
-
   static ref SINGLE_STAR_GLOB: Pattern = Pattern::new("*").unwrap();
-
   static ref DOUBLE_STAR: &'static str = "**";
   static ref DOUBLE_STAR_GLOB: Pattern = Pattern::new("**").unwrap();
-
   static ref EMPTY_IGNORE: Arc<Gitignore> = Arc::new(Gitignore::empty());
 }
 
@@ -852,9 +849,9 @@ mod posixfs_test {
   extern crate tempdir;
   extern crate testutil;
 
+  use self::testutil::make_file;
   use super::{Dir, File, Link, PathStat, PathStatGetter, PosixFS, ResettablePool, Stat};
   use futures::Future;
-  use self::testutil::make_file;
   use std;
   use std::path::{Path, PathBuf};
   use std::sync::Arc;

--- a/src/rust/engine/fs/src/pool.rs
+++ b/src/rust/engine/fs/src/pool.rs
@@ -3,8 +3,8 @@
 
 use std::sync::RwLock;
 
-use futures_cpupool::{self, CpuFuture, CpuPool};
 use futures::future::IntoFuture;
+use futures_cpupool::{self, CpuFuture, CpuPool};
 
 ///
 /// A wrapper around a CpuPool, to add the ability to drop the pool before forking,

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -564,9 +564,9 @@ mod local {
   use digest::{Digest as DigestTrait, FixedOutput};
   use futures::future;
   use hashing::{Digest, Fingerprint};
+  use lmdb::Error::{KeyExist, NotFound};
   use lmdb::{self, Cursor, Database, DatabaseFlags, Environment, RwTransaction, Transaction,
              WriteFlags, NO_OVERWRITE, NO_SYNC, NO_TLS};
-  use lmdb::Error::{KeyExist, NotFound};
   use resettable::Resettable;
   use sha2::Sha256;
   use std::collections::{BinaryHeap, HashMap};
@@ -575,9 +575,9 @@ mod local {
   use std::sync::Arc;
   use std::time;
 
-  use pool::ResettablePool;
-  use super::MAX_LOCAL_STORE_SIZE_BYTES;
   use super::super::EMPTY_FINGERPRINT;
+  use super::MAX_LOCAL_STORE_SIZE_BYTES;
+  use pool::ResettablePool;
 
   #[derive(Clone)]
   pub struct ByteStore {
@@ -994,11 +994,11 @@ mod local {
 
   #[cfg(test)]
   pub mod tests {
+    use super::super::super::safe_create_dir_all;
+    use super::{ByteStore, EntryType, ResettablePool};
     use bytes::Bytes;
     use futures::Future;
     use hashing::{Digest, Fingerprint};
-    use super::{ByteStore, EntryType, ResettablePool};
-    use super::super::super::safe_create_dir_all;
     use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
     use std::path::Path;
     use std::sync::Arc;
@@ -1522,8 +1522,8 @@ mod remote {
   use bytes::{Bytes, BytesMut};
   use digest::{Digest as DigestTrait, FixedOutput};
   use futures::{self, future, Future, Sink, Stream};
-  use hashing::{Digest, Fingerprint};
   use grpcio;
+  use hashing::{Digest, Fingerprint};
   use resettable::Resettable;
   use sha2::Sha256;
   use std::cmp::min;
@@ -1739,8 +1739,8 @@ mod remote {
 
     extern crate tempdir;
 
-    use super::ByteStore;
     use super::super::EntryType;
+    use super::ByteStore;
     use bytes::Bytes;
     use futures::Future;
     use hashing::Digest;

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -27,10 +27,12 @@ impl super::CommandRunner for CommandRunner {
   ///
   fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<ExecuteProcessResult, String> {
     let workdir = try_future!(
-      tempdir::TempDir::new("process-execution").map_err(|err| format!(
-        "Error making tempdir for local process execution: {:?}",
-        err
-      ))
+      tempdir::TempDir::new("process-execution").map_err(|err| {
+        format!(
+          "Error making tempdir for local process execution: {:?}",
+          err
+        )
+      })
     );
 
     let store = self.store.clone();
@@ -105,10 +107,11 @@ mod tests {
   extern crate tempdir;
   extern crate testutil;
 
+  use self::testutil::{as_bytes, owned_string_vec};
+  use super::super::CommandRunner as CommandRunnerTrait;
+  use super::{ExecuteProcessRequest, ExecuteProcessResult};
   use fs;
   use futures::Future;
-  use super::{ExecuteProcessRequest, ExecuteProcessResult};
-  use super::super::CommandRunner as CommandRunnerTrait;
   use std;
   use std::collections::{BTreeMap, BTreeSet};
   use std::env;
@@ -116,7 +119,6 @@ mod tests {
   use std::path::{Path, PathBuf};
   use std::sync::Arc;
   use tempdir::TempDir;
-  use self::testutil::{as_bytes, owned_string_vec};
   use testutil::data::{TestData, TestDirectory};
 
   #[test]

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -8,8 +8,8 @@ use digest::{Digest as DigestTrait, FixedOutput};
 use fs::{self, Store};
 use futures::{future, Future};
 use futures_timer::Delay;
-use hashing::{Digest, Fingerprint};
 use grpcio;
+use hashing::{Digest, Fingerprint};
 use protobuf::{self, Message, ProtobufEnum};
 use resettable::Resettable;
 use sha2::Sha256;
@@ -268,10 +268,12 @@ impl CommandRunner {
             try_future!(
               precondition_failure
                 .merge_from_bytes(details.get_value())
-                .map_err(|e| ExecutionError::Fatal(format!(
-                  "Error deserializing FailedPrecondition proto: {:?}",
-                  e
-                )))
+                .map_err(|e| {
+                  ExecutionError::Fatal(format!(
+                    "Error deserializing FailedPrecondition proto: {:?}",
+                    e
+                  ))
+                })
             );
 
             let mut missing_digests =
@@ -464,14 +466,14 @@ mod tests {
   use futures::Future;
   use grpcio;
   use hashing::Digest;
-  use protobuf::{self, Message, ProtobufEnum};
   use mock;
+  use protobuf::{self, Message, ProtobufEnum};
   use tempdir::TempDir;
   use testutil::data::{TestData, TestDirectory};
   use testutil::{as_bytes, owned_string_vec};
 
-  use super::{CommandRunner, ExecuteProcessRequest, ExecuteProcessResult, ExecutionError};
   use super::super::CommandRunner as CommandRunnerTrait;
+  use super::{CommandRunner, ExecuteProcessRequest, ExecuteProcessResult, ExecutionError};
   use std::collections::{BTreeMap, BTreeSet};
   use std::iter::{self, FromIterator};
   use std::sync::Arc;

--- a/src/rust/engine/src/core.rs
+++ b/src/rust/engine/src/core.rs
@@ -4,8 +4,8 @@
 use fnv::FnvHasher;
 
 use std::collections::HashMap;
-use std::{fmt, hash};
 use std::ops::Drop;
+use std::{fmt, hash};
 
 use externs;
 use handles::{enqueue_drop_handle, Handle};

--- a/src/rust/engine/src/graph.rs
+++ b/src/rust/engine/src/graph.rs
@@ -8,14 +8,14 @@ use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+use futures::future::{self, Future};
 use petgraph::Direction;
 use petgraph::stable_graph::{NodeIndex, StableDiGraph, StableGraph};
-use futures::future::{self, Future};
 
-use externs;
 use boxfuture::Boxable;
 use context::ContextFactory;
 use core::{Failure, Noop, FNV};
+use externs;
 use hashing;
 use nodes::{DigestFile, Node, NodeFuture, NodeKey, NodeResult, TryInto};
 
@@ -341,7 +341,7 @@ impl InnerGraph {
     };
 
     try!(f.write_all(b"digraph plans {\n"));
-    try!(f.write_fmt(format_args!("  node[colorscheme={}];\n", viz_color_scheme),));
+    try!(f.write_fmt(format_args!("  node[colorscheme={}];\n", viz_color_scheme)));
     try!(f.write_all(b"  concentrate=true;\n"));
     try!(f.write_all(b"  rankdir=TB;\n"));
 
@@ -371,7 +371,7 @@ impl InnerGraph {
 
         // Write an entry per edge.
         let dep_str = dep_entry.format::<NodeKey>();
-        try!(f.write_fmt(format_args!("    \"{}\" -> \"{}\"\n", node_str, dep_str),));
+        try!(f.write_fmt(format_args!("    \"{}\" -> \"{}\"\n", node_str, dep_str)));
       }
     }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -4,8 +4,8 @@
 extern crate bazel_protos;
 extern crate tempdir;
 
-use std::error::Error;
 use std::collections::BTreeMap;
+use std::error::Error;
 use std::fmt;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
@@ -18,8 +18,8 @@ use context::{Context, Core};
 use core::{throw, Failure, Key, Noop, TypeConstraint, Value, Variants};
 use externs;
 use fs::{self, Dir, File, FileContent, Link, PathGlobs, PathStat, StoreFileByDigest, VFS};
-use process_execution::{self, CommandRunner};
 use hashing;
+use process_execution::{self, CommandRunner};
 use rule_graph;
 use selectors;
 use tasks::{self, Intrinsic, IntrinsicKind};

--- a/src/rust/engine/src/rule_graph.rs
+++ b/src/rust/engine/src/rule_graph.rs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::collections::{hash_map, HashMap, HashSet, VecDeque};
-use std::hash::Hash;
 use std::fmt;
+use std::hash::Hash;
 use std::io;
 
 use core::{Function, Key, TypeConstraint, TypeId, Value, ANY_TYPE};


### PR DESCRIPTION
Update to rust 1.26, explicitly use Itertools::flatten to avoid https://github.com/rust-lang/rust/issues/48919, and apply necessary rustfmt changes.

I experimented with a few different OSX versions, but there is a segfault for all versions of OSX (*that are available on travis) below `xcode8` / `OSX 10.11`. So, landing this change would raise pants' minimum OSX requirement to `10.11`.