### PR TITLE
Add go_protobuf_library

### DIFF
--- a/contrib/go/3rdparty/go/github.com/golang/protobuf/proto/BUILD
+++ b/contrib/go/3rdparty/go/github.com/golang/protobuf/proto/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+go_remote_library(rev='v1.1.0')
+

--- a/contrib/go/README.md
+++ b/contrib/go/README.md
@@ -279,6 +279,31 @@ You can run your Go tests with `./pants test [go targets]`. Any
 [standard Go tests](https://golang.org/pkg/testing/) found amongst the targets will be compiled and 
 run with output sent to the console.
 
+## Protocol Buffers
+
+Pants integrates [Go support for protocol buffers](https://github.com/golang/protobuf) with the
+`go_protobuf_library` target.
+
+Go targets may depend on a `go_protobuf_library` targets as if it were a `go_library` target.
+Behind the scenes, Pants will generate Go code from the protobuf sources and exposes it as if it
+were a regular Go library.
+
+For example,
+[`contrib/go/examples/src/protobuf/org/pantsbuild/example/route/BUILD`](https://github.com/pantsbuild/pants/blob/master/contrib/go/examples/src/protobuf/org/pantsbuild/example/route/BUILD)
+defines a `go_protobuf_library` target. Notice how it depends on another `go_protobuf_library`
+to satisfy imports in the IDL file.
+
+!inc[start-at=go_protobuf_library](examples/src/protobuf/org/pantsbuild/example/route/BUILD)
+
+[`contrib/go/examples/src/go/distance/BUILD`](https://github.com/pantsbuild/pants/blob/master/contrib/go/examples/src/go/distance/BUILD)
+depends on the `go_protobuf_library`, which transitively depends on another protobuf library.
+
+!inc[start-at=go_binary](examples/src/go/distance/BUILD)
+
+In Go, we can import and use the protobuf generated code as it were regular Go code.
+
+!inc[start-at=main](examples/src/go/distance/main.go)
+
 ## Working with other Go ecosystem tools
 
 Go and the Go ecosystem provide rich tool support. From native Go tools like `go list` and `go vet`

--- a/contrib/go/examples/src/go/distance/BUILD
+++ b/contrib/go/examples/src/go/distance/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This target must be build with protoc that recognizes `option go_package`
+# ./pants run contrib/go/examples/src/go/distance/ --protoc-version=3.5.1
+go_binary(
+  dependencies=[
+    'contrib/go/examples/src/protobuf/org/pantsbuild/example/route:route-go',
+  ]
+)
+

--- a/contrib/go/examples/src/go/distance/BUILD
+++ b/contrib/go/examples/src/go/distance/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # This target must be build with protoc that recognizes `option go_package`
-# ./pants run contrib/go/examples/src/go/distance/ --protoc-version=3.5.1
+# ./pants run contrib/go/examples/src/go/distance/ --protoc-gen-go-protobuf-version=3.4.1
 go_binary(
   dependencies=[
     'contrib/go/examples/src/protobuf/org/pantsbuild/example/route:route-go',

--- a/contrib/go/examples/src/go/distance/main.go
+++ b/contrib/go/examples/src/go/distance/main.go
@@ -1,0 +1,27 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package main
+
+import (
+	"github.com/golang/protobuf/proto"
+	"pantsbuild/example/distance"
+	"pantsbuild/example/route"
+)
+
+func main() {
+	r := &route.Route{
+		Name: proto.String("example_route"),
+		Distances: []*distance.Distance{
+			{
+				Unit:   proto.String("parsecs"),
+				Number: proto.Int64(27),
+			},
+			{
+				Unit:   proto.String("mm"),
+				Number: proto.Int64(2),
+			},
+		},
+	}
+	println(r.String())
+}

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/distance/BUILD
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/distance/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+go_protobuf_library(name='distance-go')
+

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/distance/distances.proto
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/distance/distances.proto
@@ -1,0 +1,15 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.distance;
+
+option go_package = "pantsbuild/example/distance";
+
+/**
+ * Structure for expressing distance measures: 8mm, 12 parsecs, etc.
+ * Not so useful on its own.
+ */
+message Distance {
+  optional string unit = 1;
+  required int64 number = 2;
+}

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/route/BUILD
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/route/BUILD
@@ -1,0 +1,9 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+go_protobuf_library(
+  name='route-go',
+  dependencies=[
+    'contrib/go/examples/src/protobuf/org/pantsbuild/example/distance:distance-go',
+  ],
+)

--- a/contrib/go/examples/src/protobuf/org/pantsbuild/example/route/route.proto
+++ b/contrib/go/examples/src/protobuf/org/pantsbuild/example/route/route.proto
@@ -1,0 +1,18 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+package org.pantsbuild.example.route;
+
+import "org/pantsbuild/example/distance/distances.proto";
+
+option go_package = "pantsbuild/example/route";
+
+
+/**
+ * Structure for expressing a simple route with distances
+ * Not so useful on its own.
+ */
+message Route {
+  optional string name = 1;
+  repeated org.pantsbuild.example.distance.Distance distances = 2;
+}

--- a/contrib/go/src/python/pants/contrib/go/register.py
+++ b/contrib/go/src/python/pants/contrib/go/register.py
@@ -10,6 +10,7 @@ from pants.goal.task_registrar import TaskRegistrar as task
 
 from pants.contrib.go.targets.go_binary import GoBinary
 from pants.contrib.go.targets.go_library import GoLibrary
+from pants.contrib.go.targets.go_protobuf_library import GoProtobufLibrary
 from pants.contrib.go.targets.go_remote_library import GoRemoteLibrary
 from pants.contrib.go.targets.go_thrift_library import GoThriftLibrary
 from pants.contrib.go.tasks.go_binary_create import GoBinaryCreate
@@ -19,6 +20,7 @@ from pants.contrib.go.tasks.go_compile import GoCompile
 from pants.contrib.go.tasks.go_fetch import GoFetch
 from pants.contrib.go.tasks.go_fmt import GoFmt
 from pants.contrib.go.tasks.go_go import GoEnv, GoGo
+from pants.contrib.go.tasks.go_protobuf_gen import GoProtobufGen
 from pants.contrib.go.tasks.go_run import GoRun
 from pants.contrib.go.tasks.go_test import GoTest
 from pants.contrib.go.tasks.go_thrift_gen import GoThriftGen
@@ -29,6 +31,7 @@ def build_file_aliases():
     targets={
       GoBinary.alias(): TargetMacro.Factory.wrap(GoBinary.create, GoBinary),
       GoLibrary.alias(): TargetMacro.Factory.wrap(GoLibrary.create, GoLibrary),
+      GoProtobufLibrary.alias(): GoProtobufLibrary,
       GoThriftLibrary.alias(): GoThriftLibrary,
       'go_remote_libraries': TargetMacro.Factory.wrap(GoRemoteLibrary.from_packages,
                                                       GoRemoteLibrary),
@@ -39,6 +42,7 @@ def build_file_aliases():
 
 def register_goals():
   task(name='go-thrift', action=GoThriftGen).install('gen')
+  task(name='go-protobuf', action=GoProtobufGen).install('gen')
   task(name='go', action=GoBuildgen).install('buildgen')
   task(name='go', action=GoGo).install('go')
   task(name='go-env', action=GoEnv).install()

--- a/contrib/go/src/python/pants/contrib/go/subsystems/protoc_gen_go.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/protoc_gen_go.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import logging
+import os
+
+from pants.backend.codegen.protobuf.subsystems.protoc import Protoc
+from pants.base.workunit import WorkUnitLabel
+from pants.scm.git import Git
+from pants.subsystem.subsystem import Subsystem, SubsystemError
+from pants.util.dirutil import safe_mkdir
+from pants.util.memo import memoized_method
+
+from pants.contrib.go.subsystems.go_distribution import GoDistribution
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProtocGenGo(Subsystem):
+  """A compiled protobuf plugin that generates Go code.
+
+  For details, see https://github.com/golang/protobuf
+  """
+  options_scope = 'protoc-gen-go'
+
+  @classmethod
+  def register_options(cls, register):
+    super(ProtocGenGo, cls).register_options(register)
+    register('--version', default='v1.1.0',
+             help='Version of protoc-gen-go plugin to use when generating code')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(ProtocGenGo, cls).subsystem_dependencies() + (Protoc.scoped(cls), GoDistribution,)
+
+  @memoized_method
+  def select(self, context):
+    self.get_options()
+    workdir = os.path.join(self.get_options().pants_workdir, self.options_scope,
+                           'versions', self.get_options().version)
+    tool_path = os.path.join(workdir, 'bin/protoc-gen-go')
+
+    if not os.path.exists(tool_path):
+      safe_mkdir(workdir, clean=True)
+
+      # Checkout the git repo at a given version. `go get` always gets master.
+      repo = Git.clone('https://github.com/golang/protobuf.git',
+                       os.path.join(workdir, 'src/github.com/golang/protobuf'))
+      repo.set_state(self.get_options().version)
+
+      go = GoDistribution.global_instance()
+      result, go_cmd = go.execute_go_cmd(
+        cmd='install',
+        gopath=workdir,
+        args=['github.com/golang/protobuf/protoc-gen-go'],
+        workunit_factory=context.new_workunit,
+        workunit_labels=[WorkUnitLabel.BOOTSTRAP],
+      )
+
+      if result != 0:
+        raise SubsystemError('{} failed with exit code {}'.format(go_cmd, result))
+
+    logger.info('Selected {} binary bootstrapped to: {}'.format(self.options_scope, tool_path))
+    return tool_path

--- a/contrib/go/src/python/pants/contrib/go/targets/go_protobuf_library.py
+++ b/contrib/go/src/python/pants/contrib/go/targets/go_protobuf_library.py
@@ -1,0 +1,55 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants.base.payload import Payload
+from pants.build_graph.target import Target
+
+from pants.contrib.go.targets.go_local_source import GoLocalSource
+from pants.contrib.go.targets.go_target import GoTarget
+
+
+class GoProtobufLibrary(Target):
+  """A Go library generated from Protobuf IDL files."""
+
+  default_sources_globs = '*.proto'
+
+  def __init__(self,
+               address=None,
+               payload=None,
+               sources=None,
+               **kwargs):
+    """
+    :param sources: protobuf source files
+    :type sources: :class:`pants.source.wrapped_globs.FilesetWithSpec` or list of strings. Paths
+                   are relative to the BUILD file's directory.
+    """
+    payload = payload or Payload()
+    payload.add_field('sources',
+                      self.create_sources_field(sources, address.spec_path, key_arg='sources'))
+
+    super(GoProtobufLibrary, self).__init__(payload=payload, address=address, **kwargs)
+
+  @classmethod
+  def alias(cls):
+    return "go_protobuf_library"
+
+
+class GoProtobufGenLibrary(GoTarget):
+
+  def __init__(self, sources=None, address=None, payload=None, **kwargs):
+    payload = payload or Payload()
+    payload.add_fields({
+      'sources': self.create_sources_field(sources=sources,
+                                           sources_rel_path=address.spec_path,
+                                           key_arg='sources'),
+    })
+    super(GoProtobufGenLibrary, self).__init__(address=address, payload=payload, **kwargs)
+
+  @property
+  def import_path(self):
+    """The import path as used in import statements in `.go` source files."""
+    return GoLocalSource.local_import_path(self.target_base, self.address)

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_binary_fingerprint_strategy.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_binary_fingerprint_strategy.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import hashlib
 
 from pants.base.fingerprint_strategy import FingerprintStrategy
+
 from pants.contrib.go.targets.go_binary import GoBinary
 
 

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_compile.py
@@ -103,7 +103,7 @@ class GoCompile(GoWorkspaceTask):
     result, go_cmd = self.go_dist.execute_go_cmd(
       'install', gopath=gopath, args=args,
       workunit_factory=self.context.new_workunit,
-      workunit_name='install {}'.format(target.address.spec),
+      workunit_name='install {}'.format(target.import_path),
       workunit_labels=[WorkUnitLabel.COMPILER])
     if result != 0:
       raise TaskError('{} failed with exit code {}'.format(go_cmd, result))

--- a/contrib/go/src/python/pants/contrib/go/tasks/go_protobuf_gen.py
+++ b/contrib/go/src/python/pants/contrib/go/tasks/go_protobuf_gen.py
@@ -1,0 +1,107 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+import re
+
+from pants.backend.codegen.protobuf.subsystems.protoc import Protoc
+from pants.base.build_environment import get_buildroot
+from pants.base.exceptions import TaskError
+from pants.base.workunit import WorkUnitLabel
+from pants.option.custom_types import target_option
+from pants.task.simple_codegen_task import SimpleCodegenTask
+from pants.util.dirutil import safe_mkdir
+from pants.util.memo import memoized_property
+from pants.util.process_handler import subprocess
+from twitter.common.collections import OrderedSet
+
+from pants.contrib.go.subsystems.protoc_gen_go import ProtocGenGo
+from pants.contrib.go.targets.go_protobuf_library import GoProtobufGenLibrary, GoProtobufLibrary
+
+
+class GoProtobufGen(SimpleCodegenTask):
+
+  _NAMESPACE_PARSER = re.compile(r'^\s*option\s+go_package\s*=\s*"([^\s]+)"\s*;', re.MULTILINE)
+
+  @classmethod
+  def register_options(cls, register):
+    super(GoProtobufGen, cls).register_options(register)
+
+    register('--import-target', type=target_option, fingerprint=True,
+             help='Target that will be added as a dependency of protoc-generated Go code.')
+
+  @classmethod
+  def subsystem_dependencies(cls):
+    return super(GoProtobufGen, cls).subsystem_dependencies() + (Protoc.scoped(cls), ProtocGenGo,)
+
+  @memoized_property
+  def _protoc(self):
+    return Protoc.scoped_instance(self).select(context=self.context)
+
+  def synthetic_target_extra_dependencies(self, target, target_workdir):
+    import_target = self.get_options().import_target
+    if import_target is None:
+      raise TaskError('Option import_target in scope {} must be set.'.format(
+        self.options_scope))
+    return self.context.resolve(import_target)
+
+  def synthetic_target_type(self, target):
+    return GoProtobufGenLibrary
+
+  def is_gentarget(self, target):
+    return isinstance(target, GoProtobufLibrary)
+
+  @classmethod
+  def product_types(cls):
+    return ['go']
+
+  def execute_codegen(self, target, target_workdir):
+    target_cmd = [self._protoc]
+
+    protoc_gen_go = ProtocGenGo.global_instance().select(self.context)
+    env = os.environ.copy()
+    env['PATH'] = ':'.join([os.path.dirname(protoc_gen_go), env['PATH']])
+
+    bases = OrderedSet(tgt.target_base for tgt in target.closure() if self.is_gentarget(tgt))
+    for base in bases:
+      target_cmd.append('-I={}'.format(os.path.join(get_buildroot(), base)))
+
+    outdir = os.path.join(target_workdir, 'src', 'go')
+    safe_mkdir(outdir)
+    target_cmd.append('--go_out={}'.format(outdir))
+
+    all_sources = list(target.sources_relative_to_buildroot())
+    for source in all_sources:
+      file_cmd = target_cmd + [os.path.join(get_buildroot(), source)]
+      with self.context.new_workunit(name=source,
+                                     labels=[WorkUnitLabel.TOOL],
+                                     cmd=' '.join(file_cmd)) as workunit:
+        self.context.log.info(' '.join(file_cmd))
+        result = subprocess.call(file_cmd,
+                                 env=env,
+                                 stdout=workunit.output('stdout'),
+                                 stderr=workunit.output('stderr'))
+        if result != 0:
+          raise TaskError('{} ... exited non-zero ({})'.format(self._protoc, result))
+
+  @property
+  def _copy_target_attributes(self):
+    return [a for a in super(GoProtobufGen, self)._copy_target_attributes if a != 'provides']
+
+  def synthetic_target_dir(self, target, target_workdir):
+    all_sources = list(target.sources_relative_to_buildroot())
+    source = all_sources[0]
+    namespace = self._get_go_namespace(source)
+    return os.path.join(target_workdir, 'src', 'go', namespace.replace(".", os.path.sep))
+
+  @classmethod
+  def _get_go_namespace(cls, source):
+    with open(source) as fh:
+      namespace = cls._NAMESPACE_PARSER.search(fh.read())
+      if not namespace:
+        raise TaskError('File {} must contain "option go_package"'.format(source))
+      return namespace.group(1)

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/BUILD
@@ -29,3 +29,14 @@ python_tests(
       'contrib/go/src/python/pants/contrib/go/subsystems',
     ]
 )
+
+python_tests(
+  name='integration',
+  sources = globs('test_*_integration.py'),
+  dependencies=[
+    'contrib/go/src/python/pants/contrib/go/subsystems',
+    'tests/python/pants_test:int-test',
+  ],
+  tags={'integration'},
+  timeout=180,
+)

--- a/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_protoc_gen_go_integration.py
+++ b/contrib/go/tests/python/pants_test/contrib/go/subsystems/test_protoc_gen_go_integration.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class ProtocGenGoTest(PantsRunIntegrationTest):
+
+  def test_go_compile_distance(self):
+    args = ['compile', 'contrib/go/examples/src/go/distance']
+    pants_run = self.run_pants(args)
+    self.assert_success(pants_run)

--- a/pants.ini
+++ b/pants.ini
@@ -270,9 +270,6 @@ skip: True
 [protoc.gen.go-protobuf]
 version=3.4.1
 
-[protoc.protoc-gen-go]
-version==3.4.1
-
 [pycheck-class-factoring]
 skip: True
 

--- a/pants.ini
+++ b/pants.ini
@@ -161,6 +161,10 @@ allow_dups: True
 antlr3_deps: ["3rdparty/python:antlr-3.1.3"]
 
 
+[gen.go-protobuf]
+import_target: contrib/go/3rdparty/go/github.com/golang/protobuf/proto
+
+
 [compile.errorprone]
 command_line_options: [
     # See http://errorprone.info/bugpatterns for all patterns
@@ -262,6 +266,12 @@ skip: True
 
 [fmt.scalafix]
 skip: True
+
+[protoc.gen.go-protobuf]
+version=3.4.1
+
+[protoc.protoc-gen-go]
+version==3.4.1
 
 [pycheck-class-factoring]
 skip: True

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -197,7 +197,7 @@ class SimpleCodegenTask(Task):
     return True
 
   def _get_synthetic_address(self, target, target_workdir):
-    synthetic_name = target.name
+    synthetic_name = target.id
     sources_rel_path = os.path.relpath(target_workdir, get_buildroot())
     synthetic_address = Address(sources_rel_path, synthetic_name)
     return synthetic_address

--- a/src/python/pants/task/simple_codegen_task.py
+++ b/src/python/pants/task/simple_codegen_task.py
@@ -197,7 +197,7 @@ class SimpleCodegenTask(Task):
     return True
 
   def _get_synthetic_address(self, target, target_workdir):
-    synthetic_name = target.id
+    synthetic_name = target.name
     sources_rel_path = os.path.relpath(target_workdir, get_buildroot())
     synthetic_address = Address(sources_rel_path, synthetic_name)
     return synthetic_address


### PR DESCRIPTION
Following the per-language `*_protobuf_library` pattern, here we add `go_protobuf_library` support and as simple example showing how to use it.