### PR TITLE
FileContents is gotten from DirectoryDigest not Snapshot

### DIFF
--- a/src/python/pants/engine/build_files.py
+++ b/src/python/pants/engine/build_files.py
@@ -17,7 +17,7 @@ from pants.base.specs import (AscendantAddresses, DescendantAddresses, SiblingAd
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.build_graph.address_lookup_error import AddressLookupError
 from pants.engine.addressable import AddressableDescriptor, BuildFileAddresses
-from pants.engine.fs import FilesContent, PathGlobs, Snapshot
+from pants.engine.fs import DirectoryDigest, FilesContent, PathGlobs, Snapshot
 from pants.engine.mapper import AddressFamily, AddressMap, AddressMapper, ResolveError
 from pants.engine.objects import Locatable, SerializableFactory, Validatable
 from pants.engine.rules import RootRule, SingletonRule, TaskRule, rule
@@ -46,7 +46,8 @@ def parse_address_family(address_mapper, directory):
   path_globs = PathGlobs.create('',
                                 include=patterns,
                                 exclude=address_mapper.build_ignore_patterns)
-  files_content = yield Get(FilesContent, PathGlobs, path_globs)
+  snapshot = yield Get(Snapshot, PathGlobs, path_globs)
+  files_content = yield Get(FilesContent, DirectoryDigest, snapshot.directory_digest)
 
   if not files_content:
     raise ResolveError('Directory "{}" does not contain build files.'.format(directory.path))

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -118,5 +118,6 @@ EMPTY_SNAPSHOT = Snapshot(
 def create_fs_rules():
   """Creates rules that consume the intrinsic filesystem types."""
   return [
+    RootRule(DirectoryDigest),
     RootRule(PathGlobs),
   ]

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1,3 +1,5 @@
+use FileContent;
+
 use bazel_protos;
 use boxfuture::{BoxFuture, Boxable};
 use bytes::Bytes;
@@ -353,7 +355,7 @@ impl Store {
     }
   }
 
-  fn expand_directory(&self, digest: Digest) -> BoxFuture<HashMap<Digest, EntryType>, String> {
+  pub fn expand_directory(&self, digest: Digest) -> BoxFuture<HashMap<Digest, EntryType>, String> {
     let accumulator = Arc::new(Mutex::new(HashMap::new()));
 
     self
@@ -470,6 +472,79 @@ impl Store {
         None => Err(format!("File with digest {:?} not found", digest)),
       })
       .to_boxed()
+  }
+
+  // Returns files sorted by their path.
+  pub fn contents_for_directory(
+    &self,
+    directory: bazel_protos::remote_execution::Directory,
+  ) -> BoxFuture<Vec<FileContent>, String> {
+    let accumulator = Arc::new(Mutex::new(HashMap::new()));
+    self
+      .contents_for_directory_helper(directory, PathBuf::new(), accumulator.clone())
+      .map(|()| {
+        let map = Arc::try_unwrap(accumulator).unwrap().into_inner().unwrap();
+        let mut vec: Vec<FileContent> = map
+          .into_iter()
+          .map(|(path, content)| FileContent { path, content })
+          .collect();
+        vec.sort_by(|l, r| l.path.cmp(&r.path));
+        vec
+      })
+      .to_boxed()
+  }
+
+  // Assumes that all fingerprints it encounters are valid.
+  fn contents_for_directory_helper(
+    &self,
+    directory: bazel_protos::remote_execution::Directory,
+    path_so_far: PathBuf,
+    contents_wrapped: Arc<Mutex<HashMap<PathBuf, Bytes>>>,
+  ) -> BoxFuture<(), String> {
+    let contents_wrapped_copy = contents_wrapped.clone();
+    let path_so_far_copy = path_so_far.clone();
+    let store_copy = self.clone();
+    let file_futures = future::join_all(
+      directory
+        .get_files()
+        .iter()
+        .map(move |file_node| {
+          let path = path_so_far_copy.join(file_node.get_name());
+          let contents_wrapped_copy = contents_wrapped_copy.clone();
+          store_copy
+            .load_file_bytes_with(file_node.get_digest().into(), |b| b)
+            .and_then(move |maybe_bytes| {
+              maybe_bytes
+                .ok_or_else(|| format!("Couldn't find file contents for {:?}", path))
+                .map(move |bytes| {
+                  let mut contents = contents_wrapped_copy.lock().unwrap();
+                  contents.insert(path, bytes);
+                })
+            })
+        })
+        .collect::<Vec<_>>(),
+    );
+    let store = self.clone();
+    let dir_futures = future::join_all(
+      directory
+        .get_directories()
+        .into_iter()
+        .map(move |dir_node| {
+          let digest = dir_node.get_digest().into();
+          let path = path_so_far.join(dir_node.get_name());
+          let store = store.clone();
+          let contents_wrapped = contents_wrapped.clone();
+          store
+            .load_directory(digest)
+            .and_then(move |maybe_dir| {
+              maybe_dir
+                .ok_or_else(|| format!("Could not find sub-directory with digest {:?}", digest))
+            })
+            .and_then(move |dir| store.contents_for_directory_helper(dir, path, contents_wrapped))
+        })
+        .collect::<Vec<_>>(),
+    );
+    file_futures.join(dir_futures).map(|(_, _)| ()).to_boxed()
   }
 }
 
@@ -1928,7 +2003,7 @@ mod remote {
 
 #[cfg(test)]
 mod tests {
-  use super::{local, EntryType, Store};
+  use super::{local, EntryType, FileContent, Store};
 
   use bazel_protos;
   use bytes::Bytes;
@@ -2814,6 +2889,103 @@ mod tests {
     assert_eq!(
       store.load_directory(testdir.digest()).wait(),
       Ok(Some(testdir.directory()))
+    );
+  }
+
+  #[test]
+  fn contents_for_directory_empty() {
+    let store_dir = TempDir::new("store").unwrap();
+    let store = new_local_store(store_dir.path());
+    let empty_directory = TestDirectory::empty().directory();
+    store
+      .record_directory(&empty_directory, false)
+      .wait()
+      .expect("Error saving Directory");
+
+    let file_contents = store
+      .contents_for_directory(empty_directory)
+      .wait()
+      .expect("Getting FileContents");
+
+    assert_same_filecontents(file_contents, vec![]);
+  }
+
+  #[test]
+  fn contents_for_directory() {
+    let roland = TestData::roland();
+    let catnip = TestData::catnip();
+    let testdir = TestDirectory::containing_roland();
+    let recursive_testdir = TestDirectory::recursive();
+
+    let store_dir = TempDir::new("store").unwrap();
+    let store = new_local_store(store_dir.path());
+    store
+      .record_directory(&recursive_testdir.directory(), false)
+      .wait()
+      .expect("Error saving recursive Directory");
+    store
+      .record_directory(&testdir.directory(), false)
+      .wait()
+      .expect("Error saving Directory");
+    store
+      .store_file_bytes(roland.bytes(), false)
+      .wait()
+      .expect("Error saving file bytes");
+    store
+      .store_file_bytes(catnip.bytes(), false)
+      .wait()
+      .expect("Error saving catnip file bytes");
+
+    let file_contents = store
+      .contents_for_directory(recursive_testdir.directory())
+      .wait()
+      .expect("Getting FileContents");
+
+    assert_same_filecontents(
+      file_contents,
+      vec![
+        FileContent {
+          path: PathBuf::from("cats").join("roland"),
+          content: roland.bytes(),
+        },
+        FileContent {
+          path: PathBuf::from("treats"),
+          content: catnip.bytes(),
+        },
+      ],
+    );
+  }
+
+  fn assert_same_filecontents(left: Vec<FileContent>, right: Vec<FileContent>) {
+    assert_eq!(
+      left.len(),
+      right.len(),
+      "FileContents did not match, different lengths: left: {:?} right: {:?}",
+      left,
+      right
+    );
+
+    let mut success = true;
+    for (index, (l, r)) in left.iter().zip(right.iter()).enumerate() {
+      if l.path != r.path {
+        success = false;
+        eprintln!(
+          "Paths did not match for index {}: {:?}, {:?}",
+          index, l.path, r.path
+        );
+      }
+      if l.content != r.content {
+        success = false;
+        eprintln!(
+          "Content did not match for index {}: {:?}, {:?}",
+          index, l.content, r.content
+        );
+      }
+    }
+    assert!(
+      success,
+      "FileContents did not match: Left: {:?}, Right: {:?}",
+      left, right
     );
   }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -339,14 +339,38 @@ impl Select {
             kind: IntrinsicKind::FilesContent,
             ..
           }) => {
+            let ref edges = context
+              .core
+              .rule_graph
+              .edges_for_inner(entry)
+              .expect("Expected edges to exist for FilesContent intrinsic.");
             let context = context.clone();
-            self
-              .snapshot(&context, &entry)
-              .and_then(move |snapshot| {
-                // Request the file contents of the Snapshot, and then store them.
-                snapshot
-                  .contents(context.core.store.clone())
-                  .map_err(|e| throw(&e))
+            Select::new(
+              context.core.types.directory_digest.clone(),
+              self.subject.clone(),
+              self.variants.clone(),
+              edges,
+            ).run(context.clone())
+              .and_then(|directory_digest_val| {
+                lift_digest(&directory_digest_val).map_err(|str| throw(&str))
+              })
+              .and_then(move |digest| {
+                let store = context.core.store.clone();
+                context
+                  .core
+                  .store
+                  .load_directory(digest)
+                  .map_err(|str| throw(&str))
+                  .and_then(move |maybe_directory| {
+                    maybe_directory
+                      .ok_or_else(|| format!("Could not find directory with digest {:?}", digest))
+                      .map_err(|str| throw(&str))
+                  })
+                  .and_then(move |directory| {
+                    store
+                      .contents_for_directory(directory)
+                      .map_err(|str| throw(&str))
+                  })
                   .map(move |files_content| Snapshot::store_files_content(&context, &files_content))
               })
               .to_boxed()
@@ -430,6 +454,18 @@ impl From<Select> for NodeKey {
   }
 }
 
+fn lift_digest(digest: &Value) -> Result<hashing::Digest, String> {
+  let fingerprint = externs::project_str(&digest, "fingerprint");
+  let digest_length = externs::project_str(&digest, "serialized_bytes_length");
+  let digest_length_as_usize = digest_length
+    .parse::<usize>()
+    .map_err(|err| format!("Length was not a usize: {:?}", err))?;
+  Ok(hashing::Digest(
+    hashing::Fingerprint::from_hex_string(&fingerprint)?,
+    digest_length_as_usize,
+  ))
+}
+
 ///
 /// A Node that represents executing a process.
 ///
@@ -437,18 +473,6 @@ impl From<Select> for NodeKey {
 pub struct ExecuteProcess(process_execution::ExecuteProcessRequest);
 
 impl ExecuteProcess {
-  fn lift_digest(digest: &Value) -> Result<hashing::Digest, String> {
-    let fingerprint = externs::project_str(&digest, "fingerprint");
-    let digest_length = externs::project_str(&digest, "serialized_bytes_length");
-    let digest_length_as_usize = digest_length
-      .parse::<usize>()
-      .map_err(|err| format!("Length was not a usize: {:?}", err))?;
-    Ok(hashing::Digest(
-      hashing::Fingerprint::from_hex_string(&fingerprint)?,
-      digest_length_as_usize,
-    ))
-  }
-
   ///
   /// Lifts a Key representing a python ExecuteProcessRequest value into a ExecuteProcess Node.
   ///
@@ -464,7 +488,7 @@ impl ExecuteProcess {
         env_var_parts[2 * i + 1].clone(),
       );
     }
-    let digest = Self::lift_digest(&externs::project_ignoring_type(&value, "input_files"))
+    let digest = lift_digest(&externs::project_ignoring_type(&value, "input_files"))
       .map_err(|err| format!("Error parsing digest {}", err))?;
 
     Ok(ExecuteProcess(process_execution::ExecuteProcessRequest {

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -89,7 +89,7 @@ impl Tasks {
       Intrinsic {
         kind: IntrinsicKind::FilesContent,
         product: types.files_content,
-        input: types.snapshot,
+        input: types.directory_digest,
       },
       Intrinsic {
         kind: IntrinsicKind::ProcessExecution,

--- a/tests/python/pants_test/engine/examples/planners.py
+++ b/tests/python/pants_test/engine/examples/planners.py
@@ -17,7 +17,7 @@ from pants.base.project_tree import Dir
 from pants.build_graph.address import Address
 from pants.engine.addressable import addressable_list
 from pants.engine.build_files import create_graph_rules
-from pants.engine.fs import FilesContent, PathGlobs, Snapshot, create_fs_rules
+from pants.engine.fs import DirectoryDigest, FilesContent, PathGlobs, Snapshot, create_fs_rules
 from pants.engine.mapper import AddressFamily, AddressMapper
 from pants.engine.parser import SymbolTable
 from pants.engine.rules import SingletonRule, TaskRule, rule
@@ -130,7 +130,8 @@ def calculate_package_search_path(jvm_package_name, source_roots):
 @rule(ScalaSources, [Select(ScalaInferredDepsSources)])
 def reify_scala_sources(sources):
   """Given a ScalaInferredDepsSources object, create ScalaSources."""
-  source_files_content = yield Get(FilesContent, PathGlobs, sources.path_globs)
+  snapshot = yield Get(Snapshot, PathGlobs, sources.path_globs)
+  source_files_content = yield Get(FilesContent, DirectoryDigest, snapshot.directory_digest)
   packages = set()
   import_re = re.compile(r'^import ([^;]*);?$')
   for filecontent in source_files_content.dependencies:

--- a/tests/python/pants_test/engine/test_build_files.py
+++ b/tests/python/pants_test/engine/test_build_files.py
@@ -32,7 +32,8 @@ class ParseAddressFamilyTest(unittest.TestCase):
     """Test that parsing an empty BUILD file results in an empty AddressFamily."""
     address_mapper = AddressMapper(JsonParser(TestTable()))
     af = run_rule(parse_address_family, address_mapper, Dir('/dev/null'), {
-        (FilesContent, PathGlobs): lambda _: FilesContent([FileContent('/dev/null/BUILD', '')])
+        (Snapshot, PathGlobs): lambda _: Snapshot(DirectoryDigest(str("abc"), 10), (File('/dev/null/BUILD'),)),
+        (FilesContent, DirectoryDigest): lambda _: FilesContent([FileContent('/dev/null/BUILD', '')]),
       })
     self.assertEquals(len(af.objects_by_name), 0)
 

--- a/tests/python/pants_test/engine/test_fs.py
+++ b/tests/python/pants_test/engine/test_fs.py
@@ -55,7 +55,8 @@ class FSTest(unittest.TestCase, SchedulerTestBase, AbstractClass):
   def assert_content(self, filespecs, expected_content):
     with self.mk_project_tree() as project_tree:
       scheduler = self.mk_scheduler(rules=create_fs_rules(), project_tree=project_tree)
-      result = self.execute(scheduler, FilesContent, self.specs('', *filespecs))[0]
+      snapshot = self.execute_expecting_one_result(scheduler, Snapshot, self.specs('', *filespecs)).value
+      result = self.execute_expecting_one_result(scheduler, FilesContent, snapshot.directory_digest).value
       actual_content = {f.path: f.content for f in result.dependencies}
       self.assertEquals(expected_content, actual_content)
 


### PR DESCRIPTION
Before this, FileContents was actually gotten via PathGlobs, which means
that only Snapshots taken from source files could actually have their
contents retrieved.

This will allow us to actually get FileContents for the output of
process execution.