### PR TITLE
Separate the resolution cache and repository cache in Ivy

### DIFF
--- a/src/python/pants/backend/jvm/tasks/ivy_resolve.py
+++ b/src/python/pants/backend/jvm/tasks/ivy_resolve.py
@@ -147,7 +147,7 @@ class IvyResolve(IvyTaskMixin, NailgunTask):
     report = None
     org = IvyUtils.INTERNAL_ORG_NAME
     name = result.resolve_hash_name
-    xsl = os.path.join(self.ivy_cache_dir, 'ivy-report.xsl')
+    xsl = os.path.join(self.ivy_resolution_cache_dir, 'ivy-report.xsl')
 
     # Xalan needs this dir to exist - ensure that, but do no more - we have no clue where this
     # points.
@@ -180,7 +180,7 @@ class IvyResolve(IvyTaskMixin, NailgunTask):
     css = os.path.join(self._outdir, 'ivy-report.css')
     if os.path.exists(css):
       os.unlink(css)
-    shutil.copy(os.path.join(self.ivy_cache_dir, 'ivy-report.css'), self._outdir)
+    shutil.copy(os.path.join(self.ivy_resolution_cache_dir, 'ivy-report.css'), self._outdir)
 
     if self._open and report:
       try:

--- a/src/python/pants/ivy/bootstrapper.py
+++ b/src/python/pants/ivy/bootstrapper.py
@@ -87,7 +87,7 @@ class Bootstrapper(object):
     """
     return Ivy(self._get_classpath(bootstrap_workunit_factory),
                ivy_settings=self._ivy_subsystem.get_options().ivy_settings,
-               ivy_cache_dir=self._ivy_subsystem.get_options().cache_dir,
+               ivy_resolution_cache_dir=self._ivy_subsystem.resolution_cache_dir(),
                extra_jvm_options=self._ivy_subsystem.extra_jvm_options())
 
   def _get_classpath(self, workunit_factory):
@@ -159,5 +159,5 @@ class Bootstrapper(object):
 
     return Ivy(bootstrap_jar_path,
                ivy_settings=options.bootstrap_ivy_settings or options.ivy_settings,
-               ivy_cache_dir=options.cache_dir,
+               ivy_resolution_cache_dir=self._ivy_subsystem.resolution_cache_dir(),
                extra_jvm_options=self._ivy_subsystem.extra_jvm_options())

--- a/src/python/pants/ivy/ivy_subsystem.py
+++ b/src/python/pants/ivy/ivy_subsystem.py
@@ -39,7 +39,14 @@ class IvySubsystem(Subsystem):
     register('--ivy-profile', advanced=True, default=cls._DEFAULT_VERSION,
              help='The version of ivy to fetch.')
     register('--cache-dir', advanced=True, default=os.path.expanduser('~/.ivy2/pants'),
-             help='Directory to store artifacts retrieved by Ivy.')
+             help='The default directory used for both the Ivy resolution and repository caches.'
+                  'If you want to isolate the resolution cache from the repository cache, we '
+                  'recommend setting both the --resolution-cache-dir and --repository-cache-dir '
+                  'instead of using --cache-dir')
+    register('--resolution-cache-dir', advanced=True,
+             help='Directory to store Ivy resolution artifacts.')
+    register('--repository-cache-dir', advanced=True,
+             help='Directory to store Ivy repository artifacts.')
     register('--ivy-settings', advanced=True,
              help='Location of XML configuration file for Ivy settings.')
     register('--bootstrap-ivy-settings', advanced=True,
@@ -93,3 +100,15 @@ class IvySubsystem(Subsystem):
   def _parse_proxy_string(self, proxy_string):
     parse_result = urllib.parse.urlparse(proxy_string)
     return parse_result.hostname, parse_result.port
+
+  def resolution_cache_dir(self):
+    if self.get_options().resolution_cache_dir:
+      return self.get_options().resolution_cache_dir
+    else:
+      return self.get_options().cache_dir
+
+  def repository_cache_dir(self):
+    if self.get_options().repository_cache_dir:
+      return self.get_options().repository_cache_dir
+    else:
+      return self.get_options().cache_dir

--- a/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_ivy_utils.py
@@ -593,7 +593,8 @@ class IvyUtilsResolveStepsTest(TestBase):
       'hash_name',
       None,
       False,
-      'cache_dir',
+      'resolution_cache_dir',
+      'repository_cache_dir',
       'workdir')
 
     # Stub resolving and creating the result, returning one missing artifacts.
@@ -608,7 +609,9 @@ class IvyUtilsResolveStepsTest(TestBase):
                          'hash_name',
                          False,
                          None,
-                         'ivy_cache_dir', 'global_ivy_workdir')
+                         'ivy_resolution_cache_dir',
+                         'ivy_repository_cache_dir',
+                         'global_ivy_workdir')
 
     # Stub resolving and creating the result, returning one missing artifacts.
     fetch._do_fetch = do_nothing

--- a/tests/python/pants_test/ivy/test_bootstrapper.py
+++ b/tests/python/pants_test/ivy/test_bootstrapper.py
@@ -22,7 +22,7 @@ class BootstrapperTest(unittest.TestCase):
     ivy_subsystem = IvySubsystem.global_instance()
     bootstrapper = Bootstrapper(ivy_subsystem=ivy_subsystem)
     ivy = bootstrapper.ivy()
-    self.assertIsNotNone(ivy.ivy_cache_dir)
+    self.assertIsNotNone(ivy.ivy_resolution_cache_dir)
     self.assertIsNone(ivy.ivy_settings)
     bootstrap_jar_path = os.path.join(ivy_subsystem.get_options().pants_bootstrapdir,
                                       'tools', 'jvm', 'ivy', 'bootstrap.jar')
@@ -36,5 +36,5 @@ class BootstrapperTest(unittest.TestCase):
 
   def test_default_ivy(self):
     ivy = Bootstrapper.default_ivy()
-    self.assertIsNotNone(ivy.ivy_cache_dir)
+    self.assertIsNotNone(ivy.ivy_resolution_cache_dir)
     self.assertIsNone(ivy.ivy_settings)


### PR DESCRIPTION
### Problem

Ivy separates it's notion of repository cache (where the jars are stored) from the resolution cache (where it's xml files are stored).    See http://ant.apache.org/ivy/history/2.4.0/settings/caches.html for more information.   In pants you cant separate the notion of the two cache directories so if you want to share a cache with multiple workers they will overwrite and delete the others resolution xml files. 

### Solution

Separate the notion of repository cache from resolution cache so you can share jars between builds and they won't overwrite or delete the intermediate xml files.

ivy-cache can still be specified and will be the default for the resolution and repository cache if they are not specified.

### Result

With this change we can share a repository cache across our CI workers which reduces the test start up time. 

In order for it to work you need to specify the settings in pants.ini e.g.

```
[ivy]
repository_cache_dir: /shared-cache/pants-ivy-cache
resolution_cache_dir: %(homedir)s/.ivy2/pants
ivy_settings: %(pants_supportdir)s/ivy/ivysettings-cached.xml
```

And update the ivysettings.xml with the repository cache information

```
<?xml version="1.0"?>
<ivysettings>
  <include file="${ivy.settings.dir}/ivysettings.xml"/>

  <caches default="default" lockStrategy="artifact-lock-nio" useOrigin="false" repositoryCacheDir="/shared-cache/pants-ivy-cache">
    <cache name="default"/>
  </caches>
</ivysettings>
```