### PR TITLE
Use tokio for scheduler requests and local process execution

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -711,6 +711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "process_execution"
 version = "0.0.1"
 dependencies = [
+ "async_semaphore 0.0.1",
  "bazel_protos 0.0.1",
  "boxfuture 0.0.1",
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -621,6 +621,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-named-pipes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +650,15 @@ dependencies = [
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -728,6 +758,7 @@ dependencies = [
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
+ "tokio-process 0.2.1 (git+https://github.com/alexcrichton/tokio-process?rev=b50c293fb8dd5db5aaa5632d430497116c27d258)",
 ]
 
 [[package]]
@@ -907,6 +938,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "socket2"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1096,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-process"
+version = "0.2.1"
+source = "git+https://github.com/alexcrichton/tokio-process?rev=b50c293fb8dd5db5aaa5632d430497116c27d258#b50c293fb8dd5db5aaa5632d430497116c27d258"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-reactor"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1121,21 @@ dependencies = [
  "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-signal"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1284,7 +1355,10 @@ dependencies = [
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
+"checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
+"checksum mio-uds 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "84c7b5caa3a118a6e34dbac36504503b1e8dc5835e833306b9d6af0e05929f79"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum miow 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9224c91f82b3c47cf53dcf78dfaa20d6888fbcc5d272d5f2fcdf8a697f3c987d"
 "checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
@@ -1314,6 +1388,7 @@ dependencies = [
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
+"checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -1329,7 +1404,9 @@ dependencies = [
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
 "checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
+"checksum tokio-process 0.2.1 (git+https://github.com/alexcrichton/tokio-process?rev=b50c293fb8dd5db5aaa5632d430497116c27d258)" = "<none>"
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
+"checksum tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6a5bf935a0151cc8899aa806ce6a425bdaec79ed4034de1a1e6bfa247e2def"
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5783254b10c7c84a56f62c74766ef7e5b83d1f13053218c7cab8d3f2c826fa0e"
 "checksum tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535fed0ccee189f3d48447587697ba3fd234b3dbbb091f0ec4613ddfec0a7c4c"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -23,6 +23,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_semaphore"
+version = "0.0.1"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -15,6 +15,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +175,36 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,7 +234,9 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
+ "resettable 0.0.1",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -497,6 +537,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazycell"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +591,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mio"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mktemp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +643,16 @@ dependencies = [
  "hashing 0.0.1",
  "protobuf 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -788,6 +877,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "sha2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +892,11 @@ dependencies = [
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -903,6 +1002,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-executor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-fs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-reactor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tcp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-threadpool"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-timer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-udp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,9 +1205,19 @@ dependencies = [
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea58cd16fd6c9d120b5bcb01d63883ae4cc7ba2aed35c1841b862a3c7ef6639"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
@@ -1017,6 +1232,9 @@ dependencies = [
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
 "checksum crossbeam 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bd66663db5a988098a89599d4857919b3acf7f61402e61365acfd3919857b9be"
+"checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
+"checksum crossbeam-epoch 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b4e2817eb773f770dcb294127c011e22771899c21d18fce7dd739c0b9832e81"
+"checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
@@ -1049,13 +1267,18 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum lmdb 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "44ac7bf1552c1386b70e77ff9d801971f19641bf2dc08b981cd2397bf812c65d"
 "checksum lmdb-sys 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3db58e1767416fc1e9e3265635d3bb7bf3677a0dc8d4e8d6ee14850ec5c11ae9"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
+"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mktemp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77001ceb9eed65439f3dc2a2543f9ba1417d912686bf224a7738d0966e6dcd69"
+"checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
@@ -1080,7 +1303,9 @@ dependencies = [
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
+"checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
@@ -1092,6 +1317,15 @@ dependencies = [
 "checksum thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
+"checksum tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d00555353b013e170ed8bc4e13f648a317d1fd12157dbcae13f7013f6cf29f5"
+"checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
+"checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
+"checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
+"checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
+"checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
+"checksum tokio-threadpool 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5783254b10c7c84a56f62c74766ef7e5b83d1f13053218c7cab8d3f2c826fa0e"
+"checksum tokio-timer 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535fed0ccee189f3d48447587697ba3fd234b3dbbb091f0ec4613ddfec0a7c4c"
+"checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
@@ -1108,3 +1342,4 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
+"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
- "tokio-process 0.2.1 (git+https://github.com/alexcrichton/tokio-process?rev=b50c293fb8dd5db5aaa5632d430497116c27d258)",
+ "tokio-process 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1098,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "tokio-process"
 version = "0.2.1"
-source = "git+https://github.com/alexcrichton/tokio-process?rev=b50c293fb8dd5db5aaa5632d430497116c27d258#b50c293fb8dd5db5aaa5632d430497116c27d258"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1404,7 +1404,7 @@ dependencies = [
 "checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
 "checksum tokio-fs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "76766830bbf9a2d5bfb50c95350d56a2e79e2c80f675967fff448bc615899708"
 "checksum tokio-io 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6af9eb326f64b2d6b68438e1953341e00ab3cf54de7e35d92bfc73af8555313a"
-"checksum tokio-process 0.2.1 (git+https://github.com/alexcrichton/tokio-process?rev=b50c293fb8dd5db5aaa5632d430497116c27d258)" = "<none>"
+"checksum tokio-process 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de38febefe683adab7070c0f705afd6247582d0b1780d9eb745c77a0d4e88b"
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
 "checksum tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6a5bf935a0151cc8899aa806ce6a425bdaec79ed4034de1a1e6bfa247e2def"
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -66,10 +66,12 @@ boxfuture = { path = "boxfuture" }
 enum_primitive = "0.1.1"
 fnv = "1.0.5"
 fs = { path = "fs" }
-futures = "0.1.16"
+futures = "0.1"
 hashing = { path = "hashing" }
 lazy_static = "0.2.2"
 log = "0.4"
 petgraph = "0.4.5"
 process_execution = { path = "process_execution" }
+resettable = { path = "resettable" }
+tokio = "0.1"
 tempdir = "0.3.5"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -25,6 +25,7 @@ cc = "1.0"
 # (e.g. fs_util) won't be included when we build/test things.
 members = [
   ".",
+  "async_semaphore",
   "boxfuture",
   "fs",
   "fs/brfs",
@@ -48,6 +49,7 @@ members = [
 # On Ubuntu, that means installing libfuse-dev. On OSX, that means installing OSXFUSE.
 default-members = [
   ".",
+  "async_semaphore",
   "boxfuture",
   "fs",
   "fs/fs_util",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -68,7 +68,7 @@ boxfuture = { path = "boxfuture" }
 enum_primitive = "0.1.1"
 fnv = "1.0.5"
 fs = { path = "fs" }
-futures = "0.1"
+futures = "^0.1.16"
 hashing = { path = "hashing" }
 lazy_static = "0.2.2"
 log = "0.4"

--- a/src/rust/engine/async_semaphore/Cargo.toml
+++ b/src/rust/engine/async_semaphore/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+version = "0.0.1"
+name = "async_semaphore"
+authors = [ "Pants Build <pantsbuild@gmail.com>" ]
+
+[dependencies]
+futures = "0.1"

--- a/src/rust/engine/async_semaphore/Cargo.toml
+++ b/src/rust/engine/async_semaphore/Cargo.toml
@@ -4,4 +4,4 @@ name = "async_semaphore"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
-futures = "0.1"
+futures = "^0.1.16"

--- a/src/rust/engine/async_semaphore/src/lib.rs
+++ b/src/rust/engine/async_semaphore/src/lib.rs
@@ -1,0 +1,180 @@
+extern crate futures;
+
+use std::sync::{Arc, Mutex};
+use std::collections::VecDeque;
+
+use futures::{Async, Poll};
+use futures::future::Future;
+use futures::task::{self, Task};
+
+struct Inner {
+  waiters: VecDeque<Task>,
+  available_permits: usize,
+}
+
+#[derive(Clone)]
+pub struct AsyncSemaphore {
+  inner: Arc<Mutex<Inner>>,
+}
+
+impl AsyncSemaphore {
+  pub fn new(permits: usize) -> AsyncSemaphore {
+    AsyncSemaphore {
+      inner: Arc::new(Mutex::new(Inner {
+        waiters: VecDeque::new(),
+        available_permits: permits,
+      })),
+    }
+  }
+
+  ///
+  /// Returns a Future that resolves to a Permit for the semaphore. The semaphore remains acquired
+  /// until the Permit is dropped.
+  ///
+  /// You should generally prefer to use `with_acquired`, as it is less error prone.
+  ///
+  fn acquire(&self) -> PermitFuture {
+    PermitFuture {
+      inner: Some(self.inner.clone()),
+    }
+  }
+
+  ///
+  /// Runs the given Future-creating function (and the Future it returns) under the semaphore.
+  ///
+  pub fn with_acquired<F, B, T, E>(&self, f: F) -> Box<Future<Item = T, Error = E> + Send>
+  where
+    F: FnOnce() -> B + Send + 'static,
+    B: Future<Item = T, Error = E> + Send + 'static,
+  {
+    Box::new(
+      self
+        .acquire()
+        .map_err(|()| panic!("Acquisition is infalliable."))
+        .and_then(|permit| {
+          f().map(move |t| {
+            drop(permit);
+            t
+          })
+        }),
+    )
+  }
+}
+
+pub struct Permit {
+  inner: Arc<Mutex<Inner>>,
+}
+
+impl Drop for Permit {
+  fn drop(&mut self) {
+    let task = {
+      let mut inner = self.inner.lock().unwrap();
+      inner.available_permits += 1;
+      if let Some(task) = inner.waiters.pop_front() {
+        task
+      } else {
+        return;
+      }
+    };
+    task.notify();
+  }
+}
+
+pub struct PermitFuture {
+  inner: Option<Arc<Mutex<Inner>>>,
+}
+
+impl Future for PermitFuture {
+  type Item = Permit;
+  type Error = ();
+
+  fn poll(&mut self) -> Poll<Permit, ()> {
+    let inner = self.inner.take().expect("cannot poll PermitFuture twice");
+    let acquired = {
+      let mut inner = inner.lock().unwrap();
+      if inner.available_permits == 0 {
+        inner.waiters.push_back(task::current());
+        false
+      } else {
+        inner.available_permits -= 1;
+        true
+      }
+    };
+    if acquired {
+      Ok(Async::Ready(Permit { inner }))
+    } else {
+      self.inner = Some(inner);
+      Ok(Async::NotReady)
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+
+  use super::AsyncSemaphore;
+  use futures::{future, Future};
+  use std::sync::mpsc;
+  use std::thread;
+  use std::time::Duration;
+
+  #[test]
+  fn acquire_and_release() {
+    let sema = AsyncSemaphore::new(1);
+
+    sema
+      .with_acquired(|| future::ok::<_, ()>(()))
+      .wait()
+      .unwrap();
+  }
+
+  #[test]
+  fn at_most_n_acquisitions() {
+    let sema = AsyncSemaphore::new(1);
+    let handle1 = sema.clone();
+    let handle2 = sema.clone();
+
+    let (tx_thread1, acquired_thread1) = mpsc::channel();
+    let (unblock_thread1, rx_thread1) = mpsc::channel();
+    let (tx_thread2, acquired_thread2) = mpsc::channel();
+
+    thread::spawn(move || {
+      handle1
+        .with_acquired(move || {
+          // Indicate that we've acquired, and then wait to be signaled to exit.
+          tx_thread1.send(()).unwrap();
+          rx_thread1.recv().unwrap();
+          future::ok::<_, ()>(())
+        })
+        .wait()
+        .unwrap();
+    });
+
+    // Wait for thread1 to acquire, and then launch thread2.
+    acquired_thread1
+      .recv_timeout(Duration::from_secs(5))
+      .expect("thread1 didn't acquire.");
+
+    thread::spawn(move || {
+      handle2
+        .with_acquired(move || {
+          tx_thread2.send(()).unwrap();
+          future::ok::<_, ()>(())
+        })
+        .wait()
+        .unwrap();
+    });
+
+    // thread2 should not signal until we unblock thread1.
+    match acquired_thread2.recv_timeout(Duration::from_millis(500)) {
+      Err(_) => (),
+      Ok(_) => panic!("thread2 should not have acquired while thread1 was holding."),
+    }
+
+    // Unblock thread1 and confirm that thread2 acquires.
+    unblock_thread1.send(()).unwrap();
+    acquired_thread2
+      .recv_timeout(Duration::from_secs(5))
+      .expect("thread2 didn't acquire.");
+  }
+}

--- a/src/rust/engine/boxfuture/Cargo.toml
+++ b/src/rust/engine/boxfuture/Cargo.toml
@@ -4,4 +4,4 @@ name = "boxfuture"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
-futures = "0.1.16"
+futures = "0.1"

--- a/src/rust/engine/boxfuture/Cargo.toml
+++ b/src/rust/engine/boxfuture/Cargo.toml
@@ -4,4 +4,4 @@ name = "boxfuture"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
-futures = "0.1"
+futures = "^0.1.16"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -9,8 +9,8 @@ boxfuture = { path = "../boxfuture" }
 byteorder = "1"
 bytes = "0.4.5"
 digest = "0.6.2"
-futures = "0.1.16"
-futures-cpupool = "0.1.6"
+futures = "0.1"
+futures-cpupool = "0.1"
 glob = "0.2.11"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../hashing" }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -9,7 +9,7 @@ boxfuture = { path = "../boxfuture" }
 byteorder = "1"
 bytes = "0.4.5"
 digest = "0.6.2"
-futures = "0.1"
+futures = "^0.1.16"
 futures-cpupool = "0.1"
 glob = "0.2.11"
 grpcio = { version = "0.2.0", features = ["secure"] }

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -10,7 +10,7 @@ env_logger = "0.5.4"
 errno = "0.2.3"
 fs = { path = ".." }
 fuse = "0.3.1"
-futures = "0.1.16"
+futures = "0.1"
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -10,7 +10,7 @@ env_logger = "0.5.4"
 errno = "0.2.3"
 fs = { path = ".." }
 fuse = "0.3.1"
-futures = "0.1"
+futures = "^0.1.16"
 hashing = { path = "../../hashing" }
 libc = "0.2.39"
 log = "0.4.1"

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -10,6 +10,6 @@ bytes = "0.4.5"
 clap = "2"
 env_logger = "0.5.4"
 fs = { path = ".." }
-futures = "0.1.16"
+futures = "0.1"
 hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -10,6 +10,6 @@ bytes = "0.4.5"
 clap = "2"
 env_logger = "0.5.4"
 fs = { path = ".." }
-futures = "0.1"
+futures = "^0.1.16"
 hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -4,6 +4,7 @@ name = "process_execution"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
+async_semaphore = { path = "../async_semaphore" }
 bazel_protos = { path = "bazel_protos" }
 boxfuture = { path = "../boxfuture" }
 bytes = "0.4.5"

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -10,7 +10,7 @@ boxfuture = { path = "../boxfuture" }
 bytes = "0.4.5"
 digest = "0.6.2"
 fs = { path = "../fs" }
-futures = "0.1"
+futures = "^0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../hashing" }
 log = "0.4"
@@ -19,8 +19,7 @@ resettable = { path = "../resettable" }
 sha2 = "0.6.0"
 tempdir = "0.3.5"
 futures-timer = "0.1"
-# TODO: A master sha that is likely to be released as 0.2.1.
-tokio-process = { git = "https://github.com/alexcrichton/tokio-process", rev = "b50c293fb8dd5db5aaa5632d430497116c27d258" }
+tokio-process = "0.2.1"
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -9,7 +9,7 @@ boxfuture = { path = "../boxfuture" }
 bytes = "0.4.5"
 digest = "0.6.2"
 fs = { path = "../fs" }
-futures = "0.1.16"
+futures = "0.1"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../hashing" }
 log = "0.4"
@@ -17,7 +17,7 @@ protobuf = { version = "1.4.1", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.6.0"
 tempdir = "0.3.5"
-futures-timer = "0.1.1"
+futures-timer = "0.1"
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -19,6 +19,8 @@ resettable = { path = "../resettable" }
 sha2 = "0.6.0"
 tempdir = "0.3.5"
 futures-timer = "0.1"
+# TODO: A master sha that is likely to be released as 0.2.1.
+tokio-process = { git = "https://github.com/alexcrichton/tokio-process", rev = "b50c293fb8dd5db5aaa5632d430497116c27d258" }
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
 bytes = "0.4.5"
-futures = "0.1"
+futures = "^0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/bazel_protos/Cargo.toml
+++ b/src/rust/engine/process_execution/bazel_protos/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 
 [dependencies]
 bytes = "0.4.5"
-futures = "0.1.16"
+futures = "0.1"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -20,6 +20,7 @@ extern crate sha2;
 extern crate tempdir;
 #[cfg(test)]
 extern crate testutil;
+extern crate tokio_process;
 
 use boxfuture::BoxFuture;
 use bytes::Bytes;

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -6,6 +6,8 @@ use futures::{future, Future};
 use std::process::Command;
 use std::sync::Arc;
 
+use tokio_process::CommandExt;
+
 use super::{ExecuteProcessRequest, ExecuteProcessResult};
 
 use bytes::Bytes;
@@ -50,7 +52,8 @@ impl super::CommandRunner for CommandRunner {
                   // to stop automatic PATH searching.
                   .env("PATH", "")
                   .envs(env)
-                  .output().map_err(|e| format!("Error executing process: {:?}", e))
+                  .output_async()
+                  .map_err(|e| format!("Error executing process: {:?}", e))
                   .map(|output| (output, workdir))
       })
       .and_then(|(output, workdir)| {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -154,25 +154,22 @@ impl CommandRunner {
   const BACKOFF_MAX_WAIT_MILLIS: u64 = 5000;
 
   pub fn new(address: String, thread_count: usize, store: Store) -> CommandRunner {
-    let env = Resettable::new(Arc::new(move || {
-      Arc::new(grpcio::Environment::new(thread_count))
-    }));
+    let env = Resettable::new(move || Arc::new(grpcio::Environment::new(thread_count)));
     let env2 = env.clone();
-    let channel = Resettable::new(Arc::new(move || {
-      grpcio::ChannelBuilder::new(env2.get()).connect(&address)
-    }));
+    let channel =
+      Resettable::new(move || grpcio::ChannelBuilder::new(env2.get()).connect(&address));
     let channel2 = channel.clone();
     let channel3 = channel.clone();
-    let execution_client = Resettable::new(Arc::new(move || {
+    let execution_client = Resettable::new(move || {
       Arc::new(bazel_protos::remote_execution_grpc::ExecutionClient::new(
         channel2.get(),
       ))
-    }));
-    let operations_client = Resettable::new(Arc::new(move || {
+    });
+    let operations_client = Resettable::new(move || {
       Arc::new(bazel_protos::operations_grpc::OperationsClient::new(
         channel3.get(),
       ))
-    }));
+    });
 
     CommandRunner {
       channel,

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -9,5 +9,5 @@ clap = "2"
 env_logger = "0.5.4"
 fs = { path = "../fs" }
 hashing = { path = "../hashing" }
-futures = "0.1.16"
+futures = "0.1"
 process_execution = { path = "../process_execution" }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -9,5 +9,5 @@ clap = "2"
 env_logger = "0.5.4"
 fs = { path = "../fs" }
 hashing = { path = "../hashing" }
-futures = "0.1"
+futures = "^0.1.16"
 process_execution = { path = "../process_execution" }

--- a/src/rust/engine/resettable/src/lib.rs
+++ b/src/rust/engine/resettable/src/lib.rs
@@ -24,10 +24,10 @@ where
   // Sadly there is no way to accept an Fn() -> T because it's not Sized, so we need to accept an
   // Arc of one. This is not at all ergonomic, but at some point "impl trait" will come along and
   // allow us to remove this monstrosity.
-  pub fn new(make: Arc<Fn() -> T>) -> Resettable<T> {
+  pub fn new<F: Fn() -> T + 'static>(make: F) -> Resettable<T> {
     Resettable {
       val: Arc::new(RwLock::new(None)),
-      make: make,
+      make: Arc::new(make),
     }
   }
 

--- a/src/rust/engine/resettable/src/lib.rs
+++ b/src/rust/engine/resettable/src/lib.rs
@@ -21,9 +21,6 @@ impl<T> Resettable<T>
 where
   T: Clone + Send + Sync,
 {
-  // Sadly there is no way to accept an Fn() -> T because it's not Sized, so we need to accept an
-  // Arc of one. This is not at all ergonomic, but at some point "impl trait" will come along and
-  // allow us to remove this monstrosity.
   pub fn new<F: Fn() -> T + 'static>(make: F) -> Resettable<T> {
     Resettable {
       val: Arc::new(RwLock::new(None)),

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -23,6 +23,10 @@ use types::Types;
 /// The core context shared (via Arc) between the Scheduler and the Context objects of
 /// all running Nodes.
 ///
+/// Over time, most usage of `ResettablePool` (which wraps use of blocking APIs) should migrate
+/// to the Tokio `Runtime`. The next candidate is likely to be migrating PosixFS to tokio-fs once
+/// https://github.com/tokio-rs/tokio/issues/369 is resolved.
+///
 pub struct Core {
   pub graph: Graph,
   pub tasks: Tasks,

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -29,7 +29,9 @@ extern crate lazy_static;
 extern crate log;
 extern crate petgraph;
 extern crate process_execution;
+extern crate resettable;
 extern crate tempdir;
+extern crate tokio;
 
 use std::ffi::CStr;
 use std::fs::File;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -514,19 +514,12 @@ impl Node for ExecuteProcess {
   fn run(self, context: Context) -> NodeFuture<ProcessResult> {
     let request = self.0;
 
-    // TODO: Process pool management should likely move into the `process_execution` crate, which
-    // will have different strategies depending on remote/local execution.
-    let core = context.core.clone();
     context
       .core
-      .fs_pool
-      .spawn_fn(move || {
-        core
-          .command_runner
-          .run(request)
-          .map(|result| ProcessResult(result))
-          .map_err(|e| throw(&format!("Failed to execute process: {}", e)))
-      })
+      .command_runner
+      .run(request)
+      .map(|result| ProcessResult(result))
+      .map_err(|e| throw(&format!("Failed to execute process: {}", e)))
       .to_boxed()
   }
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use futures::future::{self, Future};
+use futures::sync::oneshot;
 
 use boxfuture::{BoxFuture, Boxable};
 use context::{Context, ContextFactory, Core};
@@ -158,6 +159,7 @@ impl Scheduler {
     roots: Vec<Root>,
     count: usize,
   ) -> BoxFuture<Vec<Result<Value, Failure>>, ()> {
+    let executor = core.runtime.get().executor();
     // Attempt all roots in parallel, failing fast to retry for `Invalidated`.
     let roots_res = future::join_all(
       roots
@@ -188,9 +190,10 @@ impl Scheduler {
 
     // If the join failed (due to `Invalidated`, since that is the only error we propagate), retry
     // the entire set of roots.
-    roots_res
-      .or_else(move |_| Scheduler::execute_helper(core, roots, count - 1))
-      .to_boxed()
+    oneshot::spawn(
+      roots_res.or_else(move |_| Scheduler::execute_helper(core, roots, count - 1)),
+      &executor,
+    ).to_boxed()
   }
 
   ///

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -6,7 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 [dependencies]
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
-futures = "0.1.16"
+futures = "0.1"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -6,7 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 [dependencies]
 bazel_protos = { path = "../../process_execution/bazel_protos" }
 bytes = "0.4.5"
-futures = "0.1"
+futures = "^0.1.16"
 grpcio = { version = "0.2.0", features = ["secure"] }
 hashing = { path = "../../hashing" }
 protobuf = { version = "1.4.1", features = ["with-bytes"] }


### PR DESCRIPTION
### Problem

As described in #5763, we're currently sharing a thread pool between filesystem access and process execution, and we'd like to be able to control the number of concurrent filesystem accesses and running processes independently.

Additionally (as mentioned in comments there), the proliferation of context switching between various threadpools is likely to bog us down as we add more resources that we'd like to control (optionally blocking) access to.

### Solution

Introduce a dependency on `tokio` at the root of engine requests in the `Scheduler` (which ensures that all `Future`s not run explicitly on a `CpuPool` are running on a `tokio` `Runtime`.

Also add a dependency on `tokio-process` for local process execution, and remove usage of the filesystem pool for process execution.

Finally, add `AsyncSemaphore` to control access to resources without blocking or context switching.

### Result

Fixes #5763 and unblocks usage of `tokio-timeout` immediately, and `tokio-fs` once https://github.com/tokio-rs/tokio/issues/369 is resolved.