### PR TITLE
Add the --owner-of= usage on Target Address documentation

### DIFF
--- a/src/docs/target_addresses.md
+++ b/src/docs/target_addresses.md
@@ -44,8 +44,8 @@ The following target addresses all specify the same single target.
         $ ./pants --owner-of=examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java list
         examples/src/java/org/pantsbuild/example/hello/main:main
     
-    It's also worth noting that `owner-of=` can also receive a list of files and it will execute
-    the goal on all the targets that own those files.
+    It's also worth noting that multiple passes of `owner-of=` are accepted in order to work with multiple 
+    files and pants will execute the goal on all the targets that own those files.
 
 -   Relative paths and trailing forward slashes are ignored on the
     command-line to accommodate tab completion:

--- a/src/docs/target_addresses.md
+++ b/src/docs/target_addresses.md
@@ -37,6 +37,16 @@ The following target addresses all specify the same single target.
 
     It's idiomatic to omit the repetition of the target name in this case.
 
+-   If the address of the target that owns a certain file is not known, the `--owner-of=` global
+    option can be passed to run the goal on the target which own that file.
+
+        ::::bash
+        $ ./pants --owner-of=examples/src/java/org/pantsbuild/example/hello/main/HelloMain.java list
+        examples/src/java/org/pantsbuild/example/hello/main:main
+    
+    It's also worth noting that `owner-of=` can also receive a list of files and it will execute
+    the goal on all the targets that own those files.
+
 -   Relative paths and trailing forward slashes are ignored on the
     command-line to accommodate tab completion:
 


### PR DESCRIPTION
### Problem

The documentation of the feature proposed in PR #5930

### Solution

I decided to put it inside Target Addresses because that is where a user would look if they needed a feature like this, I think.

### Result

More docs, and that's always good.