### PR TITLE
Invalidate all task outputs on source root changes.

### DIFF
--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -208,35 +208,36 @@ class SourceRootConfig(Subsystem):
   def register_options(cls, register):
     super(SourceRootConfig, cls).register_options(register)
     register('--unmatched', choices=['create', 'fail'], default='create', advanced=True,
+             fingerprint=True,
              help='Configures the behavior when sources are defined outside of any configured '
                   'source root. `create` will cause a source root to be implicitly created at '
                   'the definition location of the sources; `fail` will trigger an error.')
-    register('--lang-canonicalizations', metavar='<map>', type=dict,
+    register('--lang-canonicalizations', metavar='<map>', type=dict, fingerprint=True,
              default=cls._DEFAULT_LANG_CANONICALIZATIONS, advanced=True,
              help='Map of language aliases to their canonical names.')
 
     pattern_help_fmt = ('A list of source root patterns for {} code. Use a "*" wildcard path '
                         'segment to match the language name, which will be canonicalized.')
-    register('--source-root-patterns', metavar='<list>', type=list,
+    register('--source-root-patterns', metavar='<list>', type=list, fingerprint=True,
              default=cls._DEFAULT_SOURCE_ROOT_PATTERNS, advanced=True,
              help=pattern_help_fmt.format('source'))
-    register('--test-root-patterns', metavar='<list>', type=list,
+    register('--test-root-patterns', metavar='<list>', type=list, fingerprint=True,
              default=cls._DEFAULT_TEST_ROOT_PATTERNS, advanced=True,
              help=pattern_help_fmt.format('test'))
-    register('--thirdparty-root-patterns', metavar='<list>', type=list,
+    register('--thirdparty-root-patterns', metavar='<list>', type=list, fingerprint=True,
              default=cls._DEFAULT_THIRDPARTY_ROOT_PATTERNS, advanced=True,
              help=pattern_help_fmt.format('third-party'))
 
     fixed_help_fmt = ('A map of source roots for {} code to list of languages. '
                       'Useful when you want to enumerate fixed source roots explicitly, '
                       'instead of relying on patterns.')
-    register('--source-roots', metavar='<map>', type=dict,
+    register('--source-roots', metavar='<map>', type=dict, fingerprint=True,
              default=cls._DEFAULT_SOURCE_ROOTS, advanced=True,
              help=fixed_help_fmt.format('source'))
-    register('--test-roots', metavar='<map>', type=dict,
+    register('--test-roots', metavar='<map>', type=dict, fingerprint=True,
              default=cls._DEFAULT_TEST_ROOTS, advanced=True,
              help=fixed_help_fmt.format('test'))
-    register('--thirdparty-roots', metavar='<map>', type=dict,
+    register('--thirdparty-roots', metavar='<map>', type=dict, fingerprint=True,
              default=cls._DEFAULT_THIRDPARTY_ROOTS, advanced=True,
              help=fixed_help_fmt.format('third-party'))
 

--- a/src/python/pants/task/BUILD
+++ b/src/python/pants/task/BUILD
@@ -20,6 +20,7 @@ python_library(
     'src/python/pants/reporting',
     'src/python/pants/scm',
     'src/python/pants/scm/subsystems:changed',
+    'src/python/pants/source',
     'src/python/pants/subsystem',
     'src/python/pants/util:dirutil',
     'src/python/pants/util:memo',

--- a/src/python/pants/task/task.py
+++ b/src/python/pants/task/task.py
@@ -23,6 +23,7 @@ from pants.option.optionable import Optionable
 from pants.option.options_fingerprinter import OptionsFingerprinter
 from pants.option.scope import ScopeInfo
 from pants.reporting.reporting_utils import items_to_report_element
+from pants.source.source_root import SourceRootConfig
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.dirutil import safe_mkdir, safe_rm_oldest_items_in_dir
 from pants.util.memo import memoized_method, memoized_property
@@ -87,8 +88,8 @@ class TaskBase(SubsystemClientMixin, Optionable, AbstractClass):
 
   @classmethod
   def subsystem_dependencies(cls):
-    return super(TaskBase, cls).subsystem_dependencies() + (CacheSetup.scoped(cls),
-                                                            BuildInvalidator.Factory)
+    return (super(TaskBase, cls).subsystem_dependencies() +
+            (CacheSetup.scoped(cls), BuildInvalidator.Factory, SourceRootConfig))
 
   @classmethod
   def product_types(cls):


### PR DESCRIPTION
Prior to this change, modifying source roots did not cause any invalidation, which is obviously a bug.

Invalidating everything may be a bit aggressive, but finessing exactly what would need to be invalidated in each case is tricky, and source root changes are infrequent, so this seems fine.
