### PR TITLE
From<Digest> no longer panics

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -10,6 +10,7 @@ mod pool;
 pub use pool::ResettablePool;
 
 extern crate bazel_protos;
+#[macro_use]
 extern crate boxfuture;
 extern crate byteorder;
 extern crate bytes;

--- a/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
+++ b/src/rust/engine/process_execution/bazel_protos/src/conversions.rs
@@ -9,12 +9,11 @@ impl<'a> From<&'a hashing::Digest> for super::remote_execution::Digest {
   }
 }
 
-impl<'a> From<&'a super::remote_execution::Digest> for hashing::Digest {
+impl<'a> From<&'a super::remote_execution::Digest> for Result<hashing::Digest, String> {
   fn from(d: &super::remote_execution::Digest) -> Self {
-    hashing::Digest(
-      hashing::Fingerprint::from_hex_string(d.get_hash()).expect("Bad fingerprint in Digest"),
-      d.get_size_bytes() as usize,
-    )
+    hashing::Fingerprint::from_hex_string(d.get_hash())
+      .map_err(|err| format!("Bad fingerprint in Digest {:?}: {:?}", d.get_hash(), err))
+      .map(|fingerprint| hashing::Digest(fingerprint, d.get_size_bytes() as usize))
   }
 }
 
@@ -43,13 +42,27 @@ mod tests {
     bazel_digest
       .set_hash("0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff".to_owned());
     bazel_digest.set_size_bytes(10);
-    let converted: hashing::Digest = (&bazel_digest).into();
+    let converted: Result<hashing::Digest, String> = (&bazel_digest).into();
     let want = hashing::Digest(
       hashing::Fingerprint::from_hex_string(
         "0123456789abcdeffedcba98765432100000000000000000ffffffffffffffff",
       ).unwrap(),
       10,
     );
-    assert_eq!(converted, want);
+    assert_eq!(converted, Ok(want));
+  }
+
+  #[test]
+  fn from_bad_bazel_digest() {
+    let mut bazel_digest = super::super::remote_execution::Digest::new();
+    bazel_digest.set_hash("0".to_owned());
+    bazel_digest.set_size_bytes(10);
+    let converted: Result<hashing::Digest, String> = (&bazel_digest).into();
+    let err = converted.expect_err("Want Err converting bad digest");
+    assert!(
+      err.starts_with("Bad fingerprint in Digest \"0\":"),
+      "Bad error message: {}",
+      err
+    );
   }
 }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -72,7 +72,8 @@ impl super::CommandRunner for CommandRunner {
       Ok((command, execute_request)) => {
         let command_runner = self.clone();
         let command_digest = try_future!(execute_request.get_action().get_command_digest().into());
-        self.upload_command(&command, command_digest)
+        self
+          .upload_command(&command, command_digest)
           .and_then(move |_| {
             debug!(
               "Executing remotely request: {:?} (command: {:?})",
@@ -459,10 +460,7 @@ impl CommandRunner {
         if output_file.has_digest() {
           let digest: Result<Digest, String> = output_file.get_digest().into();
           let mut underlying_path_map = path_map.lock().unwrap();
-          underlying_path_map.insert(
-            output_file_path_buf.clone(),
-            digest?,
-          );
+          underlying_path_map.insert(output_file_path_buf.clone(), digest?);
         } else {
           let raw_content = output_file.content.clone();
           let path_map_3 = path_map.clone();

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -376,7 +376,8 @@ impl bazel_protos::remote_execution_grpc::ContentAddressableStorage for StubCASR
     let blobs = self.blobs.lock().unwrap();
     let mut response = bazel_protos::remote_execution::FindMissingBlobsResponse::new();
     for digest in req.get_blob_digests() {
-      let hashing_digest: Digest = digest.into();
+      let hashing_digest_result: Result<Digest, String> = digest.into();
+      let hashing_digest = hashing_digest_result.expect("Bad digest");
       if !blobs.contains_key(&hashing_digest.0) {
         response.mut_missing_blob_digests().push(digest.clone())
       }


### PR DESCRIPTION
We often do this conversion on things returned from a remote execution
API, and we shouldn't panic based on uncontrolled external input.