### PR TITLE
Improve logging/handling of signaled, killed, and terminated tests

### DIFF
--- a/testprojects/tests/python/pants/timeout/BUILD
+++ b/testprojects/tests/python/pants/timeout/BUILD
@@ -10,3 +10,8 @@ python_tests(
   name = 'ignores_terminate',
   sources = ['test_ignores_terminate.py']
 )
+
+python_tests(
+  name = 'terminates_self',
+  sources = ['test_terminates_self.py']
+)

--- a/testprojects/tests/python/pants/timeout/test_terminates_self.py
+++ b/testprojects/tests/python/pants/timeout/test_terminates_self.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import signal
+import time
+
+
+def test_terminates_self():
+  time.sleep(1)
+
+  os.kill(os.getpid(), signal.SIGTERM)

--- a/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
+++ b/tests/python/pants_test/backend/jvm/tasks/test_junit_run_integration.py
@@ -137,7 +137,7 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(['clean-all',
                                 'test.junit',
                                 '--timeouts',
-                                '--timeout-default=1',
+                                '--timeout-default=5',
                                 '--timeout-terminate-wait=1',
                                 '--test=org.pantsbuild.testproject.timeout.ShortSleeperTest',
                                 sleeping_target])
@@ -149,7 +149,7 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(['clean-all',
                                 'test.junit',
                                 '--timeouts',
-                                '--timeout-default=1',
+                                '--timeout-default=5',
                                 '--timeout-terminate-wait=1',
                                 '--test=org.pantsbuild.testproject.timeout.LongSleeperTest',
                                 sleeping_target])
@@ -160,7 +160,7 @@ class JunitRunIntegrationTest(PantsRunIntegrationTest):
     self.assertLess(end - start, 120)
 
     # Ensure that the timeout triggered.
-    self.assertIn(" timed out after 1 seconds", pants_run.stdout_data)
+    self.assertIn(" timed out after 5 seconds", pants_run.stdout_data)
 
   def test_junit_tests_using_cucumber(self):
     test_spec = 'testprojects/tests/java/org/pantsbuild/testproject/cucumber'

--- a/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
+++ b/tests/python/pants_test/backend/python/tasks/test_pytest_run_integration.py
@@ -59,7 +59,7 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     pants_run = self.run_pants(['clean-all',
                                 'test.pytest',
                                 '--timeout-terminate-wait=2',
-                                '--timeout-default=1',
+                                '--timeout-default=5',
                                 '--coverage=auto',
                                 '--cache-ignore',
                                 'testprojects/tests/python/pants/timeout:ignores_terminate'])
@@ -73,11 +73,28 @@ class PytestRunIntegrationTest(PantsRunIntegrationTest):
     self.assertIn("No .coverage file was found! Skipping coverage reporting", pants_run.stdout_data)
 
     # Ensure that the timeout message triggered.
-    self.assertIn("FAILURE: Timeout of 1 seconds reached.", pants_run.stdout_data)
+    self.assertIn("FAILURE: Timeout of 5 seconds reached.", pants_run.stdout_data)
 
     # Ensure that the warning about killing triggered.
-    self.assertIn("WARN] Timed out test did not terminate gracefully after 2 seconds, "
-                  "killing...", pants_run.stderr_data)
+    self.assertIn("Timed out test did not terminate gracefully after 2 seconds, "
+                  "killing...", pants_run.stdout_data)
+
+  def test_pytest_run_killed_by_signal(self):
+    start = time.time()
+    pants_run = self.run_pants(['clean-all',
+                                'test.pytest',
+                                '--timeout-terminate-wait=2',
+                                '--timeout-default=5',
+                                '--cache-ignore',
+                                'testprojects/tests/python/pants/timeout:terminates_self'])
+    end = time.time()
+    self.assert_failure(pants_run)
+
+    # Ensure that the failure took less than 100 seconds to run to allow for test overhead.
+    self.assertLess(end - start, 100)
+
+    # Ensure that we get a message indicating the abnormal exit.
+    self.assertIn("FAILURE: Test was killed by signal", pants_run.stdout_data)
 
   def test_pytest_explicit_coverage(self):
     with temporary_dir(cleanup=False) as coverage_dir:

--- a/tests/python/pants_test/projects/test_testprojects_integration.py
+++ b/tests/python/pants_test/projects/test_testprojects_integration.py
@@ -61,6 +61,7 @@ class TestProjectsIntegrationTest(ProjectIntegrationTest):
       'testprojects/tests/python/pants/dummies:failing_target',
       'testprojects/tests/scala/org/pantsbuild/testproject/non_exports:C',
       'testprojects/src/scala/org/pantsbuild/testproject/exclude_direct_dep',
+      'testprojects/tests/python/pants/timeout:terminates_self',
       # These don't pass without special config.
       'testprojects/tests/java/org/pantsbuild/testproject/depman:new-tests',
       'testprojects/tests/java/org/pantsbuild/testproject/depman:old-tests',


### PR DESCRIPTION
### Problem

While debugging #5611, I determined that when a test was killed by a signal (and thus had a negative return value from `poll()`), `TestRunnerTaskMixin` incorrectly interpreted the failure as a still-living and hung process, and would later try to kill it. There were a few broken tests allowing for this, but primarily: `test_pytest_run_timeout_cant_terminate` was not waiting long enough for the tested-test to start up, and so was killing it before it had its signal handler in place.

Additionally, the usage of a `Timer` + `poll()` to implement test termination meant that we were guaranteed to wait the full `timeout_terminate_wait` time (10 seconds by default) before `poll()`ing to see whether the test had exited.

### Solution

1. Interpret `poll() == None` as a still running process, and `poll() < 0` as a process killed by a signal.
2. Report processes killed by signals before our initial attempt to kill them (which should expose a SIGSEV in #5611).
3. Rather than a timer, use `wait()` between `terminate()` and `kill()`, which avoids unnecessary sleeping.

### Result

Improved debuggability for tests that exit abnormally.