### PR TITLE
Core has a CommandRunner

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -69,6 +69,8 @@ pub struct ExecuteProcessResult {
   pub output_directory: hashing::Digest,
 }
 
-pub trait CommandRunner {
+pub trait CommandRunner: Send + Sync {
   fn run(&self, req: ExecuteProcessRequest) -> BoxFuture<ExecuteProcessResult, String>;
+
+  fn reset_prefork(&self);
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -98,6 +98,11 @@ impl super::CommandRunner for CommandRunner {
       })
       .to_boxed()
   }
+
+  fn reset_prefork(&self) {
+    self.store.reset_prefork();
+    self.fs_pool.reset();
+  }
 }
 
 #[cfg(test)]

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -140,6 +140,13 @@ impl super::CommandRunner for CommandRunner {
       Err(err) => future::err(err).to_boxed(),
     }
   }
+
+  fn reset_prefork(&self) {
+    self.channel.reset();
+    self.env.reset();
+    self.execution_client.reset();
+    self.operations_client.reset();
+  }
 }
 
 impl CommandRunner {
@@ -174,13 +181,6 @@ impl CommandRunner {
       operations_client,
       store,
     }
-  }
-
-  pub fn reset_prefork(&self) {
-    self.channel.reset();
-    self.env.reset();
-    self.execution_client.reset();
-    self.operations_client.reset();
   }
 
   fn upload_command(

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -18,7 +18,7 @@ use context::{Context, Core};
 use core::{throw, Failure, Key, Noop, TypeConstraint, Value, Variants};
 use externs;
 use fs::{self, Dir, File, FileContent, Link, PathGlobs, PathStat, StoreFileByDigest, VFS};
-use process_execution::{self, CommandRunner};
+use process_execution;
 use hashing;
 use rule_graph;
 use selectors;
@@ -514,10 +514,7 @@ impl Node for ExecuteProcess {
   fn run(self, context: Context) -> NodeFuture<ProcessResult> {
     let request = self.0;
 
-    let command_runner = process_execution::local::CommandRunner::new(
-      context.core.store.clone(),
-      context.core.fs_pool.clone(),
-    );
+    let command_runner = context.core.command_runner.clone();
 
     // TODO: Process pool management should likely move into the `process_execution` crate, which
     // will have different strategies depending on remote/local execution.


### PR DESCRIPTION
Instead of making a new one for each ExecuteProcess Node.

This will allow us to configure a local vs remote execution strategy,
and use a single local or remote CommandRunner which we set up when we
make our Core.