### PR TITLE
[release.sh] Use git configured gpg binary if one is set

### DIFF
--- a/build-support/bin/release.sh
+++ b/build-support/bin/release.sh
@@ -377,13 +377,17 @@ EOM
 )
   get_pgp_keyid &> /dev/null || die "${msg}"
   echo "Found the following key for release signing:"
-  gpg -k $(get_pgp_keyid)
+  $(get_pgp_program) -k $(get_pgp_keyid)
   read -p "Is this the correct key? [Yn]: " answer
   [[ "${answer:-y}" =~ [Yy]([Ee][Ss])? ]] || die "${msg}"
 }
 
 function get_pgp_keyid() {
   git config --get user.signingkey
+}
+
+function get_pgp_program() {
+  git config --get gpg.program || echo "gpg"
 }
 
 function tag_release() {
@@ -640,8 +644,8 @@ function publish_packages() {
   activate_twine
   trap deactivate RETURN
 
-  twine upload --sign --identity=$(get_pgp_keyid) "${DEPLOY_PANTS_WHEEL_DIR}/${PANTS_STABLE_VERSION}"/*.whl
-  twine upload --sign --identity=$(get_pgp_keyid) "${DEPLOY_PANTS_SDIST_DIR}/${PANTS_STABLE_VERSION}"/*.tar.gz
+  twine upload --sign --sign-with=$(get_pgp_program) --identity=$(get_pgp_keyid) "${DEPLOY_PANTS_WHEEL_DIR}/${PANTS_STABLE_VERSION}"/*.whl
+  twine upload --sign --sign-with=$(get_pgp_program) --identity=$(get_pgp_keyid) "${DEPLOY_PANTS_SDIST_DIR}/${PANTS_STABLE_VERSION}"/*.tar.gz
 
   end_travis_section
 }


### PR DESCRIPTION
For some reason, my local install of gpg includes both gpg 2 and gpg v1. When I run with the command `gpg`, I get gpg v1. My keys are setup by gpg v2. That's on my path as `gpg2`.

I setup git so that git knows to use `gpg2`, but pants' release doesn't.

This patch changes release.sh to look up the gpg binary from git's config, just like the signing key.
