### PR TITLE
Populate output_directory in ExecuteProcessResponse

### DIFF
--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -52,6 +52,19 @@ impl Snapshot {
       .to_boxed()
   }
 
+  pub fn digest_from_path_stats<
+    S: StoreFileByDigest<Error> + Sized + Clone,
+    Error: fmt::Debug + 'static + Send,
+  >(
+    store: Store,
+    file_digester: S,
+    path_stats: Vec<PathStat>,
+  ) -> BoxFuture<Digest, String> {
+    let mut sorted_path_stats = path_stats.clone();
+    sorted_path_stats.sort_by(|a, b| a.path().cmp(b.path()));
+    Snapshot::ingest_directory_from_sorted_path_stats(store, file_digester, sorted_path_stats)
+  }
+
   fn ingest_directory_from_sorted_path_stats<
     S: StoreFileByDigest<Error> + Sized + Clone,
     Error: fmt::Debug + 'static + Send,


### PR DESCRIPTION
> ###

 Problem

See #5709 
tl;dr: We don't currently populate the output_files field in the response from remote.

### Solution

Now we populate the output files and tests have been added to verify the behavior. 
