### PR TITLE
Fix rust log level comparison

### DIFF
--- a/src/rust/engine/src/externs.rs
+++ b/src/rust/engine/src/externs.rs
@@ -554,7 +554,7 @@ impl FfiLogger {
 
 impl log::Log for FfiLogger {
   fn enabled(&self, metadata: &log::Metadata) -> bool {
-    metadata.level() >= self.level_filter
+    metadata.level() <= self.level_filter
   }
 
   fn log(&self, record: &log::Record) {


### PR DESCRIPTION
I've manually verified that this works by adding some warn!, info! and
debug! statements, and seeing that they get displayed appropriately.

There isn't a non-convoluted test I can add here, because we don't info
or warn log things on any usefully testable paths.