### PR TITLE
Add deprecation warning for pep8 'plugin' in pythonstyle suppress file

### DIFF
--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/checker.py
@@ -68,7 +68,7 @@ class PythonCheckStyleTask(LintTaskMixin, Task):
     register('--strict', fingerprint=True, type=bool,
              help='If enabled, have non-zero exit status for any nit at WARNING or higher.')
     register('--suppress', fingerprint=True, type=file_option, default=None,
-             help='Takes a XML file where specific rules on specific files will be skipped.')
+             help='Takes a text file where specific rules on specific files will be skipped.')
     register('--fail', fingerprint=True, default=True, type=bool,
              help='Prevent test failure but still produce output for problems.')
 
@@ -173,7 +173,7 @@ class PythonCheckStyleTask(LintTaskMixin, Task):
   def execute(self):
     """Run Checkstyle on all found non-synthetic source files."""
 
-    # If we are linting for Python 3, skip lint altogether. 
+    # If we are linting for Python 3, skip lint altogether.
     # Long-term Python 3 linting solution tracked by:
     # https://github.com/pantsbuild/pants/issues/5764
     interpreter = self.context.products.get_data(PythonInterpreter)

--- a/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/file_excluder.py
+++ b/contrib/python/src/python/pants/contrib/python/checks/tasks/checkstyle/file_excluder.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import os
 import re
 
+from pants.base.deprecated import deprecated_conditional
 from pants.base.exceptions import TaskError
 
 
@@ -22,6 +23,14 @@ class FileExcluder(object):
           if line and not line.startswith('#') and '::' in line:
             pattern, plugins = line.strip().split('::', 2)
             plugins = plugins.split()
+
+            deprecated_conditional(
+              lambda: 'pep8' in plugins,
+              '1.10.0.dev0',
+              'The pep8 check has been renamed to pycodestyle. '
+              'Please update your suppression file: "{}". The pep8 option'.format(excludes_path)
+            )
+            map(lambda p:p if p != 'pep8' else 'pycodestyle', plugins)
 
             self.excludes[pattern] = {
               'regex': re.compile(pattern),


### PR DESCRIPTION
### Problem

In https://github.com/pantsbuild/pants/pull/5867 pep8 was deprecated in favor pycodestyle but using "pep8" in the suppression file was not deprecated 

### Solution

Log a warning when pep8 is seen in the suppression file and change it to pycodestyle

### Result

We have a deprecation message for pep8 usage in the suppression file that still works with pycodestyle.