### PR TITLE
add @classproperty

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -17,6 +17,7 @@ from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
 from pants.util.memo import memoized_method
+from pants.util.meta import classproperty
 from pants.util.objects import datatype
 
 
@@ -37,9 +38,7 @@ class GlobMatchErrorBehavior(datatype(['failure_behavior'])):
 
   default_option_value = WARN
 
-  # FIXME(cosmicexplorer): add helpers in pants.util.memo for class properties and memoized class
-  # properties!
-  @classmethod
+  @classproperty
   @memoized_method
   def _singletons(cls):
     return { behavior: cls(behavior) for behavior in cls.allowed_values }
@@ -50,7 +49,7 @@ class GlobMatchErrorBehavior(datatype(['failure_behavior'])):
       return value
     if not value:
       value = cls.default_value
-    return cls._singletons()[value]
+    return cls._singletons[value]
 
   def __new__(cls, *args, **kwargs):
     this_object = super(GlobMatchErrorBehavior, cls).__new__(cls, *args, **kwargs)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -16,8 +16,7 @@ from pants.option.custom_types import dir_option
 from pants.option.optionable import Optionable
 from pants.option.scope import ScopeInfo
 from pants.subsystem.subsystem_client_mixin import SubsystemClientMixin
-from pants.util.memo import memoized_method
-from pants.util.meta import classproperty
+from pants.util.memo import memoized_classproperty
 from pants.util.objects import datatype
 
 
@@ -38,8 +37,7 @@ class GlobMatchErrorBehavior(datatype(['failure_behavior'])):
 
   default_option_value = WARN
 
-  @classproperty
-  @memoized_method
+  @memoized_classproperty
   def _singletons(cls):
     return { behavior: cls(behavior) for behavior in cls.allowed_values }
 

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -144,6 +144,9 @@ def memoized_method(func=None, key_factory=per_instance, **kwargs):
   ...   def name(self):
   ...     pass
 
+  NB: this decorator can be used below an `@classproperty` or `@classmethod` decorator to memoize a
+  class-level property or method.
+
   :API: public
 
   :param func: The function to wrap.  Only generally passed by the python runtime and should be

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -146,9 +146,6 @@ def memoized_method(func=None, key_factory=per_instance, **kwargs):
   ...   def name(self):
   ...     pass
 
-  NB: this decorator can be used below an `@classproperty` or `@classmethod` decorator to memoize a
-  class-level property or method.
-
   :API: public
 
   :param func: The function to wrap.  Only generally passed by the python runtime and should be

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -9,7 +9,7 @@ import functools
 import inspect
 from contextlib import contextmanager
 
-from pants.util.meta import classproperty
+from pants.util.meta import classproperty, staticproperty
 
 
 # Used as a sentinel that disambiguates tuples passed in *args from coincidentally matching tuples
@@ -228,22 +228,20 @@ def memoized_property(func=None, key_factory=per_instance, **kwargs):
   return property(fget=getter, fdel=lambda self: getter.forget(self))
 
 
-def memoized_classmethod(func=None, **kwargs):
-  getter = memoized_method(func=func, **kwargs)
-  return classmethod(getter)
+def memoized_classmethod(*args, **kwargs):
+  return classmethod(memoized_method(*args, **kwargs))
 
 
-def memoized_classproperty(func=None, **kwargs):
-  return classproperty(memoized_classmethod(func=func, **kwargs))
+def memoized_classproperty(*args, **kwargs):
+  return classproperty(memoized_classmethod(*args, **kwargs))
 
 
-def memoized_staticmethod(func=None, **kwargs):
-  getter = memoized(func=func, **kwargs)
-  return staticmethod(getter)
+def memoized_staticmethod(*args, **kwargs):
+  return staticmethod(memoized(*args, **kwargs))
 
 
-def memoized_staticproperty(func=None, **kwargs):
-  return classproperty(memoized_staticmethod(func=func, **kwargs))
+def memoized_staticproperty(*args, **kwargs):
+  return staticproperty(memoized_staticmethod(*args, **kwargs))
 
 
 def testable_memoized_property(func=None, key_factory=per_instance, **kwargs):

--- a/src/python/pants/util/memo.py
+++ b/src/python/pants/util/memo.py
@@ -9,6 +9,8 @@ import functools
 import inspect
 from contextlib import contextmanager
 
+from pants.util.meta import classproperty
+
 
 # Used as a sentinel that disambiguates tuples passed in *args from coincidentally matching tuples
 # formed from kwargs item pairs.
@@ -224,6 +226,24 @@ def memoized_property(func=None, key_factory=per_instance, **kwargs):
   """
   getter = memoized_method(func=func, key_factory=key_factory, **kwargs)
   return property(fget=getter, fdel=lambda self: getter.forget(self))
+
+
+def memoized_classmethod(func=None, **kwargs):
+  getter = memoized_method(func=func, **kwargs)
+  return classmethod(getter)
+
+
+def memoized_classproperty(func=None, **kwargs):
+  return classproperty(memoized_classmethod(func=func, **kwargs))
+
+
+def memoized_staticmethod(func=None, **kwargs):
+  getter = memoized(func=func, **kwargs)
+  return staticmethod(getter)
+
+
+def memoized_staticproperty(func=None, **kwargs):
+  return classproperty(memoized_staticmethod(func=func, **kwargs))
 
 
 def testable_memoized_property(func=None, key_factory=per_instance, **kwargs):

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -18,11 +18,11 @@ class SingletonMetaclass(type):
 
 
 class ClassPropertyDescriptor(object):
-  """Define a readable class property, given a function.
+  """Define a readable class property, given a function."""
 
-  See https://docs.python.org/2/howto/descriptor.html for more details.
-  """
-
+  # NB: it seems overriding __set__ and __delete__ require defining a metaclass or overriding
+  # __setattr__/__delattr__ (see
+  # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property).
   def __init__(self, fget, doc=None):
     self.fget = fget
 
@@ -31,6 +31,7 @@ class ClassPropertyDescriptor(object):
     else:
       self.__doc__ = doc
 
+  # See https://docs.python.org/2/howto/descriptor.html for more details.
   def __get__(self, obj, objtype=None):
     if objtype is None:
       objtype = type(obj)
@@ -38,7 +39,10 @@ class ClassPropertyDescriptor(object):
 
 
 def classproperty(func):
-  """Use as a decorator on a method definition to access it as a property of the class."""
+  """Use as a decorator on a method definition to access it as a property of the class.
+
+  NB: setting or deleting the attribute of this name will overwrite this property!
+  """
   if not isinstance(func, (classmethod, staticmethod)):
     func = classmethod(func)
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -42,10 +42,17 @@ def classproperty(func):
 
   This decorator can be applied to a method, a classmethod, or a staticmethod.
 
-  The docstring of the classproperty `x` for a class `C` can be obtained by
-  `C.__dict__['x'].__doc__`.
+  Caveats:
+  - If this property is accessed on an instance of the class, it will run with the instance as the
+    first argument, NOT the class. If an instance field `_x` shadows a class-level field `_x`, and
+    the classproperty uses the `_x` field to compute its value, the instance field will be used
+    instead when calculating the property's result, which may be surprising. This does not affect
+    the behavior when applied to a staticmethod. See the test cases for this file for an example.
 
-  NB: setting or deleting the attribute of this name will overwrite this property!
+  - Setting or deleting the attribute of this name will overwrite this property.
+
+  - The docstring of the classproperty `x` for a class `C` can be obtained by
+    `C.__dict__['x'].__doc__`.
   """
   doc = func.__doc__
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -17,6 +17,34 @@ class SingletonMetaclass(type):
     return cls.instance
 
 
+class ClassPropertyDescriptor(object):
+  """Define a readable class property, given a function.
+
+  See https://docs.python.org/2/howto/descriptor.html for more details.
+  """
+
+  def __init__(self, fget, doc=None):
+    self.fget = fget
+
+    if doc is None:
+      self.__doc__ = fget.__doc__
+    else:
+      self.__doc__ = doc
+
+  def __get__(self, obj, objtype=None):
+    if objtype is None:
+      objtype = type(obj)
+    return self.fget.__get__(obj, objtype)()
+
+
+def classproperty(func):
+  """Use as a decorator on a method definition to access it as a property of the class."""
+  if not isinstance(func, (classmethod, staticmethod)):
+    func = classmethod(func)
+
+  return ClassPropertyDescriptor(func)
+
+
 # Extend Singleton and your class becomes a singleton, each construction returns the same instance.
 Singleton = SingletonMetaclass(str('Singleton'), (object,), {})
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -62,6 +62,16 @@ def classproperty(func):
   return ClassPropertyDescriptor(func, doc)
 
 
+def staticproperty(func):
+  """???"""
+  doc = func.__doc__
+
+  if not isinstance(func, staticmethod):
+    func = staticmethod(func)
+
+  return ClassPropertyDescriptor(func, doc)
+
+
 # Extend Singleton and your class becomes a singleton, each construction returns the same instance.
 Singleton = SingletonMetaclass(str('Singleton'), (object,), {})
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -38,9 +38,19 @@ class ClassPropertyDescriptor(object):
 
 
 def classproperty(func):
-  """Use as a decorator on a method definition to access it as a property of the class.
+  """Use as a decorator on a method definition to make it a class-level attribute.
 
-  This decorator can be applied to a method, a classmethod, or a staticmethod.
+  This decorator can be applied to a method, a classmethod, or a staticmethod. This decorator will
+  bind the first argument to the class object.
+
+  Usage:
+  >>> class Foo(object):
+  ...   @classproperty
+  ...   def name(cls):
+  ...     return cls.__name__
+  ...
+  >>> Foo.name
+  'Foo'
 
   Caveats:
   - If this property is accessed on an instance of the class, it will run with the instance as the
@@ -63,7 +73,23 @@ def classproperty(func):
 
 
 def staticproperty(func):
-  """???"""
+  """Use as a decorator on a method definition to make it a class-level attribute (without binding).
+
+  This decorator can be applied to a method or a staticmethod. This decorator does not bind any
+  arguments.
+
+  Usage:
+  >>> other_x = 'value'
+  >>> class Foo(object):
+  ...   @staticproperty
+  ...   def x():
+  ...     return other_x
+  ...
+  >>> Foo.x
+  'value'
+
+  See the docstring for :class:`classproperty` for further caveats on usage.
+  """
   doc = func.__doc__
 
   if not isinstance(func, staticmethod):

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -20,16 +20,13 @@ class SingletonMetaclass(type):
 class ClassPropertyDescriptor(object):
   """Define a readable class property, given a function."""
 
-  # NB: it seems overriding __set__ and __delete__ require defining a metaclass or overriding
+  # NB: it seems overriding __set__ and __delete__ would require defining a metaclass or overriding
   # __setattr__/__delattr__ (see
-  # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property).
-  def __init__(self, fget, doc=None):
+  # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property). The current solution
+  # doesn't require any modifications to the class definition beyond declaring a @classproperty.
+  def __init__(self, fget, doc):
     self.fget = fget
-
-    if doc is None:
-      self.__doc__ = fget.__doc__
-    else:
-      self.__doc__ = doc
+    self.__doc__ = doc
 
   # See https://docs.python.org/2/howto/descriptor.html for more details.
   def __get__(self, obj, objtype=None):
@@ -41,12 +38,19 @@ class ClassPropertyDescriptor(object):
 def classproperty(func):
   """Use as a decorator on a method definition to access it as a property of the class.
 
+  This decorator can be applied to a method, a classmethod, or a staticmethod.
+
+  The docstring of the classproperty `x` for a class `C` can be obtained by
+  `C.__dict__['x'].__doc__`.
+
   NB: setting or deleting the attribute of this name will overwrite this property!
   """
+  doc = func.__doc__
+
   if not isinstance(func, (classmethod, staticmethod)):
     func = classmethod(func)
 
-  return ClassPropertyDescriptor(func)
+  return ClassPropertyDescriptor(func, doc)
 
 
 # Extend Singleton and your class becomes a singleton, each construction returns the same instance.

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -52,17 +52,10 @@ def classproperty(func):
   >>> Foo.name
   'Foo'
 
-  Caveats:
-  - If this property is accessed on an instance of the class, it will run with the instance as the
-    first argument, NOT the class. If an instance field `_x` shadows a class-level field `_x`, and
-    the classproperty uses the `_x` field to compute its value, the instance field will be used
-    instead when calculating the property's result, which may be surprising. This does not affect
-    the behavior when applied to a staticmethod. See the test cases for this file for an example.
+  Setting or deleting the attribute of this name will overwrite this property.
 
-  - Setting or deleting the attribute of this name will overwrite this property.
-
-  - The docstring of the classproperty `x` for a class `C` can be obtained by
-    `C.__dict__['x'].__doc__`.
+  The docstring of the classproperty `x` for a class `C` can be obtained by
+  `C.__dict__['x'].__doc__`.
   """
   doc = func.__doc__
 
@@ -88,7 +81,10 @@ def staticproperty(func):
   >>> Foo.x
   'value'
 
-  See the docstring for :class:`classproperty` for further caveats on usage.
+  Setting or deleting the attribute of this name will overwrite this property.
+
+  The docstring of the classproperty `x` for a class `C` can be obtained by
+  `C.__dict__['x'].__doc__`.
   """
   doc = func.__doc__
 

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -20,10 +20,12 @@ class SingletonMetaclass(type):
 class ClassPropertyDescriptor(object):
   """Define a readable class property, given a function."""
 
-  # NB: it seems overriding __set__ and __delete__ would require defining a metaclass or overriding
-  # __setattr__/__delattr__ (see
+  # TODO: it seems overriding __set__ and __delete__ would require defining a metaclass or
+  # overriding __setattr__/__delattr__ (see
   # https://stackoverflow.com/questions/5189699/how-to-make-a-class-property). The current solution
-  # doesn't require any modifications to the class definition beyond declaring a @classproperty.
+  # doesn't require any modifications to the class definition beyond declaring a @classproperty.  If
+  # we can set __delete__ and have it work, we can use that e.g. to clear the cache for a new
+  # `@memoized_classproperty` decorator.
   def __init__(self, fget, doc):
     self.fget = fget
     self.__doc__ = doc

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -81,6 +81,7 @@ python_tests(
   name = 'meta',
   sources = ['test_meta.py'],
   dependencies = [
+    'tests/python/pants_test:test_base',
     'src/python/pants/util:meta',
   ]
 )

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -74,6 +74,7 @@ python_tests(
   sources = ['test_memo.py'],
   dependencies = [
     'src/python/pants/util:memo',
+    'src/python/pants/util:meta',
   ]
 )
 

--- a/tests/python/pants_test/util/BUILD
+++ b/tests/python/pants_test/util/BUILD
@@ -82,8 +82,8 @@ python_tests(
   name = 'meta',
   sources = ['test_meta.py'],
   dependencies = [
-    'tests/python/pants_test:test_base',
     'src/python/pants/util:meta',
+    'tests/python/pants_test:test_base',
   ]
 )
 

--- a/tests/python/pants_test/util/test_memo.py
+++ b/tests/python/pants_test/util/test_memo.py
@@ -7,7 +7,8 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 
 import unittest
 
-from pants.util.memo import memoized, memoized_method, memoized_property, per_instance, testable_memoized_property
+from pants.util.memo import (memoized, memoized_method, memoized_property, per_instance,
+                             testable_memoized_property)
 from pants.util.meta import classproperty
 
 

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -47,9 +47,25 @@ class WithProp(object):
     "some docs"
     return cls._value
 
+  @classmethod
+  def some_method(cls):
+    return cls._value
+
+  @classproperty
+  @staticmethod
+  def static_property():
+    return "static"
+
 
 class OverridingValueField(WithProp):
   _value = 4
+
+
+class OverridingValueInit(WithProp):
+
+  def __init__(self, v):
+    # This will override the class's _value when calculating the @classmethod and @classproperty.
+    self._value = v
 
 
 class OverridingMethodDefSuper(WithProp):
@@ -69,12 +85,22 @@ class ClassPropertyTest(TestBase):
     self.assertEqual(3, WithProp.some_property)
     self.assertEqual(3, WithProp().some_property)
 
+    self.assertEqual(3, WithProp.some_method())
+    self.assertEqual(3, WithProp().some_method())
+
+    self.assertEqual("static", WithProp.static_property)
+    self.assertEqual("static", WithProp().static_property)
+
   def test_docstring(self):
     self.assertEqual("some docs", WithProp.__dict__['some_property'].__doc__)
 
   def test_override_value(self):
     self.assertEqual(4, OverridingValueField.some_property)
     self.assertEqual(4, OverridingValueField().some_property)
+
+  def test_override_inst_value(self):
+    self.assertEqual(3, OverridingValueInit(3).some_property)
+    self.assertEqual(3, OverridingValueInit(3).some_method())
 
   def test_override_method_super(self):
     self.assertEqual(5, OverridingMethodDefSuper.some_property)

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -44,7 +44,8 @@ class WithProp(object):
   _value = 3
 
   @classproperty
-  def f(cls):
+  def some_property(cls):
+    "some docs"
     return cls._value
 
 
@@ -57,40 +58,56 @@ class OverridingMethodDefSuper(WithProp):
   _other_value = 2
 
   @classproperty
-  def f(cls):
-    return super(OverridingMethodDefSuper, cls).f + cls._other_value
+  def some_property(cls):
+    return super(OverridingMethodDefSuper, cls).some_property + cls._other_value
 
 
 class ClassPropertyTest(TestBase):
   def test_access(self):
-    self.assertEqual(3, WithProp.f)
-    self.assertEqual(3, WithProp().f)
+    self.assertEqual(3, WithProp.some_property)
+    self.assertEqual(3, WithProp().some_property)
+
+  def test_docstring(self):
+    self.assertEqual("some docs", WithProp.__dict__['some_property'].__doc__)
 
   def test_override_value(self):
-    self.assertEqual(4, OverridingValueField.f)
-    self.assertEqual(4, OverridingValueField().f)
+    self.assertEqual(4, OverridingValueField.some_property)
+    self.assertEqual(4, OverridingValueField().some_property)
 
   def test_override_method_super(self):
-    self.assertEqual(5, OverridingMethodDefSuper.f)
-    self.assertEqual(5, OverridingMethodDefSuper().f)
+    self.assertEqual(5, OverridingMethodDefSuper.some_property)
+    self.assertEqual(5, OverridingMethodDefSuper().some_property)
+
+  def test_modify_class_value(self):
+    class WithFieldToModify(object):
+      _z = 44
+
+      @classproperty
+      def f(cls):
+        return cls._z
+
+    self.assertEqual(44, WithFieldToModify.f)
+
+    WithFieldToModify._z = 72
+    self.assertEqual(72, WithFieldToModify.f)
 
   def test_has_attr(self):
-    self.assertTrue(hasattr(WithProp, 'f'))
-    self.assertTrue(hasattr(WithProp(), 'f'))
+    self.assertTrue(hasattr(WithProp, 'some_property'))
+    self.assertTrue(hasattr(WithProp(), 'some_property'))
 
   def test_set_attr(self):
     class SetValue(object):
       _x = 3
 
       @classproperty
-      def x(cls):
+      def x_property(cls):
         return cls._x
 
-    self.assertEqual(3, SetValue.x)
+    self.assertEqual(3, SetValue.x_property)
 
     # The @classproperty is gone, this is just a regular property now.
-    SetValue.x = 4
-    self.assertEqual(4, SetValue.x)
+    SetValue.x_property = 4
+    self.assertEqual(4, SetValue.x_property)
     # The source field is unmodified.
     self.assertEqual(3, SetValue._x)
 
@@ -99,12 +116,12 @@ class ClassPropertyTest(TestBase):
       _y = 45
 
       @classproperty
-      def y(cls):
+      def y_property(cls):
         return cls._y
 
-    self.assertEqual(45, DeleteValue.y)
+    self.assertEqual(45, DeleteValue.y_property)
 
     # The @classproperty is gone, but the source field is still alive.
-    del DeleteValue.y
-    self.assertFalse(hasattr(DeleteValue, 'y'))
+    del DeleteValue.y_property
+    self.assertFalse(hasattr(DeleteValue, 'y_property'))
     self.assertTrue(hasattr(DeleteValue, '_y'))

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -8,10 +8,11 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
 import unittest
 from abc import abstractmethod, abstractproperty
 
-from pants.util.meta import AbstractClass, Singleton
+from pants.util.meta import AbstractClass, Singleton, classproperty
+from pants_test.test_base import TestBase
 
 
-class AbstractClassTest(unittest.TestCase):
+class AbstractClassTest(TestBase):
   def test_abstract_property(self):
     class AbstractProperty(AbstractClass):
       @abstractproperty
@@ -31,9 +32,79 @@ class AbstractClassTest(unittest.TestCase):
       AbstractMethod()
 
 
-class SingletonTest(unittest.TestCase):
+class SingletonTest(TestBase):
   def test_singleton(self):
     class One(Singleton):
       pass
 
     self.assertIs(One(), One())
+
+
+class WithProp(object):
+  _value = 3
+
+  @classproperty
+  def f(cls):
+    return cls._value
+
+
+class OverridingValueField(WithProp):
+  _value = 4
+
+
+class OverridingMethodDefSuper(WithProp):
+
+  _other_value = 2
+
+  @classproperty
+  def f(cls):
+    return super(OverridingMethodDefSuper, cls).f + cls._other_value
+
+
+class ClassPropertyTest(TestBase):
+  def test_access(self):
+    self.assertEqual(3, WithProp.f)
+    self.assertEqual(3, WithProp().f)
+
+  def test_override_value(self):
+    self.assertEqual(4, OverridingValueField.f)
+    self.assertEqual(4, OverridingValueField().f)
+
+  def test_override_method_super(self):
+    self.assertEqual(5, OverridingMethodDefSuper.f)
+    self.assertEqual(5, OverridingMethodDefSuper().f)
+
+  def test_has_attr(self):
+    self.assertTrue(hasattr(WithProp, 'f'))
+    self.assertTrue(hasattr(WithProp(), 'f'))
+
+  def test_set_attr(self):
+    class SetValue(object):
+      _x = 3
+
+      @classproperty
+      def x(cls):
+        return cls._x
+
+    self.assertEqual(3, SetValue.x)
+
+    # The @classproperty is gone, this is just a regular property now.
+    SetValue.x = 4
+    self.assertEqual(4, SetValue.x)
+    # The source field is unmodified.
+    self.assertEqual(3, SetValue._x)
+
+  def test_delete_attr(self):
+    class DeleteValue(object):
+      _y = 45
+
+      @classproperty
+      def y(cls):
+        return cls._y
+
+    self.assertEqual(45, DeleteValue.y)
+
+    # The @classproperty is gone, but the source field is still alive.
+    del DeleteValue.y
+    self.assertFalse(hasattr(DeleteValue, 'y'))
+    self.assertTrue(hasattr(DeleteValue, '_y'))

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -63,6 +63,9 @@ class OverridingMethodDefSuper(WithProp):
 
 
 class ClassPropertyTest(TestBase):
+  # TODO: The assertions on both the class and an instance of it might not be necessary, if class
+  # attributes are assumed to always be the same on their instances.
+
   def test_access(self):
     self.assertEqual(3, WithProp.some_property)
     self.assertEqual(3, WithProp().some_property)
@@ -88,6 +91,8 @@ class ClassPropertyTest(TestBase):
 
     self.assertEqual(44, WithFieldToModify.f)
 
+    # The classproperty reflects the change in state (is not cached by python or something else
+    # weird we might do).
     WithFieldToModify._z = 72
     self.assertEqual(72, WithFieldToModify.f)
 

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, generators, nested_scopes, print_function,
                         unicode_literals, with_statement)
 
-import unittest
 from abc import abstractmethod, abstractproperty
 
 from pants.util.meta import AbstractClass, Singleton, classproperty

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -43,12 +43,12 @@ class WithProp(object):
   _value = 'val0'
 
   @classproperty
-  def some_property(cls):
+  def class_property(cls):
     "some docs"
     return cls._value
 
   @classmethod
-  def some_method(cls):
+  def class_method(cls):
     return cls._value
 
   @staticproperty
@@ -77,18 +77,18 @@ class OverridingMethodDefSuper(WithProp):
   _other_value = 'o0'
 
   @classproperty
-  def some_property(cls):
-    return super(OverridingMethodDefSuper, cls).some_property + cls._other_value
+  def class_property(cls):
+    return super(OverridingMethodDefSuper, cls).class_property + cls._other_value
 
 
 class ClassPropertyTest(TestBase):
 
   def test_access(self):
-    self.assertEqual('val0', WithProp.some_property)
-    self.assertEqual('val0', WithProp().some_property)
+    self.assertEqual('val0', WithProp.class_property)
+    self.assertEqual('val0', WithProp().class_property)
 
-    self.assertEqual('val0', WithProp.some_method())
-    self.assertEqual('val0', WithProp().some_method())
+    self.assertEqual('val0', WithProp.class_method())
+    self.assertEqual('val0', WithProp().class_method())
 
     self.assertEqual('static_property', WithProp.static_property)
     self.assertEqual('static_property', WithProp().static_property)
@@ -97,23 +97,23 @@ class ClassPropertyTest(TestBase):
     self.assertEqual('static_method', WithProp().static_method())
 
   def test_has_attr(self):
-    self.assertTrue(hasattr(WithProp, 'some_property'))
-    self.assertTrue(hasattr(WithProp(), 'some_property'))
+    self.assertTrue(hasattr(WithProp, 'class_property'))
+    self.assertTrue(hasattr(WithProp(), 'class_property'))
 
   def test_docstring(self):
-    self.assertEqual("some docs", WithProp.__dict__['some_property'].__doc__)
+    self.assertEqual("some docs", WithProp.__dict__['class_property'].__doc__)
 
   def test_override_value(self):
-    self.assertEqual('val1', OverridingValueField.some_property)
-    self.assertEqual('val1', OverridingValueField().some_property)
+    self.assertEqual('val1', OverridingValueField.class_property)
+    self.assertEqual('val1', OverridingValueField().class_property)
 
   def test_override_inst_value(self):
-    self.assertEqual('v1', OverridingValueInit('v1').some_property)
-    self.assertEqual('v1', OverridingValueInit('v1').some_method())
+    self.assertEqual('val0', OverridingValueInit('v1').class_property)
+    self.assertEqual('val0', OverridingValueInit('v1').class_method())
 
   def test_override_method_super(self):
-    self.assertEqual('val0o0', OverridingMethodDefSuper.some_property)
-    self.assertEqual('val0o0', OverridingMethodDefSuper().some_property)
+    self.assertEqual('val0o0', OverridingMethodDefSuper.class_property)
+    self.assertEqual('val0o0', OverridingMethodDefSuper().class_property)
 
   def test_modify_class_value(self):
     class WithFieldToModify(object):
@@ -163,7 +163,7 @@ class ClassPropertyTest(TestBase):
         return cls._y
 
       @staticproperty
-      def staticproperty():
+      def static_property():
         return 's0'
 
     self.assertEqual('y0', DeleteValue.class_property)

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -44,7 +44,7 @@ class WithProp(object):
 
   @classproperty
   def class_property(cls):
-    "some docs"
+    "class_property docs"
     return cls._value
 
   @classmethod
@@ -53,6 +53,7 @@ class WithProp(object):
 
   @staticproperty
   def static_property():
+    "static_property docs"
     return 'static_property'
 
   @staticmethod
@@ -101,7 +102,8 @@ class ClassPropertyTest(TestBase):
     self.assertTrue(hasattr(WithProp(), 'class_property'))
 
   def test_docstring(self):
-    self.assertEqual("some docs", WithProp.__dict__['class_property'].__doc__)
+    self.assertEqual("class_property docs", WithProp.__dict__['class_property'].__doc__)
+    self.assertEqual("static_property docs", WithProp.__dict__['static_property'].__doc__)
 
   def test_override_value(self):
     self.assertEqual('val1', OverridingValueField.class_property)

--- a/tests/python/pants_test/util/test_meta.py
+++ b/tests/python/pants_test/util/test_meta.py
@@ -64,7 +64,8 @@ class OverridingValueField(WithProp):
 class OverridingValueInit(WithProp):
 
   def __init__(self, v):
-    # This will override the class's _value when calculating the @classmethod and @classproperty.
+    # This will override the class's _value when evaluating the @classmethod and @classproperty as
+    # an instance method/property.
     self._value = v
 
 
@@ -78,8 +79,6 @@ class OverridingMethodDefSuper(WithProp):
 
 
 class ClassPropertyTest(TestBase):
-  # TODO: The assertions on both the class and an instance of it might not be necessary, if class
-  # attributes are assumed to always be the same on their instances.
 
   def test_access(self):
     self.assertEqual(3, WithProp.some_property)


### PR DESCRIPTION
### Problem

There's no way to declare a method to be accessible as a property of the class, instead of every instance.

### Solution

- add `@classproperty` and `@staticproperty` decorators to `meta.py`
- add the memoized forms of the above to `memo.py`, as well as their method forms: `memoized_classproperty`, `memoized_staticproperty`, `memoized_staticmethod`, `memoized_classmethod`
- add testing for all of the above
- consume `@memoized_classproperty` in the definition of `GlobMatchErrorBehavior`