### PR TITLE
Fix visualize-to option post addition of Sessions

### DIFF
--- a/src/python/pants/engine/native.py
+++ b/src/python/pants/engine/native.py
@@ -218,7 +218,7 @@ void execution_request_destroy(ExecutionRequest*);
 
 uint64_t graph_len(Scheduler*);
 uint64_t graph_invalidate(Scheduler*, BufferBuffer);
-void graph_visualize(Scheduler*, ExecutionRequest*, char*);
+PyResult graph_visualize(Scheduler*, Session*, char*);
 void graph_trace(Scheduler*, ExecutionRequest*, char*);
 
 PyResult  execution_add_root_select(Scheduler*, ExecutionRequest*, Key, TypeConstraint);

--- a/src/python/pants/engine/scheduler.py
+++ b/src/python/pants/engine/scheduler.py
@@ -258,8 +258,9 @@ class Scheduler(object):
                                      TypeId(self._to_id(get.subject)))
     self._native.lib.tasks_task_end(self._tasks)
 
-  def visualize_graph_to_file(self, execution_request, filename):
-    self._native.lib.graph_visualize(self._scheduler, execution_request, bytes(filename))
+  def visualize_graph_to_file(self, session, filename):
+    res = self._native.lib.graph_visualize(self._scheduler, session, bytes(filename))
+    self._raise_or_return(res)
 
   def visualize_rule_graph_to_file(self, filename):
     self._native.lib.rule_graph_visualize(
@@ -399,13 +400,12 @@ class SchedulerSession(object):
     for line in self._scheduler.graph_trace(execution_request.native):
       yield line
 
-  def visualize_graph_to_file(self, execution_request, filename):
+  def visualize_graph_to_file(self, filename):
     """Visualize a graph walk by writing graphviz `dot` output to a file.
 
-    :param ExecutionRequest execution_request: A set of roots to visualize from.
     :param str filename: The filename to output the graphviz output to.
     """
-    self._scheduler.visualize_graph_to_file(execution_request.native, filename)
+    self._scheduler.visualize_graph_to_file(self._session, filename)
 
   def visualize_rule_graph_to_file(self, filename):
     self._scheduler.visualize_rule_graph_to_file(filename)

--- a/src/python/pants/pantsd/service/pailgun_service.py
+++ b/src/python/pants/pantsd/service/pailgun_service.py
@@ -61,6 +61,7 @@ class PailgunService(PantsService):
       self._logger.debug('execution commandline: %s', arguments)
       options, _ = OptionsInitializer(OptionsBootstrapper(args=arguments)).setup(init_logging=False)
 
+      graph_helper, target_roots = None, None
       try:
         self._logger.debug('warming the product graph via %s', self._scheduler_service)
         # N.B. This call is made in the pre-fork daemon context for reach and reuse of the

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -439,20 +439,17 @@ pub extern "C" fn graph_len(scheduler_ptr: *mut Scheduler) -> u64 {
 #[no_mangle]
 pub extern "C" fn graph_visualize(
   scheduler_ptr: *mut Scheduler,
-  execution_request_ptr: *mut ExecutionRequest,
+  session_ptr: *mut Session,
   path_ptr: *const raw::c_char,
-) {
+) -> PyResult {
   with_scheduler(scheduler_ptr, |scheduler| {
-    with_execution_request(execution_request_ptr, |execution_request| {
+    with_session(session_ptr, |session| {
       let path_str = unsafe { CStr::from_ptr(path_ptr).to_string_lossy().into_owned() };
       let path = PathBuf::from(path_str);
-      // TODO: This should likely return an error condition to python.
-      //   see https://github.com/pantsbuild/pants/issues/4025
       scheduler
-        .visualize(execution_request, path.as_path())
-        .unwrap_or_else(|e| {
-          println!("Failed to visualize to {}: {:?}", path.display(), e);
-        });
+        .visualize(session, path.as_path())
+        .map_err(|e| format!("Failed to visualize to {}: {:?}", path.display(), e))
+        .into()
     })
   })
 }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -84,8 +84,8 @@ impl Scheduler {
     }
   }
 
-  pub fn visualize(&self, request: &ExecutionRequest, path: &Path) -> io::Result<()> {
-    self.core.graph.visualize(&request.root_nodes(), path)
+  pub fn visualize(&self, session: &Session, path: &Path) -> io::Result<()> {
+    self.core.graph.visualize(&session.root_nodes(), path)
   }
 
   pub fn trace(&self, request: &ExecutionRequest, path: &Path) -> io::Result<()> {

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -124,6 +124,7 @@ python_tests(
     'src/python/pants/build_graph',
     'src/python/pants/engine:nodes',
     'src/python/pants/engine:scheduler',
+    'src/python/pants/util:contextutil',
     'tests/python/pants_test/engine/examples:planners',
     'tests/python/pants_test/engine/examples:scheduler_inputs',
     'tests/python/pants_test/engine:util',
@@ -208,7 +209,7 @@ python_tests(
   name='scheduler_integration',
   sources=['test_scheduler_integration.py'],
   dependencies=[
-    'tests/python/pants_test/base:context_utils',
+    'src/python/pants/util:contextutil',
     'tests/python/pants_test:int-test',
   ],
   tags={'integration'},

--- a/tests/python/pants_test/engine/BUILD
+++ b/tests/python/pants_test/engine/BUILD
@@ -205,6 +205,16 @@ python_tests(
 )
 
 python_tests(
+  name='scheduler_integration',
+  sources=['test_scheduler_integration.py'],
+  dependencies=[
+    'tests/python/pants_test/base:context_utils',
+    'tests/python/pants_test:int-test',
+  ],
+  tags={'integration'},
+)
+
+python_tests(
   name='scheduler_test_base',
   sources=['scheduler_test_base.py'],
   dependencies=[

--- a/tests/python/pants_test/engine/scheduler_test_base.py
+++ b/tests/python/pants_test/engine/scheduler_test_base.py
@@ -73,8 +73,8 @@ class SchedulerTestBase(object):
     states = [state for _, state in result.root_products]
     if any(type(state) is not Return for state in states):
       with temporary_file_path(cleanup=False, suffix='.dot') as dot_file:
-        scheduler.visualize_graph_to_file(request, dot_file)
-        raise ValueError('At least one request failed: {}. Visualized as {}'.format(states, dot_file))
+        scheduler.visualize_graph_to_file(dot_file)
+        raise ValueError('At least one root failed: {}. Visualized as {}'.format(states, dot_file))
     return list(state.value for state in states)
 
   def execute_expecting_one_result(self, scheduler, product, subject):

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -36,7 +36,7 @@ class EngineExamplesTest(unittest.TestCase):
   def test_serial_execution_simple(self):
     request = self.request([Classpath], self.java)
     result = self.scheduler.execute(request)
-    self.scheduler.visualize_graph_to_file(request, 'blah/run.0.dot')
+    self.scheduler.visualize_graph_to_file('blah/run.0.dot')
     self.assertEqual(Return(Classpath(creator='javac')), result.root_products[0][1])
     self.assertIsNone(result.error)
 

--- a/tests/python/pants_test/engine/test_engine.py
+++ b/tests/python/pants_test/engine/test_engine.py
@@ -13,6 +13,7 @@ from pants.build_graph.address import Address
 from pants.engine.nodes import Return
 from pants.engine.rules import RootRule, TaskRule, rule
 from pants.engine.selectors import Get, Select
+from pants.util.contextutil import temporary_dir
 from pants.util.objects import datatype
 from pants_test.engine.examples.planners import Classpath, setup_json_scheduler
 from pants_test.engine.scheduler_test_base import SchedulerTestBase
@@ -36,7 +37,8 @@ class EngineExamplesTest(unittest.TestCase):
   def test_serial_execution_simple(self):
     request = self.request([Classpath], self.java)
     result = self.scheduler.execute(request)
-    self.scheduler.visualize_graph_to_file('blah/run.0.dot')
+    with temporary_dir() as tempdir:
+      self.scheduler.visualize_graph_to_file(os.path.join(tempdir, 'run.0.dot'))
     self.assertEqual(Return(Classpath(creator='javac')), result.root_products[0][1])
     self.assertIsNone(result.error)
 

--- a/tests/python/pants_test/engine/test_scheduler.py
+++ b/tests/python/pants_test/engine/test_scheduler.py
@@ -232,7 +232,7 @@ class SchedulerTest(unittest.TestCase):
 
     with temporary_dir() as td:
       output_path = os.path.join(td, 'output.dot')
-      self.scheduler.visualize_graph_to_file(build_request, output_path)
+      self.scheduler.visualize_graph_to_file(output_path)
       with open(output_path, 'rb') as fh:
         graphviz_output = fh.read().strip()
 

--- a/tests/python/pants_test/engine/test_scheduler_integration.py
+++ b/tests/python/pants_test/engine/test_scheduler_integration.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+# Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
+                        unicode_literals, with_statement)
+
+import os
+
+from pants.util.contextutil import temporary_dir
+from pants_test.pants_run_integration_test import PantsRunIntegrationTest
+
+
+class SchedulerIntegrationTest(PantsRunIntegrationTest):
+
+  def test_visualize_to(self):
+    # Tests usage of the `--native-engine-visualize-to=` option, which triggers background
+    # visualization of the graph. There are unit tests confirming the content of the rendered
+    # results.
+    with temporary_dir() as destdir:
+      args = [
+          '--native-engine-visualize-to={}'.format(destdir),
+          'list',
+          'examples/src/scala/org/pantsbuild/example/hello/welcome',
+        ]
+      self.assert_success(self.run_pants(args))
+      self.assertTrue(len(os.listdir(destdir)) > 0)


### PR DESCRIPTION
### Problem

When `Sessions` were added, the "static" reference to the most recent `ExecutionRequest` was removed from the `Scheduler`. But that reference was still in use by `_maybe_visualize` (used in the background when `--native-engine-visualize-to` was set)... which didn't have an integration test.

### Solution

Since visualizing "the most recent request" didn't really make sense in all contexts where `_maybe_visualize` was used anyway, switch to visualizing all roots that have been requested within a `Session`. Cover this with an integration test.

### Result

`--native-engine-visualize-to`  works, and is protected against future breakage.