### PR TITLE
Use tempfile crate not tempdir crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -242,7 +242,7 @@ dependencies = [
  "petgraph 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "process_execution 0.0.1",
  "resettable 0.0.1",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -335,7 +335,7 @@ dependencies = [
  "protobuf 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resettable 0.0.1",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
 ]
 
@@ -756,7 +756,7 @@ dependencies = [
  "protobuf 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resettable 0.0.1",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "testutil 0.0.1",
  "tokio-process 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -787,7 +787,7 @@ name = "protoc"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -980,12 +980,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
+name = "tempfile"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1393,7 +1396,7 @@ dependencies = [
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
-"checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+"checksum tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47776f63b85777d984a50ce49d6b9e58826b6a3766a449fc95bc66cd5663c15b"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -76,4 +76,4 @@ petgraph = "0.4.5"
 process_execution = { path = "process_execution" }
 resettable = { path = "resettable" }
 tokio = "0.1"
-tempdir = "0.3.5"
+tempfile = "3"

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.6.0"
-tempdir = "0.3.5"
+tempfile = "3"
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -19,5 +19,5 @@ time = "0.1.39"
 
 [dev-dependencies]
 bytes = "0.4.5"
-tempdir = "0.3.5"
+tempfile = "3"
 testutil = { path = "../../testutil" }

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -640,21 +640,19 @@ fn unmount(mount_path: &str) -> i32 {
 
 #[cfg(test)]
 mod test {
-  extern crate tempdir;
+  extern crate tempfile;
   extern crate testutil;
 
   use fs;
   use futures::future::Future;
   use hashing;
-  use self::tempdir::TempDir;
   use std::sync::Arc;
   use super::mount;
   use self::testutil::{file, data::{TestData, TestDirectory}};
 
   #[test]
   fn missing_digest() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),
@@ -671,8 +669,7 @@ mod test {
 
   #[test]
   fn read_file_by_digest() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),
@@ -697,8 +694,7 @@ mod test {
 
   #[test]
   fn list_directory() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),
@@ -727,8 +723,7 @@ mod test {
 
   #[test]
   fn read_file_from_directory() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),
@@ -759,8 +754,7 @@ mod test {
 
   #[test]
   fn list_recursive_directory() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),
@@ -800,8 +794,7 @@ mod test {
 
   #[test]
   fn read_file_from_recursive_directory() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),
@@ -846,8 +839,7 @@ mod test {
 
   #[test]
   fn files_are_correctly_executable() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),
@@ -879,13 +871,19 @@ mod test {
   pub fn digest_to_filepath(digest: &hashing::Digest) -> String {
     format!("{}-{}", digest.0, digest.1)
   }
+
+  pub fn make_dirs() -> (tempfile::TempDir, tempfile::TempDir) {
+    let store_dir = tempfile::Builder::new().prefix("store").tempdir().unwrap();
+    let mount_dir = tempfile::Builder::new().prefix("mount").tempdir().unwrap();
+    (store_dir, mount_dir)
+  }
 }
 
 // TODO: Write a bunch more syscall-y tests to test that each syscall for each file/directory type
 // acts as we expect.
 #[cfg(test)]
 mod syscall_tests {
-  extern crate tempdir;
+  extern crate tempfile;
   extern crate testutil;
 
   use fs;
@@ -894,15 +892,14 @@ mod syscall_tests {
   use std::sync::Arc;
   use super::mount;
   use super::test::digest_to_filepath;
-  use self::tempdir::TempDir;
   use self::testutil::data::TestData;
   use std::ffi::CString;
   use std::path::Path;
+  use test::make_dirs;
 
   #[test]
   fn read_file_by_digest_exact_bytes() {
-    let store_dir = TempDir::new("store").unwrap();
-    let mount_dir = TempDir::new("mount").unwrap();
+    let (store_dir, mount_dir) = make_dirs();
 
     let store = fs::Store::local_only(
       store_dir.path(),

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -33,7 +33,7 @@ extern crate mock;
 extern crate protobuf;
 extern crate resettable;
 extern crate sha2;
-extern crate tempdir;
+extern crate tempfile;
 #[cfg(test)]
 extern crate testutil;
 
@@ -1145,7 +1145,7 @@ fn safe_create_dir_all(path: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod posixfs_test {
-  extern crate tempdir;
+  extern crate tempfile;
   extern crate testutil;
 
   use self::testutil::make_file;
@@ -1157,21 +1157,21 @@ mod posixfs_test {
 
   #[test]
   fn is_executable_false() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     make_file(&dir.path().join("marmosets"), &[], 0o611);
     assert_only_file_is_executable(dir.path(), false);
   }
 
   #[test]
   fn is_executable_true() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     make_file(&dir.path().join("photograph_marmosets"), &[], 0o700);
     assert_only_file_is_executable(dir.path(), true);
   }
 
   #[test]
   fn read_file() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let path = PathBuf::from("marmosets");
     let content = "cute".as_bytes().to_vec();
     make_file(
@@ -1191,7 +1191,7 @@ mod posixfs_test {
 
   #[test]
   fn read_file_missing() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     new_posixfs(&dir.path())
       .read_file(&File {
         path: PathBuf::from("marmosets"),
@@ -1203,7 +1203,7 @@ mod posixfs_test {
 
   #[test]
   fn stat_executable_file() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("photograph_marmosets");
     make_file(&dir.path().join(&path), &[], 0o700);
@@ -1218,7 +1218,7 @@ mod posixfs_test {
 
   #[test]
   fn stat_nonexecutable_file() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("marmosets");
     make_file(&dir.path().join(&path), &[], 0o600);
@@ -1233,7 +1233,7 @@ mod posixfs_test {
 
   #[test]
   fn stat_dir() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("enclosure");
     std::fs::create_dir(dir.path().join(&path)).unwrap();
@@ -1245,7 +1245,7 @@ mod posixfs_test {
 
   #[test]
   fn stat_symlink() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("marmosets");
     make_file(&dir.path().join(&path), &[], 0o600);
@@ -1267,7 +1267,7 @@ mod posixfs_test {
 
   #[test]
   fn stat_missing() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     posix_fs
       .stat(PathBuf::from("no_marmosets"))
@@ -1276,7 +1276,7 @@ mod posixfs_test {
 
   #[test]
   fn scandir_empty() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("empty_enclosure");
     std::fs::create_dir(dir.path().join(&path)).unwrap();
@@ -1285,7 +1285,7 @@ mod posixfs_test {
 
   #[test]
   fn scandir() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     let path = PathBuf::from("enclosure");
     std::fs::create_dir(dir.path().join(&path)).unwrap();
@@ -1335,7 +1335,7 @@ mod posixfs_test {
 
   #[test]
   fn scandir_missing() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let posix_fs = new_posixfs(&dir.path());
     posix_fs
       .scandir(&Dir(PathBuf::from("no_marmosets_here")))
@@ -1345,7 +1345,7 @@ mod posixfs_test {
 
   #[test]
   fn path_stats_for_paths() {
-    let dir = tempdir::TempDir::new("posixfs").unwrap();
+    let dir = tempfile::TempDir::new().unwrap();
     let root_path = dir.path();
 
     // File tree:

--- a/src/rust/engine/fs/src/snapshot.rs
+++ b/src/rust/engine/fs/src/snapshot.rs
@@ -1,8 +1,6 @@
 // Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-extern crate tempdir;
-
 use bazel_protos;
 use boxfuture::{BoxFuture, Boxable};
 use futures::Future;
@@ -353,12 +351,11 @@ impl StoreFileByDigest<String> for OneOffStoreFileByDigest {
 
 #[cfg(test)]
 mod tests {
-  extern crate tempdir;
+  extern crate tempfile;
   extern crate testutil;
 
   use futures::future::Future;
   use hashing::{Digest, Fingerprint};
-  use tempdir::TempDir;
   use self::testutil::make_file;
   use self::testutil::data::TestDirectory;
 
@@ -372,11 +369,22 @@ mod tests {
 
   const STR: &str = "European Burmese";
 
-  fn setup() -> (Store, TempDir, Arc<PosixFS>, OneOffStoreFileByDigest) {
+  fn setup() -> (
+    Store,
+    tempfile::TempDir,
+    Arc<PosixFS>,
+    OneOffStoreFileByDigest,
+  ) {
     let pool = Arc::new(ResettablePool::new("test-pool-".to_string()));
     // TODO: Pass a remote CAS address through.
-    let store = Store::local_only(TempDir::new("lmdb_store").unwrap(), pool.clone()).unwrap();
-    let dir = TempDir::new("root").unwrap();
+    let store = Store::local_only(
+      tempfile::Builder::new()
+        .prefix("lmdb_store")
+        .tempdir()
+        .unwrap(),
+      pool.clone(),
+    ).unwrap();
+    let dir = tempfile::Builder::new().prefix("root").tempdir().unwrap();
     let posix_fs = Arc::new(PosixFS::new(dir.path(), pool, vec![]).unwrap());
     let file_saver = OneOffStoreFileByDigest::new(store.clone(), posix_fs.clone());
     (store, dir, posix_fs, file_saver)

--- a/src/rust/engine/fs/src/store.rs
+++ b/src/rust/engine/fs/src/store.rs
@@ -1000,12 +1000,12 @@ mod local {
     use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
     use std::path::Path;
     use std::sync::Arc;
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use testutil::data::{TestData, TestDirectory};
 
     #[test]
     fn save_file() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
 
       let testdata = TestData::roland();
       assert_eq!(
@@ -1018,7 +1018,7 @@ mod local {
 
     #[test]
     fn save_file_is_idempotent() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
 
       let testdata = TestData::roland();
       new_store(dir.path())
@@ -1035,7 +1035,7 @@ mod local {
 
     #[test]
     fn save_file_collision_preserves_first() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
 
       let bogus_value = Bytes::new();
       let realdata = TestData::roland();
@@ -1086,7 +1086,7 @@ mod local {
     #[test]
     fn roundtrip_file() {
       let testdata = TestData::roland();
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
 
       let store = new_store(dir.path());
       let hash = store
@@ -1098,7 +1098,7 @@ mod local {
 
     #[test]
     fn missing_file() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       assert_eq!(
         load_file_bytes(&new_store(dir.path()), TestData::roland().fingerprint()),
         Ok(None)
@@ -1107,7 +1107,7 @@ mod local {
 
     #[test]
     fn record_and_load_directory_proto() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let testdir = TestDirectory::containing_roland();
 
       assert_eq!(
@@ -1125,7 +1125,7 @@ mod local {
 
     #[test]
     fn missing_directory() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let testdir = TestDirectory::containing_roland();
 
       assert_eq!(
@@ -1136,7 +1136,7 @@ mod local {
 
     #[test]
     fn file_is_not_directory_proto() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let testdata = TestData::roland();
 
       new_store(dir.path())
@@ -1152,7 +1152,7 @@ mod local {
 
     #[test]
     fn garbage_collect_nothing_to_do() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       let bytes = Bytes::from("0123456789");
       store
@@ -1174,7 +1174,7 @@ mod local {
 
     #[test]
     fn garbage_collect_nothing_to_do_with_lease() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       let bytes = Bytes::from("0123456789");
       store
@@ -1197,7 +1197,7 @@ mod local {
 
     #[test]
     fn garbage_collect_remove_one_of_two_files_no_leases() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       let bytes_1 = Bytes::from("0123456789");
       let fingerprint_1 = Fingerprint::from_hex_string(
@@ -1231,7 +1231,7 @@ mod local {
 
     #[test]
     fn garbage_collect_remove_both_files_no_leases() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       let bytes_1 = Bytes::from("0123456789");
       let fingerprint_1 = Fingerprint::from_hex_string(
@@ -1266,7 +1266,7 @@ mod local {
 
     #[test]
     fn garbage_collect_remove_one_of_two_directories_no_leases() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
 
       let testdir = TestDirectory::containing_roland();
       let other_testdir = TestDirectory::containing_dnalor();
@@ -1300,7 +1300,7 @@ mod local {
 
     #[test]
     fn garbage_collect_remove_file_with_leased_directory() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
 
       let testdir = TestDirectory::containing_roland();
@@ -1332,7 +1332,7 @@ mod local {
 
     #[test]
     fn garbage_collect_remove_file_while_leased_file() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
 
       let testdir = TestDirectory::containing_roland();
@@ -1363,7 +1363,7 @@ mod local {
 
     #[test]
     fn garbage_collect_fail_because_too_many_leases() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
 
       let testdir = TestDirectory::containing_roland();
@@ -1402,7 +1402,7 @@ mod local {
     fn entry_type_for_file() {
       let testdata = TestData::roland();
       let testdir = TestDirectory::containing_roland();
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       store
         .store_bytes(EntryType::Directory, testdir.bytes(), false)
@@ -1422,7 +1422,7 @@ mod local {
     fn entry_type_for_directory() {
       let testdata = TestData::roland();
       let testdir = TestDirectory::containing_roland();
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       store
         .store_bytes(EntryType::Directory, testdir.bytes(), false)
@@ -1442,7 +1442,7 @@ mod local {
     fn entry_type_for_missing() {
       let testdata = TestData::roland();
       let testdir = TestDirectory::containing_roland();
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       store
         .store_bytes(EntryType::Directory, testdir.bytes(), false)
@@ -1460,7 +1460,7 @@ mod local {
 
     #[test]
     pub fn empty_file_is_known() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       let empty_file = TestData::empty();
       assert_eq!(
@@ -1473,7 +1473,7 @@ mod local {
 
     #[test]
     pub fn empty_directory_is_known() {
-      let dir = TempDir::new("store").unwrap();
+      let dir = TempDir::new().unwrap();
       let store = new_store(dir.path());
       let empty_dir = TestDirectory::empty();
       assert_eq!(
@@ -1732,7 +1732,7 @@ mod remote {
   #[cfg(test)]
   mod tests {
 
-    extern crate tempdir;
+    extern crate tempfile;
 
     use super::ByteStore;
     use super::super::EntryType;
@@ -2052,7 +2052,7 @@ mod tests {
   use std::path::{Path, PathBuf};
   use std::sync::Arc;
   use std::time::Duration;
-  use tempdir::TempDir;
+  use tempfile::TempDir;
   use testutil::data::{TestData, TestDirectory};
 
   pub fn big_file_fingerprint() -> Fingerprint {
@@ -2121,7 +2121,7 @@ mod tests {
 
   #[test]
   fn load_file_prefers_local() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let testdata = TestData::roland();
 
@@ -2140,7 +2140,7 @@ mod tests {
 
   #[test]
   fn load_directory_prefers_local() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let testdir = TestDirectory::containing_roland();
 
@@ -2161,7 +2161,7 @@ mod tests {
 
   #[test]
   fn load_file_falls_back_and_backfills() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let testdata = TestData::roland();
 
@@ -2181,7 +2181,7 @@ mod tests {
 
   #[test]
   fn load_directory_falls_back_and_backfills() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let cas = new_cas(1024);
 
@@ -2205,7 +2205,7 @@ mod tests {
 
   #[test]
   fn load_file_missing_is_none() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let cas = StubCAS::empty();
     assert_eq!(
@@ -2220,7 +2220,7 @@ mod tests {
 
   #[test]
   fn load_directory_missing_is_none() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let cas = StubCAS::empty();
     assert_eq!(
@@ -2234,7 +2234,7 @@ mod tests {
 
   #[test]
   fn load_file_remote_error_is_error() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let cas = StubCAS::always_errors();
     let error = load_file_bytes(
@@ -2250,7 +2250,7 @@ mod tests {
 
   #[test]
   fn load_directory_remote_error_is_error() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let cas = StubCAS::always_errors();
     let error = new_store(dir.path(), cas.address())
@@ -2266,7 +2266,7 @@ mod tests {
 
   #[test]
   fn malformed_remote_directory_is_error() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let testdata = TestData::roland();
 
@@ -2309,7 +2309,7 @@ mod tests {
       non_canonical_directory_bytes.len(),
     );
 
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let cas = StubCAS::with_unverified_content(
       1024,
@@ -2337,7 +2337,7 @@ mod tests {
 
   #[test]
   fn wrong_remote_file_bytes_is_error() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let testdata = TestData::roland();
 
@@ -2362,7 +2362,7 @@ mod tests {
 
   #[test]
   fn wrong_remote_directory_bytes_is_error() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let testdir = TestDirectory::containing_dnalor();
 
@@ -2387,7 +2387,7 @@ mod tests {
 
   #[test]
   fn expand_empty_directory() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let empty_dir = TestDirectory::empty();
 
@@ -2403,7 +2403,7 @@ mod tests {
 
   #[test]
   fn expand_flat_directory() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let roland = TestData::roland();
     let testdir = TestDirectory::containing_roland();
@@ -2427,7 +2427,7 @@ mod tests {
 
   #[test]
   fn expand_recursive_directory() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let roland = TestData::roland();
     let catnip = TestData::catnip();
@@ -2459,7 +2459,7 @@ mod tests {
 
   #[test]
   fn expand_missing_directory() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let digest = TestDirectory::containing_roland().digest();
     let error = new_local_store(dir.path())
       .expand_directory(digest)
@@ -2474,7 +2474,7 @@ mod tests {
 
   #[test]
   fn expand_directory_missing_subdir() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
 
     let recursive_testdir = TestDirectory::recursive();
 
@@ -2499,7 +2499,7 @@ mod tests {
 
   #[test]
   fn uploads_files() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = StubCAS::empty();
 
     let testdata = TestData::roland();
@@ -2524,7 +2524,7 @@ mod tests {
 
   #[test]
   fn uploads_directories_recursively() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = StubCAS::empty();
 
     let testdata = TestData::roland();
@@ -2559,7 +2559,7 @@ mod tests {
 
   #[test]
   fn uploads_files_recursively_when_under_three_digests_ignoring_items_already_in_cas() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = StubCAS::empty();
 
     let testdata = TestData::roland();
@@ -2600,7 +2600,7 @@ mod tests {
 
   #[test]
   fn does_not_reupload_file_already_in_cas_when_requested_with_three_other_digests() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = StubCAS::empty();
 
     let catnip = TestData::catnip();
@@ -2651,7 +2651,7 @@ mod tests {
 
   #[test]
   fn does_not_reupload_big_file_already_in_cas() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = StubCAS::empty();
 
     new_local_store(dir.path())
@@ -2684,7 +2684,7 @@ mod tests {
 
   #[test]
   fn upload_missing_files() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = StubCAS::empty();
 
     let testdata = TestData::roland();
@@ -2703,7 +2703,7 @@ mod tests {
 
   #[test]
   fn upload_missing_file_in_directory() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = StubCAS::empty();
 
     let testdir = TestDirectory::containing_roland();
@@ -2732,10 +2732,10 @@ mod tests {
 
   #[test]
   fn materialize_missing_file() {
-    let materialize_dir = TempDir::new("materialize").unwrap();
+    let materialize_dir = TempDir::new().unwrap();
     let file = materialize_dir.path().join("file");
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
     store
       .materialize_file(file.clone(), TestData::roland().digest(), false)
@@ -2745,12 +2745,12 @@ mod tests {
 
   #[test]
   fn materialize_file() {
-    let materialize_dir = TempDir::new("materialize").unwrap();
+    let materialize_dir = TempDir::new().unwrap();
     let file = materialize_dir.path().join("file");
 
     let testdata = TestData::roland();
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
     store
       .store_file_bytes(testdata.bytes(), false)
@@ -2766,12 +2766,12 @@ mod tests {
 
   #[test]
   fn materialize_file_executable() {
-    let materialize_dir = TempDir::new("materialize").unwrap();
+    let materialize_dir = TempDir::new().unwrap();
     let file = materialize_dir.path().join("file");
 
     let testdata = TestData::roland();
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
     store
       .store_file_bytes(testdata.bytes(), false)
@@ -2787,9 +2787,9 @@ mod tests {
 
   #[test]
   fn materialize_missing_directory() {
-    let materialize_dir = TempDir::new("materialize").unwrap();
+    let materialize_dir = TempDir::new().unwrap();
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
     store
       .materialize_directory(
@@ -2802,14 +2802,14 @@ mod tests {
 
   #[test]
   fn materialize_directory() {
-    let materialize_dir = TempDir::new("materialize").unwrap();
+    let materialize_dir = TempDir::new().unwrap();
 
     let roland = TestData::roland();
     let catnip = TestData::catnip();
     let testdir = TestDirectory::containing_roland();
     let recursive_testdir = TestDirectory::recursive();
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
     store
       .record_directory(&recursive_testdir.directory(), false)
@@ -2853,12 +2853,12 @@ mod tests {
 
   #[test]
   fn materialize_directory_executable() {
-    let materialize_dir = TempDir::new("materialize").unwrap();
+    let materialize_dir = TempDir::new().unwrap();
 
     let catnip = TestData::catnip();
     let testdir = TestDirectory::with_mixed_executable_files();
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
     store
       .record_directory(&testdir.directory(), false)
@@ -2889,7 +2889,7 @@ mod tests {
 
   #[test]
   fn works_after_reset_prefork() {
-    let dir = TempDir::new("store").unwrap();
+    let dir = TempDir::new().unwrap();
     let cas = new_cas(1024);
 
     let testdata = TestData::roland();
@@ -2920,7 +2920,7 @@ mod tests {
 
   #[test]
   fn contents_for_directory_empty() {
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
 
     let file_contents = store
@@ -2938,7 +2938,7 @@ mod tests {
     let testdir = TestDirectory::containing_roland();
     let recursive_testdir = TestDirectory::recursive();
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = new_local_store(store_dir.path());
     store
       .record_directory(&recursive_testdir.directory(), false)

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -17,11 +17,11 @@ log = "0.4"
 protobuf = { version = "1.4.1", features = ["with-bytes"] }
 resettable = { path = "../resettable" }
 sha2 = "0.6.0"
-tempdir = "0.3.5"
+tempfile = "3"
 futures-timer = "0.1"
 tokio-process = "0.2.1"
 
 [dev-dependencies]
 mock = { path = "../testutil/mock" }
-tempdir = "0.3.5"
+tempfile = "3"
 testutil = { path = "../testutil" }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -17,7 +17,7 @@ extern crate protobuf;
 extern crate resettable;
 extern crate sha2;
 #[cfg(test)]
-extern crate tempdir;
+extern crate tempfile;
 #[cfg(test)]
 extern crate testutil;
 extern crate tokio_process;

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -510,7 +510,7 @@ mod tests {
   use hashing::Digest;
   use protobuf::{self, Message, ProtobufEnum};
   use mock;
-  use tempdir::TempDir;
+  use tempfile::TempDir;
   use testutil::data::{TestData, TestDirectory};
   use testutil::{as_bytes, owned_string_vec};
 
@@ -665,7 +665,7 @@ mod tests {
       ))
     };
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store_dir_path = store_dir.path();
 
     let cas = mock::StubCAS::empty();
@@ -962,7 +962,7 @@ mod tests {
       ))
     };
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let cas = mock::StubCAS::with_content(1024, vec![], vec![TestDirectory::containing_roland()]);
     let store = fs::Store::with_remote(
       store_dir,
@@ -1016,7 +1016,7 @@ mod tests {
       ))
     };
 
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let cas = mock::StubCAS::with_content(1024, vec![], vec![TestDirectory::containing_roland()]);
     let store = fs::Store::with_remote(
       store_dir,
@@ -1382,7 +1382,7 @@ mod tests {
   }
 
   fn create_command_runner(address: String, cas: &mock::StubCAS) -> CommandRunner {
-    let store_dir = TempDir::new("store").unwrap();
+    let store_dir = TempDir::new().unwrap();
     let store = fs::Store::with_remote(
       store_dir,
       Arc::new(fs::ResettablePool::new("test-pool-".to_owned())),

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -30,7 +30,6 @@ extern crate log;
 extern crate petgraph;
 extern crate process_execution;
 extern crate resettable;
-extern crate tempdir;
 extern crate tokio;
 
 use std::ffi::CStr;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 extern crate bazel_protos;
-extern crate tempdir;
 
 use std::collections::BTreeMap;
 use std::error::Error;


### PR DESCRIPTION
tempdir is deprecated, and got merged into tempfile, which has now had
stable releases.