### PR TITLE
Only depend on subprocess32 if running in python2.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -27,7 +27,7 @@ requests[security]>=2.5.0,<2.19
 scandir==1.2
 setproctitle==1.1.10
 setuptools==30.0.0
-subprocess32==3.2.7
+subprocess32==3.2.7 ; python_version<'3'
 six>=1.9.0,<2
 thrift>=0.9.1
 wheel==0.29.0


### PR DESCRIPTION
subprocess32 will not install in python3. 

Granted, Pants currently only runs in python2. However it is possible for python3 code in some repo to depend on Pants as a library (whether or not the Pants methods it calls will work in python3 is of course questionable). Nonetheless, in this case we don't want to attempt to install subprocess32 as a transitive dep. 

And besides, it's good hygiene for the day we make Pants py3 compatible.