### PR TITLE
Update pep8 to pycodestyle

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -11,11 +11,11 @@ isort==4.2.5
 Markdown==2.1.1
 mock==2.0.0
 packaging==16.8
-pathspec==0.5.0
 parameterized==0.6.1
-pep8==1.6.2
+pathspec==0.5.0
 pex==1.3.2
 psutil==4.3.0
+pycodestyle==2.4.0
 pyflakes==2.0.0
 Pygments==1.4
 pyopenssl==17.3.0
@@ -27,7 +27,7 @@ requests[security]>=2.5.0,<2.19
 scandir==1.2
 setproctitle==1.1.10
 setuptools==30.0.0
-subprocess32==3.2.7 ; python_version<'3'
 six>=1.9.0,<2
+subprocess32==3.2.7 ; python_version<'3'
 thrift>=0.9.1
 wheel==0.29.0

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/BUILD
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/BUILD
@@ -5,7 +5,7 @@ python_library(
   name='all',
   sources=rglobs('*.py'),
   dependencies=[
-    '3rdparty/python:pep8',
+    '3rdparty/python:pycodestyle',
     '3rdparty/python:pyflakes',
     '3rdparty/python:pex',
     'src/python/pants/backend/python/targets:python',

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/common.py
@@ -312,7 +312,7 @@ class CheckSyntaxError(Exception):
     line_range = slice(self._syntax_error.lineno, self._syntax_error.lineno + 1)
     lines = OffByOneList(self._blob.split('\n'))
     # NB: E901 is the SyntaxError PEP8 code.
-    # See:https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+    # See:https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
     return Nit('E901', Nit.ERROR, self.filename,
                'SyntaxError: {error}'.format(error=self._syntax_error.msg),
                line_range=line_range, lines=lines)

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/indentation.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/indentation.py
@@ -11,7 +11,7 @@ from pants.contrib.python.checks.tasks.checkstyle.common import CheckstylePlugin
 
 
 # TODO(wickman) Update this to sanitize line continuation styling as we have
-# disabled it from pep8.py due to mismatched indentation styles.
+# disabled it from pycodestyle.py due to mismatched indentation styles.
 class Indentation(CheckstylePlugin):
   """Enforce proper indentation."""
   INDENT_LEVEL = 2  # the one true way

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pycodestyle.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pycodestyle.py
@@ -5,19 +5,19 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import pep8
+import pycodestyle
 
 from pants.contrib.python.checks.tasks.checkstyle.common import CheckstylePlugin, Nit, PythonFile
 
 
-class PEP8Error(Nit):
+class PyCodeStyleError(Nit):
   def __init__(self, python_file, code, line_number, text):
     line_range = python_file.line_range(line_number)
     lines = python_file.lines[line_range]
-    super(PEP8Error, self).__init__(code, Nit.ERROR, python_file, text, line_range, lines)
+    super(PyCodeStyleError, self).__init__(code, Nit.ERROR, python_file, text, line_range, lines)
 
 
-class PantsReporter(pep8.BaseReport):
+class PantsReporter(pycodestyle.BaseReport):
   def init_file(self, filename, lines, expected, line_offset):
     super(PantsReporter, self).init_file(filename, lines, expected, line_offset)
     self._python_file = PythonFile.parse(filename)
@@ -26,7 +26,7 @@ class PantsReporter(pep8.BaseReport):
   def error(self, line_number, offset, text, check):
     code = super(PantsReporter, self).error(line_number, offset, text, check)
     if code:
-      self._errors.append(PEP8Error(self._python_file, code, line_number, text[5:]))
+      self._errors.append(PyCodeStyleError(self._python_file, code, line_number, text[5:]))
     return code
 
   @property
@@ -34,12 +34,12 @@ class PantsReporter(pep8.BaseReport):
     return self._errors
 
 
-class PEP8Checker(CheckstylePlugin):
-  """Enforce PEP8 checks from the pep8 tool."""
+class PyCodeStyleChecker(CheckstylePlugin):
+  """Enforce PEP8 checks from the pycodestyle tool."""
 
   def __init__(self, *args, **kwargs):
-    super(PEP8Checker, self).__init__(*args, **kwargs)
-    self.STYLE_GUIDE = pep8.StyleGuide(
+    super(PyCodeStyleChecker, self).__init__(*args, **kwargs)
+    self.STYLE_GUIDE = pycodestyle.StyleGuide(
         max_line_length=self.options.max_length,
         verbose=False,
         reporter=PantsReporter,

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pycodestyle_subsystem.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/pycodestyle_subsystem.py
@@ -8,10 +8,13 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants.contrib.python.checks.tasks.checkstyle.plugin_subsystem_base import PluginSubsystemBase
 
 
-class PEP8Subsystem(PluginSubsystemBase):
-  options_scope = 'pycheck-pep8'
+class PyCodeStyleSubsystem(PluginSubsystemBase):
+  options_scope = 'pycheck-pycodestyle'
 
-  # Code reference is here: https://pep8.readthedocs.io/en/latest/intro.html#error-codes
+  deprecated_options_scope = 'pycheck-pep8'
+  deprecated_options_scope_removal_version = '1.10.0.dev0'
+
+  # Code reference is here: https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
   DEFAULT_IGNORE_CODES = (
     # continuation_line_indentation
     'E121', # continuation line under-indented for hanging indent
@@ -36,7 +39,7 @@ class PEP8Subsystem(PluginSubsystemBase):
     #     class Error(Exception): pass
     #     class DerpError(Error): pass
     #     class HerpError(Error): pass
-    # We disable the pep8.py checking for these and instead have a more lenient filter
+    # We disable the pycodestyle.py checking for these and instead have a more lenient filter
     # in the whitespace checker.
     'E701', # multiple statements on one line (colon)
     'E301', # expected 1 blank line, found 0
@@ -46,12 +49,12 @@ class PEP8Subsystem(PluginSubsystemBase):
 
   @classmethod
   def register_options(cls, register):
-    super(PEP8Subsystem, cls).register_options(register)
+    super(PyCodeStyleSubsystem, cls).register_options(register)
     register('--ignore', fingerprint=True, type=list, default=cls.DEFAULT_IGNORE_CODES,
              help='Prevent test failure but still produce output for problems.')
     register('--max-length', fingerprint=True, type=int, default=100,
-             help='Max line length to use for PEP8 checks.')
+             help='Max line length to use for pycodestyle checks.')
 
   def get_plugin_type(self):
-    from pants.contrib.python.checks.tasks.checkstyle.pep8 import PEP8Checker
-    return PEP8Checker
+    from pants.contrib.python.checks.tasks.checkstyle.pycodestyle import PyCodeStyleChecker
+    return PyCodeStyleChecker

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/register_plugins.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/register_plugins.py
@@ -18,9 +18,9 @@ from pants.contrib.python.checks.tasks.checkstyle.missing_contextmanager_subsyst
 from pants.contrib.python.checks.tasks.checkstyle.new_style_classes_subsystem import \
   NewStyleClassesSubsystem
 from pants.contrib.python.checks.tasks.checkstyle.newlines_subsystem import NewlinesSubsystem
-from pants.contrib.python.checks.tasks.checkstyle.pep8_subsystem import PEP8Subsystem
 from pants.contrib.python.checks.tasks.checkstyle.print_statements_subsystem import \
   PrintStatementsSubsystem
+from pants.contrib.python.checks.tasks.checkstyle.pycodestyle_subsystem import PyCodeStyleSubsystem
 from pants.contrib.python.checks.tasks.checkstyle.pyflakes_subsystem import FlakeCheckSubsystem
 from pants.contrib.python.checks.tasks.checkstyle.trailing_whitespace_subsystem import \
   TrailingWhitespaceSubsystem
@@ -41,4 +41,4 @@ def register_plugins(task):
   task.register_plugin('pyflakes', FlakeCheckSubsystem)
   task.register_plugin('trailing-whitespace', TrailingWhitespaceSubsystem)
   task.register_plugin('variable-names', VariableNamesSubsystem)
-  task.register_plugin('pep8', PEP8Subsystem)
+  task.register_plugin('pycodestyle', PyCodeStyleSubsystem)

--- a/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_pycodestyle.py
+++ b/contrib/python/tests/python/pants_test/contrib/python/checks/tasks/checkstyle/test_pycodestyle.py
@@ -8,34 +8,34 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 from pants_test.contrib.python.checks.tasks.checkstyle.plugin_test_base import \
   CheckstylePluginTestBase
 
-from pants.contrib.python.checks.tasks.checkstyle.pep8 import PEP8Checker
+from pants.contrib.python.checks.tasks.checkstyle.pycodestyle import PyCodeStyleChecker
 
 
-class PEP8CheckerTest(CheckstylePluginTestBase):
-  plugin_type = PEP8Checker
+class PyCodeStyleCheckerTest(CheckstylePluginTestBase):
+  plugin_type = PyCodeStyleChecker
 
   @property
   def file_required(self):
     return True
 
   def get_plugin(self, file_content, **options):
-    return super(PEP8CheckerTest, self).get_plugin(file_content,
+    return super(PyCodeStyleCheckerTest, self).get_plugin(file_content,
                                                    max_length=options.get('max_length', 10),
                                                    ignore=options.get('ignore', False))
 
-  def test_pep8(self):
+  def test_pycodestyle(self):
     self.assertNoNits('')
 
-  def test_pep8_line_length(self):
+  def test_pycodestyle_line_length(self):
     self.assertNit('# Longer than 10.\n', 'E501', expected_line_number='001')
 
-  def test_pep8_nit_lines(self):
-    # Pep8 supports `# noqa` for certain checks, but not all, whereas the higher level pants checker
-    # always supports `# noqa` no matter the provenance of the check, iff the check has a relevant
-    # line marked `# noqa`.
+  def test_pycodestyle_nit_lines(self):
+    # Pycodestyle supports `# noqa` for certain checks, but not all, whereas the higher level pants
+    # checker always supports `# noqa` no matter the provenance of the check, iff the check has a
+    # relevant line marked `# noqa`.
     #
-    # This test verifies that E221 does not respect `# noqa` at the pep8 check level, but that the
-    # resulting nit does have an appropriate set of lines for the higher-level pants checker
-    # `# noqa` support.
+    # This test verifies that E221 does not respect `# noqa` at the pycodestyle check level, but
+    # that the resulting nit does have an appropriate set of lines for the higher-level pants
+    # checker `# noqa` support.
     nit = self.assertNit('A  = "Longer than 10."  # noqa\n', 'E221', expected_line_number='001')
     self.assertEqual(['A  = "Longer than 10."  # noqa'], nit.lines)

--- a/pants.ini
+++ b/pants.ini
@@ -266,7 +266,7 @@ skip: True
 [pycheck-class-factoring]
 skip: True
 
-[pycheck-pep8]
+[pycheck-pycodestyle]
 skip: True
 
 [pycheck-import-order]

--- a/src/python/pants/notes/master.rst
+++ b/src/python/pants/notes/master.rst
@@ -7221,7 +7221,7 @@ This release completes the deprecated cycle for two options and removes them:
 Two existing tasks not installed by default have been moved from `pantsbuild.pants` to
 `pantsbuild.pants.contrib.python.checks`.  You can add `pantsbuild.pants.contrib.python.checks` to
 your `plugins` list in `pants.ini` to get these tasks installed and start verifying your python
-BUILD deps and to check that your python code conforms to pep8 and various other lints.
+BUILD deps and to check that your python code conforms to pycodestyle and various other lints.
 
 API Changes
 ~~~~~~~~~~~


### PR DESCRIPTION
### Problem

The pep8 project was moved to pycodestyle https://pypi.org/project/pycodestyle/

### Solution

Update pep8 to pycodestyle

### Result

Most of the checks should be the same. 

Release Notes for pycodestyle from https://github.com/PyCQA/pycodestyle/blob/master/CHANGES.txt

```
2.4.0 (2018-04-10)
------------------

New checks:

* Add W504 warning for checking that a break doesn't happen after a binary
  operator. This check is ignored by default. PR #502.
* Add W605 warning for invalid escape sequences in string literals. PR #676.
* Add W606 warning for 'async' and 'await' reserved keywords being introduced
  in Python 3.7. PR #684.
* Add E252 error for missing whitespace around equal sign in type annotated
  function arguments with defaults values. PR #717.

Changes:

* An internal bisect search has replaced a linear search in order to improve
  efficiency. PR #648.
* pycodestyle now uses PyPI trove classifiers in order to document supported
  python versions on PyPI. PR #654.
* 'setup.cfg' '[wheel]' section has been renamed to '[bdist_wheel]', as
  the former is legacy. PR #653.
* pycodestyle now handles very long lines much more efficiently for python
  3.2+. Fixes #643. PR #644.
* You can now write 'pycodestyle.StyleGuide(verbose=True)' instead of
  'pycodestyle.StyleGuide(verbose=True, paths=['-v'])' in order to achieve
  verbosity. PR #663.
* The distribution of pycodestyle now includes the license text in order to
  comply with open source licenses which require this. PR #694.
* 'maximum_line_length' now ignores shebang ('#!') lines. PR #736.
* Add configuration option for the allowed number of blank lines. It is
  implemented as a top level dictionary which can be easily overwritten. Fixes
  #732. PR #733.

Bugs:

* Prevent a 'DeprecationWarning', and a 'SyntaxError' in future python, caused
  by an invalid escape sequence. PR #625.
* Correctly report E501 when the first line of a docstring is too long.
  Resolves #622. PR #630.
* Support variable annotation when variable start by a keyword, such as class
  variable type annotations in python 3.6. PR #640.
* pycodestyle internals have been changed in order to allow 'python3 -m
  cProfile' to report correct metrics. PR #647.
* Fix a spelling mistake in the description of E722. PR #697.
* 'pycodestyle --diff' now does not break if your 'gitconfig' enables
  'mnemonicprefix'. PR #706.

2.3.1 (2017-01-31)
------------------

Bugs:

* Fix regression in detection of E302 and E306; #618, #620

2.3.0 (2017-01-30)
------------------

New Checks:

* Add E722 warning for bare ``except`` clauses
* Report E704 for async function definitions (``async def``)

Bugs:

* Fix another E305 false positive for variables beginning with "class" or
  "def"
* Fix detection of multiple spaces between ``async`` and ``def``
* Fix handling of variable annotations. Stop reporting E701 on Python 3.6 for
  variable annotations.

2.2.0 (2016-11-14)
------------------

Announcements:

* Added Make target to obtain proper tarball file permissions; #599

Bugs:

* Fixed E305 regression caused by #400; #593

2.1.0 (2016-11-04)
------------------

Announcements:

* Change all references to the pep8 project to say pycodestyle; #530

Changes:

* Report E302 for blank lines before an "async def"; #556
* Update our list of tested and supported Python versions which are 2.6, 2.7,
  3.2, 3.3, 3.4 and 3.5 as well as the nightly Python build and PyPy.
* Report E742 and E743 for functions and classes badly named 'l', 'O', or 'I'.
* Report E741 on 'global' and 'nonlocal' statements, as well as prohibited
  single-letter variables.
* Deprecated use of `[pep8]` section name in favor of `[pycodestyle]`; #591
* Report E722 when bare except clause is used; #579

Bugs:

* Fix opt_type AssertionError when using Flake8 2.6.2 and pycodestyle; #561
* Require two blank lines after toplevel def, class; #536
* Remove accidentally quadratic computation based on the number of colons. This
  will make pycodestyle faster in some cases; #314

2.0.0 (2016-05-31)
------------------

Announcements:

* Repository renamed to `pycodestyle`; Issue #466 / #481.
* Added joint Code of Conduct as member of PyCQA; #483

Changes:

* Added tox test support for Python 3.5 and pypy3
* Added check E275 for whitespace on `from ... import ...` lines; #489 / #491
* Added W503 to the list of codes ignored by default ignore list; #498
* Removed use of project level `.pep8` configuration file; #364

Bugs:

* Fixed bug with treating `~` operator as binary; #383 / #384
* Identify binary operators as unary; #484 / #485

1.7.0 (2016-01-12)
------------------

Announcements:

* Repository moved to PyCQA Organization on GitHub:
  https://github.com/pycqa/pep8

Changes:

* Reverted the fix in #368, "options passed on command line are only ones
  accepted" feature. This has many unintended consequences in pep8 and flake8
  and needs to be reworked when I have more time.
* Added support for Python 3.5. (Issue #420 & #459)
* Added support for multi-line config_file option parsing. (Issue #429)
* Improved parameter parsing. (Issues #420 & #456)

Bugs:

* Fixed BytesWarning on Python 3. (Issue #459)
```