### PR TITLE
Sort list goal output

### DIFF
--- a/src/python/pants/backend/graph_info/tasks/listtargets.py
+++ b/src/python/pants/backend/graph_info/tasks/listtargets.py
@@ -71,4 +71,5 @@ class ListTargets(ConsoleTask):
       result = print_fn(target)
       if result and result not in visited:
         visited.add(result)
-        yield result
+
+    return sorted(visited)


### PR DESCRIPTION
### Problem

The output of `./pants list` is not sorted, which regularly confuses users who have to `| sort` the output.

### Solution

Here we sort the output. Collecting the results and sorting them before displaying the output does not appear to have a noticeable impact on performance, which takes ~4 seconds in the pants repo at present, and its basically the same with the sort, since the bulk of the time is building the graph.

### Result

Running `./pants list ::` now produces sorted output.