### PR TITLE
Rust compilation is more robust and fast

### DIFF
--- a/build-support/bin/native/bootstrap_code.sh
+++ b/build-support/bin/native/bootstrap_code.sh
@@ -54,8 +54,11 @@ function calculate_current_hash() {
 function _build_native_code() {
   # Builds the native code, and echos the path of the built binary.
 
-  "${REPO_ROOT}/build-support/bin/native/cargo" build ${MODE_FLAG} \
-    --manifest-path "${NATIVE_ROOT}/Cargo.toml" || die
+  (
+    cd "${REPO_ROOT}"
+    "${REPO_ROOT}/build-support/bin/native/cargo" build ${MODE_FLAG} \
+      --manifest-path "${NATIVE_ROOT}/Cargo.toml" -p engine
+  ) || die
   echo "${NATIVE_ROOT}/target/${MODE}/libengine.${LIB_EXTENSION}"
 }
 


### PR DESCRIPTION
1. Make sure we're in the repo before compiling, so that .cargo/config
   is picked up. Otherwise running pants from outside the repo root
   fails to link on OSX.
2. Only build the engine, not all binaries, when what we want is the
   engine.