### PR TITLE
Script BinaryUtils can be captured as snapshots

### DIFF
--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -199,7 +199,7 @@ class Script(BinaryToolBase):
         PathGlobs((script_relpath,), ()),
         bootstrapdir,
       ),
-    ))
+    ))[0]
     return (script_relpath, snapshot)
 
 

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from pants.binaries.binary_util import BinaryRequest, BinaryUtilPrivate
+from pants.engine.fs import PathGlobs, PathGlobsAndRoot
 from pants.fs.archive import XZCompressedTarArchiver, create_archiver
 from pants.subsystem.subsystem import Subsystem
 from pants.util.memo import memoized_method, memoized_property
@@ -189,6 +190,17 @@ class Script(BinaryToolBase):
   :API: public
   """
   platform_dependent = False
+
+  def hackily_snapshot(self, context):
+    bootstrapdir = self.__class__.global_instance().get_options().pants_bootstrapdir
+    script_relpath = os.path.relpath(self.select(context), bootstrapdir)
+    snapshot = context._scheduler.capture_snapshots((
+      PathGlobsAndRoot(
+        PathGlobs((script_relpath,), ()),
+        bootstrapdir,
+      ),
+    ))
+    return (script_relpath, snapshot)
 
 
 class ExecutablePathProvider(object):

--- a/src/python/pants/binaries/binary_tool.py
+++ b/src/python/pants/binaries/binary_tool.py
@@ -192,7 +192,7 @@ class Script(BinaryToolBase):
   platform_dependent = False
 
   def hackily_snapshot(self, context):
-    bootstrapdir = self.__class__.global_instance().get_options().pants_bootstrapdir
+    bootstrapdir = self.get_options().pants_bootstrapdir
     script_relpath = os.path.relpath(self.select(context), bootstrapdir)
     snapshot = context._scheduler.capture_snapshots((
       PathGlobsAndRoot(


### PR DESCRIPTION
This is a hacky transition step until we pull the BinaryUtils subsystem
into v2.

I could not work out how to unit test this change, as I could not create
a context object which actually had the options I specified.

An integration test, however, will follow shortly.