### PR TITLE
Fix using classpath jars with compiler plugins

### DIFF
--- a/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/javac/javac_compile.py
@@ -114,8 +114,8 @@ class JavacCompile(JvmCompile):
     if JvmPlatform.global_instance().get_options().compiler == 'javac':
       return super(JavacCompile, self).execute()
 
-  def compile(self, args, classpath, sources, classes_output_dir, upstream_analysis, analysis_file,
-              zinc_args_file, settings, fatal_warnings, zinc_file_manager,
+  def compile(self, ctx, args, classpath, upstream_analysis,
+              settings, fatal_warnings, zinc_file_manager,
               javac_plugin_map, scalac_plugin_map):
     try:
       distribution = JvmPlatform.preferred_jvm_distribution([settings], strict=True)
@@ -137,7 +137,7 @@ class JavacCompile(JvmCompile):
       javac_cmd.extend(settings_args)
 
     javac_cmd.extend([
-      '-d', classes_output_dir,
+      '-d', ctx.classes_dir,
       # TODO: support -release
       '-source', str(settings.source_level),
       '-target', str(settings.target_level),
@@ -152,7 +152,7 @@ class JavacCompile(JvmCompile):
     else:
       javac_cmd.extend(self.get_options().fatal_warnings_disabled_args)
 
-    with argfile.safe_args(sources, self.get_options()) as batched_sources:
+    with argfile.safe_args(ctx.sources, self.get_options()) as batched_sources:
       javac_cmd.extend(batched_sources)
 
       with self.context.new_workunit(name='javac',

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -156,7 +156,7 @@ class JvmCompile(NailgunTaskBase):
 
   @classmethod
   def implementation_version(cls):
-    return super(JvmCompile, cls).implementation_version() + [('JvmCompile', 2)]
+    return super(JvmCompile, cls).implementation_version() + [('JvmCompile', 3)]
 
   @classmethod
   def prepare(cls, options, round_manager):
@@ -246,21 +246,17 @@ class JvmCompile(NailgunTaskBase):
   def select_source(self, source_file_path):
     raise NotImplementedError()
 
-  def compile(self, args, classpath, sources, classes_output_dir, upstream_analysis, analysis_file,
-              zinc_args_file, settings, fatal_warnings, zinc_file_manager,
+  def compile(self, ctx, args, classpath, upstream_analysis,
+              settings, fatal_warnings, zinc_file_manager,
               javac_plugin_map, scalac_plugin_map):
     """Invoke the compiler.
 
-    Must raise TaskError on compile failure.
+    Subclasses must implement. Must raise TaskError on compile failure.
 
-    Subclasses must implement.
-    :param list args: Arguments to the compiler (such as jmake or zinc).
+    :param CompileContext ctx: A CompileContext for the target to compile.
+    :param list args: Arguments to the compiler (such as javac or zinc).
     :param list classpath: List of classpath entries.
-    :param list sources: Source files.
-    :param str classes_output_dir: Where to put the compiled output.
-    :param upstream_analysis:
-    :param analysis_file: Where to write the compile analysis.
-    :param zinc_args_file: Where to write the args zinc was invoked with.
+    :param upstream_analysis: A map from classpath entry to analysis file for dependencies.
     :param JvmPlatformSettings settings: platform settings determining the -source, -target, etc for
       javac to use.
     :param fatal_warnings: whether to convert compilation warnings to errors.
@@ -492,13 +488,10 @@ class JvmCompile(NailgunTaskBase):
 
         try:
           self.compile(
+            ctx,
             self._args,
             classpath,
-            ctx.sources,
-            ctx.classes_dir,
             upstream_analysis,
-            ctx.analysis_file,
-            ctx.zinc_args_file,
             settings,
             fatal_warnings,
             zinc_file_manager,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/jvm_compile.py
@@ -457,23 +457,20 @@ class JvmCompile(NailgunTaskBase):
       with open(path, 'w') as f:
         f.write(text.encode('utf-8'))
 
-  def _compile_vts(self, vts, target, sources, analysis_file, upstream_analysis, classpath, outdir,
-                   log_dir, zinc_args_file, progress_message, settings, fatal_warnings,
+  def _compile_vts(self, vts, ctx, upstream_analysis, classpath, progress_message, settings, fatal_warnings,
                    zinc_file_manager, counter):
     """Compiles sources for the given vts into the given output dir.
 
-    vts - versioned target set
-    sources - sources for this target set
-    analysis_file - the analysis file to manipulate
-    classpath - a list of classpath entries
-    outdir - the output dir to send classes to
+    :param vts: VersionedTargetSet with one entry for the target.
+    :param ctx: - A CompileContext instance for the target.
+    :param classpath: A list of classpath entries
 
     May be invoked concurrently on independent target sets.
 
     Postcondition: The individual targets in vts are up-to-date, as if each were
                    compiled individually.
     """
-    if not sources:
+    if not ctx.sources:
       self.context.log.warn('Skipping {} compile for targets with no sources:\n  {}'
                             .format(self.name(), vts.targets))
     else:
@@ -483,7 +480,7 @@ class JvmCompile(NailgunTaskBase):
       self.context.log.info(
         counter_str,
         'Compiling ',
-        items_to_report_element(sources, '{} source'.format(self.name())),
+        items_to_report_element(ctx.sources, '{} source'.format(self.name())),
         ' in ',
         items_to_report_element([t.address.reference() for t in vts.targets], 'target'),
         ' (',
@@ -491,31 +488,31 @@ class JvmCompile(NailgunTaskBase):
         ').')
       with self.context.new_workunit('compile', labels=[WorkUnitLabel.COMPILER]) as compile_workunit:
         if self.get_options().capture_classpath:
-          self._record_compile_classpath(classpath, vts.targets, outdir)
+          self._record_compile_classpath(classpath, vts.targets, ctx.classes_dir)
 
         try:
           self.compile(
             self._args,
             classpath,
-            sources,
-            outdir,
+            ctx.sources,
+            ctx.classes_dir,
             upstream_analysis,
-            analysis_file,
-            zinc_args_file,
+            ctx.analysis_file,
+            ctx.zinc_args_file,
             settings,
             fatal_warnings,
             zinc_file_manager,
-            self._get_plugin_map('javac', self._zinc.javac_compiler_plugins_src(self), target),
-            self._get_plugin_map('scalac', self._zinc.scalac_compiler_plugins_src(self), target),
+            self._get_plugin_map('javac', self._zinc.javac_compiler_plugins_src(self), ctx.target),
+            self._get_plugin_map('scalac', self._zinc.scalac_compiler_plugins_src(self), ctx.target),
           )
-          self._capture_logs(compile_workunit, log_dir)
+          self._capture_logs(compile_workunit, ctx.log_dir)
         except TaskError:
           if self.get_options().suggest_missing_deps:
             logs = [path
                     for _, name, _, path in self._find_logs(compile_workunit)
                     if name == self.name()]
             if logs:
-              self._find_missing_deps(logs, target)
+              self._find_missing_deps(logs, ctx.target)
           raise
 
   def _capture_logs(self, workunit, destination):
@@ -736,14 +733,9 @@ class JvmCompile(NailgunTaskBase):
         zinc_file_manager = dep_context.defaulted_property(tgt, lambda x: x.zinc_file_manager)
         with Timer() as timer:
           self._compile_vts(vts,
-                            ctx.target,
-                            ctx.sources,
-                            ctx.analysis_file,
+                            ctx,
                             upstream_analysis,
                             cp_entries,
-                            ctx.classes_dir,
-                            ctx.log_dir,
-                            ctx.zinc_args_file,
                             progress_message,
                             tgt.platform,
                             fatal_warnings,

--- a/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
+++ b/src/python/pants/backend/jvm/tasks/jvm_compile/zinc/zinc_compile.py
@@ -280,13 +280,13 @@ class BaseZincCompile(JvmCompile):
     # - We also search in the extra scalac plugin dependencies, if specified.
     # - In scala 2.11 and up, the plugin's classpath element can be a dir, but for 2.10 it must be
     #   a jar.  So in-repo plugins will only work with 2.10 if --use-classpath-jars is true.
-    # - We exclude our own classes_dir, because if we're a plugin ourselves, then our
+    # - We exclude our own classes_dir/jar_file, because if we're a plugin ourselves, then our
     #   classes_dir doesn't have scalac-plugin.xml yet, and we don't want that fact to get
     #   memoized (which in practice will only happen if this plugin uses some other plugin, thus
     #   triggering the plugin search mechanism, which does the memoizing).
     scalac_plugin_search_classpath = (
       (set(classpath) | set(self.scalac_plugin_classpath_elements())) -
-      {ctx.classes_dir}
+      {ctx.classes_dir, ctx.jar_file}
     )
     zinc_args.extend(self._scalac_plugin_args(scalac_plugin_map, scalac_plugin_search_classpath))
     if upstream_analysis:


### PR DESCRIPTION
### Problem

In cases where `--use-classpath-jars` is set, the classpath entry for a target will be a `ctx.jar_file` rather than `ctx.output_dir`, but the compiler plugin map building was not accounting for this, and thus failed to inspect the (non-existent) jar file for any plugins it contained.

### Solution

Refactor `JvmCompile.compile` and subclasses to take the `CompileContext` (rather than an ever-growing list of parameters), and exclude the `ctx.jar_file` from plugin searches.

### Result

`--use-classpath-jars` works with compiler plugins.