### PR TITLE
Fix Go distribution SYSTEM_ID key

### DIFF
--- a/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
+++ b/contrib/go/src/python/pants/contrib/go/subsystems/go_distribution.py
@@ -20,7 +20,7 @@ class GoReleaseUrlGenerator(BinaryToolUrlGenerator):
   _DIST_URL_FMT = 'https://storage.googleapis.com/golang/go{version}.{system_id}.tar.gz'
 
   _SYSTEM_ID = {
-    'darwin': 'darwin-amd64',
+    'mac': 'darwin-amd64',
     'linux': 'linux-amd64',
   }
 


### PR DESCRIPTION
I tried to run the contrib tests on my mac because they failed because this key is wrong