### PR TITLE
Use write_all not write

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -312,7 +312,7 @@ fn execute(top_match: clap::ArgMatches) -> Result<(), ExitError> {
         }?;
         match proto_bytes {
           Some(bytes) => {
-            io::stdout().write(&bytes).unwrap();
+            io::stdout().write_all(&bytes).unwrap();
             Ok(())
           }
           None => Err(ExitError(

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -27,7 +27,7 @@ pub fn as_bytes(str: &str) -> Bytes {
 
 pub fn make_file(path: &Path, contents: &[u8], mode: u32) {
   let mut file = std::fs::File::create(&path).unwrap();
-  file.write(contents).unwrap();
+  file.write_all(contents).unwrap();
   let mut permissions = std::fs::metadata(path).unwrap().permissions();
   permissions.set_mode(mode);
   file.set_permissions(permissions).unwrap();


### PR DESCRIPTION
write may not write all bytes, and will not return an error if only a
partial write was performed.

This was surfaced by clippy; I don't think clippy is stable enough to
turn on on CI, but I may start running occasional clippy checks to look
for issues / things to clean up.