### PR TITLE
Split short-form from long-form of setup_legacy_graph

### DIFF
--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -89,7 +89,8 @@ class GoalRunnerFactory(object):
       native = Native.create(self._global_options)
       native.set_panic_handler()
       graph_scheduler_helper = EngineInitializer.setup_legacy_graph(native,
-                                                                    self._global_options)
+                                                                    self._global_options,
+                                                                    self._build_config)
       graph_helper = graph_scheduler_helper.new_session()
 
     target_roots = target_roots or TargetRootsCalculator.create(

--- a/src/python/pants/bin/goal_runner.py
+++ b/src/python/pants/bin/goal_runner.py
@@ -23,7 +23,6 @@ from pants.init.engine_initializer import EngineInitializer
 from pants.init.subprocess import Subprocess
 from pants.init.target_roots_calculator import TargetRootsCalculator
 from pants.java.nailgun_executor import NailgunProcessGroup
-from pants.option.global_options import GlobMatchErrorBehavior
 from pants.option.ranked_value import RankedValue
 from pants.reporting.reporting import Reporting
 from pants.scm.subsystems.changed import Changed
@@ -77,23 +76,9 @@ class GoalRunnerFactory(object):
       result = help_printer.print_help()
       self._exiter(result)
 
-  def _init_graph(self,
-                  pants_ignore_patterns,
-                  build_ignore_patterns,
-                  exclude_target_regexps,
-                  target_specs,
-                  target_roots,
-                  workdir,
-                  graph_helper,
-                  subproject_build_roots):
+  def _init_graph(self, target_roots, graph_helper):
     """Determine the BuildGraph, AddressMapper and spec_roots for a given run.
 
-    :param list pants_ignore_patterns: The pants ignore patterns from '--pants-ignore'.
-    :param list build_ignore_patterns: The build ignore patterns from '--build-ignore',
-                                       applied during BUILD file searching.
-    :param str workdir: The pants workdir.
-    :param list exclude_target_regexps: Regular expressions for targets to be excluded.
-    :param list target_specs: The original target specs.
     :param TargetRoots target_roots: The existing `TargetRoots` object, if any.
     :param LegacyGraphSession graph_helper: A LegacyGraphSession to use for graph construction,
                                             if available. This would usually come from the daemon.
@@ -103,22 +88,9 @@ class GoalRunnerFactory(object):
     if not graph_helper:
       native = Native.create(self._global_options)
       native.set_panic_handler()
-      graph_helper = EngineInitializer.setup_legacy_graph(
-        pants_ignore_patterns,
-        workdir,
-        self._global_options.build_file_imports,
-        glob_match_error_behavior=GlobMatchErrorBehavior.create(
-          self._global_options.glob_expansion_failure),
-        native=native,
-        build_file_aliases=self._build_config.registered_aliases(),
-        rules=self._build_config.rules(),
-        build_ignore_patterns=build_ignore_patterns,
-        exclude_target_regexps=exclude_target_regexps,
-        subproject_roots=subproject_build_roots,
-        include_trace_on_error=self._options.for_global_scope().print_exception_stacktrace,
-        remote_store_server=self._options.for_global_scope().remote_store_server,
-        remote_execution_server=self._options.for_global_scope().remote_execution_server,
-      ).new_session()
+      graph_scheduler_helper = EngineInitializer.setup_legacy_graph(native,
+                                                                    self._global_options)
+      graph_helper = graph_scheduler_helper.new_session()
 
     target_roots = target_roots or TargetRootsCalculator.create(
       options=self._options,
@@ -169,14 +141,8 @@ class GoalRunnerFactory(object):
   def _setup_context(self):
     with self._run_tracker.new_workunit(name='setup', labels=[WorkUnitLabel.SETUP]):
       self._build_graph, self._address_mapper, scheduler, target_roots = self._init_graph(
-        self._global_options.pants_ignore,
-        self._global_options.build_ignore,
-        self._global_options.exclude_target_regexp,
-        self._options.target_specs,
         self._target_roots,
-        self._global_options.pants_workdir,
         self._daemon_graph_helper,
-        self._global_options.subproject_roots
       )
 
       goals = self._determine_goals(self._requested_goals)

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -127,20 +127,36 @@ class EngineInitializer(object):
     return build_config.registered_aliases()
 
   @staticmethod
-  def setup_legacy_graph(pants_ignore_patterns,
-                         workdir,
-                         build_file_imports_behavior,
-                         build_root=None,
-                         native=None,
-                         build_file_aliases=None,
-                         glob_match_error_behavior=None,
-                         rules=None,
-                         build_ignore_patterns=None,
-                         exclude_target_regexps=None,
-                         subproject_roots=None,
-                         include_trace_on_error=True,
-                         remote_store_server=None,
-                         remote_execution_server=None,
+  def setup_legacy_graph(native, bootstrap_options):
+    """Construct and return the components necessary for LegacyBuildGraph construction."""
+    return EngineInitializer.setup_legacy_graph_extended(
+      bootstrap_options.pants_ignore,
+      bootstrap_options.pants_workdir,
+      bootstrap_options.build_file_imports,
+      native=native,
+      build_ignore_patterns=bootstrap_options.build_ignore,
+      exclude_target_regexps=bootstrap_options.exclude_target_regexp,
+      subproject_roots=bootstrap_options.subproject_roots,
+      remote_store_server=bootstrap_options.remote_store_server,
+      remote_execution_server=bootstrap_options.remote_execution_server,
+    )
+
+  @staticmethod
+  def setup_legacy_graph_extended(
+    pants_ignore_patterns,
+    workdir,
+    build_file_imports_behavior,
+    build_root=None,
+    native=None,
+    build_file_aliases=None,
+    glob_match_error_behavior=None,
+    rules=None,
+    build_ignore_patterns=None,
+    exclude_target_regexps=None,
+    subproject_roots=None,
+    include_trace_on_error=True,
+    remote_store_server=None,
+    remote_execution_server=None
   ):
     """Construct and return the components necessary for LegacyBuildGraph construction.
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -163,6 +163,7 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Read additional specs from this file, one per line')
     register('--verify-config', type=bool, default=True, daemon=False,
              help='Verify that all config file values correspond to known options.')
+
     register('--build-ignore', advanced=True, type=list, fromfile=True,
              default=['.*/', default_rel_distdir, 'bower_components/',
                       'node_modules/', '*.egg-info/'],
@@ -174,6 +175,12 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
              help='Paths to ignore for all filesystem operations performed by pants '
                   '(e.g. BUILD file scanning, glob matching, etc). '
                   'Patterns use the gitignore syntax (https://git-scm.com/docs/gitignore).')
+    register('--glob-expansion-failure', type=str,
+             choices=GlobMatchErrorBehavior.allowed_values,
+             default=GlobMatchErrorBehavior.default_option_value,
+             help="Raise an exception if any targets declaring source files "
+                  "fail to match any glob provided in the 'sources' argument.")
+
     register('--exclude-target-regexp', advanced=True, type=list, default=[], daemon=False,
              metavar='<regexp>', help='Exclude target roots that match these regexes.')
     register('--subproject-roots', type=list, advanced=True, fromfile=True, default=[],
@@ -195,6 +202,8 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--native-engine-visualize-to', advanced=True, default=None, type=dir_option, daemon=False,
              help='A directory to write execution and rule graphs to as `dot` files. The contents '
                   'of the directory will be overwritten if any filenames collide.')
+    register('--print-exception-stacktrace', advanced=True, type=bool,
+             help='Print to console the full exception stack trace if encountered.')
 
     # BinaryUtil options.
     register('--binaries-baseurls', type=list, advanced=True,
@@ -283,16 +292,6 @@ class GlobalOptionsRegistrar(SubsystemClientMixin, Optionable):
     register('--max-subprocess-args', advanced=True, type=int, default=100, recursive=True,
              help='Used to limit the number of arguments passed to some subprocesses by breaking '
              'the command up into multiple invocations.')
-    register('--print-exception-stacktrace', advanced=True, type=bool,
-             help='Print to console the full exception stack trace if encountered.')
     register('--lock', advanced=True, type=bool, default=True,
              help='Use a global lock to exclude other versions of pants from running during '
                   'critical operations.')
-    # TODO: Make a custom type abstract class (or something) to automate the production of an option
-    # with specific allowed values from a datatype (ideally using singletons for the allowed
-    # values).
-    register('--glob-expansion-failure', type=str,
-             choices=GlobMatchErrorBehavior.allowed_values,
-             default=GlobMatchErrorBehavior.default_option_value,
-             help="Raise an exception if any targets declaring source files "
-                  "fail to match any glob provided in the 'sources' argument.")

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -18,6 +18,7 @@ from pants.base.exiter import Exiter
 from pants.bin.daemon_pants_runner import DaemonExiter, DaemonPantsRunner
 from pants.engine.native import Native
 from pants.init.engine_initializer import EngineInitializer
+from pants.init.options_initializer import OptionsInitializer
 from pants.init.target_roots_calculator import TargetRootsCalculator
 from pants.logging.setup import setup_logging
 from pants.option.arg_splitter import GLOBAL_SCOPE
@@ -115,8 +116,10 @@ class PantsDaemon(FingerprintedProcessManager):
       if full_init:
         build_root = get_buildroot()
         native = Native.create(bootstrap_options_values)
+        _, build_config = OptionsInitializer(OptionsBootstrapper()).setup(init_logging=False)
         legacy_graph_scheduler = EngineInitializer.setup_legacy_graph(native,
-                                                                      bootstrap_options_values)
+                                                                      bootstrap_options_values,
+                                                                      build_config)
         services, port_map = cls._setup_services(
           build_root,
           bootstrap_options_values,

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -115,7 +115,8 @@ class PantsDaemon(FingerprintedProcessManager):
       if full_init:
         build_root = get_buildroot()
         native = Native.create(bootstrap_options_values)
-        legacy_graph_scheduler = cls._setup_legacy_graph_scheduler(native, bootstrap_options_values)
+        legacy_graph_scheduler = EngineInitializer.setup_legacy_graph(native,
+                                                                      bootstrap_options_values)
         services, port_map = cls._setup_services(
           build_root,
           bootstrap_options_values,
@@ -137,21 +138,6 @@ class PantsDaemon(FingerprintedProcessManager):
     @staticmethod
     def _parse_bootstrap_options():
       return OptionsBootstrapper().get_bootstrap_options()
-
-    @staticmethod
-    def _setup_legacy_graph_scheduler(native, bootstrap_options):
-      """Initializes a `LegacyGraphScheduler` instance."""
-      return EngineInitializer.setup_legacy_graph(
-        bootstrap_options.pants_ignore,
-        bootstrap_options.pants_workdir,
-        bootstrap_options.build_file_imports,
-        native=native,
-        build_ignore_patterns=bootstrap_options.build_ignore,
-        exclude_target_regexps=bootstrap_options.exclude_target_regexp,
-        subproject_roots=bootstrap_options.subproject_roots,
-        remote_store_server=bootstrap_options.remote_store_server,
-        remote_execution_server=bootstrap_options.remote_execution_server,
-      )
 
     @staticmethod
     def _setup_services(build_root, bootstrap_options, legacy_graph_scheduler, watchman):

--- a/tests/python/pants_test/engine/legacy/BUILD
+++ b/tests/python/pants_test/engine/legacy/BUILD
@@ -13,6 +13,7 @@ python_tests(
     'src/python/pants/util:contextutil',
     'src/python/pants/util:dirutil',
     'tests/python/pants_test/engine:util',
+    'tests/python/pants_test:test_base'
   ]
 )
 

--- a/tests/python/pants_test/engine/legacy/test_address_mapper.py
+++ b/tests/python/pants_test/engine/legacy/test_address_mapper.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, generators, nested_scopes, pr
                         unicode_literals, with_statement)
 
 import os
-import unittest
 
 import mock
 
@@ -16,17 +15,14 @@ from pants.build_graph.address_mapper import AddressMapper
 from pants.engine.legacy.address_mapper import LegacyAddressMapper
 from pants.engine.nodes import Throw
 from pants.engine.scheduler import ExecutionResult
-from pants.init.engine_initializer import EngineInitializer
 from pants.util.contextutil import temporary_dir
 from pants.util.dirutil import safe_file_dump, safe_mkdir
-from pants_test.engine.util import init_native
+from pants_test.test_base import TestBase
 
 
-class LegacyAddressMapperTest(unittest.TestCase):
+class LegacyAddressMapperTest(TestBase):
 
-  _native = init_native()
-
-  def create_build_files(self, build_root):
+  def create_build_files(self):
     # Create BUILD files
     # build_root:
     #   BUILD
@@ -38,15 +34,15 @@ class LegacyAddressMapperTest(unittest.TestCase):
     #       BUILD
     #   dir_b:
     #     BUILD
-    dir_a = os.path.join(build_root, 'dir_a')
-    dir_b = os.path.join(build_root, 'dir_b')
+    dir_a = os.path.join(self.build_root, 'dir_a')
+    dir_b = os.path.join(self.build_root, 'dir_b')
     dir_a_subdir = os.path.join(dir_a, 'subdir')
     safe_mkdir(dir_a)
     safe_mkdir(dir_b)
     safe_mkdir(dir_a_subdir)
 
-    safe_file_dump(os.path.join(build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")')
-    safe_file_dump(os.path.join(build_root, 'BUILD.other'), 'target(name="c")')
+    safe_file_dump(os.path.join(self.build_root, 'BUILD'), 'target(name="a")\ntarget(name="b")')
+    safe_file_dump(os.path.join(self.build_root, 'BUILD.other'), 'target(name="c")')
 
     safe_file_dump(os.path.join(dir_a, 'BUILD'), 'target(name="a")\ntarget(name="b")')
     safe_file_dump(os.path.join(dir_a, 'BUILD.other'), 'target(name="c")')
@@ -55,54 +51,40 @@ class LegacyAddressMapperTest(unittest.TestCase):
 
     safe_file_dump(os.path.join(dir_a_subdir, 'BUILD'), 'target(name="a")')
 
-  def create_address_mapper(self, build_root):
-    work_dir = os.path.join(build_root, '.pants.d')
-    scheduler = EngineInitializer.setup_legacy_graph(
-      [],
-      work_dir,
-      build_file_imports_behavior='allow',
-      build_root=build_root,
-      native=self._native
-    ).scheduler
-    return LegacyAddressMapper(scheduler.new_session(), build_root)
-
   def test_is_valid_single_address(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
+    self.create_build_files()
+    mapper = self.address_mapper
 
-      self.assertFalse(mapper.is_valid_single_address(SingleAddress('dir_a', 'foo')))
-      self.assertTrue(mapper.is_valid_single_address(SingleAddress('dir_a', 'a')))
-      with self.assertRaises(TypeError):
-        mapper.is_valid_single_address('foo')
+    self.assertFalse(mapper.is_valid_single_address(SingleAddress('dir_a', 'foo')))
+    self.assertTrue(mapper.is_valid_single_address(SingleAddress('dir_a', 'a')))
+    with self.assertRaises(TypeError):
+      mapper.is_valid_single_address('foo')
 
   def test_scan_build_files(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
+    self.create_build_files()
+    mapper = self.address_mapper
 
-      build_files = mapper.scan_build_files('')
-      self.assertEqual(build_files,
-                       {'BUILD', 'BUILD.other',
-                        'dir_a/BUILD', 'dir_a/BUILD.other',
-                        'dir_b/BUILD', 'dir_a/subdir/BUILD'})
+    build_files = mapper.scan_build_files('')
+    self.assertEqual(build_files,
+                      {'BUILD', 'BUILD.other',
+                      'dir_a/BUILD', 'dir_a/BUILD.other',
+                      'dir_b/BUILD', 'dir_a/subdir/BUILD'})
 
-      build_files = mapper.scan_build_files('dir_a/subdir')
-      self.assertEqual(build_files, {'dir_a/subdir/BUILD'})
+    build_files = mapper.scan_build_files('dir_a/subdir')
+    self.assertEqual(build_files, {'dir_a/subdir/BUILD'})
 
   def test_scan_build_files_edge_cases(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
+    self.create_build_files()
+    mapper = self.address_mapper
 
-      # A non-existent dir.
-      build_files = mapper.scan_build_files('foo')
-      self.assertEqual(build_files, set())
+    # A non-existent dir.
+    build_files = mapper.scan_build_files('foo')
+    self.assertEqual(build_files, set())
 
-      # A dir with no BUILD files.
-      safe_mkdir(os.path.join(build_root, 'empty'))
-      build_files = mapper.scan_build_files('empty')
-      self.assertEqual(build_files, set())
+    # A dir with no BUILD files.
+    safe_mkdir(os.path.join(self.build_root, 'empty'))
+    build_files = mapper.scan_build_files('empty')
+    self.assertEqual(build_files, set())
 
   def test_is_declaring_file(self):
     scheduler = mock.Mock()
@@ -119,72 +101,64 @@ class LegacyAddressMapperTest(unittest.TestCase):
       'path/BUILD'))
 
   def test_addresses_in_spec_path(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
-      addresses = mapper.addresses_in_spec_path('dir_a')
-      self.assertEqual(addresses,
-                       {Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c')})
+    self.create_build_files()
+    mapper = self.address_mapper
+    addresses = mapper.addresses_in_spec_path('dir_a')
+    self.assertEqual(addresses,
+                      {Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c')})
 
   def test_addresses_in_spec_path_no_dir(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
-      with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
-        mapper.addresses_in_spec_path('foo')
-      self.assertIn('does not match any targets.', str(cm.exception))
+    self.create_build_files()
+    mapper = self.address_mapper
+    with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
+      mapper.addresses_in_spec_path('foo')
+    self.assertIn('does not match any targets.', str(cm.exception))
 
   def test_addresses_in_spec_path_no_build_files(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      safe_mkdir(os.path.join(build_root, 'foo'))
-      mapper = self.create_address_mapper(build_root)
-      with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
-        mapper.addresses_in_spec_path('foo')
-      self.assertIn('does not match any targets.', str(cm.exception))
+    self.create_build_files()
+    safe_mkdir(os.path.join(self.build_root, 'foo'))
+    mapper = self.address_mapper
+    with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
+      mapper.addresses_in_spec_path('foo')
+    self.assertIn('does not match any targets.', str(cm.exception))
 
   def test_scan_specs(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
-      addresses = mapper.scan_specs([SingleAddress('dir_a', 'a'), SiblingAddresses('')])
-      self.assertEqual(addresses,
-                       {Address('', 'a'), Address('', 'b'), Address('', 'c'), Address('dir_a', 'a')})
+    self.create_build_files()
+    mapper = self.address_mapper
+    addresses = mapper.scan_specs([SingleAddress('dir_a', 'a'), SiblingAddresses('')])
+    self.assertEqual(addresses,
+                      {Address('', 'a'), Address('', 'b'), Address('', 'c'), Address('dir_a', 'a')})
 
   def test_scan_specs_bad_spec(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
-      with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
-        mapper.scan_specs([SingleAddress('dir_a', 'd')])
-      self.assertIn('does not match any targets.', str(cm.exception))
+    self.create_build_files()
+    mapper = self.address_mapper
+    with self.assertRaises(AddressMapper.BuildFileScanError) as cm:
+      mapper.scan_specs([SingleAddress('dir_a', 'd')])
+    self.assertIn('does not match any targets.', str(cm.exception))
 
   def test_scan_addresses(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
-      addresses = mapper.scan_addresses()
-      self.assertEqual(addresses,
-                       {Address('', 'a'), Address('', 'b'), Address('', 'c'),
-                        Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c'),
-                        Address('dir_b', 'a'), Address('dir_a/subdir', 'a')})
+    self.create_build_files()
+    mapper = self.address_mapper
+    addresses = mapper.scan_addresses()
+    self.assertEqual(addresses,
+                      {Address('', 'a'), Address('', 'b'), Address('', 'c'),
+                      Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c'),
+                      Address('dir_b', 'a'), Address('dir_a/subdir', 'a')})
 
   def test_scan_addresses_with_root_specified(self):
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
-      addresses = mapper.scan_addresses(os.path.join(build_root, 'dir_a'))
-      self.assertEqual(addresses,
-                       {Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c'),
-                        Address('dir_a/subdir', 'a')})
+    self.create_build_files()
+    mapper = self.address_mapper
+    addresses = mapper.scan_addresses(os.path.join(self.build_root, 'dir_a'))
+    self.assertEqual(addresses,
+                      {Address('dir_a', 'a'), Address('dir_a', 'b'), Address('dir_a', 'c'),
+                      Address('dir_a/subdir', 'a')})
 
   def test_scan_addresses_bad_dir(self):
     # scan_addresses() should not raise an error.
-    with temporary_dir() as build_root:
-      self.create_build_files(build_root)
-      mapper = self.create_address_mapper(build_root)
-      addresses = mapper.scan_addresses(os.path.join(build_root, 'foo'))
-      self.assertEqual(addresses, set())
+    self.create_build_files()
+    mapper = self.address_mapper
+    addresses = mapper.scan_addresses(os.path.join(self.build_root, 'foo'))
+    self.assertEqual(addresses, set())
 
   def test_other_throw_is_fail(self):
     # scan_addresses() should raise an error if the scheduler returns an error it can't ignore.

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -50,7 +50,8 @@ class GraphTestBase(unittest.TestCase):
 
     with temporary_dir() as work_dir:
       path_ignore_patterns = path_ignore_patterns or []
-      graph_helper = EngineInitializer.setup_legacy_graph(
+      # TODO: This test should be swapped to using TestBase.
+      graph_helper = EngineInitializer.setup_legacy_graph_extended(
         path_ignore_patterns,
         work_dir,
         build_file_imports_behavior,

--- a/tests/python/pants_test/engine/legacy/test_graph.py
+++ b/tests/python/pants_test/engine/legacy/test_graph.py
@@ -41,6 +41,12 @@ class GraphTestBase(unittest.TestCase):
     options.target_specs = specs
     return options
 
+  def _default_build_file_aliases(self):
+    # TODO: Get default BuildFileAliases by extending BaseTest post
+    #   https://github.com/pantsbuild/pants/issues/4401
+    _, build_config = OptionsInitializer(OptionsBootstrapper()).setup(init_logging=False)
+    return build_config.registered_aliases()
+
   @contextmanager
   def graph_helper(self,
                    build_file_aliases=None,
@@ -50,6 +56,7 @@ class GraphTestBase(unittest.TestCase):
 
     with temporary_dir() as work_dir:
       path_ignore_patterns = path_ignore_patterns or []
+      build_file_aliases = build_file_aliases or self._default_build_file_aliases()
       # TODO: This test should be swapped to using TestBase.
       graph_helper = EngineInitializer.setup_legacy_graph_extended(
         path_ignore_patterns,
@@ -166,12 +173,6 @@ class GraphInvalidationTest(GraphTestBase):
 
   def test_sources_ordering_glob(self):
     self._ordering_test('testprojects/src/resources/org/pantsbuild/testproject/ordering:globs')
-
-  def _default_build_file_aliases(self):
-    # TODO: Get default BuildFileAliases by extending BaseTest post
-    #   https://github.com/pantsbuild/pants/issues/4401
-    _, build_config = OptionsInitializer(OptionsBootstrapper()).setup(init_logging=False)
-    return build_config.registered_aliases()
 
   def test_target_macro_override(self):
     """Tests that we can "wrap" an existing target type with additional functionality.

--- a/tests/python/pants_test/pantsd/test_pantsd_integration.py
+++ b/tests/python/pants_test/pantsd/test_pantsd_integration.py
@@ -102,9 +102,10 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
             # (>104-108 characters), so we override that here with a shorter path.
             'watchman_socket_path': '/tmp/watchman.{}.sock'.format(os.getpid()),
             'level': log_level,
-            'pants_subprocessdir': pid_dir
+            'pants_subprocessdir': pid_dir,
           }, extra_config or {})
         }
+        print('>>> config: \n{}\n'.format(pantsd_config))
         checker = PantsDaemonMonitor(pid_dir)
         self.assert_success_runner(workdir, pantsd_config, ['kill-pantsd'])
         try:
@@ -178,7 +179,15 @@ class TestPantsDaemonIntegration(PantsRunIntegrationTest):
       checker.assert_started()
 
   def test_pantsd_run(self):
-    with self.pantsd_successful_run_context('debug') as (pantsd_run, checker, workdir, _):
+    extra_config = {
+        # Muddies the logs with warnings: once all of the warnings in the repository
+        # are fixed, this can be removed.
+        'glob_expansion_failure': 'ignore',
+      }
+    with self.pantsd_successful_run_context(
+          'debug',
+          extra_config=extra_config
+        ) as (pantsd_run, checker, workdir, _):
       pantsd_run(['list', '3rdparty:'])
       checker.assert_started()
 

--- a/tests/python/pants_test/test_base.py
+++ b/tests/python/pants_test/test_base.py
@@ -325,7 +325,9 @@ class TestBase(unittest.TestCase):
     if cls._scheduler is not None:
       return
 
-    graph_session = EngineInitializer.setup_legacy_graph(
+    # NB: This uses the long form of initialization because it needs to directly specify
+    # `cls.alias_groups` rather than having them be provided by bootstrap options.
+    graph_session = EngineInitializer.setup_legacy_graph_extended(
       pants_ignore_patterns=None,
       workdir=cls._pants_workdir(),
       build_file_imports_behavior='allow',


### PR DESCRIPTION
### Problem

`EngineInitializer.setup_legacy_graph` takes 14 arguments, but the two "real" callsites for it were independently constructing those arguments from the bootstrap options. This lead to an issue where the two real callsites went out of sync (see #5897).

### Solution

Rename the 14-arg form to `*_extended`, and give the shorter name to a 3-arg form that uses the bootstrap options. Additionally, clean-up/remove/explain callsites using the extended form.

### Result

Fixes #5897 and avoids issues like it.