### PR TITLE
Update pyflakes to 2.0.0

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,7 +16,7 @@ parameterized==0.6.1
 pep8==1.6.2
 pex==1.3.2
 psutil==4.3.0
-pyflakes==1.1.0
+pyflakes==2.0.0
 Pygments==1.4
 pyopenssl==17.3.0
 pystache==0.5.3

--- a/src/python/pants/build_graph/app_base.py
+++ b/src/python/pants/build_graph/app_base.py
@@ -258,7 +258,7 @@ class AppBase(Target):
 
   @classmethod
   def binary_target_type(cls):
-    raise NotImplemented('Must implement in subclass (e.g.: `return PythonBinary`)')
+    raise NotImplementedError('Must implement in subclass (e.g.: `return PythonBinary`)')
 
   @classmethod
   def compute_dependency_specs(cls, kwargs=None, payload=None):


### PR DESCRIPTION
### Problem

We're running an old version of pyflakes

### Solution

Update to latest version of pyflakes

### Result

pyflakes release notes from https://github.com/PyCQA/pyflakes/blob/master/NEWS.txt
```
2.0.0 (2018-05-20)
  - Drop support for EOL Python <2.7 and 3.2-3.3
  - Check for unused exception binding in `except:` block
  - Handle string literal type annotations
  - Ignore redefinitions of `_`, unless originally defined by import
  - Support `__class__` without `self` in Python 3
  - Issue an error for `raise NotImplemented(...)`

1.6.0 (2017-08-03)
  - Process function scope variable annotations for used names
  - Find Python files without extensions by their shebang

1.5.0 (2017-01-09)
  - Enable support for PEP 526 annotated assignments

1.4.0 (2016-12-30):
  - Change formatting of ImportStarMessage to be consistent with other errors
  - Support PEP 498 "f-strings"

1.3.0 (2016-09-01):
  - Fix PyPy2 Windows IntegrationTests
  - Check for duplicate dictionary keys
  - Fix TestMain tests on Windows
  - Fix "continue" and "break" checks ignoring py3.5's "async for" loop

1.2.3 (2016-05-12):
  - Fix TypeError when processing relative imports

1.2.2 (2016-05-06):
  - Avoid traceback when exception is del-ed in except

1.2.1 (2015-05-05):
  - Fix false RedefinedWhileUnused for submodule imports

1.2.0 (2016-05-03):
  - Warn against reusing exception names after the except: block on Python 3
  - Improve the error messages for imports
```