### PR TITLE
Add a facility for exposing metrics from the native engine

### DIFF
--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -81,9 +81,9 @@ class DaemonPantsRunner(ProcessManager):
     :param list args: The arguments (i.e. sys.argv) for this run.
     :param dict env: The environment (i.e. os.environ) for this run.
     :param TargetRoots target_roots: The `TargetRoots` for this run.
-    :param LegacyGraphHelper graph_helper: The LegacyGraphHelper instance to use for BuildGraph
-                                           construction. In the event of an exception, this will be
-                                           None.
+    :param LegacyGraphSession graph_helper: The LegacyGraphSession instance to use for BuildGraph
+                                            construction. In the event of an exception, this will be
+                                            None.
     :param threading.RLock fork_lock: A lock to use during forking for thread safety.
     :param int preceding_graph_size: The size of the graph pre-warming, for stats.
     :param Exception deferred_exception: A deferred exception from the daemon's graph construction.
@@ -202,7 +202,7 @@ class DaemonPantsRunner(ProcessManager):
     in that child process.
     """
     if self._graph_helper:
-      self._graph_helper.scheduler.pre_fork()
+      self._graph_helper.scheduler_session.pre_fork()
 
   def post_fork_child(self):
     """Post-fork child process callback executed via ProcessManager.daemonize()."""

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -74,7 +74,7 @@ class DaemonPantsRunner(ProcessManager):
   """
 
   def __init__(self, socket, exiter, args, env, target_roots, graph_helper, fork_lock,
-               preceding_graph_size, deferred_exception=None):
+               deferred_exception=None):
     """
     :param socket socket: A connected socket capable of speaking the nailgun protocol.
     :param Exiter exiter: The Exiter instance for this run.
@@ -85,7 +85,6 @@ class DaemonPantsRunner(ProcessManager):
                                             construction. In the event of an exception, this will be
                                             None.
     :param threading.RLock fork_lock: A lock to use during forking for thread safety.
-    :param int preceding_graph_size: The size of the graph pre-warming, for stats.
     :param Exception deferred_exception: A deferred exception from the daemon's graph construction.
                                          If present, this will be re-raised in the client context.
     """
@@ -97,7 +96,6 @@ class DaemonPantsRunner(ProcessManager):
     self._target_roots = target_roots
     self._graph_helper = graph_helper
     self._fork_lock = fork_lock
-    self._preceding_graph_size = preceding_graph_size
     self._deferred_exception = deferred_exception
 
   def _make_identity(self):
@@ -248,7 +246,6 @@ class DaemonPantsRunner(ProcessManager):
           daemon_build_graph=self._graph_helper
         )
         runner.set_start_time(self._maybe_get_client_start_time_from_env(self._env))
-        runner.set_preceding_graph_size(self._preceding_graph_size)
         runner.run()
       except KeyboardInterrupt:
         self._exiter.exit(1, msg='Interrupted by user.\n')

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -76,7 +76,8 @@ class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table'])):
 
   def new_session(self):
     session = self.scheduler.new_session()
-    change_calculator = EngineChangeCalculator(session, self.symbol_table, get_scm())
+    scm = get_scm()
+    change_calculator = EngineChangeCalculator(session, self.symbol_table, scm) if scm else None
     return LegacyGraphSession(session, self.symbol_table, change_calculator)
 
 

--- a/src/python/pants/bin/engine_initializer.py
+++ b/src/python/pants/bin/engine_initializer.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import logging
-from collections import namedtuple
 
 from pants.base.build_environment import get_buildroot, get_scm
 from pants.base.file_system_project_tree import FileSystemProjectTree
@@ -27,6 +26,8 @@ from pants.engine.parser import SymbolTable
 from pants.engine.scheduler import Scheduler
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.scm.change_calculator import EngineChangeCalculator
+from pants.util.objects import datatype
 
 
 logger = logging.getLogger(__name__)
@@ -70,8 +71,17 @@ class LegacySymbolTable(SymbolTable):
     return self._table
 
 
-class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'symbol_table', 'scm'])):
-  """A container for the components necessary to construct a legacy BuildGraph facade."""
+class LegacyGraphScheduler(datatype(['scheduler', 'symbol_table'])):
+  """A thin wrapper around a Scheduler configured with @rules for a symbol table."""
+
+  def new_session(self):
+    session = self.scheduler.new_session()
+    change_calculator = EngineChangeCalculator(session, self.symbol_table, get_scm())
+    return LegacyGraphSession(session, self.symbol_table, change_calculator)
+
+
+class LegacyGraphSession(datatype(['scheduler_session', 'symbol_table', 'change_calculator'])):
+  """A thin wrapper around a SchedulerSession configured with @rules for a symbol table."""
 
   def warm_product_graph(self, target_roots):
     """Warm the scheduler's `ProductGraph` with `TransitiveHydratedTargets` products.
@@ -80,28 +90,26 @@ class LegacyGraphHelper(namedtuple('LegacyGraphHelper', ['scheduler', 'symbol_ta
     """
     logger.debug('warming target_roots for: %r', target_roots)
     subjects = [Specs(tuple(target_roots.specs))]
-    scheduler_session = self.scheduler.new_session()
-    request = scheduler_session.execution_request([TransitiveHydratedTargets], subjects)
-    result = scheduler_session.execute(request)
+    request = self.scheduler_session.execution_request([TransitiveHydratedTargets], subjects)
+    result = self.scheduler_session.execute(request)
     if result.error:
       raise result.error
 
-  def create_build_graph(self, scheduler_session, target_roots, build_root=None):
+  def create_build_graph(self, target_roots, build_root=None):
     """Construct and return a `BuildGraph` given a set of input specs.
 
-    :param SchedulerSession scheduler_session: A SchedulerSession to warm the graph in.
     :param TargetRoots target_roots: The targets root of the request.
     :param string build_root: The build root.
     :returns: A tuple of (BuildGraph, AddressMapper).
     """
     logger.debug('target_roots are: %r', target_roots)
-    graph = LegacyBuildGraph.create(scheduler_session, self.symbol_table)
+    graph = LegacyBuildGraph.create(self.scheduler_session, self.symbol_table)
     logger.debug('build_graph is: %s', graph)
     # Ensure the entire generator is unrolled.
     for _ in graph.inject_roots_closure(target_roots):
       pass
 
-    address_mapper = LegacyAddressMapper(scheduler_session, build_root or get_buildroot())
+    address_mapper = LegacyAddressMapper(self.scheduler_session, build_root or get_buildroot())
     logger.debug('address_mapper is: %s', address_mapper)
     return graph, address_mapper
 
@@ -145,11 +153,10 @@ class EngineInitializer(object):
                                   under the current build root.
     :param bool include_trace_on_error: If True, when an error occurs, the error message will
                 include the graph trace.
-    :returns: A LegacyGraphHelper.
+    :returns: A LegacyGraphScheduler.
     """
 
     build_root = build_root or get_buildroot()
-    scm = get_scm()
 
     if not build_file_aliases:
       build_file_aliases = EngineInitializer.get_default_build_file_aliases()
@@ -192,4 +199,4 @@ class EngineInitializer(object):
       include_trace_on_error=include_trace_on_error,
     )
 
-    return LegacyGraphHelper(scheduler, symbol_table, scm)
+    return LegacyGraphScheduler(scheduler, symbol_table)

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -34,11 +34,7 @@ class LocalPantsRunner(object):
     self._target_roots = target_roots
     self._daemon_build_graph = daemon_build_graph
     self._options_bootstrapper = options_bootstrapper
-    self._preceding_graph_size = -1
     self._run_start_time = None
-
-  def set_preceding_graph_size(self, size):
-    self._preceding_graph_size = size
 
   def set_start_time(self, start_time):
     self._run_start_time = start_time
@@ -80,9 +76,6 @@ class LocalPantsRunner(object):
       repro = Reproducer.global_instance().create_repro()
       if repro:
         repro.capture(run_tracker.run_info.get_as_dict())
-
-      # Record the preceding product graph size.
-      run_tracker.pantsd_stats.set_preceding_graph_size(self._preceding_graph_size)
 
       # Setup and run GoalRunner.
       goal_runner = GoalRunner.Factory(root_dir,

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -207,7 +207,7 @@ Value scheduler_metrics(Scheduler*, Session*);
 RawNodes* scheduler_execute(Scheduler*, Session*, ExecutionRequest*);
 void scheduler_destroy(Scheduler*);
 
-Session* session_create(void);
+Session* session_create(Scheduler*);
 void session_destroy(Session*);
 
 ExecutionRequest* execution_request_create(void);
@@ -704,8 +704,8 @@ class Native(object):
   def new_execution_request(self):
     return self.gc(self.lib.execution_request_create(), self.lib.execution_request_destroy)
 
-  def new_session(self):
-    return self.gc(self.lib.session_create(), self.lib.session_destroy)
+  def new_session(self, scheduler):
+    return self.gc(self.lib.session_create(scheduler), self.lib.session_destroy)
 
   def new_scheduler(self,
                     tasks,

--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -111,7 +111,7 @@ typedef _Bool               (*extern_ptr_satisfied_by)(ExternContext*, Value*, V
 typedef _Bool               (*extern_ptr_satisfied_by_type)(ExternContext*, Value*, TypeId*);
 typedef Value               (*extern_ptr_store_tuple)(ExternContext*, Value*, uint64_t);
 typedef Value               (*extern_ptr_store_bytes)(ExternContext*, uint8_t*, uint64_t);
-typedef Value               (*extern_ptr_store_i32)(ExternContext*, int32_t);
+typedef Value               (*extern_ptr_store_i64)(ExternContext*, int64_t);
 typedef ValueBuffer         (*extern_ptr_project_multi)(ExternContext*, Value*, uint8_t*, uint64_t);
 typedef Value               (*extern_ptr_project_ignoring_type)(ExternContext*, Value*, uint8_t*, uint64_t);
 typedef Value               (*extern_ptr_create_exception)(ExternContext*, uint8_t*, uint64_t);
@@ -156,7 +156,7 @@ void externs_set(ExternContext*,
                  extern_ptr_satisfied_by_type,
                  extern_ptr_store_tuple,
                  extern_ptr_store_bytes,
-                 extern_ptr_store_i32,
+                 extern_ptr_store_i64,
                  extern_ptr_project_ignoring_type,
                  extern_ptr_project_multi,
                  extern_ptr_create_exception,
@@ -250,7 +250,7 @@ extern "Python" {
   _Bool               extern_satisfied_by_type(ExternContext*, Value*, TypeId*);
   Value               extern_store_tuple(ExternContext*, Value*, uint64_t);
   Value               extern_store_bytes(ExternContext*, uint8_t*, uint64_t);
-  Value               extern_store_i32(ExternContext*, int32_t);
+  Value               extern_store_i64(ExternContext*, int64_t);
   Value               extern_project_ignoring_type(ExternContext*, Value*, uint8_t*, uint64_t);
   ValueBuffer         extern_project_multi(ExternContext*, Value*, uint8_t*, uint64_t);
   Value               extern_create_exception(ExternContext*, uint8_t*, uint64_t);
@@ -412,10 +412,10 @@ def _initialize_externs(ffi):
     return c.to_value(bytes(ffi.buffer(bytes_ptr, bytes_len)))
 
   @ffi.def_extern()
-  def extern_store_i32(context_handle, i32):
+  def extern_store_i64(context_handle, i64):
     """Given a context and int32_t, return a new Value to represent the int32_t."""
     c = ffi.from_handle(context_handle)
-    return c.to_value(i32)
+    return c.to_value(i64)
 
   @ffi.def_extern()
   def extern_project_ignoring_type(context_handle, val, field_str_ptr, field_str_len):
@@ -669,7 +669,7 @@ class Native(object):
                            self.ffi_lib.extern_satisfied_by_type,
                            self.ffi_lib.extern_store_tuple,
                            self.ffi_lib.extern_store_bytes,
-                           self.ffi_lib.extern_store_i32,
+                           self.ffi_lib.extern_store_i64,
                            self.ffi_lib.extern_project_ignoring_type,
                            self.ffi_lib.extern_project_multi,
                            self.ffi_lib.extern_create_exception,

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -31,8 +31,7 @@ logger = logging.getLogger(__name__)
 class ExecutionRequest(datatype(['roots', 'native'])):
   """Holds the roots for an execution, which might have been requested by a user.
 
-  To create an ExecutionRequest, see `LocalScheduler.build_request` (which performs goal
-  translation) or `LocalScheduler.execution_request`.
+  To create an ExecutionRequest, see `SchedulerSession.execution_request`.
 
   :param roots: Roots for this request.
   :type roots: list of tuples of subject and product.
@@ -71,26 +70,43 @@ class ExecutionError(Exception):
   pass
 
 
-class WrappedNativeScheduler(object):
-  def __init__(self, native, build_root, work_dir, ignore_patterns, rule_index):
+class Scheduler(object):
+  def __init__(self, native, project_tree, work_dir, rules, include_trace_on_error=True):
+    """
+    :param native: An instance of engine.native.Native.
+    :param project_tree: An instance of ProjectTree for the current build root.
+    :param work_dir: The pants work dir.
+    :param rules: A set of Rules which is used to compute values in the graph.
+    :param include_trace_on_error: Include the trace through the graph upon encountering errors.
+    :type include_trace_on_error: bool
+    """
     self._native = native
+    self.include_trace_on_error = include_trace_on_error
+
     # TODO: The only (?) case where we use inheritance rather than exact type unions.
     has_products_constraint = SubclassesOf(HasProducts)
+
+    # Validate and register all provided and intrinsic tasks.
+    rule_index = RuleIndex.create(list(rules))
     self._root_subject_types = sorted(rule_index.roots)
+
+    # If configured, visualize the rule graph before asserting that it is valid.
+    if self.visualize_to_dir() is not None:
+      rule_graph_name = 'rule_graph.dot'
+      self.visualize_rule_graph_to_file(os.path.join(self.visualize_to_dir(), rule_graph_name))
 
     # Create the native Scheduler and Session.
     # TODO: This `_tasks` reference could be a local variable, since it is not used
     # after construction.
     self._tasks = native.new_tasks()
     self._register_rules(rule_index)
-    self.reset_session()
 
     self._scheduler = native.new_scheduler(
       self._tasks,
       self._root_subject_types,
-      build_root,
+      project_tree.build_root,
       work_dir,
-      ignore_patterns,
+      project_tree.ignore_patterns,
       Snapshot,
       FileContent,
       FilesContent,
@@ -112,6 +128,8 @@ class WrappedNativeScheduler(object):
       constraint_for(ExecuteProcessResult),
       constraint_for(GeneratorType),
     )
+
+    self.assert_ruleset_valid()
 
   def _root_type_ids(self):
     return self._to_ids_buf(sorted(self._root_subject_types))
@@ -252,9 +270,6 @@ class WrappedNativeScheduler(object):
   def graph_len(self):
     return self._native.lib.graph_len(self._scheduler)
 
-  def exec_reset(self):
-    self._native.lib.execution_reset(self._scheduler)
-
   def add_root_selection(self, execution_request, subject, product):
     res = self._native.lib.execution_add_root_select(self._scheduler,
                                                      execution_request,
@@ -272,15 +287,8 @@ class WrappedNativeScheduler(object):
   def pre_fork(self):
     self._native.lib.scheduler_pre_fork(self._scheduler)
 
-  def reset_session(self):
-    """Resets the Session for this Scheduler.
-
-    This has the effect of clearing metrics, but no other memoized data (ie, not the Graph).
-    """
-    self._session = self._native.new_session()
-
-  def run_and_return_roots(self, execution_request):
-    raw_roots = self._native.lib.scheduler_execute(self._scheduler, execution_request, self._session)
+  def run_and_return_roots(self, session, execution_request):
+    raw_roots = self._native.lib.scheduler_execute(self._scheduler, session, execution_request)
     try:
       roots = []
       for raw_root in self._native.unpack(raw_roots.nodes_ptr, raw_roots.nodes_len):
@@ -302,50 +310,22 @@ class WrappedNativeScheduler(object):
   def garbage_collect_store(self):
     self._native.lib.garbage_collect_store(self._scheduler)
 
+  def new_session(self):
+    """Creates a new SchedulerSession for this Scheduler."""
+    return SchedulerSession(self, self._native.new_session())
 
-class LocalScheduler(object):
-  """A scheduler that expands a product Graph by executing user defined Rules."""
 
-  def __init__(self,
-               work_dir,
-               goals,
-               rules,
-               project_tree,
-               native,
-               include_trace_on_error=True):
-    """
-    :param goals: A dict from a goal name to a product type. A goal is just an alias for a
-           particular (possibly synthetic) product.
-    :param rules: A set of Rules which is used to compute values in the product graph.
-    :param project_tree: An instance of ProjectTree for the current build root.
-    :param work_dir: The pants work dir.
-    :param native: An instance of engine.native.Native.
-    :param include_trace_on_error: Include the trace through the graph upon encountering errors.
-    :type include_trace_on_error: bool
-    """
-    self._products_by_goal = goals
-    self._project_tree = project_tree
-    self._include_trace_on_error = include_trace_on_error
+class SchedulerSession(object):
+  """A handle to a shared underlying Scheduler and a unique Session.
+
+  Generally a Session corresponds to a single run of pants: some metrics are specific to
+  a Session.
+  """
+
+  def __init__(self, scheduler, session):
+    self._scheduler = scheduler
+    self._session = session
     self._run_count = 0
-
-    # Create the ExternContext, and the native Scheduler.
-    self._execution_request = None
-
-    # Validate and register all provided and intrinsic tasks.
-    rules = list(rules)
-    rule_index = RuleIndex.create(rules)
-    self._scheduler = WrappedNativeScheduler(native,
-                                             project_tree.build_root,
-                                             work_dir,
-                                             project_tree.ignore_patterns,
-                                             rule_index)
-
-    # If configured, visualize the rule graph before asserting that it is valid.
-    if self._scheduler.visualize_to_dir() is not None:
-      rule_graph_name = 'rule_graph.dot'
-      self.visualize_rule_graph_to_file(os.path.join(self._scheduler.visualize_to_dir(), rule_graph_name))
-
-    self._scheduler.assert_ruleset_valid()
 
   def graph_len(self):
     return self._scheduler.graph_len()
@@ -365,19 +345,6 @@ class LocalScheduler(object):
 
   def visualize_rule_graph_to_file(self, filename):
     self._scheduler.visualize_rule_graph_to_file(filename)
-
-  def build_request(self, goals, subjects):
-    """Translate the given goal names into product types, and return an ExecutionRequest.
-
-    :param goals: The list of goal names supplied on the command line.
-    :type goals: list of string
-    :param subjects: A list of Spec and/or PathGlobs objects.
-    :type subject: list of :class:`pants.base.specs.Spec`, `pants.build_graph.Address`, and/or
-      :class:`pants.engine.fs.PathGlobs` objects.
-    :returns: An ExecutionRequest for the given goals and subjects.
-    """
-    return self.execution_request([self._products_by_goal[goal_name] for goal_name in goals],
-                                  subjects)
 
   def execution_request(self, products, subjects):
     """Create and return an ExecutionRequest for the given products and subjects.
@@ -415,9 +382,6 @@ class LocalScheduler(object):
   def node_count(self):
     return self._scheduler.graph_len()
 
-  def reset_session(self):
-    self._scheduler.reset_session()
-
   def pre_fork(self):
     self._scheduler.pre_fork()
 
@@ -430,7 +394,7 @@ class LocalScheduler(object):
     """
     start_time = time.time()
     roots = zip(execution_request.roots,
-                self._scheduler.run_and_return_roots(execution_request.native))
+                self._scheduler.run_and_return_roots(self._session, execution_request.native))
 
     if self._scheduler.visualize_to_dir() is not None:
       name = 'run.{}.dot'.format(self._run_count)
@@ -486,7 +450,7 @@ class LocalScheduler(object):
     # TODO: See https://github.com/pantsbuild/pants/issues/3912
     throw_root_states = tuple(state for root, state in result.root_products if type(state) is Throw)
     if throw_root_states:
-      if self._include_trace_on_error:
+      if self._scheduler.include_trace_on_error:
         cumulative_trace = '\n'.join(self.trace(request))
         raise ExecutionError('Received unexpected Throw state(s):\n{}'.format(cumulative_trace))
 

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -91,11 +91,6 @@ class Scheduler(object):
     rule_index = RuleIndex.create(list(rules))
     self._root_subject_types = sorted(rule_index.roots)
 
-    # If configured, visualize the rule graph before asserting that it is valid.
-    if self.visualize_to_dir() is not None:
-      rule_graph_name = 'rule_graph.dot'
-      self.visualize_rule_graph_to_file(os.path.join(self.visualize_to_dir(), rule_graph_name))
-
     # Create the native Scheduler and Session.
     # TODO: This `_tasks` reference could be a local variable, since it is not used
     # after construction.
@@ -129,6 +124,11 @@ class Scheduler(object):
       constraint_for(ExecuteProcessResult),
       constraint_for(GeneratorType),
     )
+
+    # If configured, visualize the rule graph before asserting that it is valid.
+    if self.visualize_to_dir() is not None:
+      rule_graph_name = 'rule_graph.dot'
+      self.visualize_rule_graph_to_file(os.path.join(self.visualize_to_dir(), rule_graph_name))
 
     if validate:
       self._assert_ruleset_valid()

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -283,8 +283,9 @@ class Scheduler(object):
   def visualize_to_dir(self):
     return self._native.visualize_to_dir
 
-  def to_keys(self, subjects):
-    return list(self._to_key(subject) for subject in subjects)
+  def _metrics(self, session):
+    metrics_val = self._native.lib.scheduler_metrics(self._scheduler, session)
+    return {k: v for k, v in self._from_value(metrics_val)}
 
   def pre_fork(self):
     self._native.lib.scheduler_pre_fork(self._scheduler)
@@ -383,6 +384,10 @@ class SchedulerSession(object):
 
   def node_count(self):
     return self._scheduler.graph_len()
+
+  def metrics(self):
+    """Returns metrics for this SchedulerSession as a dict of metric name to metric value."""
+    return self._scheduler._metrics(self._session)
 
   def pre_fork(self):
     self._scheduler.pre_fork()

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -321,7 +321,7 @@ class Scheduler(object):
 
   def new_session(self):
     """Creates a new SchedulerSession for this Scheduler."""
-    return SchedulerSession(self, self._native.new_session())
+    return SchedulerSession(self, self._native.new_session(self._scheduler))
 
 
 class SchedulerSession(object):

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -129,7 +129,7 @@ class Scheduler(object):
       constraint_for(GeneratorType),
     )
 
-    self.assert_ruleset_valid()
+    self._assert_ruleset_valid()
 
   def _root_type_ids(self):
     return self._to_ids_buf(sorted(self._root_subject_types))
@@ -141,7 +141,7 @@ class Scheduler(object):
         for line in fd.readlines():
           yield line.rstrip()
 
-  def assert_ruleset_valid(self):
+  def _assert_ruleset_valid(self):
     raw_value = self._native.lib.validator_run(self._scheduler)
     value = self._from_value(raw_value)
 

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -162,7 +162,6 @@ class Context(object):
     yield
     self.run_tracker.pantsd_stats.set_scheduler_metrics(self._scheduler.metrics())
     self._set_affected_target_count_in_runtracker()
-    self._set_resulting_graph_size_in_runtracker()
 
   def _set_target_root_count_in_runtracker(self):
     """Sets the target root count in the run tracker's daemon stats object."""
@@ -177,12 +176,6 @@ class Context(object):
     target_count = len(self.build_graph)
     self.run_tracker.pantsd_stats.set_affected_targets_size(target_count)
     return target_count
-
-  def _set_resulting_graph_size_in_runtracker(self):
-    """Sets the resulting graph size in the run tracker's daemon stats object."""
-    node_count = self._scheduler.graph_len()
-    self.run_tracker.pantsd_stats.set_resulting_graph_size(node_count)
-    return node_count
 
   def submit_background_work_chain(self, work_chain, parent_workunit_name=None):
     """

--- a/src/python/pants/goal/context.py
+++ b/src/python/pants/goal/context.py
@@ -160,8 +160,8 @@ class Context(object):
     """A contextmanager that sets metrics in the context of a (v1) engine execution."""
     self._set_target_root_count_in_runtracker()
     yield
+    self.run_tracker.pantsd_stats.set_scheduler_metrics(self._scheduler.metrics())
     self._set_affected_target_count_in_runtracker()
-    self._set_affected_target_files_count_in_runtracker()
     self._set_resulting_graph_size_in_runtracker()
 
   def _set_target_root_count_in_runtracker(self):
@@ -177,13 +177,6 @@ class Context(object):
     target_count = len(self.build_graph)
     self.run_tracker.pantsd_stats.set_affected_targets_size(target_count)
     return target_count
-
-  def _set_affected_target_files_count_in_runtracker(self):
-    """Sets the realized target file count in the run tracker's daemon stats object."""
-    # TODO: Move this file counting into the `ProductGraph`.
-    target_file_count = self.build_graph.target_file_count()
-    self.run_tracker.pantsd_stats.set_affected_targets_file_count(target_file_count)
-    return target_file_count
 
   def _set_resulting_graph_size_in_runtracker(self):
     """Sets the resulting graph size in the run tracker's daemon stats object."""

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -15,6 +15,10 @@ class PantsDaemonStats(object):
     self.affected_targets_size = 0
     self.affected_targets_file_count = 0
     self.resulting_graph_size = None
+    self.scheduler_metrics = {}
+
+  def set_scheduler_metrics(self, scheduler_metrics):
+    self.scheduler_metrics = scheduler_metrics
 
   def set_preceding_graph_size(self, size):
     self.preceding_graph_size = size
@@ -25,17 +29,15 @@ class PantsDaemonStats(object):
   def set_affected_targets_size(self, size):
     self.affected_targets_size = size
 
-  def set_affected_targets_file_count(self, count):
-    self.affected_targets_file_count = count
-
   def set_resulting_graph_size(self, size):
     self.resulting_graph_size = size
 
   def get_all(self):
-    return {
+    res = dict(self.scheduler_metrics)
+    res.update({
       'preceding_graph_size': self.preceding_graph_size,
       'target_root_size': self.target_root_size,
       'affected_targets_size': self.affected_targets_size,
-      'affected_targets_file_count': self.affected_targets_file_count,
       'resulting_graph_size': self.resulting_graph_size,
-    }
+    })
+    return res

--- a/src/python/pants/goal/pantsd_stats.py
+++ b/src/python/pants/goal/pantsd_stats.py
@@ -10,18 +10,13 @@ class PantsDaemonStats(object):
   """Tracks various stats about the daemon."""
 
   def __init__(self):
-    self.preceding_graph_size = None
     self.target_root_size = 0
     self.affected_targets_size = 0
     self.affected_targets_file_count = 0
-    self.resulting_graph_size = None
     self.scheduler_metrics = {}
 
   def set_scheduler_metrics(self, scheduler_metrics):
     self.scheduler_metrics = scheduler_metrics
-
-  def set_preceding_graph_size(self, size):
-    self.preceding_graph_size = size
 
   def set_target_root_size(self, size):
     self.target_root_size = size
@@ -29,15 +24,10 @@ class PantsDaemonStats(object):
   def set_affected_targets_size(self, size):
     self.affected_targets_size = size
 
-  def set_resulting_graph_size(self, size):
-    self.resulting_graph_size = size
-
   def get_all(self):
     res = dict(self.scheduler_metrics)
     res.update({
-      'preceding_graph_size': self.preceding_graph_size,
       'target_root_size': self.target_root_size,
       'affected_targets_size': self.affected_targets_size,
-      'resulting_graph_size': self.resulting_graph_size,
     })
     return res

--- a/src/python/pants/pantsd/pailgun_server.py
+++ b/src/python/pants/pantsd/pailgun_server.py
@@ -77,6 +77,10 @@ class PailgunHandler(PailgunHandlerBase):
     with maybe_profiled(environment.get('PANTSD_PROFILE')):
       self._run_pants(self.request, arguments, environment)
 
+    # NB: This represents the end of pantsd's involvement in the request, but the request will
+    # continue to run post-fork.
+    self.logger.info('pailgun request completed: `{}`'.format(' '.join(arguments)))
+
   def handle_error(self, exc=None):
     """Error handler for failed calls to handle()."""
     if exc:

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -115,11 +115,11 @@ class PantsDaemon(FingerprintedProcessManager):
       if full_init:
         build_root = get_buildroot()
         native = Native.create(bootstrap_options_values)
-        legacy_graph_helper = cls._setup_legacy_graph_helper(native, bootstrap_options_values)
+        legacy_graph_scheduler = cls._setup_legacy_graph_scheduler(native, bootstrap_options_values)
         services, port_map = cls._setup_services(
           build_root,
           bootstrap_options_values,
-          legacy_graph_helper,
+          legacy_graph_scheduler,
           watchman
         )
 
@@ -139,8 +139,8 @@ class PantsDaemon(FingerprintedProcessManager):
       return OptionsBootstrapper().get_bootstrap_options()
 
     @staticmethod
-    def _setup_legacy_graph_helper(native, bootstrap_options):
-      """Initializes a `LegacyGraphHelper` instance."""
+    def _setup_legacy_graph_scheduler(native, bootstrap_options):
+      """Initializes a `LegacyGraphScheduler` instance."""
       return EngineInitializer.setup_legacy_graph(
         bootstrap_options.pants_ignore,
         bootstrap_options.pants_workdir,
@@ -152,7 +152,7 @@ class PantsDaemon(FingerprintedProcessManager):
       )
 
     @staticmethod
-    def _setup_services(build_root, bootstrap_options, legacy_graph_helper, watchman):
+    def _setup_services(build_root, bootstrap_options, legacy_graph_scheduler, watchman):
       """Initialize pantsd services.
 
       :returns: A tuple of (`tuple` service_instances, `dict` port_map).
@@ -165,7 +165,7 @@ class PantsDaemon(FingerprintedProcessManager):
 
       scheduler_service = SchedulerService(
         fs_event_service,
-        legacy_graph_helper,
+        legacy_graph_scheduler,
         build_root,
         bootstrap_options.pantsd_invalidation_globs
       )
@@ -178,7 +178,7 @@ class PantsDaemon(FingerprintedProcessManager):
         scheduler_service=scheduler_service
       )
 
-      store_gc_service = StoreGCService(legacy_graph_helper.scheduler)
+      store_gc_service = StoreGCService(legacy_graph_scheduler.scheduler)
 
       return (
         # Services.

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -58,10 +58,6 @@ class PailgunService(PantsService):
       graph_helper = None
       deferred_exc = None
 
-      # Capture the size of the graph prior to any warming, for stats.
-      preceding_graph_size = self._scheduler_service.product_graph_len()
-      self._logger.debug('resident graph size: %s', preceding_graph_size)
-
       self._logger.debug('execution commandline: %s', arguments)
       options, _ = OptionsInitializer(OptionsBootstrapper(args=arguments)).setup(init_logging=False)
 
@@ -88,7 +84,6 @@ class PailgunService(PantsService):
         target_roots,
         graph_helper,
         self.fork_lock,
-        preceding_graph_size,
         deferred_exc
       )
 

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -64,16 +64,15 @@ class PailgunService(PantsService):
 
       self._logger.debug('execution commandline: %s', arguments)
       options, _ = OptionsInitializer(OptionsBootstrapper(args=arguments)).setup(init_logging=False)
-      target_roots = self._target_roots_calculator.create(
-        options,
-        change_calculator=self._scheduler_service.change_calculator
-      )
 
       try:
         self._logger.debug('warming the product graph via %s', self._scheduler_service)
         # N.B. This call is made in the pre-fork daemon context for reach and reuse of the
         # resident scheduler.
-        graph_helper = self._scheduler_service.warm_product_graph(target_roots)
+        graph_helper, target_roots = self._scheduler_service.warm_product_graph(
+          options,
+          self._target_roots_calculator
+        )
       except Exception:
         deferred_exc = sys.exc_info()
         self._logger.warning(

--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -62,8 +62,8 @@ pub fn store_bytes(bytes: &[u8]) -> Value {
   with_externs(|e| (e.store_bytes)(e.context, bytes.as_ptr(), bytes.len() as u64))
 }
 
-pub fn store_i32(val: i32) -> Value {
-  with_externs(|e| (e.store_i32)(e.context, val))
+pub fn store_i64(val: i64) -> Value {
+  with_externs(|e| (e.store_i64)(e.context, val))
 }
 
 pub fn project_ignoring_type(value: &Value, field: &str) -> Value {
@@ -221,7 +221,7 @@ pub struct Externs {
   pub satisfied_by_type: SatisfiedByTypeExtern,
   pub store_tuple: StoreTupleExtern,
   pub store_bytes: StoreBytesExtern,
-  pub store_i32: StoreI32Extern,
+  pub store_i64: StoreI64Extern,
   pub project_ignoring_type: ProjectIgnoringTypeExtern,
   pub project_multi: ProjectMultiExtern,
   pub type_to_str: TypeToStrExtern,
@@ -255,7 +255,7 @@ pub type StoreTupleExtern = extern "C" fn(*const ExternContext, *const Value, u6
 
 pub type StoreBytesExtern = extern "C" fn(*const ExternContext, *const u8, u64) -> Value;
 
-pub type StoreI32Extern = extern "C" fn(*const ExternContext, i32) -> Value;
+pub type StoreI64Extern = extern "C" fn(*const ExternContext, i64) -> Value;
 
 #[repr(C)]
 #[derive(Debug)]

--- a/src/rust/engine/src/graph.rs
+++ b/src/rust/engine/src/graph.rs
@@ -197,36 +197,32 @@ impl InnerGraph {
   ///
   fn detect_cycle(&self, src_id: EntryId, dst_id: EntryId) -> bool {
     // Search either forward from the dst, or backward from the src.
-    let (root, needle, dependents) = {
+    let (root, needle, direction) = {
       let out_from_dst = self.pg.neighbors(dst_id).count();
       let in_to_src = self
         .pg
         .neighbors_directed(src_id, Direction::Incoming)
         .count();
       if out_from_dst < in_to_src {
-        (dst_id, src_id, false)
+        (dst_id, src_id, Direction::Outgoing)
       } else {
-        (src_id, dst_id, true)
+        (src_id, dst_id, Direction::Incoming)
       }
     };
 
     // Search for an existing path from dst to src.
     let mut roots = VecDeque::new();
     roots.push_back(root);
-    self.walk(roots, dependents).any(|eid| eid == needle)
+    self.walk(roots, direction).any(|eid| eid == needle)
   }
 
   ///
   /// Begins a topological Walk from the given roots.
   ///
-  fn walk(&self, roots: VecDeque<EntryId>, dependents: bool) -> Walk {
+  fn walk(&self, roots: VecDeque<EntryId>, direction: Direction) -> Walk {
     Walk {
       graph: self,
-      direction: if dependents {
-        Direction::Incoming
-      } else {
-        Direction::Outgoing
-      },
+      direction: direction,
       deque: roots,
       walked: HashSet::default(),
     }
@@ -236,18 +232,14 @@ impl InnerGraph {
   /// Begins a topological walk from the given roots. Provides both the current entry as well as the
   /// depth from the root.
   ///
-  fn leveled_walk<P>(&self, roots: Vec<EntryId>, predicate: P, dependents: bool) -> LeveledWalk<P>
+  fn leveled_walk<P>(&self, roots: Vec<EntryId>, predicate: P, direction: Direction) -> LeveledWalk<P>
   where
     P: Fn(EntryId, Level) -> bool,
   {
     let rrr = roots.into_iter().map(|r| (r, 0)).collect::<VecDeque<_>>();
     LeveledWalk {
       graph: self,
-      direction: if dependents {
-        Direction::Incoming
-      } else {
-        Direction::Outgoing
-      },
+      direction: direction,
       deque: rrr,
       walked: HashSet::default(),
       predicate: predicate,
@@ -279,7 +271,7 @@ impl InnerGraph {
           })
         })
         .collect();
-      self.walk(root_ids, true).map(|eid| eid).collect()
+      self.walk(root_ids, Direction::Incoming).map(|eid| eid).collect()
     };
 
     // Then remove all entries in one shot.
@@ -321,7 +313,7 @@ impl InnerGraph {
     );
   }
 
-  fn visualize(&self, roots: &Vec<NodeKey>, path: &Path) -> io::Result<()> {
+  fn visualize(&self, roots: &[NodeKey], path: &Path) -> io::Result<()> {
     let file = try!(File::create(path));
     let mut f = BufWriter::new(file);
     let mut viz_colors = HashMap::new();
@@ -352,7 +344,7 @@ impl InnerGraph {
       .collect();
     let predicate = |_| true;
 
-    for eid in self.walk(root_entries, false) {
+    for eid in self.walk(root_entries, Direction::Outgoing) {
       let entry = self.unsafe_entry_for_id(eid);
       let node_str = entry.format::<NodeKey>();
 
@@ -439,7 +431,7 @@ impl InnerGraph {
       .entry_id(&EntryKey::Valid(root.clone()))
       .map(|&eid| vec![eid])
       .unwrap_or_else(|| vec![]);
-    for t in self.leveled_walk(root_entries, |eid, _| !is_bottom(eid), false) {
+    for t in self.leveled_walk(root_entries, |eid, _| !is_bottom(eid), Direction::Outgoing) {
       let (eid, level) = t;
       try!(write!(&mut f, "{}\n", _format(eid, level)));
     }
@@ -448,21 +440,34 @@ impl InnerGraph {
     Ok(())
   }
 
+  fn reachable_digest_count(&self, roots: &[NodeKey]) -> usize {
+    let root_ids =
+      roots.iter()
+        .cloned()
+        .filter_map(|node| self.entry_id(&EntryKey::Valid(node)))
+        .cloned()
+        .collect();
+    self.digests_internal(self.walk(root_ids, Direction::Outgoing).collect()).count()
+  }
+
   fn all_digests(&self) -> Vec<hashing::Digest> {
-    self
-      .pg
-      .node_indices()
-      .map(|node_index| self.pg.node_weight(node_index))
-      .filter_map(|maybe_entry| maybe_entry)
-      .filter_map(|entry| match entry.node.content() {
-        &NodeKey::DigestFile(_) => Some(entry.peek::<DigestFile>()),
-        _ => None,
-      })
-      .filter_map(|output| match output {
-        Some(Ok(digest)) => Some(digest),
-        _ => None,
-      })
-      .collect()
+    self.digests_internal(self.pg.node_indices().collect()).collect()
+  }
+
+  fn digests_internal<'g>(&'g self, entryids: Vec<EntryId>) -> Box<Iterator<Item=hashing::Digest> + 'g> {
+    Box::new(
+      entryids
+        .into_iter()
+        .filter_map(move |eid| self.entry_for_id(eid))
+        .filter_map(|entry| match entry.node.content() {
+          &NodeKey::DigestFile(_) => Some(entry.peek::<DigestFile>()),
+          _ => None,
+        })
+        .filter_map(|output| match output {
+          Some(Ok(digest)) => Some(digest),
+          _ => None,
+        })
+    )   
   }
 }
 
@@ -576,9 +581,14 @@ impl Graph {
     inner.trace(root, path)
   }
 
-  pub fn visualize(&self, roots: &Vec<NodeKey>, path: &Path) -> io::Result<()> {
+  pub fn visualize(&self, roots: &[NodeKey], path: &Path) -> io::Result<()> {
     let inner = self.inner.lock().unwrap();
     inner.visualize(roots, path)
+  }
+
+  pub fn reachable_digest_count(&self, roots: &[NodeKey]) -> usize {
+    let inner = self.inner.lock().unwrap();
+    inner.reachable_digest_count(roots)
   }
 
   pub fn all_digests(&self) -> Vec<hashing::Digest> {

--- a/src/rust/engine/src/graph.rs
+++ b/src/rust/engine/src/graph.rs
@@ -232,7 +232,12 @@ impl InnerGraph {
   /// Begins a topological walk from the given roots. Provides both the current entry as well as the
   /// depth from the root.
   ///
-  fn leveled_walk<P>(&self, roots: Vec<EntryId>, predicate: P, direction: Direction) -> LeveledWalk<P>
+  fn leveled_walk<P>(
+    &self,
+    roots: Vec<EntryId>,
+    predicate: P,
+    direction: Direction,
+  ) -> LeveledWalk<P>
   where
     P: Fn(EntryId, Level) -> bool,
   {
@@ -271,7 +276,10 @@ impl InnerGraph {
           })
         })
         .collect();
-      self.walk(root_ids, Direction::Incoming).map(|eid| eid).collect()
+      self
+        .walk(root_ids, Direction::Incoming)
+        .map(|eid| eid)
+        .collect()
     };
 
     // Then remove all entries in one shot.
@@ -441,20 +449,27 @@ impl InnerGraph {
   }
 
   fn reachable_digest_count(&self, roots: &[NodeKey]) -> usize {
-    let root_ids =
-      roots.iter()
-        .cloned()
-        .filter_map(|node| self.entry_id(&EntryKey::Valid(node)))
-        .cloned()
-        .collect();
-    self.digests_internal(self.walk(root_ids, Direction::Outgoing).collect()).count()
+    let root_ids = roots
+      .iter()
+      .cloned()
+      .filter_map(|node| self.entry_id(&EntryKey::Valid(node)))
+      .cloned()
+      .collect();
+    self
+      .digests_internal(self.walk(root_ids, Direction::Outgoing).collect())
+      .count()
   }
 
   fn all_digests(&self) -> Vec<hashing::Digest> {
-    self.digests_internal(self.pg.node_indices().collect()).collect()
+    self
+      .digests_internal(self.pg.node_indices().collect())
+      .collect()
   }
 
-  fn digests_internal<'g>(&'g self, entryids: Vec<EntryId>) -> Box<Iterator<Item=hashing::Digest> + 'g> {
+  fn digests_internal<'g>(
+    &'g self,
+    entryids: Vec<EntryId>,
+  ) -> Box<Iterator<Item = hashing::Digest> + 'g> {
     Box::new(
       entryids
         .into_iter()
@@ -466,8 +481,8 @@ impl InnerGraph {
         .filter_map(|output| match output {
           Some(Ok(digest)) => Some(digest),
           _ => None,
-        })
-    )   
+        }),
+    )
   }
 }
 

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -44,7 +44,7 @@ use externs::{Buffer, BufferBuffer, CallExtern, CloneValExtern, CreateExceptionE
               DropHandlesExtern, EqualsExtern, EvalExtern, ExternContext, Externs,
               GeneratorSendExtern, IdentifyExtern, LogExtern, ProjectIgnoringTypeExtern,
               ProjectMultiExtern, PyResult, SatisfiedByExtern, SatisfiedByTypeExtern,
-              StoreBytesExtern, StoreI32Extern, StoreTupleExtern, TypeIdBuffer, TypeToStrExtern,
+              StoreBytesExtern, StoreI64Extern, StoreTupleExtern, TypeIdBuffer, TypeToStrExtern,
               ValToStrExtern};
 use rule_graph::{GraphMaker, RuleGraph};
 use scheduler::{ExecutionRequest, RootResult, Scheduler, Session};
@@ -135,7 +135,7 @@ pub extern "C" fn externs_set(
   satisfied_by_type: SatisfiedByTypeExtern,
   store_tuple: StoreTupleExtern,
   store_bytes: StoreBytesExtern,
-  store_i32: StoreI32Extern,
+  store_i64: StoreI64Extern,
   project_ignoring_type: ProjectIgnoringTypeExtern,
   project_multi: ProjectMultiExtern,
   create_exception: CreateExceptionExtern,
@@ -158,7 +158,7 @@ pub extern "C" fn externs_set(
     satisfied_by_type,
     store_tuple,
     store_bytes,
-    store_i32,
+    store_i64,
     project_ignoring_type,
     project_multi,
     create_exception,
@@ -268,8 +268,8 @@ pub extern "C" fn scheduler_metrics(
         .into_iter()
         .map(|(metric, value)| {
           externs::store_tuple(&[
-            externs::store_bytes(&metric.bytes().collect::<Vec<_>>()),
-            externs::store_i32(value),
+            externs::store_bytes(metric.as_bytes()),
+            externs::store_i64(value),
           ])
         })
         .collect::<Vec<_>>();

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -474,8 +474,10 @@ pub extern "C" fn nodes_destroy(raw_nodes_ptr: *mut RawNodes) {
 }
 
 #[no_mangle]
-pub extern "C" fn session_create() -> *const Session {
-  Box::into_raw(Box::new(Session::new()))
+pub extern "C" fn session_create(scheduler_ptr: *mut Scheduler) -> *const Session {
+  with_scheduler(scheduler_ptr, |scheduler| {
+    Box::into_raw(Box::new(Session::new(scheduler)))
+  })
 }
 
 #[no_mangle]

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -360,7 +360,7 @@ impl Select {
                   &[
                     externs::store_bytes(&result.0.stdout),
                     externs::store_bytes(&result.0.stderr),
-                    externs::store_i32(result.0.exit_code),
+                    externs::store_i64(result.0.exit_code as i64),
                   ],
                 )
               })
@@ -748,7 +748,7 @@ impl Snapshot {
       &context.core.types.construct_snapshot,
       &[
         externs::store_bytes(&(item.digest.0).to_hex().as_bytes()),
-        externs::store_i32(item.digest.1 as i32),
+        externs::store_i64(item.digest.1 as i64),
         externs::store_tuple(&path_stats),
       ],
     )

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -22,9 +22,9 @@ pub struct Session {
 }
 
 impl Session {
-  fn new() -> Session {
+  pub fn new() -> Session {
     Session {
-      roots: Mutex::new(HashSet::new())
+      roots: Mutex::new(HashSet::new()),
     }
   }
 
@@ -34,7 +34,7 @@ impl Session {
   }
 
   fn root_nodes(&self) -> Vec<NodeKey> {
-    let mut roots = self.roots.lock().unwrap();
+    let roots = self.roots.lock().unwrap();
     roots.iter().map(|r| r.clone().into()).collect()
   }
 }
@@ -118,11 +118,17 @@ impl Scheduler {
   }
 
   ///
-  /// TODO: Convert `extern::store_i32` to i64, and expand the range here. 
+  /// TODO: Convert `extern::store_i32` to i64, and expand the range here.
   ///
   pub fn metrics(&self, session: &Session) -> HashMap<&str, i32> {
     let mut m = HashMap::new();
-    m.insert("affected_files", self.core.graph.reachable_digest_count(&session.root_nodes()) as i32);
+    m.insert(
+      "affected_files",
+      self
+        .core
+        .graph
+        .reachable_digest_count(&session.root_nodes()) as i32,
+    );
     m
   }
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -123,7 +123,7 @@ impl Scheduler {
   pub fn metrics(&self, session: &Session) -> HashMap<&str, i32> {
     let mut m = HashMap::new();
     m.insert(
-      "affected_files",
+      "affected_file_count",
       self
         .core
         .graph

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -24,13 +24,16 @@ use selectors;
 /// they use internal mutability in order to avoid exposing locks to callers.
 ///
 pub struct Session {
+  // The total size of the graph at Session-creation time.
+  preceding_graph_size: usize,
   // The set of roots that have been requested within this session.
   roots: Mutex<HashSet<Root>>,
 }
 
 impl Session {
-  pub fn new() -> Session {
+  pub fn new(scheduler: &Scheduler) -> Session {
     Session {
+      preceding_graph_size: scheduler.core.graph.len(),
       roots: Mutex::new(HashSet::new()),
     }
   }
@@ -136,6 +139,8 @@ impl Scheduler {
         .graph
         .reachable_digest_count(&session.root_nodes()) as i64,
     );
+    m.insert("preceding_graph_size", session.preceding_graph_size as i64);
+    m.insert("resulting_graph_size", self.core.graph.len() as i64);
     m
   }
 

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -16,6 +16,13 @@ use nodes::{NodeKey, Select};
 use rule_graph;
 use selectors;
 
+///
+/// A Session represents a related series of requests (generally: one run of the pants CLI) on an
+/// underlying Scheduler, and is a useful scope for metrics.
+///
+/// Both Scheduler and Session are exposed to python and expected to be used by multiple threads, so
+/// they use internal mutability in order to avoid exposing locks to callers.
+///
 pub struct Session {
   // The set of roots that have been requested within this session.
   roots: Mutex<HashSet<Root>>,
@@ -118,16 +125,16 @@ impl Scheduler {
   }
 
   ///
-  /// TODO: Convert `extern::store_i32` to i64, and expand the range here.
+  /// Return Scheduler and per-Session metrics.
   ///
-  pub fn metrics(&self, session: &Session) -> HashMap<&str, i32> {
+  pub fn metrics(&self, session: &Session) -> HashMap<&str, i64> {
     let mut m = HashMap::new();
     m.insert(
       "affected_file_count",
       self
         .core
         .graph
-        .reachable_digest_count(&session.root_nodes()) as i32,
+        .reachable_digest_count(&session.root_nodes()) as i64,
     );
     m
   }

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -57,13 +57,13 @@ class LegacyAddressMapperTest(unittest.TestCase):
 
   def create_address_mapper(self, build_root):
     work_dir = os.path.join(build_root, '.pants.d')
-    scheduler, _, _ = EngineInitializer.setup_legacy_graph(
+    scheduler = EngineInitializer.setup_legacy_graph(
       [],
       work_dir,
       build_file_imports_behavior='allow',
       build_root=build_root,
       native=self._native
-    )
+    ).scheduler
     return LegacyAddressMapper(scheduler.new_session(), build_root)
 
   def test_is_valid_single_address(self):

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -64,7 +64,7 @@ class LegacyAddressMapperTest(unittest.TestCase):
       build_root=build_root,
       native=self._native
     )
-    return LegacyAddressMapper(scheduler, build_root)
+    return LegacyAddressMapper(scheduler.new_session(), build_root)
 
   def test_is_valid_single_address(self):
     with temporary_dir() as build_root:

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -63,7 +63,8 @@ class GraphTestBase(unittest.TestCase):
   def create_graph_from_specs(self, graph_helper, specs):
     Subsystem.reset()
     target_roots = self.create_target_roots(specs)
-    graph = graph_helper.create_build_graph(target_roots)[0]
+    session = graph_helper.scheduler.new_session()
+    graph = graph_helper.create_build_graph(session, target_roots)[0]
     return graph, target_roots
 
   def create_target_roots(self, specs):

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -58,13 +58,13 @@ class GraphTestBase(unittest.TestCase):
     with self.graph_helper(build_file_aliases=build_file_aliases) as graph_helper:
       graph, target_roots = self.create_graph_from_specs(graph_helper, specs)
       addresses = tuple(graph.inject_roots_closure(target_roots))
-      yield graph, addresses, graph_helper.scheduler
+      yield graph, addresses, graph_helper.scheduler.new_session()
 
   def create_graph_from_specs(self, graph_helper, specs):
     Subsystem.reset()
     target_roots = self.create_target_roots(specs)
-    session = graph_helper.scheduler.new_session()
-    graph = graph_helper.create_build_graph(session, target_roots)[0]
+    session = graph_helper.new_session()
+    graph = session.create_build_graph(target_roots)[0]
     return graph, target_roots
 
   def create_target_roots(self, specs):

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -10,7 +10,7 @@ import shutil
 
 from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.engine.nodes import Return, Throw
-from pants.engine.scheduler import LocalScheduler
+from pants.engine.scheduler import Scheduler
 from pants.util.contextutil import temporary_file_path
 from pants.util.dirutil import safe_mkdtemp, safe_rmtree
 from pants_test.engine.util import init_native
@@ -48,17 +48,16 @@ class SchedulerTestBase(object):
                    project_tree=None,
                    work_dir=None,
                    include_trace_on_error=True):
-    """Creates a Scheduler with the given Rules installed."""
+    """Creates a SchedulerSession for a Scheduler with the given Rules installed."""
     rules = rules or []
-    goals = {}
     work_dir = work_dir or self._create_work_dir()
     project_tree = project_tree or self.mk_fs_tree(work_dir=work_dir)
-    return LocalScheduler(work_dir,
-                          goals,
-                          rules,
+    scheduler = Scheduler(self._native,
                           project_tree,
-                          self._native,
+                          work_dir,
+                          rules,
                           include_trace_on_error=include_trace_on_error)
+    return scheduler.new_session()
 
   def context_with_scheduler(self, scheduler, *args, **kwargs):
     return self.context(*args, scheduler=scheduler, **kwargs)

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -30,12 +30,11 @@ class EngineExamplesTest(unittest.TestCase):
 
     self.java = Address.parse('src/java/simple')
 
-  def request(self, goals, *addresses):
-    return self.scheduler.build_request(goals=goals,
-                                        subjects=addresses)
+  def request(self, products, *addresses):
+    return self.scheduler.execution_request(products, addresses)
 
   def test_serial_execution_simple(self):
-    request = self.request(['compile'], self.java)
+    request = self.request([Classpath], self.java)
     result = self.scheduler.execute(request)
     self.scheduler.visualize_graph_to_file(request, 'blah/run.0.dot')
     self.assertEqual(Return(Classpath(creator='javac')), result.root_products[0][1])

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -332,7 +332,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       SingletonRule(B, B()),
     ]
 
-    subgraph = self.create_subgraph(A, rules, SubA())
+    subgraph = self.create_subgraph(A, rules, SubA(), validate=False)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -351,7 +351,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(Exactly(A), [], noop),
     ]
 
-    fullgraph = self.create_full_graph(rules)
+    fullgraph = self.create_full_graph(rules, validate=False)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -372,7 +372,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(Exactly(B), [Select(D), Select(A)], noop),
     ]
 
-    fullgraph = self.create_full_graph(rules)
+    fullgraph = self.create_full_graph(rules, validate=False)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -393,7 +393,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(Exactly(A), [Select(B)], noop),
       TaskRule(Exactly(A), [], noop),
     ]
-    subgraph = self.create_subgraph(A, rules, SubA())
+    subgraph = self.create_subgraph(A, rules, SubA(), validate=False)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -525,7 +525,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(Exactly(A), [SelectDependencies(B, SubA, field_types=(D,))], noop),
       SingletonRule(C, C()),
     ]
-    subgraph = self.create_subgraph(A, rules, SubA())
+    subgraph = self.create_subgraph(A, rules, SubA(), validate=False)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -565,7 +565,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(A, [Select(SubA)], noop)
     ]
 
-    subgraph = self.create_subgraph(B, rules, SubA())
+    subgraph = self.create_subgraph(B, rules, SubA(), validate=False)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -646,18 +646,12 @@ class RuleGraphMakerTest(unittest.TestCase):
                      }""").strip(),
       subgraph)
 
-  def create_full_graph(self, rules):
-    scheduler = create_scheduler(rules)
-
+  def create_full_graph(self, rules, validate=True):
+    scheduler = create_scheduler(rules, validate=validate)
     return "\n".join(scheduler.rule_graph_visualization())
 
-  def create_real_subgraph(self, rules, root_subject, product_type):
-    scheduler = create_scheduler(rules)
-
-    return "\n".join(scheduler.rule_subgraph_visualization(root_subject, product_type))
-
-  def create_subgraph(self, requested_product, rules, subject):
-    rules = rules + _suba_root_rules
-    return self.create_real_subgraph(rules, type(subject), requested_product)
+  def create_subgraph(self, requested_product, rules, subject, validate=True):
+    scheduler = create_scheduler(rules + _suba_root_rules, validate=validate)
+    return "\n".join(scheduler.rule_subgraph_visualization(type(subject), requested_product))
 
   assert_equal_with_printing = assert_equal_with_printing

--- a/tests/python/pants_test/engine/test_rules.py
+++ b/tests/python/pants_test/engine/test_rules.py
@@ -12,13 +12,11 @@ from pants.engine.build_files import create_graph_rules
 from pants.engine.fs import create_fs_rules
 from pants.engine.mapper import AddressMapper
 from pants.engine.rules import RootRule, RuleIndex, SingletonRule, TaskRule
-from pants.engine.scheduler import WrappedNativeScheduler
 from pants.engine.selectors import Get, Select, SelectDependencies
 from pants.util.objects import Exactly
 from pants_test.engine.examples.parsers import JsonParser
 from pants_test.engine.examples.planners import Goal
-from pants_test.engine.util import (TargetTable, assert_equal_with_printing,
-                                    create_native_scheduler, init_native)
+from pants_test.engine.util import TargetTable, assert_equal_with_printing, create_scheduler
 
 
 class AGoal(Goal):
@@ -75,15 +73,11 @@ class RuleIndexTest(unittest.TestCase):
 
 
 class RulesetValidatorTest(unittest.TestCase):
-  def create_validator(self, goal_to_product, rules):
-    return create_native_scheduler(rules)
-
   def test_ruleset_with_missing_product_type(self):
     rules = _suba_root_rules + [TaskRule(A, [Select(B)], noop)]
-    scheduler = create_native_scheduler(rules)
 
     with self.assertRaises(ValueError) as cm:
-      scheduler.assert_ruleset_valid()
+      create_scheduler(rules)
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
@@ -94,9 +88,8 @@ class RulesetValidatorTest(unittest.TestCase):
 
   def test_ruleset_with_rule_with_two_missing_selects(self):
     rules = _suba_root_rules + [TaskRule(A, [Select(B), Select(C)], noop)]
-    validator = self.create_validator({}, rules)
     with self.assertRaises(ValueError) as cm:
-      validator.assert_ruleset_valid()
+      create_scheduler(rules)
 
     self.assert_equal_with_printing(dedent("""
                      Rules with errors: 1
@@ -108,9 +101,7 @@ class RulesetValidatorTest(unittest.TestCase):
 
   def test_ruleset_with_selector_only_provided_as_root_subject(self):
     rules = [RootRule(B), TaskRule(A, [Select(B)], noop)]
-    validator = self.create_validator({}, rules)
-
-    validator.assert_ruleset_valid()
+    create_scheduler(rules)
 
   def test_ruleset_with_superclass_of_selected_type_produced_fails(self):
     rules = [
@@ -118,10 +109,9 @@ class RulesetValidatorTest(unittest.TestCase):
       TaskRule(A, [Select(B)], noop),
       TaskRule(B, [Select(SubA)], noop)
     ]
-    validator = self.create_validator({}, rules)
 
     with self.assertRaises(ValueError) as cm:
-      validator.assert_ruleset_valid()
+      create_scheduler(rules)
     self.assert_equal_with_printing(dedent("""
                                       Rules with errors: 2
                                         (A, (Select(B),), noop):
@@ -131,29 +121,12 @@ class RulesetValidatorTest(unittest.TestCase):
                                       """).strip(),
                                     str(cm.exception))
 
-  @unittest.skip('testing api not used by non-example code')
-  def test_ruleset_with_goal_not_produced(self):
-    # The graph is complete, but the goal 'goal-name' requests A,
-    # which is not produced by any rule.
-    rules = _suba_root_rules + [
-      TaskRule(B, [Select(SubA)], noop)
-    ]
-
-    validator = self.create_validator({'goal-name': AGoal}, rules)
-    with self.assertRaises(ValueError) as cm:
-      validator.assert_ruleset_valid()
-
-    self.assert_equal_with_printing("no task for product used by goal \"goal-name\": AGoal",
-                                    str(cm.exception))
-
   def test_ruleset_with_explicit_type_constraint(self):
     rules = _suba_root_rules + [
       TaskRule(Exactly(A), [Select(B)], noop),
       TaskRule(B, [Select(A)], noop)
     ]
-    validator = self.create_validator({}, rules)
-
-    validator.assert_ruleset_valid()
+    create_scheduler(rules)
 
   def test_ruleset_with_failure_due_to_incompatible_subject_for_singleton(self):
     rules = [
@@ -161,10 +134,9 @@ class RulesetValidatorTest(unittest.TestCase):
       TaskRule(D, [Select(C)], noop),
       SingletonRule(B, B()),
     ]
-    validator = self.create_validator({}, rules)
 
     with self.assertRaises(ValueError) as cm:
-      validator.assert_ruleset_valid()
+      create_scheduler(rules)
 
     # This error message could note near matches like the singleton.
     self.assert_equal_with_printing(dedent("""
@@ -179,10 +151,9 @@ class RulesetValidatorTest(unittest.TestCase):
       RootRule(A),
       TaskRule(A, [SelectDependencies(B, SubA, field_types=(D,))], noop),
     ]
-    validator = self.create_validator({}, rules)
 
     with self.assertRaises(ValueError) as cm:
-      validator.assert_ruleset_valid()
+      create_scheduler(rules)
 
     self.assert_equal_with_printing(dedent("""
                              Rules with errors: 1
@@ -199,10 +170,9 @@ class RulesetValidatorTest(unittest.TestCase):
       TaskRule(D, [Select(A), SelectDependencies(A, SubA, field_types=(C,))], noop),
       TaskRule(A, [Select(SubA)], noop)
     ]
-    validator = self.create_validator({}, rules)
 
     with self.assertRaises(ValueError) as cm:
-      validator.assert_ruleset_valid()
+      create_scheduler(rules)
 
     self.assert_equal_with_printing(dedent("""
                       Rules with errors: 2
@@ -225,7 +195,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       RootRule(SubA),
       TaskRule(Exactly(A), [Select(SubA)], noop)
     ]
-    fullgraph = self.create_full_graph(RuleIndex.create(rules))
+    fullgraph = self.create_full_graph(rules)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -242,8 +212,7 @@ class RuleGraphMakerTest(unittest.TestCase):
     address_mapper = AddressMapper(JsonParser(symbol_table), '*.BUILD.json')
     rules = create_graph_rules(address_mapper, symbol_table) + create_fs_rules()
 
-    rule_index = RuleIndex.create(rules)
-    fullgraph_str = self.create_full_graph(rule_index)
+    fullgraph_str = self.create_full_graph(rules)
 
     print('---diagnostic------')
     print(fullgraph_str)
@@ -277,7 +246,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(A, [Select(SubA)], noop),
       TaskRule(B, [Select(A)], noop)
     ]
-    fullgraph = self.create_full_graph(RuleIndex.create(rules))
+    fullgraph = self.create_full_graph(rules)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -382,7 +351,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(Exactly(A), [], noop),
     ]
 
-    fullgraph = self.create_full_graph(RuleIndex.create(rules))
+    fullgraph = self.create_full_graph(rules)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -403,7 +372,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(Exactly(B), [Select(D), Select(A)], noop),
     ]
 
-    fullgraph = self.create_full_graph(RuleIndex.create(rules))
+    fullgraph = self.create_full_graph(rules)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -617,7 +586,7 @@ class RuleGraphMakerTest(unittest.TestCase):
       TaskRule(A, [Select(SubA)], noop)
     ]
 
-    subgraph = self.create_full_graph(RuleIndex.create(rules))
+    subgraph = self.create_full_graph(rules)
 
     self.assert_equal_with_printing(dedent("""
                      digraph {
@@ -677,29 +646,18 @@ class RuleGraphMakerTest(unittest.TestCase):
                      }""").strip(),
       subgraph)
 
-  def create_scheduler(self, rule_index):
-    native = init_native()
-    scheduler = WrappedNativeScheduler(
-      native=native,
-      build_root='/tmp',
-      work_dir='/tmp/.pants.d',
-      ignore_patterns=tuple(),
-      rule_index=rule_index)
-    return scheduler
-
-  def create_full_graph(self, rule_index):
-    scheduler = self.create_scheduler(rule_index)
+  def create_full_graph(self, rules):
+    scheduler = create_scheduler(rules)
 
     return "\n".join(scheduler.rule_graph_visualization())
 
-  def create_real_subgraph(self, rule_index, root_subject, product_type):
-    scheduler = self.create_scheduler(rule_index)
+  def create_real_subgraph(self, rules, root_subject, product_type):
+    scheduler = create_scheduler(rules)
 
     return "\n".join(scheduler.rule_subgraph_visualization(root_subject, product_type))
 
   def create_subgraph(self, requested_product, rules, subject):
     rules = rules + _suba_root_rules
-    rule_index = RuleIndex.create(rules)
-    return self.create_real_subgraph(rule_index, type(subject), requested_product)
+    return self.create_real_subgraph(rules, type(subject), requested_product)
 
   assert_equal_with_printing = assert_equal_with_printing

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -19,8 +19,8 @@ from pants.engine.selectors import Select, SelectVariant
 from pants.util.contextutil import temporary_dir
 from pants_test.engine.examples.planners import (ApacheThriftJavaConfiguration, Classpath, GenGoal,
                                                  Jar, ThriftSources, setup_json_scheduler)
-from pants_test.engine.util import (assert_equal_with_printing, create_native_scheduler,
-                                    init_native, remove_locations_from_traceback)
+from pants_test.engine.util import (assert_equal_with_printing, create_scheduler, init_native,
+                                    remove_locations_from_traceback)
 
 
 walk = "TODO: Should port tests that attempt to inspect graph internals to the native code."
@@ -265,11 +265,11 @@ class SchedulerTraceTest(unittest.TestCase):
       TaskRule(A, [Select(B)], nested_raise)
     ]
 
-    scheduler = create_native_scheduler(rules)
+    scheduler = create_scheduler(rules)
     request = scheduler._native.new_execution_request()
     subject = B()
     scheduler.add_root_selection(request, subject, A)
-    scheduler.run_and_return_roots(request)
+    scheduler.new_session().run_and_return_roots(request)
 
     trace = '\n'.join(scheduler.graph_trace(request))
     # NB removing location info to make trace repeatable

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -5,15 +5,16 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
+import os
 import re
 from types import GeneratorType
 
+from pants.base.file_system_project_tree import FileSystemProjectTree
 from pants.binaries.binary_util import BinaryUtilPrivate
 from pants.engine.addressable import addressable_list
 from pants.engine.native import Native
 from pants.engine.parser import SymbolTable
-from pants.engine.rules import RuleIndex
-from pants.engine.scheduler import WrappedNativeScheduler
+from pants.engine.scheduler import Scheduler
 from pants.engine.selectors import Get
 from pants.engine.struct import HasProducts, Struct
 from pants.util.objects import SubclassesOf
@@ -88,12 +89,10 @@ def init_native():
   return Native.create(opts.for_global_scope())
 
 
-def create_native_scheduler(rules):
-  """Create a WrappedNativeScheduler, with an initialized native instance."""
-  rule_index = RuleIndex.create(rules)
+def create_scheduler(rules):
+  """Create a Scheduler."""
   native = init_native()
-  scheduler = WrappedNativeScheduler(native, '.', './.pants.d', [], rule_index)
-  return scheduler
+  return Scheduler(native, FileSystemProjectTree(os.getcwd()), './.pants.d', rules)
 
 
 class Target(Struct, HasProducts):

--- a/tests/python/pants_test/engine/util.py
+++ b/tests/python/pants_test/engine/util.py
@@ -89,10 +89,10 @@ def init_native():
   return Native.create(opts.for_global_scope())
 
 
-def create_scheduler(rules):
+def create_scheduler(rules, validate=True):
   """Create a Scheduler."""
   native = init_native()
-  return Scheduler(native, FileSystemProjectTree(os.getcwd()), './.pants.d', rules)
+  return Scheduler(native, FileSystemProjectTree(os.getcwd()), './.pants.d', rules, validate=validate)
 
 
 class Target(Struct, HasProducts):


### PR DESCRIPTION
### Problem

As described in #5736, some of the metrics we've recently added introduce dependencies on having constructed a `BuildGraph`. In order to unblock removing the `BuildGraph` requirement in #4769, we'd like to replace those metrics with forward compatible metrics computed in the native engine.

### Solution

Split out a `Session` type which represents a scope for metrics capture. Currently the `Session` records the root requests that were made during its lifetime, which allows it to later determine which nodes are reachable from those roots. In future, additional metrics could be captured in the `Session` object at the beginning (ie, when it is created) or "end" (when `session.metrics()` is called) of the `Session`.

The python objects representing the scheduler were renamed to `Scheduler` and `SchedulerSession` to represent this split. `pantsd` reuses a `Scheduler` for its entire lifetime, but creates a new `SchedulerSession` per client request, which is then used post fork as well.

### Result

The `affected_target_file_count` metric was replaced with `affected_file_count` metric, based on the count of digests reachable from all of the roots in a session. Fixes #5736 and unblocks adding further scheduler metrics.